### PR TITLE
fix(api): validate forwarded headers and sanitize proxy

### DIFF
--- a/backend/Extensions/HttpContextExtensions.cs
+++ b/backend/Extensions/HttpContextExtensions.cs
@@ -41,10 +41,11 @@ public static class HttpContextExtensions
         var trimmed = configuredBaseUrl.TrimEnd('/');
         if (!string.IsNullOrWhiteSpace(trimmed) && trimmed != "http://localhost:3000")
             return trimmed;
-        var scheme = httpContext.Request.Headers["X-Forwarded-Proto"].FirstOrDefault()
-                     ?? httpContext.Request.Scheme;
-        var host = httpContext.Request.Headers["X-Forwarded-Host"].FirstOrDefault()
-                   ?? httpContext.Request.Host.Value;
+
+        // Prefer Scheme/Host as populated by ForwardedHeadersMiddleware from a
+        // trusted proxy — never read raw X-Forwarded-* (spoofable).
+        var scheme = httpContext.Request.Scheme;
+        var host = httpContext.Request.Host.Value;
         return $"{scheme}://{host}";
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Net;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NWebDav.Server;
@@ -113,6 +115,19 @@ class Program
             builder.Host.UseSerilog();
             builder.Services.AddControllers();
             builder.Services.AddHealthChecks();
+            builder.Services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                    | ForwardedHeaders.XForwardedProto
+                    | ForwardedHeaders.XForwardedHost;
+                // Default: only trust the in-container frontend proxy (loopback).
+                // Widen via TRUSTED_PROXY_CIDRS for split-container topologies.
+                options.KnownProxies.Clear();
+                options.KnownIPNetworks.Clear();
+                options.KnownProxies.Add(IPAddress.Loopback);
+                options.KnownProxies.Add(IPAddress.IPv6Loopback);
+                ApplyTrustedProxyCidrs(options);
+            });
             builder.Services
                 .AddWebdavBasicAuthentication(configManager)
                 .AddSingleton(configManager)
@@ -201,6 +216,8 @@ class Program
 
             // run
             var app = builder.Build();
+            // Must run before anything that reads Scheme/Host/RemoteIpAddress.
+            app.UseForwardedHeaders();
             _ = app.Services.GetRequiredService<QueueManager>();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
@@ -226,6 +243,28 @@ class Program
     private static LogEventLevel AtLeast(LogEventLevel configured, LogEventLevel minimum)
     {
         return configured > minimum ? configured : minimum;
+    }
+
+    private static void ApplyTrustedProxyCidrs(ForwardedHeadersOptions options)
+    {
+        var raw = EnvironmentUtil.GetEnvironmentVariable("TRUSTED_PROXY_CIDRS");
+        if (raw is null) return;
+
+        foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (System.Net.IPNetwork.TryParse(part, out var network))
+            {
+                options.KnownIPNetworks.Add(network);
+            }
+            else if (IPAddress.TryParse(part, out var proxyAddress))
+            {
+                options.KnownProxies.Add(proxyAddress);
+            }
+            else
+            {
+                Log.Warning("Ignoring invalid TRUSTED_PROXY_CIDRS entry: {Entry}", part);
+            }
+        }
     }
 
     private static void BlockUpgradesToV06X()

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -119,6 +119,8 @@ The image runs two processes: the frontend and public proxy on port `3000`, and 
 
 > [!IMPORTANT]
 > Port `3000` serves plain HTTP. If NzbDav will be reachable outside your trusted network, put it behind an HTTPS reverse proxy and do not expose the container port directly to the internet. WebDAV uses Basic authentication, so remote access without TLS exposes credentials. When the proxy runs on the Docker host, bind the port to localhost with `127.0.0.1:3000:3000`.
