### PR TITLE
feat(usenet): skip same StorageGroup providers after article 430

### DIFF
--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -34,12 +34,14 @@ public class MultiConnectionNntpClient(
     long? byteLimit = null,
     long bytesUsedOffset = 0,
     int priority = 0,
-    int? pipeliningDepth = null
+    int? pipeliningDepth = null,
+    string storageGroup = ""
 ) : NntpClient
 {
     public ProviderType ProviderType { get; } = type;
     public int Priority { get; } = priority;
     public string Host { get; } = providerName;
+    public string StorageGroup { get; } = storageGroup;
 
     private static readonly ConcurrentDictionary<string, int> TimeoutCounts = new();
     private static long _lastTimeoutFlushTicks = DateTime.UtcNow.Ticks;

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -188,6 +188,9 @@ public class MultiProviderNntpClient(
         var fallbackCompletionOwnedByTransfer = false;
         var primaryStopwatch = Stopwatch.StartNew();
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses = null;
+        // Fresh per article resolution. Do not mark on the initial batch 430 so the
+        // intentional primary retry below is never skipped by its own miss.
+        var missingGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         try
         {
             UsenetDecodedBodyResponse? response = null;
@@ -242,6 +245,16 @@ public class MultiProviderNntpClient(
             foreach (var provider in retryProviders)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var group = NormalizeStorageGroup(provider.StorageGroup);
+                if (group.Length > 0 && missingGroups.Contains(group))
+                {
+                    Log.Debug(
+                        "Skipping provider `{Host}` on storage group `{Group}` — " +
+                        "a sibling provider already reported the article missing.",
+                        provider.Host, group);
+                    continue;
+                }
+
                 coordinator.AddTransfer();
                 var deferredCallback = new DeferredArticleBodyCallback();
                 var stopwatch = Stopwatch.StartNew();
@@ -280,6 +293,11 @@ public class MultiProviderNntpClient(
                         RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
                             stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0);
                         (priorMisses ??= []).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
+                        if (responseType == UsenetResponseType.NoArticleWithThatMessageId &&
+                            group.Length > 0)
+                        {
+                            missingGroups.Add(group);
+                        }
                         deferredCallback.Discard();
                         coordinator.CompleteAttempt();
                     }
@@ -415,12 +433,25 @@ public class MultiProviderNntpClient(
         var attribution = AttributionContext.Value;
         if (attribution != null) attribution.Host = null;
         ExceptionDispatchInfo? lastException = null;
+        T? lastNoArticleResult = null;
+        var lastOutcomeWasException = false;
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses = null;
+        var missingGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var orderedProviders = SelectOrderedProviders(out var reserved);
         using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
-        for (var index = 0; index < orderedProviders.Count; index++)
+        var attemptIndex = 0;
+        foreach (var provider in orderedProviders)
         {
-            var provider = orderedProviders[index];
+            var group = NormalizeStorageGroup(provider.StorageGroup);
+            if (group.Length > 0 && missingGroups.Contains(group))
+            {
+                Log.Debug(
+                    "Skipping provider `{Host}` on storage group `{Group}` — " +
+                    "a sibling provider already reported the article missing.",
+                    provider.Host, group);
+                continue;
+            }
+
             var deferredCallback = new DeferredArticleBodyCallback();
             var stopwatch = Stopwatch.StartNew();
             try
@@ -434,8 +465,8 @@ public class MultiProviderNntpClient(
                     if (attribution != null) attribution.Host = provider.Host;
                     _usageTracker.RecordSuccess(provider.Host);
                     RecordFetch(provider.Host, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, index);
-                    if (index > 0)
+                        stopwatch.ElapsedMilliseconds, attemptIndex);
+                    if (attemptIndex > 0)
                     {
                         _usageTracker.RecordFailoverSave();
                         RecordFailoverMisses(priorMisses, provider.Host);
@@ -446,17 +477,20 @@ public class MultiProviderNntpClient(
                 }
 
                 deferredCallback.Discard();
-                if (result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId &&
-                    index < orderedProviders.Count - 1)
+                if (result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
                 {
                     RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
-                        stopwatch.ElapsedMilliseconds, index);
+                        stopwatch.ElapsedMilliseconds, attemptIndex);
                     (priorMisses ??= []).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
+                    lastNoArticleResult = result;
+                    lastOutcomeWasException = false;
+                    if (group.Length > 0) missingGroups.Add(group);
+                    attemptIndex++;
                     continue;
                 }
 
                 RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
-                    stopwatch.ElapsedMilliseconds, index);
+                    stopwatch.ElapsedMilliseconds, attemptIndex);
                 InvokeCompletionCallback(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 return result;
@@ -465,10 +499,12 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 var reason = ClassifyException(e);
-                RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds, index);
+                RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds, attemptIndex);
                 (priorMisses ??= []).Add((provider.Host, reason));
                 deferredCallback.Discard();
                 lastException = ExceptionDispatchInfo.Capture(e);
+                lastOutcomeWasException = true;
+                attemptIndex++;
             }
             catch
             {
@@ -479,8 +515,10 @@ public class MultiProviderNntpClient(
             }
         }
 
+        // Terminal 430 after skips/exhaustion must fire the completion callback exactly once.
         InvokeCompletionCallback(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
-        lastException?.Throw();
+        if (lastOutcomeWasException) lastException!.Throw();
+        if (lastNoArticleResult is not null) return lastNoArticleResult;
         throw new Exception("There are no usenet providers configured.");
     }
 
@@ -493,26 +531,38 @@ public class MultiProviderNntpClient(
         var attribution = AttributionContext.Value;
         if (attribution != null) attribution.Host = null;
         ExceptionDispatchInfo? lastException = null;
+        T? lastNoArticleResult = null;
+        var lastOutcomeWasException = false;
+        MultiConnectionNntpClient? lastAttemptedProvider = null;
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses = null;
+        var missingGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var orderedProviders = SelectOrderedProviders(out var reserved);
         using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
-        for (var i = 0; i < orderedProviders.Count; i++)
+        var attemptIndex = 0;
+        foreach (var provider in orderedProviders)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var provider = orderedProviders[i];
-            var isLastProvider = i == orderedProviders.Count - 1;
-
-            if (lastException is not null)
+            var group = NormalizeStorageGroup(provider.StorageGroup);
+            if (group.Length > 0 && missingGroups.Contains(group))
             {
-                var failedProvider = orderedProviders[i - 1];
+                Log.Debug(
+                    "Skipping provider `{Host}` on storage group `{Group}` — " +
+                    "a sibling provider already reported the article missing.",
+                    provider.Host, group);
+                continue;
+            }
+
+            if (lastException is not null && lastAttemptedProvider is not null)
+            {
                 var msg = lastException.SourceException.Message;
                 Log.Information(
                     "Provider {FailedProvider} error: {ErrorMessage}. Falling back to {NextProvider}",
-                    failedProvider.Host,
+                    lastAttemptedProvider.Host,
                     msg,
                     provider.Host);
             }
 
+            lastAttemptedProvider = provider;
             var stopwatch = Stopwatch.StartNew();
             try
             {
@@ -520,16 +570,21 @@ public class MultiProviderNntpClient(
                 stopwatch.Stop();
 
                 // if no article with that message-id is found, try again with the next provider.
-                if (!isLastProvider && result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+                // Only a definitive 430 marks the storage group missing — never a connection error.
+                if (result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
                 {
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, i);
+                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
                     (priorMisses ??= new()).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
+                    lastNoArticleResult = result;
+                    lastOutcomeWasException = false;
+                    if (group.Length > 0) missingGroups.Add(group);
+                    attemptIndex++;
                     continue;
                 }
 
                 // attribute the response to this provider, unless it was a "missing" hit
                 // from the last provider (in which case nobody actually answered).
-                if (attribution != null && result.ResponseType != UsenetResponseType.NoArticleWithThatMessageId)
+                if (attribution != null)
                     attribution.Host = provider.Host;
 
                 // record per-queue-item attribution only for bytes-bearing responses (BODY/ARTICLE).
@@ -538,8 +593,8 @@ public class MultiProviderNntpClient(
                                           or UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
                 {
                     _usageTracker.RecordSuccess(provider.Host);
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, i);
-                    if (i > 0)
+                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    if (attemptIndex > 0)
                     {
                         _usageTracker.RecordFailoverSave();
                         RecordFailoverMisses(priorMisses, rescuer: provider.Host);
@@ -548,7 +603,7 @@ public class MultiProviderNntpClient(
                 }
                 else
                 {
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, i);
+                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
                 }
 
                 return result;
@@ -557,20 +612,26 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 var reason = ClassifyException(e);
-                RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds, i);
+                RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds, attemptIndex);
                 (priorMisses ??= new()).Add((provider.Host, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
+                lastOutcomeWasException = true;
+                attemptIndex++;
             }
         }
 
-        if (lastException is not null)
+        // Whichever terminal outcome occurred on the last attempted provider wins,
+        // matching the original fallback precedence (a later connection error beats
+        // an earlier 430, and a later 430 beats an earlier error).
+        if (lastOutcomeWasException)
         {
             Log.Warning(
                 "All providers exhausted. Last error from {Provider}: {ErrorMessage}",
-                orderedProviders[^1].Host,
-                lastException.SourceException.Message);
+                lastAttemptedProvider?.Host ?? "unknown",
+                lastException!.SourceException.Message);
             lastException.Throw();
         }
+        if (lastNoArticleResult is not null) return lastNoArticleResult;
         throw new Exception("There are no usenet providers configured.");
     }
 
@@ -627,6 +688,8 @@ public class MultiProviderNntpClient(
         if (ex is System.IO.IOException || ex is System.Net.Sockets.SocketException) return SegmentFetch.FetchStatus.Network;
         return SegmentFetch.FetchStatus.Other;
     }
+
+    private static string NormalizeStorageGroup(string? value) => value?.Trim() ?? "";
 
     private List<MultiConnectionNntpClient> SelectOrderedProviders(out MultiConnectionNntpClient? reserved)
     {

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -107,7 +107,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             connectionDetails.ByteLimit,
             connectionDetails.BytesUsedOffset,
             connectionDetails.Priority,
-            connectionDetails.PipeliningDepth
+            connectionDetails.PipeliningDepth,
+            connectionDetails.StorageGroup
         );
     }
 

--- a/backend/Config/UsenetProviderConfig.cs
+++ b/backend/Config/UsenetProviderConfig.cs
@@ -29,6 +29,15 @@ public class UsenetProviderConfig
         // still the real NNTP target and the stable key used for metrics/logs.
         public string? Nickname { get; set; }
 
+        /// <summary>
+        /// Optional label grouping providers that share the same upstream storage
+        /// (identical article availability). When set, and one provider on the
+        /// group reports an article as missing (NNTP 430), remaining providers
+        /// sharing the same label are skipped for that request. Empty (default)
+        /// means the provider is never grouped or skipped.
+        /// </summary>
+        public string StorageGroup { get; set; } = "";
+
         // null or 0 = no cap. Used by block-account holders to stop a paid block
         // from being drained beyond its purchased size.
         public long? ByteLimit { get; set; }

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -138,6 +138,9 @@ Set your username and password.
 | Max Connections | Your provider's allowed maximum (for example, `20`) |
 | Type | `Pool Connections` |
 | Use SSL | Checked |
+| Storage group (optional) | Leave blank unless multiple providers share the same upstream storage |
+
+**Storage group (optional):** If you have multiple providers that resell the *same* upstream storage (identical article availability), give them the same free-text label. When one reports an article missing (NNTP 430), NzbDav skips the remaining providers sharing that label for that request instead of re-probing the same storage. Connection errors never trigger a skip. Only group providers you are sure share storage *and* the same takedown/retention policy — otherwise a miss on one reseller could hide an article still available on another.
 
 **C. WebDAV settings (`Settings` → `WebDAV`)**
 

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -83,6 +83,10 @@ type ConnectionDetails = {
     // Optional user-set label. Shown in the UI in place of Host when present;
     // Host stays the real NNTP target.
     Nickname?: string;
+    // Optional label for providers that share upstream storage. When one reports
+    // an article missing (NNTP 430), siblings with the same label are skipped
+    // for that request.
+    StorageGroup?: string;
     PreviousType?: ProviderType;
     // null/0 = uncapped. Stored as bytes; the modal lets the user type a
     // friendlier MB/GB/TB value that gets converted on save.
@@ -533,6 +537,18 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                                 </div>
                                             </div>
 
+                                            {provider.StorageGroup?.trim() && (
+                                                <div className={'relative flex min-w-0 items-center gap-2'}>
+                                                    <div className={'text-blue-400'}>
+                                                        <Icon name="storage" className="!text-[18px]" />
+                                                    </div>
+                                                    <div className={'flex min-w-0 flex-col'}>
+                                                        <span className={'text-[11px] uppercase tracking-wide text-slate-500'}>Storage group</span>
+                                                        <span className={'truncate text-sm text-slate-200'}>{provider.StorageGroup.trim()}</span>
+                                                    </div>
+                                                </div>
+                                            )}
+
                                         </div>
 
                                         <UsageRow
@@ -731,6 +747,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
     const initialUsed = bytesToValueAndUnit(provider?.BytesUsedOffset);
 
     const [nickname, setNickname] = useState(provider?.Nickname || "");
+    const [storageGroup, setStorageGroup] = useState(provider?.StorageGroup || "");
     const [host, setHost] = useState(provider?.Host || "");
     const [port, setPort] = useState(provider?.Port?.toString() || "");
     const [useSsl, setUseSsl] = useState(provider?.UseSsl ?? true);
@@ -761,6 +778,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             const lim = bytesToValueAndUnit(provider?.ByteLimit);
             const used = bytesToValueAndUnit(provider?.BytesUsedOffset);
             setNickname(provider?.Nickname || "");
+            setStorageGroup(provider?.StorageGroup || "");
             setHost(provider?.Host || "");
             setPort(provider?.Port?.toString() || "");
             setUseSsl(provider?.UseSsl ?? true);
@@ -943,6 +961,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             : (provider?.BytesUsedResetAt ?? 0);
 
         const trimmedNickname = nickname.trim();
+        const trimmedStorageGroup = storageGroup.trim();
         onSave({
             Type: type,
             Host: host,
@@ -954,12 +973,13 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             PipeliningDepth: pipeliningDepth.trim() === "" ? null : parseInt(pipeliningDepth, 10),
             Priority: provider?.Priority ?? 0,
             Nickname: trimmedNickname === "" ? undefined : trimmedNickname,
+            StorageGroup: trimmedStorageGroup,
             PreviousType: type === ProviderType.Disabled ? provider?.PreviousType : undefined,
             ByteLimit: byteLimit,
             BytesUsedOffset: offsetToPersist,
             BytesUsedResetAt: resetAtToPersist,
         });
-    }, [type, host, port, useSsl, user, pass, maxConnections, pipeliningDepth, nickname, provider, isEditing, limitValue, limitUnit, initialUsedValue, initialUsedUnit, onSave]);
+    }, [type, host, port, useSsl, user, pass, maxConnections, pipeliningDepth, nickname, storageGroup, provider, isEditing, limitValue, limitUnit, initialUsedValue, initialUsedUnit, onSave]);
 
     const handleOverlayClick = useCallback((e: React.MouseEvent) => {
         if (e.target === e.currentTarget) {
@@ -1016,6 +1036,26 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                             />
                             <div className={styles["form-hint"]}>
                                 Friendly label shown in the UI in place of the hostname.
+                            </div>
+                        </div>
+
+                        <div className={`${styles["form-group"]} ${styles["full-width"]}`}>
+                            <label htmlFor="provider-storage-group" className={styles["form-label"]}>
+                                Storage group (optional)
+                            </label>
+                            <input
+                                type="text"
+                                id="provider-storage-group"
+                                className={styles["form-input"]}
+                                placeholder="e.g. omicron"
+                                value={storageGroup}
+                                onChange={(e) => setStorageGroup(e.target.value)}
+                            />
+                            <div className={styles["form-hint"]}>
+                                Give providers that share the same upstream storage (identical article
+                                availability) the same label. When one reports an article missing, the others
+                                with this label are skipped for that request to reduce latency. Leave blank
+                                unless you are sure they share storage and the same takedown/retention policy.
                             </div>
                         </div>
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
@@ -136,12 +137,182 @@ public class MultiProviderNntpClientTests
         Assert.Equal(0, connection.SingularRequests);
     }
 
-    private static MultiConnectionNntpClient CreateProvider(INntpClient connection)
+    [Fact]
+    public async Task StorageGroup_SameGroupMiss_SkipsSiblingProvider()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var sibling = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(sibling, host: "b.example", storageGroup: "omicron"),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.NoArticleWithThatMessageId, response.ResponseType);
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(0, sibling.SingularRequests);
+    }
+
+    [Fact]
+    public async Task StorageGroup_ConnectionError_DoesNotSkipSibling()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularException = _ => new IOException("connection reset"),
+        };
+        var sibling = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(sibling, host: "b.example", storageGroup: "omicron"),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        // MultiConnectionNntpClient retries the failed connection once before failing over.
+        Assert.True(first.SingularRequests >= 1);
+        Assert.Equal(1, sibling.SingularRequests);
+    }
+
+    [Fact]
+    public async Task StorageGroup_DifferentGroups_StillFailsOver()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var other = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(other, host: "b.example", storageGroup: "eweka"),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(1, other.SingularRequests);
+    }
+
+    [Fact]
+    public async Task StorageGroup_Empty_PreservesFailover()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var second = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example"),
+            CreateProvider(second, host: "b.example"),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(1, second.SingularRequests);
+    }
+
+    [Fact]
+    public async Task StorageGroup_BatchPrimaryRetry_NotSkippedBySameGroupSibling()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 222,
+        };
+        var sibling = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primary, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(sibling, host: "b.example", storageGroup: "omicron"),
+        ]);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["segment"], onConnectionReadyAgain: null, CancellationToken.None);
+        var response = await batch.Responses[0];
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.Equal(1, primary.SingularRequests);
+        Assert.Equal(0, sibling.SingularRequests);
+    }
+
+    [Fact]
+    public async Task StorageGroup_StreamingTerminalMiss_FiresCompletionCallbackOnce()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var sibling = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var callbacks = new List<ArticleBodyResult>();
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(sibling, host: "b.example", storageGroup: "omicron"),
+        ]);
+
+        var response = await client.DecodedBodyAsync(
+            "segment", callbacks.Add, CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.NoArticleWithThatMessageId, response.ResponseType);
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(0, sibling.SingularRequests);
+        Assert.Single(callbacks);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, callbacks[0]);
+    }
+
+    private static MultiConnectionNntpClient CreateProvider(
+        INntpClient connection,
+        string host = "test",
+        string storageGroup = "")
     {
         var pool = new ConnectionPool<INntpClient>(
             maxConnections: 1, _ => ValueTask.FromResult(connection));
         return new MultiConnectionNntpClient(
-            pool, ProviderType.Pooled, new ProviderCircuitBreaker("test"), "test");
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker(host),
+            host,
+            storageGroup: storageGroup);
     }
 
     private sealed class ScriptedNntpClient : NntpClient
