### PR TITLE
fix(sab): adopt elfhosted addfile nzbname + JSON converter fallback

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -25,9 +25,14 @@ public class AddFileRequest()
             context.Request.Form.Files["name"] ??
             throw new BadHttpRequestException("Invalid nzbFile/name param");
 
+        // Prefer the nzbname query/form param (set by some SAB clients); fall back to the
+        // form file's filename. Without this, file.FileName can be null/empty and downstream
+        // Regex.Match throws a 500. Adopted from elfhosted/rebased-v3.
+        var fileName = ResolveFileName(context.GetRequestParam("nzbname"), file.FileName);
+
         return new AddFileRequest()
         {
-            FileName = file.FileName,
+            FileName = fileName,
             ContentType = file.ContentType,
             NzbFileStream = file.OpenReadStream(),
             Category = context.GetRequestParam("cat") ?? configManager.GetManualUploadCategory(),
@@ -35,6 +40,21 @@ public class AddFileRequest()
             PostProcessing = MapPostProcessingOption(context.GetRequestParam("pp")),
             CancellationToken = context.RequestAborted
         };
+    }
+
+    /// <summary>
+    /// Resolve the NZB filename from an optional SAB <c>nzbname</c> param and the uploaded file name.
+    /// </summary>
+    internal static string ResolveFileName(string? nzbName, string? formFileName)
+    {
+        var fileName = !string.IsNullOrWhiteSpace(nzbName)
+            ? (nzbName.EndsWith(".nzb", StringComparison.OrdinalIgnoreCase) ? nzbName : $"{nzbName}.nzb")
+            : formFileName;
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new BadHttpRequestException("NZB filename could not be determined.");
+
+        return fileName;
     }
 
     protected static QueueItem.PriorityOption MapPriorityOption(string? priority)

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+﻿using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -9,6 +11,7 @@ using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
+using Serilog;
 
 namespace NzbWebDAV.Database;
 
@@ -181,7 +184,7 @@ public sealed class DavDatabaseContext : DbContext
                 .HasConversion(new ValueConverter<string[], string>
                 (
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                    v => JsonSerializer.Deserialize<string[]>(v, (JsonSerializerOptions?)null) ?? Array.Empty<string>()
+                    v => DeserializeOrFallback<string[]>(v) ?? Array.Empty<string>()
                 ))
                 .HasColumnType("TEXT") // store raw JSON
                 .IsRequired();
@@ -205,8 +208,7 @@ public sealed class DavDatabaseContext : DbContext
                 .HasConversion(new ValueConverter<DavRarFile.RarPart[], string>
                 (
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                    v => JsonSerializer.Deserialize<DavRarFile.RarPart[]>(v, (JsonSerializerOptions?)null)
-                         ?? Array.Empty<DavRarFile.RarPart>()
+                    v => DeserializeOrFallback<DavRarFile.RarPart[]>(v) ?? Array.Empty<DavRarFile.RarPart>()
                 ))
                 .HasColumnType("TEXT") // store raw JSON
                 .IsRequired();
@@ -230,8 +232,7 @@ public sealed class DavDatabaseContext : DbContext
                 .HasConversion(new ValueConverter<DavMultipartFile.Meta, string>
                 (
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                    v => JsonSerializer.Deserialize<DavMultipartFile.Meta>(v, (JsonSerializerOptions?)null) ??
-                         new DavMultipartFile.Meta()
+                    v => DeserializeOrFallback<DavMultipartFile.Meta>(v) ?? new DavMultipartFile.Meta()
                 ))
                 .HasColumnType("TEXT") // store raw JSON
                 .IsRequired();
@@ -758,5 +759,43 @@ public sealed class DavDatabaseContext : DbContext
         BlobNzbFiles.Clear();
         BlobRarFiles.Clear();
         BlobMultipartFiles.Clear();
