### PR TITLE
fix(queue): heal lazy RAR volume size underestimates

### DIFF
--- a/backend/Exceptions/RarSeekPastEndException.cs
+++ b/backend/Exceptions/RarSeekPastEndException.cs
@@ -1,0 +1,9 @@
+namespace NzbWebDAV.Exceptions;
+
+// Header parse failed because the parser seeked beyond the stream's declared
+// length. Distinct from generic corruption: it usually means the volume's
+// stream length was estimated too small (see LazyRarResolver's measured-size
+// retry), not that the archive data itself is bad.
+public class RarSeekPastEndException(string message) : CorruptRarException(message)
+{
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -139,7 +139,12 @@ class Program
                     new ProviderUsageTracker(sp.GetRequiredService<ActiveReadRegistry>()))
                 .AddSingleton<QueueItemSourceTracker>()
                 .AddSingleton<UsenetStreamingClient>()
-                .AddSingleton<LazyRarResolver>()
+                // LazyRarResolver takes INntpClient (for testability) but must
+                // use the shared streaming client; wire it explicitly instead
+                // of registering a container-wide INntpClient binding.
+                .AddSingleton<LazyRarResolver>(sp => new LazyRarResolver(
+                    sp.GetRequiredService<UsenetStreamingClient>(),
+                    sp.GetRequiredService<ConfigManager>()))
                 .AddSingleton<QueueManager>()
                 .AddSingleton<NzbResolutionCache>()
                 .AddSingleton<PreferredOrderStore>()

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -134,21 +134,24 @@ public class LazyRarProcessor(
         };
 
         var trailingInfos = sorted.Skip(1).ToList();
