### PR TITLE
fix(ui): adopt elfhosted healthz, ErrorBoundary, unhandledRejection hardening

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,4 +1,5 @@
 import {
+  isRouteErrorResponse,
   Links,
   Meta,
   Outlet,
@@ -6,6 +7,7 @@ import {
   ScrollRestoration,
   useLocation,
   useNavigation,
+  useRouteError,
 } from "react-router";
 
 import "./app.css";
@@ -108,4 +110,51 @@ export default function App({ loaderData }: Route.ComponentProps) {
   }
 
   return <Outlet />;
+}
+
+// Root ErrorBoundary catches loader/component throws that aren't handled closer
+// to the route. Without this, an SSR loader that rejects (e.g. backend fetch
+// timeout while the backend is busy) bubbles to React Router's default 500 with
+// no UI. Keep this page free of PageLayout so we don't re-run the root loader
+// and loop back into the same failure. Adopted from elfhosted/rebased-v3.
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const isUndiciTimeout =
+    error instanceof Error &&
+    /fetch failed|ConnectTimeoutError|HeadersTimeoutError|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT/i.test(
+      `${error.message} ${(error.cause as Error)?.message ?? ""}`,
+    );
+
+  let title = "Something went wrong";
+  let detail: string;
+  if (isUndiciTimeout) {
+    title = "Backend temporarily unavailable";
+    detail =
+      "The nzbdav backend is still starting up or is busy processing a large queue. Wait a moment and refresh the page.";
+  } else if (isRouteErrorResponse(error)) {
+    title = `${error.status} ${error.statusText}`;
+    detail = typeof error.data === "string" ? error.data : "";
+  } else if (error instanceof Error) {
+    detail = error.message;
+  } else {
+    detail = "Unknown error.";
+  }
+
+  return (
+    <main className="flex min-h-dvh w-full items-center justify-center bg-gray-900 px-4 py-8 text-white">
+      <div className="w-full max-w-lg space-y-4 rounded-xl border border-slate-700/70 bg-gray-800 p-6 shadow-xl shadow-black/20 sm:p-8">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+          {detail ? <p className="text-sm leading-relaxed text-slate-300">{detail}</p> : null}
+        </div>
+        <button
+          type="button"
+          className="button-small flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600"
+          onClick={() => window.location.reload()}
+        >
+          Reload
+        </button>
+      </div>
+    </main>
+  );
 }

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -9,6 +9,19 @@ const BUILD_PATH = "../build/server/index.js";
 const DEVELOPMENT = process.env.NODE_ENV === "development";
 const PORT = Number.parseInt(process.env.PORT || "3000");
 
+// Keep the frontend alive when the backend is slow. SSR loaders fetch the
+// backend; when those fetches reject and a loader doesn't catch them, the
+// rejection can become an unhandledRejection that Node terminates on by
+// default (v15+). Logging without crashing keeps /healthz, /assets, and
+// websockets up while the affected SSR request returns an error page.
+// Adopted from elfhosted/rebased-v3.
+//
+// Deliberately do not hook uncaughtException: that fires for fatal errors
+// where restarting the process is the right answer.
+process.on("unhandledRejection", (reason) => {
+  logger.error("Unhandled promise rejection:", reason);
+});
+
 // Initialize the express app
 const app = express();
 app.use(
@@ -33,6 +46,14 @@ app.use(
   }),
 );
 app.disable("x-powered-by");
+
+// Frontend-local healthcheck. Registered BEFORE request logging and the React
+// Router catch-all so probes bypass SSR and stay quiet in access logs.
+// Adopted from elfhosted/rebased-v3.
+app.get("/healthz", (_req, res) => {
+  res.status(200).type("text/plain").send("ok");
+});
+
 app.use(requestLogger);
 
 // Initialize the websocket server as soon as both it and the server-module are ready


### PR DESCRIPTION
## Summary
- Adopted from [elfhosted/nzbdav `elfhosted/rebased-v3`](https://github.com/elfhosted/nzbdav/tree/elfhosted/rebased-v3):
  - `GET /healthz` on the Express frontend **before** request logging / React Router so probes do not trigger SSR or depend on the backend.
  - `process.on("unhandledRejection")` logs without crashing Node when SSR loader fetches time out.
  - Root `ErrorBoundary` with a flat, design-language-aligned error page (including backend timeout messaging) so the WebUI stays usable when the backend is degraded.

Closes #107
Closes #77

## Test plan
- [x] `cd frontend && npm run typecheck`
- [ ] `GET /healthz` returns `ok` with 200 while backend is stopped / slow
- [ ] Force a root loader backend timeout and confirm ErrorBoundary UI + Reload (Node process stays up)
- [ ] Confirm backend `/health` and Docker entrypoint probes are unchanged