### PR TITLE
perf/fix: mrghxst ports for path lookup, header cache, api-key, config, and client dedupe

### DIFF
--- a/backend/Api/Controllers/BaseApiController.cs
+++ b/backend/Api/Controllers/BaseApiController.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using NzbWebDAV.Extensions;
-using NzbWebDAV.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Auth;
+using NzbWebDAV.Config;
 using Serilog;
 
 namespace NzbWebDAV.Api.Controllers;
@@ -19,11 +20,8 @@ public abstract class BaseApiController : ControllerBase
         {
             if (RequiresAuthentication)
             {
-                var apiKey = HttpContext.GetRequestApiKey();
-                if (apiKey == null)
-                    throw new UnauthorizedAccessException("API Key Required");
-                if (!apiKey.FixedTimeEquals(EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY")))
-                    throw new UnauthorizedAccessException("API Key Incorrect");
+                var configManager = HttpContext.RequestServices.GetRequiredService<ConfigManager>();
+                ApiKeyValidator.Validate(HttpContext, configManager);
             }
 
             return await HandleRequest().ConfigureAwait(false);

--- a/backend/Api/Controllers/BaseApiController.cs
+++ b/backend/Api/Controllers/BaseApiController.cs
@@ -26,7 +26,7 @@ public abstract class BaseApiController : ControllerBase
 
             return await HandleRequest().ConfigureAwait(false);
         }
-        catch (BadHttpRequestException e)
+        catch (Exception e) when (e is BadHttpRequestException or ArgumentException)
         {
             return BadRequest(new BaseApiResponse()
             {

--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -39,6 +39,13 @@ public class DeleteWebdavItemController(DavDatabaseClient dbClient, ConfigManage
     {
         var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0) return null;
+
+        // Preserve per-segment unescape semantics: a name containing an encoded %2F
+        // must stay inside one segment rather than becoming an extra path separator.
+        var absolutePath = "/" + string.Join('/', parts.Select(Uri.UnescapeDataString));
+        var byPath = await dbClient.GetItemByPathAsync(absolutePath, ct).ConfigureAwait(false);
+        if (byPath is not null) return byPath;
+
         var current = DavItem.Root;
         foreach (var raw in parts)
         {

--- a/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
+++ b/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
@@ -13,6 +13,11 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
 {
     private async Task<UpdateConfigResponse> UpdateConfig(UpdateConfigRequest request)
     {
+        // Validate incoming values up-front so a malformed value is rejected here with a
+        // clear message instead of throwing later deep inside a request or background task.
+        // Run before webdav.pass hashing so validation sees the raw submitted value.
+        ConfigManager.ValidateConfigItems(request.ConfigItems);
+
         var configNames = request.ConfigItems.Select(x => x.ConfigName).ToHashSet();
         var existingItems = await dbClient.Ctx.ConfigItems
             .Where(c => configNames.Contains(c.ConfigName))
@@ -29,7 +34,7 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
                 item.ConfigValue,
                 existingValue);
 
-            if (item.ConfigName == "webdav.pass" &&
+            if (item.ConfigName == ConfigKeys.WebdavPass &&
                 !ConfigSecretMasker.IsMaskToken(item.ConfigValue))
                 resolvedValue = PasswordUtil.Hash(resolvedValue);
 

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -11,11 +11,11 @@ using NzbWebDAV.Api.SabControllers.GetStatus;
 using NzbWebDAV.Api.SabControllers.GetVersion;
 using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
+using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Queue;
-using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Serilog;
 
@@ -118,17 +118,7 @@ public class SabApiController(
         public Task<IActionResult> HandleRequest()
         {
             if (RequiresAuthentication)
-            {
-                var apiKey = httpContext.GetRequestApiKey();
-                var isValidKey = apiKey?.IsAny(
-                    configManager.GetApiKey(),
-                    EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY")
-                );
-                if (!isValidKey.HasValue)
-                    throw new UnauthorizedAccessException("API Key Required");
-                if (!isValidKey.Value)
-                    throw new UnauthorizedAccessException("API Key Incorrect");
-            }
+                ApiKeyValidator.Validate(httpContext, configManager);
 
             return Handle();
         }

--- a/backend/Auth/ApiKeyValidator.cs
+++ b/backend/Auth/ApiKeyValidator.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Auth;
+
+/// <summary>
+/// The single api-key check shared by both API surfaces — the custom <c>/api/*</c>
+/// controllers and the SABnzbd-compatible <c>/api?mode=</c> dispatcher. Previously the two
+/// used different rules (one accepted only the env key, the other accepted either the env key
+/// or the configured key), which was an inconsistency on a security boundary. Both now accept
+/// the same set: the user-configured api key and the frontend/backend env key.
+/// </summary>
+public static class ApiKeyValidator
+{
+    public static void Validate(HttpContext httpContext, ConfigManager configManager)
+    {
+        var apiKey = httpContext.GetRequestApiKey();
+        if (apiKey == null)
+            throw new UnauthorizedAccessException("API Key Required");
+
+        var isValid = apiKey.IsAny(
+            configManager.GetApiKey(),
+            EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
+        if (!isValid)
+            throw new UnauthorizedAccessException("API Key Incorrect");
+    }
+}

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -39,10 +39,10 @@ public class RcloneClient
         configManager.OnConfigChanged += (_, configEventArgs) =>
         {
             var changedConfig = configEventArgs.ChangedConfig;
-            if (changedConfig.TryGetValue("rclone.host", out var host)) Host = host;
-            if (changedConfig.TryGetValue("rclone.user", out var user)) User = user;
-            if (changedConfig.TryGetValue("rclone.pass", out var pass)) Pass = pass;
-            if (changedConfig.ContainsKey("rclone.rc-enabled"))
+            if (changedConfig.TryGetValue(ConfigKeys.RcloneHost, out var host)) Host = host;
+            if (changedConfig.TryGetValue(ConfigKeys.RcloneUser, out var user)) User = user;
+            if (changedConfig.TryGetValue(ConfigKeys.RclonePass, out var pass)) Pass = pass;
+            if (changedConfig.ContainsKey(ConfigKeys.RcloneRcEnabled))
                 IsRemoteControlEnabled = configManager.IsRcloneRemoteControlEnabled();
         };
     }

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -34,16 +34,16 @@ public class DownloadingNntpClient : WrappingNntpClient
 
     private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs e)
     {
-        if (e.ChangedConfig.ContainsKey("usenet.max-download-connections")
-            || e.ChangedConfig.ContainsKey("usenet.providers"))
+        if (e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxDownloadConnections)
+            || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders))
             _streamingSemaphore.UpdateMaxAllowed(_configManager.GetMaxDownloadConnections());
 
-        if (e.ChangedConfig.ContainsKey("usenet.max-queue-connections")
-            || e.ChangedConfig.ContainsKey("usenet.max-download-connections")
-            || e.ChangedConfig.ContainsKey("usenet.providers"))
+        if (e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxQueueConnections)
+            || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxDownloadConnections)
+            || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders))
             _queueSemaphore.UpdateMaxAllowed(_configManager.GetMaxQueueConnections());
 
-        if (e.ChangedConfig.ContainsKey("usenet.streaming-priority"))
+        if (e.ChangedConfig.ContainsKey(ConfigKeys.UsenetStreamingPriority))
             _streamingSemaphore.UpdatePriorityOdds(_configManager.GetStreamingPriority());
     }
 

--- a/backend/Clients/Usenet/HeaderCachingNntpClient.cs
+++ b/backend/Clients/Usenet/HeaderCachingNntpClient.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Memoizes yEnc headers (segment byte offset/size) so that seeking does not repeatedly
+/// re-download article bodies just to read their headers.
+/// <para>
+/// Reading a yEnc header requires issuing a BODY command, which streams (and therefore
+/// transfers) the whole article. Plex/Jellyfin seek around a file many times during
+/// playback, and <see cref="Streams.NzbFileStream"/> probes headers on every seek via an
+/// interpolation search. yEnc headers are immutable for a given segment id, so caching them
+/// turns every repeat probe into a network-free lookup.
+/// </para>
+/// <para>
+/// The cache is intentionally simple and lives on the long-lived streaming client. It is
+/// bounded by <see cref="MaxEntries"/> (entries are tiny — a handful of integers and a short
+/// name); on overflow it is cleared rather than evicted one-by-one, which is cheap and rare
+/// given the high cap.
+/// </para>
+/// </summary>
+public class HeaderCachingNntpClient(INntpClient usenetClient) : WrappingNntpClient(usenetClient)
+{
+    private const int MaxEntries = 500_000;
+
+    private readonly ConcurrentDictionary<string, UsenetYencHeader> _cache = new();
+    private readonly Lock _overflowLock = new();
+
+    public override async Task<UsenetYencHeader> GetYencHeadersAsync(string segmentId, CancellationToken ct)
+    {
+        if (_cache.TryGetValue(segmentId, out var cached))
+            return cached;
+
+        var header = await base.GetYencHeadersAsync(segmentId, ct).ConfigureAwait(false);
+
+        if (_cache.Count >= MaxEntries)
+        {
+            lock (_overflowLock)
+            {
+                if (_cache.Count >= MaxEntries) _cache.Clear();
+            }
+        }
+
+        _cache.TryAdd(segmentId, header);
+        return header;
+    }
+}

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -40,23 +40,29 @@ public class UsenetStreamingClient : WrappingNntpClient
     {
         var multiProviderClient = CreateMultiProviderClient(configManager, websocketManager, usageTracker, metricsWriter, bytesTracker);
         var downloadingClient = new DownloadingNntpClient(multiProviderClient, configManager);
-        if (!configManager.IsSegmentCacheEnabled()) return downloadingClient;
-        try
+        INntpClient inner = downloadingClient;
+        if (configManager.IsSegmentCacheEnabled())
         {
-            return new SegmentCacheNntpClient(
-                downloadingClient,
-                configManager.GetSegmentCachePath(),
-                configManager.GetSegmentCacheMaxBytes(),
-                usageTracker,
-                metricsWriter
-            );
+            try
+            {
+                inner = new SegmentCacheNntpClient(
+                    downloadingClient,
+                    configManager.GetSegmentCachePath(),
+                    configManager.GetSegmentCacheMaxBytes(),
+                    usageTracker,
+                    metricsWriter
+                );
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Segment cache disabled: failed to initialise at {Path}.",
+                    configManager.GetSegmentCachePath());
+            }
         }
-        catch (Exception e)
-        {
-            Log.Warning(e, "Segment cache disabled: failed to initialise at {Path}.",
-                configManager.GetSegmentCachePath());
-            return downloadingClient;
-        }
+
+        // Always wrap with header caching so seek probes reuse immutable yEnc headers
+        // even when the optional on-disk segment body cache is disabled.
+        return new HeaderCachingNntpClient(inner);
     }
 
     private static MultiProviderNntpClient CreateMultiProviderClient

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -21,7 +21,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         configManager.OnConfigChanged += (_, configEventArgs) =>
         {
             // if unrelated config changed, do nothing
-            if (!configEventArgs.ChangedConfig.ContainsKey("usenet.providers")) return;
+            if (!configEventArgs.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders)) return;
 
             // update the connection-pool according to the new config
             var newUsenetClient = CreateDownloadingNntpClient(configManager, websocketManager, usageTracker, metricsWriter, bytesTracker);

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -1,4 +1,5 @@
 ﻿using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models.Nzb;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
@@ -71,6 +72,12 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient
         SegmentId segmentId, UsenetExclusiveConnection exclusiveConnection, CancellationToken cancellationToken) =>
         _usenetClient.DecodedArticleAsync(segmentId, exclusiveConnection, cancellationToken);
 
+    public override Task<UsenetYencHeader> GetYencHeadersAsync(
+        string segmentId, CancellationToken cancellationToken) =>
+        _usenetClient.GetYencHeadersAsync(segmentId, cancellationToken);
+
+    public override Task<long> GetFileSizeAsync(NzbFile file, CancellationToken cancellationToken) =>
+        _usenetClient.GetFileSizeAsync(file, cancellationToken);
 
     public override IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync(
         IReadOnlyList<string> segmentIds, int depth, CancellationToken cancellationToken) =>

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -1,0 +1,155 @@
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// The single source of truth for every configuration key persisted in the
+/// <c>ConfigItems</c> table. Using constants instead of scattered string literals
+/// means a key can be found (and renamed) from one place, and that the getters in
+/// <see cref="ConfigManager"/> and the <c>OnConfigChanged</c> subscribers cannot
+/// silently drift apart.
+/// </summary>
+public static class ConfigKeys
+{
+    // api
+    public const string ApiCategories = "api.categories";
+    public const string ApiCompletedDownloadsDir = "api.completed-downloads-dir";
+    public const string ApiDownloadFileBlocklist = "api.download-file-blocklist";
+    public const string ApiDuplicateNzbBehavior = "api.duplicate-nzb-behavior";
+    public const string ApiEnsureArticleExistenceCategories = "api.ensure-article-existence-categories";
+    public const string ApiEnsureImportableVideo = "api.ensure-importable-video";
+    public const string ApiIgnoreHistoryLimit = "api.ignore-history-limit";
+    public const string ApiImportStrategy = "api.import-strategy";
+    public const string ApiKey = "api.key";
+    public const string ApiLazyRarParsing = "api.lazy-rar-parsing";
+    public const string ApiManualCategory = "api.manual-category";
+    public const string ApiNzbBackupEnabled = "api.nzb-backup-enabled";
+    public const string ApiNzbBackupLocation = "api.nzb-backup-location";
+    public const string ApiSearchUserAgent = "api.search-user-agent";
+    public const string ApiStrmKey = "api.strm-key";
+    public const string ApiUserAgent = "api.user-agent";
+
+    // usenet
+    public const string UsenetArticleBufferSize = "usenet.article-buffer-size";
+    public const string UsenetCascadeEnabled = "usenet.cascade.enabled";
+    public const string UsenetMaxDownloadConnections = "usenet.max-download-connections";
+    public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
+    public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";
+    public const string UsenetMaxQueueConnections = "usenet.max-queue-connections";
+    public const string UsenetPipelinedBodyRequests = "usenet.pipelined-body-requests";
+    public const string UsenetPipeliningDepth = "usenet.pipelining.depth";
+    public const string UsenetPipeliningEnabled = "usenet.pipelining.enabled";
+    public const string UsenetProviders = "usenet.providers";
+    public const string UsenetSegmentCacheEnabled = "usenet.segment-cache.enabled";
+    public const string UsenetSegmentCacheMaxGb = "usenet.segment-cache.max-gb";
+    public const string UsenetSegmentCachePath = "usenet.segment-cache.path";
+    public const string UsenetStreamingPriority = "usenet.streaming-priority";
+
+    // webdav
+    public const string WebdavEnforceReadonly = "webdav.enforce-readonly";
+    public const string WebdavPass = "webdav.pass";
+    public const string WebdavPreviewPar2Files = "webdav.preview-par2-files";
+    public const string WebdavShowHiddenFiles = "webdav.show-hidden-files";
+    public const string WebdavUser = "webdav.user";
+
+    // media / repair / arr
+    public const string MediaLibraryDir = "media.library-dir";
+    public const string RepairEnable = "repair.enable";
+    public const string RepairHealthcheckConcurrency = "repair.healthcheck-concurrency";
+    public const string ArrInstances = "arr.instances";
+
+    // rclone
+    public const string RcloneHost = "rclone.host";
+    public const string RcloneMountDir = "rclone.mount-dir";
+    public const string RclonePass = "rclone.pass";
+    public const string RcloneRcEnabled = "rclone.rc-enabled";
+    public const string RcloneUser = "rclone.user";
+
+    // general / db / maintenance
+    public const string GeneralBaseUrl = "general.base-url";
+    public const string DbIsStartupVacuumEnabled = "db.is-startup-vacuum-enabled";
+    public const string MaintenanceRemoveOrphanedScheduleEnabled = "maintenance.remove-orphaned-schedule-enabled";
+    public const string MaintenanceRemoveOrphanedScheduleTime = "maintenance.remove-orphaned-schedule-time";
+
+    // play
+    public const string PlayCandidateNegativeCacheMinutes = "play.candidate-negative-cache-minutes";
+    public const string PlayExcludePatterns = "play.exclude-patterns";
+    public const string PlayHedgeDelaySeconds = "play.hedge-delay-seconds";
+    public const string PlayMaxAttempts = "play.max-attempts";
+    public const string PlayMaxCandidates = "play.max-candidates";
+    public const string PlayPreferSubtitles = "play.prefer-subtitles";
+    public const string PlayTotalBudgetSeconds = "play.total-budget-seconds";
+    public const string PlayVerifyMode = "play.verify-mode";
+    public const string PlayVerifySampleCount = "play.verify-sample-count";
+    public const string PlayWatchdogEnabled = "play.watchdog-enabled";
+
+    // grab
+    public const string GrabStallFailoverCeilingSeconds = "grab.stall-failover-ceiling-seconds";
+    public const string GrabStallFailoverEnabled = "grab.stall-failover-enabled";
+    public const string GrabStallFailoverWindowSeconds = "grab.stall-failover-window-seconds";
+
+    // variants
+    public const string VariantsEvictionActiveGraceSeconds = "variants.eviction-active-grace-seconds";
+    public const string VariantsEvictionStrategy = "variants.eviction-strategy";
+    public const string VariantsFallbackOnFailure = "variants.fallback-on-failure";
+    public const string VariantsMaxPerGroup = "variants.max-per-group";
+    public const string VariantsMode = "variants.mode";
+    public const string VariantsReplayStrategy = "variants.replay-strategy";
+    public const string VariantsTolerancePct = "variants.tolerance-pct";
+
+    // preflight
+    public const string PreflightIndexerMaxWaitSeconds = "preflight.indexer-max-wait-seconds";
+    public const string PreflightMaxAttempts = "preflight.max-attempts";
+    public const string PreflightMode = "preflight.mode";
+    public const string PreflightTtlSeconds = "preflight.ttl-seconds";
+
+    // watchtower
+    public const string WatchtowerActiveSetCap = "watchtower.active-set-cap";
+    public const string WatchtowerAutoThroughput = "watchtower.auto-throughput";
+    public const string WatchtowerDailyResolveBudget = "watchtower.daily-resolve-budget";
+    public const string WatchtowerEnabled = "watchtower.enabled";
+    public const string WatchtowerGrabCapPerResolve = "watchtower.grab-cap-per-resolve";
+    public const string WatchtowerKeepfreshBaseSeconds = "watchtower.keepfresh-base-seconds";
+    public const string WatchtowerKeepfreshMaxSeconds = "watchtower.keepfresh-max-seconds";
+    public const string WatchtowerMinGrabs = "watchtower.min-grabs";
+    public const string WatchtowerProfileToken = "watchtower.profile-token";
+    public const string WatchtowerRanking = "watchtower.ranking";
+    public const string WatchtowerResolveConcurrency = "watchtower.resolve-concurrency";
+    public const string WatchtowerSeasonBundleFallback = "watchtower.season-bundle-fallback";
+    public const string WatchtowerSeasonBundleFallbackMaxEpisodes = "watchtower.season-bundle-fallback-max-episodes";
+    public const string WatchtowerSeasonBundleFallbackRecentCount = "watchtower.season-bundle-fallback-recent-count";
+    public const string WatchtowerSeasonBundleFallbackScope = "watchtower.season-bundle-fallback-scope";
+    public const string WatchtowerSeasonBundles = "watchtower.season-bundles";
+    public const string WatchtowerSeriesCapKeep = "watchtower.series-cap-keep";
+    public const string WatchtowerSeriesMaxEpisodes = "watchtower.series-max-episodes";
+    public const string WatchtowerSeriesRecentCount = "watchtower.series-recent-count";
+    public const string WatchtowerSeriesScope = "watchtower.series-scope";
+    public const string WatchtowerShortlistDepth = "watchtower.shortlist-depth";
+    public const string WatchtowerSizeCeilingBytes = "watchtower.size-ceiling-bytes";
+    public const string WatchtowerSizeFloorBytes = "watchtower.size-floor-bytes";
+    public const string WatchtowerSyncIntervalSeconds = "watchtower.sync-interval-seconds";
+    public const string WatchtowerUnavailableRetrySeconds = "watchtower.unavailable-retry-seconds";
+    public const string WatchtowerVerboseLogging = "watchtower.verbose-logging";
+    public const string WatchtowerVerifySampleCount = "watchtower.verify-sample-count";
+    public const string WatchtowerVerifyTimeoutSeconds = "watchtower.verify-timeout-seconds";
+
+    // warden
+    public const string WardenBackboneScope = "warden.backbone-scope";
+    public const string WardenHideDead = "warden.hide-dead";
+    public const string WardenMaxSourceEntries = "warden.max-source-entries";
+    public const string WardenQuorum = "warden.quorum";
+
+    // search
+    /// <summary>Prefix shared by all search-exclude keys (used with <c>StartsWith</c>).</summary>
+    public const string SearchExcludePrefix = "search.exclude";
+    public const string SearchExcludePatterns = "search.exclude-patterns";
+    public const string SearchExcludeSyncCache = "search.exclude-sync-cache";
+    public const string SearchExcludeSyncRefreshMinutes = "search.exclude-sync-refresh-minutes";
+    public const string SearchExcludeSyncUrls = "search.exclude-sync-urls";
+
+    // indexers / profiles
+    public const string IndexersInstances = "indexers.instances";
+    public const string ProfilesInstances = "profiles.instances";
+
+    // database
+    public const string DatabaseHealthcheckRetentionDays = "database.healthcheck-retention-days";
+    public const string DatabaseHistoryRetentionDays = "database.history-retention-days";
+}

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -50,43 +50,59 @@ public class ConfigManager
 
     private T? GetConfigValue<T>(string configName)
     {
+        string? rawValue;
+        var cacheKey = (configName, typeof(T));
+
         lock (_config)
         {
             if (!_config.TryGetValue(configName, out var storedValue)) return default;
-            var rawValue = StringUtil.EmptyToNull(storedValue);
+            rawValue = StringUtil.EmptyToNull(storedValue);
             if (rawValue == null) return default;
 
-            var cacheKey = (configName, typeof(T));
+            if (_deserializedConfig.TryGetValue(cacheKey, out var cachedValue))
+                return cachedValue is null ? default : (T)cachedValue;
+        }
+
+        // Deserialize outside the lock so large JSON payloads (providers, indexers)
+        // do not block other config readers on the hot path.
+        var value = JsonSerializer.Deserialize<T>(rawValue);
+
+        lock (_config)
+        {
             if (_deserializedConfig.TryGetValue(cacheKey, out var cachedValue))
                 return cachedValue is null ? default : (T)cachedValue;
 
-            var value = JsonSerializer.Deserialize<T>(rawValue);
-            _deserializedConfig[cacheKey] = value;
+            if (_config.TryGetValue(configName, out var storedValue) &&
+                StringUtil.EmptyToNull(storedValue) == rawValue)
+            {
+                _deserializedConfig[cacheKey] = value;
+            }
+
             return value;
         }
     }
 
     public bool IsWardenHideDeadEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("warden.hide-dead"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WardenHideDead));
         return v is null || v == "true";
     }
 
     public int GetWardenQuorum()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("warden.quorum"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WardenQuorum));
         return v is not null && int.TryParse(v, out var n) && n >= 1 ? n : 2;
     }
 
     public int GetWardenMaxSourceEntries()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("warden.max-source-entries"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WardenMaxSourceEntries));
         return v is not null && int.TryParse(v, out var n) && n > 0 ? n : 2_000_000;
     }
 
     public bool IsWardenBackboneScopeEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("warden.backbone-scope"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WardenBackboneScope));
         return v is null || v == "true";
     }
 
