### PR TITLE
fix(db): adopt elfhosted read-only SQLite PRAGMA hardening (#160)

### DIFF
--- a/backend/Database/Interceptors/SqliteMainDbPragmas.cs
+++ b/backend/Database/Interceptors/SqliteMainDbPragmas.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Serilog;
 
 namespace NzbWebDAV.Database.Interceptors;
 
@@ -7,13 +8,51 @@ public class SqliteMainDbPragmas : DbConnectionInterceptor
 {
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText =
-            "PRAGMA foreign_keys = ON;" +
-            "PRAGMA journal_mode = WAL;" +
-            "PRAGMA busy_timeout = 5000;" +
-            "PRAGMA synchronous = NORMAL;" +
-            "PRAGMA temp_store = MEMORY;";
-        command.ExecuteNonQuery();
+        try
+        {
+            using var command = connection.CreateCommand();
+
+            // Connection-level; usually succeeds even on read-only databases.
+            command.CommandText = "PRAGMA foreign_keys = ON;";
+            command.ExecuteNonQuery();
+
+            command.CommandText = "PRAGMA busy_timeout = 5000;";
+            command.ExecuteNonQuery();
+
+            command.CommandText = "PRAGMA temp_store = MEMORY;";
+            command.ExecuteNonQuery();
+
+            // WAL / synchronous may attempt writes to the DB file. Skip when the
+            // connection string explicitly requests read-only mode (CI/goss, etc).
+            if (IsExplicitlyReadOnly(connection.ConnectionString))
+                return;
+
+            try
+            {
+                command.CommandText = "PRAGMA journal_mode = WAL;";
+                _ = command.ExecuteScalar();
+
+                command.CommandText = "PRAGMA synchronous = NORMAL;";
+                command.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(
+                    ex,
+                    "Could not set WAL/synchronous PRAGMA on main SQLite connection; database may be read-only.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "SQLite main connection opened but PRAGMA commands failed. Continuing without PRAGMA changes.");
+        }
+    }
+
+    internal static bool IsExplicitlyReadOnly(string? connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString)) return false;
+        return connectionString.Contains("mode=readonly", StringComparison.OrdinalIgnoreCase)
+               || connectionString.Contains("mode=read-only", StringComparison.OrdinalIgnoreCase)
+               || connectionString.Contains("Mode=ReadOnly", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/backend/Database/Interceptors/SqliteMetricsPragmas.cs
+++ b/backend/Database/Interceptors/SqliteMetricsPragmas.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Serilog;
 
 namespace NzbWebDAV.Database.Interceptors;
 
@@ -13,15 +14,43 @@ public class SqliteMetricsPragmas : DbConnectionInterceptor
 {
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText =
-            "PRAGMA journal_mode = WAL;" +
-            "PRAGMA synchronous = NORMAL;" +
-            "PRAGMA temp_store = MEMORY;" +
-            "PRAGMA mmap_size = 268435456;" +
-            "PRAGMA cache_size = -65536;" +
-            "PRAGMA journal_size_limit = 67108864;" +
-            "PRAGMA auto_vacuum = INCREMENTAL;";
-        command.ExecuteNonQuery();
+        try
+        {
+            using var command = connection.CreateCommand();
+
+            if (SqliteMainDbPragmas.IsExplicitlyReadOnly(connection.ConnectionString))
+            {
+                // Still apply read-only-safe settings that do not rewrite the DB header.
+                command.CommandText =
+                    "PRAGMA temp_store = MEMORY;" +
+                    "PRAGMA mmap_size = 268435456;" +
+                    "PRAGMA cache_size = -65536;";
+                command.ExecuteNonQuery();
+                return;
+            }
+
+            try
+            {
+                command.CommandText =
+                    "PRAGMA journal_mode = WAL;" +
+                    "PRAGMA synchronous = NORMAL;" +
+                    "PRAGMA temp_store = MEMORY;" +
+                    "PRAGMA mmap_size = 268435456;" +
+                    "PRAGMA cache_size = -65536;" +
+                    "PRAGMA journal_size_limit = 67108864;" +
+                    "PRAGMA auto_vacuum = INCREMENTAL;";
+                command.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(
+                    ex,
+                    "Could not set metrics SQLite PRAGMAs; database may be read-only.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "SQLite metrics connection opened but PRAGMA commands failed. Continuing without PRAGMA changes.");
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Database/SqliteMainDbPragmasTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteMainDbPragmasTests.cs
@@ -1,0 +1,18 @@
+using NzbWebDAV.Database.Interceptors;
+
+namespace NzbWebDAV.Tests.Database;
+
+public class SqliteMainDbPragmasTests
+{
+    [Theory]
+    [InlineData("Data Source=db.sqlite;Mode=ReadOnly", true)]
+    [InlineData("Data Source=db.sqlite;mode=readonly", true)]
+    [InlineData("Data Source=db.sqlite;mode=read-only", true)]
+    [InlineData("Data Source=db.sqlite", false)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    public void IsExplicitlyReadOnly_DetectsReadOnlyModes(string? connectionString, bool expected)
+    {
+        Assert.Equal(expected, SqliteMainDbPragmas.IsExplicitlyReadOnly(connectionString));
+    }
+}


### PR DESCRIPTION
## Summary
- Adopts read-only SQLite PRAGMA hardening from [elfhosted/nzbdav](https://github.com/elfhosted/nzbdav) commit `892f468`.
- Adapted to current `SqliteMainDbPragmas` / `SqliteMetricsPragmas` (the fork patched the older `SqliteForeignKeyEnabler`).
- Closes #160.

Connection open no longer aborts when WAL/synchronous PRAGMAs fail on a read-only DB or filesystem; foreign_keys and other safe settings still apply when possible.

## Test plan
- [ ] Normal writable DB startup still enables WAL
- [ ] Read-only connection string / filesystem: app continues with a warning instead of crashing
- [ ] `dotnet test --filter FullyQualifiedName~SqliteMainDbPragmasTests`