### PR TITLE
fix(ui): safe-decode paths in proxy auth and compression

### DIFF
--- a/frontend/app/auth/auth-middleware.server.test.ts
+++ b/frontend/app/auth/auth-middleware.server.test.ts
@@ -75,13 +75,14 @@ describe("authMiddleware", () => {
     expect(isAuthenticatedMock).not.toHaveBeenCalled();
   });
 
-  it("throws on malformed URI paths", async () => {
+  it("redirects malformed URI paths instead of throwing", async () => {
+    isAuthenticatedMock.mockResolvedValueOnce(false);
     const next = vi.fn();
     const res = mockRes();
 
-    await expect(
-      authMiddleware(mockReq("/%E0%A4%A"), res, next),
-    ).rejects.toThrow(URIError);
+    await authMiddleware(mockReq("/%E0%A4%A"), res, next);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, "/login");
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/auth/auth-middleware.server.ts
+++ b/frontend/app/auth/auth-middleware.server.ts
@@ -1,5 +1,6 @@
 import type express from "express";
 import { isAuthenticated } from "~/auth/authentication.server";
+import { safeDecodePath } from "../../server/proxy-path";
 
 // Paths that do not require authentication. Every other path is protected.
 const PUBLIC_PATHS = [
@@ -15,9 +16,9 @@ export async function authMiddleware(
   res: express.Response,
   next: express.NextFunction,
 ): Promise<void> {
-  // Allow explicitly public paths
-  const pathname = decodeURIComponent(req.path);
-  if (PUBLIC_PATHS.includes(pathname)) return next();
+  // Allow explicitly public paths (malformed encoding is not public)
+  const pathname = safeDecodePath(req.path);
+  if (pathname !== null && PUBLIC_PATHS.includes(pathname)) return next();
 
   // Allow authenticated sessions
   if (await isAuthenticated(req)) return next();

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -3,6 +3,7 @@ import express from "express";
 import http from "http";
 import { WebSocketServer } from "ws";
 import { logger, requestLogger } from "./server/logger.js";
+import { shouldSkipCompression } from "./server/proxy-path.js";
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = "../build/server/index.js";
@@ -28,16 +29,7 @@ app.use(
   compression({
     // Don't compress proxied WebDAV/media/API responses; keep Content-Length intact for seek
     filter: (req, res) => {
-      const path = decodeURIComponent(req.path || "");
-      if (
-        path.startsWith("/view") ||
-        path.startsWith("/.ids") ||
-        path.startsWith("/nzbs") ||
-        path.startsWith("/content") ||
-        path.startsWith("/completed-symlinks") ||
-        path.startsWith("/api") ||
-        path.startsWith("/adapters/")
-      ) {
+      if (shouldSkipCompression(req.path || "")) {
         return false;
       }
       return compression.filter(req, res);

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -4,7 +4,7 @@ import express from "express";
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { websocketServer } from "./websocket.server";
-import { shouldProxyToBackend } from "./proxy-path";
+import { safeDecodePath, shouldProxyToBackend } from "./proxy-path";
 import { logger } from "./logger";
 import { authMiddleware } from "~/auth/auth-middleware.server";
 import { setApiKeyForAuthenticatedRequests } from "./inject-api-key.server";
@@ -78,8 +78,10 @@ const credentialRateLimiter = rateLimit({
     return remoteAddress ? ipKeyGenerator(remoteAddress) : "unknown";
   },
   skip: (req) => {
-    return req.method.toUpperCase() !== "POST"
-      || !credentialPaths.has(decodeURIComponent(req.path));
+    if (req.method.toUpperCase() !== "POST") return true;
+    // Malformed encoding is not a credential path; must not throw (see #217).
+    const decodedPath = safeDecodePath(req.path);
+    return decodedPath === null || !credentialPaths.has(decodedPath);
   },
   handler: (req, res, _next, options) => {
     logger.warn(

--- a/frontend/server/proxy-path.test.ts
+++ b/frontend/server/proxy-path.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { shouldProxyToBackend } from "./proxy-path";
+import { safeDecodePath, shouldProxyToBackend, shouldSkipCompression } from "./proxy-path";
+
+describe("safeDecodePath", () => {
+  it("decodes valid percent-encoding", () => {
+    expect(safeDecodePath("/%61pi/get-config")).toBe("/api/get-config");
+  });
+
+  it.each(["/%zz", "/view%", "/%E0%A4%A"])(
+    "returns null for malformed path %s",
+    (path) => {
+      expect(safeDecodePath(path)).toBeNull();
+    },
+  );
+});
 
 describe("shouldProxyToBackend", () => {
   it.each(["PROPFIND", "propfind", "OPTIONS", "options"])(
@@ -28,10 +41,29 @@ describe("shouldProxyToBackend", () => {
     expect(shouldProxyToBackend("GET", "/%61pi/get-config")).toBe(true);
   });
 
+  it.each(["/%zz", "/view%"])(
+    "does not proxy malformed path %s",
+    (path) => {
+      expect(shouldProxyToBackend("GET", path)).toBe(false);
+    },
+  );
+
   it.each(["/", "/login", "/settings", "/assets/app.js"])(
     "leaves frontend path %s to React Router",
     (path) => {
       expect(shouldProxyToBackend("GET", path)).toBe(false);
     },
   );
+});
+
+describe("shouldSkipCompression", () => {
+  it("skips compression for backend paths", () => {
+    expect(shouldSkipCompression("/view/movies")).toBe(true);
+    expect(shouldSkipCompression("/api/get-config")).toBe(true);
+  });
+
+  it("does not skip for frontend paths or malformed encoding", () => {
+    expect(shouldSkipCompression("/login")).toBe(false);
+    expect(shouldSkipCompression("/%zz")).toBe(false);
+  });
 });

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -8,11 +8,30 @@ const BACKEND_PATH_PREFIXES = [
   "/adapters/",
 ];
 
-export function shouldProxyToBackend(method: string, pathname: string): boolean {
-  const decodedPath = decodeURIComponent(pathname);
-  const normalizedMethod = method.toUpperCase();
+/** Decode a path; return null on malformed percent-encoding instead of throwing. */
+export function safeDecodePath(path: string): string | null {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return null;
+  }
+}
 
-  return normalizedMethod === "PROPFIND"
-    || normalizedMethod === "OPTIONS"
-    || BACKEND_PATH_PREFIXES.some((prefix) => decodedPath.startsWith(prefix));
+export function shouldProxyToBackend(method: string, pathname: string): boolean {
+  const normalizedMethod = method.toUpperCase();
+  if (normalizedMethod === "PROPFIND" || normalizedMethod === "OPTIONS") {
+    return true;
+  }
+
+  const decodedPath = safeDecodePath(pathname);
+  if (decodedPath === null) return false;
+
+  return BACKEND_PATH_PREFIXES.some((prefix) => decodedPath.startsWith(prefix));
+}
+
+/** True when compression should be skipped for backend-proxied media/API paths. */
+export function shouldSkipCompression(pathname: string): boolean {
+  const decodedPath = safeDecodePath(pathname);
+  if (decodedPath === null) return false;
+  return BACKEND_PATH_PREFIXES.some((prefix) => decodedPath.startsWith(prefix));
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["server.ts", "server/logger.ts", "server/startup-grace.ts", "vite.config.ts", "vitest.config.ts"],
+  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/startup-grace.ts", "vite.config.ts", "vitest.config.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- Add shared `safeDecodePath` that returns `null` on malformed percent-encoding.
- Use it in proxy allowlist, auth middleware, and compression skip filter.
- On `null`: do not proxy; treat as non-public (auth redirect); do not skip compression.

## Reasoning
`decodeURIComponent` throws `URIError` on `/%zz` etc., which Express 5 turns into noisy 500s for unauthenticated clients. Fail closed rather than inventing a path.

## Test plan
- [x] Vitest: `proxy-path.test.ts`, `auth-middleware.server.test.ts`
- [ ] `/%zz` no longer produces a 500 from proxy/auth/compression gates

Fixes #217