### PR TITLE
feat: adopt Pukabyte fork repair, queue, and logging fixes

### DIFF
--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
@@ -39,6 +40,31 @@ public class MultiConnectionNntpClient(
     public ProviderType ProviderType { get; } = type;
     public int Priority { get; } = priority;
     public string Host { get; } = providerName;
+
+    private static readonly ConcurrentDictionary<string, int> TimeoutCounts = new();
+    private static long _lastTimeoutFlushTicks = DateTime.UtcNow.Ticks;
+
+    private static void IncrementTimeoutCount(string provider)
+    {
+        TimeoutCounts.AddOrUpdate(provider, 1, (_, existing) => existing + 1);
+        MaybeFlushTimeoutCounts();
+    }
+
+    private static void MaybeFlushTimeoutCounts()
+    {
+        var nowTicks = DateTime.UtcNow.Ticks;
+        var last = Interlocked.Read(ref _lastTimeoutFlushTicks);
+        if (nowTicks - last < TimeSpan.FromSeconds(60).Ticks)
+            return;
+        if (Interlocked.CompareExchange(ref _lastTimeoutFlushTicks, nowTicks, last) != last)
+            return;
+
+        foreach (var key in TimeoutCounts.Keys)
+        {
+            if (TimeoutCounts.TryRemove(key, out var count) && count > 0)
+                Log.Warning("[{ProviderName}] {Count} NNTP timeouts in the last 60 seconds", key, count);
+        }
+    }
 
     public int? ConfiguredPipeliningDepth { get; } = pipeliningDepth;
     // null or non-positive = uncapped. Routing reads these to decide whether
@@ -319,6 +345,7 @@ public class MultiConnectionNntpClient(
                 // the wait before MultiProviderNntpClient can fall over to the next
                 // provider. Replace the socket (the read may have left partial bytes
                 // on the wire) and propagate so the outer provider loop moves on.
+                IncrementTimeoutCount(providerName);
                 deferredCallback.Discard();
                 circuitBreaker.RecordFailure();
                 LogException(() => connectionLock?.Replace());

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -504,10 +504,13 @@ public class MultiProviderNntpClient(
 
             if (lastException is not null)
             {
+                var failedProvider = orderedProviders[i - 1];
                 var msg = lastException.SourceException.Message;
-                Log.Debug(
-                    "Encountered error during NNTP operation: {ErrorMessage}. Trying another provider",
-                    msg);
+                Log.Information(
+                    "Provider {FailedProvider} error: {ErrorMessage}. Falling back to {NextProvider}",
+                    failedProvider.Host,
+                    msg,
+                    provider.Host);
             }
 
             var stopwatch = Stopwatch.StartNew();
@@ -560,7 +563,14 @@ public class MultiProviderNntpClient(
             }
         }
 
-        lastException?.Throw();
+        if (lastException is not null)
+        {
+            Log.Warning(
+                "All providers exhausted. Last error from {Provider}: {ErrorMessage}",
+                orderedProviders[^1].Host,
+                lastException.SourceException.Message);
+            lastException.Throw();
+        }
         throw new Exception("There are no usenet providers configured.");
     }
 

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -188,7 +188,7 @@ public abstract class NntpClient : INntpClient
                 SegmentId: segmentId,
                 Result: await StatAsync(segmentId, token).ConfigureAwait(false)
             ))
-            .WithConcurrencyAsync(concurrency);
+            .WithConcurrencyAsync(concurrency, token);
 
         var processed = 0;
         await foreach (var task in tasks.ConfigureAwait(false))

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -708,6 +708,20 @@ public class ConfigManager
                && GetArrConfig().GetInstanceCount() > 0;
     }
 
