### PR TITLE
perf(ui): speed up Overview with sectioned stats and 24h rollups

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -41,130 +41,102 @@ public class GetOverviewStatsController(
     {
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var window = request.Window;
+        var sections = request.Sections;
         var (windowMs, bucketSize, label) = ResolveWindow(window, nowMs);
         var windowStart = window == GetOverviewStatsRequest.OverviewWindow.AllTime
             ? 0
             : nowMs - windowMs;
+        var wantWindow = sections.HasFlag(GetOverviewStatsRequest.OverviewSections.Window);
+        var wantDetail = sections.HasFlag(GetOverviewStatsRequest.OverviewSections.Detail);
+        var wantStatic = sections.HasFlag(GetOverviewStatsRequest.OverviewSections.Static);
+        var useRollups =
+            window == GetOverviewStatsRequest.OverviewWindow.Last7Days ||
+            window == GetOverviewStatsRequest.OverviewWindow.Last30Days ||
+            window == GetOverviewStatsRequest.OverviewWindow.AllTime;
 
         var nicknamesByHost = configManager.GetUsenetProviderConfig().Providers
             .Where(p => !string.IsNullOrWhiteSpace(p.Nickname))
             .GroupBy(p => p.Host, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First().Nickname, StringComparer.OrdinalIgnoreCase);
 
-        await using var metrics = new MetricsDbContext();
-        var useRollups =
-            window == GetOverviewStatsRequest.OverviewWindow.Last7Days ||
-            window == GetOverviewStatsRequest.OverviewWindow.Last30Days ||
-            window == GetOverviewStatsRequest.OverviewWindow.AllTime;
+        var included = new List<string>();
+        var tiles = new GetOverviewStatsResponse.LiveTiles();
+        var throughput = new List<GetOverviewStatsResponse.ThroughputPoint>();
+        var providers = new List<GetOverviewStatsResponse.ProviderRow>();
+        var sessionsBlock = new GetOverviewStatsResponse.SessionsBlock();
+        var heatmap = new GetOverviewStatsResponse.HeatmapBlock();
+        var failover = new GetOverviewStatsResponse.FailoverBlock();
+        var latency = new GetOverviewStatsResponse.LatencyBlock();
+        var errors = new List<GetOverviewStatsResponse.ErrorSlice>();
+        var catalogue = new GetOverviewStatsResponse.CatalogueBlock();
+        var indexers = new List<GetOverviewStatsResponse.IndexerRow>();
+        var indexerApiUsage = new List<GetOverviewStatsResponse.IndexerApiUsageRow>();
+        var lifetime = new GetOverviewStatsResponse.LifetimeBlock();
+        var records = new GetOverviewStatsResponse.RecordsBlock();
+        long totalArticles = 0, totalErrors = 0, totalBytesFetched = 0;
 
-        // Sessions live up to 90 d, so they work fine for every window. We keep using
-        // the raw ReadSessions table for sessions stats regardless of `useRollups`.
-        var sessions = await metrics.ReadSessions
-            .Where(x => x.EndedAt >= windowStart)
-            .Select(x => new { x.StartedAt, x.EndedAt, x.DurationMs, x.BytesServed, x.FailoverSaves })
-            .ToListAsync().ConfigureAwait(false);
+        Task<WindowSectionResult>? windowTask = null;
+        Task<DetailSectionResult>? detailTask = null;
+        Task<StaticSectionResult>? staticTask = null;
 
-        GetOverviewStatsResponse.LiveTiles liveTiles;
-        List<GetOverviewStatsResponse.ThroughputPoint> throughput;
-        List<GetOverviewStatsResponse.ProviderRow> providers;
-        GetOverviewStatsResponse.LatencyBlock latency;
-        List<GetOverviewStatsResponse.ErrorSlice> errors;
-        long totalArticles, totalErrors, totalBytesFetched;
-        GetOverviewStatsResponse.FailoverBlock failover;
+        if (wantWindow)
+            windowTask = BuildWindowSectionAsync(window, windowStart, windowMs, bucketSize, nowMs, useRollups, nicknamesByHost);
+        if (wantDetail && !useRollups)
+            detailTask = BuildDetailSectionAsync(windowStart);
+        if (wantStatic)
+            staticTask = BuildStaticSectionAsync();
 
-        var readsSaved = sessions.LongCount(s => s.FailoverSaves > 0);
-        var failoverBucket = ResolveFailoverBucket(window);
+        var tasks = new List<Task>();
+        if (windowTask is not null) tasks.Add(windowTask);
+        if (detailTask is not null) tasks.Add(detailTask);
+        if (staticTask is not null) tasks.Add(staticTask);
+        if (tasks.Count > 0)
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        long? previousSaves = null;
-        if (window != GetOverviewStatsRequest.OverviewWindow.AllTime)
+        if (windowTask is not null)
         {
-            var prevStart = windowStart - windowMs;
-            previousSaves = await metrics.ProviderHourly
-                .Where(h => h.Hour >= prevStart && h.Hour < windowStart)
-                .SumAsync(h => (long?)h.FailoverSaves).ConfigureAwait(false) ?? 0L;
+            var w = await windowTask.ConfigureAwait(false);
+            included.Add("window");
+            tiles = w.Tiles;
+            throughput = w.Throughput;
+            providers = w.Providers;
+            sessionsBlock = w.Sessions;
+            heatmap = w.Heatmap;
+            failover = w.Failover;
+            totalArticles = w.TotalArticles;
+            totalErrors = w.TotalErrors;
+            totalBytesFetched = w.TotalBytesFetched;
         }
 
-        var heatmap = await BuildHeatmapAsync(metrics, window, nowMs).ConfigureAwait(false);
-
-        if (useRollups)
+        if (detailTask is not null)
         {
-            var hours = await metrics.ProviderHourly
-                .Where(h => h.Hour >= windowStart)
-                .Select(h => new { h.Hour, h.Provider, h.Articles, h.BytesFetched, h.Errors, h.Retries, h.FailoverSaves, h.SumDurationMs })
-                .ToListAsync().ConfigureAwait(false);
-
-            var sinceMinute = nowMs - OneMinute;
-            var recentStatuses = await metrics.SegmentFetches
-                .Where(x => x.At >= sinceMinute)
-                .Select(x => x.Status)
-                .ToListAsync().ConfigureAwait(false);
-            liveTiles = BuildLiveTiles(
-                recentStatuses.Count,
-                recentStatuses.Count(status => status != SegmentFetch.FetchStatus.Ok));
-            throughput = BuildThroughputFromHourly(hours.Select(h => (h.Hour, h.Articles, h.Errors, h.BytesFetched)), sessions.Select(s => (s.EndedAt, s.BytesServed)), bucketSize);
-            providers = BuildProvidersFromHourly(hours, windowStart, bucketSize, nowMs, nicknamesByHost);
-            latency = new GetOverviewStatsResponse.LatencyBlock();
-            errors = new List<GetOverviewStatsResponse.ErrorSlice>();
-            totalArticles = hours.Sum(h => h.Articles);
-            totalErrors = hours.Sum(h => h.Errors);
-            totalBytesFetched = hours.Sum(h => h.BytesFetched);
-            var failoverEdges = await metrics.FailoverHourly
-                .Where(f => f.Hour >= windowStart)
-                .Select(f => new { f.FromProvider, f.Reason, f.Count })
-                .ToListAsync().ConfigureAwait(false);
-            failover = BuildFailover(
-                hours.Where(h => h.FailoverSaves > 0).Select(h => (h.Hour, h.Provider, h.FailoverSaves)),
-                failoverEdges.Select(e => (e.FromProvider, e.Reason, e.Count)),
-                totalArticles, sessions.Count, readsSaved, previousSaves, failoverBucket, nicknamesByHost);
+            var d = await detailTask.ConfigureAwait(false);
+            included.Add("detail");
+            latency = d.Latency;
+            errors = d.Errors;
         }
-        else
+        else if (wantDetail && useRollups)
         {
-            // Short windows: raw fetches give us per-event detail (heatmap, latency, errors).
-            var fetches = await metrics.SegmentFetches
-                .Where(x => x.At >= windowStart)
-                .Select(x => new { x.At, x.Provider, x.Status, x.DurationMs, x.Retries })
-                .ToListAsync().ConfigureAwait(false);
-
-            var perMinuteBytes = await metrics.ProviderMinutes
-                .Where(p => p.Minute >= windowStart)
-                .GroupBy(p => p.Provider)
-                .Select(g => new { Provider = g.Key, Bytes = g.Sum(x => x.BytesFetched) })
-                .ToDictionaryAsync(x => x.Provider, x => x.Bytes).ConfigureAwait(false);
-
-            var sinceMinute = nowMs - OneMinute;
-            var articlesLastMinute = fetches.Count(f => f.At >= sinceMinute);
-            var errorsLastMinute = fetches.Count(f => f.At >= sinceMinute && f.Status != SegmentFetch.FetchStatus.Ok);
-
-            liveTiles = BuildLiveTiles(articlesLastMinute, errorsLastMinute);
-            throughput = BuildThroughput(fetches.Select(f => (f.At, f.Status)), sessions.Select(s => (s.EndedAt, s.BytesServed)), bucketSize);
-            providers = BuildProviders(fetches, perMinuteBytes, windowStart, bucketSize, window, nicknamesByHost);
-            latency = BuildLatency(fetches.Where(f => f.Status == SegmentFetch.FetchStatus.Ok).Select(f => f.DurationMs));
-            errors = BuildErrors(fetches.Select(f => f.Status));
-            totalArticles = throughput.Sum(p => p.Articles);
-            totalErrors = throughput.Sum(p => p.Errors);
-            totalBytesFetched = perMinuteBytes.Values.Sum();
-            var failoverEdges = await metrics.FailoverMisses
-                .Where(f => f.At >= windowStart)
-                .Select(f => new { f.FromProvider, f.Reason })
-                .ToListAsync().ConfigureAwait(false);
-            failover = BuildFailover(
-                fetches.Where(f => f.Status == SegmentFetch.FetchStatus.Ok && f.Retries > 0)
-                    .Select(f => (f.At, f.Provider, 1L)),
-                failoverEdges.Select(e => (e.FromProvider, e.Reason, 1L)),
-                totalArticles, sessions.Count, readsSaved, previousSaves, failoverBucket, nicknamesByHost);
+            // Long windows hide latency/errors in the UI; acknowledge the section as empty.
+            included.Add("detail");
         }
 
-        var catalogue = await BuildCatalogueAsync().ConfigureAwait(false);
-        var sessionsBlock = BuildSessionsBlock(sessions.Select(s => (s.DurationMs, s.BytesServed)));
-        var indexers = await BuildIndexersAsync().ConfigureAwait(false);
-        var indexerApiUsage = await BuildIndexerApiUsageAsync().ConfigureAwait(false);
-        var lifetime = await BuildLifetimeAsync(metrics).ConfigureAwait(false);
-        var records = await BuildRecordsAsync(metrics).ConfigureAwait(false);
+        if (staticTask is not null)
+        {
+            var s = await staticTask.ConfigureAwait(false);
+            included.Add("static");
+            catalogue = s.Catalogue;
+            indexers = s.Indexers;
+            indexerApiUsage = s.IndexerApiUsage;
+            lifetime = s.Lifetime;
+            records = s.Records;
+        }
 
         return new GetOverviewStatsResponse
         {
             Window = label,
-            Tiles = liveTiles,
+            IncludedSections = included,
+            Tiles = tiles,
             Throughput = throughput,
             TotalArticles = totalArticles,
             TotalErrors = totalErrors,
@@ -180,8 +152,238 @@ public class GetOverviewStatsController(
             Lifetime = lifetime,
             Records = records,
             Failover = failover,
-            MetricsHealth = BuildMetricsHealth(),
+            MetricsHealth = wantWindow || wantStatic ? BuildMetricsHealth() : new GetOverviewStatsResponse.MetricsHealthBlock(),
         };
+    }
+
+    private sealed record WindowSectionResult(
+        GetOverviewStatsResponse.LiveTiles Tiles,
+        List<GetOverviewStatsResponse.ThroughputPoint> Throughput,
+        List<GetOverviewStatsResponse.ProviderRow> Providers,
+        GetOverviewStatsResponse.SessionsBlock Sessions,
+        GetOverviewStatsResponse.HeatmapBlock Heatmap,
+        GetOverviewStatsResponse.FailoverBlock Failover,
+        long TotalArticles,
+        long TotalErrors,
+        long TotalBytesFetched);
+
+    private sealed record DetailSectionResult(
+        GetOverviewStatsResponse.LatencyBlock Latency,
+        List<GetOverviewStatsResponse.ErrorSlice> Errors);
+
+    private sealed record StaticSectionResult(
+        GetOverviewStatsResponse.CatalogueBlock Catalogue,
+        List<GetOverviewStatsResponse.IndexerRow> Indexers,
+        List<GetOverviewStatsResponse.IndexerApiUsageRow> IndexerApiUsage,
+        GetOverviewStatsResponse.LifetimeBlock Lifetime,
+        GetOverviewStatsResponse.RecordsBlock Records);
+
+    private async Task<WindowSectionResult> BuildWindowSectionAsync(
+        GetOverviewStatsRequest.OverviewWindow window,
+        long windowStart,
+        long windowMs,
+        long bucketSize,
+        long nowMs,
+        bool useRollups,
+        IReadOnlyDictionary<string, string?> nicknamesByHost)
+    {
+        await using var metricsSessions = new MetricsDbContext();
+        await using var metricsHeatmap = new MetricsDbContext();
+        await using var metricsPrev = new MetricsDbContext();
+        await using var metricsA = new MetricsDbContext();
+        await using var metricsB = new MetricsDbContext();
+        await using var metricsLive = new MetricsDbContext();
+
+        var sessionsTask = metricsSessions.ReadSessions
+            .Where(x => x.EndedAt >= windowStart)
+            .Select(x => new { x.StartedAt, x.EndedAt, x.DurationMs, x.BytesServed, x.FailoverSaves })
+            .ToListAsync();
+        var heatmapTask = BuildHeatmapAsync(metricsHeatmap, window, nowMs);
+        var previousSavesTask = LoadPreviousFailoverSavesAsync(metricsPrev, window, windowStart, windowMs);
+        var sinceMinute = nowMs - OneMinute;
+        var liveCountsTask = metricsLive.SegmentFetches
+            .Where(x => x.At >= sinceMinute)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Articles = g.Count(),
+                Errors = g.Count(x => x.Status != SegmentFetch.FetchStatus.Ok),
+            })
+            .FirstOrDefaultAsync();
+
+        List<(long At, string Provider, long Saves)> rescues;
+        List<(string From, SegmentFetch.FetchStatus Reason, long Count)> misses;
+        List<GetOverviewStatsResponse.ThroughputPoint> throughput;
+        List<GetOverviewStatsResponse.ProviderRow> providers;
+        long totalArticles, totalErrors, totalBytesFetched;
+
+        if (useRollups)
+        {
+            var hoursTask = metricsA.ProviderHourly
+                .Where(h => h.Hour >= windowStart)
+                .Select(h => new { h.Hour, h.Provider, h.Articles, h.BytesFetched, h.Errors, h.Retries, h.FailoverSaves, h.SumDurationMs })
+                .ToListAsync();
+            var failoverEdgesTask = metricsB.FailoverHourly
+                .Where(f => f.Hour >= windowStart)
+                .Select(f => new { f.FromProvider, f.Reason, f.Count })
+                .ToListAsync();
+
+            await Task.WhenAll(sessionsTask, heatmapTask, previousSavesTask, liveCountsTask, hoursTask, failoverEdgesTask)
+                .ConfigureAwait(false);
+
+            var hours = await hoursTask.ConfigureAwait(false);
+            var sessions = await sessionsTask.ConfigureAwait(false);
+            var failoverEdges = await failoverEdgesTask.ConfigureAwait(false);
+
+            throughput = BuildThroughputFromHourly(
+                hours.Select(h => (h.Hour, h.Articles, h.Errors, h.BytesFetched)),
+                sessions.Select(s => (s.EndedAt, s.BytesServed)),
+                bucketSize);
+            providers = BuildProvidersFromHourly(hours, windowStart, bucketSize, nowMs, nicknamesByHost);
+            totalArticles = hours.Sum(h => h.Articles);
+            totalErrors = hours.Sum(h => h.Errors);
+            totalBytesFetched = hours.Sum(h => h.BytesFetched);
+            rescues = hours.Where(h => h.FailoverSaves > 0)
+                .Select(h => (h.Hour, h.Provider, h.FailoverSaves))
+                .ToList();
+            misses = failoverEdges.Select(e => (e.FromProvider, e.Reason, e.Count)).ToList();
+        }
+        else
+        {
+            // 24h: use minute rollups — do not materialize every SegmentFetch row.
+            await using var metricsC = new MetricsDbContext();
+            var minutesTask = metricsA.ProviderMinutes
+                .Where(p => p.Minute >= windowStart)
+                .Select(p => new
+                {
+                    p.Minute, p.Provider, p.Articles, p.BytesFetched, p.Errors, p.Retries,
+                    p.FailoverSaves, p.SumDurationMs
+                })
+                .ToListAsync();
+            var throughputMinutesTask = metricsB.ThroughputMinutes
+                .Where(t => t.Minute >= windowStart)
+                .Select(t => new { t.Minute, t.Articles, t.Errors, t.BytesServed })
+                .ToListAsync();
+            var failoverMissesTask = metricsC.FailoverMisses
+                .Where(f => f.At >= windowStart)
+                .Select(f => new { f.FromProvider, f.Reason })
+                .ToListAsync();
+
+            await Task.WhenAll(
+                    sessionsTask, heatmapTask, previousSavesTask, liveCountsTask,
+                    minutesTask, throughputMinutesTask, failoverMissesTask)
+                .ConfigureAwait(false);
+
+            var minutes = await minutesTask.ConfigureAwait(false);
+            var throughputMinutes = await throughputMinutesTask.ConfigureAwait(false);
+            var failoverMisses = await failoverMissesTask.ConfigureAwait(false);
+
+            throughput = BuildThroughputFromMinutes(
+                throughputMinutes.Select(t => (t.Minute, t.Articles, t.Errors, t.BytesServed)),
+                bucketSize);
+            providers = BuildProvidersFromMinutes(
+                minutes.Select(m => (m.Minute, m.Provider, m.Articles, m.BytesFetched, m.Errors, m.Retries, m.SumDurationMs)),
+                windowStart, window, nicknamesByHost);
+            totalArticles = minutes.Sum(m => m.Articles);
+            totalErrors = minutes.Sum(m => m.Errors);
+            totalBytesFetched = minutes.Sum(m => m.BytesFetched);
+            rescues = minutes.Where(m => m.FailoverSaves > 0)
+                .Select(m => (m.Minute, m.Provider, m.FailoverSaves))
+                .ToList();
+            misses = failoverMisses.Select(e => (e.FromProvider, e.Reason, 1L)).ToList();
+        }
+
+        var sessionsRows = await sessionsTask.ConfigureAwait(false);
+        var heatmap = await heatmapTask.ConfigureAwait(false);
+        var previousSaves = await previousSavesTask.ConfigureAwait(false);
+        var liveCounts = await liveCountsTask.ConfigureAwait(false);
+
+        var readsSaved = sessionsRows.LongCount(s => s.FailoverSaves > 0);
+        var failover = BuildFailover(
+            rescues,
+            misses,
+            totalArticles,
+            sessionsRows.Count,
+            readsSaved,
+            previousSaves,
+            ResolveFailoverBucket(window),
+            nicknamesByHost);
+
+        var tiles = BuildLiveTiles(liveCounts?.Articles ?? 0, liveCounts?.Errors ?? 0);
+        var sessionsBlock = BuildSessionsBlock(sessionsRows.Select(s => (s.DurationMs, s.BytesServed)));
+
+        return new WindowSectionResult(
+            tiles, throughput, providers, sessionsBlock, heatmap, failover,
+            totalArticles, totalErrors, totalBytesFetched);
+    }
+
+    private static async Task<long?> LoadPreviousFailoverSavesAsync(
+        MetricsDbContext metrics,
+        GetOverviewStatsRequest.OverviewWindow window,
+        long windowStart,
+        long windowMs)
+    {
+        if (window == GetOverviewStatsRequest.OverviewWindow.AllTime)
+            return null;
+        return await metrics.ProviderHourly
+            .Where(h => h.Hour >= windowStart - windowMs && h.Hour < windowStart)
+            .SumAsync(h => (long?)h.FailoverSaves)
+            .ConfigureAwait(false) ?? 0L;
+    }
+
+    private async Task<DetailSectionResult> BuildDetailSectionAsync(long windowStart)
+    {
+        await using var metricsLatency = new MetricsDbContext();
+        await using var metricsErrors = new MetricsDbContext();
+
+        var durationsTask = metricsLatency.SegmentFetches
+            .Where(x => x.At >= windowStart && x.Status == SegmentFetch.FetchStatus.Ok)
+            .Select(x => x.DurationMs)
+            .ToListAsync();
+        var errorGroupsTask = metricsErrors.SegmentFetches
+            .Where(x => x.At >= windowStart && x.Status != SegmentFetch.FetchStatus.Ok)
+            .GroupBy(x => x.Status)
+            .Select(g => new { Status = g.Key, Count = (long)g.Count() })
+            .ToListAsync();
+
+        await Task.WhenAll(durationsTask, errorGroupsTask).ConfigureAwait(false);
+
+        var durations = await durationsTask.ConfigureAwait(false);
+        var errorGroups = await errorGroupsTask.ConfigureAwait(false);
+
+        return new DetailSectionResult(
+            BuildLatency(durations),
+            errorGroups
+                .Select(e => new GetOverviewStatsResponse.ErrorSlice
+                {
+                    Status = e.Status.ToString(),
+                    Count = e.Count,
+                })
+                .OrderByDescending(s => s.Count)
+                .ToList());
+    }
+
+    private async Task<StaticSectionResult> BuildStaticSectionAsync()
+    {
+        await using var metricsLifetime = new MetricsDbContext();
+        await using var metricsRecords = new MetricsDbContext();
+        await using var davIndexers = new DavDatabaseContext();
+
+        var catalogueTask = BuildCatalogueAsync(davDb.Ctx);
+        var indexersTask = BuildIndexersAsync(davIndexers);
+        var apiUsageTask = BuildIndexerApiUsageAsync();
+        var lifetimeTask = BuildLifetimeAsync(metricsLifetime);
+        var recordsTask = BuildRecordsAsync(metricsRecords);
+
+        await Task.WhenAll(catalogueTask, indexersTask, apiUsageTask, lifetimeTask, recordsTask)
+            .ConfigureAwait(false);
+
+        return new StaticSectionResult(
+            await catalogueTask.ConfigureAwait(false),
+            await indexersTask.ConfigureAwait(false),
+            await apiUsageTask.ConfigureAwait(false),
+            await lifetimeTask.ConfigureAwait(false),
+            await recordsTask.ConfigureAwait(false));
     }
 
     private GetOverviewStatsResponse.MetricsHealthBlock BuildMetricsHealth()
