### PR TITLE
fix(auth): hmac-key password verification cache

### DIFF
--- a/backend/Utils/PasswordUtil.cs
+++ b/backend/Utils/PasswordUtil.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace NzbWebDAV.Utils;
@@ -7,6 +9,7 @@ public static class PasswordUtil
 {
     private static readonly MemoryCache Cache = new(new MemoryCacheOptions() { SizeLimit = 5 });
     private static readonly PasswordHasher<object> Hasher = new();
+    private static readonly byte[] CacheKeySecret = RandomNumberGenerator.GetBytes(32);
 
     public static string Hash(string password, string salt = "")
     {
@@ -22,12 +25,25 @@ public static class PasswordUtil
         // database. Password hashing is intentionally designed to be super slow in order to slow down brute
         // force attacks. Several hundred milliseconds would be added to every single webdav request
         // when the "--use-cookies" Rclone argument is not used, if not for the memory cache added here.
-        return Cache.GetOrCreate(new CacheKey(hash, password, salt), cacheEntry =>
+        var cacheKey = CreateCacheKey(hash, password, salt);
+        return Cache.GetOrCreate(cacheKey, cacheEntry =>
         {
             cacheEntry.Size = 1;
+            cacheEntry.SetSlidingExpiration(TimeSpan.FromMinutes(5));
             return Hasher.VerifyHashedPassword(null!, hash, password + salt);
         }) == PasswordVerificationResult.Success;
     }
 
-    private record CacheKey(string Hash, string Password, string Salt);
+    private static string CreateCacheKey(string hash, string password, string salt)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(string.Concat(hash, "\0", password, "\0", salt));
+        try
+        {
+            return Convert.ToHexString(HMACSHA256.HashData(CacheKeySecret, keyBytes));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(keyBytes);
+        }
+    }
 }

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -76,6 +76,17 @@ public class UtilityTests
     }
 
     [Fact]
+    public void PasswordVerify_CacheHitsPreserveCorrectness()
+    {
+        var hash = PasswordUtil.Hash("secret", "account");
+
+        Assert.True(PasswordUtil.Verify(hash, "secret", "account"));
+        Assert.True(PasswordUtil.Verify(hash, "secret", "account"));
+        Assert.False(PasswordUtil.Verify(hash, "wrong", "account"));
+        Assert.False(PasswordUtil.Verify(hash, "wrong", "account"));
+    }
+
+    [Fact]
     public void InterpolationSearch_FindsIrregularByteRange()
     {
         LongRange[] ranges =


### PR DESCRIPTION
## Summary
- Replace `PasswordUtil` plaintext `CacheKey(hash, password, salt)` with an HMAC-SHA256 hex key over those fields using a process-lifetime secret.
- Add 5-minute sliding expiration (match WebDAV credential cache); keep `SizeLimit = 5`.
- Extend `UtilityTests` to confirm verify + cache-hit correctness.

## Reasoning
Plaintext in the cache key table keeps secrets resident for the entry lifetime. HMAC keys preserve hit behavior for Rclone without `--use-cookies` while matching `ServiceCollectionAuthExtensions.VerifyPasswordWithCache`.

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~UtilityTests.Password`
- [ ] Wrong password still fails; correct password still succeeds on repeat verifies

Fixes #232