@@ -106,8 +122,8 @@ public class ConfigManager
             }
         }
 
-        if (configItems.Any(x => x.ConfigName.StartsWith("search.exclude", StringComparison.Ordinal)
-                                 || x.ConfigName == "play.exclude-patterns"))
+        if (configItems.Any(x => x.ConfigName.StartsWith(ConfigKeys.SearchExcludePrefix, StringComparison.Ordinal)
+                                 || x.ConfigName == ConfigKeys.PlayExcludePatterns))
         {
             lock (_excludeLock) { _compiledExcludeCache = null; }
         }
@@ -116,9 +132,147 @@ public class ConfigManager
         OnConfigChanged?.Invoke(this, new ConfigEventArgs { ChangedConfig = changedConfig });
     }
 
+    /// <summary>
+    /// Validates incoming config values, failing fast for anything that would otherwise throw
+    /// deep inside a request/background task at read time (non-numeric ints, non-boolean flags,
+    /// malformed JSON). Empty values are treated as "unset" and always allowed, matching the
+    /// getters' fallback-to-default behavior.
+    /// </summary>
+    public static void ValidateConfigItems(IEnumerable<ConfigItem> configItems)
+    {
+        foreach (var item in configItems)
+        {
+            var value = StringUtil.EmptyToNull(item.ConfigValue);
+            if (value == null) continue;
+
+            switch (item.ConfigName)
+            {
+                case ConfigKeys.UsenetMaxDownloadConnections:
+                case ConfigKeys.UsenetMaxQueueConnections:
+                case ConfigKeys.UsenetPipeliningDepth:
+                case ConfigKeys.UsenetArticleBufferSize:
+                case ConfigKeys.UsenetSegmentCacheMaxGb:
+                case ConfigKeys.UsenetStreamingPriority:
+                case ConfigKeys.WardenQuorum:
+                case ConfigKeys.WardenMaxSourceEntries:
+                case ConfigKeys.PlayTotalBudgetSeconds:
+                case ConfigKeys.PlayHedgeDelaySeconds:
+                case ConfigKeys.PlayMaxCandidates:
+                case ConfigKeys.PlayMaxAttempts:
+                case ConfigKeys.PlayVerifySampleCount:
+                case ConfigKeys.PlayCandidateNegativeCacheMinutes:
+                case ConfigKeys.GrabStallFailoverWindowSeconds:
+                case ConfigKeys.GrabStallFailoverCeilingSeconds:
+                case ConfigKeys.SearchExcludeSyncRefreshMinutes:
+                case ConfigKeys.VariantsTolerancePct:
+                case ConfigKeys.VariantsMaxPerGroup:
+                case ConfigKeys.VariantsEvictionActiveGraceSeconds:
+                case ConfigKeys.PreflightMaxAttempts:
+                case ConfigKeys.PreflightTtlSeconds:
+                case ConfigKeys.PreflightIndexerMaxWaitSeconds:
+                case ConfigKeys.WatchtowerSizeFloorBytes:
+                case ConfigKeys.WatchtowerSizeCeilingBytes:
+                case ConfigKeys.WatchtowerMinGrabs:
+                case ConfigKeys.WatchtowerShortlistDepth:
+                case ConfigKeys.WatchtowerGrabCapPerResolve:
+                case ConfigKeys.WatchtowerVerifySampleCount:
+                case ConfigKeys.WatchtowerVerifyTimeoutSeconds:
+                case ConfigKeys.WatchtowerActiveSetCap:
+                case ConfigKeys.WatchtowerResolveConcurrency:
+                case ConfigKeys.WatchtowerDailyResolveBudget:
+                case ConfigKeys.WatchtowerSyncIntervalSeconds:
+                case ConfigKeys.WatchtowerKeepfreshBaseSeconds:
+                case ConfigKeys.WatchtowerKeepfreshMaxSeconds:
+                case ConfigKeys.WatchtowerUnavailableRetrySeconds:
+                case ConfigKeys.WatchtowerSeriesMaxEpisodes:
+                case ConfigKeys.WatchtowerSeriesRecentCount:
+                case ConfigKeys.WatchtowerSeasonBundleFallbackRecentCount:
+                case ConfigKeys.WatchtowerSeasonBundleFallbackMaxEpisodes:
+                case ConfigKeys.RepairHealthcheckConcurrency:
+                case ConfigKeys.DatabaseHistoryRetentionDays:
+                case ConfigKeys.DatabaseHealthcheckRetentionDays:
+                case ConfigKeys.MaintenanceRemoveOrphanedScheduleTime:
+                    RequireLong(item.ConfigName, value);
+                    break;
+
+                case ConfigKeys.ApiEnsureImportableVideo:
+                case ConfigKeys.ApiIgnoreHistoryLimit:
+                case ConfigKeys.ApiLazyRarParsing:
+                case ConfigKeys.ApiNzbBackupEnabled:
+                case ConfigKeys.WebdavShowHiddenFiles:
+                case ConfigKeys.WebdavEnforceReadonly:
+                case ConfigKeys.WebdavPreviewPar2Files:
+                case ConfigKeys.UsenetMaxDownloadConnectionsPerStream:
+                case ConfigKeys.UsenetPipeliningEnabled:
+                case ConfigKeys.UsenetCascadeEnabled:
+                case ConfigKeys.UsenetPipelinedBodyRequests:
+                case ConfigKeys.UsenetSegmentCacheEnabled:
+                case ConfigKeys.PlayWatchdogEnabled:
+                case ConfigKeys.PlayPreferSubtitles:
+                case ConfigKeys.GrabStallFailoverEnabled:
+                case ConfigKeys.VariantsFallbackOnFailure:
+                case ConfigKeys.WatchtowerEnabled:
+                case ConfigKeys.WatchtowerAutoThroughput:
+                case ConfigKeys.WatchtowerVerboseLogging:
+                case ConfigKeys.WatchtowerSeasonBundles:
+                case ConfigKeys.WatchtowerSeasonBundleFallback:
+                case ConfigKeys.WardenHideDead:
+                case ConfigKeys.WardenBackboneScope:
+                case ConfigKeys.RepairEnable:
+                case ConfigKeys.RcloneRcEnabled:
+                case ConfigKeys.DbIsStartupVacuumEnabled:
+                case ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled:
+                    RequireBool(item.ConfigName, value);
+                    break;
+
+                case ConfigKeys.UsenetProviders:
+                    RequireJson<UsenetProviderConfig>(item.ConfigName, value);
+                    break;
+
+                case ConfigKeys.ArrInstances:
+                    RequireJson<ArrConfig>(item.ConfigName, value);
+                    break;
+
+                case ConfigKeys.IndexersInstances:
+                    RequireJson<IndexerConfig>(item.ConfigName, value);
+                    break;
+
+                case ConfigKeys.ProfilesInstances:
+                    RequireJson<ProfileConfig>(item.ConfigName, value);
+                    break;
+            }
+        }
+
+        return;
+
+        static void RequireLong(string key, string value)
+        {
+            if (!long.TryParse(value, out _))
+                throw new ArgumentException($"Config value for '{key}' must be a whole number, but was '{value}'.");
+        }
+
+        static void RequireBool(string key, string value)
+        {
+            if (!bool.TryParse(value, out _))
+                throw new ArgumentException($"Config value for '{key}' must be 'true' or 'false', but was '{value}'.");
+        }
+
+        static void RequireJson<T>(string key, string value)
+        {
+            try
+            {
+                JsonSerializer.Deserialize<T>(value);
+            }
+            catch (JsonException e)
+            {
+                throw new ArgumentException($"Config value for '{key}' is not valid JSON: {e.Message}");
+            }
+        }
+    }
+
     public string GetRcloneMountDir()
     {
-        var mountDir = StringUtil.EmptyToNull(GetConfigValue("rclone.mount-dir"))
+        var mountDir = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RcloneMountDir))
                        ?? EnvironmentUtil.GetEnvironmentVariable("MOUNT_DIR")
                        ?? "/mnt/nzbdav";
         if (mountDir.EndsWith('/')) mountDir = mountDir.TrimEnd('/');
