### PR TITLE
fix(ui): remove dead /p/ proxy prefix from allowlists

### DIFF
--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -36,7 +36,6 @@ app.use(
         path.startsWith("/content") ||
         path.startsWith("/completed-symlinks") ||
         path.startsWith("/api") ||
-        path.startsWith("/p/") ||
         path.startsWith("/adapters/")
       ) {
         return false;

--- a/frontend/server/proxy-path.test.ts
+++ b/frontend/server/proxy-path.test.ts
@@ -18,7 +18,6 @@ describe("shouldProxyToBackend", () => {
     "/nzbs/file.nzb",
     "/content/file.mkv",
     "/completed-symlinks/movie",
-    "/p/profile-token/play/item.mkv",
     "/adapters/addon/profile-token/manifest.json",
     "/adapters/newznab/profile-token/api",
   ])("proxies backend path %s", (path) => {

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -5,7 +5,6 @@ const BACKEND_PATH_PREFIXES = [
   "/nzbs",
   "/content",
   "/completed-symlinks",
-  "/p/",
   "/adapters/",
 ];
 


### PR DESCRIPTION
## Summary
- Remove `/p/` from `BACKEND_PATH_PREFIXES` and compression skip list
- Update proxy-path tests accordingly

Fixes #182

## Test plan
- [ ] `npm test -- server/proxy-path.test.ts` passes
- [ ] Frontend CI green