### PR TITLE
fix(api): compare profile tokens in constant time

### DIFF
--- a/backend/Api/Controllers/Profiles/Adapters/FailoverOrderController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/FailoverOrderController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 using Serilog;
@@ -47,7 +48,7 @@ public class FailoverOrderController(
         foreach (var id in ids)
         {
             var entry = cache.Get(id);
-            if (entry is null || !string.Equals(entry.ProfileToken, token, StringComparison.Ordinal))
+            if (entry is null || !entry.ProfileToken.FixedTimeEquals(token))
                 continue;
 
             var c = entry.Primary;

--- a/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 using Serilog;
@@ -28,7 +29,7 @@ public class NzbProxyController(
 
         var entry = cache.Get(playToken);
         if (entry is null) return NotFound("Link expired. Re-search to refresh.");
-        if (entry.ProfileToken != token) return NotFound();
+        if (!entry.ProfileToken.FixedTimeEquals(token)) return NotFound();
 
         var candidate = entry.Primary;
         if (string.IsNullOrWhiteSpace(candidate.NzbUrl)) return NotFound();

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -70,7 +70,7 @@ public class ProfilePlayController(
 
     private async Task<IActionResult> HandleAsync(string token, string nzbToken)
     {
-        var profile = configManager.GetProfileConfig().Profiles.FirstOrDefault(x => x.Token == token);
+        var profile = configManager.GetProfileConfig().FindByToken(token);
         if (profile is null) return NotFound();
 
         var entry = cache.Get(nzbToken);

--- a/backend/Config/ProfileConfig.cs
+++ b/backend/Config/ProfileConfig.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Config;
 
@@ -10,6 +11,22 @@ public class ProfileConfig
     {
         foreach (var p in Profiles) p.MigrateLegacy();
         return this;
+    }
+
+    /// <summary>
+    /// Find a profile by token using constant-time comparisons over the full list
+    /// (no early exit) so timing does not leak token prefix/position.
+    /// </summary>
+    public Profile? FindByToken(string token)
+    {
+        Profile? match = null;
+        foreach (var profile in Profiles)
+        {
+            // Always compare; keep the first match without short-circuiting the loop.
+            if (token.FixedTimeEquals(profile.Token) && match is null)
+                match = profile;
+        }
+        return match;
     }
 
     public class Profile

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -29,7 +29,7 @@ public class SearchProfileService(
     private const int MaxSearchPages = 50;
 
     public ProfileConfig.Profile? GetProfile(string token)
-        => configManager.GetProfileConfig().Profiles.FirstOrDefault(x => x.Token == token);
+        => configManager.GetProfileConfig().FindByToken(token);
 
     public bool IsAdapterEnabled(string profileToken, string adapter)
     {

--- a/tests/NzbWebDAV.Tests/Config/ProfileConfigFindByTokenTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ProfileConfigFindByTokenTests.cs
@@ -1,0 +1,56 @@
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ProfileConfigFindByTokenTests
+{
+    [Fact]
+    public void FindByToken_ReturnsMatchingProfile()
+    {
+        var config = new ProfileConfig
+        {
+            Profiles =
+            [
+                new ProfileConfig.Profile { Token = "aaaaaaaaaaaaaaaaaaaaaaaa", Name = "A" },
+                new ProfileConfig.Profile { Token = "bbbbbbbbbbbbbbbbbbbbbbbb", Name = "B" },
+            ],
+        };
+
+        var match = config.FindByToken("bbbbbbbbbbbbbbbbbbbbbbbb");
+
+        Assert.NotNull(match);
+        Assert.Equal("B", match.Name);
+    }
+
+    [Fact]
+    public void FindByToken_ReturnsNullOnMiss()
+    {
+        var config = new ProfileConfig
+        {
+            Profiles =
+            [
+                new ProfileConfig.Profile { Token = "aaaaaaaaaaaaaaaaaaaaaaaa", Name = "A" },
+            ],
+        };
+
+        Assert.Null(config.FindByToken("cccccccccccccccccccccccc"));
+    }
+
+    [Fact]
+    public void FindByToken_ReturnsFirstMatchWhenDuplicatesExist()
+    {
+        var config = new ProfileConfig
+        {
+            Profiles =
+            [
+                new ProfileConfig.Profile { Token = "dddddddddddddddddddddddd", Name = "First" },
+                new ProfileConfig.Profile { Token = "dddddddddddddddddddddddd", Name = "Second" },
+            ],
+        };
+
+        var match = config.FindByToken("dddddddddddddddddddddddd");
+
+        Assert.NotNull(match);
+        Assert.Equal("First", match.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ProfileConfig.FindByToken` that compares every profile with `FixedTimeEquals` and keeps the first match without exiting the loop early.
- Use it from `SearchProfileService.GetProfile` and `ProfilePlayController`.
- Use `FixedTimeEquals` for cache entry `ProfileToken` checks in NzbProxy and FailoverOrder.

## Reasoning
Unauthenticated adapter routes previously used ordinal `==` / `FirstOrDefault`, which can leak token prefix/position via timing. Profile lists are tiny, so a full scan is cheap. Hex tokens remain case-sensitive.

## Test plan
- [x] `ProfileConfigFindByTokenTests`
- [ ] Valid profile token still resolves; wrong token still 404

Fixes #234