### PR TITLE
feat(api): sync exclude-filter patterns from remote URLs

### DIFF
--- a/backend/Api/Controllers/ExcludeSync/ExcludeSyncController.cs
+++ b/backend/Api/Controllers/ExcludeSync/ExcludeSyncController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.ExcludeSync;
+
+/// <summary>
+/// GET  <c>/api/exclude-sync</c> — current per-URL sync status (no network).
+/// POST <c>/api/exclude-sync</c> — force an immediate refresh of every configured URL,
+/// then return the resulting status. Used by the "Sync now" button in settings.
+/// </summary>
+[ApiController]
+[Route("api/exclude-sync")]
+public class ExcludeSyncController(SearchExcludeSyncService syncService) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        if (HttpMethods.IsPost(HttpContext.Request.Method))
+        {
+            var refreshed = await syncService
+                .RefreshAllAsync(force: true, HttpContext.RequestAborted).ConfigureAwait(false);
+            return Ok(new ExcludeSyncResponse { Status = true, Urls = refreshed });
+        }
+
+        return Ok(new ExcludeSyncResponse { Status = true, Urls = syncService.GetStatus() });
+    }
+}

--- a/backend/Api/Controllers/ExcludeSync/ExcludeSyncResponse.cs
+++ b/backend/Api/Controllers/ExcludeSync/ExcludeSyncResponse.cs
@@ -1,0 +1,8 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.ExcludeSync;
+
+public sealed class ExcludeSyncResponse : BaseApiResponse
+{
+    public IReadOnlyList<ExcludeSyncStatus> Urls { get; set; } = Array.Empty<ExcludeSyncStatus>();
+}

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -15,6 +16,12 @@ public class ConfigManager
 
     private readonly Dictionary<string, string> _config = new();
     private readonly Dictionary<(string Name, Type Type), object?> _deserializedConfig = new();
+    // Compiled exclude patterns are cached and rebuilt only when an exclude-related
+    // config key changes (see UpdateValues / LoadConfig), rather than recompiled on
+    // every search. Guarded by its own lock so searches and config writes don't
+    // contend on _config.
+    private readonly object _excludeLock = new();
+    private IReadOnlyList<Regex>? _compiledExcludeCache;
     public event EventHandler<ConfigEventArgs>? OnConfigChanged;
 
     public async Task LoadConfig()
@@ -30,6 +37,7 @@ public class ConfigManager
                 _config[configItem.ConfigName] = configItem.ConfigValue;
             }
         }
+        lock (_excludeLock) { _compiledExcludeCache = null; }
     }
 
     private string? GetConfigValue(string configName)
@@ -96,6 +104,12 @@ public class ConfigManager
                     _deserializedConfig.Remove(cacheKey);
                 }
             }
+        }
+
+        if (configItems.Any(x => x.ConfigName.StartsWith("search.exclude", StringComparison.Ordinal)
+                                 || x.ConfigName == "play.exclude-patterns"))
+        {
+            lock (_excludeLock) { _compiledExcludeCache = null; }
         }
 
         var changedConfig = configItems.ToDictionary(x => x.ConfigName, x => x.ConfigValue);
@@ -360,30 +374,78 @@ public class ConfigManager
         return int.TryParse(v, out var n) ? Math.Clamp(n, 5, 120) : 5;
     }
 
+    public const int DefaultExcludeSyncRefreshMinutes = 720;
+
     public IReadOnlyList<Regex> GetSearchExcludePatterns()
     {
+        lock (_excludeLock)
+        {
+            return _compiledExcludeCache ??= BuildExcludePatterns();
+        }
+    }
+
+    // Synced patterns (last-good cache, in configured-URL order) take precedence and are
+    // emitted first; the manual textarea is appended after, with exact duplicates dropped
+    // so a pattern present in both sources is compiled and evaluated only once.
+    private IReadOnlyList<Regex> BuildExcludePatterns()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var compiled = new List<Regex>();
+
+        var cache = GetSearchExcludeSyncCache();
+        foreach (var url in GetSearchExcludeSyncUrls())
+        {
+            if (!cache.Urls.TryGetValue(url, out var entry)) continue;
+            foreach (var item in entry.Items)
+                if (ExcludePatternParser.Parse(item) is { } p && seen.Add(p.Key))
+                    compiled.Add(p.Regex);
+        }
+
         var raw = GetConfigValue("search.exclude-patterns");
         if (string.IsNullOrWhiteSpace(raw)) raw = GetConfigValue("play.exclude-patterns");
-        if (string.IsNullOrWhiteSpace(raw)) return Array.Empty<Regex>();
-
-        var patterns = new List<Regex>();
-        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        if (!string.IsNullOrWhiteSpace(raw))
         {
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0 || trimmed.StartsWith('#')) continue;
-            try
-            {
-                patterns.Add(new Regex(
-                    trimmed,
-                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
-                    TimeSpan.FromMilliseconds(250)));
-            }
-            catch (ArgumentException e)
-            {
-                Log.Warning("Skipping invalid search.exclude-patterns regex {Pattern}: {Message}", trimmed, e.Message);
-            }
+            foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                if (ExcludePatternParser.Parse(line) is { } p && seen.Add(p.Key))
+                    compiled.Add(p.Regex);
         }