@@ -220,7 +422,6 @@ public class GetOverviewStatsController(
                 ResetAtMs = s.ResetAt.ToUnixTimeMilliseconds(),
                 ResetHourUtc = resetHourByName.GetValueOrDefault(s.IndexerName),
             })
-            // Surface indexers with the most usage first, then by name for stability.
             .OrderByDescending(r => r.ApiHits + r.DownloadHits)
             .ThenBy(r => r.Name)
             .ToList();
@@ -354,23 +555,16 @@ public class GetOverviewStatsController(
         };
     }
 
-    private static List<GetOverviewStatsResponse.ThroughputPoint> BuildThroughput(
-        IEnumerable<(long At, SegmentFetch.FetchStatus Status)> fetches,
-        IEnumerable<(long EndedAt, long BytesServed)> sessions,
+    private static List<GetOverviewStatsResponse.ThroughputPoint> BuildThroughputFromMinutes(
+        IEnumerable<(long Minute, long Articles, long Errors, long BytesServed)> minutes,
         long bucketSize)
     {
         var byBucket = new Dictionary<long, (long Articles, long Errors, long BytesServed)>();
-        foreach (var (at, status) in fetches)
+        foreach (var m in minutes)
         {
-            var b = at - (at % bucketSize);
+            var b = m.Minute - (m.Minute % bucketSize);
             byBucket.TryGetValue(b, out var cur);
-            byBucket[b] = (cur.Articles + 1, cur.Errors + (status != SegmentFetch.FetchStatus.Ok ? 1 : 0), cur.BytesServed);
-        }
-        foreach (var (endedAt, bytes) in sessions)
-        {
-            var b = endedAt - (endedAt % bucketSize);
-            byBucket.TryGetValue(b, out var cur);
-            byBucket[b] = (cur.Articles, cur.Errors, cur.BytesServed + bytes);
+            byBucket[b] = (cur.Articles + m.Articles, cur.Errors + m.Errors, cur.BytesServed + m.BytesServed);
         }
 
         return byBucket
@@ -416,32 +610,29 @@ public class GetOverviewStatsController(
             .ToList();
     }
 
-    private static List<GetOverviewStatsResponse.ProviderRow> BuildProviders<T>(
-        List<T> fetches,
-        IReadOnlyDictionary<string, long> bytesByProvider,
+    private static List<GetOverviewStatsResponse.ProviderRow> BuildProvidersFromMinutes(
+        IEnumerable<(long Minute, string Provider, long Articles, long BytesFetched, long Errors, long Retries, long SumDurationMs)> minutes,
         long windowStart,
-        long bucketSize,
         GetOverviewStatsRequest.OverviewWindow window,
-        IReadOnlyDictionary<string, string?> nicknamesByHost) where T : class
+        IReadOnlyDictionary<string, string?> nicknamesByHost)
     {
-        var is7d = window == GetOverviewStatsRequest.OverviewWindow.Last7Days;
-        var sparkBuckets = is7d ? 168 : 24;
+        var sparkBuckets = window == GetOverviewStatsRequest.OverviewWindow.Last7Days ? 168 : 24;
         var sparkSize = OneHour;
         var sparkStart = windowStart - (windowStart % sparkSize);
 
         var byProvider = new Dictionary<string, ProviderAccumulator>();
-        foreach (var f in fetches.Cast<dynamic>())
+        foreach (var m in minutes)
         {
-            string host = f.Provider;
-            if (!byProvider.TryGetValue(host, out var acc))
+            if (!byProvider.TryGetValue(m.Provider, out var acc))
                 acc = new ProviderAccumulator(sparkBuckets);
-            acc.Articles++;
-            acc.SumDurationMs += f.DurationMs;
-            if (f.Status != SegmentFetch.FetchStatus.Ok) acc.Errors++;
-            acc.Retries += f.Retries;
-            var idx = (int)(((long)f.At - sparkStart) / sparkSize);
-            if (idx >= 0 && idx < sparkBuckets) acc.Spark[idx]++;
-            byProvider[host] = acc;
+            acc.Articles += m.Articles;
+            acc.Errors += m.Errors;
+            acc.Retries += m.Retries;
+            acc.SumDurationMs += m.SumDurationMs;
+            acc.Bytes += m.BytesFetched;
+            var idx = (int)((m.Minute - sparkStart) / sparkSize);
+            if (idx >= 0 && idx < sparkBuckets) acc.Spark[idx] += m.Articles;
+            byProvider[m.Provider] = acc;
         }
 
         return byProvider
@@ -450,7 +641,7 @@ public class GetOverviewStatsController(
                 Provider = kv.Key,
                 Nickname = nicknamesByHost.GetValueOrDefault(kv.Key),
                 Articles = kv.Value.Articles,
-                BytesFetched = bytesByProvider.GetValueOrDefault(kv.Key, 0L),
+                BytesFetched = kv.Value.Bytes,
                 Errors = kv.Value.Errors,
                 Retries = kv.Value.Retries,
                 AvgDurationMs = kv.Value.Articles > 0 ? (double)kv.Value.SumDurationMs / kv.Value.Articles : 0,
@@ -468,7 +659,6 @@ public class GetOverviewStatsController(
         long nowMs,
         IReadOnlyDictionary<string, string?> nicknamesByHost)
     {
-        // Spark for 30d/all-time rolls up to daily.
         var totalSpan = nowMs - windowStart;
         var sparkSize = OneDay;
         var sparkBuckets = Math.Max(1, (int)Math.Min(60, totalSpan / sparkSize + 1));
@@ -619,31 +809,11 @@ public class GetOverviewStatsController(
         };
     }
 
-    private static List<GetOverviewStatsResponse.ErrorSlice> BuildErrors(IEnumerable<SegmentFetch.FetchStatus> statuses)
-    {
-        var counts = new Dictionary<SegmentFetch.FetchStatus, long>();
-        foreach (var s in statuses)
-        {
-            if (s == SegmentFetch.FetchStatus.Ok) continue;
-            counts.TryGetValue(s, out var c);
-            counts[s] = c + 1;
-        }
-
-        return counts
-            .Select(kv => new GetOverviewStatsResponse.ErrorSlice
-            {
-                Status = kv.Key.ToString(),
-                Count = kv.Value,
-            })
-            .OrderByDescending(s => s.Count)
-            .ToList();
-    }
-
-    private async Task<GetOverviewStatsResponse.CatalogueBlock> BuildCatalogueAsync()
+    private static async Task<GetOverviewStatsResponse.CatalogueBlock> BuildCatalogueAsync(DavDatabaseContext ctx)
     {
         var sevenDaysAgo = DateTime.UtcNow.AddDays(-7);
 
-        var files = davDb.Ctx.Items.Where(i => i.Type == DavItem.ItemType.UsenetFile);
+        var files = ctx.Items.Where(i => i.Type == DavItem.ItemType.UsenetFile);
         var fileCount = await files.CountAsync().ConfigureAwait(false);
         var totalBytes = await files.SumAsync(i => (long?)i.FileSize).ConfigureAwait(false) ?? 0L;
         var largest = await files.MaxAsync(i => (long?)i.FileSize).ConfigureAwait(false) ?? 0L;
@@ -676,10 +846,10 @@ public class GetOverviewStatsController(
         };
     }
 
-    private async Task<List<GetOverviewStatsResponse.IndexerRow>> BuildIndexersAsync()
+    private static async Task<List<GetOverviewStatsResponse.IndexerRow>> BuildIndexersAsync(DavDatabaseContext ctx)
     {
         var cutoff = DateTime.UtcNow.AddDays(-30);
-        var rows = await davDb.Ctx.HistoryItems
+        var rows = await ctx.HistoryItems
             .Where(h => h.CreatedAt >= cutoff && h.IndexerName != null)
             .GroupBy(h => h.IndexerName!)
             .Select(g => new
@@ -712,8 +882,6 @@ public class GetOverviewStatsController(
 
     private static async Task<GetOverviewStatsResponse.LifetimeBlock> BuildLifetimeAsync(MetricsDbContext metrics)
     {
-        // ProviderHourly is the long-retention truth for fetched bytes & articles (365 d).
-        // ReadSessions retains 90 d, so "read" lifetime is approximate beyond that window.
         var bytesFetched = await metrics.ProviderHourly
             .SumAsync(x => (long?)x.BytesFetched).ConfigureAwait(false) ?? 0L;
         var articles = await metrics.ProviderHourly
@@ -742,8 +910,6 @@ public class GetOverviewStatsController(
 
     private static async Task<GetOverviewStatsResponse.RecordsBlock> BuildRecordsAsync(MetricsDbContext metrics)
     {
-        // Busiest day = sum bytes-fetched per UTC day across the entire hourly history.
-        // SQLite returns Hour as ms; integer-divide by OneDay to bucket by day.
         var dayRow = await metrics.ProviderHourly
             .GroupBy(x => x.Hour / OneDay)
             .Select(g => new { DayBucket = g.Key, Bytes = g.Sum(x => x.BytesFetched) })

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsRequest.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsRequest.cs
@@ -6,21 +6,49 @@ namespace NzbWebDAV.Api.Controllers.GetOverviewStats;
 public class GetOverviewStatsRequest
 {
     public OverviewWindow Window { get; init; } = OverviewWindow.Last24Hours;
+    public OverviewSections Sections { get; init; } = OverviewSections.All;
     public CancellationToken CancellationToken { get; init; }
 
     public GetOverviewStatsRequest(HttpContext context)
     {
         CancellationToken = context.RequestAborted;
         var w = context.GetQueryParam("window");
-        if (w is null) return;
-        Window = w.ToLowerInvariant() switch
+        if (w is not null)
         {
-            "24h" => OverviewWindow.Last24Hours,
-            "7d" => OverviewWindow.Last7Days,
-            "30d" => OverviewWindow.Last30Days,
-            "all" => OverviewWindow.AllTime,
-            _ => throw new BadHttpRequestException("Invalid window parameter (use 24h, 7d, 30d, or all)")
-        };
+            Window = w.ToLowerInvariant() switch
+            {
+                "24h" => OverviewWindow.Last24Hours,
+                "7d" => OverviewWindow.Last7Days,
+                "30d" => OverviewWindow.Last30Days,
+                "all" => OverviewWindow.AllTime,
+                _ => throw new BadHttpRequestException("Invalid window parameter (use 24h, 7d, 30d, or all)")
+            };
+        }
+
+        Sections = ParseSections(context.GetQueryParam("sections"));
+    }
+
+    private static OverviewSections ParseSections(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw) ||
+            raw.Equals("all", StringComparison.OrdinalIgnoreCase))
+            return OverviewSections.All;
+
+        var result = OverviewSections.None;
+        foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            result |= part.ToLowerInvariant() switch
+            {
+                "window" => OverviewSections.Window,
+                "detail" => OverviewSections.Detail,
+                "static" => OverviewSections.Static,
+                "all" => OverviewSections.All,
+                _ => throw new BadHttpRequestException(
+                    "Invalid sections parameter (use window, detail, static, or all)")
+            };
+        }
+
+        return result == OverviewSections.None ? OverviewSections.All : result;
     }
 
     public enum OverviewWindow
@@ -29,5 +57,15 @@ public class GetOverviewStatsRequest
         Last7Days,
         Last30Days,
         AllTime,
+    }
+
+    [Flags]
+    public enum OverviewSections
+    {
+        None = 0,
+        Window = 1,
+        Detail = 2,
+        Static = 4,
+        All = Window | Detail | Static,
     }
 }

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -3,6 +3,10 @@ namespace NzbWebDAV.Api.Controllers.GetOverviewStats;
 public class GetOverviewStatsResponse
 {
     public string Window { get; init; } = "24h";
+
+    /// <summary>Which section groups were populated in this response (window, detail, static).</summary>
+    public List<string> IncludedSections { get; init; } = new();
+
     public LiveTiles Tiles { get; init; } = new();
     public List<ThroughputPoint> Throughput { get; init; } = new();
     public long TotalArticles { get; init; }

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -148,7 +148,7 @@ describe("BackendClient", () => {
     })).resolves.toEqual(logs);
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
-      "http://backend/api/get-overview-stats?window=7d",
+      "http://backend/api/get-overview-stats?window=7d&sections=all",
       "http://backend/api/get-logs?limit=50&levels=Warning%2CError&source=Queue&search=failed+request&beforeSequence=42",
     ]);
   });

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -316,8 +316,11 @@ class BackendClient {
         return data;
     }
 
-    public async getOverviewStats(window: OverviewWindow = "24h"): Promise<OverviewStatsResponse> {
-        const url = `${process.env.BACKEND_URL}/api/get-overview-stats?window=${window}`;
+    public async getOverviewStats(
+        window: OverviewWindow = "24h",
+        sections: OverviewSections = "all",
+    ): Promise<OverviewStatsResponse> {
+        const url = `${process.env.BACKEND_URL}/api/get-overview-stats?window=${window}&sections=${sections}`;
         const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
         const response = await fetch(url, {
             method: "GET",
@@ -635,9 +638,11 @@ export enum RepairAction {
 }
 
 export type OverviewWindow = "24h" | "7d" | "30d" | "all";
+export type OverviewSections = "all" | "window" | "detail" | "static" | string;
 
 export type OverviewStatsResponse = {
     window: OverviewWindow,
+    includedSections?: string[],
     tiles: {
         activeReads: number,
         articlesPerMinute: number,

--- a/frontend/app/routes/overview/route.module.css
+++ b/frontend/app/routes/overview/route.module.css
@@ -99,6 +99,24 @@
     gap: 16px;
 }
 
+.skeleton {
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-subtle);
+    background: linear-gradient(
+        90deg,
+        var(--bg-elevated) 0%,
+        color-mix(in srgb, var(--bg-elevated) 60%, var(--bg-surface)) 50%,
+        var(--bg-elevated) 100%
+    );
+    background-size: 200% 100%;
+    animation: overviewSkeletonPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes overviewSkeletonPulse {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+}
+
 @media (max-width: 800px) {
     .twoCol {
         grid-template-columns: 1fr;

--- a/frontend/app/routes/overview/route.module.css.d.ts
+++ b/frontend/app/routes/overview/route.module.css.d.ts
@@ -10,5 +10,6 @@ declare const styles: {
   readonly windowOption: string;
   readonly windowActive: string;
   readonly twoCol: string;
+  readonly skeleton: string;
 };
 export = styles;

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/route";
 import styles from "./route.module.css";
-import { backendClient, type LiveStatsMessage, type OverviewStatsResponse, type OverviewWindow } from "~/clients/backend-client.server";
+import { type LiveStatsMessage, type OverviewStatsResponse, type OverviewWindow } from "~/clients/backend-client.server";
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { receiveMessage } from "~/utils/websocket-util";
 import { DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCenter, type DragEndEvent } from "@dnd-kit/core";
@@ -21,6 +21,7 @@ import { RecordsBlock } from "./components/records-block/records-block";
 import { FailoverSaves } from "./components/failover-saves/failover-saves";
 import { SortableRow } from "./components/sortable-row/sortable-row";
 import { useRowOrder } from "./utils/use-row-order";
+import { EMPTY_OVERVIEW_STATS, mergeOverviewStats } from "./utils/merge-overview-stats";
 
 const topicNames = {
     liveStats: 'ls',
@@ -51,49 +52,103 @@ const DEFAULT_ROW_ORDER = [
     "lifetime",
 ] as const;
 
+/** Shell-only loader — stats load client-side in sections so first paint is instant. */
 export async function loader() {
-    const stats = await backendClient.getOverviewStats("24h");
-    return { stats };
+    return { stats: null as OverviewStatsResponse | null };
 }
 
-export default function Overview({ loaderData }: Route.ComponentProps) {
-    const [stats, setStats] = useState<OverviewStatsResponse>(loaderData.stats);
+export function shouldRevalidate() {
+    return false;
+}
+
+function Skeleton({ height = 120 }: { height?: number }) {
+    return (
+        <div
+            className={styles.skeleton}
+            style={{ minHeight: height }}
+            aria-hidden="true"
+        />
+    );
+}
+
+export default function Overview(_props: Route.ComponentProps) {
+    const [stats, setStats] = useState<OverviewStatsResponse>(EMPTY_OVERVIEW_STATS);
     const [window, setWindow] = useState<OverviewWindow>("24h");
     const [editMode, setEditMode] = useState(false);
     const [connectedAt, setConnectedAt] = useState<number | null>(null);
     const [lastLiveStatsAt, setLastLiveStatsAt] = useState<number | null>(null);
     const [transportFailed, setTransportFailed] = useState(false);
     const [liveClock, setLiveClock] = useState(() => Date.now());
+    const [windowLoaded, setWindowLoaded] = useState(false);
+    const [detailLoaded, setDetailLoaded] = useState(false);
+    const [staticLoaded, setStaticLoaded] = useState(false);
     const { order, save, reset } = useRowOrder(DEFAULT_ROW_ORDER);
 
     const liveTiles = stats.tiles;
     const isLongWindow = window === "7d" || window === "30d" || window === "all";
 
-    // Re-fetch on window change + every 30s so chart, heatmap, providers, etc.
-    // stay fresh without manual refresh. Skipped when the tab is hidden so
-    // background tabs don't churn the backend; an immediate refetch fires when
-    // the tab becomes visible again.
+    // Window section: load on mount / window change, poll every 30s while visible.
     useEffect(() => {
         let cancelled = false;
-        const refetch = async () => {
+        setWindowLoaded(false);
+        if (isLongWindow) setDetailLoaded(true);
+        else setDetailLoaded(false);
+
+        const fetchWindow = async () => {
             if (typeof document !== "undefined" && document.hidden) return;
             try {
-                const res = await fetch(`/api/get-overview-stats?window=${window}`);
+                const res = await fetch(`/api/get-overview-stats?window=${window}&sections=window`);
                 if (!res.ok || cancelled) return;
                 const data: OverviewStatsResponse = await res.json();
-                if (!cancelled) setStats(data);
+                if (cancelled) return;
+                setStats(s => mergeOverviewStats(s, data));
+                setWindowLoaded(true);
             } catch { /* network blip, retry next tick */ }
         };
-        refetch();
-        const interval = setInterval(refetch, 30_000);
-        const onVisible = () => { if (!document.hidden) refetch(); };
+
+        fetchWindow();
+        const interval = setInterval(fetchWindow, 30_000);
+        const onVisible = () => { if (!document.hidden) fetchWindow(); };
         document.addEventListener("visibilitychange", onVisible);
         return () => {
             cancelled = true;
             clearInterval(interval);
             document.removeEventListener("visibilitychange", onVisible);
         };
-    }, [window]);
+    }, [window, isLongWindow]);
+
+    // Detail (latency + errors): once per 24h window selection — not on the 30s poll.
+    useEffect(() => {
+        if (isLongWindow) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch(`/api/get-overview-stats?window=${window}&sections=detail`);
+                if (!res.ok || cancelled) return;
+                const data: OverviewStatsResponse = await res.json();
+                if (cancelled) return;
+                setStats(s => mergeOverviewStats(s, data));
+                setDetailLoaded(true);
+            } catch { /* ignore */ }
+        })();
+        return () => { cancelled = true; };
+    }, [window, isLongWindow]);
+
+    // Static blocks: once per page visit.
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch(`/api/get-overview-stats?window=${window}&sections=static`);
+                if (!res.ok || cancelled) return;
+                const data: OverviewStatsResponse = await res.json();
+                if (cancelled) return;
+                setStats(s => mergeOverviewStats(s, data));
+                setStaticLoaded(true);
+            } catch { /* ignore */ }
+        })();
+        return () => { cancelled = true; };
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps -- once per visit
 
     const onWsMessage = useCallback((topic: string, message: string) => {
         if (topic !== topicNames.liveStats) return;
@@ -151,54 +206,80 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     const rowContent = useMemo<Record<string, ReactNode>>(() => ({
         liveTiles: <LiveTiles tiles={liveTiles} />,
         liveReads: <LiveReadsPanel />,
-        throughput: (
-            <ThroughputChart
-                points={stats.throughput}
-                totalArticles={stats.totalArticles}
-                totalErrors={stats.totalErrors}
-                totalBytesServed={stats.sessions.totalBytesServed}
-                window={window}
-            />
-        ),
-        activity: (
-            <ActivityHeatmap
-                maxCell={stats.heatmap.maxCell}
-                mode={stats.heatmap.mode}
-                windowStartMs={stats.heatmap.windowStartMs}
-                windowEndMs={stats.heatmap.windowEndMs}
-                bucketSizeMs={stats.heatmap.bucketSizeMs}
-                cells={stats.heatmap.cells}
-            />
-        ),
-        latency: !isLongWindow
+        throughput: windowLoaded
             ? (
-                <LatencyHistogram
-                    p50Ms={stats.latency.p50Ms}
-                    p95Ms={stats.latency.p95Ms}
-                    p99Ms={stats.latency.p99Ms}
-                    samples={stats.latency.samples}
-                    buckets={stats.latency.buckets}
+                <ThroughputChart
+                    points={stats.throughput}
+                    totalArticles={stats.totalArticles}
+                    totalErrors={stats.totalErrors}
+                    totalBytesServed={stats.sessions.totalBytesServed}
+                    window={window}
                 />
             )
+            : <Skeleton height={180} />,
+        activity: windowLoaded
+            ? (
+                <ActivityHeatmap
+                    maxCell={stats.heatmap.maxCell}
+                    mode={stats.heatmap.mode}
+                    windowStartMs={stats.heatmap.windowStartMs}
+                    windowEndMs={stats.heatmap.windowEndMs}
+                    bucketSizeMs={stats.heatmap.bucketSizeMs}
+                    cells={stats.heatmap.cells}
+                />
+            )
+            : <Skeleton height={140} />,
+        latency: !isLongWindow
+            ? (detailLoaded
+                ? (
+                    <LatencyHistogram
+                        p50Ms={stats.latency.p50Ms}
+                        p95Ms={stats.latency.p95Ms}
+                        p99Ms={stats.latency.p99Ms}
+                        samples={stats.latency.samples}
+                        buckets={stats.latency.buckets}
+                    />
+                )
+                : <Skeleton height={160} />)
             : null,
         errorsSessions: (
             <div className={styles.twoCol}>
-                {!isLongWindow && <ErrorDonut errors={stats.errors} />}
-                <SessionsBlock sessions={stats.sessions} window={window} />
+                {!isLongWindow && (
+                    detailLoaded
+                        ? <ErrorDonut errors={stats.errors} />
+                        : <Skeleton height={160} />
+                )}
+                {windowLoaded
+                    ? <SessionsBlock sessions={stats.sessions} window={window} />
+                    : <Skeleton height={160} />}
             </div>
         ),
-        providers: <ProviderScoreboard providers={stats.providers} window={window} />,
-        failover: <FailoverSaves failover={stats.failover} window={window} />,
-        indexers: <IndexerScoreboard indexers={stats.indexers} />,
-        indexerApiUsage: <IndexerApiUsage rows={stats.indexerApiUsage} />,
+        providers: windowLoaded
+            ? <ProviderScoreboard providers={stats.providers} window={window} />
+            : <Skeleton height={160} />,
+        failover: windowLoaded
+            ? <FailoverSaves failover={stats.failover} window={window} />
+            : <Skeleton height={180} />,
+        indexers: staticLoaded
+            ? <IndexerScoreboard indexers={stats.indexers} />
+            : <Skeleton height={140} />,
+        indexerApiUsage: staticLoaded
+            ? <IndexerApiUsage rows={stats.indexerApiUsage} />
+            : <Skeleton height={120} />,
         recordsCatalogue: (
             <div className={styles.twoCol}>
-                <RecordsBlock records={stats.records} />
-                <CatalogueBlock catalogue={stats.catalogue} />
+                {staticLoaded
+                    ? <RecordsBlock records={stats.records} />
+                    : <Skeleton height={120} />}
+                {staticLoaded
+                    ? <CatalogueBlock catalogue={stats.catalogue} />
+                    : <Skeleton height={120} />}
             </div>
         ),
-        lifetime: <LifetimeBlock lifetime={stats.lifetime} />,
-    }), [liveTiles, stats, window, isLongWindow]);
+        lifetime: staticLoaded
+            ? <LifetimeBlock lifetime={stats.lifetime} />
+            : <Skeleton height={120} />,
+    }), [liveTiles, stats, window, isLongWindow, windowLoaded, detailLoaded, staticLoaded]);
 
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_OVERVIEW_STATS, mergeOverviewStats } from "./merge-overview-stats";
+import type { OverviewStatsResponse } from "~/clients/backend-client.server";
+
+function partial(overrides: Partial<OverviewStatsResponse> & { includedSections: string[] }): OverviewStatsResponse {
+    return { ...EMPTY_OVERVIEW_STATS, ...overrides };
+}
+
+describe("mergeOverviewStats", () => {
+    it("merges window section without wiping static data", () => {
+        const withStatic = mergeOverviewStats(
+            EMPTY_OVERVIEW_STATS,
+            partial({
+                includedSections: ["static"],
+                catalogue: { fileCount: 42, totalBytes: 100, largestFileBytes: 50, addedLast7Days: 3 },
+                indexers: [{ name: "NZB", completed: 1, failed: 0, bytesCompleted: 10, avgSeconds: 2, successRate: 1 }],
+            }),
+        );
+
+        const withWindow = mergeOverviewStats(
+            withStatic,
+            partial({
+                includedSections: ["window"],
+                totalArticles: 99,
+                throughput: [{ bucket: 1, articles: 5, errors: 0, bytesServed: 10 }],
+                tiles: { activeReads: 2, articlesPerMinute: 10, errorsPerMinute: 0, bytesServedPerMinute: 1000 },
+            }),
+        );
+
+        expect(withWindow.totalArticles).toBe(99);
+        expect(withWindow.throughput).toHaveLength(1);
+        expect(withWindow.catalogue.fileCount).toBe(42);
+        expect(withWindow.indexers).toHaveLength(1);
+        expect(withWindow.includedSections).toEqual(expect.arrayContaining(["static", "window"]));
+    });
+
+    it("merges detail latency without clearing window throughput", () => {
+        const withWindow = mergeOverviewStats(
+            EMPTY_OVERVIEW_STATS,
+            partial({
+                includedSections: ["window"],
+                throughput: [{ bucket: 1, articles: 5, errors: 0, bytesServed: 10 }],
+            }),
+        );
+
+        const withDetail = mergeOverviewStats(
+            withWindow,
+            partial({
+                includedSections: ["detail"],
+                latency: { p50Ms: 12, p95Ms: 40, p99Ms: 90, samples: 100, buckets: [] },
+                errors: [{ status: "Missing", count: 3 }],
+            }),
+        );
+
+        expect(withDetail.throughput).toHaveLength(1);
+        expect(withDetail.latency.p50Ms).toBe(12);
+        expect(withDetail.errors).toEqual([{ status: "Missing", count: 3 }]);
+    });
+});

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -1,0 +1,109 @@
+import type { OverviewStatsResponse } from "~/clients/backend-client.server";
+
+export const EMPTY_OVERVIEW_STATS: OverviewStatsResponse = {
+    window: "24h",
+    includedSections: [],
+    tiles: {
+        activeReads: 0,
+        articlesPerMinute: 0,
+        errorsPerMinute: 0,
+        bytesServedPerMinute: 0,
+    },
+    throughput: [],
+    totalArticles: 0,
+    totalErrors: 0,
+    totalBytesFetched: 0,
+    providers: [],
+    catalogue: { fileCount: 0, totalBytes: 0, largestFileBytes: 0, addedLast7Days: 0 },
+    sessions: {
+        count: 0,
+        totalBytesServed: 0,
+        avgDurationMs: 0,
+        longestDurationMs: 0,
+        biggestReadBytes: 0,
+    },
+    heatmap: {
+        maxCell: 0,
+        mode: "day",
+        windowStartMs: 0,
+        windowEndMs: 0,
+        bucketSizeMs: 3_600_000,
+        cells: [],
+    },
+    latency: { p50Ms: 0, p95Ms: 0, p99Ms: 0, samples: 0, buckets: [] },
+    errors: [],
+    indexers: [],
+    indexerApiUsage: [],
+    lifetime: {
+        bytesFetched: 0,
+        bytesRead: 0,
+        articles: 0,
+        readSessions: 0,
+        readSeconds: 0,
+        firstSeenAt: null,
+    },
+    records: {
+        bestDayBytes: 0,
+        bestDayAt: null,
+        bestHourBytes: 0,
+        bestHourAt: null,
+    },
+    failover: {
+        articlesRecovered: 0,
+        previousArticlesRecovered: null,
+        segmentsCovered: 0,
+        readsSaved: 0,
+        readSessions: 0,
+        totalArticles: 0,
+        bucketSizeMs: 3_600_000,
+        rescuedBy: [],
+        rescuedFrom: [],
+        reasons: [],
+        buckets: [],
+    },
+    metricsHealth: {
+        queued: 0,
+        dropped: 0,
+        lastSuccessfulFlushAtMs: 0,
+        lastFlushError: null,
+    },
+};
+
+export function mergeOverviewStats(
+    prev: OverviewStatsResponse,
+    partial: OverviewStatsResponse,
+): OverviewStatsResponse {
+    const sections = new Set(partial.includedSections ?? ["all"]);
+    const includeAll = sections.has("all");
+    const next: OverviewStatsResponse = { ...prev };
+
+    if (includeAll || sections.has("window")) {
+        next.window = partial.window;
+        next.tiles = partial.tiles;
+        next.throughput = partial.throughput;
+        next.totalArticles = partial.totalArticles;
+        next.totalErrors = partial.totalErrors;
+        next.totalBytesFetched = partial.totalBytesFetched;
+        next.providers = partial.providers;
+        next.sessions = partial.sessions;
+        next.heatmap = partial.heatmap;
+        next.failover = partial.failover;
+        next.metricsHealth = partial.metricsHealth;
+    }
+    if (includeAll || sections.has("detail")) {
+        next.latency = partial.latency;
+        next.errors = partial.errors;
+    }
+    if (includeAll || sections.has("static")) {
+        next.catalogue = partial.catalogue;
+        next.indexers = partial.indexers;
+        next.indexerApiUsage = partial.indexerApiUsage;
+        next.lifetime = partial.lifetime;
+        next.records = partial.records;
+    }
+
+    next.includedSections = [
+        ...new Set([...(prev.includedSections ?? []), ...(partial.includedSections ?? [])]),
+    ];
+    return next;
+}

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsRequestTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetOverviewStatsRequestTests
+{
+    [Theory]
+    [InlineData(null, GetOverviewStatsRequest.OverviewSections.All)]
+    [InlineData("", GetOverviewStatsRequest.OverviewSections.All)]
+    [InlineData("all", GetOverviewStatsRequest.OverviewSections.All)]
+    [InlineData("window", GetOverviewStatsRequest.OverviewSections.Window)]
+    [InlineData("detail", GetOverviewStatsRequest.OverviewSections.Detail)]
+    [InlineData("static", GetOverviewStatsRequest.OverviewSections.Static)]
+    [InlineData("window,detail", GetOverviewStatsRequest.OverviewSections.Window | GetOverviewStatsRequest.OverviewSections.Detail)]
+    [InlineData("window, static", GetOverviewStatsRequest.OverviewSections.Window | GetOverviewStatsRequest.OverviewSections.Static)]
+    public void ParsesSectionsQueryParam(string? sections, GetOverviewStatsRequest.OverviewSections expected)
+    {
+        var context = new DefaultHttpContext();
+        if (sections is not null)
+            context.Request.QueryString = new QueryString($"?sections={sections}");
+
+        var request = new GetOverviewStatsRequest(context);
+
+        Assert.Equal(expected, request.Sections);
+    }
+
+    [Fact]
+    public void RejectsUnknownSection()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?sections=window,nope");
+
+        Assert.Throws<BadHttpRequestException>(() => new GetOverviewStatsRequest(context));
+    }
+
+    [Theory]
+    [InlineData("24h", GetOverviewStatsRequest.OverviewWindow.Last24Hours)]
+    [InlineData("7d", GetOverviewStatsRequest.OverviewWindow.Last7Days)]
+    [InlineData("30d", GetOverviewStatsRequest.OverviewWindow.Last30Days)]
+    [InlineData("all", GetOverviewStatsRequest.OverviewWindow.AllTime)]
+    public void ParsesWindowQueryParam(string window, GetOverviewStatsRequest.OverviewWindow expected)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?window={window}&sections=window");
+
+        var request = new GetOverviewStatsRequest(context);
+
+        Assert.Equal(expected, request.Window);
+        Assert.Equal(GetOverviewStatsRequest.OverviewSections.Window, request.Sections);
+    }
+}


### PR DESCRIPTION
## Summary
- Overview no longer blocks SSR on a monolithic `get-overview-stats` call; the page shell paints immediately with skeletons.
- Split the API into `sections=window|detail|static` so charts poll independently from catalogue/lifetime/indexers and latency/errors.
- Drive 24h window stats from `ProviderMinutes` / `ThroughputMinutes` instead of loading every `SegmentFetch`, and parallelize independent DB queries.

## Test plan
- [ ] Cold-load Overview — header/shell appears immediately; widgets fill in as sections return
- [ ] Confirm 24h throughput, providers, failover, heatmap, and sessions look correct
- [ ] Confirm latency + error donut load for 24h and stay hidden on 7d/30d/all
- [ ] Switch windows and verify only window (+ detail on 24h) refetch; static blocks stay put
- [ ] Leave the tab open ~30s and confirm only window section re-polls
- [ ] `dotnet test` filter `GetOverviewStatsRequestTests` and frontend merge/client tests pass