-        var partSizes = trailingInfos
-            .Select(pi => pi.FileSize ?? (long)(pi.NzbFile.GetTotalYencodedSize() * YencDecodeRatio))
-            .ToArray();
 
         var pending = new List<DavMultipartFile.PendingPart>(trailingInfos.Count);
         var pendingSum = 0L;
         for (var i = 0; i < trailingInfos.Count; i++)
         {
             var partInfo = trailingInfos[i];
-            var partSize = partSizes[i];
-            var estimate = Math.Max(0, partSize - ContinuationHeaderGuess);
+            // Stream length must be an upper bound: SharpCompress seekable
+            // header parsing seeks to dataStart+packedSize before yielding
+            // the file header. Encoded size is always >= decoded size, so
+            // use it (not *0.95) when PAR2 FileSize is unavailable.
+            var streamLength = partInfo.FileSize ?? partInfo.NzbFile.GetTotalYencodedSize();
+            var estimateSource = partInfo.FileSize
+                ?? (long)(partInfo.NzbFile.GetTotalYencodedSize() * YencDecodeRatio);
+            var estimate = Math.Max(0, estimateSource - ContinuationHeaderGuess);
             pending.Add(new DavMultipartFile.PendingPart
             {
                 SegmentIds = partInfo.NzbFile.GetSegmentIds(),
-                SegmentIdByteRange = LongRange.FromStartAndSize(0, partSize),
+                SegmentIdByteRange = LongRange.FromStartAndSize(0, streamLength),
                 EstimatedDataSize = estimate,
             });
             pendingSum += estimate;

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -16,7 +16,7 @@ namespace NzbWebDAV.Services;
 // First reader to need part N pays the cost (~1 segment fetch + parse);
 // subsequent readers reuse the resolved FilePart. The whole resolved
 // archive is written back to the blob-store so restarts also reuse it.
-public class LazyRarResolver(UsenetStreamingClient usenetClient, ConfigManager configManager)
+public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManager)
 {
     // Coalesces concurrent resolution requests for the same volume.
     // Keyed by the volume's first segment ID so two readers asking for the
@@ -25,6 +25,10 @@ public class LazyRarResolver(UsenetStreamingClient usenetClient, ConfigManager c
     private readonly ConcurrentDictionary<(Guid, string), Task<DavMultipartFile.FilePart>> _inFlight = new();
 
     private readonly ConcurrentDictionary<Guid, Persistor> _persistors = new();
+
+    // Test seam: when set, volume opens skip NzbFileStream/yEnc so unit tests
+    // can feed a crafted RAR with an understated Length without rapidyenc.
+    internal Func<string[], long, Stream>? VolumeStreamFactory { get; set; }
 
     private sealed class Persistor
     {
@@ -143,16 +147,52 @@ public class LazyRarResolver(UsenetStreamingClient usenetClient, ConfigManager c
         var pathInArchive = meta.PathInArchive
             ?? throw new InvalidOperationException("Lazy RAR meta missing PathInArchive.");
 
-        await using var stream = usenetClient.GetFileStream(
-            pending.SegmentIds, pending.SegmentIdByteRange.Count, articleBufferSize: 0);
+        var estimatedSize = pending.SegmentIdByteRange.Count;
+        try
+        {
+            return await ParseVolumeHeaderAsync(
+                    pending, pathInArchive, meta.ArchivePassword, estimatedSize, ct)
+                .ConfigureAwait(false);
+        }
+        catch (RarSeekPastEndException)
+        {
+            // Pending SegmentIdByteRange was estimated (e.g. yEnc*0.95) and
+            // understated the real volume length. Measure from the last
+            // segment's yEnc header and retry once with the exact size.
+            var measuredSize = await MeasureVolumeSizeAsync(pending.SegmentIds, ct)
+                .ConfigureAwait(false);
+            if (measuredSize <= estimatedSize)
+                throw;
+
+            Log.Debug(
+                "Lazy RAR volume size estimate {Estimated} was too small for multipart {Id}; " +
+                "retrying header parse with measured size {Measured}.",
+                estimatedSize, mpf.Id, measuredSize);
+            return await ParseVolumeHeaderAsync(
+                    pending, pathInArchive, meta.ArchivePassword, measuredSize, ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task<DavMultipartFile.FilePart> ParseVolumeHeaderAsync(
+        DavMultipartFile.PendingPart pending,
+        string pathInArchive,
+        string? password,
+        long fileSize,
+        CancellationToken ct)
+    {
+        await using var stream = OpenVolumeStream(pending.SegmentIds, fileSize);
 
         // Find-and-stop so SharpCompress never seeks past the matched header.
         // The seek would force NzbFileStream to fire InterpolationSearch
         // (~7 STAT calls), which is the main reason naïve full-walk
         // resolution stalls playback at every volume boundary.
+        // Note: seekable SharpCompress still seeks past the matched file's
+        // packed data before yielding the header, so fileSize must be at
+        // least dataStart + packedSize.
         var match = await RarUtil.FindFirstFileHeaderAsync(
             stream,
-            meta.ArchivePassword,
+            password,
             h => h.GetFileName() == pathInArchive,
             ct).ConfigureAwait(false)
             ?? throw new CorruptRarException(
@@ -166,6 +206,18 @@ public class LazyRarResolver(UsenetStreamingClient usenetClient, ConfigManager c
             SegmentIdByteRange = LongRange.FromStartAndSize(0, dataStart + dataSize),
             FilePartByteRange = LongRange.FromStartAndSize(dataStart, dataSize),
         };
+    }
+
+    private Stream OpenVolumeStream(string[] segmentIds, long fileSize) =>
+        VolumeStreamFactory?.Invoke(segmentIds, fileSize)
+        ?? usenetClient.GetFileStream(segmentIds, fileSize, articleBufferSize: 0);
+
+    private async Task<long> MeasureVolumeSizeAsync(string[] segmentIds, CancellationToken ct)
+    {
+        if (segmentIds.Length == 0) return 0;
+        var headers = await usenetClient.GetYencHeadersAsync(segmentIds[^1], ct)
+            .ConfigureAwait(false);
+        return headers.PartOffset + headers.PartSize;
     }
 
     // Atomically appends consecutive resolveds that match the head of

--- a/backend/Utils/RarUtil.cs
+++ b/backend/Utils/RarUtil.cs
@@ -176,7 +176,7 @@ public static class RarUtil
         {
             var offset = FormatActualValue(seekPastEnd!.ActualValue);
             var length = TryGetStreamLength(stream);
-            mapped = new CorruptRarException(
+            mapped = new RarSeekPastEndException(
                 $"Failed to parse RAR volume headers (seek past stream end at offset {offset}; stream length {length})");
             return true;
         }

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -1,0 +1,319 @@
+using System.Buffers.Binary;
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class LazyRarResolverTests
+{
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_RetriesWithMeasuredSize_WhenPendingEstimateIsShort()
+    {
+        const string pathInArchive = "movie.mkv";
+        const int packedSize = 1000;
+        var volumeBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize);
+        var trueSize = volumeBytes.Length;
+        var underestimatedSize = (long)(trueSize * 0.95);
+        Assert.True(underestimatedSize < trueSize);
+
+        // Sanity: understated Length alone is enough to fail header parse.
+        await using (var shortStream = new BoundedLengthStream(volumeBytes, underestimatedSize))
+        {
+            var ex = await Assert.ThrowsAsync<RarSeekPastEndException>(async () =>
+                await RarUtil.FindFirstFileHeaderAsync(
+                    shortStream,
+                    password: null,
+                    h => h.GetFileName() == pathInArchive,
+                    CancellationToken.None));
+            Assert.Contains("seek past stream end", ex.Message);
+        }
+
+        const string segmentId = "vol2-seg0";
+        var client = new MeasuringNntpClient(segmentId, trueSize);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            // Bypass NzbFileStream/yEnc (rapidyenc native is not available on
+            // all local RID targets). Still exercises the understated-Length
+            // failure and measured-size retry path.
+            VolumeStreamFactory = (_, size) => new BoundedLengthStream(volumeBytes, size),
+        };
+
+        var mpf = new DavMultipartFile
+        {
+            Id = Guid.NewGuid(),
+            Metadata = new DavMultipartFile.Meta
+            {
+                IsLazy = true,
+                PathInArchive = pathInArchive,
+                FileParts =
+                [
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = ["vol1-seg0"],
+                        SegmentIdByteRange = LongRange.FromStartAndSize(0, 100),
+                        FilePartByteRange = LongRange.FromStartAndSize(10, 90),
+                    }
+                ],
+                PendingParts =
+                [
+                    new DavMultipartFile.PendingPart
+                    {
+                        SegmentIds = [segmentId],
+                        SegmentIdByteRange = LongRange.FromStartAndSize(0, underestimatedSize),
+                        EstimatedDataSize = underestimatedSize - 80,
+                    }
+                ],
+            }
+        };
+
+        var meta = await resolver.EnsureResolvedThroughAsync(mpf, long.MaxValue, CancellationToken.None);
+
+        Assert.False(meta.IsLazy);
+        Assert.Empty(meta.PendingParts);
+        Assert.Equal(2, meta.FileParts.Length);
+        var resolved = meta.FileParts[1];
+        Assert.Equal([segmentId], resolved.SegmentIds);
+        Assert.Equal(packedSize, resolved.FilePartByteRange.Count);
+        Assert.Equal(resolved.FilePartByteRange.StartInclusive + packedSize,
+            resolved.SegmentIdByteRange.Count);
+        Assert.True(client.MeasuredSizeRequests > 0);
+    }
+
+    // Minimal RAR4 multi-volume continuation: mark + archive(VOLUME) +
+    // stored file header (HAS_DATA|SPLIT_BEFORE) + packed payload.
+    private static byte[] BuildRar4ContinuationVolume(string fileName, int packedSize)
+    {
+        using var ms = new MemoryStream();
+        ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
+
+        // Archive header (HEAD_SIZE=13 including CRC).
+        {
+            Span<byte> body = stackalloc byte[11];
+            body[0] = 0x73;
+            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], 0x0001); // MHD_VOLUME
+            BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
+            WriteHeader(ms, body);
+        }
+
+        var nameBytes = Encoding.ASCII.GetBytes(fileName);
+        var headSize = (ushort)(32 + nameBytes.Length);
+        {
+            var body = new byte[headSize - 2];
+            var o = 0;
+            body[o++] = 0x74;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), 0x8001); // HAS_DATA|SPLIT_BEFORE
+            o += 2;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)packedSize); // ADD_SIZE
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)packedSize); // UNP_SIZE
+            o += 4;
+            body[o++] = 2; // HostOS Unix
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileCRC
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileTime
+            o += 4;
+            body[o++] = 20; // UnpVer
+            body[o++] = 0x30; // store
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), (ushort)nameBytes.Length);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // Attr
+            o += 4;
+            nameBytes.CopyTo(body.AsSpan(o));
+            WriteHeader(ms, body);
+        }
+
+        ms.Write(new byte[packedSize]);
+        return ms.ToArray();
+    }
+
+    private static void WriteHeader(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
+    {
+        var crc = RarCrc16(bodyWithoutCrc);
+        Span<byte> hdr = stackalloc byte[bodyWithoutCrc.Length + 2];
+        BinaryPrimitives.WriteUInt16LittleEndian(hdr, crc);
+        bodyWithoutCrc.CopyTo(hdr[2..]);
+        stream.Write(hdr);
+    }
+
+    private static ushort RarCrc16(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (var i = 0; i < 8; i++)
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+        }
+
+        return (ushort)(~crc);
+    }
+
+    // Only GetYencHeadersAsync is used by the measured-size retry path.
+    private sealed class MeasuringNntpClient(string segmentId, long measuredSize) : NntpClient
+    {
+        public int MeasuredSizeRequests { get; private set; }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId id,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId id,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string id, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId id,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId id,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetYencHeader> GetYencHeadersAsync(
+            string id, CancellationToken ct)
+        {
+            MeasuredSizeRequests++;
+            Assert.Equal(segmentId, id);
+            return Task.FromResult(new UsenetYencHeader
+            {
+                FileName = "volume.rar",
+                FileSize = measuredSize,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = measuredSize,
+            });
+        }
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    // Mirrors NzbFileStream's strict Length check so understated Length
+    // fails the SharpCompress data-end seek the same way production does.
+    private sealed class BoundedLengthStream(byte[] data, long length) : Stream
+    {
+        private long _position;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => length;
+
+        public override long Position
+        {
+            get => _position;
+            set
+            {
+                if (value < 0 || value > length)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), value, "Seek position is outside stream bounds.");
+                }
+
+                _position = value;
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_position >= length) return 0;
+            var n = (int)Math.Min(count, length - _position);
+            Array.Copy(data, _position, buffer, offset, n);
+            _position += n;
+            return n;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            var absolute = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+            };
+            Position = absolute;
+            return _position;
+        }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/RarUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/RarUtilTests.cs
@@ -16,7 +16,8 @@ public class RarUtilTests
             "Seek position is outside stream bounds.");
 
         Assert.True(RarUtil.TryMapHeaderParseFailure(seekPastEnd, stream, out var mapped));