-        return patterns;
+
+        return compiled;
+    }
+
+    /// <summary>Configured synced-exclude source URLs (http/https only, de-duplicated, in order).</summary>
+    public IReadOnlyList<string> GetSearchExcludeSyncUrls()
+    {
+        var raw = GetConfigValue("search.exclude-sync-urls");
+        if (string.IsNullOrWhiteSpace(raw)) return Array.Empty<string>();
+
+        var urls = new List<string>();
+        // Exact-match dedup: URL paths are case-sensitive, so two URLs that differ only
+        // by path casing are distinct sources and must both be kept.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (line.StartsWith('#')) continue;
+            if (!Uri.TryCreate(line, UriKind.Absolute, out var uri)) continue;
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) continue;
+            if (seen.Add(line)) urls.Add(line);
+        }
+        return urls;
+    }
+
+    public int GetSearchExcludeSyncRefreshMinutes()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue("search.exclude-sync-refresh-minutes"));
+        if (v == null) return DefaultExcludeSyncRefreshMinutes;
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 15, 10080) : DefaultExcludeSyncRefreshMinutes;
+    }
+
+    public ExcludeSyncCache GetSearchExcludeSyncCache()
+    {
+        var raw = StringUtil.EmptyToNull(GetConfigValue("search.exclude-sync-cache"));
+        if (raw == null) return new ExcludeSyncCache();
+        try { return JsonSerializer.Deserialize<ExcludeSyncCache>(raw) ?? new ExcludeSyncCache(); }
+        catch (JsonException) { return new ExcludeSyncCache(); }
     }
 
     public string GetVariantsMode()

