### PR TITLE
fix: repair-path link cache, health hot-loops, and pool WS flood

### DIFF
--- a/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
@@ -6,11 +6,22 @@ namespace NzbWebDAV.Clients.Usenet.Connections;
 
 public class ConnectionPoolStats
 {
+    // Pool-changed events fire on every connection borrow/return — hundreds per second under
+    // load. Websocket updates are coalesced: events only update in-memory counters, and a
+    // single flush task emits the latest per-provider stats at most once per interval.
+    // The flush is trailing-edge, so the final state after a burst is always sent.
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(200);
+
     private readonly int[] _live;
     private readonly int[] _idle;
+    private readonly int[] _latestLive;
+    private readonly int[] _latestIdle;
+    private readonly bool[] _dirty;
     private readonly int _max;
     private int _totalLive;
     private int _totalIdle;
+    private int _flushScheduled; // 0 == false, 1 == true
+    private readonly Lock _lock = new();
     private readonly UsenetProviderConfig _providerConfig;
     private readonly WebsocketManager _websocketManager;
 
@@ -19,6 +30,9 @@ public class ConnectionPoolStats
         var count = providerConfig.Providers.Count;
         _live = new int[count];
         _idle = new int[count];
+        _latestLive = new int[count];
+        _latestIdle = new int[count];
+        _dirty = new bool[count];
         _max = providerConfig.Providers
             .Where(x => x.Type == ProviderType.Pooled)
             .Select(x => x.MaxConnections)
@@ -34,9 +48,13 @@ public class ConnectionPoolStats
 
         void OnEvent(object? _, ConnectionPoolChangedEventArgs args)
         {
-            if (_providerConfig.Providers[providerIndex].Type == ProviderType.Pooled)
+            lock (_lock)
             {
-                lock (this)
+                _latestLive[providerIndex] = args.Live;
+                _latestIdle[providerIndex] = args.Idle;
+                _dirty[providerIndex] = true;
+
+                if (_providerConfig.Providers[providerIndex].Type == ProviderType.Pooled)
                 {
                     _live[providerIndex] = args.Live;
                     _idle[providerIndex] = args.Idle;
@@ -45,9 +63,33 @@ public class ConnectionPoolStats
                 }
             }
 
-            var message = $"{providerIndex}|{args.Live}|{args.Idle}|{_totalLive}|{_max}|{_totalIdle}";
-            _websocketManager.SendMessage(WebsocketTopic.UsenetConnections, message);
+            if (Interlocked.CompareExchange(ref _flushScheduled, 1, 0) == 0)
+                _ = FlushAfterDelayAsync();
         }
+    }
+
+    private async Task FlushAfterDelayAsync()
+    {
+        await Task.Delay(FlushInterval).ConfigureAwait(false);
+
+        // allow a new flush to be scheduled *before* taking the snapshot,
+        // so events arriving after the snapshot are never lost.
+        Volatile.Write(ref _flushScheduled, 0);
+
+        List<string> messages;
+        lock (_lock)
+        {
+            messages = new List<string>();
+            for (var i = 0; i < _dirty.Length; i++)
+            {
+                if (!_dirty[i]) continue;
+                _dirty[i] = false;
+                messages.Add($"{i}|{_latestLive[i]}|{_latestIdle[i]}|{_totalLive}|{_max}|{_totalIdle}");
+            }
+        }
+
+        foreach (var message in messages)
+            _ = _websocketManager.SendMessage(WebsocketTopic.UsenetConnections, message);
     }
 
     public sealed class ConnectionPoolChangedEventArgs(int live, int idle, int max) : EventArgs

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -11,7 +11,8 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     // file
     public Task<DavItem?> GetFileById(string id)
     {
-        var guid = Guid.Parse(id);
+        // non-guid names (e.g. clients probing /.ids paths) are simply not found
+        if (!Guid.TryParse(id, out var guid)) return Task.FromResult<DavItem?>(null);
         return ctx.Items.AsNoTracking().FirstOrDefaultAsync(i => i.Id == guid);
     }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -170,9 +170,13 @@ public class HealthCheckService : BackgroundService
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
 
