### PR TITLE
feat(db): live progress UI for long database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!IMPORTANT]
+> This fork includes database schema upgrades that can take quite a while to complete. The app will be down during that time.
+>
+> Early adopters are reporting **2x network throughput** capability and a **400% reduction in seek time**.
+
 <p align="center">
   <img width="1101" height="238" alt="NzbDav" src="https://github.com/user-attachments/assets/b14165f4-24ff-4abe-8af6-3ca852e781d4" />
 </p>
@@ -27,8 +32,6 @@ This project is a maintained fork of [nzbdav-dev/nzbdav](https://github.com/nzbd
 
 Read the full story in the [release announcement](docs/release-announcement.md).
 
-Early adopters are reporting **2x network throughput** capability and a **400% reduction in seek time**.
-
 ## Special thanks
 
 Special thanks to the forks and contributors whose ideas we absorbed:
@@ -42,24 +45,65 @@ Special thanks to the forks and contributors whose ideas we absorbed:
 
 ## Features
 
-* 📁 **WebDAV server** — host your virtual filesystem over HTTP(S)
-* ☁️ **Mount NZB documents** — browse NZB contents instantly, no download needed
-* 📽️ **Full streaming & seeking** — jump to any point in your video streams
-* 🗃️ **Archive streaming** — view, stream, and seek inside RAR and 7z archives
-* 🔓 **Password-protected archives** — stream encrypted content transparently
-* 🔀 **Multiple Usenet providers** — automatic failover with per-provider circuit breakers
-* 📊 **Live operations dashboard** — throughput, latency, errors, active reads, provider usage, failover saves, and indexer activity
-* 🧭 **Provider routing and limits** — cascade priorities, per-provider data caps, usage resets, and connection benchmarking
-* 🔎 **Built-in indexer search** — configure Newznab indexers, track API usage, search them manually, and mount results
-* 🎛️ **Search profiles and adapters** — expose selected indexers through token-scoped Addon, Newznab, and JSON APIs
-* 🐕 **Watchdog playback failover** — verify candidates, retry failed releases, and inspect each playback attempt
-* 🛡️ **Warden dead-release ledger** — remember unavailable releases, combine trusted remote ledgers, and import, export, or back up the data
-* 📡 **Watchtower proactive resolution** — keep wanted movies and episodes mapped to verified releases before playback
-* 📜 **Live log viewer** — filter, follow, and download backend logs from the admin UI
-* 🗂️ **WebDAV management** — browse, download, and delete eligible virtual filesystem items from the UI
-* 💙 **Health checks & optional repairs** — monitor content health and trigger replacements through Radarr/Sonarr when configured
-* 🧩 **SABnzbd-compatible API** — drop-in replacement for SABnzbd
-* 🙌 **Sonarr/Radarr integration** — import through Rclone symlinks or lightweight STRM files
+* 📁 **WebDAV server**
+  Host your virtual filesystem over HTTP(S)
+
+* ☁️ **Mount NZB documents**
+  Browse NZB contents instantly, no download needed
+
+* 📽️ **Full streaming & seeking**
+  Jump to any point in your video streams
+
+* 🚀 **NNTP article pipelining**
+  Optional pipelined article fetches for higher throughput and faster seeks
+
+* 🗃️ **Archive streaming**
+  View, stream, and seek inside RAR and 7z archives
+
+* 🔓 **Password-protected archives**
+  Stream encrypted content transparently
+
+* 🔀 **Multiple Usenet providers**
+  Automatic failover with per-provider circuit breakers
+
+* 📊 **Live operations dashboard**
+  Throughput, latency, errors, active reads, provider usage, failover saves, and indexer activity
+
+* 🧭 **Provider routing and limits**
+  Cascade priorities, per-provider data caps, usage resets, and connection benchmarking
+
+* 🔎 **Built-in indexer search**
+  Configure Newznab indexers, track API usage, search them manually, and mount results
+
+* 🚫 **Search exclude filters**
+  Manual regex excludes plus auto-synced remote lists (e.g. TRaSH) with refresh status
+
+* 🎛️ **Search profiles and adapters**
+  Expose selected indexers through token-scoped Addon, Newznab, and JSON APIs
+
+* 🐕 **Watchdog playback failover**
+  Verify candidates, retry failed releases, and inspect each playback attempt
+
+* 🛡️ **Warden dead-release ledger**
+  Remember unavailable releases, combine trusted remote ledgers, and import, export, or back up the data
+
+* 📡 **Watchtower proactive resolution**
+  Keep wanted movies and episodes mapped to verified releases before playback
+
+* 📜 **Live log viewer**
+  Filter, follow, and download backend logs from the admin UI
+
+* 🗂️ **WebDAV management**
+  Browse, download, and delete eligible virtual filesystem items from the UI
+
+* 💙 **Health checks & optional repairs**
+  Monitor content health and trigger replacements through Radarr/Sonarr when configured
+
+* 🧩 **SABnzbd-compatible API**
+  Drop-in replacement for SABnzbd
+
+* 🙌 **Sonarr/Radarr integration**
+  Import through Rclone symlinks or lightweight STRM files
 
 ## Quick start
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -83,21 +83,7 @@ class Program
             // run database migration, if necessary.
             if (args.Contains("--db-migration"))
             {
-                var argIndex = args.ToList().IndexOf("--db-migration");
-                var targetMigration = args.Length > argIndex + 1 ? args[argIndex + 1] : null;
-                Log.Information(
-                    "Applying database migrations{Target}",
-                    targetMigration is null ? string.Empty : $" through {targetMigration}");
-                await databaseContext.Database
-                    .MigrateAsync(targetMigration, SigtermUtil.GetCancellationToken())
-                    .ConfigureAwait(false);
-                Log.Information("Database migrations completed");
-
-                await using var metricsContext = new MetricsDbContext();
-                await metricsContext.Database
-                    .MigrateAsync(SigtermUtil.GetCancellationToken())
-                    .ConfigureAwait(false);
-                await PerformDatabaseVacuumIfEnabled();
+                await RunDatabaseMigrationsAsync(databaseContext, args).ConfigureAwait(false);
                 return;
             }
 
@@ -276,11 +262,108 @@ class Program
         Environment.Exit(1);
     }
 
