### PR TITLE
fix(usenet): include file path in missing-article zero-fill warnings

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -78,20 +78,23 @@ public interface INntpClient : IDisposable
         NzbFile nzbFile,
         int articleBufferSize,
         CancellationToken ct,
-        bool usePipelinedBodyRequests = true);
+        bool usePipelinedBodyRequests = true,
+        string? fileName = null);
 
     NzbFileStream GetFileStream(
         NzbFile nzbFile,
         long fileSize,
         int articleBufferSize,
-        bool usePipelinedBodyRequests = true);
+        bool usePipelinedBodyRequests = true,
+        string? fileName = null);
 
     NzbFileStream GetFileStream(
         string[] segmentIds,
         long fileSize,
         int articleBufferSize,
         LongRange[]? segmentByteRanges = null,
-        bool usePipelinedBodyRequests = true);
+        bool usePipelinedBodyRequests = true,
+        string? fileName = null);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -127,7 +127,8 @@ public abstract class NntpClient : INntpClient
         NzbFile nzbFile,
         int articleBufferSize,
         CancellationToken ct,
-        bool usePipelinedBodyRequests = true)
+        bool usePipelinedBodyRequests = true,
+        string? fileName = null)
     {
         var segmentIds = nzbFile.GetSegmentIds();
         var fileSize = await GetFileSizeAsync(nzbFile, ct).ConfigureAwait(false);
@@ -137,14 +138,16 @@ public abstract class NntpClient : INntpClient
             this,
             articleBufferSize,
             nzbFile.GetSegmentByteRanges(),
-            usePipelinedBodyRequests);
+            usePipelinedBodyRequests,
+            ResolveFileName(fileName, nzbFile));
     }
 
     public virtual NzbFileStream GetFileStream(
         NzbFile nzbFile,
         long fileSize,
         int articleBufferSize,
-        bool usePipelinedBodyRequests = true)
+        bool usePipelinedBodyRequests = true,
+        string? fileName = null)
     {
         return new NzbFileStream(
             nzbFile.GetSegmentIds(),
@@ -152,7 +155,8 @@ public abstract class NntpClient : INntpClient
             this,
             articleBufferSize,
             nzbFile.GetSegmentByteRanges(),
-            usePipelinedBodyRequests
+            usePipelinedBodyRequests,
+            ResolveFileName(fileName, nzbFile)
         );
     }
 
@@ -161,7 +165,8 @@ public abstract class NntpClient : INntpClient
         long fileSize,
         int articleBufferSize,
         LongRange[]? segmentByteRanges = null,
-        bool usePipelinedBodyRequests = true)
+        bool usePipelinedBodyRequests = true,
+        string? fileName = null)
     {
         return new NzbFileStream(
             segmentIds,
@@ -169,7 +174,15 @@ public abstract class NntpClient : INntpClient
             this,
             articleBufferSize,
             segmentByteRanges,
-            usePipelinedBodyRequests);
+            usePipelinedBodyRequests,
+            fileName);
+    }
+
+    private static string? ResolveFileName(string? fileName, NzbFile nzbFile)
+    {
+        if (!string.IsNullOrEmpty(fileName)) return fileName;
+        var subjectName = nzbFile.GetSubjectFileName();
+        return string.IsNullOrEmpty(subjectName) ? null : subjectName;
     }
 
     public virtual async Task CheckAllSegmentsAsync

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -14,6 +14,7 @@ public class DavMultipartFileStream : Stream
     private readonly int _articleBufferSize;
     private readonly LazyRarResolver? _resolver;
     private readonly bool _usePipelinedBodyRequests;
+    private readonly string? _fileName;
     private readonly long _length;
 
     private long _position;
@@ -25,13 +26,15 @@ public class DavMultipartFileStream : Stream
         INntpClient usenetClient,
         int articleBufferSize,
         LazyRarResolver? resolver,
