### PR TITLE
feat(db): adopt elfhosted SAB history retention (#158)

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -821,6 +821,26 @@ public class ConfigManager
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
+    /// <summary>
+    /// Days to keep SAB history rows. 0 disables age-based pruning.
+    /// Config key wins over DATABASE_HISTORY_RETENTION_DAYS; default is 90.
+    /// Automatic retention never deletes mounted WebDAV content.
+    /// </summary>
+    public int GetHistoryRetentionDays()
+    {
+        return GetRetentionDaysSetting(
+            "database.history-retention-days",
+            "DATABASE_HISTORY_RETENTION_DAYS",
+            defaultValue: 90);
+    }
+
+    private int GetRetentionDaysSetting(string configKey, string environmentVariable, int defaultValue)
+    {
+        var rawValue = StringUtil.EmptyToNull(GetConfigValue(configKey))
+                       ?? EnvironmentUtil.GetEnvironmentVariable(environmentVariable);
+        return int.TryParse(rawValue, out var parsed) && parsed >= 0 ? parsed : defaultValue;
+    }
+
     public bool IsNzbBackupEnabled()
     {
         var defaultValue = false;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -177,6 +177,7 @@ class Program
                 .AddHostedService<BlobCleanupService>()
                 .AddHostedService<NzbBlobCleanupService>()
                 .AddHostedService<HistoryCleanupService>()
+                .AddHostedService<HistoryRetentionService>()
                 .AddHostedService<WatchdogPurgeService>()
                 .AddHostedService<DavCleanupService>()
                 .AddHostedService<UsenetFileToBlobstoreMigrationService>()

--- a/backend/Services/HistoryRetentionService.cs
+++ b/backend/Services/HistoryRetentionService.cs
@@ -1,0 +1,106 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Prunes aged SAB history rows without deleting mounted WebDAV content.
+/// Uses RemoveHistoryItemsAsync(deleteFiles: false) so HistoryCleanupService
+/// clears HistoryItemId links instead of removing DavItems.
+/// Inspired by elfhosted/nzbdav database maintenance (PR #199 retention idea).
+/// </summary>
+public class HistoryRetentionService(ConfigManager configManager) : BackgroundService
+{
+    private const int BatchSize = 100;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+
+        var interval = GetInterval();
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+                await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+            {
+                return;
+            }
+        }
+    }
+
+    internal static async Task<int> SweepAsync(
+        DavDatabaseClient dbClient,
+        int retentionDays,
+        CancellationToken ct)
+    {
+        if (retentionDays <= 0) return 0;
+
+        var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+        var totalRemoved = 0;
+
+        while (true)
+        {
+            var ids = await dbClient.Ctx.HistoryItems
+                .AsNoTracking()
+                .Where(x => x.CreatedAt < cutoff)
+                .OrderBy(x => x.CreatedAt)
+                .Select(x => x.Id)
+                .Take(BatchSize)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            if (ids.Count == 0) break;
+
+            await dbClient.RemoveHistoryItemsAsync(ids, deleteFiles: false, ct).ConfigureAwait(false);
+            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+            dbClient.Ctx.ChangeTracker.Clear();
+            totalRemoved += ids.Count;
+
+            if (ids.Count < BatchSize) break;
+        }
+
+        return totalRemoved;
+    }
+
+    private async Task SafeSweepAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var retentionDays = configManager.GetHistoryRetentionDays();
+            if (retentionDays <= 0) return;
+
+            await using var dbContext = new DavDatabaseContext();
+            var dbClient = new DavDatabaseClient(dbContext);
+            var removed = await SweepAsync(dbClient, retentionDays, stoppingToken).ConfigureAwait(false);
+            if (removed > 0)
+            {
+                Log.Information(
+                    "History retention removed {Removed} SAB history row(s) older than {Days} days (mounted files preserved)",
+                    removed,
+                    retentionDays);
+            }
+        }
+        catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "History retention sweep failed: {Message}", ex.Message);
+        }
+    }
+
+    private static TimeSpan GetInterval()
+    {
+        var hours = EnvironmentUtil.GetLongVariable("DATABASE_MAINTENANCE_INTERVAL_HOURS") ?? 6;
+        return TimeSpan.FromHours(Math.Max(1, hours));
+    }
+}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -484,6 +484,17 @@ For series, pass `type=series&id=tt0944947&season=1&episode=1`. Hitting the `pla
 
 ## Phase 7 — Operations
 
+### Database retention
+
+NzbDav can prune aged SAB history rows so the history table does not grow without bound:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DATABASE_HISTORY_RETENTION_DAYS` | `90` | Keep SAB history entries for this many days. Set to `0` to retain everything. Mounted WebDAV content is **not** deleted. |
+| `DATABASE_MAINTENANCE_INTERVAL_HOURS` | `6` | How often the background retention sweep runs. |
+
+These can also be set under **Settings → Maintenance** (`database.history-retention-days`).
+
 ### Back up NzbDav
 
 Back up the host directory mapped to `/config` (shown as `./config` in this guide). It contains the database, settings, credentials, and persisted application data, so store the backup securely. Stop the container or use a filesystem snapshot to get a consistent backup:

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Select } from "~/components/ui/form";
+import { Checkbox, Input, Select } from "~/components/ui/form";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
@@ -25,6 +25,28 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                 </label>
                     <p className="text-xs leading-relaxed text-slate-400" id="db-startup-vacuum-enabled-help">
                         When enabled, nzbdav will run a SQLite VACUUM on the database at every startup. This reclaims unused disk space and can improve query performance over time, but may increase startup time for large databases.