-            // update the database
-            davItem.LastHealthCheck = DateTimeOffset.UtcNow;
-            davItem.NextHealthCheck = davItem.ReleaseDate + 2 * (davItem.LastHealthCheck - davItem.ReleaseDate);
+            // update the database.
+            // the next check is scheduled so the interval doubles with the item's age since release.
+            // clamp to a minimum interval: a null release-date (zero-segment item) or a future-dated
+            // article header would otherwise schedule the item in the past and hot-loop the service.
+            var utcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             var healthyMessage = sampled.Count < totalSegments
                 ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
                 : "File is healthy.";
@@ -215,6 +219,20 @@ public class HealthCheckService : BackgroundService
                 HealthCheckResult.RepairAction.ActionNeeded,
                 $"Unexpected NNTP response during health check: {e.Message}", ct).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Schedules the next health check so the interval doubles with the item's age since release,
+    /// floored at one hour from <paramref name="utcNow"/> so null or future release dates cannot
+    /// schedule the item in the past and hot-loop the service.
+    /// </summary>
+    public static DateTimeOffset ComputeNextHealthCheck(DateTimeOffset? releaseDate, DateTimeOffset utcNow)
+    {
+        var minimumNextHealthCheck = utcNow + TimeSpan.FromHours(1);
+        var nextHealthCheck = releaseDate + 2 * (utcNow - releaseDate);
+        return nextHealthCheck == null || nextHealthCheck < minimumNextHealthCheck
+            ? minimumNextHealthCheck
+            : nextHealthCheck.Value;
     }
 
     /// <summary>

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -1,4 +1,5 @@
-﻿using NzbWebDAV.Config;
+﻿using System.Collections.Concurrent;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 
@@ -9,7 +10,8 @@ namespace NzbWebDAV.Utils;
 /// </summary>
 public static class OrganizedLinksUtil
 {
-    private static readonly Dictionary<Guid, string> Cache = new();
+    // Concurrent because health-check repairs and maintenance tasks can walk the library at the same time.
+    private static readonly ConcurrentDictionary<Guid, string> Cache = new();
 
     /// <summary>
     /// Searches organized media library for a symlink or strm pointing to the given target
@@ -62,7 +64,9 @@ public static class OrganizedLinksUtil
         string? result = null;
         foreach (var davItemLink in GetLibraryDavItemLinks(configManager))
         {
-            Cache[targetDavItem.Id] = davItemLink.LinkPath;
+            // cache every link found during the walk under its own dav-item id,
+            // so subsequent lookups for other items skip the full library scan.
+            Cache[davItemLink.DavItemId] = davItemLink.LinkPath;
             if (davItemLink.DavItemId == targetDavItem.Id)
                 result = davItemLink.LinkPath;
         }
@@ -97,7 +101,7 @@ public static class OrganizedLinksUtil
         };
     }
 
-    private static DavItemLink? GetDavItemLink(SymlinkAndStrmUtil.SymlinkInfo symlinkInfo, string mountDir)
+    internal static DavItemLink? GetDavItemLink(SymlinkAndStrmUtil.SymlinkInfo symlinkInfo, string mountDir)
     {
         var targetPath = symlinkInfo.TargetPath;
         if (!targetPath.StartsWith(mountDir)) return null;
@@ -105,24 +109,29 @@ public static class OrganizedLinksUtil
         targetPath = targetPath.StartsWith('/') ? targetPath : $"/{targetPath}";
         if (!targetPath.StartsWith("/.ids")) return null;
         var guid = Path.GetFileNameWithoutExtension(targetPath);
+        // a foreign/hand-made symlink under the mount dir must not abort the library walk
+        if (!Guid.TryParse(guid, out var davItemId)) return null;
         return new DavItemLink()
         {
             LinkPath = symlinkInfo.SymlinkPath,
-            DavItemId = Guid.Parse(guid),
+            DavItemId = davItemId,
             SymlinkOrStrmInfo = symlinkInfo
         };
     }
 
