### PR TITLE
fix(health): treat NNTP 451 as missing during health checks

### DIFF
--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -155,13 +155,13 @@ public class BaseNntpClient : NntpClient
     }
 
     /// <summary>
-    /// Only a clean 430 means the article is missing. Anything else (e.g. a
-    /// buffered "400 idle timeout" from a connection the server already closed)
-    /// is a connection-level problem and must be retryable.
+    /// Definitive missing (430 / provider 451) means the article is gone.
+    /// Anything else (e.g. a buffered "400 idle timeout" from a connection the
+    /// server already closed) is a connection-level problem and must be retryable.
     /// </summary>
     private static Exception CreateArticleFetchException(SegmentId segmentId, UsenetResponse response)
     {
-        return response.ResponseType == UsenetResponseType.NoArticleWithThatMessageId
+        return UsenetArticleAvailability.IsDefinitiveMissing(response)
             ? new UsenetArticleNotFoundException(segmentId, response.ResponseMessage)
             : new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage);
     }

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -217,7 +217,7 @@ public class MultiProviderNntpClient(
                 return WrapStreamForByteCounting(response, primaryProvider.Host);
             }
 
-            if (response?.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+            if (response != null && UsenetArticleAvailability.IsDefinitiveMissing(response))
             {
                 primaryStopwatch.Stop();
                 RecordFetch(primaryProvider.Host, SegmentFetch.FetchStatus.Missing,
@@ -225,13 +225,13 @@ public class MultiProviderNntpClient(
                 (priorMisses ??= []).Add((primaryProvider.Host, SegmentFetch.FetchStatus.Missing));
             }
 
-            // Retry the primary provider once before falling back. Even a clean 430 can
-            // be transient when a provider routes requests across different spool nodes.
+            // Retry the primary provider once before falling back. Even a definitive miss
+            // (430 / provider 451) can be transient when a provider routes across spool nodes.
             // Anything else (a faulted response task, or a stale connection's buffered
             // goodbye line such as "400 idle timeout") remains a connection-level failure.
             IReadOnlyList<MultiConnectionNntpClient> retryProviders =
                 [primaryProvider, .. fallbackProviders];
-            if (response?.ResponseType != UsenetResponseType.NoArticleWithThatMessageId)
+            if (response == null || !UsenetArticleAvailability.IsDefinitiveMissing(response))
             {
                 if (response != null)
                 {
@@ -293,7 +293,7 @@ public class MultiProviderNntpClient(
                         RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
                             stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0);
                         (priorMisses ??= []).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
-                        if (responseType == UsenetResponseType.NoArticleWithThatMessageId &&
+                        if (UsenetArticleAvailability.IsDefinitiveMissing(response) &&
                             group.Length > 0)
                         {
                             missingGroups.Add(group);
@@ -477,7 +477,7 @@ public class MultiProviderNntpClient(
                 }
 
                 deferredCallback.Discard();
-                if (result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+                if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
                     RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
                         stopwatch.ElapsedMilliseconds, attemptIndex);
@@ -570,8 +570,9 @@ public class MultiProviderNntpClient(
                 stopwatch.Stop();
 
                 // if no article with that message-id is found, try again with the next provider.
-                // Only a definitive 430 marks the storage group missing — never a connection error.
-                if (result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+                // Only a definitive miss (430 / provider 451) marks the storage group missing —
+                // never a connection error.
+                if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
                     RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
                     (priorMisses ??= new()).Add((provider.Host, SegmentFetch.FetchStatus.Missing));

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -210,9 +210,9 @@ public abstract class NntpClient : INntpClient
             if (task.Result.ResponseType == UsenetResponseType.ArticleExists) continue;
             await childCt.CancelAsync().ConfigureAwait(false);
 
-            // Only a clean 430 proves the article is missing; any other response
-            // (e.g. a stale connection's goodbye line) must not fail the health check.
-            if (task.Result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+            // Definitive missing (430 / provider 451) fails the health check; any other
+            // response (e.g. a stale connection's goodbye line) must stay retryable.
+            if (UsenetArticleAvailability.IsDefinitiveMissing(task.Result))
                 throw new UsenetArticleNotFoundException(task.SegmentId, task.Result.ResponseMessage);
             throw new UsenetUnexpectedResponseException(task.SegmentId, task.Result.ResponseMessage);
         }
@@ -294,7 +294,7 @@ public abstract class NntpClient : INntpClient
         try
         {
             var response = await responseTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            if (response.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+            if (UsenetArticleAvailability.IsDefinitiveMissing(response))
             {
                 return new PipelinedBodyResult
                 {

--- a/backend/Clients/Usenet/UsenetArticleAvailability.cs
+++ b/backend/Clients/Usenet/UsenetArticleAvailability.cs
@@ -1,0 +1,23 @@
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Classifies NNTP article responses as definitive "missing" vs connection-level failures.
+/// </summary>
+public static class UsenetArticleAvailability
+{
+    /// <summary>
+    /// Provider-specific "article unavailable" (e.g. Giganews/UsenetBucket DMCA).
+    /// Treated like a clean 430 — the article is gone from that storage group.
+    /// </summary>
+    public const int ArticleUnavailable = 451;
+
+    /// <summary>
+    /// True for a definitive missing-article response: RFC 430, or provider 451.
+    /// Connection-level codes (e.g. buffered 400 goodbye) must remain false so they stay retryable.
+    /// </summary>
+    public static bool IsDefinitiveMissing(UsenetResponse response) =>
+        response.ResponseType == UsenetResponseType.NoArticleWithThatMessageId
+        || response.ResponseCode == ArticleUnavailable;
+}

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -200,6 +200,21 @@ public class HealthCheckService : BackgroundService
             // when usenet article is missing, perform repairs
             await Repair(davItem, dbClient, ct).ConfigureAwait(false);
         }
+        catch (UsenetUnexpectedResponseException e)
+        {
+            // Connection-level STAT failures (e.g. buffered 400 goodbye) must not trigger
+            // repair or leave NextHealthCheck unset — defer and surface ActionNeeded.
+            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
+            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            var utcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                $"Unexpected NNTP response during health check: {e.Message}", ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -300,6 +300,116 @@ public class MultiProviderNntpClientTests
         Assert.Equal(ArticleBodyResult.NotRetrieved, callbacks[0]);
     }
 
+    [Fact]
+    public async Task StorageGroup_SameGroupMiss451_SkipsSiblingProvider()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 451,
+            SingularResponseCode = 451,
+        };
+        var sibling = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(sibling, host: "b.example", storageGroup: "omicron"),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(451, response.ResponseCode);
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(0, sibling.SingularRequests);
+    }
+
+    [Fact]
+    public async Task StorageGroup_DifferentGroups_FailsOverOn451()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 451,
+            SingularResponseCode = 451,
+        };
+        var other = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example", storageGroup: "omicron"),
+            CreateProvider(other, host: "b.example", storageGroup: "eweka"),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(1, other.SingularRequests);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_With451AcrossProviders_ThrowsArticleNotFound()
+    {
+        var first = new ScriptedNntpClient
+        {
+            BatchResponseCode = 451,
+            SingularResponseCode = 451,
+        };
+        var second = new ScriptedNntpClient
+        {
+            BatchResponseCode = 451,
+            SingularResponseCode = 451,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(first, host: "a.example"),
+            CreateProvider(second, host: "b.example"),
+        ]);
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.CheckAllSegmentsAsync(["segment"], 1, null, CancellationToken.None));
+
+        Assert.Equal(1, first.SingularRequests);
+        Assert.Equal(1, second.SingularRequests);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_With400_ThrowsUnexpectedResponse()
+    {
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 400,
+            SingularResponseCode = 400,
+        };
+        using var client = new MultiProviderNntpClient([CreateProvider(connection)]);
+
+        var exception = await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(() =>
+            client.CheckAllSegmentsAsync(["segment"], 1, null, CancellationToken.None));
+
+        Assert.IsAssignableFrom<RetryableDownloadException>(exception);
+    }
+
+    [Fact]
+    public async Task BatchResponse_With451Exhausted_ThrowsArticleNotFound()
+    {
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 451,
+            SingularResponseCode = 451,
+        };
+        using var client = new MultiProviderNntpClient([CreateProvider(connection)]);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["segment"], onConnectionReadyAgain: null, CancellationToken.None);
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() => batch.Responses[0]);
+    }
+
     private static MultiConnectionNntpClient CreateProvider(
         INntpClient connection,
         string host = "test",
@@ -359,6 +469,7 @@ public class MultiProviderNntpClientTests
         {
             (int)UsenetResponseType.ArticleRetrievedBodyFollows => ArticleBodyResult.Retrieved,
             (int)UsenetResponseType.NoArticleWithThatMessageId => ArticleBodyResult.NotFound,
+            UsenetArticleAvailability.ArticleUnavailable => ArticleBodyResult.NotFound,
             _ => ArticleBodyResult.NotRetrieved,
         };
 
@@ -383,8 +494,19 @@ public class MultiProviderNntpClientTests
             throw new NotSupportedException();
 
         public override Task<UsenetStatResponse> StatAsync(
-            SegmentId segmentId, CancellationToken cancellationToken) =>
-            throw new NotSupportedException();
+            SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            SingularRequests++;
+            if (SingularException != null)
+                throw SingularException(segmentId.ToString());
+
+            return Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = SingularResponseCode,
+                ResponseMessage = $"{SingularResponseCode} scripted stat <{segmentId}>",
+                ArticleExists = SingularResponseCode == (int)UsenetResponseType.ArticleExists,
+            });
+        }
 
         public override Task<UsenetHeadResponse> HeadAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -1,0 +1,187 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class NntpClientCheckAllSegmentsTests
+{
+    [Fact]
+    public async Task CheckAllSegmentsAsync_With451_ThrowsArticleNotFound()
+    {
+        var client = new StatCodeClient(451);
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None));
+
+        Assert.Equal("seg@example", exception.SegmentId);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_With430_ThrowsArticleNotFound()
+    {
+        var client = new StatCodeClient(430);
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_With400_ThrowsUnexpectedResponse()
+    {
+        var client = new StatCodeClient(400);
+
+        var exception = await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(() =>
+            client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None));
+
+        Assert.IsAssignableFrom<RetryableDownloadException>(exception);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_With223_Succeeds()
+    {
+        var client = new StatCodeClient(223);
+
+        await client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task MapPipelinedBodyResult_With451_ReportsNotFound()
+    {
+        var client = new BodyCodeClient(451);
+
+        PipelinedBodyResult? result = null;
+        await foreach (var item in client.DecodedBodiesPipelinedAsync(
+                           ["seg@example"], 1, CancellationToken.None))
+            result = item;
+
+        Assert.NotNull(result);
+        Assert.False(result.Found);
+        Assert.Null(result.Stream);
+    }
+
+    private sealed class StatCodeClient(int responseCode) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = responseCode,
+                ResponseMessage = $"{responseCode} <{segmentId}>",
+                ArticleExists = responseCode == (int)UsenetResponseType.ArticleExists,
+            });
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class BodyCodeClient(int responseCode) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var success = responseCode == (int)UsenetResponseType.ArticleRetrievedBodyFollows;
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = responseCode,
+                ResponseMessage = $"{responseCode} scripted body",
+                Stream = success ? new YencStream(new MemoryStream([], writable: false)) : null,
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(id => DecodedBodyAsync(id, cancellationToken))
+                .ToArray();
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/UsenetArticleAvailabilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/UsenetArticleAvailabilityTests.cs
@@ -1,0 +1,26 @@
+using NzbWebDAV.Clients.Usenet;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class UsenetArticleAvailabilityTests
+{
+    [Theory]
+    [InlineData(430, true)]
+    [InlineData(451, true)]
+    [InlineData(400, false)]
+    [InlineData(223, false)]
+    [InlineData(222, false)]
+    [InlineData(423, false)]
+    public void IsDefinitiveMissing_ClassifiesResponseCodes(int responseCode, bool expected)
+    {
+        var response = new UsenetStatResponse
+        {
+            ResponseCode = responseCode,
+            ResponseMessage = $"{responseCode} test",
+            ArticleExists = responseCode == 223,
+        };
+
+        Assert.Equal(expected, UsenetArticleAvailability.IsDefinitiveMissing(response));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -22,8 +22,22 @@ internal sealed class FakeNntpClient(
         throw new NotSupportedException();
 
     public override Task<UsenetStatResponse> StatAsync(
-        SegmentId segmentId, CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
+        SegmentId segmentId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var key = segmentId.ToString();
+        var exists = segments.ContainsKey(key);
+        return Task.FromResult(new UsenetStatResponse
+        {
+            ResponseCode = exists
+                ? (int)UsenetResponseType.ArticleExists
+                : (int)UsenetResponseType.NoArticleWithThatMessageId,
+            ResponseMessage = exists
+                ? $"223 0 0 <{key}>"
+                : $"430 No such article <{key}>",
+            ArticleExists = exists,
+        });
+    }
 
     public override Task<UsenetHeadResponse> HeadAsync(
         SegmentId segmentId, CancellationToken cancellationToken) =>


### PR DESCRIPTION
## Summary
- Treat provider NNTP `451` (DMCA/unavailable) like `430` so health checks trigger repair instead of aborting with `UsenetUnexpectedResponseException`
- Fail over across providers on `451` the same way as a clean miss
- Defer items on other unexpected STAT responses (+1 day, ActionNeeded) so the health loop no longer spins without updating `NextHealthCheck`

## Test plan
- [x] Unit tests for `UsenetArticleAvailability` (430/451 vs 400/223)
- [x] `CheckAllSegmentsAsync` 451 → not found; 400 → unexpected/retryable
- [x] MultiProvider 451 same-group skip, cross-group failover, exhausted miss
- [ ] Deploy and confirm UsenetBucket health checks repair (or record unhealthy) instead of logging the background health-check error loop