### PR TITLE
fix(nntp): drain replaced clients before disposal

### DIFF
--- a/backend/Clients/Usenet/INntpConnectionStats.cs
+++ b/backend/Clients/Usenet/INntpConnectionStats.cs
@@ -1,0 +1,12 @@
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Exposes in-flight connection counts so replaced clients can drain before dispose.
+/// </summary>
+public interface INntpConnectionStats
+{
+    /// <summary>
+    /// Borrowed connections plus pending provider selections still holding capacity.
+    /// </summary>
+    int InFlightConnections { get; }
+}

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -78,6 +78,7 @@ public class MultiConnectionNntpClient(
     public int IdleConnections => connectionPool.IdleConnections;
     public int ActiveConnections => connectionPool.ActiveConnections;
     public int AvailableConnections => connectionPool.AvailableConnections;
+    public int InFlightConnections => ActiveConnections + PendingSelections;
 
     private int _pendingSelections;
     public int PendingSelections => Volatile.Read(ref _pendingSelections);

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -20,8 +20,9 @@ public class MultiProviderNntpClient(
     MetricsWriter? metricsWriter = null,
     ProviderBytesTracker? bytesTracker = null,
     Func<bool>? cascadeEnabled = null
-) : NntpClient
+) : NntpClient, INntpConnectionStats
 {
+    public int InFlightConnections => providers.Sum(p => p.InFlightConnections);
     private readonly ProviderUsageTracker _usageTracker = usageTracker ?? new ProviderUsageTracker();
     private static readonly AsyncLocal<Guid?> ReadSessionScope = new();
     internal static Guid? CurrentReadSessionId => ReadSessionScope.Value;

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -116,17 +116,19 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
 
     /// <summary>
     /// Test hook: swap with an explicit grace period and wait for the drain loop to finish.
+    /// Drains inline (no background loop) so exactly one consumer works the queue.
     /// </summary>
     internal Task ReplaceUnderlyingClientForTestsAsync(
         INntpClient usenetClient, TimeSpan gracePeriod, CancellationToken cancellationToken = default)
     {
         var old = _usenetClient;
         _usenetClient = usenetClient;
-        EnqueueForRetirement(old, DateTimeOffset.UtcNow + gracePeriod);
+        EnqueueForRetirement(old, DateTimeOffset.UtcNow + gracePeriod, startDrainLoop: false);
         return DrainRetiringClientsAsync(cancellationToken);
     }
 
-    private void EnqueueForRetirement(INntpClient old, DateTimeOffset? deadline = null)
+    private void EnqueueForRetirement(
+        INntpClient old, DateTimeOffset? deadline = null, bool startDrainLoop = true)
     {
         deadline ??= DateTimeOffset.UtcNow + RetirementGracePeriod;
 
@@ -140,7 +142,8 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
 
         Interlocked.Increment(ref _retiringCount);
         _retiringClients.Enqueue((old, deadline.Value));
-        EnsureDrainLoop();
+        if (startDrainLoop)
+            EnsureDrainLoop();
     }
 
     private void EnsureDrainLoop()

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -1,12 +1,24 @@
-﻿using NzbWebDAV.Clients.Usenet.Models;
+﻿using System.Collections.Concurrent;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models.Nzb;
+using Serilog;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
 
-public class WrappingNntpClient(INntpClient usenetClient) : NntpClient
+public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpConnectionStats
 {
+    private const int MaxRetiringClients = 4;
+    private static readonly TimeSpan RetirementGracePeriod = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DrainPollInterval = TimeSpan.FromMilliseconds(250);
+
     private INntpClient _usenetClient = usenetClient;
+    private readonly ConcurrentQueue<(INntpClient Client, DateTimeOffset Deadline)> _retiringClients = new();
+    private int _retiringCount;
+    private int _drainLoopRunning;
+
+    public int InFlightConnections =>
+        _usenetClient is INntpConnectionStats stats ? stats.InFlightConnections : 0;
 
     public override Task ConnectAsync(
         string host, int port, bool useSsl, CancellationToken cancellationToken) =>
@@ -91,16 +103,118 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient
         IReadOnlyList<string> segmentIds, int depth, CancellationToken cancellationToken) =>
         _usenetClient.DecodedArticlesPipelinedAsync(segmentIds, depth, cancellationToken);
 
+    /// <summary>
+    /// Swap the live client immediately so new requests use new pools, then retire the
+    /// old client after in-flight borrows drain (or a bounded grace period).
+    /// </summary>
     protected void ReplaceUnderlyingClient(INntpClient usenetClient)
     {
         var old = _usenetClient;
         _usenetClient = usenetClient;
-        if (old is IDisposable disposable)
-            disposable.Dispose();
+        EnqueueForRetirement(old);
+    }
+
+    /// <summary>
+    /// Test hook: swap with an explicit grace period and wait for the drain loop to finish.
+    /// </summary>
+    internal Task ReplaceUnderlyingClientForTestsAsync(
+        INntpClient usenetClient, TimeSpan gracePeriod, CancellationToken cancellationToken = default)
+    {
+        var old = _usenetClient;
+        _usenetClient = usenetClient;
+        EnqueueForRetirement(old, DateTimeOffset.UtcNow + gracePeriod);
+        return DrainRetiringClientsAsync(cancellationToken);
+    }
+
+    private void EnqueueForRetirement(INntpClient old, DateTimeOffset? deadline = null)
+    {
+        deadline ??= DateTimeOffset.UtcNow + RetirementGracePeriod;
+
+        // Bound stacked rapid saves: force-dispose the oldest excess clients.
+        while (Volatile.Read(ref _retiringCount) >= MaxRetiringClients
+               && _retiringClients.TryDequeue(out var excess))
+        {
+            Interlocked.Decrement(ref _retiringCount);
+            TryDispose(excess.Client, forced: true);
+        }
+
+        Interlocked.Increment(ref _retiringCount);
+        _retiringClients.Enqueue((old, deadline.Value));
+        EnsureDrainLoop();
+    }
+
+    private void EnsureDrainLoop()
+    {
+        if (Interlocked.CompareExchange(ref _drainLoopRunning, 1, 0) != 0)
+            return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await DrainRetiringClientsAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _drainLoopRunning, 0);
+                // A replace may have enqueued while we were clearing the flag.
+                if (!_retiringClients.IsEmpty)
+                    EnsureDrainLoop();
+            }
+        });
+    }
+
+    private async Task DrainRetiringClientsAsync(CancellationToken cancellationToken)
+    {
+        while (!_retiringClients.IsEmpty)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_retiringClients.TryPeek(out var next))
+                break;
+
+            var inFlight = next.Client is INntpConnectionStats stats
+                ? stats.InFlightConnections
+                : 0;
+            var expired = DateTimeOffset.UtcNow >= next.Deadline;
+
+            if (inFlight > 0 && !expired)
+            {
+                await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (!_retiringClients.TryDequeue(out next))
+                break;
+
+            Interlocked.Decrement(ref _retiringCount);
+            TryDispose(next.Client, forced: inFlight > 0);
+        }
+    }
+
+    private static void TryDispose(INntpClient client, bool forced)
+    {
+        try
+        {
+            if (forced)
+                Log.Debug("Force-disposing replaced NNTP client after grace period with in-flight work remaining");
+            client.Dispose();
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Failed to dispose replaced NNTP client");
+        }
     }
 
     public override void Dispose()
     {
+        // Dispose the live client and anything still retiring.
+        while (_retiringClients.TryDequeue(out var retiring))
+        {
+            Interlocked.Decrement(ref _retiringCount);
+            TryDispose(retiring.Client, forced: true);
+        }
+
         _usenetClient.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
@@ -1,0 +1,104 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models.Nzb;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class WrappingNntpClientRetirementTests
+{
+    [Fact]
+    public async Task ReplaceUnderlyingClient_DrainsUntilInFlightZero()
+    {
+        var oldClient = new CountingDisposableClient { InFlightConnections = 1 };
+        var wrapper = new TestWrappingClient(oldClient);
+        var newClient = new CountingDisposableClient();
+
+        var drainTask = wrapper.ReplaceUnderlyingClientForTestsAsync(
+            newClient, TimeSpan.FromSeconds(5));
+
+        Assert.False(oldClient.Disposed);
+
+        oldClient.InFlightConnections = 0;
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(oldClient.Disposed);
+        Assert.False(newClient.Disposed);
+        Assert.Equal(0, wrapper.InFlightConnections);
+    }
+
+    [Fact]
+    public async Task ReplaceUnderlyingClient_ForceDisposesAfterGracePeriod()
+    {
+        var oldClient = new CountingDisposableClient { InFlightConnections = 5 };
+        var wrapper = new TestWrappingClient(oldClient);
+        var newClient = new CountingDisposableClient();
+
+        await wrapper.ReplaceUnderlyingClientForTestsAsync(
+            newClient, TimeSpan.FromMilliseconds(50));
+
+        Assert.True(oldClient.Disposed);
+    }
+
+    private sealed class TestWrappingClient(INntpClient inner) : WrappingNntpClient(inner);
+
+    private sealed class CountingDisposableClient : NntpClient, INntpConnectionStats
+    {
+        public int InFlightConnections { get; set; }
+        public bool Disposed { get; private set; }
+
+        public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds, Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetYencHeader> GetYencHeadersAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<long> GetFileSizeAsync(NzbFile file, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+            Disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Swap `_usenetClient` immediately on provider config change; enqueue the old client for retirement.
- Background drain until `InFlightConnections == 0` (active borrows + pending selections) or 60s grace, then dispose.
- Bound retirement queue (max 4) for rapid successive saves; expose `INntpConnectionStats` through MultiProvider / Wrapping layers.

## Reasoning
Synchronous `Dispose()` on settings save aborts in-flight playback/queue borrows. Swap-first keeps new settings live; drain reduces `NotRetrieved` spikes. Forced dispose after grace may still fail in-flight work — goal is spike reduction, not eliminating forced teardown. Completion callbacks must still fire once per AGENTS.md invariants.

## Test plan
- [x] `WrappingNntpClientRetirementTests` (drain to zero; force after grace)
- [ ] Manual: change usenet providers during playback/queue download

Fixes #235