### PR TITLE
chore(ci): cache NuGet packages for backend CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,20 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore backend
+        run: dotnet restore backend/NzbWebDAV.csproj && dotnet restore tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
+
       - name: Build backend
         working-directory: backend
-        run: dotnet publish -c Release -o ./publish
+        run: dotnet publish -c Release -o ./publish --no-restore
 
       - name: Test backend
-        run: dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release
+        run: dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore


### PR DESCRIPTION
## Summary
- Cache `~/.nuget/packages` with `actions/cache` keyed on csproj hashes
- Shared `dotnet restore` then `--no-restore` on publish/test
- No packages.lock.json

Fixes #188

## Test plan
- [ ] Backend CI restores from cache on subsequent runs
- [ ] Build and tests still pass