### PR TITLE
fix(auth): close username-enumeration timing oracle

### DIFF
--- a/backend/Api/Controllers/Authenticate/AuthenticateController.cs
+++ b/backend/Api/Controllers/Authenticate/AuthenticateController.cs
@@ -15,11 +15,22 @@ public class AuthenticateController(DavDatabaseClient dbClient) : BaseApiControl
             .Where(a => a.Type == request.Type && a.Username == request.Username)
             .FirstOrDefaultAsync().ConfigureAwait(false);
 
+        // Always run Verify (dummy hash when account is missing) so timing does not
+        // enumerate valid usernames by skipping the expensive PBKDF2 path.
+        var verified = account != null
+            ? PasswordUtil.Verify(account.PasswordHash, request.Password, account.RandomSalt)
+            : RunDummyVerify(request.Password);
+
         return new AuthenticateResponse()
         {
-            Authenticated = account != null
-                && PasswordUtil.Verify(account.PasswordHash, request.Password, account.RandomSalt)
+            Authenticated = account != null && verified
         };
+    }
+
+    private static bool RunDummyVerify(string password)
+    {
+        PasswordUtil.VerifyDummy(password);
+        return false;
     }
 
     protected override async Task<IActionResult> HandleRequest()

--- a/backend/Auth/ServiceCollectionAuthExtensions.cs
+++ b/backend/Auth/ServiceCollectionAuthExtensions.cs
@@ -8,6 +8,7 @@ using NWebDav.Server;
 using NWebDav.Server.Authentication;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Auth;
@@ -59,8 +60,14 @@ public static class ServiceCollectionAuthExtensions
             return Task.CompletedTask;
         }
 
-        if (context.Username == user &&
-            VerifyPasswordWithCache(context.Username, context.Password, passwordHash))
+        // Always run hash verification (dummy when username mismatches) so timing
+        // does not enumerate the configured WebDAV username.
+        var usernameMatches = context.Username.FixedTimeEquals(user);
+        var passwordOk = usernameMatches
+            ? VerifyPasswordWithCache(context.Username, context.Password, passwordHash)
+            : RunDummyPasswordVerify(context.Password);
+
+        if (usernameMatches && passwordOk)
         {
             var claims = new[]
             {
@@ -101,5 +108,11 @@ public static class ServiceCollectionAuthExtensions
         {
             CryptographicOperations.ZeroMemory(credentialBytes);
         }
+    }
+
+    private static bool RunDummyPasswordVerify(string password)
+    {
+        PasswordUtil.VerifyDummy(password);
+        return false;
     }
 }

--- a/backend/Utils/PasswordUtil.cs
+++ b/backend/Utils/PasswordUtil.cs
@@ -11,6 +11,9 @@ public static class PasswordUtil
     private static readonly PasswordHasher<object> Hasher = new();
     private static readonly byte[] CacheKeySecret = RandomNumberGenerator.GetBytes(32);
 
+    // Used when the account/user is missing so Verify still runs (closes username-enumeration timing).
+    private static readonly string DummyHash = Hasher.HashPassword(null!, "nzbdav-dummy-password");
+
     public static string Hash(string password, string salt = "")
     {
         return Hasher.HashPassword(null!, password + salt);
@@ -32,6 +35,15 @@ public static class PasswordUtil
             cacheEntry.SetSlidingExpiration(TimeSpan.FromMinutes(5));
             return Hasher.VerifyHashedPassword(null!, hash, password + salt);
         }) == PasswordVerificationResult.Success;
+    }
+
+    /// <summary>
+    /// Runs the same PBKDF2 verify path against a static dummy hash and discards the result.
+    /// Call this when the account/user does not exist so timing matches a failed password check.
+    /// </summary>
+    public static void VerifyDummy(string password, string salt = "")
+    {
+        _ = Verify(DummyHash, password, salt);
     }
 
     private static string CreateCacheKey(string hash, string password, string salt)

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -87,6 +87,14 @@ public class UtilityTests
     }
 
     [Fact]
+    public void PasswordVerifyDummy_DoesNotAuthenticate()
+    {
+        // Dummy verify must complete without throwing and must not imply success.
+        PasswordUtil.VerifyDummy("any-password");
+        PasswordUtil.VerifyDummy("any-password", "salt");
+    }
+
+    [Fact]
     public void InterpolationSearch_FindsIrregularByteRange()
     {
         LongRange[] ranges =


### PR DESCRIPTION
## Summary
- Always run `PasswordUtil.Verify` on UI login and WebDAV basic auth; when the account/user is missing, verify against a static dummy PBKDF2 hash and discard the result.
- Compare WebDAV usernames with `FixedTimeEquals`.
- Add `PasswordUtil.VerifyDummy` shared by both call sites.

## Reasoning
Skipped PBKDF2 is the dominant timing oracle for username enumeration. Response contracts stay identical (`Authenticated` bool / WebDAV 401). Residual DB-lookup timing is accepted and out of scope.

**Depends on:** #287 (HMAC cache keys in `PasswordUtil`). Retarget base to `main` after that merges.

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~UtilityTests.Password`
- [ ] Unknown username vs wrong password both return `Authenticated: false` / WebDAV 401
- [ ] Valid credentials still succeed

Fixes #230