### PR TITLE
refactor(db): encapsulate pending blob writes on DavDatabaseContext

### DIFF
--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -63,10 +63,43 @@ public sealed class DavDatabaseContext : DbContext
     public DbSet<ListSource> ListSources => Set<ListSource>();
     public DbSet<WantedItem> WantedItems => Set<WantedItem>();
 
-    // blob items
-    public List<DavNzbFile> BlobNzbFiles = [];
-    public List<DavRarFile> BlobRarFiles = [];
-    public List<DavMultipartFile> BlobMultipartFiles = [];
+    // Pending blob writes for the current unit of work (flushed in SaveChangesAsync).
+    private readonly List<DavNzbFile> _blobNzbFiles = [];
+    private readonly List<DavRarFile> _blobRarFiles = [];
+    private readonly List<DavMultipartFile> _blobMultipartFiles = [];
+
+    public IReadOnlyList<DavNzbFile> BlobNzbFiles => _blobNzbFiles;
+    public IReadOnlyList<DavRarFile> BlobRarFiles => _blobRarFiles;
+    public IReadOnlyList<DavMultipartFile> BlobMultipartFiles => _blobMultipartFiles;
+
+    public void AddBlob(DavNzbFile file) => _blobNzbFiles.Add(file);
+    public void AddBlob(DavRarFile file) => _blobRarFiles.Add(file);
+    public void AddBlob(DavMultipartFile file) => _blobMultipartFiles.Add(file);
+
+    public void RemoveNzbBlob(Guid? id)
+    {
+        if (id is null) return;
+        _blobNzbFiles.RemoveAll(x => x.Id == id);
+    }
+
+    public void RemoveRarBlob(Guid? id)
+    {
+        if (id is null) return;
+        _blobRarFiles.RemoveAll(x => x.Id == id);
+    }
+
+    public void RemoveMultipartBlob(Guid? id)
+    {
+        if (id is null) return;
+        _blobMultipartFiles.RemoveAll(x => x.Id == id);
+    }
+
+    public void ClearBlobs()
+    {
+        _blobNzbFiles.Clear();
+        _blobRarFiles.Clear();
+        _blobMultipartFiles.Clear();
+    }
 
     // tables
     protected override void OnModelCreating(ModelBuilder b)
@@ -680,9 +713,7 @@ public sealed class DavDatabaseContext : DbContext
             _ = RcloneVfsForget(addedOrRemovedDavItems);
 
             // clear pending blob writes
-            BlobNzbFiles.Clear();
-            BlobRarFiles.Clear();
-            BlobMultipartFiles.Clear();
+            ClearBlobs();
 
             // return
             return result;
@@ -756,9 +787,7 @@ public sealed class DavDatabaseContext : DbContext
     public void ClearChangeTracker()
     {
         ChangeTracker.Clear();
-        BlobNzbFiles.Clear();
-        BlobRarFiles.Clear();
-        BlobMultipartFiles.Clear();
+        ClearBlobs();
     }
 
     /// <summary>

--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -41,7 +41,7 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
             );
 
             dbClient.Ctx.Items.Add(davItem);
-            dbClient.Ctx.BlobNzbFiles.Add(davNzbFile);
+            dbClient.Ctx.AddBlob(davNzbFile);
         }
     }
 }

--- a/backend/Queue/FileAggregators/MultipartMkvAggregator.cs
+++ b/backend/Queue/FileAggregators/MultipartMkvAggregator.cs
@@ -54,7 +54,7 @@ public class MultipartMkvAggregator(
             );
 
             dbClient.Ctx.Items.Add(davItem);
-            dbClient.Ctx.BlobMultipartFiles.Add(davMultipartFile);
+            dbClient.Ctx.AddBlob(davMultipartFile);
         }
     }
 }

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -68,7 +68,7 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
         );
 
         dbClient.Ctx.Items.Add(davItem);
-        dbClient.Ctx.BlobMultipartFiles.Add(davMultipartFile);
+        dbClient.Ctx.AddBlob(davMultipartFile);
     }
 
     private void ProcessArchive(List<RarProcessor.StoredFileSegment> fileSegments)
@@ -131,7 +131,7 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             );
 
             dbClient.Ctx.Items.Add(davItem);
-            dbClient.Ctx.BlobMultipartFiles.Add(davMultipartFile);
+            dbClient.Ctx.AddBlob(davMultipartFile);
         }
     }
 

--- a/backend/Queue/FileAggregators/SevenZipAggregator.cs
+++ b/backend/Queue/FileAggregators/SevenZipAggregator.cs
@@ -60,7 +60,7 @@ public class SevenZipAggregator(
             );
 
             dbClient.Ctx.Items.Add(davItem);
-            dbClient.Ctx.BlobMultipartFiles.Add(davMultipartFile);
+            dbClient.Ctx.AddBlob(davMultipartFile);
         }
     }
 }

--- a/backend/Queue/PostProcessors/BlocklistedFilePostProcessor.cs
+++ b/backend/Queue/PostProcessors/BlocklistedFilePostProcessor.cs
@@ -41,7 +41,7 @@ public class BlocklistedFilePostProcessor(ConfigManager configManager, DavDataba
     {
         if (davItem.SubType == DavItem.ItemSubType.NzbFile)
         {
-            dbClient.Ctx.BlobNzbFiles.RemoveAll(x => x.Id == davItem.FileBlobId);
+            dbClient.Ctx.RemoveNzbBlob(davItem.FileBlobId);
             var file = dbClient.Ctx.ChangeTracker.Entries<DavNzbFile>()
                 .Where(x => x.State == EntityState.Added)
                 .Select(x => x.Entity)
@@ -52,7 +52,7 @@ public class BlocklistedFilePostProcessor(ConfigManager configManager, DavDataba
 
         else if (davItem.SubType == DavItem.ItemSubType.RarFile)
         {
-            dbClient.Ctx.BlobRarFiles.RemoveAll(x => x.Id == davItem.FileBlobId);
+            dbClient.Ctx.RemoveRarBlob(davItem.FileBlobId);
             var file = dbClient.Ctx.ChangeTracker.Entries<DavRarFile>()
                 .Where(x => x.State == EntityState.Added)
                 .Select(x => x.Entity)
@@ -63,7 +63,7 @@ public class BlocklistedFilePostProcessor(ConfigManager configManager, DavDataba
 
         else if (davItem.SubType == DavItem.ItemSubType.MultipartFile)
         {
-            dbClient.Ctx.BlobMultipartFiles.RemoveAll(x => x.Id == davItem.FileBlobId);
+            dbClient.Ctx.RemoveMultipartBlob(davItem.FileBlobId);
             var file = dbClient.Ctx.ChangeTracker.Entries<DavMultipartFile>()
                 .Where(x => x.State == EntityState.Added)
                 .Select(x => x.Entity)


### PR DESCRIPTION
## Summary
- Encapsulate pending blob unit-of-work state behind AddBlob/Remove*Blob/ClearBlobs
- Expose read-only lists for SaveChangesAsync iteration
- Update aggregator and blocklist post-processor call sites

Fixes #189

## Test plan
- [ ] Backend builds
- [ ] Backend tests pass in CI