-    private static async Task PerformDatabaseVacuumIfEnabled()
+    private static async Task RunDatabaseMigrationsAsync(DavDatabaseContext databaseContext, string[] args)
+    {
+        var ct = SigtermUtil.GetCancellationToken();
+        var argIndex = args.ToList().IndexOf("--db-migration");
+        var targetMigration = args.Length > argIndex + 1 ? args[argIndex + 1] : null;
+
+        // An explicit target (design-time tooling / tests) uses the simple,
+        // single-call path. Progress tracking only covers the common upgrade
+        // path where all pending migrations are applied.
+        if (targetMigration is not null)
+        {
+            Log.Information("Applying database migrations through {Target}", targetMigration);
+            await databaseContext.Database.MigrateAsync(targetMigration, ct).ConfigureAwait(false);
+            Log.Information("Database migrations completed");
+            await using var metricsContext = new MetricsDbContext();
+            await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
+            await PerformDatabaseVacuumIfEnabled().ConfigureAwait(false);
+            return;
+        }
+
+        var pending = (await databaseContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
+        var vacuumEnabled = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);
+
+        // Build the ordered list of maintenance steps: each pending migration,
+        // then the metrics database, then the optional vacuum.
+        var steps = new List<MigrationProgress.MigrationStep>();
+        foreach (var id in pending)
+            steps.Add(new MigrationProgress.MigrationStep(id, MigrationProgress.FriendlyName(id), MigrationProgress.IsSlow(id)));
+        steps.Add(new MigrationProgress.MigrationStep(MigrationProgress.MetricsStepId, "Metrics database", false));
+        if (vacuumEnabled)
+            steps.Add(new MigrationProgress.MigrationStep(MigrationProgress.VacuumStepId, "Optimizing database (vacuum)", true));
+
+        var progress = new MigrationProgress();
+        progress.Initialize(steps);
+
+        // Serve live progress on the backend port for the duration of the migration.
+        await using var statusServer = await MigrationStatusServer.StartAsync(progress, ct).ConfigureAwait(false);
+
+        try
+        {
+            if (pending.Count == 0)
+                Log.Information("No pending database migrations");
+
+            for (var i = 0; i < steps.Count; i++)
+            {
+                var step = steps[i];
+                Log.Information(
+                    "Database maintenance step {Index}/{Total}: {Name}",
+                    i + 1, steps.Count, step.Name);
+                progress.BeginStep(step.Id);
+
+                if (step.Id == MigrationProgress.MetricsStepId)
+                {
+                    await using var metricsContext = new MetricsDbContext();
+                    await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
+                }
+                else if (step.Id == MigrationProgress.VacuumStepId)
+                {
+                    await databaseContext.Database.ExecuteSqlRawAsync("VACUUM;", ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    await databaseContext.Database.MigrateAsync(step.Id, ct).ConfigureAwait(false);
+                }
+
+                progress.CompleteStep(step.Id);
+            }
+
+            progress.Complete();
+            Log.Information("Database migrations completed");
+
+            // Brief grace so the status page can render the final state before
+            // this process exits and the port goes dark.
+            if (statusServer is not null)
+                await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            progress.Fail(ex.Message);
+            Log.Error(ex, "Database migration failed");
+
+            // Keep the failure visible on the status page briefly before exiting.
+            if (statusServer is not null)
+            {
+                try { await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false); }
+                catch { /* ignore */ }
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task<bool> IsDatabaseStartupVacuumEnabledAsync()
     {
         var configManager = new ConfigManager();
         await configManager.LoadConfig().ConfigureAwait(false);
-        if (configManager.IsDatabaseStartupVacuumEnabled())
+        return configManager.IsDatabaseStartupVacuumEnabled();
+    }
+
+    private static async Task PerformDatabaseVacuumIfEnabled()
+    {
+        if (await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false))
         {
             Log.Information("Performing database vacuum");
             await using var databaseContext = new DavDatabaseContext();

--- a/backend/Services/MigrationProgress.cs
+++ b/backend/Services/MigrationProgress.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Thread-safe, in-memory snapshot of the blocking database-migration phase.
+/// Written by the migration runner in <c>Program.cs</c> and read by the
+/// <see cref="MigrationStatusServer"/> so the frontend can render live progress
+/// while the real backend is not yet accepting requests.
+/// </summary>
+public sealed class MigrationProgress
+{
+    // Synthetic step ids for work that is not an EF migration.
+    public const string MetricsStepId = "__metrics__";
+    public const string VacuumStepId = "__vacuum__";
+
+    // Migrations known to perform full-table rewrites/rebuilds. Flagged so the
+    // UI can warn that they may take a long time on large databases.
+    private static readonly HashSet<string> SlowMigrations = new()
+    {
+        "20250819221618_Add-Path-To-DavItem",
+        "20250824100609_Add-IdPrefix-To-DavItems",
+        "20260129182923_Update-DavItems-Type-And-SubType",
+        "20260203071130_Add-DavCleanupItems-Table",
+        "20260712000000_Fix-Empty-Categories",
+    };
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private static readonly Regex MigrationPrefix = new(@"^\d{14}_", RegexOptions.Compiled);
+
+    private readonly object _lock = new();
+    private readonly long _startedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    private readonly List<StepState> _steps = new();
+    private string _state = "running";
+    private string? _error;
+
+    public sealed record MigrationStep(string Id, string Name, bool Slow);
+
+    public void Initialize(IReadOnlyList<MigrationStep> steps)
+    {
+        lock (_lock)
+        {
+            _steps.Clear();
+            foreach (var step in steps)
+                _steps.Add(new StepState(step.Id, step.Name, step.Slow));
+        }
+    }
+
+    public void BeginStep(string id)
+    {
+        lock (_lock)
+        {
+            var step = _steps.FirstOrDefault(x => x.Id == id);
+            if (step is null) return;
+            step.Status = "running";
+            step.StartedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+    }
+
+    public void CompleteStep(string id)
+    {
+        lock (_lock)
+        {
+            var step = _steps.FirstOrDefault(x => x.Id == id);
+            if (step is null) return;
+            step.Status = "completed";
+            step.FinishedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+    }
+
+    public void Complete()
+    {
+        lock (_lock) _state = "completed";
+    }
+
+    /// <summary>Marks the currently running step and the overall run as failed.</summary>
+    public void Fail(string error)
+    {
+        lock (_lock)
+        {
+            _state = "failed";
+            _error = error;
+            var running = _steps.FirstOrDefault(x => x.Status == "running");
+            if (running is not null)
+            {
+                running.Status = "failed";
+                running.FinishedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            }
+        }
+    }
+
+    public string ToJson()
+    {
+        lock (_lock)
+        {
+            var snapshot = new Snapshot(
+                State: _state,
+                StartedAt: _startedAtMs,
+                Completed: _steps.Count(x => x.Status == "completed"),
+                Total: _steps.Count,
+                CurrentStep: _steps.FirstOrDefault(x => x.Status == "running")?.Name,
+                Error: _error,
+                Steps: _steps
+                    .Select(x => new StepSnapshot(x.Id, x.Name, x.Status, x.Slow, x.StartedAtMs, x.FinishedAtMs))
+                    .ToList());
+            return JsonSerializer.Serialize(snapshot, JsonOptions);
+        }
+    }
+
+    /// <summary>Turns "20250819221618_Add-Path-To-DavItem" into "Add Path To DavItem".</summary>
+    public static string FriendlyName(string migrationId)
+    {
+        var withoutPrefix = MigrationPrefix.Replace(migrationId, string.Empty);
+        return withoutPrefix.Replace('-', ' ').Replace('_', ' ').Trim();
+    }
+
+    public static bool IsSlow(string migrationId) => SlowMigrations.Contains(migrationId);
+
+    private sealed class StepState(string id, string name, bool slow)
+    {
+        public string Id { get; } = id;
+        public string Name { get; } = name;
+        public bool Slow { get; } = slow;
+        public string Status { get; set; } = "pending";
+        public long? StartedAtMs { get; set; }
+        public long? FinishedAtMs { get; set; }
+    }
+
+    private sealed record Snapshot(
+        string State,
+        long StartedAt,
+        int Completed,
+        int Total,
+        string? CurrentStep,
+        string? Error,
+        IReadOnlyList<StepSnapshot> Steps);
+
+    private sealed record StepSnapshot(
+        string Id,
+        string Name,
+        string Status,
+        bool Slow,
+        long? StartedAt,
+        long? FinishedAt);
+}

--- a/backend/Services/MigrationStatusServer.cs
+++ b/backend/Services/MigrationStatusServer.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// A minimal HTTP server that runs for the duration of the blocking
+/// <c>--db-migration</c> phase. It binds the same port the real backend will
+/// later use (via <c>ASPNETCORE_URLS</c>) and serves migration progress at
+/// <c>/api/migration-status</c> so the frontend can render a live status page.
+/// Every other route (including <c>/health</c>) returns 503 so the entrypoint
+/// health poll and frontend loaders keep retrying until the real backend is up.
+/// </summary>
+public sealed class MigrationStatusServer : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+
+    private MigrationStatusServer(WebApplication app) => _app = app;
+
+    public static async Task<MigrationStatusServer?> StartAsync(MigrationProgress progress, CancellationToken ct)
+    {
+        try
+        {
+            var builder = WebApplication.CreateBuilder();
+            // Keep this process quiet; migration progress is logged via Serilog.
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.None);
+
+            var app = builder.Build();
+
+            app.MapGet("/api/migration-status", (HttpContext context) =>
+            {
+                context.Response.ContentType = "application/json";
+                return context.Response.WriteAsync(progress.ToJson());
+            });
+
+            app.MapFallback((HttpContext context) =>
+            {
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                context.Response.ContentType = "application/json";
+                return context.Response.WriteAsync("{\"status\":\"migrating\"}");
+            });
+
+            await app.StartAsync(ct).ConfigureAwait(false);
+            return new MigrationStatusServer(app);
+        }
+        catch (Exception ex)
+        {
+            // A missing status page must never block the actual migration.
+            Log.Warning(ex, "Could not start migration status server; migration progress UI is unavailable");
+            return null;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await _app.StopAsync(stopCts.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error stopping migration status server");
+        }
+
+        await _app.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,6 +106,13 @@ if [ -n "$OWNERSHIP_MISMATCH" ]; then
     chown -R "$PUID:$PGID" "$CONFIG_PATH"
 fi
 
+# Start the frontend first so it can serve the database-maintenance progress
+# page (via the backend's migration status server) while migrations run. The
+# migration step below can take a long time on large databases.
+cd /app/frontend
+su-exec "$USER_NAME" npm run start &
+FRONTEND_PID=$!
+
 # Run backend database migration
 cd /app/backend
 echo "Running database maintenance."
@@ -113,6 +120,10 @@ su-exec "$USER_NAME" ./NzbWebDAV --db-migration
 MIGRATION_EXIT_CODE=$?
 if [ "$MIGRATION_EXIT_CODE" -ne 0 ]; then
     echo "Database migration failed. Exiting with error code $MIGRATION_EXIT_CODE."
+    if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
+        kill "$FRONTEND_PID"
+        wait "$FRONTEND_PID" 2>/dev/null
+    fi
     exit "$MIGRATION_EXIT_CODE"
 fi
 echo "Done with database maintenance."
@@ -138,16 +149,15 @@ while true; do
         echo "Backend failed health check after $MAX_BACKEND_HEALTH_RETRIES retries. Exiting."
         kill "$BACKEND_PID"
         wait "$BACKEND_PID"
+        if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
+            kill "$FRONTEND_PID"
+            wait "$FRONTEND_PID" 2>/dev/null
+        fi
         exit 1
     fi
 
     sleep "$MAX_BACKEND_HEALTH_RETRY_DELAY"
 done
-
-# Run frontend as "$USER_NAME" in background
-cd /app/frontend
-su-exec "$USER_NAME" npm run start &
-FRONTEND_PID=$!
 
 # Wait for either to exit
 wait_either "$BACKEND_PID" "$FRONTEND_PID"

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type MigrationStepStatus = "pending" | "running" | "completed" | "failed";
+
+export type MigrationStep = {
+  id: string;
+  name: string;
+  status: MigrationStepStatus;
+  slow: boolean;
+  startedAt: number | null;
+  finishedAt: number | null;
+};
+
+export type MigrationStatus = {
+  state: "running" | "completed" | "failed";
+  startedAt: number;
+  completed: number;
+  total: number;
+  currentStep: string | null;
+  error: string | null;
+  steps: MigrationStep[];
+};
+
+function isMigrationStatus(value: unknown): value is MigrationStatus {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.state === "string" && Array.isArray(v.steps);
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) ms = 0;
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hours > 0 ? `${hours}:${pad(minutes)}:${pad(seconds)}` : `${minutes}:${pad(seconds)}`;
+}
+
+type Phase = "checking" | "connecting" | "migrating" | "fallback";
+
+type FallbackProps = {
+  title: string;
+  detail: string;
+  showReload: boolean;
+};
+
+/**
+ * Client-side wrapper rendered by the root ErrorBoundary. It polls
+ * `/api/migration-status`; while the backend is applying database migrations
+ * (the blocking startup phase) it renders a live progress page. Otherwise it
+ * falls back to the generic error card the ErrorBoundary computed.
+ */
+export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
+  const [phase, setPhase] = useState<Phase>("checking");
+  const [status, setStatus] = useState<MigrationStatus | null>(null);
+  const seenMigration = useRef(false);
+  const reloadScheduled = useRef(false);
+
+  const scheduleReload = useCallback((delayMs: number) => {
+    if (reloadScheduled.current) return;
+    reloadScheduled.current = true;
+    window.setTimeout(() => window.location.reload(), delayMs);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const res = await fetch("/api/migration-status", {
+          headers: { accept: "application/json" },
+          cache: "no-store",
+        });
+        if (cancelled) return;
+
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (cancelled) return;
+          if (isMigrationStatus(data)) {
+            seenMigration.current = true;
+            setStatus(data);
+            setPhase("migrating");
+            if (data.state === "completed") scheduleReload(1500);
+            return;
+          }
+          // 200 but not migration-shaped: the real backend answered, so this
+          // is a genuine error rather than the migration phase.
+          setPhase("fallback");
+          return;
+        }
+
+        // The backend port is not serving yet (starting up or handing off
+        // from the migration process to the real backend). Reload periodically
+        // so the real app loads as soon as the backend is reachable.
+        if (res.status === 502 || res.status === 503) {
+          setPhase("connecting");
+          scheduleReload(5000);
+          return;
+        }
+
+        setPhase("fallback");
+      } catch {
+        if (cancelled) return;
+        // Network failure: nothing is listening on the backend port yet.
+        setPhase("connecting");
+        scheduleReload(5000);
+      }
+    };
+
+    poll();
+    const interval = window.setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [scheduleReload]);
+
+  if (phase === "migrating" && status) {
+    return <MigrationProgressView status={status} />;
+  }
+
+  if (phase === "checking" || phase === "connecting") {
+    return (
+      <MigrationShell
+        title={seenMigration.current ? "Finishing up" : "Connecting to nzbdav"}
+        subtitle={
+          seenMigration.current
+            ? "Database maintenance finished. Waiting for the server to start..."
+            : "Waiting for the backend to respond..."
+        }
+      >
+        <div className="flex items-center gap-3 text-sm text-slate-300">
+          <Spinner />
+          <span>This can take a moment during startup.</span>
+        </div>
+      </MigrationShell>
+    );
+  }
+
+  // Generic error fallback (mirrors the previous ErrorBoundary card).
+  return (
+    <MigrationShell title={fallback.title} subtitle={fallback.detail}>
+      {fallback.showReload ? (
+        <button
+          type="button"
+          className="button-small flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600"
+          onClick={() => window.location.reload()}
+        >
+          Reload
+        </button>
+      ) : null}
+    </MigrationShell>
+  );
+}
+
+function MigrationProgressView({ status }: { status: MigrationStatus }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const total = status.total || status.steps.length;
+  const completed = status.completed;
+  const percent = total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0;
+  const overallElapsed = formatDuration(now - status.startedAt);
+  const runningStep = status.steps.find((s) => s.status === "running") ?? null;
+  const currentElapsed = runningStep?.startedAt ? formatDuration(now - runningStep.startedAt) : null;
+
+  const failed = status.state === "failed";
+  const done = status.state === "completed";
+
+  let title = "Database maintenance in progress";
+  let subtitle =
+    "nzbdav is upgrading your database. This is a one-time step after an update and can take a while on large libraries. The app will load automatically when it finishes.";
+  if (done) {
+    title = "Maintenance complete";
+    subtitle = "Starting nzbdav...";
+  } else if (failed) {
+    title = "Database maintenance failed";
+    subtitle = "The upgrade could not be completed. Check the container logs for details.";
+  }
+
+  return (
+    <MigrationShell title={title} subtitle={subtitle} wide>
+      {failed && status.error ? (
+        <div className="rounded border border-rose-600/50 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+          {status.error}
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>
+            Step {Math.min(completed + (done || failed ? 0 : 1), total)} of {total}
+          </span>
+          <span className="font-mono">Elapsed {overallElapsed}</span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-slate-700/60">
+          <div
+            className={`h-full rounded-full transition-all duration-500 ${failed ? "bg-rose-500" : done ? "bg-emerald-500" : "bg-blue-500"}`}
+            style={{ width: `${done ? 100 : percent}%` }}
+          />
+        </div>
+        {runningStep && !done && !failed ? (
+          <div className="flex items-center gap-2 text-sm text-slate-300">
+            <Spinner />
+            <span>
+              {runningStep.name}
+              {currentElapsed ? <span className="ml-1 font-mono text-slate-400">({currentElapsed})</span> : null}
+            </span>
+          </div>
+        ) : null}
+        {runningStep?.slow && !done && !failed ? (
+          <div className="rounded border border-amber-600/50 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+            This step rewrites large tables and may take a long time on big databases. This is expected.
+          </div>
+        ) : null}
+      </div>
+
+      <ol className="space-y-1.5">
+        {status.steps.map((step) => (
+          <li key={step.id} className="flex items-center gap-2.5 text-sm">
+            <StepIcon status={step.status} />
+            <span
+              className={
+                step.status === "completed"
+                  ? "text-slate-400 line-through decoration-slate-600"
+                  : step.status === "running"
+                    ? "text-white"
+                    : step.status === "failed"
+                      ? "text-rose-300"
+                      : "text-slate-400"
+              }
+            >
+              {step.name}
+            </span>
+            {step.slow && step.status === "pending" ? (
+              <span className="text-[10px] uppercase tracking-wide text-amber-400/80">may be slow</span>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+
+      {failed ? (
+        <button
+          type="button"
+          className="button-small flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600"
+          onClick={() => window.location.reload()}
+        >
+          Reload
+        </button>
+      ) : null}
+    </MigrationShell>
+  );
+}
+
+function MigrationShell({
+  title,
+  subtitle,
+  children,
+  wide,
+}: {
+  title: string;
+  subtitle?: string;
+  children?: React.ReactNode;
+  wide?: boolean;
+}) {
+  return (
+    <main className="flex min-h-dvh w-full items-center justify-center bg-gray-900 px-4 py-8 text-white">
+      <div
+        className={`w-full ${wide ? "max-w-xl" : "max-w-lg"} space-y-4 rounded-xl border border-slate-700/70 bg-gray-800 p-6 shadow-xl shadow-black/20 sm:p-8`}
+      >
+        <div className="flex items-center gap-3">
+          <img className="h-9 w-9" src="/logo.svg" alt="NzbDav" />
+          <div className="space-y-1">
+            <h1 className="text-xl font-bold tracking-tight">{title}</h1>
+            {subtitle ? <p className="text-sm leading-relaxed text-slate-300">{subtitle}</p> : null}
+          </div>
+        </div>
+        {children}
+      </div>
+    </main>
+  );
+}
+
+function StepIcon({ status }: { status: MigrationStepStatus }) {
+  if (status === "completed") {
+    return <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-emerald-400" aria-hidden />;
+  }
+  if (status === "running") {
+    return <Spinner />;
+  }
+  if (status === "failed") {
+    return <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-rose-500" aria-hidden />;
+  }
+  return <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-slate-600" aria-hidden />;
+}
+
+function Spinner() {
+  return (
+    <span
+      className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-slate-500 border-t-blue-400"
+      aria-hidden
+    />
+  );
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -20,6 +20,7 @@ import { Loading } from "./routes/_index/components/loading/loading";
 import { getAppVersion } from "./utils/version.server";
 import { checkForUpdate } from "./utils/update-check.server";
 import { backendClient } from "./clients/backend-client.server";
+import { MigrationBoundary } from "./components/migration-progress";
 
 export async function loader({ request }: Route.LoaderArgs) {
   // Single-fetch navigation/revalidation uses internal `.data` URLs
@@ -151,21 +152,8 @@ export function ErrorBoundary() {
     detail = "Unknown error.";
   }
 
-  return (
-    <main className="flex min-h-dvh w-full items-center justify-center bg-gray-900 px-4 py-8 text-white">
-      <div className="w-full max-w-lg space-y-4 rounded-xl border border-slate-700/70 bg-gray-800 p-6 shadow-xl shadow-black/20 sm:p-8">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
-          {detail ? <p className="text-sm leading-relaxed text-slate-300">{detail}</p> : null}
-        </div>
-        <button
-          type="button"
-          className="button-small flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600"
-          onClick={() => window.location.reload()}
-        >
-          Reload
-        </button>
-      </div>
-    </main>
-  );
+  // A loader throw is also how the app surfaces the blocking database-migration
+  // phase (the backend only serves /api/migration-status then). MigrationBoundary
+  // polls that endpoint and shows live progress, falling back to this error card.
+  return <MigrationBoundary fallback={{ title, detail, showReload: true }} />;
 }


### PR DESCRIPTION
## Summary
- Apply pending EF migrations one step at a time with shared progress state, and host a mini status server on the backend port during `--db-migration` (`GET /api/migration-status`).
- Start the frontend before migration in Docker so users see a live "Database maintenance in progress" splash (step list, elapsed timers, slow-step warnings) instead of a dead container for up to ~2 hours.
- Document the long upgrade migration in the README and refresh the feature list.

## Test plan
- [ ] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [ ] `cd frontend && npm run typecheck && npm test`
- [ ] Run `./NzbWebDAV --db-migration` with pending migrations while the frontend is up; confirm `/api/migration-status` updates and the splash renders
- [ ] Confirm splash auto-reloads into the app after migration completes and the real backend is healthy
- [ ] Confirm migration failure shows the error state briefly, then exits non-zero
- [ ] Docker: confirm `entrypoint.sh` starts frontend before migration and cleans up frontend on migration/health failure
- [ ] Interrupt mid-migration (`docker stop`) and restart; confirm remaining migrations resume from `__EFMigrationsHistory`