@@ -166,12 +337,7 @@ public class MultiProviderNntpClientTests
             var responses = segmentIds
                 .Select(segmentId => Task.FromResult(CreateResponse(segmentId, BatchResponseCode)))
                 .ToArray();
-            onConnectionReadyAgain?.Invoke(BatchResponseCode switch
-            {
-                (int)UsenetResponseType.ArticleRetrievedBodyFollows => ArticleBodyResult.Retrieved,
-                (int)UsenetResponseType.NoArticleWithThatMessageId => ArticleBodyResult.NotFound,
-                _ => ArticleBodyResult.NotRetrieved,
-            });
+            onConnectionReadyAgain?.Invoke(ToArticleBodyResult(BatchResponseCode));
             return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
         }
 
@@ -185,9 +351,16 @@ public class MultiProviderNntpClientTests
                 throw SingularException(segmentId.ToString());
 
             var response = CreateResponse(segmentId, SingularResponseCode);
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            onConnectionReadyAgain?.Invoke(ToArticleBodyResult(SingularResponseCode));
             return Task.FromResult(response);
         }
+
+        private static ArticleBodyResult ToArticleBodyResult(int responseCode) => responseCode switch
+        {
+            (int)UsenetResponseType.ArticleRetrievedBodyFollows => ArticleBodyResult.Retrieved,
+            (int)UsenetResponseType.NoArticleWithThatMessageId => ArticleBodyResult.NotFound,
+            _ => ArticleBodyResult.NotRetrieved,
+        };
 
         private static UsenetDecodedBodyResponse CreateResponse(SegmentId segmentId, int responseCode)
         {


### PR DESCRIPTION
## Summary
- Adds optional per-provider **Storage group** config (renamed from mrghxst “Backbone” to avoid Warden naming collision).
- On a definitive NNTP 430, skips remaining providers sharing that label for the request in `RunFromPoolWithBackup`, `RunStreamingFromPoolWithBackup`, and `ResolveBatchResponseAsync` (primary retry preserved).
- UI field + setup-guide caveat; empty label keeps existing failover behavior.

Closes #244

Related (explicit non-fixes / context):
- Does not address #122 (non-video skip-vs-fail on miss)
- Does not address #162 (elfhosted NNTP cascade / AIMD)
- Inspired by mrghxst/nzbdav@4d52fa5; sibling mrghxst ports: #237, #242, #243, #245, #246, #247, #248

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~MultiProviderNntpClientTests` (13 passed)
- [ ] Leave Storage group blank — multi-provider failover unchanged
- [ ] Two providers same group: first 430 skips second for that request
- [ ] Connection error on first does not skip same-group sibling
- [ ] Batch path: primary 430 then singular success still works with a same-group sibling present
- [ ] Save/load Storage group in Usenet settings modal