### PR TITLE
chore(deps): remove unused Microsoft.AspNetCore.OpenApi package

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -10,7 +10,6 @@
 
     <ItemGroup>
       <PackageReference Include="MemoryPack" Version="1.21.4" />
-      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Remove unused `Microsoft.AspNetCore.OpenApi` PackageReference from `backend/NzbWebDAV.csproj`
- Clears the vulnerable `Microsoft.OpenApi` transitive without runtime behavior changes

Fixes #178

## Test plan
- [ ] Backend builds cleanly
- [ ] Backend tests pass in CI