+    /// <summary>
+    /// Max concurrent NNTP STAT connections for health checks.
+    /// Capped at the configured provider pool size to avoid pool starvation.
+    /// </summary>
+    public int GetHealthCheckConcurrency()
+    {
+        var poolSize = GetUsenetProviderConfig().TotalPooledConnections;
+        var configured = int.Parse(
+            StringUtil.EmptyToNull(GetConfigValue("repair.healthcheck-concurrency"))
+            ?? "50"
+        );
+        return Math.Clamp(configured, 1, Math.Max(1, poolSize));
+    }
+
     public ArrConfig GetArrConfig()
     {
         var defaultValue = new ArrConfig();

--- a/backend/Extensions/IEnumerableTaskExtensions.cs
+++ b/backend/Extensions/IEnumerableTaskExtensions.cs
@@ -65,7 +65,8 @@ public static class IEnumerableTaskExtensions
     public static async IAsyncEnumerable<T> WithConcurrencyAsync<T>
     (
         this IEnumerable<Task<T>> tasks,
-        int concurrency
+        int concurrency,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         if (concurrency < 1)
@@ -74,6 +75,7 @@ public static class IEnumerableTaskExtensions
         var runningTasks = new HashSet<Task<T>>();
         foreach (var task in tasks)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             runningTasks.Add(task);
             if (runningTasks.Count < concurrency) continue;
             var completedTask = await Task.WhenAny(runningTasks).ConfigureAwait(false);
@@ -83,6 +85,7 @@ public static class IEnumerableTaskExtensions
 
         while (runningTasks.Count > 0)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var completedTask = await Task.WhenAny(runningTasks).ConfigureAwait(false);
             runningTasks.Remove(completedTask);
             yield return await completedTask.ConfigureAwait(false);

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
 using NWebDav.Server.Helpers;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
@@ -8,8 +11,17 @@ using Serilog;
 
 namespace NzbWebDAV.Middlewares;
 
-public class ExceptionMiddleware(RequestDelegate next)
+public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManager)
 {
+    private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentMissingArticles = new();
+    private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentConnectionLimitErrors = new();
+    private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentSeekErrors = new();
+    private static readonly ConcurrentDictionary<Guid, DateTime> RecentRepairTriggers = new();
+    private static readonly TimeSpan DedupeWindow = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan RepairDedupeWindow = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
+    private static int _callCount;
+
     public async Task InvokeAsync(HttpContext context)
     {
         try
@@ -35,10 +47,24 @@ public class ExceptionMiddleware(RequestDelegate next)
             }
 
             var filePath = GetRequestFilePath(context);
-            Log.Error(
-                "File {FilePath} has missing articles: {Reason}",
-                filePath,
-                notFound!.Message);
+            var dedupeKey = $"{filePath}|{notFound!.SegmentId}";
+            LogWithDedup(RecentMissingArticles, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Error(
+                        "File {FilePath} has missing articles: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        notFound.Message,
+                        suppressed);
+                else
+                    Log.Error(
+                        "File {FilePath} has missing articles: {Reason}",
+                        filePath,
+                        notFound.Message);
+            });
+
+            if (context.Items["DavItem"] is DavItem davItem)
+                ScheduleRepair(davItem.Id);
         }
         catch (SeekPositionNotFoundException)
         {
@@ -50,10 +76,60 @@ public class ExceptionMiddleware(RequestDelegate next)
 
             var filePath = GetRequestFilePath(context);
             var seekPosition = context.Request.GetRange()?.Start?.ToString() ?? "unknown";
-            Log.Error(
-                "File {FilePath} could not seek to byte position {SeekPosition}",
-                filePath,
-                seekPosition);
+            var dedupeKey = $"{filePath}|{seekPosition}";
+            LogWithDedup(RecentSeekErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Error(
+                        "File {FilePath} could not seek to byte position {SeekPosition} (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        seekPosition,
+                        suppressed);
+                else
+                    Log.Error(
+                        "File {FilePath} could not seek to byte position {SeekPosition}",
+                        filePath,
+                        seekPosition);
+            });
+        }
+        catch (CouldNotLoginToUsenetException e)
+        {
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 503;
+            }
+
+            var filePath = GetRequestFilePath(context);
+            var errorDetail = e.InnerException?.Message ?? e.Message;
+            if (errorDetail.Contains("connection limit", StringComparison.OrdinalIgnoreCase))
+            {
+                LogWithDedup(RecentConnectionLimitErrors, errorDetail, suppressed =>
+                {
+                    if (suppressed > 0)
+                        Log.Warning(
+                            "Provider connection limit reached: {ErrorMessage} (suppressed {SuppressedCount} duplicates in last 60s)",
+                            errorDetail,
+                            suppressed);
+                    else
+                        Log.Warning("Provider connection limit reached: {ErrorMessage}", errorDetail);
+                });
+            }
+            else
+            {
+                Log.Error("File {FilePath} provider authentication failed: {ErrorMessage}", filePath, errorDetail);
+            }
+        }
+        catch (CouldNotConnectToUsenetException e)
+        {
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 503;
+            }
+
+            var filePath = GetRequestFilePath(context);
+            Log.Error("File {FilePath} could not connect to usenet provider: {ErrorMessage}", filePath, e.Message);
         }
         catch (Exception e) when (IsDavItemRequest(context))
         {
@@ -84,6 +160,118 @@ public class ExceptionMiddleware(RequestDelegate next)
                     filePath,
                     seekPosition);
             }
