### PR TITLE
fix(ui): return 405 for POST requests to index route

### DIFF
--- a/frontend/app/routes/_index/route.test.ts
+++ b/frontend/app/routes/_index/route.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { action } from "./route";
+
+describe("_index route action", () => {
+  it("returns 405 for POST requests", async () => {
+    const response = await action();
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(405);
+    expect(await response.text()).toBe("Method Not Allowed");
+    expect(response.headers.get("Allow")).toBe("GET, HEAD");
+  });
+});

--- a/frontend/app/routes/_index/route.tsx
+++ b/frontend/app/routes/_index/route.tsx
@@ -4,3 +4,10 @@ import type { Route } from "./+types/route";
 export async function loader({ request }: Route.LoaderArgs) {
     return redirect("/overview")
 }
+
+export async function action() {
+    return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+    });
+}


### PR DESCRIPTION
## Summary

- Add an explicit `action` on the index route that returns `405 Method Not Allowed` with `Allow: GET, HEAD`
- Stops React Router from throwing and logging a stack trace when intermittent `POST /` requests hit the frontend (e.g. from WebDAV clients on port 3000)
- Add unit test for the 405 response

Fixes #100

Upstream: nzbdav-dev/nzbdav#206

## Test plan

- [x] `npm test -- app/routes/_index/route.test.ts`
- [x] `npm run typecheck`
- [ ] `curl -X POST http://localhost:3000/` (with auth disabled or session cookie) returns 405 without React Router error in logs