+>
+> For adapter/Newznab absolute links and STRM URLs, set an explicit **Base URL** under Settings (preferred). Without it, public scheme/host come only from trusted forwarded headers: the frontend strips client `X-Forwarded-*` and rewrites canonical values for the backend (which trusts loopback by default). TLS-terminating reverse proxies should set `TRUST_PROXY=1` on the container so Express honors the proxy’s forwarded headers when rewriting, **or** set Base URL explicitly — otherwise generated links may stay `http://`. Split-container topologies can widen backend trust with `TRUSTED_PROXY_CIDRS` (comma-separated IPs or CIDRs).
 
 ### 2. Core configuration
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -13,9 +13,20 @@ import {
   isExpectedBackendConnectionError,
   isWithinBackendStartupGrace,
 } from "./startup-grace";
+import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
 
 export const app = express();
 export const initializeWebsocketServer = websocketServer.initialize;
+
+const trustProxy =
+  process.env.TRUST_PROXY === "1"
+  || process.env.TRUST_PROXY?.toLowerCase() === "true"
+  || process.env.TRUST_PROXY?.toLowerCase() === "yes";
+if (trustProxy) {
+  // Opt-in: honor X-Forwarded-* from the reverse proxy in front of this container.
+  // Required for correct public scheme/host when rewriting headers to the backend.
+  app.set("trust proxy", 1);
+}
 
 let loggedStartupWait = false;
 let lastProxyFailureLogAt = 0;