+        }
+    }
+
+    private void ScheduleRepair(Guid davItemId)
+    {
+        if (!configManager.IsRepairJobEnabled())
+            return;
+
+        var now = DateTime.UtcNow;
+        var isDuplicate = false;
+        RecentRepairTriggers.AddOrUpdate(
+            davItemId,
+            _ => now,
+            (_, existing) =>
+            {
+                if (now - existing < RepairDedupeWindow)
+                {
+                    isDuplicate = true;
+                    return existing;
+                }
+                return now;
+            });
+
+        if (isDuplicate)
+            return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await using var dbContext = new DavDatabaseContext();
+                var item = await dbContext.Items.FindAsync(davItemId).ConfigureAwait(false);
+                if (item == null)
+                    return;
+
+                // UnixEpoch sorts first in HealthCheckService (non-null before null, then ascending).
+                // Only skip if already urgent — overdue items must still be bumped (Pukabyte#4).
+                var urgent = DateTimeOffset.UnixEpoch;
+                if (item.NextHealthCheck == urgent)
+                    return;
+
+                item.NextHealthCheck = urgent;
+                await dbContext.SaveChangesAsync().ConfigureAwait(false);
+                Log.Information("Scheduled dynamic repair for {FilePath}", item.Path);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to schedule dynamic repair for DavItem {DavItemId}", davItemId);
+            }
+        });
+    }
+
+    private static void LogWithDedup(
+        ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> store,
+        string key,
+        Action<int> logAction)
+    {
+        var now = DateTime.UtcNow;
+        var suppressed = 0;
+        var shouldLog = false;
+
+        store.AddOrUpdate(
+            key,
+            _ =>
+            {
+                shouldLog = true;
+                return (now, 0);
+            },
+            (_, existing) =>
+            {
+                if (now - existing.LastLogged < DedupeWindow)
+                {
+                    suppressed = existing.SuppressedCount + 1;
+                    return (existing.LastLogged, suppressed);
+                }
+
+                shouldLog = true;
+                suppressed = existing.SuppressedCount;
+                return (now, 0);
+            });
+
+        if (shouldLog)
+            logAction(suppressed);
+
+        CleanupStaleEntries();
+    }
+
+    private static void CleanupStaleEntries()
+    {
+        if (Interlocked.Increment(ref _callCount) % 100 != 0)
+            return;
+
+        var cutoff = DateTime.UtcNow - CleanupThreshold;
+        foreach (var kvp in RecentMissingArticles)
+        {
+            if (kvp.Value.LastLogged < cutoff)
+                RecentMissingArticles.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in RecentConnectionLimitErrors)
+        {
+            if (kvp.Value.LastLogged < cutoff)
+                RecentConnectionLimitErrors.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in RecentSeekErrors)
+        {
+            if (kvp.Value.LastLogged < cutoff)
+                RecentSeekErrors.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in RecentRepairTriggers)
+        {
+            if (kvp.Value < cutoff)
+                RecentRepairTriggers.TryRemove(kvp.Key, out _);
         }
     }
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -51,6 +51,7 @@ class Program
             .MinimumLevel.Override("Microsoft.AspNetCore.Hosting", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Mvc", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Routing", AtLeast(level, LogEventLevel.Warning))