@@ -127,19 +281,19 @@ public class ConfigManager
 
     public string GetApiKey()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("api.key"))
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiKey))
                ?? EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY");
     }
 
     public string GetStrmKey()
     {
-        return GetConfigValue("api.strm-key")
-               ?? throw new InvalidOperationException("The `api.strm-key` config does not exist.");
+        return GetConfigValue(ConfigKeys.ApiStrmKey)
+               ?? throw new InvalidOperationException($"The `{ConfigKeys.ApiStrmKey}` config does not exist.");
     }
 
     public List<string> GetApiCategories()
     {
-        var value = StringUtil.EmptyToNull(GetConfigValue("api.categories"))
+        var value = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiCategories))
                     ?? EnvironmentUtil.GetEnvironmentVariable("CATEGORIES")
                     ?? "audio,software,tv,movies";
 
@@ -152,20 +306,20 @@ public class ConfigManager
 
     public string GetManualUploadCategory()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("api.manual-category"))
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiManualCategory))
                ?? "uncategorized";
     }
 
     public string? GetWebdavUser()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("webdav.user"))
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavUser))
                ?? EnvironmentUtil.GetEnvironmentVariable("WEBDAV_USER")
                ?? "admin";
     }
 
     public string? GetWebdavPasswordHash()
     {
-        var hashedPass = StringUtil.EmptyToNull(GetConfigValue("webdav.pass"));
+        var hashedPass = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavPass));
         if (hashedPass != null) return hashedPass;
         var pass = EnvironmentUtil.GetEnvironmentVariable("WEBDAV_PASSWORD");
         if (pass != null) return PasswordUtil.Hash(pass);
@@ -175,20 +329,20 @@ public class ConfigManager
     public bool IsEnsureImportableVideoEnabled()
     {
         var defaultValue = true;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("api.ensure-importable-video"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiEnsureImportableVideo));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public bool ShowHiddenWebdavFiles()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.show-hidden-files"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavShowHiddenFiles));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public string? GetLibraryDir()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("media.library-dir"));
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.MediaLibraryDir));
     }
 
     // The total connection budget used for webdav streaming. "0" or empty means
@@ -197,7 +351,7 @@ public class ConfigManager
     // a manual override.
     public int GetMaxDownloadConnections()
     {
-        var configured = StringUtil.EmptyToNull(GetConfigValue("usenet.max-download-connections"));
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxDownloadConnections));
         if (configured is null || !int.TryParse(configured, out var value) || value <= 0)
             return GetUsenetProviderConfig().TotalPooledConnections;
         return value;
@@ -209,7 +363,7 @@ public class ConfigManager
     // still caps the actual number of open connections.
     public bool IsMaxDownloadConnectionsPerStream()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("usenet.max-download-connections-per-stream"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxDownloadConnectionsPerStream));
         return v != null && bool.Parse(v);
     }
 
@@ -224,7 +378,7 @@ public class ConfigManager
 
     private double GetMaxDownloadConnectionsPerStreamFraction()
     {
-        var preset = StringUtil.EmptyToNull(GetConfigValue("usenet.max-download-connections-per-stream-preset"));
+        var preset = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxDownloadConnectionsPerStreamPreset));
         return preset?.ToLowerInvariant() switch
         {
             "low" => 0.25,
@@ -238,7 +392,7 @@ public class ConfigManager
     public int GetMaxQueueConnections()
     {
         var pool = Math.Max(1, GetUsenetProviderConfig().TotalPooledConnections);
-        var configured = StringUtil.EmptyToNull(GetConfigValue("usenet.max-queue-connections"));
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxQueueConnections));
         if (configured is null || !int.TryParse(configured, out var value))
             return pool;
         return Math.Clamp(value, 1, pool);
@@ -246,19 +400,19 @@ public class ConfigManager
 
     public bool IsPipeliningEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("usenet.pipelining.enabled"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetPipeliningEnabled));
         return v != null && bool.Parse(v);
     }
 
     public bool IsCascadeEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("usenet.cascade.enabled"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetCascadeEnabled));
         return v != null && bool.Parse(v);
     }
 
     public int GetPipeliningDepth()
     {
-        var configured = StringUtil.EmptyToNull(GetConfigValue("usenet.pipelining.depth"));
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetPipeliningDepth));
         if (configured is null || !int.TryParse(configured, out var value)) return 8;
         return Math.Clamp(value, 1, 64);
     }
@@ -266,7 +420,7 @@ public class ConfigManager
     public int GetArticleBufferSize()
     {
         return int.Parse(
-            StringUtil.EmptyToNull(GetConfigValue("usenet.article-buffer-size"))
+            StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetArticleBufferSize))
             ?? "40"
         );
     }
@@ -274,25 +428,25 @@ public class ConfigManager
     public bool IsPipelinedBodyRequestsEnabled()
     {
         var configValue = StringUtil.EmptyToNull(
-            GetConfigValue("usenet.pipelined-body-requests"));
+            GetConfigValue(ConfigKeys.UsenetPipelinedBodyRequests));
         return configValue == null || bool.Parse(configValue);
     }
 
     public bool IsSegmentCacheEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("usenet.segment-cache.enabled"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheEnabled));
         return v != null && bool.Parse(v);
     }
 
     public string GetSegmentCachePath()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("usenet.segment-cache.path"))
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCachePath))
                ?? "/config/segment-cache";
     }
 
     public long GetSegmentCacheMaxBytes()
     {
-        var gb = long.Parse(StringUtil.EmptyToNull(GetConfigValue("usenet.segment-cache.max-gb")) ?? "10");
+        var gb = long.Parse(StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheMaxGb)) ?? "10");
         return Math.Max(1, gb) * 1024L * 1024L * 1024L;
     }
 
