### PR TITLE
fix(sab): make history delete idempotent for missing ids

### DIFF
--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Api.SabControllers.RemoveFromHistory;
@@ -16,7 +18,19 @@ public class RemoveFromHistoryController(
     public async Task<RemoveFromHistoryResponse> RemoveFromHistory(RemoveFromHistoryRequest request)
     {
         await dbClient.RemoveHistoryItemsAsync(request.NzoIds, request.DeleteCompletedFiles, request.CancellationToken).ConfigureAwait(false);
-        await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+        try
+        {
+            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex) when (ex.Entries.All(e => e.Entity is HistoryItem))
+        {
+            // A HistoryItem vanished between RemoveHistoryItemsAsync's existence check and this save
+            // (a concurrent delete). The SAB API delete is idempotent, so that outcome is success.
+            //
+            // The `when` filter matters: on the deleteFiles=true path this SaveChanges also removes
+            // joined DavItem rows. A concurrency conflict on THOSE is a real conflict, not an
+            // already-deleted history row, and must not be swallowed.
+        }
         _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", request.NzoIds));
         return new RemoveFromHistoryResponse() { Status = true };
     }

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -218,10 +218,23 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             return;
         }
 
-        Ctx.HistoryItems.RemoveRange(ids.Select(id => new HistoryItem() { Id = id }));
-        Ctx.HistoryCleanupItems.AddRange(ids.Select(x => new HistoryCleanupItem
+        // Only remove ids that actually exist. Attaching stub entities for ids that are already
+        // gone makes EF emit a DELETE affecting 0 rows, which throws DbUpdateConcurrencyException
+        // and rolls back the WHOLE SaveChangesAsync -- so a batch containing one stale id would
+        // silently delete none of them (and queue none of their cleanup items). The deleteFiles
+        // branch above is already safe because it queries the rows first; this branch was not.
+        // Remove the entities we just loaded rather than fresh stubs. Attaching a stub whose key is
+        // already tracked by this context throws ("another instance with the same key is already
+        // tracked"), and stubs are what made the original code delete rows it had never checked for.
+        var existing = await Ctx.HistoryItems
+            .Where(h => ids.Contains(h.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        Ctx.HistoryItems.RemoveRange(existing);
+        Ctx.HistoryCleanupItems.AddRange(existing.Select(x => new HistoryCleanupItem
         {
-            Id = x,
+            Id = x.Id,
             DeleteMountedFiles = deleteFiles
         }));
     }


### PR DESCRIPTION
## Problem

Sonarr and Radarr call `mode=history&name=delete` as their post-import cleanup step. `RemoveHistoryItemsAsync` attaches stub `HistoryItem` entities for every requested id without checking that they exist:

```csharp
Ctx.HistoryItems.RemoveRange(ids.Select(id => new HistoryItem() { Id = id }));
```

EF then emits a `DELETE` affecting 0 rows for any id that is already gone, throws `DbUpdateConcurrencyException`, and rolls back the whole `SaveChangesAsync`. It surfaces as **HTTP 500**:

```json
{"status":false,"error":"The database operation was expected to affect 1 row(s), but actually affected 0 row(s); data may have been modified or deleted since entities were loaded."}
```

## Reproduction

Any id that does not exist is enough. No special state required:

```bash
curl "http://localhost:8080/api?mode=history&name=delete&del_files=1\
&value=00000000-0000-0000-0000-000000000000&archive=1&apikey=$KEY&output=json"
```

**Actual:** HTTP 500 with the payload above.
**Expected:** HTTP 200 `{"status": true}` — SABnzbd treats deleting an unknown id as an idempotent no-op.

Independent of `archive` and `del_files`. Reads (`mode=history`, `mode=queue`, `mode=version`) are unaffected.

## Why it matters

The failure is self-sustaining. Once a history row is gone, the arr's queue row can never be cleaned: its removal calls `history/delete`, receives a 500, keeps the row, and retries on every `RefreshMonitoredDownloads` cycle. On one install this produced **3,586 delete-500s against 6 successes** over a single container lifetime, and operators reading the 500 flood as "nzbdav is wedged" restart it — which drops in-flight work and creates more permanently-stuck rows.

`v0.6.7` still ships this. Originally reported upstream as nzbdav-dev/nzbdav#364.

## What this changes

Query the rows first and remove the **loaded entities**:

```csharp
var existing = await Ctx.HistoryItems.Where(h => ids.Contains(h.Id)).ToListAsync(ct);
Ctx.HistoryItems.RemoveRange(existing);
```

Two reasons to remove loaded entities rather than fresh stubs keyed by id:

1. **Batch correctness.** `SaveChangesAsync` is one transaction. Attaching a stub for an id that is already gone rolls the whole batch back, so a batch containing one stale id silently deletes *none* of them while the endpoint returns `{"status":true}`. Batches are reachable: `NzoIds` comes from repeatable `value=` query params concatenated with ids from the request body, and the web UI's history table posts them when clearing history.
2. **Tracked-entity conflicts.** Attaching a stub whose key is already tracked by the context throws `InvalidOperationException: The instance of entity type 'HistoryItem' cannot be tracked because another instance with the same key is already tracked.` A per-request scoped context usually hides this, but it is fragile.

The `deleteFiles == true` branch already queried its rows before removing them and was therefore never affected. This makes both branches consistent.

The remaining `DbUpdateConcurrencyException` catch covers only the narrow race where a history row vanishes between the query and the save. It is filtered to history-only entries so a genuine conflict on the joined `DavItem` rows — which the `deleteFiles == true` branch also removes — still surfaces rather than being swallowed.

## Related work

`STiXzoOR/nzbdav` found the same bug and fixed it the same way (query existing ids first), which I think is good independent confirmation of the diagnosis. That version keeps the stub entities:

```csharp
Ctx.HistoryItems.RemoveRange(existingIds.Select(id => new HistoryItem() { Id = id }));
```

which fixes the 500 but leaves points (1) and (2) above. Worth knowing if you would rather take the smaller diff — the tradeoff is the batch case and the tracking conflict.

## Verification

`AGENTS.md` notes there is no backend test suite, so this was verified by hand against a build of this branch:

- `delete(00000000-0000-0000-0000-000000000000)` → **200** `{"status":true,"error":null}`, idempotent across repeated calls.
- Batch `delete([existing, missing])` → **200**, and the existing row is deleted. Before the change the batch returned `{"status":true}` while deleting nothing.
- Control `delete([existing])` → **200**, row deleted, cleanup item queued.
- `mode=version` / `mode=queue` / `mode=history` still 200; no new exceptions on boot.
- `dotnet build backend/NzbWebDAV.csproj` clean on top of `main` (0 errors, no new warnings).

I also have an xunit project covering these three delete cases. I left it out to keep this diff focused, but I am happy to open it separately if a backend test suite is something you want.