+            .MinimumLevel.Override("Microsoft.AspNetCore.Server.Kestrel", AtLeast(level, LogEventLevel.Error))
             .MinimumLevel.Override("Microsoft.AspNetCore.DataProtection", AtLeast(level, LogEventLevel.Error))
             .WriteTo.Console(new ExpressionTemplate(
                 "[{@t:HH:mm:ss} {@l:u3}] " +

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -32,7 +32,7 @@ public static class FetchFirstSegmentsStep
 
         return await files
             .Select(x => FetchFirstSegment(x, usenetClient, cancellationToken))
-            .WithConcurrencyAsync(configManager.GetMaxQueueConnections() + 5)
+            .WithConcurrencyAsync(Math.Min(configManager.GetMaxQueueConnections() + 5, 50))
             .GetAllAsync(cancellationToken, progress).ConfigureAwait(false);
     }
 
@@ -76,7 +76,7 @@ public static class FetchFirstSegmentsStep
         {
             var rescued = await pending
                 .Select(i => RescueFirstSegment(i, files[i], usenetClient, cancellationToken))
-                .WithConcurrencyAsync(configManager.GetMaxQueueConnections() + 5)
+                .WithConcurrencyAsync(Math.Min(configManager.GetMaxQueueConnections() + 5, 50))
                 .GetAllAsync(cancellationToken).ConfigureAwait(false);
             foreach (var (i, result) in rescued)
             {
@@ -100,10 +100,20 @@ public static class FetchFirstSegmentsStep
         {
             return (index, await FetchFirstSegment(nzbFile, usenetClient, cancellationToken).ConfigureAwait(false));
         }
+        catch (UsenetArticleNotFoundException)
+        {
+            Log.Warning("First segment for `{FileName}` missing across all providers",
+                nzbFile.GetSubjectFileName());
+            return (index, BuildMissingFirstSegment(nzbFile));
+        }
         catch (Exception e) when (!e.IsCancellationException())
         {
-            Log.Warning($"First segment for `{nzbFile.GetSubjectFileName()}` unavailable from all providers: {e.Message}");
-            return (index, BuildMissingFirstSegment(nzbFile));
+            // Transient provider errors must not be treated as permanent missing segments
+            // (otherwise fail-fast would mark good NZBs failed — see nzbdav-dev#245).
+            Log.Warning(e,
+                "First segment for `{FileName}` unavailable due to provider error; not treating as permanently missing",
+                nzbFile.GetSubjectFileName());
+            throw;
         }
     }
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
@@ -210,6 +211,29 @@ public class QueueItemProcessor(
         var fileInfos = GetFileInfosStep.GetFileInfos(
             segments, par2FileDescriptors);
 
+        // step 1b -- fail fast if any important file has a permanently missing first segment.
+        // If the first segment is gone across all providers, the rest are too.
+        // Exclude known-unimportant extensions rather than matching important ones so
+        // obfuscated filenames (common on DMCA'd content) still trigger the fast abort.
+        HashSet<string> unimportantExtensions = [".par2", ".nfo", ".txt", ".sfv", ".nzb", ".srr"];
+        var missingNzbFiles = segments
+            .Where(x => x.MissingFirstSegment)
+            .Select(x => x.NzbFile)
+            .ToHashSet();
+        var importantFilesMissing = fileInfos
+            .Where(x => missingNzbFiles.Contains(x.NzbFile))
+            .Where(x => !unimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .ToList();
+        if (importantFilesMissing.Count > 0)
+        {
+            var fileNames = string.Join(", ", importantFilesMissing
+                .Select(x => string.IsNullOrEmpty(x.FileName) ? x.NzbFile.Subject : x.FileName)
+                .Take(3));
+            throw new NonRetryableDownloadException(
+                $"Missing articles: {importantFilesMissing.Count} important file(s) have missing segments " +
+                $"across all providers (e.g. {fileNames}). NZB is likely DMCA'd or expired.");
+        }
+
         // step 2a -- try altmount-style lazy RAR mounting for the rar group
         // when enabled. On success, the entire rar group is handled here
         // (only the first volume gets parsed) and skipped in step 2b. On
@@ -235,7 +259,7 @@ public class QueueItemProcessor(
             .ToMultiProgress(fileProcessors.Count);
         var fileProcessingResultsAll = await fileProcessors
             .Select(x => x!.ProcessAsync(part2Progress.SubProgress))
-            .WithConcurrencyAsync(configManager.GetMaxQueueConnections() + 5)
+            .WithConcurrencyAsync(Math.Min(configManager.GetMaxQueueConnections() + 5, 50))
             .GetAllAsync(ct).ConfigureAwait(false);
         var fileProcessingResults = fileProcessingResultsAll
             .Where(x => x is not null)
@@ -257,9 +281,7 @@ public class QueueItemProcessor(
             var part3Progress = progress
                 .Offset(100)
                 .ToPercentage(articlesToCheck.Count);
-            var healthCheckConcurrency = configManager
-                .GetUsenetProviderConfig()
-                .TotalPooledConnections;
+            var healthCheckConcurrency = configManager.GetHealthCheckConcurrency();
             await usenetClient
                 .CheckAllSegmentsAsync(articlesToCheck, healthCheckConcurrency, part3Progress, ct)
                 .ConfigureAwait(false);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -73,8 +73,8 @@ public class HealthCheckService : BackgroundService
                     continue;
                 }
 
-                // get concurrency
-                var concurrency = _configManager.GetUsenetProviderConfig().TotalPooledConnections;
+                // get concurrency (capped to avoid saturating the NNTP pool)
+                var concurrency = _configManager.GetHealthCheckConcurrency();
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
 
                 // get the davItem to health-check
@@ -110,8 +110,11 @@ public class HealthCheckService : BackgroundService
 
     public static IOrderedQueryable<DavItem> GetHealthCheckQueueItems(DavDatabaseClient dbClient)
     {
+        // Non-null NextHealthCheck first (includes urgent UnixEpoch from dynamic repair),
+        // then ascending NextHealthCheck, then newest releases.
         return GetHealthCheckQueueItemsQuery(dbClient)
-            .OrderBy(x => x.NextHealthCheck)
+            .OrderBy(x => x.NextHealthCheck == null ? 1 : 0)
+            .ThenBy(x => x.NextHealthCheck)
             .ThenByDescending(x => x.ReleaseDate)
             .ThenBy(x => x.Id);
     }
@@ -131,12 +134,26 @@ public class HealthCheckService : BackgroundService
         CancellationToken ct
     )
     {
+        // Urgent sentinel set by ExceptionMiddleware when streaming hits a missing article.
+        // Streaming already confirmed a BODY miss across providers — skip STAT-only recheck
+        // (STAT can pass while BODY returns 430; see nzbdav-dev#209) and repair immediately.
+        var isUrgentRepair = davItem.NextHealthCheck == DateTimeOffset.UnixEpoch;
+        if (isUrgentRepair)
+        {
+            Log.Information("Performing urgent dynamic repair for {FilePath}", davItem.Path);
+            await Repair(davItem, dbClient, ct).ConfigureAwait(false);
+            return;
+        }
+
         try
         {
             // update the release date, if null
             var segments = await GetAllSegments(davItem, dbClient, ct).ConfigureAwait(false);
             if (davItem.ReleaseDate == null) await UpdateReleaseDate(davItem, segments, ct).ConfigureAwait(false);
 
+            // sample large files to reduce NNTP load while keeping head/tail/stride coverage
+            var totalSegments = segments.Count;
+            var sampled = SampleSegments(segments);
 
             // setup progress tracking
             var progressHook = new Progress<int>();
@@ -148,14 +165,17 @@ public class HealthCheckService : BackgroundService
             };
 
             // perform health check
-            var progress = progressHook.ToPercentage(segments.Count);
-            await _usenetClient.CheckAllSegmentsAsync(segments, concurrency, progress, ct).ConfigureAwait(false);
+            var progress = progressHook.ToPercentage(sampled.Count);
+            await _usenetClient.CheckAllSegmentsAsync(sampled, concurrency, progress, ct).ConfigureAwait(false);
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
 
             // update the database
             davItem.LastHealthCheck = DateTimeOffset.UtcNow;
             davItem.NextHealthCheck = davItem.ReleaseDate + 2 * (davItem.LastHealthCheck - davItem.ReleaseDate);
+            var healthyMessage = sampled.Count < totalSegments
+                ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
+                : "File is healthy.";
             dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
             {
                 Id = Guid.NewGuid(),
@@ -164,7 +184,7 @@ public class HealthCheckService : BackgroundService
                 CreatedAt = DateTimeOffset.UtcNow,
                 Result = HealthCheckResult.HealthResult.Healthy,
                 RepairStatus = HealthCheckResult.RepairAction.None,
-                Message = "File is healthy."
+                Message = healthyMessage
             }));
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
         }
@@ -186,6 +206,35 @@ public class HealthCheckService : BackgroundService
             // when usenet article is missing, perform repairs
             await Repair(davItem, dbClient, ct).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// For files with more than 4000 segments, returns a stratified sample:
+    /// first 100, last 100, and evenly-spaced middle segments (~4000 total).
+    /// Small files are checked in full.
+    /// </summary>
+    public static List<string> SampleSegments(List<string> segments)
+    {
+        const int threshold = 4000;
+        if (segments.Count <= threshold) return segments;
+
+        const int headCount = 100;
+        const int tailCount = 100;
+        const int strideTarget = 4000;
+
+        var result = new HashSet<int>();
+
+        for (var i = 0; i < Math.Min(headCount, segments.Count); i++)
+            result.Add(i);
+
+        for (var i = Math.Max(0, segments.Count - tailCount); i < segments.Count; i++)
+            result.Add(i);
+
+        var stride = Math.Max(1, segments.Count / strideTarget);
+        for (var i = 0; i < segments.Count; i += stride)
+            result.Add(i);
+
+        return result.OrderBy(i => i).Select(i => segments[i]).ToList();
     }
 
     private async Task UpdateReleaseDate(DavItem davItem, List<string> segments, CancellationToken ct)

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, Input } from "~/components/ui/form";
 import { type Dispatch, type SetStateAction } from "react";
-import { className } from "~/utils/styling";
+import { isPositiveInteger } from "../usenet/usenet";
 
 type RepairsSettingsProps = {
     config: Record<string, string>
@@ -36,6 +36,23 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             <hr />
             <div className="space-y-2">
+                <label className="block text-sm font-medium text-slate-200" htmlFor="healthcheck-concurrency-input">Health Check Concurrency</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.healthcheck-concurrency"] || "50") ? "border-red-500" : ""}`}
+                    type="text"
+                    id="healthcheck-concurrency-input"
+                    aria-describedby="healthcheck-concurrency-help"
+                    placeholder="50"
+                    value={config["repair.healthcheck-concurrency"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.healthcheck-concurrency": e.target.value })} />
+                <p className="text-xs leading-relaxed text-slate-400" id="healthcheck-concurrency-help">
+                    The maximum number of concurrent NNTP connections used for health check STAT commands.
+                    Lower values reduce connection pressure on your usenet providers during health checks.
+                    Capped at your total provider pool size.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
                 <label className="block text-sm font-medium text-slate-200" htmlFor="library-dir-input">Library Directory</label>
                 <Input
                     className={'w-full'}
@@ -55,5 +72,11 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
 
 export function isRepairsSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["repair.enable"] !== newConfig["repair.enable"]
+        || config["repair.healthcheck-concurrency"] !== newConfig["repair.healthcheck-concurrency"]
         || config["media.library-dir"] !== newConfig["media.library-dir"];
+}
+
+export function isRepairsSettingsValid(newConfig: Record<string, string>) {
+    const value = newConfig["repair.healthcheck-concurrency"];
+    return value === undefined || value === "" || isPositiveInteger(value);
 }

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -83,6 +83,7 @@ const defaultConfig = {
     "preflight.ttl-seconds": "120",
     "preflight.indexer-max-wait-seconds": "5",
     "repair.enable": "false",
+    "repair.healthcheck-concurrency": "50",
     "db.is-startup-vacuum-enabled": "false",
     "maintenance.remove-orphaned-schedule-enabled": "false",
     "maintenance.remove-orphaned-schedule-time": "0",

--- a/tests/NzbWebDAV.Tests/Extensions/WithConcurrencyAsyncCancellationTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/WithConcurrencyAsyncCancellationTests.cs
@@ -1,0 +1,34 @@
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Tests.Extensions;
+
+public class WithConcurrencyAsyncCancellationTests
+{
+    [Fact]
+    public async Task WithConcurrencyAsync_ThrowsWhenTokenAlreadyCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var tasks = Enumerable.Range(0, 5).Select(i => Task.FromResult(i));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in tasks.WithConcurrencyAsync(2, cts.Token).ConfigureAwait(false))
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public async Task WithConcurrencyAsync_CompletesWithoutToken()
+    {
+        var tasks = Enumerable.Range(0, 5).Select(i => Task.FromResult(i));
+
+        var results = new List<int>();
+        await foreach (var value in tasks.WithConcurrencyAsync(2).ConfigureAwait(false))
+            results.Add(value);
+
+        Assert.Equal([0, 1, 2, 3, 4], results.OrderBy(x => x).ToList());
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
@@ -1,0 +1,88 @@
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class FailFastDeadNzbTests
+{
+    private static readonly HashSet<string> UnimportantExtensions =
+        [".par2", ".nfo", ".txt", ".sfv", ".nzb", ".srr"];
+
+    [Fact]
+    public void ImportantMissingFile_TriggersFailFastCondition()
+    {
+        var nzbFile = new NzbFile { Subject = "\"Movie.mkv\" yEnc (1/1)" };
+        var segment = new FetchFirstSegmentsStep.NzbFileWithFirstSegment
+        {
+            NzbFile = nzbFile,
+            Header = null,
+            First16KB = null,
+            MissingFirstSegment = true,
+            ReleaseDate = DateTimeOffset.UtcNow,
+        };
+        var fileInfos = GetFileInfosStep.GetFileInfos([segment], []);
+
+        var missing = fileInfos
+            .Where(x => segment.MissingFirstSegment && ReferenceEquals(x.NzbFile, nzbFile))
+            .Where(x => !UnimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .ToList();
+
+        Assert.Single(missing);
+        Assert.Equal("Movie.mkv", missing[0].FileName);
+    }
+
+    [Fact]
+    public void JunkOnlyMissing_DoesNotTriggerFailFast()
+    {
+        var nzbFile = new NzbFile { Subject = "\"release.nfo\" yEnc (1/1)" };
+        var segment = new FetchFirstSegmentsStep.NzbFileWithFirstSegment
+        {
+            NzbFile = nzbFile,
+            Header = null,
+            First16KB = null,
+            MissingFirstSegment = true,
+            ReleaseDate = DateTimeOffset.UtcNow,
+        };
+        var fileInfos = GetFileInfosStep.GetFileInfos([segment], []);
+
+        var missing = fileInfos
+            .Where(x => segment.MissingFirstSegment)
+            .Where(x => !UnimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void ObfuscatedMissingName_IsTreatedAsImportant()
+    {
+        // Obfuscated names have no known extension — exclusion list must still fail-fast.
+        var nzbFile = new NzbFile { Subject = "\"aB3xY9q\" yEnc (1/1)" };
+        var segment = new FetchFirstSegmentsStep.NzbFileWithFirstSegment
+        {
+            NzbFile = nzbFile,
+            Header = null,
+            First16KB = null,
+            MissingFirstSegment = true,
+            ReleaseDate = DateTimeOffset.UtcNow,
+        };
+        var fileInfos = GetFileInfosStep.GetFileInfos([segment], []);
+
+        var missing = fileInfos
+            .Where(x => segment.MissingFirstSegment)
+            .Where(x => !UnimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .ToList();
+
+        Assert.Single(missing);
+    }
+
+    [Fact]
+    public void UsenetArticleNotFoundException_IsNonRetryable()
+    {
+        var ex = new UsenetArticleNotFoundException("<seg@example.com>");
+        Assert.IsAssignableFrom<NonRetryableDownloadException>(ex);
+        Assert.Equal("<seg@example.com>", ex.SegmentId);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
@@ -1,0 +1,56 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class HealthCheckSampleSegmentsTests
+{
+    [Fact]
+    public void SampleSegments_ReturnsUnchangedWhenAtOrBelowThreshold()
+    {
+        var segments = Enumerable.Range(0, 4000).Select(i => $"seg-{i}").ToList();
+
+        var sampled = HealthCheckService.SampleSegments(segments);
+
+        Assert.Same(segments, sampled);
+        Assert.Equal(4000, sampled.Count);
+    }
+
+    [Fact]
+    public void SampleSegments_ReturnsUnchangedForSmallFiles()
+    {
+        var segments = Enumerable.Range(0, 100).Select(i => $"seg-{i}").ToList();
+
+        var sampled = HealthCheckService.SampleSegments(segments);
+
+        Assert.Equal(100, sampled.Count);
+        Assert.Equal(segments, sampled);
+    }
+
+    [Fact]
+    public void SampleSegments_StratifiesLargeFilesAndPreservesOrder()
+    {
+        var segments = Enumerable.Range(0, 50_000).Select(i => $"seg-{i}").ToList();
+
+        var sampled = HealthCheckService.SampleSegments(segments);
+
+        Assert.True(sampled.Count < segments.Count);
+        Assert.InRange(sampled.Count, 4000, 4500);
+        Assert.Equal("seg-0", sampled[0]);
+        Assert.Equal("seg-49999", sampled[^1]);
+        Assert.Equal(sampled, sampled.OrderBy(s => int.Parse(s["seg-".Length..])).ToList());
+    }
+
+    [Fact]
+    public void SampleSegments_IncludesHeadAndTail()
+    {
+        var segments = Enumerable.Range(0, 10_000).Select(i => $"seg-{i}").ToList();
+
+        var sampled = HealthCheckService.SampleSegments(segments);
+        var indices = sampled.Select(s => int.Parse(s["seg-".Length..])).ToHashSet();
+
+        for (var i = 0; i < 100; i++)
+            Assert.Contains(i, indices);
+        for (var i = 9900; i < 10_000; i++)
+            Assert.Contains(i, indices);
+    }
+}


### PR DESCRIPTION
## Summary

Adopts and reimplements improvements from the [Pukabyte/nzbdav](https://github.com/Pukabyte/nzbdav) fork (not cherry-picked; adapted to current upstream with additional mitigations from issue/PR audit).

| Pukabyte PR | What we adopt |
|-------------|---------------|
| [#1](https://github.com/Pukabyte/nzbdav/pull/1) | Log dedup, provider fallback logs, timeout aggregation |
| [#2](https://github.com/Pukabyte/nzbdav/pull/2) + [#4](https://github.com/Pukabyte/nzbdav/pull/4) | Dynamic repair on stream miss (+ #4 overdue-item fix) |
| [#4](https://github.com/Pukabyte/nzbdav/pull/4) | `WithConcurrencyAsync` cancellation, seek-error dedup |
| [#6](https://github.com/Pukabyte/nzbdav/pull/6) | Fail-fast dead NZBs, `SampleSegments`, concurrency cap |
| commit `12e1bb7` | `repair.healthcheck-concurrency` setting |

### Changes

1. **Dynamic repair on streaming miss** — When WebDAV playback hits `UsenetArticleNotFoundException`, schedule urgent health/repair (`NextHealthCheck = UnixEpoch`). Urgent items skip STAT-only recheck and go straight to `Repair()` (fixes STAT-pass/BODY-fail gap).
2. **Fail-fast dead NZBs** — After first-segment fetch, abort important files with permanent missing segments. `MissingFirstSegment` is only set on clean 430s (not timeouts) to avoid false failures on good NZBs.
3. **Health check segment sampling** — Background checks sample large files (~head/tail/stride); queue import-time checks stay full.
4. **Configurable health check concurrency** — `repair.healthcheck-concurrency` (default 50, capped at pool size).
5. **Log dedup + provider fallback logging** — 60s dedup for missing-article/seek/connection-limit spam; MultiProvider fallback Info logs; lazy timeout aggregation.
6. **`WithConcurrencyAsync` cancellation** — Stops launching new STAT work after cancel.

### Issues

Closes #101

Relates to #68, #82, #102, #111

Upstream references (no local mirror issue yet):
- [nzbdav-dev#85](https://github.com/nzbdav-dev/nzbdav/issues/85) — provider error handling / logging
- [nzbdav-dev#383](https://github.com/nzbdav-dev/nzbdav/issues/383) — choppy playback log spam
- [nzbdav-dev#424](https://github.com/nzbdav-dev/nzbdav/issues/424) — aggressive health checks / repairs
- [nzbdav-dev#155](https://github.com/nzbdav-dev/nzbdav/issues/155) — Active Streams UI (already shipped via Live Reads; suggest closing upstream)

Complementary open PRs (not superseded): [nzbdav-dev#385](https://github.com/nzbdav-dev/nzbdav/pull/385), [#399](https://github.com/nzbdav-dev/nzbdav/pull/399), [#465](https://github.com/nzbdav-dev/nzbdav/pull/465)

### Risk mitigations

- Urgent repair only when `repair.enable` + Arr/library configured; 5-min per-item dedup
- Fail-fast only on permanent 430 after all providers; junk extensions excluded
- Sampling background-only to reduce false-healthy risk on import
- Health concurrency capped at provider pool size

## Test plan

- [x] `dotnet test` new suites: SampleSegments, FailFastDeadNzb, WithConcurrencyAsync cancellation (10 passed)
- [x] `npm run typecheck`
- [ ] Enable repairs, stream a file with known missing articles → see "Scheduled dynamic repair" then urgent repair
- [ ] Rapid re-stream same broken file → only one repair trigger per 5 minutes
- [ ] Dead NZB with missing first segments fails within seconds
- [ ] Large-file background health check logs sampled healthy message
- [ ] Lower `repair.healthcheck-concurrency` and confirm STAT load drops