### PR TITLE
fix(sab): cap unbounded history responses

### DIFF
--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -36,7 +36,8 @@ public class GetHistoryRequest
         //   * https://github.com/Sonarr/Sonarr/issues/5452
         //
         // Because of this, NzbDAV added a setting to ignore the `limit` value specified by the Arrs.
-        // When this setting is enabled, we always return all history items.
+        // When this setting is enabled, we skip the Arr limit and apply only the server-side ceiling
+        // (see GetHistoryMaxPageSize) so responses stay bounded.
         if (limitParam is not null && !configManager.IsIgnoreSabHistoryLimitEnabled())
         {
             var isValidLimit = int.TryParse(limitParam, out var limit);
@@ -54,6 +55,10 @@ public class GetHistoryRequest
             if (!isValidPageSize) throw new BadHttpRequestException("Invalid pageSize parameter");
             Limit = pageSize;
         }
+
+        // Server-side ceiling: keep ignore-limit semantics for Arrs but never materialize
+        // an unbounded history response (default Limit is int.MaxValue).
+        Limit = Math.Min(Limit, configManager.GetHistoryMaxPageSize());
 
         if (nzoIdsParam is not null)
         {

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -57,8 +57,9 @@ public class GetHistoryRequest
         }
 
         // Server-side ceiling: keep ignore-limit semantics for Arrs but never materialize
-        // an unbounded history response (default Limit is int.MaxValue).
-        Limit = Math.Min(Limit, configManager.GetHistoryMaxPageSize());
+        // an unbounded history response (default Limit is int.MaxValue). Clamp instead of
+        // Min because a negative Take() becomes a negative SQLite LIMIT, which is unbounded.
+        Limit = Math.Clamp(Limit, 0, configManager.GetHistoryMaxPageSize());
 
         if (nzoIdsParam is not null)
         {

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -17,6 +17,7 @@ public static class ConfigKeys
     public const string ApiEnsureArticleExistenceCategories = "api.ensure-article-existence-categories";
     public const string ApiEnsureImportableVideo = "api.ensure-importable-video";
     public const string ApiIgnoreHistoryLimit = "api.ignore-history-limit";
+    public const string ApiHistoryMaxPageSize = "api.history-max-page-size";
     public const string ApiImportStrategy = "api.import-strategy";
     public const string ApiKey = "api.key";
     public const string ApiLazyRarParsing = "api.lazy-rar-parsing";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -956,6 +956,18 @@ public class ConfigManager
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
+    /// <summary>
+    /// Server-side ceiling for SAB history <c>slots</c> returned in one response.
+    /// Default 10_000 — far above a typical Arr import pass — removes the unbounded
+    /// <c>int.MaxValue</c> worst case when ignore-history-limit is enabled.
+    /// </summary>
+    public int GetHistoryMaxPageSize()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiHistoryMaxPageSize));
+        if (v == null) return 10_000;
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 100_000) : 10_000;
+    }
+
     public bool IsRepairJobEnabled()
     {
         var defaultValue = false;

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.GetHistory;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetHistoryRequestTests
+{
+    [Fact]
+    public void CapsUnboundedLimitWhenIgnoreHistoryLimitEnabled()
+    {
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        // Arrs send limit=60 but ignore-history-limit discards it → would be int.MaxValue
+        context.Request.QueryString = new QueryString("?limit=60");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(10_000, request.Limit);
+    }
+
+    [Fact]
+    public void PreservesSmallPageSizeBelowCeiling()
+    {
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?pageSize=100");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(100, request.Limit);
+    }
+
+    [Fact]
+    public void HonorsArrLimitWhenIgnoreDisabledAndBelowCeiling()
+    {
+        var config = CreateConfig(ignoreLimit: false);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=60");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(60, request.Limit);
+    }
+
+    [Fact]
+    public void CapsPageSizeAboveConfiguredCeiling()
+    {
+        var config = CreateConfig(ignoreLimit: true, maxPageSize: "500");
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?pageSize=2000");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(500, request.Limit);
+    }
+
+    [Fact]
+    public void GetHistoryMaxPageSize_DefaultsAndClamps()
+    {
+        Assert.Equal(10_000, new ConfigManager().GetHistoryMaxPageSize());
+
+        var custom = CreateConfig(ignoreLimit: true, maxPageSize: "2500");
+        Assert.Equal(2500, custom.GetHistoryMaxPageSize());
+
+        var clamped = CreateConfig(ignoreLimit: true, maxPageSize: "999999");
+        Assert.Equal(100_000, clamped.GetHistoryMaxPageSize());
+    }
+
+    private static ConfigManager CreateConfig(bool ignoreLimit, string? maxPageSize = null)
+    {
+        var items = new List<ConfigItem>
+        {
+            new()
+            {
+                ConfigName = ConfigKeys.ApiIgnoreHistoryLimit,
+                ConfigValue = ignoreLimit ? "true" : "false",
+            },
+        };
+        if (maxPageSize is not null)
+        {
+            items.Add(new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiHistoryMaxPageSize,
+                ConfigValue = maxPageSize,
+            });
+        }
+
+        var config = new ConfigManager();
+        config.UpdateValues(items);
+        return config;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -57,6 +57,19 @@ public class GetHistoryRequestTests
     }
 
     [Fact]
+    public void ClampsNegativePageSizeToZero()
+    {
+        // A negative Take() becomes a negative SQLite LIMIT (= unbounded); must clamp.
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?pageSize=-1");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(0, request.Limit);
+    }
+
+    [Fact]
     public void GetHistoryMaxPageSize_DefaultsAndClamps()
     {
         Assert.Equal(10_000, new ConfigManager().GetHistoryMaxPageSize());


### PR DESCRIPTION
## Summary
- Add `api.history-max-page-size` via `ConfigManager.GetHistoryMaxPageSize()` (default 10_000, clamp 1–100_000).
- Apply ceiling after Arr `limit` / ignore-sab-limit / frontend `pageSize` resolution in `GetHistoryRequest`.
- `TotalCount` / `noofslots` remain the full DB count; only `slots` is capped.

## Reasoning
Default `ignore-history-limit=true` plus `Limit=int.MaxValue` materializes full history on every Arr poll. A high ceiling preserves Arr import passes while removing the unbounded worst case. Retention (#158) shrinks the table over time but does not bound a single response.

## Test plan
- [x] `GetHistoryRequestTests`
- [ ] Arr ignore-limit path returns at most 10k slots with accurate total count
- [ ] Frontend `pageSize=100` unchanged

Fixes #236