### PR TITLE
feat(ui): hyperlink history job names to explore folders

### DIFF
--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -4,7 +4,7 @@ import { ConfirmModal } from "~/components/confirm-modal/confirm-modal"
 import { Link } from "react-router"
 import { type TriCheckboxState } from "../tri-checkbox/tri-checkbox"
 import type { PresentationHistorySlot } from "../../route"
-import { getLeafDirectoryName } from "~/utils/path"
+import { getExploreContentLink } from "~/utils/path"
 import { PageRow, PageTable } from "../page-table/page-table"
 import { PageSection } from "../page-section/page-section"
 import { Pagination } from "../pagination/pagination"
@@ -145,6 +145,9 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
         onIsRemovingChanged(slot.nzo_id, false);
     }, [slot.nzo_id, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
+    const folderLink = getExploreContentLink(slot.storage, slot.category);
+    const nameHref = folderLink && !slot.isRemoving && !slot.fail_message ? folderLink : null;
+
     // view
     return (
         <>
@@ -152,6 +155,7 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                 isSelected={!!slot.isSelected}
                 isRemoving={!!slot.isRemoving}
                 name={slot.name}
+                nameHref={nameHref}
                 category={slot.category}
                 status={slot.status}
                 error={slot.fail_message}
@@ -176,11 +180,7 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
 export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onRemove: () => void }) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-    // determine explore action link url
-    var downloadFolder = slot.storage && getLeafDirectoryName(slot.storage);
-    const encodedCategory = downloadFolder && encodeURIComponent(slot.category);
-    const encodedDownloadFolder = downloadFolder && encodeURIComponent(downloadFolder);
-    var folderLink = downloadFolder && `/explore/content/${encodedCategory}/${encodedDownloadFolder}`;
+    const folderLink = getExploreContentLink(slot.storage, slot.category);
 
     // determine nzb download URL
     var nzbDownloadUrl = slot.nzb_blob_id
@@ -188,7 +188,7 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
         : null;
 
     // determine whether explore action should be disabled
-    var isFolderDisabled = !downloadFolder || !!slot.isRemoving || !!slot.fail_message;
+    var isFolderDisabled = !folderLink || !!slot.isRemoving || !!slot.fail_message;
 
     const onMenuClick = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
@@ -202,12 +202,12 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
 
     return (
         <>
-            {!isFolderDisabled &&
+            {!isFolderDisabled && folderLink &&
                 <Link to={folderLink} >
                     <ActionButton type="explore" />
                 </Link>
             }
-            {isFolderDisabled &&
+            {(isFolderDisabled || !folderLink) &&
                 <ActionButton type="explore" disabled />
             }
             <div className="relative">

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -1,5 +1,6 @@
 import styles from "./page-table.module.css";
 import type { ReactNode } from "react";
+import { Link } from "react-router";
 import { TriCheckbox, type TriCheckboxState } from "../tri-checkbox/tri-checkbox";
 import { Truncate } from "../truncate/truncate";
 import { StatusBadge } from "../status-badge/status-badge";
@@ -51,6 +52,7 @@ export type PageRowProps = {
     isSelected: boolean,
     isRemoving: boolean,
     name: string,
+    nameHref?: string | null,
     category: string,
     status: string,
     percentage?: string,
@@ -62,11 +64,15 @@ export type PageRowProps = {
     onRowSelectionChanged: (isSelected: boolean) => void
 }
 export function PageRow(props: PageRowProps) {
+    const nameContent = props.nameHref
+        ? <Link to={props.nameHref} className="text-slate-200 hover:text-white hover:underline" onClick={e => e.stopPropagation()}>{props.name}</Link>
+        : props.name;
+
     return (
         <tr className={`${props.isRemoving ? "opacity-20" : ""} ${props.isUploading ? "bg-cyan-400/5 [&+tr]:border-t-[3px] [&+tr]:border-slate-900" : ""}`}>
             <td className="max-w-[200px] whitespace-nowrap border-b border-white/5 py-3 pl-0 pr-1 text-left align-middle text-slate-300">
                 <TriCheckbox state={props.isSelected} onChange={props.onRowSelectionChanged}>
-                    <Truncate>{props.name}</Truncate>
+                    <Truncate>{nameContent}</Truncate>
                     <div className="block min-[900px]:hidden">
                         <div className="mb-1 mt-1 flex gap-2.5">
                             <StatusBadge status={props.status} percentage={props.percentage} error={props.error} />

--- a/frontend/app/utils/path.ts
+++ b/frontend/app/utils/path.ts
@@ -19,3 +19,11 @@ export function getLeafDirectoryName(fullPath: string): string {
 
     return leafName;
 }
+
+/** Explore link for a completed history item's content folder, or null when unavailable. */
+export function getExploreContentLink(storage: string | null | undefined, category: string | null | undefined): string | null {
+    if (!storage || !category) return null;
+    const downloadFolder = getLeafDirectoryName(storage);
+    if (!downloadFolder) return null;
+    return `/explore/content/${encodeURIComponent(category)}/${encodeURIComponent(downloadFolder)}`;
+}

--- a/frontend/app/utils/utils.test.ts
+++ b/frontend/app/utils/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { isMaskedSecret } from "./config-mask";
 import { formatFileSize } from "./file-size";
-import { getLeafDirectoryName } from "./path";
+import { getExploreContentLink, getLeafDirectoryName } from "./path";
 import { className, classNames } from "./styling";
 import { receiveMessage } from "./websocket-util";
 
@@ -26,6 +26,24 @@ describe("getLeafDirectoryName", () => {
     ["Alien", "Alien"],
   ])("gets the leaf from %s", (path, expected) => {
     expect(getLeafDirectoryName(path)).toBe(expected);
+  });
+});
+
+describe("getExploreContentLink", () => {
+  it("builds an explore content URL", () => {
+    expect(getExploreContentLink("/completed/movies/Alien", "movies"))
+      .toBe("/explore/content/movies/Alien");
+  });
+
+  it("encodes category and folder segments", () => {
+    expect(getExploreContentLink("/completed/tv shows/Show Name", "tv shows"))
+      .toBe("/explore/content/tv%20shows/Show%20Name");
+  });
+
+  it("returns null when storage or category is missing", () => {
+    expect(getExploreContentLink(null, "movies")).toBeNull();
+    expect(getExploreContentLink("/completed/movies/Alien", null)).toBeNull();
+    expect(getExploreContentLink("", "movies")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- History job names link to `/explore/content/{category}/{folder}` when storage is available and the item is not failed/removing
- Shared `getExploreContentLink` helper used by name links and the Explore action button
- Queue names remain plain text (no content path until the job finishes)
- Explore icon action is unchanged

Closes #72

## Test plan
- [x] `npm test -- --run app/utils/utils.test.ts`
- [x] `npm run typecheck`
- [ ] Open queue/history page with a completed item and click the job name → lands in explore folder
- [ ] Failed history items still show plain (non-link) names
- [ ] Explore action button still works alongside the name link