### PR TITLE
docs: mark release-announcement.md as historical (frozen 0.7.2)

### DIFF
--- a/docs/release-announcement.md
+++ b/docs/release-announcement.md
@@ -1,4 +1,7 @@
-# NzbDav stack release announcement (0.7.x / .NET 10)
+> **Historical document (frozen as of 0.7.2).**  
+> This announcement captures the coordinated 0.7.2 stack release. Version numbers below are **not** kept current — see [GitHub Releases](https://github.com/nzbdav/nzbdav/releases) for the latest. Do not bump the tables in this file.
+
+# NzbDav stack release announcement (historical, 0.7.2)
 
 This document summarizes the coordinated releases across the [nzbdav](https://github.com/nzbdav) organization: a fork of [nzbdav-dev/nzbdav](https://github.com/nzbdav-dev/nzbdav) with ownership of the full Usenet streaming dependency tree.
 


### PR DESCRIPTION
## Summary
- Retitle and banner `docs/release-announcement.md` as a dated historical doc frozen at 0.7.2
- Point readers to GitHub Releases for current versions

Fixes #192

## Test plan
- [ ] Banner is visible at top of the doc