### PR TITLE
fix(webdav): harden RemoveUnlinkedFiles against partial library scans

### DIFF
--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -50,6 +50,32 @@ public class RemoveUnlinkedFilesTask(
         var unlinkedItems = await CountUnlinkedItems(startTime);
         Report($"Found {unlinkedItems} webdav items to remove.");
 
+        // The `linkedIdCount < 5` check above only catches a COMPLETELY empty scan. A library
+        // dir that is partially mounted, or pointed at the wrong path, can still expose a
+        // handful of symlinks and sail past it -- and then nearly every webdav item looks
+        // unlinked. Refuse to delete an implausible share of the deletable population.
+        // A healthy library here sits around 31% unlinked (samples, nfos, unimported extras),
+        // so 90% leaves wide headroom while still catching a broken scan.
+        var deletableItems = await CountDeletableItems(startTime);
+        var extremeUnlinkedRatio = deletableItems > 0 && unlinkedItems > deletableItems * 0.9;
+        if (extremeUnlinkedRatio)
+        {
+            var percent = 100.0 * unlinkedItems / deletableItems;
+            var detail =
+                $"{unlinkedItems} of {deletableItems} webdav items appear unlinked ({percent:F0}%). " +
+                $"That usually means the library directory is missing, unmounted, or misconfigured " +
+                $"rather than that the items are orphaned.";
+
+            if (!isDryRun)
+            {
+                Report($"Aborted: {detail} Cancelling to prevent accidental bulk deletion. " +
+                       $"Run a dry-run to inspect if this is genuinely expected.");
+                return;
+            }
+
+            Report($"Warning: {detail} A non-dry-run would abort.");
+        }
+
         if (isDryRun)
         {
             await DryRunIdentifyUnlinkedFiles(startTime);
@@ -117,12 +143,37 @@ public class RemoveUnlinkedFilesTask(
         Report($"Scanning all linked files...\nFound {count}...");
     }
 
+    /// <summary>
+    /// The population CountUnlinkedItems draws from: every item this task is allowed to delete,
+    /// linked or not. Must mirror CountUnlinkedItems' predicates exactly (minus the link join),
+    /// otherwise the safety ratio compares two different populations.
+    /// </summary>
+    private async Task<int> CountDeletableItems(DateTime createdBefore)
+    {
+        await using var dbContext = new DavDatabaseContext();
+        var createdBeforeStr = createdBefore.ToString("yyyy-MM-dd HH:mm:ss");
+        var usenetFileType = (int)DavItem.ItemType.UsenetFile;
+
+        return await dbContext.Database
+            .SqlQueryRaw<int>(
+                $"""
+                 SELECT COUNT(i.Id) AS Value FROM DavItems i
+                 WHERE i.Type = {usenetFileType}
+                   AND i.HistoryItemId IS NULL
+                   AND i.CreatedAt < '{createdBeforeStr}'
+                 """)
+            .FirstAsync();
+    }
+
     private async Task<int> CountUnlinkedItems(DateTime createdBefore)
     {
         await using var dbContext = new DavDatabaseContext();
         var createdBeforeStr = createdBefore.ToString("yyyy-MM-dd HH:mm:ss");
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
 
+        // LEFT JOIN is equivalent to the NOT IN subquery used by RemoveUnlinkedItems /
+        // DryRunIdentifyUnlinkedFiles; CountDeletableItems mirrors these predicates without
+        // the link join so the safety ratio compares the same population.
         var count = await dbContext.Database
             .SqlQueryRaw<int>(
                 $"""

--- a/backend/Utils/SymlinkAndStrmUtil.cs
+++ b/backend/Utils/SymlinkAndStrmUtil.cs
@@ -1,11 +1,13 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace NzbWebDAV.Utils;
 
 public static class SymlinkAndStrmUtil
 {
     private static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    private const int MaxStderrChars = 4096;
 
     public static IEnumerable<ISymlinkOrStrmInfo> GetAllSymlinksAndStrms(string directoryPath)
     {
@@ -16,9 +18,10 @@ public static class SymlinkAndStrmUtil
 
     private static IEnumerable<ISymlinkOrStrmInfo> GetAllSymlinksAndStrmsLinux(string directoryPath)
     {
+        // pipefail so find traversal errors (permission denied, etc.) are not masked by xargs.
         const string command =
             """
-            find . \( -type l -o -name '*.strm' \) -print0 | xargs -0 sh -c '
+            set -o pipefail; find . \( -type l -o -name '*.strm' \) -print0 | xargs -0 sh -c '
               for path in \"$@\"; do
                 echo \"$path\"
                 if [ \"${path##*.}\" = \"strm\" ]; then
@@ -42,6 +45,25 @@ public static class SymlinkAndStrmUtil
         };
 
         using var process = Process.Start(startInfo)!;
+
+        // Drain stderr asynchronously. Leaving it unread can fill the OS pipe buffer and
+        // deadlock find when a library tree produces many permission errors.
+        var stderrBuilder = new StringBuilder();
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            lock (stderrBuilder)
+            {
+                if (stderrBuilder.Length >= MaxStderrChars) return;
+                if (stderrBuilder.Length > 0)
+                    stderrBuilder.Append('\n');
+
+                var remaining = MaxStderrChars - stderrBuilder.Length;
+                stderrBuilder.Append(e.Data.Length <= remaining ? e.Data : e.Data[..remaining]);
+            }
+        };
+        process.BeginErrorReadLine();
+
         while (process.StandardOutput.EndOfStream == false)
         {
             var filePath = process.StandardOutput.ReadLine();
@@ -65,6 +87,18 @@ public static class SymlinkAndStrmUtil
                     TargetPath = target
                 };
             }
+        }
+
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            string stderr;
+            lock (stderrBuilder)
+                stderr = stderrBuilder.ToString();
+
+            throw new InvalidOperationException(
+                $"Library symlink scan failed with exit code {process.ExitCode}" +
+                (string.IsNullOrWhiteSpace(stderr) ? "." : $": {stderr}"));
         }
     }
 


### PR DESCRIPTION
## Summary

`RemoveUnlinkedFilesTask` could delete nearly the entire WebDAV library when a library-dir scan returned a partial but non-empty result (wrong path, partial mount, or permission-denied subtrees). The existing `< 5` linked-files guard only catches a completely empty scan.

This PR adds two complementary guards for the failure modes in #154:

1. **Fail-closed library enumeration** — Linux `find | xargs` now runs under `pipefail`, drains stderr asynchronously (avoids pipe-buffer deadlocks), and throws on non-zero exit so partial scans cannot silently drive deletions.
2. **90% unlinked-ratio abort** — real runs abort when unlinked items exceed 90% of the deletable population. Dry runs still identify candidates and warn that a non-dry-run would abort. Inspired by [Kha-kis@e2f7e4d](https://github.com/Kha-kis/nzbdav/commit/e2f7e4d30fa2f86e849876eadaa58510d17f592a); neither layer alone covers both failure modes.

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj -c Release` (0 errors)
- [ ] Manual: wrong `library-dir` with ≥5 stray links → real run aborts on ratio; dry-run lists + warns
- [ ] Manual: permission-denied subtree under library-dir → scan fails closed; no deletes
- [ ] Manual: healthy library (unlinked share well under 90%) → cleanup still proceeds
- [ ] Manual: existing `< 5` linked-files abort still works

Closes #154