-        bool usePipelinedBodyRequests)
+        bool usePipelinedBodyRequests,
+        string? fileName = null)
     {
         _mpf = mpf;
         _usenetClient = usenetClient;
         _articleBufferSize = articleBufferSize;
         _resolver = resolver;
         _usePipelinedBodyRequests = usePipelinedBodyRequests;
+        _fileName = fileName;
         _length = ComputeLength(mpf.Metadata);
 
         if (_resolver != null
@@ -238,7 +241,8 @@ public class DavMultipartFileStream : Stream
             part.SegmentIdByteRange.Count,
             _articleBufferSize,
             part.SegmentByteRanges,
-            _usePipelinedBodyRequests);
+            _usePipelinedBodyRequests,
+            _fileName);
         stream.Seek(part.FilePartByteRange.StartInclusive + extraOffset, SeekOrigin.Begin);
         return stream.LimitLength(part.FilePartByteRange.Count - extraOffset);
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -18,6 +18,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly INntpClient _usenetClient;
     private readonly long _expectedSegmentSize;
     private readonly bool _failFastOnFirstSegment;
+    private readonly string _fileName;
     private readonly Channel<Task<Stream>> _streamTasks;
     private readonly int _bodyPipelineBatchSize;
     private readonly ContextualCancellationTokenSource _cts;
@@ -29,7 +30,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         INntpClient usenetClient,
         int articleBufferSize,
         bool usePipelinedBodyRequests,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? fileName = null)
     {
         return Create(
             segmentIds,
@@ -38,7 +40,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             expectedSegmentSize: 0,
             failFastOnFirstSegment: false,
             usePipelinedBodyRequests,
-            cancellationToken);
+            cancellationToken,
+            fileName);
     }
 
     public static Stream Create
@@ -49,11 +52,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         long expectedSegmentSize,
         bool failFastOnFirstSegment,
         bool usePipelinedBodyRequests,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        string? fileName = null
     )
     {
         return articleBufferSize == 0
-            ? new UnbufferedMultiSegmentStream(segmentIds, usenetClient, expectedSegmentSize)
+            ? new UnbufferedMultiSegmentStream(segmentIds, usenetClient, expectedSegmentSize, fileName)
             : new MultiSegmentStream(
                 segmentIds,
                 usenetClient,
@@ -61,7 +65,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 expectedSegmentSize,
                 failFastOnFirstSegment,
                 usePipelinedBodyRequests,
-                cancellationToken);
+                cancellationToken,
+                fileName);
     }
 
     private MultiSegmentStream
@@ -72,13 +77,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         long expectedSegmentSize,
         bool failFastOnFirstSegment,
         bool usePipelinedBodyRequests,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        string? fileName
     )
     {
         _segmentIds = segmentIds;
         _usenetClient = usenetClient;
         _expectedSegmentSize = expectedSegmentSize;
         _failFastOnFirstSegment = failFastOnFirstSegment;
+        _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _bodyPipelineBatchSize = Math.Min(BodyPipelineBatchSize, articleBufferSize);
         _streamTasks = Channel.CreateBounded<Task<Stream>>(articleBufferSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -207,13 +214,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 if (_failFastOnFirstSegment && isFirstSegment)
                 {
-                    Log.Warning(e, "First article {SegmentId} missing on all providers at playback start. " +
-                                   "Failing the stream so the player surfaces an error.", segmentId);
+                    Log.Warning(e,
+                        "First article {SegmentId} missing on all providers at playback start while reading {FileName}. " +
+                        "Failing the stream so the player surfaces an error.",
+                        segmentId, _fileName);
                     throw;
                 }
 
                 return ZeroFillSegment(
-                    "Article {SegmentId} missing on all providers. Zero-filling {Bytes} bytes to keep playback alive.",
+                    "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
                     e.SegmentId);
             }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested)
@@ -229,13 +238,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
                 if (_failFastOnFirstSegment && isFirstSegment)
                 {
-                    Log.Warning(e, "Segment {SegmentId} unavailable at playback start after {Attempts} attempts. " +
-                                   "Failing the stream so the player surfaces an error.", segmentId, attempt + 1);
+                    Log.Warning(e,
+                        "Segment {SegmentId} unavailable at playback start after {Attempts} attempts while reading {FileName}. " +
+                        "Failing the stream so the player surfaces an error.",
+                        segmentId, attempt + 1, _fileName);
                     throw;
                 }
 
                 return ZeroFillSegment(
-                    "Segment {SegmentId} unavailable after retries. Zero-filling {Bytes} bytes to keep playback alive.",
+                    "Segment {SegmentId} unavailable after retries while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
                     segmentId, e);
             }
         }
