### PR TITLE
feat(health): adopt elfhosted health-check retention and reset (#78)

### DIFF
--- a/backend/Api/Controllers/ClearHealthCheckHistory/ClearHealthCheckHistoryController.cs
+++ b/backend/Api/Controllers/ClearHealthCheckHistory/ClearHealthCheckHistoryController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+
+namespace NzbWebDAV.Api.Controllers.ClearHealthCheckHistory;
+
+[ApiController]
+[Route("api/clear-health-check-history")]
+public class ClearHealthCheckHistoryController(DavDatabaseClient dbClient) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var ct = HttpContext.RequestAborted;
+
+        // Delete results first so AFTER DELETE triggers can decrement stats,
+        // then clear any leftover stats rows for a full reset to zero.
+        var deletedResults = await dbClient.Ctx.HealthCheckResults
+            .ExecuteDeleteAsync(ct)
+            .ConfigureAwait(false);
+
+        var deletedStats = await dbClient.Ctx.HealthCheckStats
+            .ExecuteDeleteAsync(ct)
+            .ConfigureAwait(false);
+
+        return Ok(new ClearHealthCheckHistoryResponse
+        {
+            Status = true,
+            DeletedResults = deletedResults,
+            DeletedStats = deletedStats,
+        });
+    }
+}

--- a/backend/Api/Controllers/ClearHealthCheckHistory/ClearHealthCheckHistoryResponse.cs
+++ b/backend/Api/Controllers/ClearHealthCheckHistory/ClearHealthCheckHistoryResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.Controllers.ClearHealthCheckHistory;
+
+public class ClearHealthCheckHistoryResponse : BaseApiResponse
+{
+    [JsonPropertyName("deletedResults")]
+    public required int DeletedResults { get; init; }
+
+    [JsonPropertyName("deletedStats")]
+    public required int DeletedStats { get; init; }
+}

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -821,6 +821,25 @@ public class ConfigManager
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
+    /// <summary>
+    /// Days to keep health-check result rows. 0 disables age-based pruning.
+    /// Config key wins over DATABASE_HEALTHCHECK_RETENTION_DAYS; default is 30.
+    /// </summary>
+    public int GetHealthResultRetentionDays()
+    {
+        return GetRetentionDaysSetting(
+            "database.healthcheck-retention-days",
+            "DATABASE_HEALTHCHECK_RETENTION_DAYS",
+            defaultValue: 30);
+    }
+
+    private int GetRetentionDaysSetting(string configKey, string environmentVariable, int defaultValue)
+    {
+        var rawValue = StringUtil.EmptyToNull(GetConfigValue(configKey))
+                       ?? EnvironmentUtil.GetEnvironmentVariable(environmentVariable);
+        return int.TryParse(rawValue, out var parsed) && parsed >= 0 ? parsed : defaultValue;
+    }
+
     public bool IsNzbBackupEnabled()
     {
         var defaultValue = false;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -173,6 +173,7 @@ class Program
                 .AddSingleton<LiveStatsBroadcaster>()
                 .AddHostedService(sp => sp.GetRequiredService<LiveStatsBroadcaster>())
                 .AddHostedService<HealthCheckService>()
+                .AddHostedService<HealthCheckRetentionService>()
                 .AddHostedService<ArrMonitoringService>()
                 .AddHostedService<BlobCleanupService>()
                 .AddHostedService<NzbBlobCleanupService>()

--- a/backend/Services/HealthCheckRetentionService.cs
+++ b/backend/Services/HealthCheckRetentionService.cs
@@ -1,0 +1,84 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Prunes aged HealthCheckResults so the table does not grow without bound.
+/// HealthCheckStats stay consistent via existing AFTER DELETE triggers.
+/// Inspired by elfhosted/nzbdav database maintenance (PR #199 retention idea).
+/// </summary>
+public class HealthCheckRetentionService(ConfigManager configManager) : BackgroundService
+{
+    private static readonly TimeSpan DefaultInterval = TimeSpan.FromHours(6);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+
+        var interval = GetInterval();
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+                await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+            {
+                return;
+            }
+        }
+    }
+
+    internal static async Task<int> SweepAsync(
+        DavDatabaseContext dbContext,
+        int retentionDays,
+        CancellationToken ct)
+    {
+        if (retentionDays <= 0) return 0;
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-retentionDays);
+        return await dbContext.HealthCheckResults
+            .Where(x => x.CreatedAt < cutoff)
+            .ExecuteDeleteAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task SafeSweepAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var retentionDays = configManager.GetHealthResultRetentionDays();
+            if (retentionDays <= 0) return;
+
+            await using var dbContext = new DavDatabaseContext();
+            var deleted = await SweepAsync(dbContext, retentionDays, stoppingToken).ConfigureAwait(false);
+            if (deleted > 0)
+            {
+                Log.Information(
+                    "Health-check retention removed {Deleted} rows older than {Days} days",
+                    deleted,
+                    retentionDays);
+            }
+        }
+        catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Health-check retention sweep failed: {Message}", ex.Message);
+        }
+    }
+
+    private static TimeSpan GetInterval()
+    {
+        var hours = EnvironmentUtil.GetLongVariable("DATABASE_MAINTENANCE_INTERVAL_HOURS") ?? 6;
+        return TimeSpan.FromHours(Math.Max(1, hours));
+    }
+}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -484,6 +484,17 @@ For series, pass `type=series&id=tt0944947&season=1&episode=1`. Hitting the `pla
 
 ## Phase 7 — Operations
 
+### Database retention
+
+NzbDav can prune aged health-check history so `db.sqlite` does not grow without bound:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DATABASE_HEALTHCHECK_RETENTION_DAYS` | `30` | Keep health-check result rows for this many days. Set to `0` to retain everything. |
+| `DATABASE_MAINTENANCE_INTERVAL_HOURS` | `6` | How often the background retention sweep runs. |
+
+These can also be set under **Settings → Maintenance** (`database.healthcheck-retention-days`). Use **Reset Health-Check Statistics** on that page to clear all counters immediately.
+
 ### Back up NzbDav
 
 Back up the host directory mapped to `/config` (shown as `./config` in this guide). It contains the database, settings, credentials, and persisted application data, so store the backup securely. Stop the container or use a filesystem snapshot to get a consistent backup:

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -282,6 +282,20 @@ class BackendClient {
         return data.deleted ?? 0;
     }
 