--- a/backend/Models/ExcludeSyncCache.cs
+++ b/backend/Models/ExcludeSyncCache.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Models;
+
+/// <summary>
+/// Persisted last-good snapshot of synced exclude patterns, keyed by source URL.
+/// Stored as JSON under the <c>search.exclude-sync-cache</c> config key so the filter
+/// survives upstream outages and server restarts (the fail-safe fallback).
+/// </summary>
+public sealed class ExcludeSyncCache
+{
+    [JsonPropertyName("urls")]
+    public Dictionary<string, ExcludeSyncUrlEntry> Urls { get; set; } = new();
+}
+
+public sealed class ExcludeSyncUrlEntry
+{
+    /// <summary>Pattern strings from the last successful fetch of this URL.</summary>
+    [JsonPropertyName("items")]
+    public List<string> Items { get; set; } = new();
+
+    /// <summary>Unix seconds of the last successful fetch (HTTP 200 with a parseable body).</summary>
+    [JsonPropertyName("fetchedAt")]
+    public long FetchedAt { get; set; }
+
+    /// <summary>Unix seconds of the last fetch attempt, whether it succeeded or failed.</summary>
+    [JsonPropertyName("lastChecked")]
+    public long LastChecked { get; set; }
+
+    /// <summary>ETag of the last successful fetch, used for conditional requests.</summary>
+    [JsonPropertyName("etag")]
+    public string? Etag { get; set; }
+
+    /// <summary>Error from the most recent attempt, or <c>null</c> if it succeeded.</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -156,6 +156,8 @@ class Program
                 .AddHostedService(sp => sp.GetRequiredService<WardenRemoteSourceService>())
                 .AddSingleton<WardenBackupService>()
                 .AddHostedService(sp => sp.GetRequiredService<WardenBackupService>())
+                .AddSingleton<SearchExcludeSyncService>()
+                .AddHostedService(sp => sp.GetRequiredService<SearchExcludeSyncService>())
                 .AddSingleton<PlaybackFastVerifier>()
                 .AddSingleton<WatchdogLog>()
                 .AddSingleton<PreflightCache>()

--- a/backend/Services/SearchExcludeSyncService.cs
+++ b/backend/Services/SearchExcludeSyncService.cs
@@ -1,0 +1,287 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Background service that keeps the synced exclude-pattern lists fresh.
+///
+/// On a timer (and immediately whenever the configured URLs change) it fetches each
+/// <c>search.exclude-sync-urls</c> entry, parses the regex patterns, and persists a
+/// last-good snapshot to <c>search.exclude-sync-cache</c>. <see cref="ConfigManager"/>
+/// merges that snapshot ahead of the manual patterns when it builds the compiled
+/// exclude list, so synced patterns take precedence and the manual list is appended
+/// after (with exact duplicates removed). A failed fetch keeps the previous snapshot,
+/// so the filter never empties because a source was briefly unreachable.
+/// </summary>
+public sealed class SearchExcludeSyncService : BackgroundService
+{
+    private const string CacheKey = "search.exclude-sync-cache";
+    private const long MaxDownloadBytes = 16L * 1024 * 1024; // pattern lists are small
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(15);
+
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(15) };
+
+    private readonly ConfigManager _configManager;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public SearchExcludeSyncService(ConfigManager configManager)
+    {
+        _configManager = configManager;
+        _configManager.OnConfigChanged += OnConfigChanged;
+    }
+
+    public override void Dispose()
+    {
+        _configManager.OnConfigChanged -= OnConfigChanged;
+        _gate.Dispose();
+        base.Dispose();
+    }
+
+    private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs e)
+    {
+        // React only to the inputs — NOT to our own cache writes (which would loop).
+        if (!e.ChangedConfig.ContainsKey("search.exclude-sync-urls")
+            && !e.ChangedConfig.ContainsKey("search.exclude-sync-refresh-minutes")) return;
+
+        // A freshly-set URL should apply within seconds, not at the next tick.
+        _ = Task.Run(async () =>
+        {
+            try { await RefreshAllAsync(force: true, CancellationToken.None).ConfigureAwait(false); }
+            catch (Exception ex) { Log.Debug(ex, "Exclude-sync: post-config refresh failed"); }
+        });
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try { await Task.Delay(StartupDelay, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try { await RefreshAllAsync(force: false, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
+            catch (Exception e) { Log.Debug(e, "Exclude-sync: refresh loop error"); }
+
+            try { await Task.Delay(TickInterval, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    /// <summary>Current per-URL status, read from the persisted cache (no network).</summary>
+    public IReadOnlyList<ExcludeSyncStatus> GetStatus()
+    {
+        var cache = _configManager.GetSearchExcludeSyncCache();
+        return _configManager.GetSearchExcludeSyncUrls().Select(url =>
+        {
+            cache.Urls.TryGetValue(url, out var entry);
+            return new ExcludeSyncStatus(
+                url,
+                entry?.Items.Count ?? 0,
+                entry is { FetchedAt: > 0 } ? entry.FetchedAt : null,
+                entry is { LastChecked: > 0 } ? entry.LastChecked : null,
+                entry?.Error);
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Fetch the configured URLs (those that are due, unless <paramref name="force"/>),
+    /// persist the merged snapshot, and return the resulting per-URL status.
+    /// </summary>
+    public async Task<IReadOnlyList<ExcludeSyncStatus>> RefreshAllAsync(bool force, CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var urls = _configManager.GetSearchExcludeSyncUrls();
+            var cache = _configManager.GetSearchExcludeSyncCache();
+            var refreshSeconds = (long)_configManager.GetSearchExcludeSyncRefreshMinutes() * 60;
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var changed = false;
+
+            // Forget cache entries for URLs that are no longer configured.
+            var configured = new HashSet<string>(urls, StringComparer.Ordinal);
+            foreach (var stale in cache.Urls.Keys.Where(k => !configured.Contains(k)).ToList())
+            {
+                cache.Urls.Remove(stale);
+                changed = true;
+            }
+
+            foreach (var url in urls)
+            {
+                ct.ThrowIfCancellationRequested();
+                cache.Urls.TryGetValue(url, out var entry);
+                if (!force && entry is not null && now - entry.LastChecked < refreshSeconds) continue;
+                cache.Urls[url] = await FetchAsync(url, entry, now, ct).ConfigureAwait(false);
+                changed = true;
+            }
+
+            if (changed) await PersistAsync(cache, ct).ConfigureAwait(false);
+            return GetStatus();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static async Task<ExcludeSyncUrlEntry> FetchAsync(
+        string url, ExcludeSyncUrlEntry? prev, long now, CancellationToken ct)
+    {
+        // Start from the previous snapshot so a failure or 304 keeps the last-good items.
+        var entry = new ExcludeSyncUrlEntry
+        {
+            Items = prev?.Items ?? new List<string>(),
+            FetchedAt = prev?.FetchedAt ?? 0,
+            Etag = prev?.Etag,
+            LastChecked = now,
+        };
+
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            if (!string.IsNullOrEmpty(prev?.Etag))
+                req.Headers.TryAddWithoutValidation("If-None-Match", prev.Etag);
+
+            using var resp = await Http
+                .SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (resp.StatusCode == HttpStatusCode.NotModified)
+            {
+                entry.Error = null;
+                return entry;
+            }
+            resp.EnsureSuccessStatusCode();
+
+            await using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var body = await ReadCappedAsync(stream, ct).ConfigureAwait(false);
+
+            // Keep only patterns that actually compile, so the stored snapshot, the count
+            // shown in the UI, and the log line all reflect usable patterns — not raw lines
+            // that ExcludePatternParser would silently drop on every rebuild.
+            var valid = ParsePayload(body)
+                .Where(p => ExcludePatternParser.Parse(p) is not null)
+                .ToList();
+
+            // Don't let an empty or all-invalid payload wipe a previously-good snapshot;
+            // keep the prior items/FetchedAt/Etag and surface the problem instead.
+            if (valid.Count == 0)
+            {
+                entry.Error = "Source returned no usable patterns; keeping the last good copy.";
+                return entry;
+            }
+
+            entry.Items = valid;
+            entry.FetchedAt = now;
+            entry.Etag = resp.Headers.ETag?.ToString();
+            entry.Error = null;
+            Log.Information("Exclude-sync: refreshed {Url} ({Count} patterns)", url, valid.Count);
+            return entry;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            entry.Error = e.Message;
+            Log.Warning("Exclude-sync: failed to fetch {Url}: {Message} (keeping last-good)", url, e.Message);
+            return entry;
+        }
+    }
+
+    /// <summary>
+    /// Accepts the two formats community lists publish:
+    ///   - <c>{ "values": ["regex", ...] }</c>
+    ///   - <c>[{ "pattern": "regex", "name": "...", "score": 0 }, ...]</c> (score ignored)
+    /// A bare <c>["regex", ...]</c> array is tolerated too.
+    /// </summary>
+    internal static List<string> ParsePayload(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var items = new List<string>();
+
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var el in root.EnumerateArray())
+            {
+                if (el.ValueKind == JsonValueKind.String)
+                {
+                    items.Add(el.GetString()!);
+                }
+                else if (el.ValueKind == JsonValueKind.Object
+                         && el.TryGetProperty("pattern", out var pat)
+                         && pat.ValueKind == JsonValueKind.String)
+                {
+                    items.Add(pat.GetString()!);
+                }
+            }
+            return items;
+        }
+
+        if (root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty("values", out var values)
+            && values.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var el in values.EnumerateArray())
+                if (el.ValueKind == JsonValueKind.String) items.Add(el.GetString()!);
+            return items;
+        }
+
+        throw new InvalidOperationException(
+            "Unexpected format. Expected {\"values\":[...]} or [{\"pattern\":\"...\"}].");
+    }
+
+    private static async Task<string> ReadCappedAsync(Stream stream, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[81920];
+        int read;
+        while ((read = await stream.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        {
+            if (ms.Length + read > MaxDownloadBytes)
+                throw new InvalidOperationException("Synced list exceeds the size limit.");
+            ms.Write(buffer, 0, read);
+        }
+        return Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
+    }
+
+    private async Task PersistAsync(ExcludeSyncCache cache, CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(cache);
+
+        await using var dbContext = new DavDatabaseContext();
+        var existing = await dbContext.ConfigItems
+            .FirstOrDefaultAsync(x => x.ConfigName == CacheKey, ct).ConfigureAwait(false);
+        if (existing is null)
+            dbContext.ConfigItems.Add(new ConfigItem { ConfigName = CacheKey, ConfigValue = json });
+        else
+            existing.ConfigValue = json;
+        await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Refresh the in-memory config and invalidate the compiled exclude-pattern cache.
+        _configManager.UpdateValues(new List<ConfigItem>
+        {
+            new() { ConfigName = CacheKey, ConfigValue = json },
+        });
+    }
+}
+
+/// <summary>Per-URL sync status surfaced to the settings UI.</summary>
+public sealed record ExcludeSyncStatus(
+    string Url,
+    int Count,
+    long? FetchedAt,
+    long? LastChecked,
+    string? Error);

--- a/backend/Utils/ExcludePatternParser.cs
+++ b/backend/Utils/ExcludePatternParser.cs
@@ -1,0 +1,73 @@
+using System.Text.RegularExpressions;
+using Serilog;
+
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Parses exclude-filter regex lines — from both the manual textarea and synced-URL
+/// payloads — into compiled <see cref="Regex"/> objects, and produces a stable dedup
+/// key so the same pattern arriving from different sources is compiled and run once.
+///
+/// Two input shapes are accepted:
+///   - a bare .NET regex body, e.g. <c>\.iso$</c>
+///   - a JavaScript-style wrapper, e.g. <c>/\.(iso|img)$/i</c> — the shape community
+///     lists (TRaSH-derived "excluded-regex" URLs, AIOStreams templates) publish.
+///
+/// Matching is always case-insensitive (the existing DAVX convention — authors opt out
+/// per-pattern with inline <c>(?-i:...)</c>). The <c>m</c>/<c>s</c> wrapper flags add
+/// Multiline / Singleline; other JS flags (g/u/y/n) do not affect
+/// <see cref="Regex.IsMatch(string)"/> and are ignored.
+/// </summary>
+public static class ExcludePatternParser
+{
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(250);
+
+    private const RegexOptions BaseOptions =
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled;
+
+    // /body/flags — greedy body up to the final slash, optional trailing flags.
+    private static readonly Regex JsWrapper = new(@"^/(.+)/([a-z]*)$", RegexOptions.Compiled);
+
+    public readonly record struct ParsedPattern(string Key, Regex Regex);
+
+    /// <summary>
+    /// Parse a single line. Returns <c>null</c> for blanks, <c>#</c> comments, or patterns
+    /// that fail to compile (logged and skipped — never throws).
+    /// </summary>
+    public static ParsedPattern? Parse(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return null;
+        var trimmed = line.Trim();
+        if (trimmed.Length == 0 || trimmed.StartsWith('#')) return null;
+
+        var body = trimmed;
+        var options = BaseOptions;
+        var extraFlags = "";
+
+        var wrapper = JsWrapper.Match(trimmed);
+        if (wrapper.Success)
+        {
+            body = wrapper.Groups[1].Value;
+            var flags = wrapper.Groups[2].Value;
+            // Built in a fixed order so "/x/ms" and "/x/sm" yield the same dedup key.
+            if (flags.Contains('m')) { options |= RegexOptions.Multiline; extraFlags += "m"; }
+            if (flags.Contains('s')) { options |= RegexOptions.Singleline; extraFlags += "s"; }
+        }
+
+        if (body.Length == 0) return null;
+
+        try
+        {
+            var regex = new Regex(body, options, MatchTimeout);
+            // IgnoreCase is constant, so it is excluded from the key — that lets a raw body
+            // and its /.../i wrapper form (identical intent) collapse to one entry.
+            var key = body + " " + extraFlags;
+            return new ParsedPattern(key, regex);
+        }
+        catch (ArgumentException e)
+        {
+            Log.Warning("Skipping invalid exclude pattern {Pattern}: {Message}", trimmed, e.Message);
+            return null;
+        }
+    }
+}

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -271,6 +271,28 @@ class BackendClient {
         return data.entries ?? [];
     }
 
+    public async getExcludeSyncStatus(): Promise<ExcludeSyncUrlStatus[]> {
+        const url = process.env.BACKEND_URL + "/api/exclude-sync";
+        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
+        const response = await fetch(url, { method: "GET", headers: { "x-api-key": apiKey } });
+        if (!response.ok) {
+            throw new Error(`Failed to get exclude-sync status: ${(await response.json()).error}`);
+        }
+        const data = await response.json();
+        return data.urls || [];
+    }
+
+    public async refreshExcludeSync(): Promise<ExcludeSyncUrlStatus[]> {
+        const url = process.env.BACKEND_URL + "/api/exclude-sync";
+        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
+        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey } });
+        if (!response.ok) {
+            throw new Error(`Failed to refresh exclude-sync: ${(await response.json()).error}`);
+        }
+        const data = await response.json();
+        return data.urls || [];
+    }
+
     public async clearWatchdogEntries(): Promise<number> {
         const url = process.env.BACKEND_URL + `/api/clear-watchdog-entries`;
         const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
@@ -480,6 +502,14 @@ export type DirectoryItem = {
 export type ConfigItem = {
     configName: string,
     configValue: string,
+}
+
+export type ExcludeSyncUrlStatus = {
+    url: string,
+    count: number,
+    fetchedAt: number | null,
+    lastChecked: number | null,
+    error: string | null,
 }
 
 export type WatchtowerQuery = {

--- a/frontend/app/routes/settings.exclude-sync/route.tsx
+++ b/frontend/app/routes/settings.exclude-sync/route.tsx
@@ -1,0 +1,13 @@
+import { backendClient } from "~/clients/backend-client.server";
+
+// Resource route bridging the browser to the backend's /api/exclude-sync endpoint.
+// GET  -> current per-URL sync status. POST -> force a refresh, then return status.
+export async function loader() {
+    const urls = await backendClient.getExcludeSyncStatus();
+    return Response.json({ urls });
+}
+
+export async function action() {
+    const urls = await backendClient.refreshExcludeSync();
+    return Response.json({ urls });
+}

--- a/frontend/app/routes/settings/indexers/indexers.module.css
+++ b/frontend/app/routes/settings/indexers/indexers.module.css
@@ -541,3 +541,42 @@
         flex: 1;
     }
 }
+
+.sync-controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.sync-refresh-label {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.sync-refresh-input {
+    width: 90px;
+    flex: 0 0 auto;
+}
+
+.sync-status {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 10px;
+}
+
+.sync-status-row {
+    font-size: 0.82rem;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+}
+
+.sync-status-ok {
+    color: var(--success, #22c55e);
+}
+
+.sync-status-bad {
+    color: var(--danger, #ef4444);
+}

--- a/frontend/app/routes/settings/indexers/indexers.module.css.d.ts
+++ b/frontend/app/routes/settings/indexers/indexers.module.css.d.ts
@@ -49,6 +49,13 @@ declare const styles: {
   readonly "pattern-error-pattern": string;
   readonly "pattern-error-message": string;
   readonly "pattern-hint": string;
+  readonly "sync-controls": string;
+  readonly "sync-refresh-label": string;
+  readonly "sync-refresh-input": string;
+  readonly "sync-status": string;
+  readonly "sync-status-row": string;
+  readonly "sync-status-ok": string;
+  readonly "sync-status-bad": string;
   readonly "form-checkbox-wrapper": string;
   readonly "form-checkbox": string;
   readonly "form-checkbox-label": string;

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -6,6 +6,7 @@ import { isMaskedSecret } from "~/utils/config-mask";
 type IndexersSettingsProps = {
     config: Record<string, string>
     setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
+    savedConfig?: Record<string, string>
 };
 
 interface ResultFilter {
@@ -85,6 +86,53 @@ function validateExcludePatterns(raw: string): PatternIssue[] {
     return issues;
 }
 
+type ExcludeSyncUrlStatus = {
+    url: string,
+    count: number,
+    fetchedAt: number | null,
+    lastChecked: number | null,
+    error: string | null,
+};
+
+type SyncUrlIssue = { line: number, value: string, error: string };
+
+function validateSyncUrls(raw: string): SyncUrlIssue[] {
+    const issues: SyncUrlIssue[] = [];
+    const lines = raw.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        const trimmed = lines[i].trim();
+        if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+        try {
+            const parsed = new URL(trimmed);
+            if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+                issues.push({ line: i + 1, value: trimmed, error: "must be http(s)" });
+            }
+        } catch {
+            issues.push({ line: i + 1, value: trimmed, error: "invalid URL" });
+        }
+    }
+    return issues;
+}
+
+function isRefreshValid(raw: string): boolean {
+    const trimmed = raw.trim();
+    if (trimmed === "") return true; // blank → server default (720)
+    const n = Number(trimmed);
+    return Number.isInteger(n) && n >= 15 && n <= 10080;
+}
+
+function syncHostLabel(url: string): string {
+    try { return new URL(url).host; } catch { return url; }
+}
+
+function syncRelativeTime(unixSeconds: number): string {
+    const diff = Math.floor(Date.now() / 1000) - unixSeconds;
+    if (diff < 60) return "just now";
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+    return `${Math.floor(diff / 86400)}d ago`;
+}
+
 function parseConfig(raw: string): IndexerConfig {
     try {
         const parsed = JSON.parse(raw || "{}");
@@ -132,7 +180,7 @@ function isProxyUrlValid(raw: string): boolean {
     }
 }
 
-export function IndexersSettings({ config, setNewConfig }: IndexersSettingsProps) {
+export function IndexersSettings({ config, setNewConfig, savedConfig }: IndexersSettingsProps) {
     const indexerConfig = useMemo(() => parseConfig(config["indexers.instances"]), [config]);
     const [showModal, setShowModal] = useState(false);
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -205,6 +253,47 @@ export function IndexersSettings({ config, setNewConfig }: IndexersSettingsProps
     const handleExcludePatternsChange = useCallback((value: string) => {
         setNewConfig({ ...config, "search.exclude-patterns": value });
     }, [config, setNewConfig]);
+
+    const excludeSyncUrls = config["search.exclude-sync-urls"] ?? "";
+    const excludeSyncRefresh = config["search.exclude-sync-refresh-minutes"] ?? "";
+    const syncUrlIssues = useMemo(() => validateSyncUrls(excludeSyncUrls), [excludeSyncUrls]);
+    const handleSyncUrlsChange = useCallback((value: string) => {
+        setNewConfig({ ...config, "search.exclude-sync-urls": value });
+    }, [config, setNewConfig]);
+    const handleSyncRefreshChange = useCallback((value: string) => {
+        const cleaned = value.replace(/[^0-9]/g, "");
+        setNewConfig({ ...config, "search.exclude-sync-refresh-minutes": cleaned });
+    }, [config, setNewConfig]);
+
+    const [syncStatus, setSyncStatus] = useState<ExcludeSyncUrlStatus[]>([]);
+    const [isSyncing, setIsSyncing] = useState(false);
+    const loadSyncStatus = useCallback(async () => {
+        try {
+            const res = await fetch("/settings/exclude-sync");
+            if (res.ok) setSyncStatus((await res.json()).urls ?? []);
+        } catch {
+            // status is best-effort; ignore transient failures
+        }
+    }, []);
+    // Load on mount, and re-pull after a save changes the synced URLs. The backend
+    // refetches on config change, so poll once immediately and once after it settles.
+    const savedSyncUrls = savedConfig?.["search.exclude-sync-urls"] ?? "";
+    useEffect(() => {
+        void loadSyncStatus();
+        const timer = setTimeout(() => { void loadSyncStatus(); }, 2000);
+        return () => clearTimeout(timer);
+    }, [savedSyncUrls, loadSyncStatus]);
+    const handleSyncNow = useCallback(async () => {
+        setIsSyncing(true);
+        try {
+            const res = await fetch("/settings/exclude-sync", { method: "POST" });
+            if (res.ok) setSyncStatus((await res.json()).urls ?? []);
+        } catch {
+            // ignore; the row shows the backend-reported error on the next status load
+        } finally {
+            setIsSyncing(false);
+        }
+    }, []);
 
     const defaultSearchUserAgent = config["api.search-user-agent"] ?? "";
     const handleSearchUserAgentChange = useCallback((value: string) => {
@@ -335,6 +424,66 @@ export function IndexersSettings({ config, setNewConfig }: IndexersSettingsProps
                             are dropped before being returned. Case-insensitive by default — use <code>(?-i:Foo)</code> for
                             case-sensitive. Lines starting with <code>#</code> are comments. Use this to skip
                             releases your setup can't handle, whatever the reason.
+                        </p>
+                    </div>
+
+                    <div className={`${styles["form-group"]} ${styles["full-width"]}`}>
+                        <label htmlFor="indexers-exclude-sync-urls" className={styles["form-label"]}>
+                            Synced exclude URLs <span className={styles["label-hint"]}>(auto-updating; one URL per line)</span>
+                        </label>
+                        <Textarea
+                            id="indexers-exclude-sync-urls"
+                            rows={3}
+                            spellCheck={false}
+                            className={`${styles["form-input"]} ${styles["pattern-input"]} ${syncUrlIssues.length > 0 ? styles.error : ""}`}
+                            placeholder={"# one URL per line\nhttps://raw.githubusercontent.com/.../excluded-regex.json"}
+                            value={excludeSyncUrls}
+                            onChange={e => handleSyncUrlsChange(e.target.value)} />
+                        {syncUrlIssues.length > 0 && (
+                            <div className={styles["pattern-errors"]}>
+                                {syncUrlIssues.map((iss, i) => (
+                                    <div key={i} className={styles["pattern-error"]}>
+                                        <span className={styles["pattern-error-line"]}>Line {iss.line}</span>
+                                        <code className={styles["pattern-error-pattern"]}>{iss.value}</code>
+                                        <span className={styles["pattern-error-message"]}>— {iss.error}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        <div className={styles["sync-controls"]}>
+                            <label htmlFor="indexers-exclude-sync-refresh" className={styles["sync-refresh-label"]}>
+                                Refresh every
+                            </label>
+                            <input
+                                type="text"
+                                inputMode="numeric"
+                                id="indexers-exclude-sync-refresh"
+                                className={`${styles["form-input"]} ${styles["sync-refresh-input"]} ${!isRefreshValid(excludeSyncRefresh) ? styles.error : ""}`}
+                                placeholder="720"
+                                value={excludeSyncRefresh}
+                                onChange={e => handleSyncRefreshChange(e.target.value)} />
+                            <span className={styles["label-hint"]}>minutes</span>
+                            <Button variant="secondary" size="small" onClick={handleSyncNow} disabled={isSyncing}>
+                                {isSyncing ? "Syncing…" : "Sync now"}
+                            </Button>
+                        </div>
+                        {syncStatus.length > 0 && (
+                            <div className={styles["sync-status"]}>
+                                {syncStatus.map((s, i) => (
+                                    <div key={i} className={styles["sync-status-row"]}>
+                                        {s.error
+                                            ? <span className={styles["sync-status-bad"]}>✗ {syncHostLabel(s.url)} — {s.error}</span>
+                                            : <span className={styles["sync-status-ok"]}>✓ {syncHostLabel(s.url)} — {s.count} pattern{s.count === 1 ? "" : "s"}{s.lastChecked ? ` · synced ${syncRelativeTime(s.lastChecked)}` : ""}</span>}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        <p className={styles["pattern-hint"]}>
+                            Point at one or more JSON lists of regex patterns (e.g. TRaSH-derived exclude URLs).
+                            Accepts <code>{`{ "values": ["…"] }`}</code> or <code>{`[{ "pattern": "…" }]`}</code>.
+                            Synced patterns are fetched on the interval above and take precedence; your manual
+                            patterns above are merged in after, with exact duplicates removed. If a URL can't be
+                            reached, the last good copy keeps working. Save your changes first, then use <strong>Sync now</strong>.
                         </p>
                     </div>
                 </div>
@@ -1273,7 +1422,9 @@ export function isIndexersSettingsUpdated(config: Record<string, string>, newCon
     return config["indexers.instances"] !== newConfig["indexers.instances"]
         || (config["api.user-agent"] ?? "") !== (newConfig["api.user-agent"] ?? "")
         || (config["api.search-user-agent"] ?? "") !== (newConfig["api.search-user-agent"] ?? "")
-        || (config["search.exclude-patterns"] ?? "") !== (newConfig["search.exclude-patterns"] ?? "");
+        || (config["search.exclude-patterns"] ?? "") !== (newConfig["search.exclude-patterns"] ?? "")
+        || (config["search.exclude-sync-urls"] ?? "") !== (newConfig["search.exclude-sync-urls"] ?? "")
+        || (config["search.exclude-sync-refresh-minutes"] ?? "") !== (newConfig["search.exclude-sync-refresh-minutes"] ?? "");
 }
 
 export function isIndexersSettingsValid(newConfig: Record<string, string>) {
@@ -1297,6 +1448,9 @@ export function isIndexersSettingsValid(newConfig: Record<string, string>) {
             if (i.ExtraTvCategories !== undefined && !isCategoryListValid(i.ExtraTvCategories)) return false;
         }
         if (validateExcludePatterns(newConfig["search.exclude-patterns"] ?? "").length > 0) return false;
+        if (validateSyncUrls(newConfig["search.exclude-sync-urls"] ?? "").length > 0) return false;
+        const syncRefresh = newConfig["search.exclude-sync-refresh-minutes"] ?? "";
+        if (syncRefresh.trim() !== "" && !isRefreshValid(syncRefresh)) return false;
         return true;
     } catch {
         return false;

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -71,6 +71,8 @@ const defaultConfig = {
     "grab.stall-failover-window-seconds": "2",
     "grab.stall-failover-ceiling-seconds": "5",
     "search.exclude-patterns": "",
+    "search.exclude-sync-urls": "",
+    "search.exclude-sync-refresh-minutes": "720",
     "variants.mode": "off",
     "variants.tolerance-pct": "25",
     "variants.max-per-group": "3",
@@ -271,7 +273,7 @@ function Body(props: BodyProps) {
             <Tabs options={tabOptions} value={activeTab} onChange={setActiveTab} />
             <TabPanel>
                 {activeTab === "usenet" && <UsenetSettings config={newConfig} setNewConfig={setNewConfig} />}
-                {activeTab === "indexers" && <IndexersSettings config={newConfig} setNewConfig={setNewConfig} />}
+                {activeTab === "indexers" && <IndexersSettings config={newConfig} setNewConfig={setNewConfig} savedConfig={config} />}
                 {activeTab === "profiles" && <ProfilesSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "watchdog" && <WatchdogSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "preflight" && <PreflightSettings config={newConfig} setNewConfig={setNewConfig} />}

--- a/tests/NzbWebDAV.Tests/Config/ExcludePatternMergeTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ExcludePatternMergeTests.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ExcludePatternMergeTests
+{
+    [Fact]
+    public void GetSearchExcludePatterns_SyncedFirstThenManual_DropsExactDupes()
+    {
+        var url = "https://example.com/list.json";
+        var cache = new ExcludeSyncCache
+        {
+            Urls =
+            {
+                [url] = new ExcludeSyncUrlEntry
+                {
+                    Items = [@"\.iso$", @"\.img$"],
+                    FetchedAt = 1,
+                    LastChecked = 1,
+                }
+            }
+        };
+
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = "search.exclude-sync-urls", ConfigValue = url },
+            new ConfigItem { ConfigName = "search.exclude-sync-cache", ConfigValue = JsonSerializer.Serialize(cache) },
+            new ConfigItem { ConfigName = "search.exclude-patterns", ConfigValue = "\\.iso$\n\\.mkv$" },
+        ]);
+
+        var patterns = config.GetSearchExcludePatterns();
+        Assert.Equal(3, patterns.Count);
+        Assert.Matches(patterns[0], "a.ISO");
+        Assert.Matches(patterns[1], "a.img");
+        Assert.Matches(patterns[2], "a.mkv");
+        Assert.DoesNotMatch(patterns[2], "a.iso");
+    }
+
+    [Fact]
+    public void GetSearchExcludePatterns_ReturnsCachedInstanceUntilInvalidate()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = "search.exclude-patterns", ConfigValue = "\\.iso$" },
+        ]);
+
+        var first = config.GetSearchExcludePatterns();
+        var second = config.GetSearchExcludePatterns();
+        Assert.Same(first, second);
+
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = "search.exclude-patterns", ConfigValue = "\\.mkv$" },
+        ]);
+        var third = config.GetSearchExcludePatterns();
+        Assert.NotSame(first, third);
+        Assert.Single(third);
+        Assert.Matches(third[0], "x.mkv");
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/SearchExcludeSyncServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SearchExcludeSyncServiceTests.cs
@@ -1,0 +1,42 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class SearchExcludeSyncServiceTests
+{
+    [Fact]
+    public void ParsePayload_ValuesObject()
+    {
+        var items = SearchExcludeSyncService.ParsePayload("""{"values":["a","b"]}""");
+        Assert.Equal(["a", "b"], items);
+    }
+
+    [Fact]
+    public void ParsePayload_PatternObjects()
+    {
+        var items = SearchExcludeSyncService.ParsePayload(
+            """[{"pattern":"a"},{"pattern":"b","name":"x","score":5}]""");
+        Assert.Equal(["a", "b"], items);
+    }
+
+    [Fact]
+    public void ParsePayload_BareStringArray()
+    {
+        var items = SearchExcludeSyncService.ParsePayload("""["a","b"]""");
+        Assert.Equal(["a", "b"], items);
+    }
+
+    [Fact]
+    public void ParsePayload_SkipsObjectsWithoutPattern()
+    {
+        var items = SearchExcludeSyncService.ParsePayload("""[{"name":"x"},{"pattern":"a"}]""");
+        Assert.Equal(["a"], items);
+    }
+
+    [Fact]
+    public void ParsePayload_UnexpectedObject_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            SearchExcludeSyncService.ParsePayload("""{"foo":1}"""));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/ExcludePatternParserTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ExcludePatternParserTests.cs
@@ -1,0 +1,59 @@
+using System.Text.RegularExpressions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ExcludePatternParserTests
+{
+    [Fact]
+    public void Parse_BareBody_IsCaseInsensitiveByDefault()
+    {
+        var parsed = ExcludePatternParser.Parse(@"\.iso$");
+        Assert.NotNull(parsed);
+        Assert.Matches(parsed!.Value.Regex, "FILE.ISO");
+        Assert.DoesNotMatch(parsed.Value.Regex, "FILE.mkv");
+    }
+
+    [Fact]
+    public void Parse_JsWrapper_SharesDedupKeyWithBareBody()
+    {
+        var bare = ExcludePatternParser.Parse(@"\.(iso|img)$");
+        var wrapped = ExcludePatternParser.Parse(@"/\.(iso|img)$/i");
+        Assert.NotNull(bare);
+        Assert.NotNull(wrapped);
+        Assert.Equal(bare!.Value.Key, wrapped!.Value.Key);
+        Assert.Matches(wrapped.Value.Regex, "Movie.ISO");
+    }
+
+    [Fact]
+    public void Parse_MsFlags_AreOrderIndependentInKey()
+    {
+        var ms = ExcludePatternParser.Parse("/x/ms");
+        var sm = ExcludePatternParser.Parse("/x/sm");
+        Assert.NotNull(ms);
+        Assert.NotNull(sm);
+        Assert.Equal(ms!.Value.Key, sm!.Value.Key);
+        Assert.True((ms.Value.Regex.Options & RegexOptions.Multiline) != 0);
+        Assert.True((ms.Value.Regex.Options & RegexOptions.Singleline) != 0);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("# comment")]
+    [InlineData("[")]
+    public void Parse_BlanksCommentsAndInvalid_ReturnNull(string? line)
+    {
+        Assert.Null(ExcludePatternParser.Parse(line));
+    }
+
+    [Fact]
+    public void Parse_UnknownJsFlags_AreIgnored()
+    {
+        var parsed = ExcludePatternParser.Parse("/foo/gu");
+        Assert.NotNull(parsed);
+        Assert.Equal("foo ", parsed!.Value.Key);
+        Assert.Matches(parsed.Value.Regex, "FOO");
+    }
+}


### PR DESCRIPTION
## Summary
- Sync exclude-filter regex patterns from one or more remote URLs (TRaSH-style JSON) on a schedule and via **Sync now**.
- Merge synced patterns ahead of the manual textarea, dropping exact duplicates.
- Last-good cache under `search.exclude-sync-cache` keeps filters working if a URL is temporarily unreachable (machine-managed; not exposed in settings `defaultConfig`).
- Compiled exclude-pattern cache avoids recompiling on every search.

Closes #266

Ported from [qooode/nzbdavex#32](https://github.com/qooode/nzbdavex/pull/32) (IbbyLabs). Frontend adapted to this repo's Tailwind UI kit (`Textarea`, `Button size="small"`).

## Deviations from the fork
- `SearchExcludeSyncService.ParsePayload` is `internal` for unit testing.
- Unit tests added for parser, payload parse, and merge/cache identity.

## Test plan
- [x] Backend build
- [x] Unit tests (ExcludePatternParser / SearchExcludeSync / ExcludePatternMerge — 16 passed)
- [x] Frontend typecheck + tests
- [ ] Configure a real TRaSH-style URL, save, wait ~2 s → status row shows ✓ with a pattern count
- [ ] Search via a profile → excluded titles disappear; remove the URL, save → they return
- [ ] Point at an unreachable URL → ✗ row with the error, previous patterns still filter
- [ ] **Sync now** with a modified upstream list → count updates immediately
- [ ] Restart the container → status/patterns survive (persisted snapshot)