@@ -256,14 +267,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             if (_failFastOnFirstSegment && isFirstSegment) throw;
             return ZeroFillSegment(
-                "Article {SegmentId} missing on all providers. Zero-filling {Bytes} bytes to keep playback alive.",
+                "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
                 e.SegmentId);
         }
         catch (Exception e) when (!cancellationToken.IsCancellationRequested)
         {
             if (_failFastOnFirstSegment && isFirstSegment) throw;
             return ZeroFillSegment(
-                "Segment {SegmentId} unavailable. Zero-filling {Bytes} bytes to keep playback alive.",
+                "Segment {SegmentId} unavailable while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
                 segmentId, e);
         }
     }
@@ -283,8 +294,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private Stream ZeroFillSegment(string messageTemplate, string segmentId, Exception? exception = null)
     {
         var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
-        if (exception == null) Log.Warning(messageTemplate, segmentId, fill);
-        else Log.Warning(exception, messageTemplate, segmentId, fill);
+        if (exception == null) Log.Warning(messageTemplate, segmentId, _fileName, fill);
+        else Log.Warning(exception, messageTemplate, segmentId, _fileName, fill);
         return new MemoryStream(new byte[fill], writable: false);
     }
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -16,7 +16,8 @@ public class NzbFileStream(
     INntpClient usenetClient,
     int articleBufferSize,
     LongRange[]? segmentByteRanges = null,
-    bool usePipelinedBodyRequests = true
+    bool usePipelinedBodyRequests = true,
+    string? fileName = null
 ) : FastReadOnlyStream
 {
     private const long MaximumForwardDrainBytes = 1024 * 1024;
@@ -149,8 +150,8 @@ public class NzbFileStream(
                     // turns out to be the seek target) gets zero-filled by
                     // MultiSegmentStream.
                     Log.Warning(
-                        "Seek probe hit missing article {SegmentId} (segment index {Index}). Using estimated range.",
-                        e.SegmentId, guess);
+                        "Seek probe hit missing article {SegmentId} (segment index {Index}) while reading {FileName}. Using estimated range.",
+                        e.SegmentId, guess, string.IsNullOrEmpty(fileName) ? "unknown" : fileName);
                     var start = guess * avg;
                     var end = Math.Min(fileSize, start + avg);
                     return new LongRange(start, end);
@@ -284,7 +285,8 @@ public class NzbFileStream(
             ExpectedSegmentSize,
             failFastOnFirstSegment,
             usePipelinedBodyRequests,
-            cancellationToken);
+            cancellationToken,
+            fileName);
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -10,16 +10,22 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly Memory<string> _segmentIds;
     private readonly INntpClient _usenetClient;
     private readonly long _expectedSegmentSize;
+    private readonly string _fileName;
     private Stream? _stream;
     private int _currentIndex;
     private bool _disposed;
 
 
-    public UnbufferedMultiSegmentStream(Memory<string> segmentIds, INntpClient usenetClient, long expectedSegmentSize)
+    public UnbufferedMultiSegmentStream(
+        Memory<string> segmentIds,
+        INntpClient usenetClient,
+        long expectedSegmentSize,
+        string? fileName = null)
     {
         _segmentIds = segmentIds;
         _usenetClient = usenetClient;
         _expectedSegmentSize = expectedSegmentSize;
+        _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -44,8 +50,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 {
                     var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
                     Log.Warning(
-                        "Article {SegmentId} missing on all providers. Zero-filling {Bytes} bytes to keep playback alive.",
-                        e.SegmentId, fill);
+                        "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                        e.SegmentId, _fileName, fill);
                     _stream = new MemoryStream(new byte[fill], writable: false);
                 }
             }

--- a/backend/WebDav/DatabaseStoreMultipartFile.cs
+++ b/backend/WebDav/DatabaseStoreMultipartFile.cs
@@ -52,7 +52,8 @@ public class DatabaseStoreMultipartFile(
             usenetClient,
             configManager.GetArticleBufferSize(),
             lazyRarResolver,
-            configManager.IsPipelinedBodyRequestsEnabled()
+            configManager.IsPipelinedBodyRequestsEnabled(),
+            davMultipartFile.Path
         );
 
         return multipartFile.Metadata.AesParams != null

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -41,7 +41,8 @@ public class DatabaseStoreNzbFile(
             FileSize,
             configManager.GetArticleBufferSize(),
             nzbFile.SegmentByteRanges,
-            configManager.IsPipelinedBodyRequestsEnabled()
+            configManager.IsPipelinedBodyRequestsEnabled(),
+            davNzbFile.Path
         );
     }
 }

