### PR TITLE
fix(db): repair empty categories and harden explore paths

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -29,6 +29,8 @@ public class AddFileController(
     public async Task<AddFileResponse> AddFileAsync(AddFileRequest request)
     {
         var id = Guid.NewGuid();
+        var category = StringUtil.EmptyToNull(request.Category)
+                       ?? configManager.GetManualUploadCategory();
 
         // write the file to the blob-store
         await using var stream = request.NzbFileStream;
@@ -44,7 +46,7 @@ public class AddFileController(
                 var backupLocation = configManager.GetNzbBackupLocation();
                 if (backupLocation != null)
                 {
-                    await BackupNzbAsync(id, request.FileName, request.Category, backupLocation);
+                    await BackupNzbAsync(id, request.FileName, category, backupLocation);
                 }
             }
 
@@ -61,7 +63,7 @@ public class AddFileController(
                 JobName = FilenameUtil.GetJobName(request.FileName),
                 NzbFileSize = nzbFileStream.Length,
                 TotalSegmentBytes = totalSegmentBytes,
-                Category = request.Category,
+                Category = category,
                 Priority = request.Priority,
                 PostProcessing = request.PostProcessing,
                 PauseUntil = request.PauseUntil,

--- a/backend/Database/Migrations/20250819221618_Add-Path-To-DavItem.cs
+++ b/backend/Database/Migrations/20250819221618_Add-Path-To-DavItem.cs
@@ -17,6 +17,15 @@ namespace NzbWebDAV.Database.Migrations
                 nullable: false,
                 defaultValue: "");
 
+            BuildFullPath(migrationBuilder);
+        }
+
+        /// <summary>
+        /// Rebuilds DavItems.Path for every item reachable from the WebDAV root.
+        /// Only updates rows included in the recursive CTE so orphans cannot get NULL Path.
+        /// </summary>
+        public static void BuildFullPath(MigrationBuilder migrationBuilder)
+        {
             // Populate the Path column for every existing DavItem
             // * The root DavItem is given path `/`
             // * Every other DavItem is given path `{PARENT_PATH}/{NAME}`
@@ -42,7 +51,8 @@ namespace NzbWebDAV.Database.Migrations
                 )
 
                 UPDATE DavItems
-                SET Path = (SELECT Path FROM computed WHERE DavItems.Id = computed.Id);
+                SET Path = (SELECT Path FROM computed WHERE DavItems.Id = computed.Id)
+                WHERE Id IN (SELECT Id FROM computed);
                 """
             );
         }

--- a/backend/Database/Migrations/20260712000000_Fix-Empty-Categories.cs
+++ b/backend/Database/Migrations/20260712000000_Fix-Empty-Categories.cs
@@ -1,0 +1,173 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    /// <summary>
+    /// Repairs legacy empty/whitespace Category values and empty-named /content folders
+    /// that break WebDAV paths and explore URLs. Collisions are resolved by renaming
+    /// rather than UPDATE OR IGNORE / cascade delete so migration never bricks installs
+    /// that need this repair (entrypoint exits on --db-migration failure).
+    /// </summary>
+    [DbContext(typeof(DavDatabaseContext))]
+    [Migration("20260712000000_Fix-Empty-Categories")]
+    public partial class FixEmptyCategories : Migration
+    {
+        private const string ContentFolderId = "00000000-0000-0000-0000-000000000002";
+
+        /// <summary>
+        /// Configured manual category, falling back to uncategorized.
+        /// Empty/whitespace ConfigValue is treated as unset.
+        /// </summary>
+        private const string TargetCategorySql = """
+            COALESCE(
+                NULLIF(TRIM((SELECT ConfigValue FROM ConfigItems WHERE ConfigName = 'api.manual-category')), ''),
+                'uncategorized'
+            )
+            """;
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1–3. Rename QueueItems that would collide on (Category, FileName), then
+            // rewrite empty/whitespace categories on HistoryItems and QueueItems.
+            migrationBuilder.Sql($"""
+                UPDATE QueueItems
+                SET FileName = FileName || ' (' || substr(Id, 1, 5) || ')'
+                WHERE TRIM(Category) = ''
+                  AND EXISTS (
+                      SELECT 1
+                      FROM QueueItems AS existing
+                      WHERE existing.Category = ({TargetCategorySql})
+                        AND existing.FileName = QueueItems.FileName
+                  );
+                """);
+
+            migrationBuilder.Sql($"""
+                UPDATE HistoryItems
+                SET Category = ({TargetCategorySql})
+                WHERE TRIM(Category) = '';
+                """);
+
+            migrationBuilder.Sql($"""
+                UPDATE QueueItems
+                SET Category = ({TargetCategorySql})
+                WHERE TRIM(Category) = '';
+                """);
+
+            // 4. Ensure the target category folder exists under /content.
+            migrationBuilder.Sql($"""
+                WITH target AS (
+                    SELECT ({TargetCategorySql}) AS Name
+                ),
+                new_id AS (
+                    SELECT lower(
+                        hex(randomblob(4)) || '-' ||
+                        hex(randomblob(2)) || '-' ||
+                        '4' || substr(hex(randomblob(2)), 2) || '-' ||
+                        substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)), 2) || '-' ||
+                        hex(randomblob(6))
+                    ) AS Id
+                )
+                INSERT INTO DavItems (Id, IdPrefix, CreatedAt, ParentId, Name, Type, SubType, Path)
+                SELECT
+                    new_id.Id,
+                    substr(new_id.Id, 1, 5),
+                    datetime('now'),
+                    '{ContentFolderId}',
+                    target.Name,
+                    1,
+                    101,
+                    '/content/' || target.Name
+                FROM target, new_id
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM DavItems
+                    WHERE ParentId = '{ContentFolderId}'
+                      AND Name = target.Name
+                );
+                """);
+
+            // 5–6. Rename DavItem children that would collide under the target folder,
+            // then reparent them out of the empty-named /content folder.
+            // Suffix is " (xxxxx)" (8 chars); truncate Name to keep MaxLength(255).
+            migrationBuilder.Sql($"""
+                UPDATE DavItems
+                SET Name = CASE
+                    WHEN length(Name) + 8 > 255
+                        THEN substr(Name, 1, 247) || ' (' || substr(Id, 1, 5) || ')'
+                    ELSE Name || ' (' || substr(Id, 1, 5) || ')'
+                END
+                WHERE ParentId = (
+                    SELECT Id
+                    FROM DavItems
+                    WHERE ParentId = '{ContentFolderId}'
+                      AND Name = ''
+                )
+                AND EXISTS (
+                    SELECT 1
+                    FROM DavItems AS existing
+                    WHERE existing.ParentId = (
+                        SELECT Id
+                        FROM DavItems
+                        WHERE ParentId = '{ContentFolderId}'
+                          AND Name = ({TargetCategorySql})
+                    )
+                    AND existing.Name = DavItems.Name
+                );
+                """);
+
+            migrationBuilder.Sql($"""
+                UPDATE DavItems
+                SET ParentId = (
+                    SELECT Id
+                    FROM DavItems
+                    WHERE ParentId = '{ContentFolderId}'
+                      AND Name = ({TargetCategorySql})
+                )
+                WHERE ParentId = (
+                    SELECT Id
+                    FROM DavItems
+                    WHERE ParentId = '{ContentFolderId}'
+                      AND Name = ''
+                );
+                """);
+
+            // 7–8. Guard the empty-folder delete: SQLite RAISE() only works inside
+            // triggers, so install a temp BEFORE DELETE trigger that aborts when
+            // children remain (those would be wiped by DavCleanupService after
+            // TR_DavItems_DeleteDirectory). With zero children the delete proceeds;
+            // cleanup enqueue for the folder Id itself is then a no-op.
+            migrationBuilder.Sql($"""
+                CREATE TEMP TRIGGER TR_FixEmptyCategories_AbortIfChildrenRemain
+                BEFORE DELETE ON DavItems
+                WHEN OLD.ParentId = '{ContentFolderId}'
+                  AND OLD.Name = ''
+                  AND EXISTS (
+                      SELECT 1 FROM DavItems WHERE ParentId = OLD.Id
+                  )
+                BEGIN
+                    SELECT RAISE(ABORT, 'Fix-Empty-Categories: empty category folder still has children');
+                END;
+
+                DELETE FROM DavItems
+                WHERE ParentId = '{ContentFolderId}'
+                  AND Name = '';
+
+                DROP TRIGGER IF EXISTS TR_FixEmptyCategories_AbortIfChildrenRemain;
+                """);
+
+            // 9. Rebuild Path values after reparenting/renaming.
+            AddPathToDavItem.BuildFullPath(migrationBuilder);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Intentionally left blank — data repair is not reversible.
+        }
+    }
+}

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -12,6 +12,7 @@ import { lookup as getMimeType } from 'mime-types';
 import { getDownloadKey } from "~/auth/downloads.server";
 import { Loading } from "../_index/components/loading/loading";
 import { formatFileSize } from "~/utils/file-size";
+import { parseExploreWebdavPath } from "~/utils/path";
 import { ItemMenu } from "./item-menu/item-menu";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { classNames } from "~/utils/styling";
@@ -36,7 +37,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
     // Single-fetch navigation requests use an internal `.data` URL, so derive
     // the WebDAV path from the matched wildcard rather than request.url.
-    const path = decodeURIComponent(params["*"] ?? "");
+    const parsed = parseExploreWebdavPath(params["*"] ?? "");
+    if (!parsed.ok) {
+        return {
+            parentDirectories: [],
+            items: [],
+            error: "not-found" as const,
+        };
+    }
+    const path = parsed.path;
     try {
         return {
             parentDirectories: getParentDirectories(path),
@@ -630,7 +639,8 @@ function getWebdavPath(pathname: string): string {
 }
 
 function getWebdavPathDecoded(pathname: string): string {
-    return decodeURIComponent(getWebdavPath(pathname));
+    const parsed = parseExploreWebdavPath(getWebdavPath(pathname));
+    return parsed.ok ? parsed.path : "";
 }
 
 function getRelativePath(path: string, filename: string) {

--- a/frontend/app/utils/path.ts
+++ b/frontend/app/utils/path.ts
@@ -22,8 +22,36 @@ export function getLeafDirectoryName(fullPath: string): string {
 
 /** Explore link for a completed history item's content folder, or null when unavailable. */
 export function getExploreContentLink(storage: string | null | undefined, category: string | null | undefined): string | null {
-    if (!storage || !category) return null;
+    if (!storage?.trim() || !category?.trim()) return null;
     const downloadFolder = getLeafDirectoryName(storage);
     if (!downloadFolder) return null;
-    return `/explore/content/${encodeURIComponent(category)}/${encodeURIComponent(downloadFolder)}`;
+    return `/explore/content/${encodeURIComponent(category.trim())}/${encodeURIComponent(downloadFolder)}`;
+}
+
+export type ParsedExploreWebdavPath =
+    | { ok: true; path: string }
+    | { ok: false };
+
+/**
+ * Decodes and validates an explore wildcard / WebDAV path.
+ * Rejects malformed percent-encoding and empty path segments (e.g. content//release).
+ */
+export function parseExploreWebdavPath(raw: string): ParsedExploreWebdavPath {
+    let decoded: string;
+    try {
+        decoded = decodeURIComponent(raw);
+    } catch {
+        return { ok: false };
+    }
+
+    // Drop only a leading empty segment (from a leading /) and a trailing empty
+    // segment (from a trailing /). Internal empty segments from "//" stay and
+    // are rejected so legacy /explore/content//{release} links stay not-found.
+    const parts = decoded.split("/");
+    if (parts.length > 0 && parts[0] === "") parts.shift();
+    if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
+
+    if (parts.some(segment => segment === "")) return { ok: false };
+
+    return { ok: true, path: parts.join("/") };
 }

--- a/frontend/app/utils/utils.test.ts
+++ b/frontend/app/utils/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { isMaskedSecret } from "./config-mask";
 import { formatFileSize } from "./file-size";
-import { getExploreContentLink, getLeafDirectoryName } from "./path";
+import { getExploreContentLink, getLeafDirectoryName, parseExploreWebdavPath } from "./path";
 import { className, classNames } from "./styling";
 import { receiveMessage } from "./websocket-util";
 
@@ -44,6 +44,35 @@ describe("getExploreContentLink", () => {
     expect(getExploreContentLink(null, "movies")).toBeNull();
     expect(getExploreContentLink("/completed/movies/Alien", null)).toBeNull();
     expect(getExploreContentLink("", "movies")).toBeNull();
+  });
+
+  it("returns null when storage or category is whitespace-only", () => {
+    expect(getExploreContentLink("   ", "movies")).toBeNull();
+    expect(getExploreContentLink("/completed/movies/Alien", "   ")).toBeNull();
+    expect(getExploreContentLink("/completed/movies/Alien", "")).toBeNull();
+  });
+});
+
+describe("parseExploreWebdavPath", () => {
+  it("accepts a valid encoded path", () => {
+    expect(parseExploreWebdavPath("content/tv%20shows/Alien")).toEqual({
+      ok: true,
+      path: "content/tv shows/Alien",
+    });
+  });
+
+  it("accepts the WebDAV root", () => {
+    expect(parseExploreWebdavPath("")).toEqual({ ok: true, path: "" });
+    expect(parseExploreWebdavPath("/")).toEqual({ ok: true, path: "" });
+  });
+
+  it("rejects empty path segments from double slashes", () => {
+    expect(parseExploreWebdavPath("content//Release")).toEqual({ ok: false });
+    expect(parseExploreWebdavPath("content//")).toEqual({ ok: false });
+  });
+
+  it("rejects malformed percent-encoding", () => {
+    expect(parseExploreWebdavPath("content/%E0%A4%A")).toEqual({ ok: false });
   });
 });
 

--- a/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class FixEmptyCategoriesMigrationTests
+{
+    private const string PriorMigration = "20260604120000_Add-UpdatedAtUnix-Index-To-WantedItems";
+
+    [Fact]
+    public async Task FixEmptyCategories_RepairsLegacyRowsAndRebuildsPaths()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        var emptyFolderId = Guid.NewGuid();
+        var mountId = Guid.NewGuid();
+        var collisionMountId = Guid.NewGuid();
+        var existingUncategorizedMountId = Guid.NewGuid();
+        var uncategorizedFolderId = Guid.NewGuid();
+        var emptyQueueId = Guid.NewGuid();
+        var collidingQueueId = Guid.NewGuid();
+        var existingQueueId = Guid.NewGuid();
+        var emptyHistoryId = Guid.NewGuid();
+        var whitespaceHistoryId = Guid.NewGuid();
+
+        ctx.ConfigItems.Add(new ConfigItem
+        {
+            ConfigName = "api.manual-category",
+            ConfigValue = "uncategorized",
+        });
+
+        var uncategorizedFolder = NewDirectory(uncategorizedFolderId, DavItem.ContentFolder, "uncategorized");
+        var emptyFolder = NewDirectory(emptyFolderId, DavItem.ContentFolder, "");
+        // Bypass DavItem.New path join for the empty-named folder; Path.Join drops empty segments.
+        emptyFolder.Path = "/content/";
+        var mount = NewDirectory(mountId, emptyFolder, "Release One");
+        mount.Path = "/content//Release One";
+        var collisionMount = NewDirectory(collisionMountId, emptyFolder, "Shared Release");
+        collisionMount.Path = "/content//Shared Release";
+        var existingMount = NewDirectory(existingUncategorizedMountId, uncategorizedFolder, "Shared Release");
+
+        ctx.Items.AddRange(uncategorizedFolder, emptyFolder, mount, collisionMount, existingMount);
+
+        ctx.QueueItems.AddRange(
+            new QueueItem
+            {
+                Id = emptyQueueId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "empty.nzb",
+                JobName = "empty",
+                NzbFileSize = 10,
+                TotalSegmentBytes = 20,
+                Category = "",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            },
+            new QueueItem
+            {
+                Id = collidingQueueId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "shared.nzb",
+                JobName = "shared-empty",
+                NzbFileSize = 10,
+                TotalSegmentBytes = 20,
+                Category = "",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            },
+            new QueueItem
+            {
+                Id = existingQueueId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "shared.nzb",
+                JobName = "shared-existing",
+                NzbFileSize = 10,
+                TotalSegmentBytes = 20,
+                Category = "uncategorized",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            });
+
+        ctx.HistoryItems.AddRange(
+            new HistoryItem
+            {
+                Id = emptyHistoryId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "hist-empty.nzb",
+                JobName = "hist-empty",
+                Category = "",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 20,
+                DownloadTimeSeconds = 1,
+            },
+            new HistoryItem
+            {
+                Id = whitespaceHistoryId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "hist-ws.nzb",
+                JobName = "hist-ws",
+                Category = "   ",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 20,
+                DownloadTimeSeconds = 1,
+            });
+
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        Assert.False(await ctx.Items.AsNoTracking().AnyAsync(x => x.Id == emptyFolderId));
+
+        var repairedMount = await ctx.Items.AsNoTracking()
+            .SingleAsync(x => x.Id == mountId);
+        Assert.Equal(uncategorizedFolderId, repairedMount.ParentId);
+        Assert.Equal("Release One", repairedMount.Name);
+        Assert.Equal("/content/uncategorized/Release One", repairedMount.Path);
+
+        var renamedMount = await ctx.Items.AsNoTracking()
+            .SingleAsync(x => x.Id == collisionMountId);
+        Assert.Equal(uncategorizedFolderId, renamedMount.ParentId);
+        Assert.Equal($"Shared Release ({collisionMountId.ToString().ToUpperInvariant()[..5]})", renamedMount.Name);
+        Assert.Equal($"/content/uncategorized/{renamedMount.Name}", renamedMount.Path);
+
+        var existing = await ctx.Items.AsNoTracking()
+            .SingleAsync(x => x.Id == existingUncategorizedMountId);
+        Assert.Equal("Shared Release", existing.Name);
+        Assert.Equal("/content/uncategorized/Shared Release", existing.Path);
+
+        var emptyQueue = await ctx.QueueItems.AsNoTracking()
+            .SingleAsync(x => x.Id == emptyQueueId);
+        Assert.Equal("uncategorized", emptyQueue.Category);
+        Assert.Equal("empty.nzb", emptyQueue.FileName);
+
+        var collidingQueue = await ctx.QueueItems.AsNoTracking()
+            .SingleAsync(x => x.Id == collidingQueueId);
+        Assert.Equal("uncategorized", collidingQueue.Category);
+        Assert.Equal($"shared.nzb ({collidingQueueId.ToString().ToUpperInvariant()[..5]})", collidingQueue.FileName);
+
+        var existingQueue = await ctx.QueueItems.AsNoTracking()
+            .SingleAsync(x => x.Id == existingQueueId);
+        Assert.Equal("uncategorized", existingQueue.Category);
+        Assert.Equal("shared.nzb", existingQueue.FileName);
+
+        var histories = await ctx.HistoryItems.AsNoTracking()
+            .Where(x => x.Id == emptyHistoryId || x.Id == whitespaceHistoryId)
+            .ToListAsync();
+        Assert.All(histories, h => Assert.Equal("uncategorized", h.Category));
+
+        // Deleting the empty directory enqueues its Id for cleanup; with zero children
+        // that cleanup is a no-op. No other DavCleanupItems should appear.
+        var cleanupIds = await ctx.DavCleanupItems.AsNoTracking()
+            .Select(x => x.Id)
+            .ToListAsync();
+        Assert.Equal([emptyFolderId], cleanupIds);
+    }
+
+    [Fact]
+    public async Task FixEmptyCategories_CreatesTargetCategoryFolderWhenMissing()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        var emptyFolderId = Guid.NewGuid();
+        var mountId = Guid.NewGuid();
+
+        var emptyFolder = NewDirectory(emptyFolderId, DavItem.ContentFolder, "");
+        emptyFolder.Path = "/content/";
+        var mount = NewDirectory(mountId, emptyFolder, "Orphan Release");
+        mount.Path = "/content//Orphan Release";
+
+        ctx.Items.AddRange(emptyFolder, mount);
+        ctx.HistoryItems.Add(new HistoryItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            FileName = "orphan.nzb",
+            JobName = "orphan",
+            Category = "",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+            TotalSegmentBytes = 20,
+            DownloadTimeSeconds = 1,
+        });
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        var categoryFolder = await ctx.Items.AsNoTracking()
+            .SingleAsync(x => x.ParentId == DavItem.ContentFolder.Id && x.Name == "uncategorized");
+        var repairedMount = await ctx.Items.AsNoTracking()
+            .SingleAsync(x => x.Id == mountId);
+
+        Assert.Equal(categoryFolder.Id, repairedMount.ParentId);
+        Assert.Equal("/content/uncategorized/Orphan Release", repairedMount.Path);
+        Assert.False(await ctx.Items.AsNoTracking().AnyAsync(x => x.Id == emptyFolderId));
+    }
+
+    private static DavItem NewDirectory(Guid id, DavItem parent, string name) =>
+        DavItem.New(
+            id,
+            parent,
+            name,
+            fileSize: null,
+            type: DavItem.ItemType.Directory,
+            subType: DavItem.ItemSubType.Directory,
+            releaseDate: null,
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: null);
+
+    private sealed class MigrationHarness : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        private MigrationHarness(string databasePath, DavDatabaseContext context)
+        {
+            _databasePath = databasePath;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public static async Task<MigrationHarness> CreateAsync()
+        {
+            var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-empty-cat-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+            return new MigrationHarness(databasePath, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            File.Delete(_databasePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a forward-only EF migration that rewrites empty/whitespace `QueueItems`/`HistoryItems` categories to the configured default (`uncategorized`), reparents DavItems out of empty-named `/content` folders with rename-on-collision (never silent delete), and rebuilds `DavItems.Path`.
- Normalizes category again in `AddFileController` before NZB backup and queue persist.
- Hardens explore path decoding so malformed percent-encoding and empty segments (`/explore/content//{release}`) return the existing not-found UI instead of a React Router Application Error; whitespace-only history categories no longer produce explore links.

Fixes #48
Fixes #94

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~FixEmptyCategories|FullyQualifiedName~DavDatabaseClientTests"`
- [x] `cd frontend && npm run typecheck && npm test`
- [ ] Upgrade a DB with legacy empty-category rows and confirm content appears under `/content/uncategorized/...`
- [ ] Open a history explore link that previously used `//` and confirm "Directory unavailable" instead of Application Error
- [ ] Add an NZB with empty/whitespace `cat` and confirm it lands in the configured manual category