### PR TITLE
fix(ui): quiet expected startup noise on no-migration restarts

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -286,6 +286,17 @@ class Program
         var pending = (await databaseContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
         var vacuumEnabled = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);
 
+        // Routine restarts with nothing to do: skip the status server and its
+        // grace delay so Docker does not bind/unbind :8080 just to say "idle".
+        if (MigrationProgress.IsIdleMaintenance(pending.Count, vacuumEnabled))
+        {
+            Log.Information("No pending database migrations");
+            await using var metricsContext = new MetricsDbContext();
+            await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
+            Log.Information("Database migrations completed");
+            return;
+        }
+
         // Build the ordered list of maintenance steps: each pending migration,
         // then the metrics database, then the optional vacuum.
         var steps = new List<MigrationProgress.MigrationStep>();

--- a/backend/Services/MigrationProgress.cs
+++ b/backend/Services/MigrationProgress.cs
@@ -121,6 +121,13 @@ public sealed class MigrationProgress
 
     public static bool IsSlow(string migrationId) => SlowMigrations.Contains(migrationId);
 
+    /// <summary>
+    /// True when there is nothing user-visible to report: no pending EF migrations
+    /// and vacuum is disabled. The migration runner skips the status server in this case.
+    /// </summary>
+    public static bool IsIdleMaintenance(int pendingMigrationCount, bool vacuumEnabled) =>
+        pendingMigrationCount == 0 && !vacuumEnabled;
+
     private sealed class StepState(string id, string name, bool slow)
     {
         public string Id { get; } = id;

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { backendClient } from "./backend-client.server";
+import { backendClient, BackendUnavailableError } from "./backend-client.server";
 
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -199,11 +199,23 @@ describe("BackendClient", () => {
     });
   });
 
-  it("includes the backend error when a request fails", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "unavailable" }, 503));
+  it("includes the backend error when a non-503 request fails", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "bad request" }, 400));
 
     await expect(backendClient.getQueue(1)).rejects.toThrow(
-      "Failed to get queue: unavailable",
+      "Failed to get queue: bad request",
     );
+  });
+
+  it("throws BackendUnavailableError when fetch fails", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+    await expect(backendClient.isOnboarding()).rejects.toBeInstanceOf(BackendUnavailableError);
+  });
+
+  it("throws BackendUnavailableError on 503 migrating responses", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "migrating" }, 503));
+
+    await expect(backendClient.isOnboarding()).rejects.toBeInstanceOf(BackendUnavailableError);
   });
 });

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -5,6 +5,14 @@ export class WebdavDirectoryNotFoundError extends Error {
     }
 }
 