@@ -302,13 +456,13 @@ public class ConfigManager
     // (multi-file, solid, encrypted, or compressed).
     public bool IsLazyRarParsingEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("api.lazy-rar-parsing"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiLazyRarParsing));
         return v == null || bool.Parse(v);
     }
 
     public SemaphorePriorityOdds GetStreamingPriority()
     {
-        var stringValue = StringUtil.EmptyToNull(GetConfigValue("usenet.streaming-priority"));
+        var stringValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingPriority));
         var numericalValue = int.Parse(stringValue ?? "80");
         return new SemaphorePriorityOdds() { HighPriorityOdds = numericalValue };
     }
@@ -316,13 +470,13 @@ public class ConfigManager
     public bool IsEnforceReadonlyWebdavEnabled()
     {
         var defaultValue = true;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.enforce-readonly"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavEnforceReadonly));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public HashSet<string> GetEnsureArticleExistenceCategories()
     {
-        var configValue = GetConfigValue("api.ensure-article-existence-categories");
+        var configValue = GetConfigValue(ConfigKeys.ApiEnsureArticleExistenceCategories);
         return (configValue ?? "").Split(',')
             .Select(x => x.Trim())
             .Select(x => x.ToLower())
@@ -332,41 +486,41 @@ public class ConfigManager
 
     public bool IsPlaybackWatchdogEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.watchdog-enabled"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayWatchdogEnabled));
         return v == null || bool.Parse(v);
     }
 
     public int GetPlayTotalBudgetSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.total-budget-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayTotalBudgetSeconds));
         if (v == null) return 30;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 3, 180) : 30;
     }
 
     public int GetPlayHedgeDelaySeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.hedge-delay-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayHedgeDelaySeconds));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 30) : 3;
     }
 
     public int GetPlayMaxCandidates()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.max-candidates"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayMaxCandidates));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 10) : 3;
     }
 
     public int GetPlayMaxAttempts()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.max-attempts"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayMaxAttempts));
         if (v == null) return 10;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 200) : 10;
     }
 
     public string GetPlayVerifyMode()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.verify-mode"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayVerifyMode));
         return v switch
         {
             "body" => "body",
@@ -378,40 +532,40 @@ public class ConfigManager
 
     public int GetPlayVerifySampleCount()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.verify-sample-count"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayVerifySampleCount));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 10) : 3;
     }
 
     public TimeSpan GetPlayCandidateNegativeCacheTtl()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.candidate-negative-cache-minutes"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayCandidateNegativeCacheMinutes));
         if (v == null) return TimeSpan.FromMinutes(5);
         return int.TryParse(v, out var n) ? TimeSpan.FromMinutes(Math.Clamp(n, 1, 60 * 24)) : TimeSpan.FromMinutes(5);
     }
 
     public bool IsPlaySubtitlePreferenceEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("play.prefer-subtitles"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayPreferSubtitles));
         return v == null || !bool.TryParse(v, out var enabled) || enabled;
     }
 
     public bool IsGrabStallFailoverEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("grab.stall-failover-enabled"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.GrabStallFailoverEnabled));
         return v == null || bool.Parse(v);
     }
 
     public int GetGrabStallFailoverWindowSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("grab.stall-failover-window-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.GrabStallFailoverWindowSeconds));
         if (v == null) return 2;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 2, 60) : 2;
     }
 
     public int GetGrabStallFailoverCeilingSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("grab.stall-failover-ceiling-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.GrabStallFailoverCeilingSeconds));
         if (v == null) return 5;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 5, 120) : 5;
     }
@@ -443,8 +597,8 @@ public class ConfigManager
                     compiled.Add(p.Regex);
         }
 
-        var raw = GetConfigValue("search.exclude-patterns");
-        if (string.IsNullOrWhiteSpace(raw)) raw = GetConfigValue("play.exclude-patterns");
+        var raw = GetConfigValue(ConfigKeys.SearchExcludePatterns);
+        if (string.IsNullOrWhiteSpace(raw)) raw = GetConfigValue(ConfigKeys.PlayExcludePatterns);
         if (!string.IsNullOrWhiteSpace(raw))
         {
             foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
@@ -458,7 +612,7 @@ public class ConfigManager
     /// <summary>Configured synced-exclude source URLs (http/https only, de-duplicated, in order).</summary>
     public IReadOnlyList<string> GetSearchExcludeSyncUrls()
     {
-        var raw = GetConfigValue("search.exclude-sync-urls");
+        var raw = GetConfigValue(ConfigKeys.SearchExcludeSyncUrls);
         if (string.IsNullOrWhiteSpace(raw)) return Array.Empty<string>();
 
         var urls = new List<string>();
@@ -477,14 +631,14 @@ public class ConfigManager
 
     public int GetSearchExcludeSyncRefreshMinutes()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("search.exclude-sync-refresh-minutes"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.SearchExcludeSyncRefreshMinutes));
         if (v == null) return DefaultExcludeSyncRefreshMinutes;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 15, 10080) : DefaultExcludeSyncRefreshMinutes;
     }
 
     public ExcludeSyncCache GetSearchExcludeSyncCache()
     {
-        var raw = StringUtil.EmptyToNull(GetConfigValue("search.exclude-sync-cache"));
+        var raw = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.SearchExcludeSyncCache));
         if (raw == null) return new ExcludeSyncCache();
         try { return JsonSerializer.Deserialize<ExcludeSyncCache>(raw) ?? new ExcludeSyncCache(); }
         catch (JsonException) { return new ExcludeSyncCache(); }
@@ -492,7 +646,7 @@ public class ConfigManager
 
     public string GetVariantsMode()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.mode"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsMode));
         return v switch
         {
             "smart" => "smart",
@@ -503,21 +657,21 @@ public class ConfigManager
 
     public int GetVariantsTolerancePct()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.tolerance-pct"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsTolerancePct));
         if (v == null) return 25;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 100) : 25;
     }
 
     public int GetVariantsMaxPerGroup()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.max-per-group"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsMaxPerGroup));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Max(0, n) : 3;
     }
 
     public string GetVariantsReplayStrategy()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.replay-strategy"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsReplayStrategy));
         return v switch
         {
             "largest" => "largest",
@@ -528,13 +682,13 @@ public class ConfigManager
 
     public bool IsVariantsFallbackOnFailureEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.fallback-on-failure"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsFallbackOnFailure));
         return v == null || bool.Parse(v);
     }
 
     public string GetVariantsEvictionStrategy()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.eviction-strategy"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsEvictionStrategy));
         return v switch
         {
             "largest-first" => "largest-first",
@@ -546,14 +700,14 @@ public class ConfigManager
 
     public int GetVariantsEvictionActiveGraceSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("variants.eviction-active-grace-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsEvictionActiveGraceSeconds));
         if (v == null) return 60;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 300) : 60;
     }
 
     public string GetPreflightMode()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("preflight.mode"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PreflightMode));
         return v switch
         {
             "light" => "light",
@@ -565,21 +719,21 @@ public class ConfigManager
 
     public int GetPreflightMaxAttempts()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("preflight.max-attempts"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PreflightMaxAttempts));
         if (v == null) return 20;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 50) : 20;
     }
 
     public int GetPreflightTtlSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("preflight.ttl-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PreflightTtlSeconds));
         if (v == null) return 120;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 10, 1800) : 120;
     }
 
     public int GetPreflightIndexerMaxWaitSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("preflight.indexer-max-wait-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PreflightIndexerMaxWaitSeconds));
         if (v == null) return 5;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 120) : 5;
     }
@@ -587,134 +741,134 @@ public class ConfigManager
 
     public bool IsWatchtowerEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.enabled"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerEnabled));
         return v != null ? bool.Parse(v) : false;
     }
 
     public bool IsWatchtowerAutoThroughput()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.auto-throughput"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerAutoThroughput));
         return v != null ? bool.Parse(v) : false;
     }
 
     public bool IsWatchtowerVerboseLoggingEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.verbose-logging"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerVerboseLogging));
         return v != null ? bool.Parse(v) : false;
     }
 
     public string GetWatchtowerProfileToken()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("watchtower.profile-token")) ?? "";
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerProfileToken)) ?? "";
     }
 
     public string GetWatchtowerRanking()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.ranking"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerRanking));
         return v == "largest" ? "largest" : "watchdog";
     }
 
     public long GetWatchtowerSizeFloorBytes()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.size-floor-bytes"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSizeFloorBytes));
         if (v == null) return 524288000L;
         return long.TryParse(v, out var n) ? Math.Max(0, n) : 524288000L;
     }
 
     public long GetWatchtowerSizeCeilingBytes()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.size-ceiling-bytes"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSizeCeilingBytes));
         if (v == null) return 0L;
         return long.TryParse(v, out var n) ? Math.Max(0, n) : 0L;
     }
 
     public int GetWatchtowerMinGrabs()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.min-grabs"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerMinGrabs));
         if (v == null) return 0;
         return int.TryParse(v, out var n) ? Math.Max(0, n) : 0;
     }
 
     public int GetWatchtowerShortlistDepth()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.shortlist-depth"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerShortlistDepth));
         if (v == null) return 2;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 5) : 2;
     }
 
     public int GetWatchtowerGrabCapPerResolve()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.grab-cap-per-resolve"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerGrabCapPerResolve));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 10) : 3;
     }
 
     public int GetWatchtowerVerifySampleCount()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.verify-sample-count"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerVerifySampleCount));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 20) : 3;
     }
 
     public int GetWatchtowerVerifyTimeoutSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.verify-timeout-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerVerifyTimeoutSeconds));
         if (v == null) return 10;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 2, 120) : 10;
     }
 
     public int GetWatchtowerActiveSetCap()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.active-set-cap"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerActiveSetCap));
         if (v == null) return 100;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 100000) : 100;
     }
 
     public int GetWatchtowerResolveConcurrency()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.resolve-concurrency"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerResolveConcurrency));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 16) : 3;
     }
 
     public int GetWatchtowerDailyResolveBudget()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.daily-resolve-budget"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerDailyResolveBudget));
         if (v == null) return 60;
         return int.TryParse(v, out var n) ? Math.Max(0, n) : 60;
     }
 
     public int GetWatchtowerSyncIntervalSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.sync-interval-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSyncIntervalSeconds));
         if (v == null) return 3600;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 60, 86400) : 3600;
     }
 
     public int GetWatchtowerKeepFreshBaseSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.keepfresh-base-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerKeepfreshBaseSeconds));
         if (v == null) return 21600;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 300, 604800) : 21600;
     }
 
     public int GetWatchtowerKeepFreshMaxSeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.keepfresh-max-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerKeepfreshMaxSeconds));
         if (v == null) return 604800;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 600, 2592000) : 604800;
     }
 
     public int GetWatchtowerUnavailableRetrySeconds()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.unavailable-retry-seconds"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerUnavailableRetrySeconds));
         if (v == null) return 21600;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 600, 604800) : 21600;
     }
 
     public string GetWatchtowerSeriesScope()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.series-scope"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeriesScope));
         return NormalizeSeriesScope(v) ?? "latest-season";
     }
 
@@ -733,39 +887,39 @@ public class ConfigManager
 
     public int GetWatchtowerSeriesMaxEpisodes()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.series-max-episodes"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeriesMaxEpisodes));
         if (v == null) return 50;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 1000) : 50;
     }
 
     public string GetWatchtowerSeriesCapKeep()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.series-cap-keep"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeriesCapKeep));
         return v == "oldest" ? "oldest" : "newest";
     }
 
     public int GetWatchtowerSeriesRecentCount()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.series-recent-count"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeriesRecentCount));
         if (v == null) return 3;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 100) : 3;
     }
 
     public bool IsWatchtowerSeasonBundlesEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.season-bundles"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundles));
         return v != null ? bool.Parse(v) : true;
     }
 
     public bool IsWatchtowerSeasonBundleFallbackEnabled()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.season-bundle-fallback"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundleFallback));
         return v != null ? bool.Parse(v) : false;
     }
 
     public string GetWatchtowerSeasonBundleFallbackScope()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.season-bundle-fallback-scope"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundleFallbackScope));
         return v switch
         {
             "all" => "all",
@@ -776,14 +930,14 @@ public class ConfigManager
 
     public int GetWatchtowerSeasonBundleFallbackRecentCount()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.season-bundle-fallback-recent-count"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundleFallbackRecentCount));
         if (v == null) return 2;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 100) : 2;
     }
 
     public int GetWatchtowerSeasonBundleFallbackMaxEpisodes()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue("watchtower.season-bundle-fallback-max-episodes"));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundleFallbackMaxEpisodes));
         if (v == null) return 50;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 1000) : 50;
     }
