### PR TITLE
fix(ui): unblock release Docker build and gate CI on frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         working-directory: frontend
         run: npm run typecheck
 
+      # Same production build Docker uses; catches .server import / bundler errors typecheck misses.
+      - name: Build
+        working-directory: frontend
+        run: npm run build && npm run build:server
+
       - name: Test frontend with coverage
         working-directory: frontend
         run: npm run test:coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Open `http://localhost:5173` (dev) or `http://localhost:3000` (production build)
 
 ```bash
 # Frontend
-cd frontend && npm run typecheck && npm test
+cd frontend && npm run typecheck && npm run build && npm test
 
 # Backend (from repository root)
 dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release
@@ -234,7 +234,7 @@ Do not accumulate a large uncommitted diff across unrelated areas.
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | PRs and pushes to `main` | Frontend typecheck/tests + backend build/tests |
+| `ci.yml` | PRs and pushes to `main` | Frontend lint/typecheck/build/tests + backend build/tests |
 | `codeql.yml` | PRs, pushes to `main`, and weekly schedule | CodeQL security analysis for C#, TypeScript, and GitHub Actions |
 | `pre-release.yml` | Pushes to `main` (except release commits) | Publishes `ghcr.io/.../nzbdav:dev` |
 | `release.yml` | Push to `main` | release-please versioning; publishes Docker images when a release is created |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,5 +132,6 @@ Before creating a PR:
 cd frontend
 npm run lint
 npm run typecheck
+npm run build
 npm test
 ```

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -19,7 +19,7 @@ import { PageLayout } from "./routes/_index/components/page-layout/page-layout";
 import { Loading } from "./routes/_index/components/loading/loading";
 import { getAppVersion } from "./utils/version.server";
 import { checkForUpdate } from "./utils/update-check.server";
-import { backendClient, BackendUnavailableError } from "./clients/backend-client.server";
+import { backendClient } from "./clients/backend-client.server";
 import { MigrationBoundary } from "./components/migration-progress";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -135,8 +135,10 @@ export default function App({ loaderData }: Route.ComponentProps) {
 // and loop back into the same failure. Adopted from elfhosted/rebased-v3.
 export function ErrorBoundary() {
   const error = useRouteError();
+  // Match by name — do not import BackendUnavailableError here; ErrorBoundary is a
+  // client export and .server modules must only be referenced from loader/action.
   const isBackendUnavailable =
-    error instanceof BackendUnavailableError
+    (error instanceof Error && error.name === "BackendUnavailableError")
     || (
       error instanceof Error
       && /fetch failed|ConnectTimeoutError|HeadersTimeoutError|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT/i.test(


### PR DESCRIPTION
## Summary
- Stop importing `BackendUnavailableError` from a `.server` module in the root `ErrorBoundary` (match by `error.name` instead) so `react-router build` succeeds again.
- Add `npm run build && npm run build:server` to frontend CI — the same steps Docker runs — so this class of bundler failure fails on PRs instead of only during release image publish.

## Context
[Release deploy for v0.7.13](https://github.com/nzbdav/nzbdav/actions/runs/29268171698/job/86878895724) failed with:
`Server-only module referenced by client` in `app/root.tsx`. CI previously only ran lint/typecheck/tests, which do not exercise React Router’s production code-splitting checks.

## Test plan
- [x] `cd frontend && npm run build && npm run build:server`
- [ ] CI frontend job passes including the new Build step
- [ ] After merge, republish `0.7.13` Docker images via Release workflow `workflow_dispatch`