### PR TITLE
fix(db): silence websocket warnings during database migration

### DIFF
--- a/backend/Services/MigrationStatusServer.cs
+++ b/backend/Services/MigrationStatusServer.cs
@@ -1,3 +1,4 @@
+using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -29,12 +30,18 @@ public sealed class MigrationStatusServer : IAsyncDisposable
             builder.Logging.SetMinimumLevel(LogLevel.None);
 
             var app = builder.Build();
+            app.UseWebSockets();
 
             app.MapGet("/api/migration-status", (HttpContext context) =>
             {
                 context.Response.ContentType = "application/json";
                 return context.Response.WriteAsync(progress.ToJson());
             });
+
+            // Hold frontend relay websockets open during migration so the relay
+            // does not spam ECONNREFUSED / 503 warnings. On shutdown we close
+            // with 1012 so the relay reconnects to the real backend.
+            app.Map("/ws", HandleMigrationWebSocket);
 
             app.MapFallback((HttpContext context) =>
             {
@@ -51,6 +58,60 @@ public sealed class MigrationStatusServer : IAsyncDisposable
             // A missing status page must never block the actual migration.
             Log.Warning(ex, "Could not start migration status server; migration progress UI is unavailable");
             return null;
+        }
+    }
+
+    private static async Task HandleMigrationWebSocket(HttpContext context)
+    {
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return;
+        }
+
+        using var webSocket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
+        var buffer = new byte[1024];
+
+        try
+        {
+            while (webSocket.State == WebSocketState.Open)
+            {
+                var result = await webSocket
+                    .ReceiveAsync(buffer, context.RequestAborted)
+                    .ConfigureAwait(false);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                    break;
+
+                // Ignore all frames (including the frontend API-key frame).
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Status server is shutting down or the client disconnected.
+        }
+        catch (WebSocketException)
+        {
+            // Client went away; nothing to do.
+        }
+
+        if (webSocket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+        {
+            try
+            {
+                // 1012 = Service Restart (not in WebSocketCloseStatus enum).
+                // Matches the frontend relay's reconnect path for backend handoff.
+                await webSocket
+                    .CloseAsync(
+                        (WebSocketCloseStatus)1012,
+                        "Migration complete",
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort close during shutdown.
+            }
         }
     }
 

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -64,11 +64,27 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
     let connected = false;
     let connectionFailures = 0;
     let lastFailureLogAt = 0;
+    let loggedStartupWait = false;
+    const startedAt = Date.now();
+    const startupGraceMs = 30_000;
     const url = getBackendWebsocketUrl();
 
     function logConnectionFailure(message: string, error?: unknown) {
         const now = Date.now();
         connectionFailures += 1;
+
+        // During the first ~30s after frontend start (e.g. Docker starts the
+        // frontend before --db-migration binds the backend port), connection
+        // refusals are expected. Log once at info without the error stack.
+        if (now - startedAt < startupGraceMs) {
+            if (!loggedStartupWait) {
+                logger.info("Waiting for backend to start...");
+                loggedStartupWait = true;
+                lastFailureLogAt = now;
+            }
+            return;
+        }
+
         if (connectionFailures === 1 || now - lastFailureLogAt >= 60_000) {
             logger.warn(`${message}; retrying in ${reconnectRetryDelay} ms`, error);
             lastFailureLogAt = now;


### PR DESCRIPTION
## Summary
- Accept hold-open `/ws` connections on the migration status server so the frontend relay stays connected during `--db-migration` instead of spamming `ECONNREFUSED` / `503` warnings.
- Soften expected connection-failure logs in the first ~30s after frontend start to a single info line (`Waiting for backend to start...`).

Follow-up to #269: Docker starts the frontend before migration, so the websocket relay dials the backend port while the status server (or nothing) is listening. This makes that expected boot window quiet in logs.

## Test plan
- [ ] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [ ] `cd frontend && npm run typecheck && npm test`
- [ ] Docker: confirm one friendly waiting log, then `Backend websocket connected`, and no repeated warn spam during a long migration
- [ ] After migration completes, confirm relay reconnects to the real backend (close code 1012 handoff)