### PR TITLE
feat(ui): sort providers in Usenet settings by type and priority

### DIFF
--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -223,6 +223,26 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
     const providerConfig = useMemo(() => parseProviderConfig(config["usenet.providers"]), [config]);
     const cascadeEnabled = config["usenet.cascade.enabled"] === "true";
 
+    // Display-sort by type then priority when cascade is off. Cascade mode keeps
+    // array/drag order so dnd-kit and #N badges stay coherent. Mutations still
+    // use the original config index — this never rewrites persisted order.
+    const displayedProviders = useMemo(() => {
+        const items = providerConfig.Providers.map((provider, index) => ({ provider, index }));
+        if (cascadeEnabled) return items;
+        return items.sort((a, b) => {
+            const getGroup = (type: ProviderType) => {
+                if (type === ProviderType.Pooled) return 0;
+                if (type === ProviderType.BackupAndStats || type === ProviderType.BackupOnly) return 1;
+                return 2;
+            };
+            const groupDiff = getGroup(a.provider.Type) - getGroup(b.provider.Type);
+            if (groupDiff !== 0) return groupDiff;
+            const prioDiff = (a.provider.Priority ?? 0) - (b.provider.Priority ?? 0);
+            if (prioDiff !== 0) return prioDiff;
+            return a.index - b.index;
+        });
+    }, [providerConfig.Providers, cascadeEnabled]);
+
     // handlers
     const handleAddProvider = useCallback(() => {
         setEditingIndex(null);
@@ -386,7 +406,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                     <SortableContext items={providerConfig.Providers.map(providerKey)} strategy={rectSortingStrategy}>
                     <div className={styles["providers-grid"]}>
-                        {providerConfig.Providers.map((provider, index) => {
+                        {displayedProviders.map(({ provider, index }) => {
                             const isDisabled = provider.Type === ProviderType.Disabled;
                             return (
                             <SortableItem key={providerKey(provider)} id={providerKey(provider)} disabled={!cascadeEnabled}>


### PR DESCRIPTION
## Summary
- Display-sort Usenet provider cards by type (Pooled → Backup → Disabled), then priority, when cascade is off
- Keep cascade drag/array order when cascade is on so reorder and `#N` badges stay coherent
- Mutations use original config indices; save never rewrites order for display sorting

Closes #246

## Test plan
- [ ] With cascade off: mixed Pooled / Backup / Disabled providers appear type-grouped, then by priority
- [ ] With cascade on: order remains drag/array order; drag reorder still works
- [ ] Edit / toggle / delete / usage reset still target the correct provider after display sort
- [ ] Save persists the original provider array order (no silent rewrite)