-    private static DavItemLink? GetDavItemLink(SymlinkAndStrmUtil.StrmInfo strmInfo)
+    internal static DavItemLink? GetDavItemLink(SymlinkAndStrmUtil.StrmInfo strmInfo)
     {
         var targetUrl = strmInfo.TargetUrl;
-        var absolutePath = new Uri(targetUrl).AbsolutePath;
+        // a malformed strm file must not abort the library walk
+        if (!Uri.TryCreate(targetUrl, UriKind.Absolute, out var uri)) return null;
+        var absolutePath = uri.AbsolutePath;
         if (!absolutePath.StartsWith("/view/.ids")) return null;
         var guid = Path.GetFileNameWithoutExtension(absolutePath);
+        if (!Guid.TryParse(guid, out var davItemId)) return null;
         return new DavItemLink()
         {
             LinkPath = strmInfo.StrmPath,
-            DavItemId = Guid.Parse(guid),
+            DavItemId = davItemId,
             SymlinkOrStrmInfo = strmInfo
         };
     }

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -69,6 +69,14 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetFileById_NonGuidName_ReturnsNull()
+    {
+        Assert.Null(await _client.GetFileById("not-a-guid"));
+        Assert.Null(await _client.GetFileById(".."));
+        Assert.Null(await _client.GetFileById("favicon.ico"));
+    }
+
+    [Fact]
     public async Task GetItemByPathAsync_ResolvesNestedPersistedPaths()
     {
         var directory = DavItem.New(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckNextHealthCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckNextHealthCheckTests.cs
@@ -1,0 +1,51 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class HealthCheckNextHealthCheckTests
+{
+    [Fact]
+    public void ComputeNextHealthCheck_NullReleaseDate_FloorsAtOneHour()
+    {
+        var utcNow = new DateTimeOffset(2026, 7, 13, 12, 0, 0, TimeSpan.Zero);
+
+        var next = HealthCheckService.ComputeNextHealthCheck(null, utcNow);
+
+        Assert.Equal(utcNow + TimeSpan.FromHours(1), next);
+    }
+
+    [Fact]
+    public void ComputeNextHealthCheck_FutureReleaseDate_FloorsAtOneHour()
+    {
+        var utcNow = new DateTimeOffset(2026, 7, 13, 12, 0, 0, TimeSpan.Zero);
+        var futureRelease = utcNow + TimeSpan.FromDays(7);
+
+        var next = HealthCheckService.ComputeNextHealthCheck(futureRelease, utcNow);
+
+        Assert.Equal(utcNow + TimeSpan.FromHours(1), next);
+    }
+
+    [Fact]
+    public void ComputeNextHealthCheck_RecentRelease_FloorsAtOneHour()
+    {
+        var utcNow = new DateTimeOffset(2026, 7, 13, 12, 0, 0, TimeSpan.Zero);
+        var releaseDate = utcNow - TimeSpan.FromMinutes(10);
+
+        var next = HealthCheckService.ComputeNextHealthCheck(releaseDate, utcNow);
+
+        // formula would be utcNow + 10m, which is below the 1h floor
+        Assert.Equal(utcNow + TimeSpan.FromHours(1), next);
+    }
+
+    [Fact]
+    public void ComputeNextHealthCheck_OlderRelease_DoublesAgeSinceRelease()
+    {
+        var utcNow = new DateTimeOffset(2026, 7, 13, 12, 0, 0, TimeSpan.Zero);
+        var releaseDate = utcNow - TimeSpan.FromDays(10);
+
+        var next = HealthCheckService.ComputeNextHealthCheck(releaseDate, utcNow);
+
+        // Next = Release + 2 * (Now - Release) = Now + (Now - Release) = Now + 10 days
+        Assert.Equal(utcNow + TimeSpan.FromDays(10), next);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
@@ -1,0 +1,82 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class OrganizedLinksUtilTests
+{
+    [Fact]
+    public void GetDavItemLink_Symlink_SkipsNonGuidTarget()
+    {
+        var symlink = new SymlinkAndStrmUtil.SymlinkInfo
+        {
+            SymlinkPath = "/library/movie.mkv",
+            TargetPath = "/mnt/nzbdav/.ids/not-a-guid.mkv",
+        };
+
+        var link = OrganizedLinksUtil.GetDavItemLink(symlink, "/mnt/nzbdav");
+
+        Assert.Null(link);
+    }
+
+    [Fact]
+    public void GetDavItemLink_Symlink_ParsesGuidTarget()
+    {
+        var id = Guid.NewGuid();
+        var symlink = new SymlinkAndStrmUtil.SymlinkInfo
+        {
+            SymlinkPath = "/library/movie.mkv",
+            TargetPath = $"/mnt/nzbdav/.ids/{id}.mkv",
+        };
+
+        var link = OrganizedLinksUtil.GetDavItemLink(symlink, "/mnt/nzbdav");
+
+        Assert.NotNull(link);
+        Assert.Equal(id, link.Value.DavItemId);
+        Assert.Equal("/library/movie.mkv", link.Value.LinkPath);
+    }
+
+    [Fact]
+    public void GetDavItemLink_Strm_SkipsMalformedUrl()
+    {
+        var strm = new SymlinkAndStrmUtil.StrmInfo
+        {
+            StrmPath = "/library/movie.strm",
+            TargetUrl = "not a url",
+        };
+
+        var link = OrganizedLinksUtil.GetDavItemLink(strm);
+
+        Assert.Null(link);
+    }
+
+    [Fact]
+    public void GetDavItemLink_Strm_SkipsNonGuidTarget()
+    {
+        var strm = new SymlinkAndStrmUtil.StrmInfo
+        {
+            StrmPath = "/library/movie.strm",
+            TargetUrl = "http://localhost:3000/view/.ids/not-a-guid.mkv",
+        };
+
+        var link = OrganizedLinksUtil.GetDavItemLink(strm);
+
+        Assert.Null(link);
+    }
+
+    [Fact]
+    public void GetDavItemLink_Strm_ParsesGuidTarget()
+    {
+        var id = Guid.NewGuid();
+        var strm = new SymlinkAndStrmUtil.StrmInfo
+        {
+            StrmPath = "/library/movie.strm",
+            TargetUrl = $"http://localhost:3000/view/.ids/{id}.mkv",
+        };
+
+        var link = OrganizedLinksUtil.GetDavItemLink(strm);
+
+        Assert.NotNull(link);
+        Assert.Equal(id, link.Value.DavItemId);
+        Assert.Equal("/library/movie.strm", link.Value.LinkPath);
+    }
+}


### PR DESCRIPTION
## Summary
- Floor healthy-path `NextHealthCheck` at `utcNow + 1h` so null/future release dates cannot hot-loop the health service.
- Fix organized-links cache poisoning (key by link’s own dav-item id) and skip foreign/malformed symlink/strm targets during library walks.
- Coalesce connection-pool websocket updates to a 200ms trailing-edge flush (same wire format).
- Return not-found for non-guid `/.ids` lookups instead of 500.

Ported from sibling fork [`mrghxst/nzbdav@ddb4544`](https://github.com/mrghxst/nzbdav/commit/ddb4544b616f87ab34a077637eda9b774232e723). WebsocketManager send-locks / empty-client skip were already present here and were left alone.

Related: #241 (partial mitigation via fewer pool-stat messages; does not add bounded per-socket backpressure).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~HealthCheckNextHealthCheckTests|FullyQualifiedName~OrganizedLinksUtilTests|FullyQualifiedName~GetFileById_NonGuidName_ReturnsNull"`
- [ ] Spot-check health page under repair with a library that has foreign symlinks / bad strm files
- [ ] Confirm connection-count UI still updates under load (should be smoother, not stuck)
- [ ] Probe a non-guid path under `/.ids` and confirm not-found rather than 500