### PR TITLE
docs: document preferred run-backend and sync-dev-env workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ export FRONTEND_BACKEND_API_KEY=$(head -c 32 /dev/urandom | hexdump -ve '1/1 "%.
 export BACKEND_URL=http://localhost:5000
 ```
 
+Preferred: `./scripts/run-backend.sh` (Terminal 1) + `cd frontend && npm run dev` (Terminal 2; `predev` runs `scripts/sync-dev-env.sh`). Manual alternative:
+
 ```bash
 # Terminal 1 — backend
 cd backend && dotnet publish -c Release -o ./publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,20 @@ Example installation for Arch based systems:
 sudo pacman -S dotnet-sdk aspnet-runtime nodejs npm
 ```
 
+## Preferred local workflow
+
+Use the helper scripts so the frontend and backend share env automatically:
+
+```bash
+# Terminal 1 — backend (builds, migrates, writes frontend/.env)
+./scripts/run-backend.sh
+
+# Terminal 2 — frontend (`predev` runs scripts/sync-dev-env.sh)
+cd frontend && npm install && npm run dev
+```
+
+`npm run dev` silently runs `scripts/sync-dev-env.sh` via the `predev` hook; if the API key drifts, restart the backend with `scripts/run-backend.sh`. The manual `dotnet publish` / env-var flow below remains supported.
+
 ## Build / run backend
 
 The `NzbDav.UsenetSharp` dependency is published on NuGet.org and restores without


### PR DESCRIPTION
## Summary
- Document preferred `scripts/run-backend.sh` + `npm run dev` (predev sync) in CONTRIBUTING.md
- Point AGENTS.md Local development at the same preferred flow

Fixes #193

## Test plan
- [ ] Docs match scripts/run-backend.sh and frontend predev hook behavior