+/** Thrown when the backend is unreachable or still in the migration handoff. */
+export class BackendUnavailableError extends Error {
+    public constructor(message = "Backend temporarily unavailable") {
+        super(message);
+        this.name = "BackendUnavailableError";
+    }
+}
+
 /** Builds a FormData body from a list of [name, value] entries. */
 function form(...entries: [string, string | Blob, string?][]): FormData {
     const data = new FormData();
@@ -21,16 +29,35 @@ function form(...entries: [string, string | Blob, string?][]): FormData {
  * prefixed with `errorPrefix` and suffixed with the backend's reported error.
  */
 async function call(path: string, errorPrefix: string, init?: RequestInit): Promise<any> {
-    const response = await fetch(process.env.BACKEND_URL + path, {
-        ...init,
-        headers: {
-            "x-api-key": process.env.FRONTEND_BACKEND_API_KEY || "",
-            ...(init?.headers ?? {}),
-        },
-    });
+    let response: Response;
+    try {
+        response = await fetch(process.env.BACKEND_URL + path, {
+            ...init,
+            headers: {
+                "x-api-key": process.env.FRONTEND_BACKEND_API_KEY || "",
+                ...(init?.headers ?? {}),
+            },
+        });
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new BackendUnavailableError(`${errorPrefix}: ${detail}`);
+    }
 
     if (!response.ok) {
-        throw new Error(`${errorPrefix}: ${(await response.json()).error}`);
+        const body = await response.json().catch(() => null) as
+            | { error?: unknown; status?: unknown }
+            | null;
+        if (response.status === 503 || body?.status === "migrating") {
+            throw new BackendUnavailableError(
+                `${errorPrefix}: backend is starting or migrating`,
+            );
+        }
+
+        const backendError =
+            body && typeof body === "object" && "error" in body
+                ? String(body.error ?? "unknown error")
+                : `HTTP ${response.status}`;
+        throw new Error(`${errorPrefix}: ${backendError}`);
     }
 
     return response.json();

--- a/frontend/app/components/migration-progress.test.ts
+++ b/frontend/app/components/migration-progress.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { decideMigrationStatusPoll } from "./migration-progress";
+
+describe("decideMigrationStatusPoll", () => {
+  it("keeps polling while migration JSON is running", () => {
+    const status = {
+      state: "running" as const,
+      startedAt: 1,
+      completed: 0,
+      total: 1,
+      currentStep: "Metrics database",
+      error: null,
+      steps: [],
+    };
+
+    expect(decideMigrationStatusPoll(200, status)).toEqual({
+      action: "migrating",
+      status,
+      reloadMs: undefined,
+    });
+  });
+
+  it("reloads when migration completes", () => {
+    const status = {
+      state: "completed" as const,
+      startedAt: 1,
+      completed: 1,
+      total: 1,
+      currentStep: null,
+      error: null,
+      steps: [],
+    };
+
+    expect(decideMigrationStatusPoll(200, status)).toEqual({
+      action: "migrating",
+      status,
+      reloadMs: 1500,
+    });
+  });
+
+  it("treats 404 as backend handoff complete", () => {
+    expect(decideMigrationStatusPoll(404, null)).toEqual({
+      action: "connecting",
+      reloadMs: 1500,
+    });
+  });
+
+  it("treats 502/503 as connecting with a longer reload", () => {
+    expect(decideMigrationStatusPoll(502, null)).toEqual({
+      action: "connecting",
+      reloadMs: 5000,
+    });
+    expect(decideMigrationStatusPoll(503, null)).toEqual({
+      action: "connecting",
+      reloadMs: 5000,
+    });
+  });
+
+  it("falls back and stops for unexpected responses", () => {
+    expect(decideMigrationStatusPoll(200, { hello: "world" })).toEqual({
+      action: "fallback",
+      stopPolling: true,
+    });
+    expect(decideMigrationStatusPoll(500, null)).toEqual({
+      action: "fallback",
+      stopPolling: true,
+    });
+  });
+});

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -21,10 +21,42 @@ export type MigrationStatus = {
   steps: MigrationStep[];
 };
 
-function isMigrationStatus(value: unknown): value is MigrationStatus {
+export function isMigrationStatus(value: unknown): value is MigrationStatus {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
   return typeof v.state === "string" && Array.isArray(v.steps);
+}
+
+export type MigrationPollDecision =
+  | { action: "migrating"; status: MigrationStatus; reloadMs?: number }
+  | { action: "connecting"; reloadMs: number }
+  | { action: "fallback"; stopPolling: true };
+
+/** Pure decision helper for MigrationBoundary polling (testable without React). */
+export function decideMigrationStatusPoll(
+  httpStatus: number,
+  body: unknown,
+): MigrationPollDecision {
+  if (httpStatus >= 200 && httpStatus < 300) {
+    if (isMigrationStatus(body)) {
+      return {
+        action: "migrating",
+        status: body,
+        reloadMs: body.state === "completed" ? 1500 : undefined,
+      };
+    }
+    return { action: "fallback", stopPolling: true };
+  }
+
+  if (httpStatus === 404) {
+    return { action: "connecting", reloadMs: 1500 };
+  }
+
+  if (httpStatus === 502 || httpStatus === 503) {
+    return { action: "connecting", reloadMs: 5000 };
+  }
+
+  return { action: "fallback", stopPolling: true };
 }
 
 function formatDuration(ms: number): string {
@@ -65,6 +97,19 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
 
   useEffect(() => {
     let cancelled = false;
+    let interval: number | undefined;
+
+    const stopPolling = () => {
+      if (interval !== undefined) {
+        window.clearInterval(interval);
+        interval = undefined;
+      }
+    };
+
+    const scheduleReloadAndStop = (delayMs: number) => {
+      scheduleReload(delayMs);
+      stopPolling();
+    };
 
     const poll = async () => {
       try {
@@ -74,45 +119,39 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
         });
         if (cancelled) return;
 
-        if (res.ok) {
-          const data = await res.json().catch(() => null);
-          if (cancelled) return;
-          if (isMigrationStatus(data)) {
-            seenMigration.current = true;
-            setStatus(data);
-            setPhase("migrating");
-            if (data.state === "completed") scheduleReload(1500);
-            return;
-          }
-          // 200 but not migration-shaped: the real backend answered, so this
-          // is a genuine error rather than the migration phase.
-          setPhase("fallback");
+        const body = res.ok ? await res.json().catch(() => null) : null;
+        if (cancelled) return;
+
+        const decision = decideMigrationStatusPoll(res.status, body);
+        if (decision.action === "migrating") {
+          seenMigration.current = true;
+          setStatus(decision.status);
+          setPhase("migrating");
+          if (decision.reloadMs !== undefined) scheduleReloadAndStop(decision.reloadMs);
           return;
         }
 
-        // The backend port is not serving yet (starting up or handing off
-        // from the migration process to the real backend). Reload periodically
-        // so the real app loads as soon as the backend is reachable.
-        if (res.status === 502 || res.status === 503) {
+        if (decision.action === "connecting") {
           setPhase("connecting");
-          scheduleReload(5000);
+          scheduleReloadAndStop(decision.reloadMs);
           return;
         }
 
         setPhase("fallback");
+        stopPolling();
       } catch {
         if (cancelled) return;
         // Network failure: nothing is listening on the backend port yet.
         setPhase("connecting");
-        scheduleReload(5000);
+        scheduleReloadAndStop(5000);
       }
     };
 
     poll();
-    const interval = window.setInterval(poll, 2000);
+    interval = window.setInterval(poll, 2000);
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
+      stopPolling();
     };
   }, [scheduleReload]);
 

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -19,7 +19,7 @@ import { PageLayout } from "./routes/_index/components/page-layout/page-layout";
 import { Loading } from "./routes/_index/components/loading/loading";
 import { getAppVersion } from "./utils/version.server";
 import { checkForUpdate } from "./utils/update-check.server";
-import { backendClient } from "./clients/backend-client.server";
+import { backendClient, BackendUnavailableError } from "./clients/backend-client.server";
 import { MigrationBoundary } from "./components/migration-progress";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -135,15 +135,18 @@ export default function App({ loaderData }: Route.ComponentProps) {
 // and loop back into the same failure. Adopted from elfhosted/rebased-v3.
 export function ErrorBoundary() {
   const error = useRouteError();
-  const isUndiciTimeout =
-    error instanceof Error &&
-    /fetch failed|ConnectTimeoutError|HeadersTimeoutError|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT/i.test(
-      `${error.message} ${(error.cause as Error)?.message ?? ""}`,
+  const isBackendUnavailable =
+    error instanceof BackendUnavailableError
+    || (
+      error instanceof Error
+      && /fetch failed|ConnectTimeoutError|HeadersTimeoutError|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT/i.test(
+        `${error.message} ${(error.cause as Error)?.message ?? ""}`,
+      )
     );
 
   let title = "Something went wrong";
   let detail: string;
-  if (isUndiciTimeout) {
+  if (isBackendUnavailable) {
     title = "Backend temporarily unavailable";
     detail =
       "The nzbdav backend is still starting up or is busy processing a large queue. Wait a moment and refresh the page.";

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -8,9 +8,34 @@ import { shouldProxyToBackend } from "./proxy-path";
 import { logger } from "./logger";
 import { authMiddleware } from "~/auth/auth-middleware.server";
 import { setApiKeyForAuthenticatedRequests } from "./inject-api-key.server";
+import {
+  BACKEND_FAILURE_LOG_THROTTLE_MS,
+  isExpectedBackendConnectionError,
+  isWithinBackendStartupGrace,
+} from "./startup-grace";
 
 export const app = express();
 export const initializeWebsocketServer = websocketServer.initialize;
+
+let loggedStartupWait = false;
+let lastProxyFailureLogAt = 0;
+
+function logProxyFailure(message: string, error: unknown) {
+  const now = Date.now();
+  if (isExpectedBackendConnectionError(error) && isWithinBackendStartupGrace(now)) {
+    if (!loggedStartupWait) {
+      logger.info("Waiting for backend to start...");
+      loggedStartupWait = true;
+      lastProxyFailureLogAt = now;
+    }
+    return;
+  }
+
+  if (now - lastProxyFailureLogAt >= BACKEND_FAILURE_LOG_THROTTLE_MS) {
+    logger.warn(message, error);
+    lastProxyFailureLogAt = now;
+  }
+}
 
 // Proxy all webdav and api requests to the backend
 const forwardToBackend = createProxyMiddleware({
@@ -18,7 +43,7 @@ const forwardToBackend = createProxyMiddleware({
   changeOrigin: true,
   on: {
     error: (error, req, res) => {
-      logger.error(
+      logProxyFailure(
         `Backend proxy failed for ${req.method ?? "UNKNOWN"} ${req.url ?? "unknown URL"}`,
         error,
       );

--- a/frontend/server/logger.ts
+++ b/frontend/server/logger.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from "express";
 import { createColors } from "picocolors";
+import { isWithinBackendStartupGrace } from "./startup-grace";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -118,7 +119,12 @@ export const requestLogger: RequestHandler = (req, res, next) => {
       `${colorMethod(req.method)} ${req.originalUrl} `
       + `${colorStatus(res.statusCode)} ${color.dim(`${elapsedMs.toFixed(1)} ms`)}`;
 
-    if (res.statusCode >= 500) {
+    // During Docker's frontend-first startup window, proxied 502s are expected
+    // while the backend is still binding. Downgrade so they are not double-logged
+    // as ERR alongside the proxy error handler.
+    if (res.statusCode === 502 && isWithinBackendStartupGrace()) {
+      logger.debug(message);
+    } else if (res.statusCode >= 500) {
       logger.error(message);
     } else if (res.statusCode >= 400) {
       logger.warn(message);

--- a/frontend/server/startup-grace.test.ts
+++ b/frontend/server/startup-grace.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExpectedBackendConnectionError,
+  isWithinBackendStartupGrace,
+} from "./startup-grace";
+
+describe("startup-grace helpers", () => {
+  it("recognizes ECONNREFUSED AggregateErrors", () => {
+    const error = Object.assign(new Error("proxy failed"), {
+      code: undefined,
+      cause: Object.assign(new Error("refused"), {
+        code: "ECONNREFUSED",
+        errors: [{ code: "ECONNREFUSED" }, { code: "ECONNREFUSED" }],
+      }),
+    });
+
+    expect(isExpectedBackendConnectionError(error)).toBe(true);
+    expect(isExpectedBackendConnectionError(new Error("boom"))).toBe(false);
+  });
+
+  it("reports within the startup grace window for a fresh process", () => {
+    expect(isWithinBackendStartupGrace()).toBe(true);
+  });
+});

--- a/frontend/server/startup-grace.ts
+++ b/frontend/server/startup-grace.ts
@@ -1,0 +1,23 @@
+/** Shared frontend-process clock for expected backend-not-ready noise. */
+const startedAt = Date.now();
+export const BACKEND_STARTUP_GRACE_MS = 30_000;
+export const BACKEND_FAILURE_LOG_THROTTLE_MS = 60_000;
+
+export function isWithinBackendStartupGrace(now = Date.now()): boolean {
+  return now - startedAt < BACKEND_STARTUP_GRACE_MS;
+}
+
+export function isExpectedBackendConnectionError(error: unknown): boolean {
+  const candidates: unknown[] = [error];
+  if (error && typeof error === "object") {
+    const withCause = error as { cause?: unknown; errors?: unknown[] };
+    if (withCause.cause) candidates.push(withCause.cause);
+    if (Array.isArray(withCause.errors)) candidates.push(...withCause.errors);
+  }
+
+  return candidates.some((candidate) => {
+    if (!candidate || typeof candidate !== "object") return false;
+    const code = (candidate as { code?: string }).code;
+    return code === "ECONNREFUSED" || code === "ECONNRESET" || code === "EPIPE";
+  });
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["server.ts", "server/logger.ts", "vite.config.ts", "vitest.config.ts"],
+  "include": ["server.ts", "server/logger.ts", "server/startup-grace.ts", "vite.config.ts", "vitest.config.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,

--- a/tests/NzbWebDAV.Tests/Services/MigrationProgressTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/MigrationProgressTests.cs
@@ -1,0 +1,19 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class MigrationProgressTests
+{
+    [Theory]
+    [InlineData(0, false, true)]
+    [InlineData(0, true, false)]
+    [InlineData(1, false, false)]
+    [InlineData(2, true, false)]
+    public void IsIdleMaintenance_MatchesPendingAndVacuum(
+        int pendingCount,
+        bool vacuumEnabled,
+        bool expected)
+    {
+        Assert.Equal(expected, MigrationProgress.IsIdleMaintenance(pendingCount, vacuumEnabled));
+    }
+}


### PR DESCRIPTION
## Summary

- Skip `MigrationStatusServer` and the 2s grace delay when there are no pending migrations and vacuum is disabled, so routine Docker restarts no longer bind/unbind `:8080` just to report idle.
- Mirror the websocket startup-grace pattern for HTTP proxy `ECONNREFUSED`/`ECONNRESET` (one info line, no ERR spam) and downgrade access-log 502s during the grace window.
- Stop `MigrationBoundary` polling on 404 (real backend up) and whenever a reload is scheduled.
- Add `BackendUnavailableError` for SSR fetch/503-migrating failures so `/login` no longer dumps raw `TypeError: fetch failed` / `: undefined` messages.

## Test plan

- [x] Frontend: backend-client soft-fail, migration poll decisions, startup-grace helpers
- [x] Backend: `MigrationProgress.IsIdleMaintenance` theory cases
- [x] Frontend typecheck
- [ ] Restart a healthy `latest` container with no pending migrations and confirm logs stay quiet after at most one `Waiting for backend to start...` line
- [ ] Confirm a long migration still shows the progress UI (status server still starts when work is pending)