### PR TITLE
fix(db): SQLite performance and slow migration path rebuild

### DIFF
--- a/backend/Database/Interceptors/SqliteMainDbPragmas.cs
+++ b/backend/Database/Interceptors/SqliteMainDbPragmas.cs
@@ -4,9 +4,27 @@ using Serilog;
 
 namespace NzbWebDAV.Database.Interceptors;
 
+/// <summary>
+/// Applies main-database PRAGMAs: foreign keys, busy timeout, memory temp store,
+/// a 256 MB mmap window, and a 64 MB page cache (matching the metrics DB). On
+/// write-capable connections also enables WAL, synchronous=NORMAL, and a 64 MB
+/// journal size limit so the WAL shrinks after bulk imports.
+/// </summary>
 public class SqliteMainDbPragmas : DbConnectionInterceptor
 {
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        => ApplyPragmas(connection);
+
+    public override Task ConnectionOpenedAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        ApplyPragmas(connection);
+        return Task.CompletedTask;
+    }
+
+    private static void ApplyPragmas(DbConnection connection)
     {
         try
         {
@@ -22,8 +40,14 @@ public class SqliteMainDbPragmas : DbConnectionInterceptor
             command.CommandText = "PRAGMA temp_store = MEMORY;";
             command.ExecuteNonQuery();
 
-            // WAL / synchronous may attempt writes to the DB file. Skip when the
-            // connection string explicitly requests read-only mode (CI/goss, etc).
+            command.CommandText = "PRAGMA mmap_size = 268435456;";
+            command.ExecuteNonQuery();
+
+            command.CommandText = "PRAGMA cache_size = -65536;";
+            command.ExecuteNonQuery();
+
+            // WAL / synchronous / journal_size_limit may attempt writes to the DB file.
+            // Skip when the connection string explicitly requests read-only mode (CI/goss, etc).
             if (IsExplicitlyReadOnly(connection.ConnectionString))
                 return;
 
@@ -33,6 +57,9 @@ public class SqliteMainDbPragmas : DbConnectionInterceptor
                 _ = command.ExecuteScalar();
 
                 command.CommandText = "PRAGMA synchronous = NORMAL;";
+                command.ExecuteNonQuery();
+
+                command.CommandText = "PRAGMA journal_size_limit = 67108864;";
                 command.ExecuteNonQuery();
             }
             catch (Exception ex)

--- a/backend/Database/Interceptors/SqliteMetricsPragmas.cs
+++ b/backend/Database/Interceptors/SqliteMetricsPragmas.cs
@@ -6,13 +6,25 @@ namespace NzbWebDAV.Database.Interceptors;
 
 /// <summary>
 /// Applies metrics-tuned PRAGMAs: WAL, relaxed durability (NORMAL — losing one
-/// second of metrics on a crash is acceptable), memory temp store, a 256 MB mmap
-/// window, a 64 MB page cache, and a capped WAL journal. Incremental auto-vacuum
-/// lets the retention sweep reclaim space without a full VACUUM.
+/// second of metrics on a crash is acceptable), busy timeout, memory temp store,
+/// a 256 MB mmap window, a 64 MB page cache, and a capped WAL journal. Incremental
+/// auto-vacuum lets the retention sweep reclaim space without a full VACUUM.
 /// </summary>
 public class SqliteMetricsPragmas : DbConnectionInterceptor
 {
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        => ApplyPragmas(connection);
+
+    public override Task ConnectionOpenedAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        ApplyPragmas(connection);
+        return Task.CompletedTask;
+    }
+
+    private static void ApplyPragmas(DbConnection connection)
     {
         try
         {
@@ -22,6 +34,7 @@ public class SqliteMetricsPragmas : DbConnectionInterceptor
             {
                 // Still apply read-only-safe settings that do not rewrite the DB header.
                 command.CommandText =
+                    "PRAGMA busy_timeout = 5000;" +
                     "PRAGMA temp_store = MEMORY;" +
                     "PRAGMA mmap_size = 268435456;" +
                     "PRAGMA cache_size = -65536;";
@@ -34,6 +47,7 @@ public class SqliteMetricsPragmas : DbConnectionInterceptor
                 command.CommandText =
                     "PRAGMA journal_mode = WAL;" +
                     "PRAGMA synchronous = NORMAL;" +
+                    "PRAGMA busy_timeout = 5000;" +
                     "PRAGMA temp_store = MEMORY;" +
                     "PRAGMA mmap_size = 268435456;" +
                     "PRAGMA cache_size = -65536;" +

--- a/backend/Database/Migrations/20250819221618_Add-Path-To-DavItem.cs
+++ b/backend/Database/Migrations/20250819221618_Add-Path-To-DavItem.cs
@@ -23,15 +23,19 @@ namespace NzbWebDAV.Database.Migrations
         /// <summary>
         /// Rebuilds DavItems.Path for every item reachable from the WebDAV root.
         /// Only updates rows included in the recursive CTE so orphans cannot get NULL Path.
+        /// Unchanged Paths are skipped so healthy databases avoid a full-table rewrite.
         /// </summary>
         public static void BuildFullPath(MigrationBuilder migrationBuilder)
         {
             // Populate the Path column for every existing DavItem
             // * The root DavItem is given path `/`
             // * Every other DavItem is given path `{PARENT_PATH}/{NAME}`
+            // MATERIALIZED + UPDATE…FROM: scan computed once and seek DavItems by PK
+            // (O(N log N)). The Path <> predicate skips rewriting rows that are already
+            // correct, so healthy databases write ~0 rows on later rebuilds.
             migrationBuilder.Sql(
                 """
-                WITH RECURSIVE computed(Id, Path) AS (
+                WITH RECURSIVE computed(Id, Path) AS MATERIALIZED (
                     -- base case: the root item
                     SELECT Id, '/'
                     FROM DavItems
@@ -51,8 +55,10 @@ namespace NzbWebDAV.Database.Migrations
                 )
 
                 UPDATE DavItems
-                SET Path = (SELECT Path FROM computed WHERE DavItems.Id = computed.Id)
-                WHERE Id IN (SELECT Id FROM computed);
+                SET Path = computed.Path
+                FROM computed
+                WHERE DavItems.Id = computed.Id
+                  AND DavItems.Path <> computed.Path;
                 """
             );
         }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -163,6 +163,7 @@ class Program
                 .AddSingleton<ProviderBytesTracker>()
                 .AddHostedService<MetricsRollupService>()
                 .AddHostedService<MetricsRetentionService>()
+                .AddHostedService<SqliteMaintenanceService>()
                 .AddSingleton<LiveStatsBroadcaster>()
                 .AddHostedService(sp => sp.GetRequiredService<LiveStatsBroadcaster>())
                 .AddHostedService<HealthCheckService>()

--- a/backend/Services/SqliteMaintenanceService.cs
+++ b/backend/Services/SqliteMaintenanceService.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Database;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Periodically runs <c>PRAGMA optimize</c> so the query planner has fresh
+/// <c>sqlite_stat1</c> statistics, and checkpoints the main DB WAL so it does
+/// not stay ballooned after bulk imports. First sweep ~2 minutes after startup,
+/// then every 6 hours.
+/// </summary>
+public class SqliteMaintenanceService : BackgroundService
+{
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan TickInterval = TimeSpan.FromHours(6);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(InitialDelay, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered() || stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await SafeSweepAsync().ConfigureAwait(false);
+
+            try
+            {
+                await Task.Delay(TickInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered() || stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+        }
+    }
+
+    private static async Task SafeSweepAsync()
+    {
+        try
+        {
+            await using var db = new DavDatabaseContext();
+            await using var metrics = new MetricsDbContext();
+            await SweepAsync(db, metrics).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "SqliteMaintenanceService sweep failed");
+        }
+    }
+
+    /// <summary>
+    /// Runs analysis_limit + optimize on both databases and truncating WAL
+    /// checkpoint on the main database. Exposed for tests.
+    /// </summary>
+    internal static async Task SweepAsync(
+        DavDatabaseContext db,
+        MetricsDbContext metrics,
+        CancellationToken cancellationToken = default)
+    {
+        await db.Database.ExecuteSqlRawAsync("PRAGMA analysis_limit = 400;", cancellationToken)
+            .ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync("PRAGMA optimize;", cancellationToken)
+            .ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE);", cancellationToken)
+            .ConfigureAwait(false);
+
+        await metrics.Database.ExecuteSqlRawAsync("PRAGMA analysis_limit = 400;", cancellationToken)
+            .ConfigureAwait(false);
+        await metrics.Database.ExecuteSqlRawAsync("PRAGMA optimize;", cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/HealthyTreePathMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/HealthyTreePathMigrationTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+/// <summary>
+/// Ensures the Fix-Empty-Categories + Path-Index migrations leave a healthy multi-level
+/// tree's Paths unchanged and create the unique Path index. Exercises the incremental
+/// BuildFullPath rewrite on ~5–10k already-correct rows.
+/// </summary>
+public sealed class HealthyTreePathMigrationTests
+{
+    private const string PriorMigration = "20260604120000_Add-UpdatedAtUnix-Index-To-WantedItems";
+    private const int CategoryCount = 5;
+    private const int ReleasesPerCategory = 20;
+    private const int FilesPerRelease = 50;
+
+    [Fact]
+    public async Task HealthyTree_MigratesWithoutChangingPaths_AndCreatesUniquePathIndex()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        var expectedPaths = await SeedHealthyTreeAsync(ctx);
+        Assert.True(expectedPaths.Count >= 5_000, $"Expected >= 5000 seeded rows, got {expectedPaths.Count}");
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        var actual = await ctx.Items.AsNoTracking()
+            .Select(x => new { x.Id, x.Path })
+            .ToListAsync();
+
+        foreach (var (id, path) in expectedPaths)
+        {
+            var item = Assert.Single(actual, x => x.Id == id);
+            Assert.Equal(path, item.Path);
+        }
+
+        var pathIndexExists = await IndexExistsAsync(ctx, "IX_DavItems_Path");
+        Assert.True(pathIndexExists);
+    }
+
+    private static async Task<Dictionary<Guid, string>> SeedHealthyTreeAsync(DavDatabaseContext ctx)
+    {
+        var expected = new Dictionary<Guid, string>();
+        var batch = new List<DavItem>();
+
+        for (var c = 0; c < CategoryCount; c++)
+        {
+            var category = NewDirectory(Guid.NewGuid(), DavItem.ContentFolder, $"cat-{c:D2}");
+            batch.Add(category);
+            expected[category.Id] = category.Path;
+
+            for (var r = 0; r < ReleasesPerCategory; r++)
+            {
+                var release = NewDirectory(Guid.NewGuid(), category, $"release-{r:D2}");
+                batch.Add(release);
+                expected[release.Id] = release.Path;
+
+                for (var f = 0; f < FilesPerRelease; f++)
+                {
+                    var file = DavItem.New(
+                        Guid.NewGuid(),
+                        release,
+                        $"file-{f:D3}.mkv",
+                        fileSize: 1_024,
+                        type: DavItem.ItemType.UsenetFile,
+                        subType: DavItem.ItemSubType.NzbFile,
+                        releaseDate: null,
+                        lastHealthCheck: null,
+                        historyItemId: null,
+                        fileBlobId: null);
+                    batch.Add(file);
+                    expected[file.Id] = file.Path;
+                }
+            }
+        }
+
+        // 5 categories * 20 releases * 50 files = 5000 files + 100 dirs + 5 cats = 5105
+        ctx.Items.AddRange(batch);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+        return expected;
+    }
+
+    private static DavItem NewDirectory(Guid id, DavItem parent, string name) =>
+        DavItem.New(
+            id,
+            parent,
+            name,
+            fileSize: null,
+            type: DavItem.ItemType.Directory,
+            subType: DavItem.ItemSubType.Directory,
+            releaseDate: null,
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: null);
+
+    private static async Task<bool> IndexExistsAsync(DavDatabaseContext ctx, string indexName)
+    {
+        await using var command = ctx.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != System.Data.ConnectionState.Open)
+            await command.Connection.OpenAsync();
+
+        command.CommandText =
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = $name LIMIT 1;";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = indexName;
+        command.Parameters.Add(parameter);
+
+        var result = await command.ExecuteScalarAsync();
+        return result is not null && result is not DBNull;
+    }
+
+    private sealed class MigrationHarness : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        private MigrationHarness(string databasePath, DavDatabaseContext context)
+        {
+            _databasePath = databasePath;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public static async Task<MigrationHarness> CreateAsync()
+        {
+            var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-healthy-tree-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+            return new MigrationHarness(databasePath, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            File.Delete(_databasePath);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/SqliteMainDbPragmasTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteMainDbPragmasTests.cs
@@ -1,4 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Tests.Database;
 
@@ -14,5 +19,121 @@ public class SqliteMainDbPragmasTests
     public void IsExplicitlyReadOnly_DetectsReadOnlyModes(string? connectionString, bool expected)
     {
         Assert.Equal(expected, SqliteMainDbPragmas.IsExplicitlyReadOnly(connectionString));
+    }
+
+    [Fact]
+    public async Task ConnectionOpened_AppliesMemoryAndJournalPragmas()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-main-pragmas-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .Options;
+
+            await using var ctx = new DavDatabaseContext(options);
+            await ctx.Database.OpenConnectionAsync();
+
+            Assert.Equal(268435456L, await ReadPragmaInt64Async(ctx, "mmap_size"));
+            Assert.Equal(-65536L, await ReadPragmaInt64Async(ctx, "cache_size"));
+            Assert.Equal(67108864L, await ReadPragmaInt64Async(ctx, "journal_size_limit"));
+            Assert.Equal(5000L, await ReadPragmaInt64Async(ctx, "busy_timeout"));
+        }
+        finally
+        {
+            try { File.Delete(databasePath); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task MaintenanceSweep_PopulatesSqliteStat1()
+    {
+        var configPath = Path.Combine(Path.GetTempPath(), $"nzbdav-maint-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(configPath);
+        var mainPath = Path.Combine(configPath, "db.sqlite");
+        var metricsPath = Path.Combine(configPath, "metrics.sqlite");
+
+        try
+        {
+            var mainOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={mainPath}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            await using var main = new DavDatabaseContext(mainOptions);
+            await main.Database.MigrateAsync();
+
+            var metricsOptions = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={metricsPath}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            await using var metrics = new MetricsDbContext(metricsOptions);
+            await metrics.Database.MigrateAsync();
+
+            // Ensure there is something for ANALYZE to sample.
+            await main.Database.ExecuteSqlRawAsync(
+                "INSERT OR IGNORE INTO ConfigItems (ConfigName, ConfigValue) VALUES ('test.pragma', '1');");
+
+            await SqliteMaintenanceService.SweepAsync(main, metrics);
+
+            var statCount = await ReadScalarInt64Async(main, "SELECT count(*) FROM sqlite_stat1;");
+            Assert.True(statCount > 0, "Expected PRAGMA optimize to populate sqlite_stat1");
+        }
+        finally
+        {
+            try { Directory.Delete(configPath, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static async Task<long> ReadPragmaInt64Async(DavDatabaseContext ctx, string pragma)
+    {
+        await using var command = ctx.Database.GetDbConnection().CreateCommand();
+        command.CommandText = $"PRAGMA {pragma};";
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt64(result);
+    }
+
+    private static async Task<long> ReadScalarInt64Async(DavDatabaseContext ctx, string sql)
+    {
+        await using var command = ctx.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != System.Data.ConnectionState.Open)
+            await command.Connection.OpenAsync();
+        command.CommandText = sql;
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt64(result);
+    }
+}
+
+public class SqliteMetricsPragmasTests
+{
+    [Fact]
+    public async Task ConnectionOpened_AppliesBusyTimeout()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-metrics-pragmas-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .Options;
+
+            await using var ctx = new MetricsDbContext(options);
+            await ctx.Database.OpenConnectionAsync();
+
+            await using var command = ctx.Database.GetDbConnection().CreateCommand();
+            command.CommandText = "PRAGMA busy_timeout;";
+            var result = await command.ExecuteScalarAsync();
+            Assert.Equal(5000L, Convert.ToInt64(result));
+        }
+        finally
+        {
+            try { File.Delete(databasePath); } catch { /* best effort */ }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #275.

Addresses the slow Fix-Empty-Categories / DavItems path rebuild and closes SQLite tuning gaps on the main and metrics databases.

### Commits

1. **fix(db): make DavItems path rebuild incremental and index-driven** — rewrite `BuildFullPath` to use `AS MATERIALIZED` + `UPDATE … FROM` with a changed-rows-only predicate, so healthy databases skip rewriting already-correct Paths.
2. **chore(db): migration test covering large healthy trees** — ~5k-row healthy tree through Fix-Empty-Categories + Path-Index migrations.
3. **fix(db): bring main database pragmas up to metrics parity** — `mmap_size` 256 MB, `cache_size` 64 MB, `journal_size_limit` 64 MB; also apply on async connection open.
4. **fix(db): set busy_timeout on metrics connections** — 5s busy timeout on both branches; async open support.
5. **feat(db): periodic PRAGMA optimize and WAL checkpoint maintenance** — `SqliteMaintenanceService` (~2 min after startup, then every 6 hours).
6. **chore(db): tests for pragma parity and maintenance sweep**.

Backend-only; no schema migrations added. Editing the shipped `BuildFullPath` helper is safe: EF does not checksum applied migrations, and end state is identical.

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [x] Focused DB tests pass (`HealthyTreePathMigrationTests`, `FixEmptyCategoriesMigrationTests`, pragma + maintenance tests)
- [x] `EXPLAIN QUERY PLAN` of the new UPDATE shows MATERIALIZE of `computed` (no per-row correlated scan of the CTE)
- [ ] Manual: time `--db-migration` on a large pre-`20260712` `db.sqlite` before/after; confirm identical `count(*)` / `sum(length(Path))` and a large wall-time drop
- [ ] Manual: after backend start, `PRAGMA mmap_size; PRAGMA journal_size_limit;` on main DB; after a maintenance tick, `SELECT count(*) FROM sqlite_stat1;` > 0 and WAL shrinks after checkpoint