### PR TITLE
fix(ui): match proxy allowlist on path segment boundaries

### DIFF
--- a/frontend/server/inject-api-key.server.test.ts
+++ b/frontend/server/inject-api-key.server.test.ts
@@ -35,6 +35,19 @@ describe("setApiKeyForAuthenticatedRequests", () => {
     expect(req.headers["x-api-key"]).toBeUndefined();
   });
 
+  it("ignores /apifoo bare-prefix false positives", async () => {
+    const req = mockReq({ path: "/apifoo" });
+    await setApiKeyForAuthenticatedRequests(req);
+    expect(isAuthenticatedMock).not.toHaveBeenCalled();
+  });
+
+  it("injects for decoded /api paths", async () => {
+    isAuthenticatedMock.mockResolvedValueOnce(true);
+    const req = mockReq({ path: "/%61pi/get-config" });
+    await setApiKeyForAuthenticatedRequests(req);
+    expect(req.headers["x-api-key"]).toBe("injected-key");
+  });
+
   it("leaves an existing API key alone", async () => {
     const req = mockReq({
       path: "/api/get-config",

--- a/frontend/server/inject-api-key.server.ts
+++ b/frontend/server/inject-api-key.server.ts
@@ -1,5 +1,6 @@
 import type express from "express";
 import { isAuthenticated } from "~/auth/authentication.server";
+import { isBackendApiPath } from "./proxy-path";
 
 /**
  * Inject the frontend→backend API key for authenticated UI sessions that proxy
@@ -8,8 +9,8 @@ import { isAuthenticated } from "~/auth/authentication.server";
 export async function setApiKeyForAuthenticatedRequests(
   req: express.Request,
 ): Promise<void> {
-  // if the path is not /api, do nothing
-  if (!req.path.startsWith("/api")) return;
+  // if the path is not /api (decoded, segment-bounded), do nothing
+  if (!isBackendApiPath(req.path)) return;
 
   const apikey = req.query.apikey || req.query.apiKey || req.headers["x-api-key"];
   const hasApiKey = apikey && typeof apikey === "string";

--- a/frontend/server/proxy-path.test.ts
+++ b/frontend/server/proxy-path.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { safeDecodePath, shouldProxyToBackend, shouldSkipCompression } from "./proxy-path";
+import {
+  isBackendApiPath,
+  matchesBackendPathPrefix,
+  safeDecodePath,
+  shouldProxyToBackend,
+  shouldSkipCompression,
+} from "./proxy-path";
 
 describe("safeDecodePath", () => {
   it("decodes valid percent-encoding", () => {
@@ -14,11 +20,45 @@ describe("safeDecodePath", () => {
   );
 });
 
+describe("matchesBackendPathPrefix", () => {
+  it.each([
+    "/api",
+    "/api/get-config",
+    "/view",
+    "/view/movies",
+    "/adapters",
+    "/adapters/addon/token/manifest.json",
+  ])("matches %s", (path) => {
+    expect(matchesBackendPathPrefix(path)).toBe(true);
+  });
+
+  it.each(["/apifoo", "/viewport.css", "/contents-page", "/adaptersfoo"])(
+    "rejects bare-prefix false positive %s",
+    (path) => {
+      expect(matchesBackendPathPrefix(path)).toBe(false);
+    },
+  );
+});
+
+describe("isBackendApiPath", () => {
+  it("matches /api and children", () => {
+    expect(isBackendApiPath("/api")).toBe(true);
+    expect(isBackendApiPath("/api/get-config")).toBe(true);
+    expect(isBackendApiPath("/%61pi/get-config")).toBe(true);
+  });
+
+  it("rejects /apifoo and non-api paths", () => {
+    expect(isBackendApiPath("/apifoo")).toBe(false);
+    expect(isBackendApiPath("/view")).toBe(false);
+  });
+});
+
 describe("shouldProxyToBackend", () => {
   it.each(["PROPFIND", "propfind", "OPTIONS", "options"])(
     "proxies %s requests regardless of path",
     (method) => {
       expect(shouldProxyToBackend(method, "/unrelated")).toBe(true);
+      expect(shouldProxyToBackend(method, "/apifoo")).toBe(true);
     },
   );
 
@@ -48,6 +88,13 @@ describe("shouldProxyToBackend", () => {
     },
   );
 
+  it.each(["/apifoo", "/viewport.css", "/contents-page"])(
+    "does not proxy bare-prefix false positive %s",
+    (path) => {
+      expect(shouldProxyToBackend("GET", path)).toBe(false);
+    },
+  );
+
   it.each(["/", "/login", "/settings", "/assets/app.js"])(
     "leaves frontend path %s to React Router",
     (path) => {
@@ -62,8 +109,9 @@ describe("shouldSkipCompression", () => {
     expect(shouldSkipCompression("/api/get-config")).toBe(true);
   });
 
-  it("does not skip for frontend paths or malformed encoding", () => {
+  it("does not skip for frontend paths, false positives, or malformed encoding", () => {
     expect(shouldSkipCompression("/login")).toBe(false);
+    expect(shouldSkipCompression("/viewport.css")).toBe(false);
     expect(shouldSkipCompression("/%zz")).toBe(false);
   });
 });

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -17,6 +17,21 @@ export function safeDecodePath(path: string): string | null {
   }
 }
 
+/** Match path on segment boundaries so `/apifoo` does not match `/api`. */
+export function matchesBackendPathPrefix(decodedPath: string): boolean {
+  return BACKEND_PATH_PREFIXES.some((prefix) => {
+    const normalized = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+    return decodedPath === normalized || decodedPath.startsWith(normalized + "/");
+  });
+}
+
+/** True when the path is under `/api` (decoded, segment-bounded). */
+export function isBackendApiPath(pathname: string): boolean {
+  const decodedPath = safeDecodePath(pathname);
+  if (decodedPath === null) return false;
+  return decodedPath === "/api" || decodedPath.startsWith("/api/");
+}
+
 export function shouldProxyToBackend(method: string, pathname: string): boolean {
   const normalizedMethod = method.toUpperCase();
   if (normalizedMethod === "PROPFIND" || normalizedMethod === "OPTIONS") {
@@ -26,12 +41,12 @@ export function shouldProxyToBackend(method: string, pathname: string): boolean 
   const decodedPath = safeDecodePath(pathname);
   if (decodedPath === null) return false;
 
-  return BACKEND_PATH_PREFIXES.some((prefix) => decodedPath.startsWith(prefix));
+  return matchesBackendPathPrefix(decodedPath);
 }
 
 /** True when compression should be skipped for backend-proxied media/API paths. */
 export function shouldSkipCompression(pathname: string): boolean {
   const decodedPath = safeDecodePath(pathname);
   if (decodedPath === null) return false;
-  return BACKEND_PATH_PREFIXES.some((prefix) => decodedPath.startsWith(prefix));
+  return matchesBackendPathPrefix(decodedPath);
 }


### PR DESCRIPTION
## Summary
- Match backend prefixes on segment boundaries (`path === prefix || path.startsWith(prefix + \"/\")`), normalizing trailing-slash prefixes like `/adapters/`.
- Align `setApiKeyForAuthenticatedRequests` with the same decoded `/api` check.
- `/p/` removal was already done in #201 — not repeated here.

## Reasoning
Bare `startsWith(\"/api\")` widens the unauthenticated proxy surface to `/apifoo` etc. Aligning API-key injection with decoded paths removes the latent encoded-`/api` inconsistency.

**Depends on:** #289 (safeDecode). Retarget base to `main` after that merges.

## Test plan
- [x] Vitest: `proxy-path.test.ts`, `inject-api-key.server.test.ts`
- [ ] `/apifoo`, `/viewport.css` are not proxied; `/api/foo` still is

Fixes #218