@@ -791,21 +945,21 @@ public class ConfigManager
     public bool IsPreviewPar2FilesEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.preview-par2-files"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavPreviewPar2Files));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public bool IsIgnoreSabHistoryLimitEnabled()
     {
         var defaultValue = true;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("api.ignore-history-limit"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiIgnoreHistoryLimit));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public bool IsRepairJobEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("repair.enable"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
         var isRepairJobEnabled = (configValue != null ? bool.Parse(configValue) : defaultValue);
         return isRepairJobEnabled
                && GetLibraryDir() != null
@@ -820,7 +974,7 @@ public class ConfigManager
     {
         var poolSize = GetUsenetProviderConfig().TotalPooledConnections;
         var configured = int.Parse(
-            StringUtil.EmptyToNull(GetConfigValue("repair.healthcheck-concurrency"))
+            StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckConcurrency))
             ?? "50"
         );
         return Math.Clamp(configured, 1, Math.Max(1, poolSize));
@@ -829,35 +983,35 @@ public class ConfigManager
     public ArrConfig GetArrConfig()
     {
         var defaultValue = new ArrConfig();
-        return GetConfigValue<ArrConfig>("arr.instances") ?? defaultValue;
+        return GetConfigValue<ArrConfig>(ConfigKeys.ArrInstances) ?? defaultValue;
     }
 
     public UsenetProviderConfig GetUsenetProviderConfig()
     {
         var defaultValue = new UsenetProviderConfig();
-        return GetConfigValue<UsenetProviderConfig>("usenet.providers") ?? defaultValue;
+        return GetConfigValue<UsenetProviderConfig>(ConfigKeys.UsenetProviders) ?? defaultValue;
     }
 
     public IndexerConfig GetIndexerConfig()
     {
-        return GetConfigValue<IndexerConfig>("indexers.instances") ?? new IndexerConfig();
+        return GetConfigValue<IndexerConfig>(ConfigKeys.IndexersInstances) ?? new IndexerConfig();
     }
 
     public ProfileConfig GetProfileConfig()
     {
-        return (GetConfigValue<ProfileConfig>("profiles.instances") ?? new ProfileConfig()).Normalized();
+        return (GetConfigValue<ProfileConfig>(ConfigKeys.ProfilesInstances) ?? new ProfileConfig()).Normalized();
     }
 
     public string GetDuplicateNzbBehavior()
     {
         var defaultValue = "increment";
-        return GetConfigValue("api.duplicate-nzb-behavior") ?? defaultValue;
+        return GetConfigValue(ConfigKeys.ApiDuplicateNzbBehavior) ?? defaultValue;
     }
 
     public HashSet<string> GetBlocklistedFiles()
     {
         var defaultValue = "*.nfo, *.par2, *.sfv, *sample.mkv";
-        return (GetConfigValue("api.download-file-blocklist") ?? defaultValue)
+        return (GetConfigValue(ConfigKeys.ApiDownloadFileBlocklist) ?? defaultValue)
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())
             .Where(x => !string.IsNullOrWhiteSpace(x))
@@ -867,45 +1021,45 @@ public class ConfigManager
 
     public string GetImportStrategy()
     {
-        return GetConfigValue("api.import-strategy") ?? "symlinks";
+        return GetConfigValue(ConfigKeys.ApiImportStrategy) ?? "symlinks";
     }
 
     public string GetStrmCompletedDownloadDir()
     {
-        return GetConfigValue("api.completed-downloads-dir") ?? "/data/completed-downloads";
+        return GetConfigValue(ConfigKeys.ApiCompletedDownloadsDir) ?? "/data/completed-downloads";
     }
 
     public string GetBaseUrl()
     {
-        return GetConfigValue("general.base-url") ?? "http://localhost:3000";
+        return GetConfigValue(ConfigKeys.GeneralBaseUrl) ?? "http://localhost:3000";
     }
 
     public bool IsRcloneRemoteControlEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("rclone.rc-enabled"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RcloneRcEnabled));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public string? GetRcloneHost()
     {
-        return GetConfigValue("rclone.host");
+        return GetConfigValue(ConfigKeys.RcloneHost);
     }
 
     public string? GetRcloneUser()
     {
-        return GetConfigValue("rclone.user");
+        return GetConfigValue(ConfigKeys.RcloneUser);
     }
 
     public string? GetRclonePass()
     {
-        return GetConfigValue("rclone.pass");
+        return GetConfigValue(ConfigKeys.RclonePass);
     }
 
     public string GetUserAgent()
     {
         var defaultValue = $"nzbdav/{AppVersion}";
-        return StringUtil.EmptyToNull(GetConfigValue("api.user-agent"))
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiUserAgent))
                ?? EnvironmentUtil.GetEnvironmentVariable("NZB_GRAB_USER_AGENT")
                ?? defaultValue;
     }
@@ -913,7 +1067,7 @@ public class ConfigManager
     public string GetSearchUserAgent()
     {
         var defaultValue = $"nzbdav/{AppVersion}";
-        return StringUtil.EmptyToNull(GetConfigValue("api.search-user-agent"))
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiSearchUserAgent))
                ?? EnvironmentUtil.GetEnvironmentVariable("NZB_SEARCH_USER_AGENT")
                ?? defaultValue;
     }
@@ -921,7 +1075,7 @@ public class ConfigManager
     public bool IsDatabaseStartupVacuumEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("db.is-startup-vacuum-enabled"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.DbIsStartupVacuumEnabled));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
@@ -933,7 +1087,7 @@ public class ConfigManager
     public int GetHistoryRetentionDays()
     {
         return GetRetentionDaysSetting(
-            "database.history-retention-days",
+            ConfigKeys.DatabaseHistoryRetentionDays,
             "DATABASE_HISTORY_RETENTION_DAYS",
             defaultValue: 90);
     }
@@ -945,7 +1099,7 @@ public class ConfigManager
     public int GetHealthResultRetentionDays()
     {
         return GetRetentionDaysSetting(
-            "database.healthcheck-retention-days",
+            ConfigKeys.DatabaseHealthcheckRetentionDays,
             "DATABASE_HEALTHCHECK_RETENTION_DAYS",
             defaultValue: 30);
     }
@@ -960,26 +1114,26 @@ public class ConfigManager
     public bool IsNzbBackupEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("api.nzb-backup-enabled"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiNzbBackupEnabled));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public string? GetNzbBackupLocation()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("api.nzb-backup-location"));
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiNzbBackupLocation));
     }
 
     public bool IsRemoveOrphanedFilesScheduleEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("maintenance.remove-orphaned-schedule-enabled"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public TimeSpan RemoveOrphanedFilesSchedule()
     {
         var defaultValue = TimeSpan.Zero;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("maintenance.remove-orphaned-schedule-time"));
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.MaintenanceRemoveOrphanedScheduleTime));
         if (configValue == null) return defaultValue;
         if (!int.TryParse(configValue, out var totalMinutes)) return defaultValue;
         if (totalMinutes < 0 || totalMinutes >= 24 * 60) return defaultValue;

--- a/backend/Config/UsenetPassResolver.cs
+++ b/backend/Config/UsenetPassResolver.cs
@@ -10,7 +10,7 @@ namespace NzbWebDAV.Config;
 /// </summary>
 public static class UsenetPassResolver
 {
-    public const string ProvidersConfigName = "usenet.providers";
+    public const string ProvidersConfigName = ConfigKeys.UsenetProviders;
 
     public static string Resolve(string submittedPass, ConfigManager configManager)
     {

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -36,6 +36,15 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             .FirstOrDefaultAsync(x => x.ParentId == dirId && x.Name == childName, ct);
     }
 
+    // Resolves a persisted item by its absolute virtual path in a single indexed lookup,
+    // instead of one query per path segment. Returns null for synthetic items that have no
+    // stored row (empty category folders, .ids children, the readme, etc.), in which case
+    // callers fall back to walking the collection hierarchy.
+    public Task<DavItem?> GetItemByPathAsync(string path, CancellationToken ct = default)
+    {
+        return ctx.Items.AsNoTracking().FirstOrDefaultAsync(x => x.Path == path, ct);
+    }
+
     public async Task<long> GetRecursiveSize(Guid dirId, CancellationToken ct = default)
     {
         if (dirId == DavItem.Root.Id)

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -192,6 +192,9 @@ public sealed class DavDatabaseContext : DbContext
             e.HasIndex(i => new { i.ParentId, i.Name })
                 .IsUnique();
 
+            e.HasIndex(i => i.Path)
+                .IsUnique();
+
             e.HasIndex(i => new { i.IdPrefix, i.Type });
 
             e.HasIndex(i => new { i.Type, i.HistoryItemId, i.NextHealthCheck, i.ReleaseDate, i.Id });

--- a/backend/Database/Migrations/20260713120000_Add-Path-Index-To-DavItems.cs
+++ b/backend/Database/Migrations/20260713120000_Add-Path-Index-To-DavItems.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    /// <summary>
+    /// Adds a unique index on <c>DavItems.Path</c> so WebDAV resolution can look up a
+    /// persisted item in a single query instead of walking one segment at a time.
+    /// Rebuilds Path values first and renames any leftover duplicates so the unique
+    /// index can be created safely on existing databases.
+    /// </summary>
+    [DbContext(typeof(DavDatabaseContext))]
+    [Migration("20260713120000_Add-Path-Index-To-DavItems")]
+    public partial class AddPathIndexToDavItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. Rebuild Path from the parent chain so denormalized values match Name.
+            AddPathToDavItem.BuildFullPath(migrationBuilder);
+
+            // 2. Repair any leftover duplicate Paths (should be rare after rebuild given
+            //    the unique (ParentId, Name) index). Rename later duplicates so the
+            //    unique Path index can be created without failing the migration.
+            migrationBuilder.Sql("""
+                UPDATE DavItems
+                SET Name = Name || ' (' || substr(Id, 1, 5) || ')'
+                WHERE Id IN (
+                    SELECT Id FROM (
+                        SELECT Id,
+                               ROW_NUMBER() OVER (PARTITION BY Path ORDER BY CreatedAt, Id) AS rn
+                        FROM DavItems
+                    )
+                    WHERE rn > 1
+                );
+                """);
+
+            // 3. Rebuild again so renamed Names propagate into Path (and descendants).
+            AddPathToDavItem.BuildFullPath(migrationBuilder);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DavItems_Path",
+                table: "DavItems",
+                column: "Path",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DavItems_Path",
+                table: "DavItems");
+        }
+    }
+}

--- a/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
@@ -128,6 +128,9 @@ namespace NzbWebDAV.Database.Migrations
 
                     b.HasIndex("NzbBlobId");
 
+                    b.HasIndex("Path")
+                        .IsUnique();
+
                     b.HasIndex("IdPrefix", "Type");
 
                     b.HasIndex("ParentId", "Name")

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -107,23 +107,23 @@ public class QueueItemProcessor(
                 if (attempt > MaxProviderRetryAttempts)
                 {
                     Log.Error(
-                        "Giving up on queue item {JobName} after {Attempts} provider-connection failures: {Reason}",
+                        e,
+                        "Giving up on queue item {JobName} after {Attempts} provider-connection failures",
                         queueItem.JobName,
-                        attempt - 1,
-                        e.Message);
+                        attempt - 1);
                     await MarkQueueItemCompleted(startTime, error: e.Message).ConfigureAwait(false);
                     return;
                 }
 
                 var backoff = GetProviderRetryBackoff(attempt);
                 Log.Warning(
+                    e,
                     "Provider connection issue for queue item {JobName} (attempt {Attempt}/{MaxAttempts}); " +
-                    "retrying in {BackoffSeconds:0} seconds: {Reason}",
+                    "retrying in {BackoffSeconds:0} seconds",
                     queueItem.JobName,
                     attempt,
                     MaxProviderRetryAttempts,
-                    backoff.TotalSeconds,
-                    e.Message);
+                    backoff.TotalSeconds);
                 dbClient.Ctx.ClearChangeTracker();
                 queueItem.PauseUntil = DateTime.Now + backoff;
                 dbClient.Ctx.QueueItems.Attach(queueItem);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -176,17 +176,11 @@ public class HealthCheckService : BackgroundService
             var healthyMessage = sampled.Count < totalSegments
                 ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
                 : "File is healthy.";
