### PR TITLE
fix(usenet): resolve masked passwords for speed test and connection test

### DIFF
--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
@@ -12,7 +13,8 @@ public class BenchmarkUsenetConnectionController(
     UsenetBenchmarkService benchmarkService,
     BenchmarkGate benchmarkGate,
     ActiveReadRegistry activeReads,
-    QueueManager queueManager
+    QueueManager queueManager,
+    ConfigManager configManager
 ) : BaseApiController
 {
     private async Task<BenchmarkUsenetConnectionResponse> BenchmarkAsync(BenchmarkUsenetConnectionRequest request)
@@ -69,7 +71,7 @@ public class BenchmarkUsenetConnectionController(
 
     protected override async Task<IActionResult> HandleRequest()
     {
-        var request = new BenchmarkUsenetConnectionRequest(HttpContext);
+        var request = new BenchmarkUsenetConnectionRequest(HttpContext, configManager);
         var response = await BenchmarkAsync(request).ConfigureAwait(false);
         return Ok(response);
     }

--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
@@ -21,7 +21,7 @@ public class BenchmarkUsenetConnectionRequest
     /// <summary>When true, skip the connection sweep and only tune pipelining depth.</summary>
     public bool PipeliningOnly { get; init; }
 
-    public BenchmarkUsenetConnectionRequest(HttpContext context)
+    public BenchmarkUsenetConnectionRequest(HttpContext context, ConfigManager configManager)
     {
         Host = context.Request.Form["host"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet host is required");
@@ -29,8 +29,9 @@ public class BenchmarkUsenetConnectionRequest
         User = context.Request.Form["user"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet user is required");
 
-        Pass = context.Request.Form["pass"].FirstOrDefault()
+        var submittedPass = context.Request.Form["pass"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet pass is required");
+        Pass = UsenetPassResolver.Resolve(submittedPass, configManager);
 
         var port = context.Request.Form["port"].FirstOrDefault()
                    ?? throw new BadHttpRequestException("Usenet port is required");

--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using Serilog;
@@ -8,7 +9,7 @@ namespace NzbWebDAV.Api.Controllers.TestUsenetConnection;
 
 [ApiController]
 [Route("api/test-usenet-connection")]
-public class TestUsenetConnectionController() : BaseApiController
+public class TestUsenetConnectionController(ConfigManager configManager) : BaseApiController
 {
     private async Task<TestUsenetConnectionResponse> TestUsenetConnection(TestUsenetConnectionRequest request)
     {
@@ -44,7 +45,7 @@ public class TestUsenetConnectionController() : BaseApiController
 
     protected override async Task<IActionResult> HandleRequest()
     {
-        var request = new TestUsenetConnectionRequest(HttpContext);
+        var request = new TestUsenetConnectionRequest(HttpContext, configManager);
         var response = await TestUsenetConnection(request).ConfigureAwait(false);
         return Ok(response);
     }

--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionRequest.cs
@@ -12,7 +12,7 @@ public class TestUsenetConnectionRequest
     public int Port { get; init; }
     public bool UseSsl { get; init; }
 
-    public TestUsenetConnectionRequest(HttpContext context)
+    public TestUsenetConnectionRequest(HttpContext context, ConfigManager configManager)
     {
         Host = context.Request.Form["host"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet host is required");
@@ -20,8 +20,9 @@ public class TestUsenetConnectionRequest
         User = context.Request.Form["user"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet user is required");
 
-        Pass = context.Request.Form["pass"].FirstOrDefault()
+        var submittedPass = context.Request.Form["pass"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet pass is required");
+        Pass = UsenetPassResolver.Resolve(submittedPass, configManager);
 
         var port = context.Request.Form["port"].FirstOrDefault()
                    ?? throw new BadHttpRequestException("Usenet port is required");

--- a/backend/Config/ConfigSecretMasker.cs
+++ b/backend/Config/ConfigSecretMasker.cs
@@ -105,6 +105,27 @@ public sealed class ConfigSecretMasker(string signingKey)
         return value.StartsWith(MaskPrefix, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Resolves a single masked JSON secret (e.g. a usenet provider <c>Pass</c>) against
+    /// the stored config blob. Plaintext values are returned unchanged.
+    /// </summary>
+    public string ResolveMaskedJsonSecret(string configName, string submittedValue, string? existingValue)
+    {
+        if (!IsMaskToken(submittedValue))
+            return submittedValue;
+
+        if (!JsonSecretProperties.TryGetValue(configName, out var propertyName))
+            throw InvalidMaskToken(configName);
+
+        var existingSecrets = GetExistingJsonSecrets(existingValue, propertyName);
+        var existingSecret = existingSecrets.FirstOrDefault(secret =>
+            TokenMatches(submittedValue, configName, propertyName, secret));
+        if (existingSecret == null)
+            throw InvalidMaskToken(configName);
+
+        return existingSecret;
+    }
+
     private void WriteMaskedJson(
         Utf8JsonWriter writer,
         JsonElement element,

--- a/backend/Config/UsenetPassResolver.cs
+++ b/backend/Config/UsenetPassResolver.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Resolves a usenet provider password that may be a UI mask token back to the
+/// stored plaintext, so ad-hoc endpoints (benchmark / test-connection) can auth
+/// without forcing the user to re-type the password.
+/// </summary>
+public static class UsenetPassResolver
+{
+    public const string ProvidersConfigName = "usenet.providers";
+
+    public static string Resolve(string submittedPass, ConfigManager configManager)
+    {
+        if (!ConfigSecretMasker.IsMaskToken(submittedPass))
+            return submittedPass;
+
+        var masker = new ConfigSecretMasker(
+            EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
+        var existingJson = JsonSerializer.Serialize(configManager.GetUsenetProviderConfig());
+        return masker.ResolveMaskedJsonSecret(ProvidersConfigName, submittedPass, existingJson);
+    }
+}

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -778,8 +778,6 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
     }, [show, onClose]);
 
     const handleTestConnection = useCallback(async () => {
-        if (passIsMasked) return;
-
         setIsTestingConnection(true);
         setTestError(null);
 
@@ -805,14 +803,15 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                     setTestError("Connection test failed");
                 }
             } else {
-                setTestError("Failed to test connection");
+                const data = await response.json().catch(() => null);
+                setTestError(data?.error || "Failed to test connection");
             }
         } catch (error) {
             setTestError("Network error: " + (error instanceof Error ? error.message : "Unknown error"));
         } finally {
             setIsTestingConnection(false);
         }
-    }, [host, port, useSsl, user, pass, passIsMasked]);
+    }, [host, port, useSsl, user, pass]);
 
     const handleAutoTune = useCallback(async () => {
         // Abort any previous run still in flight before starting a new one.
@@ -857,13 +856,13 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             const response = await fetch('/api/benchmark-usenet-connection', {
                 method: 'POST', body: formData, signal: controller.signal,
             });
+            const data = await response.json().catch(() => null);
             if (!response.ok) {
-                setBenchmarkError("The speed test couldn't run. Please try again.");
+                setBenchmarkError(data?.error || "The speed test couldn't run. Please try again.");
                 return;
             }
-            const data = await response.json();
-            if (!data.status || !data.result) {
-                setBenchmarkError(data.error || "The speed test couldn't run.");
+            if (!data?.status || !data.result) {
+                setBenchmarkError(data?.error || "The speed test couldn't run.");
                 return;
             }
             setBenchmarkResult(data.result as BenchmarkResult);

--- a/tests/NzbWebDAV.Tests/Config/ConfigSecretMaskerTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigSecretMaskerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Tests.Config;
@@ -53,5 +54,71 @@ public class ConfigSecretMaskerTests
         var resolvedIndexers = resolvedDocument.RootElement.GetProperty("Indexers");
         Assert.Equal("replacement", resolvedIndexers[0].GetProperty("ApiKey").GetString());
         Assert.Equal("second-secret", resolvedIndexers[1].GetProperty("ApiKey").GetString());
+    }
+
+    [Fact]
+    public void ResolveMaskedJsonSecret_ReturnsPlaintextUnchanged()
+    {
+        var masker = new ConfigSecretMasker("test-signing-key");
+
+        var resolved = masker.ResolveMaskedJsonSecret(
+            "usenet.providers",
+            "real-password",
+            """{"Providers":[{"Pass":"stored-secret"}]}""");
+
+        Assert.Equal("real-password", resolved);
+    }
+
+    [Fact]
+    public void ResolveMaskedJsonSecret_ResolvesProviderPassAgainstStoredConfig()
+    {
+        const string configName = "usenet.providers";
+        const string stored =
+            """{"Providers":[{"Host":"news.example","User":"u1","Pass":"alpha-secret"},{"Host":"backup.example","User":"u2","Pass":"beta-secret"}]}""";
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var masked = masker.MaskForResponse(configName, stored);
+        using var maskedDocument = JsonDocument.Parse(masked);
+        var secondToken = maskedDocument.RootElement
+            .GetProperty("Providers")[1]
+            .GetProperty("Pass")
+            .GetString()!;
+
+        var resolved = masker.ResolveMaskedJsonSecret(configName, secondToken, stored);
+
+        Assert.Equal("beta-secret", resolved);
+    }
+
+    [Fact]
+    public void ResolveMaskedJsonSecret_ThrowsForUnknownMaskToken()
+    {
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var otherMasker = new ConfigSecretMasker("other-signing-key");
+        var stored = """{"Providers":[{"Pass":"real-secret"}]}""";
+        var foreignToken = otherMasker.MaskForResponse("usenet.providers", stored);
+        using var document = JsonDocument.Parse(foreignToken);
+        var bogusToken = document.RootElement
+            .GetProperty("Providers")[0]
+            .GetProperty("Pass")
+            .GetString()!;
+
+        var ex = Assert.Throws<BadHttpRequestException>(() =>
+            masker.ResolveMaskedJsonSecret("usenet.providers", bogusToken, stored));
+
+        Assert.Contains("usenet.providers", ex.Message);
+    }
+
+    [Fact]
+    public void ResolveMaskedJsonSecret_ThrowsForForgedMaskToken()
+    {
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var forged = $"{ConfigSecretMasker.MaskPrefix}AAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        var ex = Assert.Throws<BadHttpRequestException>(() =>
+            masker.ResolveMaskedJsonSecret(
+                "usenet.providers",
+                forged,
+                """{"Providers":[{"Pass":"real-secret"}]}"""));
+
+        Assert.Contains("usenet.providers", ex.Message);
     }
 }

--- a/tests/NzbWebDAV.Tests/Config/UsenetPassResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/UsenetPassResolverTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class UsenetPassResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsPlaintextUnchanged()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+
+        var resolved = UsenetPassResolver.Resolve("typed-password", configManager);
+
+        Assert.Equal("typed-password", resolved);
+    }
+
+    [Fact]
+    public void Resolve_UnmasksStoredProviderPassword()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var stored = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    Type = ProviderType.Pooled,
+                    Host = "news.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "user",
+                    Pass = "stored-secret",
+                    MaxConnections = 10,
+                }
+            ]
+        });
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = "usenet.providers", ConfigValue = stored }
+        ]);
+
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var masked = masker.MaskForResponse("usenet.providers", stored);
+        using var document = JsonDocument.Parse(masked);
+        var token = document.RootElement
+            .GetProperty("Providers")[0]
+            .GetProperty("Pass")
+            .GetString()!;
+
+        var resolved = UsenetPassResolver.Resolve(token, configManager);
+
+        Assert.Equal("stored-secret", resolved);
+    }
+
+    [Fact]
+    public void Resolve_ThrowsForUnknownMaskToken()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = "usenet.providers",
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            Type = ProviderType.Pooled,
+                            Host = "news.example",
+                            Port = 563,
+                            UseSsl = true,
+                            User = "user",
+                            Pass = "stored-secret",
+                            MaxConnections = 10,
+                        }
+                    ]
+                })
+            }
+        ]);
+
+        var forged = $"{ConfigSecretMasker.MaskPrefix}AAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Assert.Throws<BadHttpRequestException>(() =>
+            UsenetPassResolver.Resolve(forged, configManager));
+    }
+
+    private static IDisposable TempEnv(string name, string value)
+    {
+        var previous = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+        return new RestoreEnv(name, previous);
+    }
+
+    private sealed class RestoreEnv(string name, string? previous) : IDisposable
+    {
+        public void Dispose() => Environment.SetEnvironmentVariable(name, previous);
+    }
+}


### PR DESCRIPTION
## Summary
- Speed test and connection test were posting the UI mask token (`__NZBDAV_SECRET_MASK_V1__:…`) as the NNTP password when editing an existing provider, causing a false “Couldn't log in” error despite working playback credentials.
- Resolve mask tokens against stored `usenet.providers` before authenticating; reject unknown/forged masks with a clear 400.
- Surface API error messages in the provider modal so failed resolves are not mistaken for bad credentials.

## Test plan
- [ ] Open Settings → Usenet → edit an existing provider (leave password masked)
- [ ] Run speed test without re-entering the password — should authenticate and complete
- [ ] Confirm forged/invalid mask returns a clear API error (not a login failure)
- [ ] Unit tests: `ConfigSecretMaskerTests` + `UsenetPassResolverTests` pass