+    public async clearHealthCheckHistory(): Promise<{ deletedResults: number; deletedStats: number }> {
+        const url = process.env.BACKEND_URL + `/api/clear-health-check-history`;
+        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
+        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey } });
+        if (!response.ok) {
+            throw new Error(`Failed to clear health-check history: ${(await response.json()).error}`);
+        }
+        const data = await response.json();
+        return {
+            deletedResults: data.deletedResults ?? 0,
+            deletedStats: data.deletedStats ?? 0,
+        };
+    }
+
     public async getHealthCheckHistory(pageSize?: number): Promise<HealthCheckHistoryResponse> {
         let url = process.env.BACKEND_URL + "/api/get-health-check-history";
 

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,7 +1,8 @@
-import { Checkbox, Select } from "~/components/ui/form";
+import { Checkbox, Input, Select } from "~/components/ui/form";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
+import { ResetHealthCheckStats } from "./reset-health-check-stats/reset-health-check-stats";
 import type { Dispatch, SetStateAction } from "react";
 
 type MaintenanceProps = {
@@ -25,6 +26,28 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                 </label>
                     <p className="text-xs leading-relaxed text-slate-400" id="db-startup-vacuum-enabled-help">
                         When enabled, nzbdav will run a SQLite VACUUM on the database at every startup. This reclaims unused disk space and can improve query performance over time, but may increase startup time for large databases.
+                    </p>
+                </div>
+                <hr />
+                <div className="space-y-2">
+                    <label className="block text-sm text-slate-300" htmlFor="healthcheck-retention-days">
+                        Health-Check History Retention (days)
+                    </label>
+                    <Input
+                        id="healthcheck-retention-days"
+                        type="number"
+                        min={0}
+                        aria-describedby="healthcheck-retention-days-help"
+                        value={config["database.healthcheck-retention-days"] ?? "30"}
+                        onChange={e => setNewConfig({
+                            ...config,
+                            "database.healthcheck-retention-days": e.target.value,
+                        })}
+                        className="max-w-xs"
+                    />
+                    <p className="text-xs leading-relaxed text-slate-400" id="healthcheck-retention-days-help">
+                        Automatically prune health-check result rows older than this many days. Set to 0 to keep everything.
+                        Can also be set with the DATABASE_HEALTHCHECK_RETENTION_DAYS environment variable.
                     </p>
                 </div>
                 <hr />
@@ -117,6 +140,14 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                             <MigrateDatabaseFilesToBlobstore savedConfig={savedConfig} />
                         </div>
                     </details>
+                    <details className={'overflow-hidden rounded border border-slate-700/70'}>
+                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-white hover:bg-white/5">
+                            Reset Health-Check Statistics
+                        </summary>
+                        <div className={'border-t border-slate-700/70 p-4'}>
+                            <ResetHealthCheckStats />
+                        </div>
+                    </details>
                 </div>
             </div>
         </div>
@@ -125,6 +156,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
 
 export function isMaintenanceSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["db.is-startup-vacuum-enabled"] !== newConfig["db.is-startup-vacuum-enabled"]
+        || config["database.healthcheck-retention-days"] !== newConfig["database.healthcheck-retention-days"]
         || config["maintenance.remove-orphaned-schedule-enabled"] !== newConfig["maintenance.remove-orphaned-schedule-enabled"]
         || config["maintenance.remove-orphaned-schedule-time"] !== newConfig["maintenance.remove-orphaned-schedule-time"];
 }

--- a/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/feedback";
+
+export function ResetHealthCheckStats() {
+    const [isRunning, setIsRunning] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const onReset = useCallback(async () => {
+        if (!window.confirm(
+            "Reset all health-check statistics and history? This cannot be undone."
+        )) {
+            return;
+        }
+
+        setIsRunning(true);
+        setMessage(null);
+        setError(null);
+        try {
+            const response = await fetch("/api/clear-health-check-history", { method: "POST" });
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                throw new Error(body.error || `Request failed (${response.status})`);
+            }
+            const data = await response.json();
+            setMessage(
+                `Reset complete. Removed ${data.deletedResults ?? 0} result row(s) and ${data.deletedStats ?? 0} stat row(s).`
+            );
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to reset health-check statistics.");
+        } finally {
+            setIsRunning(false);
+        }
+    }, []);
+
+    return (
+        <div className="space-y-3">
+            <p className="text-xs leading-relaxed text-slate-400">
+                Clears all accumulated health-check history and counters (repairs, deletions, healthy/unhealthy totals).
+            </p>
+            <Button
+                type="button"
+                variant={isRunning ? "secondary" : "danger"}
+                disabled={isRunning}
+                className="inline-flex"
+                onClick={onReset}
+            >
+                {isRunning ? "Resetting..." : "Reset Health-Check Statistics"}
+            </Button>
+            {message && <Alert variant="success">{message}</Alert>}
+            {error && <Alert variant="danger">{error}</Alert>}
+        </div>
+    );
+}

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -85,6 +85,7 @@ const defaultConfig = {
     "repair.enable": "false",
     "repair.healthcheck-concurrency": "50",
     "db.is-startup-vacuum-enabled": "false",
+    "database.healthcheck-retention-days": "30",
     "maintenance.remove-orphaned-schedule-enabled": "false",
     "maintenance.remove-orphaned-schedule-time": "0",
     "api.nzb-backup-enabled": "false",

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckRetentionServiceTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class HealthCheckRetentionServiceTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-health-retention-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task SweepAsync_DeletesOnlyRowsOlderThanRetention()
+    {
+        var oldResult = NewResult(DateTimeOffset.UtcNow.AddDays(-40));
+        var recentResult = NewResult(DateTimeOffset.UtcNow.AddDays(-5));
+        _context.HealthCheckResults.AddRange(oldResult, recentResult);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var deleted = await HealthCheckRetentionService.SweepAsync(_context, retentionDays: 30, CancellationToken.None);
+
+        Assert.Equal(1, deleted);
+        var remaining = await _context.HealthCheckResults.AsNoTracking().Select(x => x.Id).ToListAsync();
+        Assert.Equal([recentResult.Id], remaining);
+    }
+
+    [Fact]
+    public async Task SweepAsync_WithZeroRetention_DeletesNothing()
+    {
+        _context.HealthCheckResults.Add(NewResult(DateTimeOffset.UtcNow.AddDays(-400)));
+        await _context.SaveChangesAsync();
+
+        var deleted = await HealthCheckRetentionService.SweepAsync(_context, retentionDays: 0, CancellationToken.None);
+
+        Assert.Equal(0, deleted);
+        Assert.Equal(1, await _context.HealthCheckResults.CountAsync());
+    }
+
+    [Fact]
+    public async Task Reset_ClearsResultsAndStats()
+    {
+        _context.HealthCheckResults.Add(NewResult(DateTimeOffset.UtcNow));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        // Stats are populated by INSERT triggers when results are saved.
+        Assert.True(await _context.HealthCheckStats.CountAsync() > 0);
+
+        var deletedResults = await _context.HealthCheckResults.ExecuteDeleteAsync();
+        var deletedStats = await _context.HealthCheckStats.ExecuteDeleteAsync();
+
+        Assert.Equal(1, deletedResults);
+        Assert.True(deletedStats >= 0);
+        Assert.Equal(0, await _context.HealthCheckResults.CountAsync());
+        Assert.Equal(0, await _context.HealthCheckStats.CountAsync());
+    }
+
+    private static HealthCheckResult NewResult(DateTimeOffset createdAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        CreatedAt = createdAt,
+        DavItemId = Guid.NewGuid(),
+        Path = "/content/example.mkv",
+        Result = HealthCheckResult.HealthResult.Healthy,
+        RepairStatus = HealthCheckResult.RepairAction.None,
+        Message = null,
+    };
+}


### PR DESCRIPTION
## Summary
- Adopts the **health-check retention** idea from [elfhosted/nzbdav](https://github.com/elfhosted/nzbdav) / [PR #199](https://github.com/nzbdav-dev/nzbdav/pull/199) (reimplemented against current architecture).
- Adds Settings → Maintenance controls for retention days and a **Reset Health-Check Statistics** action.
- Closes #78 (upstream request: nzbdav-dev/nzbdav#107).

### Not adopted from the fork
- Brotli-in-SQLite payload compression / `auto_vacuum=FULL` — already superseded by BlobStore + opt-in startup VACUUM (PR #199 was retracted for this reason).
- NZB external cache sharing (`SHARE_NZB_*`) — ElfHosted/Zyclops-specific.

## Test plan
- [ ] Set health-check retention to a small value, create old result rows (or wait), confirm sweep removes only aged rows
- [ ] Set retention to `0`, confirm no pruning
- [ ] Use **Reset Health-Check Statistics** and confirm Health page counters return to zero
- [ ] Save retention via Settings and via `DATABASE_HEALTHCHECK_RETENTION_DAYS`
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~HealthCheckRetentionServiceTests`
- [ ] `cd frontend && npm run typecheck`