-            dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-            {
-                Id = Guid.NewGuid(),
-                DavItemId = davItem.Id,
-                Path = davItem.Path,
-                CreatedAt = DateTimeOffset.UtcNow,
-                Result = HealthCheckResult.HealthResult.Healthy,
-                RepairStatus = HealthCheckResult.RepairAction.None,
-                Message = healthyMessage
-            }));
-            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Healthy,
+                HealthCheckResult.RepairAction.None,
+                healthyMessage, ct).ConfigureAwait(false);
         }
         catch (UsenetArticleNotFoundException e)
         {
@@ -279,21 +273,15 @@ public class HealthCheckService : BackgroundService
             if (BlocklistedFilePostProcessor.MatchesAnyPattern(davItem.Name, blocklistedFiles))
             {
                 dbClient.Ctx.Items.Remove(davItem);
-                dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-                {
-                    Id = Guid.NewGuid(),
-                    DavItemId = davItem.Id,
-                    Path = davItem.Path,
-                    CreatedAt = DateTimeOffset.UtcNow,
-                    Result = HealthCheckResult.HealthResult.Unhealthy,
-                    RepairStatus = HealthCheckResult.RepairAction.Deleted,
-                    Message = string.Join(" ", [
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.Deleted,
+                    string.Join(" ", [
                         "File had missing articles.",
                         "Filename pattern is marked in settings as an ignored (unwanted) file.",
                         "Deleted file."
-                    ])
-                }));
-                await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                    ]), ct).ConfigureAwait(false);
                 return;
             }
 
@@ -303,21 +291,15 @@ public class HealthCheckService : BackgroundService
             if (symlinkOrStrmPath == null)
             {
                 dbClient.Ctx.Items.Remove(davItem);
-                dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-                {
-                    Id = Guid.NewGuid(),
-                    DavItemId = davItem.Id,
-                    Path = davItem.Path,
-                    CreatedAt = DateTimeOffset.UtcNow,
-                    Result = HealthCheckResult.HealthResult.Unhealthy,
-                    RepairStatus = HealthCheckResult.RepairAction.Deleted,
-                    Message = string.Join(" ", [
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.Deleted,
+                    string.Join(" ", [
                         "File had missing articles.",
                         "Could not find corresponding symlink or strm-file within Library Dir.",
                         "Deleted file."
-                    ])
-                }));
-                await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                    ]), ct).ConfigureAwait(false);
                 return;
             }
 
@@ -342,8 +324,8 @@ public class HealthCheckService : BackgroundService
                 catch (Exception e)
                 {
                     anInstanceFailed = true;
-                    Log.Warning("Health-check repair: could not query root folders from {Host}: {Message}",
-                                arrClient.Host, e.Message);
+                    Log.Warning(e, "Health-check repair: could not query root folders from {Host}",
+                                arrClient.Host);
                     continue;
                 }
 
@@ -365,29 +347,23 @@ public class HealthCheckService : BackgroundService
                 catch (Exception e)
                 {
                     anInstanceFailed = true;
-                    Log.Warning("Health-check repair: remove-and-search failed on {Host}: {Message}",
-                                arrClient.Host, e.Message);
+                    Log.Warning(e, "Health-check repair: remove-and-search failed on {Host}",
+                                arrClient.Host);
                     continue;
                 }
 
                 if (removedAndSearched)
                 {
                     dbClient.Ctx.Items.Remove(davItem);
-                    dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-                    {
-                        Id = Guid.NewGuid(),
-                        DavItemId = davItem.Id,
-                        Path = davItem.Path,
-                        CreatedAt = DateTimeOffset.UtcNow,
-                        Result = HealthCheckResult.HealthResult.Unhealthy,
-                        RepairStatus = HealthCheckResult.RepairAction.Repaired,
-                        Message = string.Join(" ", [
+                    await RecordHealthResult(
+                        dbClient, davItem,
+                        HealthCheckResult.HealthResult.Unhealthy,
+                        HealthCheckResult.RepairAction.Repaired,
+                        string.Join(" ", [
                             "File had missing articles.",
                             $"Corresponding {linkType} found within Library Dir.",
                             "Triggered new Arr search."
-                        ])
-                    }));
-                    await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                        ]), ct).ConfigureAwait(false);
                     return;
                 }
 
@@ -406,22 +382,16 @@ public class HealthCheckService : BackgroundService
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;
                 davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
-                dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-                {
-                    Id = Guid.NewGuid(),
-                    DavItemId = davItem.Id,
-                    Path = davItem.Path,
-                    CreatedAt = utcNow,
-                    Result = HealthCheckResult.HealthResult.Unhealthy,
-                    RepairStatus = HealthCheckResult.RepairAction.ActionNeeded,
-                    Message = string.Join(" ", [
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
                         "File had missing articles.",
                         $"Corresponding {linkType} found within Library Dir,",
                         "but at least one Arr instance could not be reached or fully queried, so ownership",
                         "of the file could not be determined. Leaving the file in place rather than deleting it."
-                    ])
-                }));
-                await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                    ]), ct).ConfigureAwait(false);
                 return;
             }
 
@@ -429,22 +399,16 @@ public class HealthCheckService : BackgroundService
             // then we can delete both the item and the link-file.
             await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
             dbClient.Ctx.Items.Remove(davItem);
-            dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-            {
-                Id = Guid.NewGuid(),
-                DavItemId = davItem.Id,
-                Path = davItem.Path,
-                CreatedAt = DateTimeOffset.UtcNow,
-                Result = HealthCheckResult.HealthResult.Unhealthy,
-                RepairStatus = HealthCheckResult.RepairAction.Deleted,
-                Message = string.Join(" ", [
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.Deleted,
+                string.Join(" ", [
                     "File had missing articles.",
                     $"Corresponding {linkType} found within Library Dir.",
                     "Could not find corresponding Radarr/Sonarr media-item to trigger a new search.",
                     $"Deleted the webdav-file and {linkType}."
-                ])
-            }));
-            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                ]), ct).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -453,18 +417,36 @@ public class HealthCheckService : BackgroundService
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
-            dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
-            {
-                Id = Guid.NewGuid(),
-                DavItemId = davItem.Id,
-                Path = davItem.Path,
-                CreatedAt = utcNow,
-                Result = HealthCheckResult.HealthResult.Unhealthy,
-                RepairStatus = HealthCheckResult.RepairAction.ActionNeeded,
-                Message = $"Error performing file repair: {e.Message}"
-            }));
-            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                $"Error performing file repair: {e.Message}", ct).ConfigureAwait(false);
         }