--- a/backend/WebDav/DatabaseStoreRarFile.cs
+++ b/backend/WebDav/DatabaseStoreRarFile.cs
@@ -51,7 +51,8 @@ public class DatabaseStoreRarFile(
             usenetClient,
             configManager.GetArticleBufferSize(),
             resolver: null,
-            usePipelinedBodyRequests: configManager.IsPipelinedBodyRequestsEnabled()
+            usePipelinedBodyRequests: configManager.IsPipelinedBodyRequestsEnabled(),
+            fileName: davRarFile.Path
         );
     }
 }

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -39,9 +40,18 @@ internal sealed class FakeNntpClient(
     {
         cancellationToken.ThrowIfCancellationRequested();
         BodyRequestCount++;
-        var response = CreateBodyResponse(segmentId);
-        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
-        return Task.FromResult(response);
+        try
+        {
+            var response = CreateBodyResponse(segmentId);
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(response);
+        }
+        catch (Exception e)
+        {
+            // Return a faulted task so pipelined batch consumers can await
+            // per-segment failures without aborting DecodedBodiesAsync itself.
+            return Task.FromException<UsenetDecodedBodyResponse>(e);
+        }
     }
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
@@ -105,7 +115,7 @@ internal sealed class FakeNntpClient(
     {
         var key = segmentId.ToString();
         if (!segments.TryGetValue(key, out var bytes))
-            throw new KeyNotFoundException($"No fake segment named {key}.");
+            throw new UsenetArticleNotFoundException(key, "430 No such article");
 
         return new UsenetDecodedBodyResponse
         {

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -2,6 +2,9 @@ using System.Text;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace NzbWebDAV.Tests.Streams;
 
@@ -116,9 +119,61 @@ public class NzbFileStreamTests
         Assert.Equal("hij", Encoding.ASCII.GetString(buffer, 0, read));
     }
 
+    [Fact]
+    public async Task MissingArticle_ZeroFillsAndLogsFileName()
+    {
+        const string fileName = "/content/show/episode.mkv";
+        const string segmentId = "missing-article";
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            // Empty segment map → UsenetArticleNotFound before any yEnc decode.
+            // Use unbuffered mode so the assertion does not depend on pipelined batch timing.
+            var client = new FakeNntpClient(new Dictionary<string, byte[]>());
+            await using var stream = MultiSegmentStream.Create(
+                new[] { segmentId }.AsMemory(),
+                client,
+                articleBufferSize: 0,
+                expectedSegmentSize: 5,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: false,
+                cancellationToken: CancellationToken.None,
+                fileName: fileName);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var buffer = new byte[5];
+            var read = await stream.ReadAsync(buffer, cts.Token);
+
+            Assert.Equal(5, read);
+            Assert.Equal(new byte[5], buffer);
+            Assert.Contains(sink.Events, e =>
+                e.Level == LogEventLevel.Warning &&
+                e.RenderMessage().Contains(fileName, StringComparison.Ordinal) &&
+                e.RenderMessage().Contains(segmentId, StringComparison.Ordinal) &&
+                e.RenderMessage().Contains("Zero-filling", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
     private static FakeNntpClient CreateClient()
     {
         return new FakeNntpClient(
             SegmentIds.Zip(SegmentBytes).ToDictionary(pair => pair.First, pair => pair.Second));
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
     }
 }


### PR DESCRIPTION
## Summary
- Thread an optional file label through `NzbFileStream` / `MultiSegmentStream` so mid-stream missing-article zero-fill warnings include the file being read
- WebDAV playback paths pass `DavItem.Path`; NZB-based streams fall back to the subject filename
- Add a focused test that asserts the warning includes the file path

## Test plan
- [ ] Stream a WebDAV file with known missing mid-stream articles and confirm logs look like: `Article … missing on all providers while reading /content/…. Zero-filling …`
- [ ] Confirm playback still continues (zero-fill behavior unchanged)
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~MissingArticle_ZeroFillsAndLogsFileName`