### PR TITLE
fix(usenet): log host/port on test-connection failures

### DIFF
--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using Serilog;
 
 namespace NzbWebDAV.Api.Controllers.TestUsenetConnection;
 
@@ -15,13 +17,28 @@ public class TestUsenetConnectionController() : BaseApiController
             await UsenetStreamingClient.CreateNewConnection(request.ToConnectionDetails(), HttpContext.RequestAborted).ConfigureAwait(false);
             return new TestUsenetConnectionResponse { Status = true, Connected = true };
         }
-        catch (CouldNotConnectToUsenetException)
+        catch (CouldNotConnectToUsenetException e)
         {
+            var inner = e.InnerException?.Message ?? e.Message;
+            Log.Warning(
+                "Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): connect error: {Error}",
+                request.Host, request.Port, request.UseSsl, request.User, inner);
             return new TestUsenetConnectionResponse { Status = true, Connected = false };
         }
-        catch (CouldNotLoginToUsenetException)
+        catch (CouldNotLoginToUsenetException e)
         {
+            var inner = e.InnerException?.Message ?? e.Message;
+            Log.Warning(
+                "Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): login error: {Error}",
+                request.Host, request.Port, request.UseSsl, request.User, inner);
             return new TestUsenetConnectionResponse { Status = true, Connected = false };
+        }
+        catch (Exception e) when (!e.IsCancellationException())
+        {
+            Log.Warning(e,
+                "Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): unexpected error",
+                request.Host, request.Port, request.UseSsl, request.User);
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary
- Log `Warning` with host, port, SSL, and user (not password) when test-usenet-connection fails to connect or log in
- Also log unexpected non-cancellation errors before rethrowing
- API response shape unchanged (`Connected: false`)

Closes #57

## Test plan
- [ ] Trigger a failed test connection (wrong host/port) from Usenet settings and confirm a Warning log line includes host/port
- [ ] Trigger a login failure (wrong credentials) and confirm a Warning log line
- [ ] Confirm successful test connection still returns `Connected: true` with no warning