### PR TITLE
fix(webdav): handle malformed and unsatisfiable /view ranges

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -79,8 +79,17 @@ public class GetWebdavItemController(
 
         if (rangeStart is not null)
         {
-            // compute
             var end = rangeEnd ?? (fileSize - 1);
+
+            // Syntactically valid but unsatisfiable → 416 (mirror WebDAV handler).
+            if (rangeStart.Value < 0 || rangeStart.Value >= fileSize || rangeStart.Value > end)
+            {
+                Response.Headers["Content-Range"] = $"bytes */{fileSize}";
+                Response.StatusCode = StatusCodes.Status416RangeNotSatisfiable;
+                await stream.DisposeAsync().ConfigureAwait(false);
+                return Stream.Null;
+            }
+
             var chunkSize = 1 + end - rangeStart.Value;
 
             // seek

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -35,28 +35,66 @@ public class GetWebdavItemRequest
         if (!VerifyDownloadKey(downloadKey, Item, configManager))
             throw new UnauthorizedAccessException("Invalid download key");
 
-        // parse range header — three RFC 7233 forms:
-        //   bytes=N-     → from byte N to EOF
-        //   bytes=N-M    → bytes N..M inclusive
-        //   bytes=-N     → last N bytes (a "suffix" range; resolved against fileSize)
-        // The old `Split("-", RemoveEmptyEntries)` silently dropped the leading
-        // empty token of the suffix form, mis-parsing "bytes=-65536" as
-        // RangeStart=65536, which served mid-file data to players asking for the
-        // MP4 MOOV / MKV SeekHead at the end of the file.
+        // Parse Range; on malformed/unparseable input leave ranges null so the
+        // controller serves full content (RFC 7233: ignore unsatisfiable Range syntax).
         var rangeHeader = context.Request.Headers["Range"].FirstOrDefault() ?? "";
-        if (!rangeHeader.StartsWith("bytes=")) return;
-        var spec = rangeHeader[6..];
-        if (spec.StartsWith("-"))
+        if (TryParseRangeHeader(rangeHeader, out var start, out var end, out var suffix))
         {
-            SuffixLength = long.Parse(spec[1..]);
+            RangeStart = start;
+            RangeEnd = end;
+            SuffixLength = suffix;
         }
-        else
+    }
+
+    /// <summary>
+    /// Parse a single RFC 7233 bytes range. Returns false for missing, non-bytes,
+    /// multi-range, or otherwise unparseable headers (caller should ignore Range).
+    /// </summary>
+    public static bool TryParseRangeHeader(
+        string rangeHeader,
+        out long? rangeStart,
+        out long? rangeEnd,
+        out long? suffixLength)
+    {
+        rangeStart = null;
+        rangeEnd = null;
+        suffixLength = null;
+
+        if (string.IsNullOrEmpty(rangeHeader) || !rangeHeader.StartsWith("bytes=", StringComparison.Ordinal))
+            return false;
+
+        var spec = rangeHeader["bytes=".Length..];
+        // Multi-range or garbage with commas is unparseable for our single-range path.
+        if (spec.Contains(','))
+            return false;
+
+        if (spec.StartsWith('-'))
         {
-            var parts = spec.Split("-");
-            RangeStart = long.Parse(parts[0]);
-            if (parts.Length > 1 && parts[1].Length > 0)
-                RangeEnd = long.Parse(parts[1]);
+            if (!long.TryParse(spec[1..], out var suffix) || suffix < 0)
+                return false;
+            suffixLength = suffix;
+            return true;
         }
+
+        var dash = spec.IndexOf('-');
+        if (dash < 0)
+            return false;
+
+        var startPart = spec[..dash];
+        var endPart = spec[(dash + 1)..];
+
+        if (!long.TryParse(startPart, out var start) || start < 0)
+            return false;
+
+        rangeStart = start;
+        if (endPart.Length > 0)
+        {
+            if (!long.TryParse(endPart, out var end) || end < 0)
+                return false;
+            rangeEnd = end;
+        }
+
+        return true;
     }
 
     private static bool VerifyDownloadKey(string? downloadKey, string path, ConfigManager configManager)

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -86,14 +86,16 @@ public class GetWebdavItemRequest
         if (!long.TryParse(startPart, out var start) || start < 0)
             return false;
 
-        rangeStart = start;
+        long? parsedEnd = null;
         if (endPart.Length > 0)
         {
             if (!long.TryParse(endPart, out var end) || end < 0)
                 return false;
-            rangeEnd = end;
+            parsedEnd = end;
         }
 
+        rangeStart = start;
+        rangeEnd = parsedEnd;
         return true;
     }
 

--- a/tests/NzbWebDAV.Tests/Api/GetWebdavItemRequestRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetWebdavItemRequestRangeTests.cs
@@ -1,0 +1,35 @@
+using NzbWebDAV.Api.Controllers.GetWebdavItem;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetWebdavItemRequestRangeTests
+{
+    [Theory]
+    [InlineData("bytes=0-99", 0L, 99L, null)]
+    [InlineData("bytes=100-", 100L, null, null)]
+    [InlineData("bytes=-65536", null, null, 65536L)]
+    public void TryParseRangeHeader_ParsesValidForms(
+        string header, long? start, long? end, long? suffix)
+    {
+        Assert.True(GetWebdavItemRequest.TryParseRangeHeader(header, out var s, out var e, out var suf));
+        Assert.Equal(start, s);
+        Assert.Equal(end, e);
+        Assert.Equal(suffix, suf);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("bytes=abc-")]
+    [InlineData("bytes=999999999999999999999-")]
+    [InlineData("bytes=0-99,200-299")]
+    [InlineData("bytes=0-xx")]
+    [InlineData("items=0-10")]
+    [InlineData("bytes=-")]
+    public void TryParseRangeHeader_IgnoresMalformed(string header)
+    {
+        Assert.False(GetWebdavItemRequest.TryParseRangeHeader(header, out var s, out var e, out var suf));
+        Assert.Null(s);
+        Assert.Null(e);
+        Assert.Null(suf);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `TryParseRangeHeader` using `long.TryParse`; malformed/multi-range/overflow → leave range null and serve full 200 content.
- After `fileSize` is known, return 416 with `Content-Range: bytes */size` for unsatisfiable ranges (`start >= fileSize` or `start > end`).

## Reasoning
`long.Parse` turned garbage Range headers into logged 500s on a download-key surface. RFC 7233 says ignore unparseable Range (serve full content). Valid-but-unsatisfiable ranges get 416, matching WebDAV `GetAndHeadHandlerPatch`. NWebDav path malformed handling is out of scope (issue Where is `/view` only).

## Test plan
- [x] `GetWebdavItemRequestRangeTests`
- [ ] Manual: garbage Range → 200; `bytes=999999-` past EOF → 416; valid range → 206

Fixes #233