### PR TITLE
fix(webdav): guard empty extension in PathUtil.ReplaceExtension

### DIFF
--- a/backend/Utils/PathUtil.cs
+++ b/backend/Utils/PathUtil.cs
@@ -10,11 +10,14 @@ public class PathUtil
             : [];
     }
 
-    public static string ReplaceExtension(string path, string newExtensions)
+    public static string ReplaceExtension(string path, string? newExtensions)
     {
         var directoryName = Path.GetDirectoryName(path);
         var filenameWithoutExtension = Path.GetFileNameWithoutExtension(path);
-        var newFilename = $"{filenameWithoutExtension}.{newExtensions.TrimStart('.')}";
+        var trimmed = newExtensions?.Trim().TrimStart('.');
+        var newFilename = string.IsNullOrEmpty(trimmed)
+            ? filenameWithoutExtension
+            : $"{filenameWithoutExtension}.{trimmed}";
         return Path.Join(directoryName, newFilename);
     }
 }

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -52,6 +52,19 @@ public class UtilityTests
             PathUtil.ReplaceExtension(Path.Join("one", "two", "file.mkv"), ".strm"));
     }
 
+    [Theory]
+    [InlineData("file.mkv", ".strm", "file.strm")]
+    [InlineData("file.mkv", "strm", "file.strm")]
+    [InlineData("file.mkv", "", "file")]
+    [InlineData("file.mkv", ".", "file")]
+    [InlineData("file.mkv", "   ", "file")]
+    [InlineData("file.mkv", null, "file")]
+    public void ReplaceExtension_HandlesEmptyAndNormalExtensions(
+        string path, string? newExtension, string expectedFilename)
+    {
+        Assert.Equal(expectedFilename, Path.GetFileName(PathUtil.ReplaceExtension(path, newExtension)));
+    }
+
     [Fact]
     public void PasswordHash_RequiresMatchingPasswordAndSalt()
     {


### PR DESCRIPTION
## Summary
- `PathUtil.ReplaceExtension` no longer appends a trailing `.` when the new extension is null, empty, whitespace, or `.`
- Adds unit coverage for empty/normal extension cases

Closes #50

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~UtilityTests`
- [ ] Spot-check STRM→symlink conversion with an empty `extension=` query param does not create `file.` paths