+    }
+
+
+    private async Task RecordHealthResult
+    (
+        DavDatabaseClient dbClient,
+        DavItem davItem,
+        HealthCheckResult.HealthResult result,
+        HealthCheckResult.RepairAction repairStatus,
+        string message,
+        CancellationToken ct
+    )
+    {
+        dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
+        {
+            Id = Guid.NewGuid(),
+            DavItemId = davItem.Id,
+            Path = davItem.Path,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Result = result,
+            RepairStatus = repairStatus,
+            Message = message
+        }));
+        await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     private HealthCheckResult SendStatus(HealthCheckResult result)

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -44,8 +44,7 @@ public class HealthCheckService : BackgroundService
         _configManager.OnConfigChanged += (_, configEventArgs) =>
         {
             // when provider settings change, clear the missing segments cache
-            if (!configEventArgs.ChangedConfig.ContainsKey("usenet.providers") &&
-                !configEventArgs.ChangedConfig.ContainsKey("usenet.host")) return;
+            if (!configEventArgs.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders)) return;
             lock (_missingSegmentIds)
             {
                 _missingSegmentIds.Clear();

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -23,8 +23,8 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
 
         _configManager.OnConfigChanged += (_, args) =>
         {
-            if (!args.ChangedConfig.ContainsKey("maintenance.remove-orphaned-schedule-enabled") &&
-                !args.ChangedConfig.ContainsKey("maintenance.remove-orphaned-schedule-time"))
+            if (!args.ChangedConfig.ContainsKey(ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled) &&
+                !args.ChangedConfig.ContainsKey(ConfigKeys.MaintenanceRemoveOrphanedScheduleTime))
                 return;
 
             var old = Interlocked.Exchange(ref _rescheduleCts, new CancellationTokenSource());

--- a/backend/Services/SearchExcludeSyncService.cs
+++ b/backend/Services/SearchExcludeSyncService.cs
@@ -51,8 +51,8 @@ public sealed class SearchExcludeSyncService : BackgroundService
     private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs e)
     {
         // React only to the inputs — NOT to our own cache writes (which would loop).
-        if (!e.ChangedConfig.ContainsKey("search.exclude-sync-urls")
-            && !e.ChangedConfig.ContainsKey("search.exclude-sync-refresh-minutes")) return;
+        if (!e.ChangedConfig.ContainsKey(ConfigKeys.SearchExcludeSyncUrls)
+            && !e.ChangedConfig.ContainsKey(ConfigKeys.SearchExcludeSyncRefreshMinutes)) return;
 
         // A freshly-set URL should apply within seconds, not at the next tick.
         _ = Task.Run(async () =>

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -127,11 +127,11 @@ public class WatchtowerService(
 
     private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs e)
     {
-        if (e.ChangedConfig.ContainsKey("watchtower.verbose-logging"))
+        if (e.ChangedConfig.ContainsKey(ConfigKeys.WatchtowerVerboseLogging))
             Log.Information("Watchtower: verbose activity logging {State}",
                 configManager.IsWatchtowerVerboseLoggingEnabled() ? "enabled" : "disabled");
 
-        if (!e.ChangedConfig.ContainsKey("watchtower.enabled")) return;
+        if (!e.ChangedConfig.ContainsKey(ConfigKeys.WatchtowerEnabled)) return;
         if (configManager.IsWatchtowerEnabled()) return;
         lock (_ctsLock) _disabledCts?.Cancel();
     }

--- a/backend/WebDav/Base/BaseStoreStreamFile.cs
+++ b/backend/WebDav/Base/BaseStoreStreamFile.cs
@@ -30,9 +30,9 @@ public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager con
         {
             onConfigChanged = (_, e) =>
             {
-                if (e.ChangedConfig.ContainsKey("usenet.max-download-connections")
-                    || e.ChangedConfig.ContainsKey("usenet.max-download-connections-per-stream-preset")
-                    || e.ChangedConfig.ContainsKey("usenet.providers"))
+                if (e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxDownloadConnections)
+                    || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxDownloadConnectionsPerStreamPreset)
+                    || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders))
                 {
                     // The response may complete (and dispose the semaphore) concurrently
                     // with a config save; never let that surface into the save path.

--- a/backend/WebDav/DatabaseStore.cs
+++ b/backend/WebDav/DatabaseStore.cs
@@ -34,7 +34,21 @@ public class DatabaseStore(
     public async Task<IStoreItem?> GetItemAsync(string path, CancellationToken cancellationToken)
     {
         path = path.Trim('/');
-        return path == "" ? _root : await _root.ResolvePath(path, cancellationToken).ConfigureAwait(false);
+        if (path == "") return _root;
+
+        // Fast path: a single indexed lookup by absolute path. This handles the overwhelmingly
+        // common case (streaming/serving a real, persisted file or directory) in one query
+        // instead of one per path segment.
+        var byPath = await dbClient.GetItemByPathAsync("/" + path, cancellationToken).ConfigureAwait(false);
+        if (byPath is not null)
+            return DatabaseStoreItemFactory.Create(
+                byPath, httpContextAccessor.HttpContext!, dbClient, configManager,
+                usenetClient, queueManager, websocketManager, lazyRarResolver);
+
+        // Fallback: walk the collection hierarchy segment-by-segment. This covers synthetic
+        // items that have no persisted row (empty category folders, .ids children, the
+        // readme, empty placeholder files created by WebDAV clients).
+        return await _root.ResolvePath(path, cancellationToken).ConfigureAwait(false);
     }
 
     public Task<IStoreItem?> GetItemAsync(Uri uri, CancellationToken cancellationToken)

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -41,7 +41,10 @@ public class DatabaseStoreCollection(
         var child = await dbClient
             .GetDirectoryChildAsync(davDirectory.Id, request.Name, request.CancellationToken)
             .ConfigureAwait(false);
-        if (child is not null) return GetItem(child);
+        if (child is not null)
+            return DatabaseStoreItemFactory.Create(
+                child, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,
+                lazyRarResolver);
 
         // return empty category folder
         var isContentFolder = davDirectory.Id == DavItem.ContentFolder.Id;
@@ -66,7 +69,9 @@ public class DatabaseStoreCollection(
             .ConfigureAwait(false);
 
         // map DavItems to IStoreItems
-        var result = children.Select(GetItem);
+        var result = children.Select(child => DatabaseStoreItemFactory.Create(
+            child, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,
+            lazyRarResolver));
 
         // include the readme file
         if (davDirectory.Id == DavItem.Root.Id)
@@ -148,35 +153,5 @@ public class DatabaseStoreCollection(
         dbClient.Ctx.HistoryItems.Remove(history);
         await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
         _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, historyItemId.Value.ToString());
-    }
-
-    private IStoreItem GetItem(DavItem davItem)
-    {
-        return davItem.SubType switch
-        {
-            DavItem.ItemSubType.IdsRoot =>
-                new DatabaseStoreIdsCollection(
-                    davItem.Name, "", httpContext, dbClient, usenetClient, configManager, lazyRarResolver),
-            DavItem.ItemSubType.NzbsRoot =>
-                new DatabaseStoreWatchFolder(
-                    davItem, dbClient, configManager, queueManager, websocketManager),
-            DavItem.ItemSubType.Directory or DavItem.ItemSubType.ContentRoot =>
-                new DatabaseStoreCollection(
-                    davItem, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,
-                    lazyRarResolver),
-            DavItem.ItemSubType.SymlinkRoot =>
-                new DatabaseStoreSymlinkCollection(
-                    davItem, dbClient, configManager),
-            DavItem.ItemSubType.NzbFile =>
-                new DatabaseStoreNzbFile(
-                    davItem, httpContext, dbClient, usenetClient, configManager),
-            DavItem.ItemSubType.RarFile =>
-                new DatabaseStoreRarFile(
-                    davItem, httpContext, dbClient, usenetClient, configManager),
-            DavItem.ItemSubType.MultipartFile =>
-                new DatabaseStoreMultipartFile(
-                    davItem, httpContext, dbClient, usenetClient, configManager, lazyRarResolver),
-            _ => throw new ArgumentException("Unrecognized directory child type.")
-        };
     }
 }

--- a/backend/WebDav/DatabaseStoreItemFactory.cs
+++ b/backend/WebDav/DatabaseStoreItemFactory.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Http;
+using NWebDav.Server.Stores;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.WebDav;
+
+/// <summary>
+/// Maps a persisted <see cref="DavItem"/> onto the corresponding NWebDav store item.
+/// Centralized here so the directory listing path (<see cref="DatabaseStoreCollection"/>)
+/// and the direct path lookup (<see cref="DatabaseStore"/>) build items identically.
+/// </summary>
+public static class DatabaseStoreItemFactory
+{
+    public static IStoreItem Create(
+        DavItem davItem,
+        HttpContext httpContext,
+        DavDatabaseClient dbClient,
+        ConfigManager configManager,
+        UsenetStreamingClient usenetClient,
+        QueueManager queueManager,
+        WebsocketManager websocketManager,
+        LazyRarResolver lazyRarResolver)
+    {
+        return davItem.SubType switch
+        {
+            DavItem.ItemSubType.IdsRoot =>
+                new DatabaseStoreIdsCollection(
+                    davItem.Name, "", httpContext, dbClient, usenetClient, configManager, lazyRarResolver),
+            DavItem.ItemSubType.NzbsRoot =>
+                new DatabaseStoreWatchFolder(
+                    davItem, dbClient, configManager, queueManager, websocketManager),
+            DavItem.ItemSubType.Directory or DavItem.ItemSubType.ContentRoot =>
+                new DatabaseStoreCollection(
+                    davItem, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,
+                    lazyRarResolver),
+            DavItem.ItemSubType.SymlinkRoot =>
+                new DatabaseStoreSymlinkCollection(
+                    davItem, dbClient, configManager),
+            DavItem.ItemSubType.NzbFile =>
+                new DatabaseStoreNzbFile(
+                    davItem, httpContext, dbClient, usenetClient, configManager),
+            DavItem.ItemSubType.RarFile =>
+                new DatabaseStoreRarFile(
+                    davItem, httpContext, dbClient, usenetClient, configManager),
+            DavItem.ItemSubType.MultipartFile =>
+                new DatabaseStoreMultipartFile(
+                    davItem, httpContext, dbClient, usenetClient, configManager, lazyRarResolver),
+            _ => throw new ArgumentException("Unrecognized directory child type.")
+        };
+    }
+}

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -105,14 +105,16 @@ describe("BackendClient", () => {
   it("adds an NZB using the configured manual category", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({
-        configItems: [{ configName: "api.manual-category", configValue: "movies" }],
+        configItems: [{ configName: "api.manual-category", configValue: "movies & shows" }],
       }))
       .mockResolvedValueOnce(jsonResponse({ nzo_ids: ["nzo-1"] }));
     const file = new File(["nzb"], "movie.nzb");
 
     await expect(backendClient.addNzb(file)).resolves.toBe("nzo-1");
     const [url, init] = fetchMock.mock.calls[1];
-    expect(url).toBe("http://backend/api?mode=addfile&cat=movies&priority=0&pp=0");
+    expect(url).toBe(
+      "http://backend/api?mode=addfile&cat=movies+%26+shows&priority=0&pp=0",
+    );
     expect((init?.body as FormData).get("nzbFile")).toBeInstanceOf(File);
   });
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -5,98 +5,69 @@ export class WebdavDirectoryNotFoundError extends Error {
     }
 }
 
+/** Builds a FormData body from a list of [name, value] entries. */
+function form(...entries: [string, string | Blob, string?][]): FormData {
+    const data = new FormData();
+    for (const [name, value, filename] of entries) {
+        if (filename !== undefined) data.append(name, value as Blob, filename);
+        else data.append(name, value);
+    }
+    return data;
+}
+
+/**
+ * Single entry point for every backend call: prepends BACKEND_URL, attaches the
+ * shared api key, and converts a non-2xx response into an Error whose message is
+ * prefixed with `errorPrefix` and suffixed with the backend's reported error.
+ */
+async function call(path: string, errorPrefix: string, init?: RequestInit): Promise<any> {
+    const response = await fetch(process.env.BACKEND_URL + path, {
+        ...init,
+        headers: {
+            "x-api-key": process.env.FRONTEND_BACKEND_API_KEY || "",
+            ...(init?.headers ?? {}),
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`${errorPrefix}: ${(await response.json()).error}`);
+    }
+
+    return response.json();
+}
+
 class BackendClient {
     public async isOnboarding(): Promise<boolean> {
-        const url = process.env.BACKEND_URL + "/api/is-onboarding";
-
-        const response = await fetch(url, {
+        const data = await call("/api/is-onboarding", "Failed to fetch onboarding status", {
             method: "GET",
-            headers: {
-                "Content-Type": "application/json",
-                "x-api-key": process.env.FRONTEND_BACKEND_API_KEY || ""
-            }
+            headers: { "Content-Type": "application/json" },
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to fetch onboarding status: ${(await response.json()).error}`);
-        }
-
-        const data = await response.json();
         return data.isOnboarding;
     }
 
     public async createAccount(username: string, password: string): Promise<boolean> {
-        const url = process.env.BACKEND_URL + "/api/create-account";
-
-        const response = await fetch(url, {
+        const data = await call("/api/create-account", "Failed to create account", {
             method: "POST",
-            headers: {
-                "x-api-key": process.env.FRONTEND_BACKEND_API_KEY || ""
-            },
-            body: (() => {
-                const form = new FormData();
-                form.append("username", username);
-                form.append("password", password);
-                form.append("type", "admin");
-                return form;
-            })()
+            body: form(["username", username], ["password", password], ["type", "admin"]),
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to create account: ${(await response.json()).error}`);
-        }
-
-        const data = await response.json();
         return data.status;
     }
 
     public async authenticate(username: string, password: string): Promise<boolean> {
-        const url = process.env.BACKEND_URL + "/api/authenticate";
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        const data = await call("/api/authenticate", "Failed to authenticate", {
             method: "POST",
-            headers: { "x-api-key": apiKey },
-            body: (() => {
-                const form = new FormData();
-                form.append("username", username);
-                form.append("password", password);
-                form.append("type", "admin");
-                return form;
-            })()
+            body: form(["username", username], ["password", password], ["type", "admin"]),
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to authenticate: ${(await response.json()).error}`);
-        }
-
-        const data = await response.json();
         return data.authenticated;
     }
 
     public async getQueue(limit: number, start: number = 0): Promise<QueueResponse> {
-        const url = process.env.BACKEND_URL + `/api?mode=queue&start=${start}&limit=${limit}`;
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to get queue: ${(await response.json()).error}`);
-        }
-
-        const data = await response.json();
+        const data = await call(`/api?mode=queue&start=${start}&limit=${limit}`, "Failed to get queue");
         return data.queue;
     }
 
     public async getHistory(limit: number, start: number = 0): Promise<HistoryResponse> {
-        const url = process.env.BACKEND_URL + `/api?mode=history&start=${start}&pageSize=${limit}`;
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to get history: ${(await response.json()).error}`);
-        }
-
-        const data = await response.json();
+        const data = await call(`/api?mode=history&start=${start}&pageSize=${limit}`, "Failed to get history");
         return data.history;
     }
 
@@ -109,23 +80,10 @@ class BackendClient {
             priority: "0",
             pp: "0",
         });
-        const url = process.env.BACKEND_URL + `/api?${params.toString()}`;
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        const data = await call(`/api?${params.toString()}`, "Failed to add nzb file", {
             method: "POST",
-            headers: { "x-api-key": apiKey },
-            body: (() => {
-                const form = new FormData();
-                form.append("nzbFile", nzbFile, nzbFile.name);
-                return form;
-            })()
+            body: form(["nzbFile", nzbFile, nzbFile.name]),
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to add nzb file: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
         if (!data.nzo_ids || data.nzo_ids.length != 1) {
             throw new Error(`Failed to add nzb file: unexpected response format`);
         }
@@ -133,22 +91,10 @@ class BackendClient {
     }
 
     public async searchIndexers(q: string, limit: number = 100): Promise<SearchIndexersResponse> {
-        const url = process.env.BACKEND_URL + "/api/search-indexers";
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        return await call("/api/search-indexers", "Failed to search indexers", {
             method: "POST",
-            headers: { "x-api-key": apiKey },
-            body: (() => {
-                const form = new FormData();
-                form.append("q", q);
-                form.append("limit", String(limit));
-                return form;
-            })()
+            body: form(["q", q], ["limit", String(limit)]),
         });
-        if (!response.ok) {
-            throw new Error(`Failed to search indexers: ${(await response.json()).error}`);
-        }
-        return await response.json();
     }
 
     public async addNzbFromUrl(nzbUrl: string, nzbName: string): Promise<string> {
@@ -162,13 +108,9 @@ class BackendClient {
             name: nzbUrl,
             nzbname: nzbName,
         });
-        const url = process.env.BACKEND_URL + `/api?${params.toString()}`;
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to add nzb url: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call(`/api?${params.toString()}`, "Failed to add nzb url", {
+            method: "POST",
+        });
         if (!data.nzo_ids || data.nzo_ids.length !== 1) {
             throw new Error("Failed to add nzb url: unexpected response format");
         }
@@ -176,148 +118,75 @@ class BackendClient {
     }
 
     public async listWebdavDirectory(directory: string): Promise<DirectoryItem[]> {
-        const url = process.env.BACKEND_URL + "/api/list-webdav-directory";
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
-            method: "POST",
-            headers: { "x-api-key": apiKey },
-            body: (() => {
-                const form = new FormData();
-                form.append("directory", directory);
-                return form;
-            })()
-        });
-
-        if (!response.ok) {
-            const error = (await response.json()).error;
-            if (response.status === 400 && error === "The directory does not exist.") {
+        try {
+            const data = await call("/api/list-webdav-directory", "Failed to list webdav directory", {
+                method: "POST",
+                body: form(["directory", directory]),
+            });
+            return data.items;
+        } catch (error) {
+            if (error instanceof Error && error.message.endsWith(": The directory does not exist.")) {
                 throw new WebdavDirectoryNotFoundError(directory);
             }
-            throw new Error(`Failed to list webdav directory: ${error}`);
+            throw error;
         }
-        const data = await response.json();
-        return data.items;
     }
 
     public async getConfig(keys: string[]): Promise<ConfigItem[]> {
-        const url = process.env.BACKEND_URL + "/api/get-config";
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        const data = await call("/api/get-config", "Failed to get config items", {
             method: "POST",
-            headers: { "x-api-key": apiKey },
-            body: (() => {
-                const form = new FormData();
-                for (const key of keys) {
-                    form.append("config-keys", key);
-                }
-                return form;
-            })()
+            body: form(...keys.map(key => ["config-keys", key] as [string, string])),
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to get config items: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
         return data.configItems || [];
     }
 
     public async updateConfig(configItems: ConfigItem[]): Promise<boolean> {
-        const url = process.env.BACKEND_URL + "/api/update-config";
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        const data = await call("/api/update-config", "Failed to update config items", {
             method: "POST",
-            headers: { "x-api-key": apiKey },
-            body: (() => {
-                const form = new FormData();
-                for (const item of configItems) {
-                    form.append(item.configName, item.configValue);
-                }
-                return form;
-            })()
+            body: form(...configItems.map(item => [item.configName, item.configValue] as [string, string])),
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to update config items: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
         return data.status;
     }
 
     public async getHealthCheckQueue(pageSize?: number): Promise<HealthCheckQueueResponse> {
-        let url = process.env.BACKEND_URL + "/api/get-health-check-queue";
-
-        if (pageSize !== undefined) {
-            url += `?pageSize=${pageSize}`;
-        }
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        const query = pageSize !== undefined ? `?pageSize=${pageSize}` : "";
+        return await call(`/api/get-health-check-queue${query}`, "Failed to get health check queue", {
             method: "GET",
-            headers: { "x-api-key": apiKey }
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to get health check queue: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
-        return data;
     }
 
     public async getWatchdogEntries(limit: number = 200): Promise<WatchdogEntry[]> {
-        const url = process.env.BACKEND_URL + `/api/get-watchdog-entries?limit=${limit}`;
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "GET", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to get watchdog entries: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call(`/api/get-watchdog-entries?limit=${limit}`, "Failed to get watchdog entries", {
+            method: "GET",
+        });
         return data.entries ?? [];
     }
 
     public async getExcludeSyncStatus(): Promise<ExcludeSyncUrlStatus[]> {
-        const url = process.env.BACKEND_URL + "/api/exclude-sync";
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "GET", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to get exclude-sync status: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call("/api/exclude-sync", "Failed to get exclude-sync status", {
+            method: "GET",
+        });
         return data.urls || [];
     }
 
     public async refreshExcludeSync(): Promise<ExcludeSyncUrlStatus[]> {
-        const url = process.env.BACKEND_URL + "/api/exclude-sync";
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to refresh exclude-sync: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call("/api/exclude-sync", "Failed to refresh exclude-sync", {
+            method: "POST",
+        });
         return data.urls || [];
     }
 
     public async clearWatchdogEntries(): Promise<number> {
-        const url = process.env.BACKEND_URL + `/api/clear-watchdog-entries`;
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to clear watchdog entries: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call(`/api/clear-watchdog-entries`, "Failed to clear watchdog entries", {
+            method: "POST",
+        });
         return data.deleted ?? 0;
     }
 
     public async clearHealthCheckHistory(): Promise<{ deletedResults: number; deletedStats: number }> {
-        const url = process.env.BACKEND_URL + `/api/clear-health-check-history`;
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to clear health-check history: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call(`/api/clear-health-check-history`, "Failed to clear health-check history", {
+            method: "POST",
+        });
         return {
             deletedResults: data.deletedResults ?? 0,
             deletedStats: data.deletedStats ?? 0,
@@ -325,40 +194,21 @@ class BackendClient {
     }
 
     public async getHealthCheckHistory(pageSize?: number): Promise<HealthCheckHistoryResponse> {
-        let url = process.env.BACKEND_URL + "/api/get-health-check-history";
-
-        if (pageSize !== undefined) {
-            url += `?pageSize=${pageSize}`;
-        }
-
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
+        const query = pageSize !== undefined ? `?pageSize=${pageSize}` : "";
+        return await call(`/api/get-health-check-history${query}`, "Failed to get health check history", {
             method: "GET",
-            headers: { "x-api-key": apiKey }
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to get health check history: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
-        return data;
     }
 
     public async getOverviewStats(
         window: OverviewWindow = "24h",
         sections: OverviewSections = "all",
     ): Promise<OverviewStatsResponse> {
-        const url = `${process.env.BACKEND_URL}/api/get-overview-stats?window=${window}&sections=${sections}`;
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, {
-            method: "GET",
-            headers: { "x-api-key": apiKey }
-        });
-
-        if (!response.ok) {
-            throw new Error(`Failed to get overview stats: ${(await response.json()).error}`);
-        }
-        return await response.json();
+        return await call(
+            `/api/get-overview-stats?window=${window}&sections=${sections}`,
+            "Failed to get overview stats",
+            { method: "GET" },
+        );
     }
 
     public async getLogs(params: GetLogsParams = {}): Promise<GetLogsResponse> {
@@ -368,13 +218,10 @@ class BackendClient {
         if (params.source) qs.set("source", params.source);
         if (params.search) qs.set("search", params.search);
         if (params.beforeSequence !== undefined) qs.set("beforeSequence", String(params.beforeSequence));
-        const url = `${process.env.BACKEND_URL}/api/get-logs${qs.toString() ? `?${qs.toString()}` : ""}`;
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "GET", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to get logs: ${(await response.json()).error}`);
-        }
-        return await response.json();
+        const query = qs.toString();
+        return await call(`/api/get-logs${query ? `?${query}` : ""}`, "Failed to get logs", {
+            method: "GET",
+        });
     }
 
     public async getWatchtower(params: WatchtowerQuery = {}): Promise<WatchtowerData> {
@@ -387,38 +234,24 @@ class BackendClient {
         if (params.expander) qs.set("expander", params.expander);
         if (params.statsOnly) qs.set("statsOnly", "1");
         const query = qs.toString();
-        const url = process.env.BACKEND_URL + "/api/get-watchtower" + (query ? `?${query}` : "");
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const response = await fetch(url, { method: "GET", headers: { "x-api-key": apiKey } });
-        if (!response.ok) {
-            throw new Error(`Failed to get watchtower: ${(await response.json()).error}`);
-        }
-        return await response.json();
+        return await call(`/api/get-watchtower${query ? `?${query}` : ""}`, "Failed to get watchtower", {
+            method: "GET",
+        });
     }
 
     public async watchtowerMutate(fields: Record<string, string>): Promise<boolean> {
-        const url = process.env.BACKEND_URL + "/api/watchtower-mutate";
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const form = new FormData();
-        for (const [k, v] of Object.entries(fields)) form.append(k, v);
-        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey }, body: form });
-        if (!response.ok) {
-            throw new Error(`Watchtower action failed: ${(await response.json()).error}`);
-        }
-        const data = await response.json();
+        const data = await call("/api/watchtower-mutate", "Watchtower action failed", {
+            method: "POST",
+            body: form(...Object.entries(fields).map(([k, v]) => [k, v] as [string, string])),
+        });
         return data.status;
     }
 
     public async discoverStremioCatalogs(manifestUrl: string): Promise<DiscoverCatalogsResponse> {
-        const url = process.env.BACKEND_URL + "/api/watchtower-discover-catalogs";
-        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
-        const form = new FormData();
-        form.append("url", manifestUrl);
-        const response = await fetch(url, { method: "POST", headers: { "x-api-key": apiKey }, body: form });
-        if (!response.ok) {
-            throw new Error(`${(await response.json()).error}`);
-        }
-        return await response.json();
+        return await call("/api/watchtower-discover-catalogs", "Failed to discover catalogs", {
+            method: "POST",
+            body: form(["url", manifestUrl]),
+        });
     }
 }
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -103,7 +103,13 @@ class BackendClient {
     public async addNzb(nzbFile: File): Promise<string> {
         const config = await this.getConfig(["api.manual-category"]);
         const category = config.find(item => item.configName === "api.manual-category")?.configValue || "uncategorized";
-        const url = process.env.BACKEND_URL + `/api?mode=addfile&cat=${category}&priority=0&pp=0`;
+        const params = new URLSearchParams({
+            mode: "addfile",
+            cat: category,
+            priority: "0",
+            pp: "0",
+        });
+        const url = process.env.BACKEND_URL + `/api?${params.toString()}`;
 
         const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
         const response = await fetch(url, {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/HeaderCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/HeaderCachingNntpClientTests.cs
@@ -1,0 +1,120 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class HeaderCachingNntpClientTests
+{
+    [Fact]
+    public async Task GetYencHeadersAsync_CachesImmutableHeadersAfterFirstFetch()
+    {
+        var inner = new CountingHeaderClient();
+        var client = new HeaderCachingNntpClient(inner);
+
+        var first = await client.GetYencHeadersAsync("segment-1", CancellationToken.None);
+        var second = await client.GetYencHeadersAsync("segment-1", CancellationToken.None);
+        var other = await client.GetYencHeadersAsync("segment-2", CancellationToken.None);
+
+        Assert.Equal(100, first.PartOffset);
+        Assert.Equal(100, second.PartOffset);
+        Assert.Equal(200, other.PartOffset);
+        Assert.Equal(2, inner.HeaderRequestCount);
+    }
+
+    private sealed class CountingHeaderClient : NntpClient
+    {
+        public int HeaderRequestCount { get; private set; }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        public override Task<UsenetYencHeader> GetYencHeadersAsync(
+            string segmentId, CancellationToken cancellationToken)
+        {
+            HeaderRequestCount++;
+            return Task.FromResult(new UsenetYencHeader
+            {
+                FileName = "fake.bin",
+                FileSize = 1_000,
+                LineLength = 128,
+                PartNumber = 1,
+                PartOffset = segmentId == "segment-1" ? 100 : 200,
+                PartSize = 50,
+                TotalParts = 10,
+            });
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -69,6 +69,34 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetItemByPathAsync_ResolvesNestedPersistedPaths()
+    {
+        var directory = DavItem.New(
+            Guid.NewGuid(), DavItem.Root, "movies", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        var nestedDirectory = DavItem.New(
+            Guid.NewGuid(), directory, "science-fiction", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        var nestedFile = DavItem.New(
+            Guid.NewGuid(), nestedDirectory, "nested.mkv", 250,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            null, null, null, null);
+
+        _context.Items.AddRange(directory, nestedDirectory, nestedFile);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var hit = await _client.GetItemByPathAsync(nestedFile.Path);
+        Assert.NotNull(hit);
+        Assert.Equal(nestedFile.Id, hit.Id);
+        Assert.Equal("/movies/science-fiction/nested.mkv", hit.Path);
+
+        Assert.Null(await _client.GetItemByPathAsync("/movies/missing.mkv"));
+    }
+
+    [Fact]
     public async Task QueueItemProcessor_MovesMissingNzbToFailedHistory()
     {
         var queueItem = new QueueItem


### PR DESCRIPTION
## Summary

Ports and fixes from the mrghxst adoption set plus adjacent audit items, as one PR with a separate conventional commit per changelog entry.

Closes #237
Closes #242
Closes #243
Closes #245
Closes #248
Closes #240
Closes #223

Does **not** close #229 / #230 (adjacent auth timing bugs).

### Commits

1. **`fix(auth)`** — unify API-key validation so admin `/api/*` accepts configured `api.key` or `FRONTEND_BACKEND_API_KEY` (#242)
2. **`fix(config)`** — `ConfigKeys`, `ValidateConfigItems` → 400, deserialize outside lock, drop stale `usenet.host` cache-clear key (#245, #240)
3. **`perf(webdav)`** — unique `DavItems.Path` index + single-query fast path with segment-walk fallback (#237)
4. **`perf(usenet)`** — always-on `HeaderCachingNntpClient` on the streaming stack; `WrappingNntpClient` now forwards `GetYencHeadersAsync` (#243)
5. **`fix(ui)`** — encode `addNzb` category with `URLSearchParams` (#223)
6. **`chore`** — dedupe `backend-client.server.ts`, `HealthCheckService.RecordHealthResult`, queue exception logging (#248)

## Test plan

- [x] Backend builds
- [x] `DavDatabaseClientTests` path lookup tests pass
- [x] `HeaderCachingNntpClientTests` pass
- [x] Frontend typecheck + all vitest tests pass
- [ ] Admin `/api/*` accepts configured `api.key` and env key; wrong key → 401
- [ ] SAB `/api?mode=*` unchanged for both keys
- [ ] Malformed config update → 400; changing `usenet.providers` clears missing-segment cache
- [ ] Nested WebDAV path resolves via indexed lookup; virtual paths (README, empty categories, `/.ids`, symlinks) still fall back
- [ ] Repeat seeks reuse cached yEnc headers (unit coverage included)
- [ ] Category with `&` / `=` in `addNzb` encodes correctly
- [ ] Health check still records/saves results; queue errors include stacks in logs