+                    </p>
+                </div>
+                <hr />
+                <div className="space-y-2">
+                    <label className="block text-sm text-slate-300" htmlFor="history-retention-days">
+                        SAB History Retention (days)
+                    </label>
+                    <Input
+                        id="history-retention-days"
+                        type="number"
+                        min={0}
+                        aria-describedby="history-retention-days-help"
+                        value={config["database.history-retention-days"] ?? "90"}
+                        onChange={e => setNewConfig({
+                            ...config,
+                            "database.history-retention-days": e.target.value,
+                        })}
+                        className="max-w-xs"
+                    />
+                    <p className="text-xs leading-relaxed text-slate-400" id="history-retention-days-help">
+                        Automatically prune SAB history rows older than this many days. Mounted WebDAV content is preserved.
+                        Set to 0 to keep everything. Can also be set with DATABASE_HISTORY_RETENTION_DAYS.
                     </p>
                 </div>
                 <hr />
@@ -125,6 +147,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
 
 export function isMaintenanceSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["db.is-startup-vacuum-enabled"] !== newConfig["db.is-startup-vacuum-enabled"]
+        || config["database.history-retention-days"] !== newConfig["database.history-retention-days"]
         || config["maintenance.remove-orphaned-schedule-enabled"] !== newConfig["maintenance.remove-orphaned-schedule-enabled"]
         || config["maintenance.remove-orphaned-schedule-time"] !== newConfig["maintenance.remove-orphaned-schedule-time"];
 }

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -85,6 +85,7 @@ const defaultConfig = {
     "repair.enable": "false",
     "repair.healthcheck-concurrency": "50",
     "db.is-startup-vacuum-enabled": "false",
+    "database.history-retention-days": "90",
     "maintenance.remove-orphaned-schedule-enabled": "false",
     "maintenance.remove-orphaned-schedule-time": "0",
     "api.nzb-backup-enabled": "false",

--- a/tests/NzbWebDAV.Tests/Services/HistoryRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HistoryRetentionServiceTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class HistoryRetentionServiceTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-history-retention-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _client = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task SweepAsync_RemovesOldHistory_PreservesDavItems()
+    {
+        var oldHistoryId = Guid.NewGuid();
+        var recentHistoryId = Guid.NewGuid();
+        var davItemId = Guid.NewGuid();
+
+        _context.HistoryItems.AddRange(
+            new HistoryItem
+            {
+                Id = oldHistoryId,
+                CreatedAt = DateTime.UtcNow.AddDays(-120),
+                FileName = "old.nzb",
+                JobName = "old-job",
+                Category = "movies",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 100,
+                DownloadTimeSeconds = 1,
+            },
+            new HistoryItem
+            {
+                Id = recentHistoryId,
+                CreatedAt = DateTime.UtcNow.AddDays(-10),
+                FileName = "recent.nzb",
+                JobName = "recent-job",
+                Category = "movies",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 100,
+                DownloadTimeSeconds = 1,
+            });
+
+        var davItem = DavItem.New(
+            davItemId, DavItem.Root, "old.mkv", 100,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            null, null, oldHistoryId, null);
+        _context.Items.Add(davItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var removed = await HistoryRetentionService.SweepAsync(_client, retentionDays: 90, CancellationToken.None);
+
+        Assert.Equal(1, removed);
+        Assert.Null(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == oldHistoryId));
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == recentHistoryId));
+
+        var cleanup = await _context.HistoryCleanupItems.AsNoTracking()
+            .SingleAsync(x => x.Id == oldHistoryId);
+        Assert.False(cleanup.DeleteMountedFiles);
+
+        // Simulate HistoryCleanupService processing deleteFiles=false.
+        await _context.Items
+            .Where(x => x.HistoryItemId == oldHistoryId)
+            .ExecuteUpdateAsync(x => x.SetProperty(p => p.HistoryItemId, (Guid?)null));
+        await _context.HistoryCleanupItems
+            .Where(x => x.Id == oldHistoryId)
+            .ExecuteDeleteAsync();
+        _context.ChangeTracker.Clear();
+
+        var preserved = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == davItemId);
+        Assert.Null(preserved.HistoryItemId);
+        Assert.Equal("old.mkv", preserved.Name);
+    }
+
+    [Fact]
+    public async Task SweepAsync_WithZeroRetention_DeletesNothing()
+    {
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow.AddDays(-400),
+            FileName = "ancient.nzb",
+            JobName = "ancient",
+            Category = "movies",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+            TotalSegmentBytes = 1,
+            DownloadTimeSeconds = 1,
+        });
+        await _context.SaveChangesAsync();
+
+        var removed = await HistoryRetentionService.SweepAsync(_client, retentionDays: 0, CancellationToken.None);
+
+        Assert.Equal(0, removed);
+        Assert.Equal(1, await _context.HistoryItems.CountAsync());
+    }
+}


### PR DESCRIPTION
## Summary
- Adopts the **history retention** idea from [elfhosted/nzbdav](https://github.com/elfhosted/nzbdav) / [PR #199](https://github.com/nzbdav-dev/nzbdav/pull/199).
- Reimplemented safely: uses `RemoveHistoryItemsAsync(..., deleteFiles: false)` so mounted DavItems are preserved (unlike the fork's raw `ExecuteDeleteAsync`).
- Closes #158.

### Not adopted from the fork
- Brotli-in-SQLite / `auto_vacuum=FULL` — superseded by BlobStore.
- NZB cache sharing — ElfHosted-specific.

## Test plan
- [ ] Set history retention to a small value; confirm only aged SAB history rows are removed
- [ ] Confirm related DavItems remain and `HistoryItemId` is cleared by HistoryCleanupService
- [ ] Set retention to `0`; confirm no pruning
- [ ] Save via Settings and via `DATABASE_HISTORY_RETENTION_DAYS`
- [ ] `dotnet test --filter FullyQualifiedName~HistoryRetentionServiceTests`
- [ ] `cd frontend && npm run typecheck`