+    }
+
+    /// <summary>
+    /// Attempts JSON deserialization; if the column contains non-JSON data
+    /// (e.g. legacy Base64+Brotli compressed format), tries to decode that.
+    /// Logs the raw value on failure for diagnostics.
+    /// Adopted from elfhosted/rebased-v3.
+    /// </summary>
+    internal static T? DeserializeOrFallback<T>(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return default;
+
+        // Fast path: value looks like JSON
+        var first = value[0];
+        if (first is '[' or '{' or '"' or '-' or (>= '0' and <= '9') or 't' or 'f' or 'n')
+        {
+            return JsonSerializer.Deserialize<T>(value, (JsonSerializerOptions?)null);
+        }
+
+        // Non-JSON data — try Base64+Brotli decode (legacy compressed format)
+        Log.Warning(
+            "Column contains non-JSON data (starts with '{First}', length={Length}), attempting Base64+Brotli decode",
+            first, value.Length);
+        try
+        {
+            var bytes = Convert.FromBase64String(value);
+            using var input = new MemoryStream(bytes);
+            using var brotli = new BrotliStream(input, CompressionMode.Decompress);
+            using var reader = new StreamReader(brotli, Encoding.UTF8);
+            var json = reader.ReadToEnd();
+            return JsonSerializer.Deserialize<T>(json, (JsonSerializerOptions?)null);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to deserialize column value. Raw value (first 200 chars): {Preview}",
+                value.Length > 200 ? value[..200] : value);
+            return default;
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.AddFile;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class AddFileRequestTests
+{
+    [Fact]
+    public void ResolveFileName_PrefersNzbNameQueryParam()
+    {
+        Assert.Equal("My.Release.nzb", AddFileRequest.ResolveFileName("My.Release", "upload.nzb"));
+    }
+
+    [Fact]
+    public void ResolveFileName_KeepsNzbExtensionOnNzbName()
+    {
+        Assert.Equal("My.Release.nzb", AddFileRequest.ResolveFileName("My.Release.nzb", "upload.nzb"));
+    }
+
+    [Fact]
+    public void ResolveFileName_FallsBackToFormFileName()
+    {
+        Assert.Equal("upload.nzb", AddFileRequest.ResolveFileName(null, "upload.nzb"));
+        Assert.Equal("upload.nzb", AddFileRequest.ResolveFileName("  ", "upload.nzb"));
+    }
+
+    [Fact]
+    public void ResolveFileName_ThrowsWhenNeitherNameIsUsable()
+    {
+        var ex = Assert.Throws<BadHttpRequestException>(() => AddFileRequest.ResolveFileName(null, null));
+        Assert.Contains("filename", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        ex = Assert.Throws<BadHttpRequestException>(() => AddFileRequest.ResolveFileName("  ", ""));
+        Assert.Contains("filename", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DeserializeOrFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DeserializeOrFallbackTests.cs
@@ -1,0 +1,53 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using NzbWebDAV.Database;
+
+namespace NzbWebDAV.Tests.Database;
+
+public class DeserializeOrFallbackTests
+{
+    [Fact]
+    public void DeserializeOrFallback_ReadsJsonArray()
+    {
+        var result = DavDatabaseContext.DeserializeOrFallback<string[]>("[\"a\",\"b\"]");
+        Assert.Equal(["a", "b"], result);
+    }
+
+    [Fact]
+    public void DeserializeOrFallback_ReturnsDefaultForEmpty()
+    {
+        Assert.Null(DavDatabaseContext.DeserializeOrFallback<string[]>(null));
+        Assert.Null(DavDatabaseContext.DeserializeOrFallback<string[]>(""));
+    }
+
+    [Fact]
+    public void DeserializeOrFallback_DecodesLegacyBase64Brotli()
+    {
+        var json = JsonSerializer.Serialize(new[] { "seg1", "seg2" });
+        var encoded = EncodeBase64Brotli(json);
+
+        var result = DavDatabaseContext.DeserializeOrFallback<string[]>(encoded);
+        Assert.Equal(["seg1", "seg2"], result);
+    }
+
+    [Fact]
+    public void DeserializeOrFallback_ReturnsDefaultForCorruptNonJson()
+    {
+        // Starts with a non-JSON character so the fallback path runs, then fails decode.
+        var result = DavDatabaseContext.DeserializeOrFallback<string[]>("!!!!not-base64!!!!");
+        Assert.Null(result);
+    }
+
+    private static string EncodeBase64Brotli(string json)
+    {
+        using var output = new MemoryStream();
+        using (var brotli = new BrotliStream(output, CompressionLevel.Fastest, leaveOpen: true))
+        using (var writer = new StreamWriter(brotli, Encoding.UTF8))
+        {
+            writer.Write(json);
+        }
+
+        return Convert.ToBase64String(output.ToArray());
+    }
+}


### PR DESCRIPTION
## Summary
- Adopted from [elfhosted/nzbdav `elfhosted/rebased-v3`](https://github.com/elfhosted/nzbdav/tree/elfhosted/rebased-v3): honour SAB `nzbname` on `addfile` so a missing upload filename no longer 500s.
- Adopted `DeserializeOrFallback` for JSON value-converter columns (`DavNzbFile` / `DavRarFile` / `DavMultipartFile`) so legacy Base64+Brotli blobs do not crash EF reads.
- Added unit tests for filename resolution and converter fallback.

Refs #89

## Test plan
- [x] `dotnet test` filter `AddFileRequestTests|DeserializeOrFallbackTests` (8 passed)
- [ ] Manual: SAB `addfile` with `nzbname` and empty/missing Content-Disposition filename
- [ ] Manual: existing queue/history still loads after upgrade