-        var ex = Assert.IsType<CorruptRarException>(mapped);
+        var ex = Assert.IsType<RarSeekPastEndException>(mapped);
+        Assert.IsAssignableFrom<CorruptRarException>(mapped);
         Assert.Contains("seek past stream end", ex.Message);
         Assert.Contains("52223980", ex.Message);
         Assert.Contains("stream length 100", ex.Message);


### PR DESCRIPTION
## Summary
- Fix lazy multipart RAR failures where trailing volumes used `yEnc*0.95` as `NzbFileStream.Length`, causing SharpCompress seekable header parsing to seek past EOF (`seek past stream end`).
- At import, use full yEnc encoded size as the stream upper bound for pending `SegmentIdByteRange` while keeping the 0.95 estimate for seek routing; at resolve time, catch `RarSeekPastEndException`, measure the real volume size from the last segment's yEnc headers, and retry once.
- Add typed `RarSeekPastEndException`, narrow `LazyRarResolver` DI wiring, and cover the retry path with a regression test.

Closes #168

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (focused LazyRarResolver / RarUtil tests passing)
- [ ] Confirm CI green on this PR
- [ ] Optional: replay a previously failing lazy multipart RAR and verify mid-archive reads no longer log seek-past-end; check debug log for measured-size retry when an old underestimate is still in the DB