### PR TITLE
chore(api): remove unread constructor parameters (CS9113)

### DIFF
--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -33,7 +33,6 @@ public class ProfilePlayController(
     QueueManager queueManager,
     WebsocketManager websocketManager,
     QueueItemSourceTracker sourceTracker,
-    LazyRarResolver lazyRarResolver,
     NzbFetchCoalescer nzbFetchCoalescer,
     PreflightCache preflightCache,
     PreflightSessionRegistry preflightSessions,

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -1,6 +1,5 @@
 using System.Text.RegularExpressions;
 using NzbWebDAV.Clients.Usenet;
-using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
@@ -19,7 +18,6 @@ namespace NzbWebDAV.Queue.FileProcessors;
 public class LazyRarProcessor(
     List<GetFileInfosStep.FileInfo> fileInfos,
     INntpClient usenetClient,
-    ConfigManager configManager,
     string? password,
     CancellationToken ct
 ) : BaseProcessor

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -243,7 +243,7 @@ public class QueueItemProcessor(
         var rarFiles = fileInfos.Where(x => GetGroupName(x) == "rar").ToList();
         if (configManager.IsLazyRarParsingEnabled() && rarFiles.Count > 0)
         {
-            var lazyProc = new LazyRarProcessor(rarFiles, usenetClient, configManager, archivePassword, ct);
+            var lazyProc = new LazyRarProcessor(rarFiles, usenetClient, archivePassword, ct);
             lazyRarResult = await lazyProc.ProcessAsync().ConfigureAwait(false) as LazyRarProcessor.Result;
         }
         var msRar = stepTimer.ElapsedMilliseconds;

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -159,7 +159,7 @@ public class DatabaseStoreCollection(
                     davItem.Name, "", httpContext, dbClient, usenetClient, configManager, lazyRarResolver),
             DavItem.ItemSubType.NzbsRoot =>
                 new DatabaseStoreWatchFolder(
-                    davItem, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager),
+                    davItem, dbClient, configManager, queueManager, websocketManager),
             DavItem.ItemSubType.Directory or DavItem.ItemSubType.ContentRoot  =>
                 new DatabaseStoreCollection(
                     davItem, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,

--- a/backend/WebDav/DatabaseStoreWatchFolder.cs
+++ b/backend/WebDav/DatabaseStoreWatchFolder.cs
@@ -1,7 +1,5 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using NWebDav.Server.Stores;
-using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -14,10 +12,8 @@ namespace NzbWebDAV.WebDav;
 
 public class DatabaseStoreWatchFolder(
     DavItem davDirectory,
-    HttpContext httpContext,
     DavDatabaseClient dbClient,
     ConfigManager configManager,
-    UsenetStreamingClient usenetClient,
     QueueManager queueManager,
     WebsocketManager websocketManager
 ) : BaseStoreReadonlyCollection


### PR DESCRIPTION
## Summary
- Remove unused primary-constructor parameters that triggered CS9113
- Update LazyRarProcessor and DatabaseStoreWatchFolder construction sites

Fixes #181

## Test plan
- [ ] Backend builds with CS9113 gone for these sites
- [ ] Backend tests pass in CI