@@ -42,6 +53,9 @@ const forwardToBackend = createProxyMiddleware({
   target: process.env.BACKEND_URL,
   changeOrigin: true,
   on: {
+    proxyReq: (proxyReq, req) => {
+      applyCanonicalForwardedHeaders(proxyReq, req as express.Request, { trustProxy });
+    },
     error: (error, req, res) => {
       logProxyFailure(
         `Backend proxy failed for ${req.method ?? "UNKNOWN"} ${req.url ?? "unknown URL"}`,
@@ -74,6 +88,9 @@ const credentialRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => {
+    // When TRUST_PROXY is set, req.ip reflects the client behind the reverse proxy.
+    // Default stays socket-IP keyed (spoof-safe without a trusted proxy story).
+    if (trustProxy && req.ip) return ipKeyGenerator(req.ip);
     const remoteAddress = req.socket.remoteAddress;
     return remoteAddress ? ipKeyGenerator(remoteAddress) : "unknown";
   },

--- a/frontend/server/forwarded-headers.test.ts
+++ b/frontend/server/forwarded-headers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type express from "express";
+import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
+
+describe("applyCanonicalForwardedHeaders", () => {
+  it("strips client forwarded headers and sets canonical values from the socket", () => {
+    const removed: string[] = [];
+    const set: Record<string, string> = {};
+    const proxyReq = {
+      removeHeader: (name: string) => {
+        removed.push(name);
+      },
+      setHeader: (name: string, value: string) => {
+        set[name] = value;
+      },
+    };
+
+    const req = {
+      protocol: "https",
+      get: (name: string) => (name.toLowerCase() === "host" ? "nzbdav.example" : undefined),
+      ip: "203.0.113.10",
+      socket: { remoteAddress: "10.0.0.2" },
+    } as unknown as express.Request;
+
+    applyCanonicalForwardedHeaders(proxyReq, req);
+
+    expect(removed).toEqual(
+      expect.arrayContaining([
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-forwarded-port",
+        "forwarded",
+      ]),
+    );
+    expect(set["X-Forwarded-Proto"]).toBe("https");
+    expect(set["X-Forwarded-Host"]).toBe("nzbdav.example");
+    expect(set["X-Forwarded-For"]).toBe("10.0.0.2");
+  });
+
+  it("uses req.ip when trustProxy is enabled", () => {
+    const set: Record<string, string> = {};
+    const proxyReq = {
+      removeHeader: () => {},
+      setHeader: (name: string, value: string) => {
+        set[name] = value;
+      },
+    };
+
+    const req = {
+      protocol: "https",
+      get: () => "nzbdav.example",
+      ip: "203.0.113.10",
+      socket: { remoteAddress: "10.0.0.2" },
+    } as unknown as express.Request;
+
+    applyCanonicalForwardedHeaders(proxyReq, req, { trustProxy: true });
+
+    expect(set["X-Forwarded-For"]).toBe("203.0.113.10");
+  });
+});

--- a/frontend/server/forwarded-headers.ts
+++ b/frontend/server/forwarded-headers.ts
@@ -1,0 +1,29 @@
+import type express from "express";
+
+/**
+ * Strip client-supplied forwarded headers and set canonical values from Express.
+ * Prevents spoofed X-Forwarded-* from being laundered through the loopback backend.
+ */
+export function applyCanonicalForwardedHeaders(
+  proxyReq: { removeHeader: (name: string) => void; setHeader: (name: string, value: string) => void },
+  req: express.Request,
+  options?: { trustProxy?: boolean },
+): void {
+  for (const header of [
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-forwarded-port",
+    "forwarded",
+  ]) {
+    proxyReq.removeHeader(header);
+  }
+
+  proxyReq.setHeader("X-Forwarded-Proto", req.protocol);
+  const host = req.get("host");
+  if (host) proxyReq.setHeader("X-Forwarded-Host", host);
+
+  const trustProxy = options?.trustProxy ?? false;
+  const clientIp = trustProxy ? req.ip : req.socket.remoteAddress;
+  if (clientIp) proxyReq.setHeader("X-Forwarded-For", clientIp);
+}

--- a/tests/NzbWebDAV.Tests/Extensions/GetPublicBaseUrlTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/GetPublicBaseUrlTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Tests.Extensions;
+
+public class GetPublicBaseUrlTests
+{
+    [Fact]
+    public void PrefersConfiguredBaseUrlOverRequest()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("evil.example");
+        context.Request.Headers["X-Forwarded-Proto"] = "https";
+        context.Request.Headers["X-Forwarded-Host"] = "evil.example";
+
+        var result = context.GetPublicBaseUrl("https://nzbdav.example");
+
+        Assert.Equal("https://nzbdav.example", result);
+    }
+
+    [Fact]
+    public void UsesRequestSchemeAndHostWhenBaseUrlIsDefault()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("nzbdav.example");
+        // Spoofed headers must be ignored — only Scheme/Host (post ForwardedHeaders) count.
+        context.Request.Headers["X-Forwarded-Proto"] = "http";
+        context.Request.Headers["X-Forwarded-Host"] = "evil.example";
+
+        var result = context.GetPublicBaseUrl("http://localhost:3000");
+
+        Assert.Equal("https://nzbdav.example", result);
+    }
+
+    [Fact]
+    public void UsesRequestSchemeAndHostWhenBaseUrlBlank()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("localhost:8080");
+
+        var result = context.GetPublicBaseUrl("");
+
+        Assert.Equal("http://localhost:8080", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Register ASP.NET `ForwardedHeadersMiddleware` with loopback KnownProxies; optional `TRUSTED_PROXY_CIDRS`.
- `GetPublicBaseUrl` uses `Request.Scheme`/`Host` only (never raw `X-Forwarded-*`).
- Frontend strips client forwarded headers and rewrites canonical values; opt-in `TRUST_PROXY=1` for Express trust + rate-limiter IP.
- Document Base URL / `TRUST_PROXY` / `TRUSTED_PROXY_CIDRS` in the setup guide.

## Reasoning
Backend-only loopback trust is insufficient: the frontend previously pass-through-laundered client `X-Forwarded-*` to the loopback backend. Coordinated strip+rewrite is required. TLS-terminating deployments that relied on unvalidated pass-through must set Base URL or `TRUST_PROXY` after this change.

Related: #216 (TRUST_PROXY for login rate limiter) — this PR implements the same env for rewriting and keys the limiter on `req.ip` when set.

## Test plan
- [x] `GetPublicBaseUrlTests`
- [x] `forwarded-headers.test.ts`
- [ ] Spoofed `X-Forwarded-Host` no longer appears in adapter links when Base URL unset
- [ ] With Base URL set, links ignore request headers

Fixes #231