### PR TITLE
fix(webdav): adopt elfhosted PROPFIND resourcetype XElement clone

### DIFF
--- a/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
@@ -13,6 +13,19 @@ internal class DavIsCollection<T> : DavString<T> where T : IStoreItem
 
 public class BaseStoreCollectionPropertyManager() : PropertyManager<BaseStoreCollection>(DavProperties)
 {
+    // The resourcetype XElement MUST NOT be a shared static. XElement parent
+    // ownership in System.Xml.Linq is mutable: adding an XElement to a new
+    // parent automatically removes it from the previous parent. NWebDav's
+    // PropFindHandler builds an XDocument per request and parents this
+    // element into <resourcetype>. With concurrent PROPFINDs, one request's
+    // XDocument has its <collection/> element ripped out mid-serialization
+    // by another, and XmlWriter then tries to close more elements than it
+    // opened — throwing "Token EndElement in state EndRootElement" and
+    // returning a half-written 500 to the client. Clone per call to keep
+    // each XDocument independent. Adopted from elfhosted/rebased-v3.
+    private static XElement NewDavResourceType()
+        => new(WebDavNamespaces.DavNs + "collection");
+
     private static readonly DavProperty<BaseStoreCollection>[] DavProperties =
     [
         new DavDisplayName<BaseStoreCollection>
@@ -21,7 +34,7 @@ public class BaseStoreCollectionPropertyManager() : PropertyManager<BaseStoreCol
         },
         new DavGetResourceType<BaseStoreCollection>
         {
-            Getter = _ => [new XElement(WebDavNamespaces.DavNs + "collection")]
+            Getter = _ => [NewDavResourceType()]
         },
         new DavGetLastModified<BaseStoreCollection>
         {


### PR DESCRIPTION
## Summary
- Adopted from [elfhosted/nzbdav `elfhosted/rebased-v3`](https://github.com/elfhosted/nzbdav/tree/elfhosted/rebased-v3): clone the `DAV:collection` `XElement` per PROPFIND instead of sharing one static instance.
- Prevents concurrent PROPFINDs from mutating each other's XML trees (`Token EndElement in state EndRootElement` / half-written 500s) when NWebDav parents the element into `<resourcetype>`.

Refs #131
Refs #103

## Test plan
- [ ] Concurrent rclone / Windows WebDAV PROPFIND against a collection mount under load
- [ ] Confirm directory listings still report `DAV:collection` resourcetype