### PR TITLE
feat(ui): Overview 1h window and queue/nav polish

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -445,6 +445,7 @@ public class GetOverviewStatsController(
     private static (long WindowMs, long BucketSize, string Label) ResolveWindow(
         GetOverviewStatsRequest.OverviewWindow window, long nowMs) => window switch
         {
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour => (OneHour, OneMinute, "1h"),
             GetOverviewStatsRequest.OverviewWindow.Last24Hours => (OneDay, OneMinute, "24h"),
             GetOverviewStatsRequest.OverviewWindow.Last7Days => (7 * OneDay, OneHour, "7d"),
             GetOverviewStatsRequest.OverviewWindow.Last30Days => (30 * OneDay, OneHour, "30d"),
@@ -454,6 +455,7 @@ public class GetOverviewStatsController(
 
     private static long ResolveFailoverBucket(GetOverviewStatsRequest.OverviewWindow window) => window switch
     {
+        GetOverviewStatsRequest.OverviewWindow.Last1Hour => OneMinute,
         GetOverviewStatsRequest.OverviewWindow.Last24Hours => OneHour,
         GetOverviewStatsRequest.OverviewWindow.Last7Days => OneDay,
         GetOverviewStatsRequest.OverviewWindow.Last30Days => OneDay,
@@ -642,8 +644,12 @@ public class GetOverviewStatsController(
         GetOverviewStatsRequest.OverviewWindow window,
         IReadOnlyDictionary<string, string?> nicknamesByHost)
     {
-        var sparkBuckets = window == GetOverviewStatsRequest.OverviewWindow.Last7Days ? 168 : 24;
-        var sparkSize = OneHour;
+        var (sparkBuckets, sparkSize) = window switch
+        {
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour => (60, OneMinute),
+            GetOverviewStatsRequest.OverviewWindow.Last7Days => (168, OneHour),
+            _ => (24, OneHour),
+        };
         var sparkStart = windowStart - (windowStart % sparkSize);
 
         var byProvider = new Dictionary<string, ProviderAccumulator>();
@@ -780,6 +786,10 @@ public class GetOverviewStatsController(
 
         return window switch
         {
+            // Heatmap is hourly; for 1h reuse the day strip so the widget stays useful.
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour
+                => ("day", OneHour, hourEnd - 23 * OneHour, hourEnd),
+
             GetOverviewStatsRequest.OverviewWindow.Last24Hours
                 => ("day", OneHour, hourEnd - 23 * OneHour, hourEnd),
 

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsRequest.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsRequest.cs
@@ -17,11 +17,12 @@ public class GetOverviewStatsRequest
         {
             Window = w.ToLowerInvariant() switch
             {
+                "1h" => OverviewWindow.Last1Hour,
                 "24h" => OverviewWindow.Last24Hours,
                 "7d" => OverviewWindow.Last7Days,
                 "30d" => OverviewWindow.Last30Days,
                 "all" => OverviewWindow.AllTime,
-                _ => throw new BadHttpRequestException("Invalid window parameter (use 24h, 7d, 30d, or all)")
+                _ => throw new BadHttpRequestException("Invalid window parameter (use 1h, 24h, 7d, 30d, or all)")
             };
         }
 
@@ -53,6 +54,7 @@ public class GetOverviewStatsRequest
 
     public enum OverviewWindow
     {
+        Last1Hour,
         Last24Hours,
         Last7Days,
         Last30Days,

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -533,7 +533,7 @@ export enum RepairAction {
     ActionNeeded = 3,
 }
 
-export type OverviewWindow = "24h" | "7d" | "30d" | "all";
+export type OverviewWindow = "1h" | "24h" | "7d" | "30d" | "all";
 export type OverviewSections = "all" | "window" | "detail" | "static" | string;
 
 export type OverviewStatsResponse = {

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -60,8 +60,8 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
               tabIndex={0}
               className={
                 hasUpdate
-                  ? "btn btn-primary h-10 min-h-10 gap-2 rounded-box px-3"
-                  : "btn btn-ghost h-10 min-h-10 gap-2 rounded-[calc(var(--radius-box)-1px)] border-0 bg-base-200 px-3 hover:bg-base-200"
+                  ? "btn btn-primary h-10 min-h-10 shrink-0 gap-2 rounded-box px-4 whitespace-nowrap"
+                  : "btn btn-ghost h-10 min-h-10 shrink-0 gap-2 rounded-[calc(var(--radius-box)-1px)] border-0 bg-base-200 px-4 whitespace-nowrap hover:bg-base-200"
               }
               aria-label={hasUpdate ? "Update available" : "App menu"}
             >
@@ -72,7 +72,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
                 </>
               ) : (
                 <>
-                  <span className="inline-flex items-center gap-2">
+                  <span className="inline-flex items-center gap-2 whitespace-nowrap">
                     <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-base-content/40">
                       Stable
                     </span>

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -79,7 +79,7 @@ export function ThroughputChart({ points, totalArticles, totalMisses, totalError
     };
 
     const hasData = points.length > 0 && maxArticles > 0;
-    const bucketLabel = window === "24h" ? "min" : (window === "all" ? "day" : "hour");
+    const bucketLabel = window === "1h" || window === "24h" ? "min" : (window === "all" ? "day" : "hour");
     const hover = hoverIdx !== null ? points[hoverIdx] : null;
 
     return (
@@ -196,7 +196,7 @@ function Total({ label, value, accent }: { label: string, value: string, accent?
 
 function formatBucketTime(ms: number, window: OverviewWindow): string {
     const d = new Date(ms);
-    if (window === "24h") {
+    if (window === "1h" || window === "24h") {
         const hh = String(d.getHours()).padStart(2, "0");
         const mm = String(d.getMinutes()).padStart(2, "0");
         return `${hh}:${mm}`;

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -36,6 +36,7 @@ const topicSubscriptions = {
 };
 
 const WINDOWS: { value: OverviewWindow, label: string }[] = [
+    { value: "1h", label: "1h" },
     { value: "24h", label: "24h" },
     { value: "7d", label: "7d" },
     { value: "30d", label: "30d" },

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -7,7 +7,7 @@ import { formatFileSize } from "~/utils/file-size";
 import type { ProviderUsage } from "~/clients/backend-client.server";
 
 const desktopHeaderClass = "hidden min-[900px]:table-cell w-[120px] text-center text-xs font-semibold uppercase tracking-wide";
-const desktopCellClass = "hidden min-[900px]:table-cell max-w-[200px] whitespace-nowrap px-1 py-3 text-center align-middle";
+const desktopCellClass = "hidden min-[900px]:table-cell max-w-[200px] min-w-0 overflow-hidden whitespace-nowrap px-1 py-3 text-center align-middle";
 
 export type PageTableProps = {
     children?: ReactNode,
@@ -162,8 +162,10 @@ const MAX_INLINE_PROVIDERS = 3;
 export function ProvidersBadge({ providers }: { providers: ProviderUsage[] }) {
     if (providers.length === 0) return null;
     const total = providers.reduce((acc, p) => acc + p.segments, 0);
-    const visible = providers.slice(0, MAX_INLINE_PROVIDERS);
-    const hidden = providers.length - visible.length;
+    // When usage exists, hide idle (0%) hosts from the inline badge; keep them in the tooltip.
+    const forInline = total > 0 ? providers.filter(p => p.segments > 0) : providers;
+    const visible = forInline.slice(0, MAX_INLINE_PROVIDERS);
+    const hidden = forInline.length - visible.length;
     const labelOf = (p: ProviderUsage) => p.nickname?.trim() || stripHost(p.host);
     const tooltip = providers
         .map(p => total > 0
@@ -171,19 +173,19 @@ export function ProvidersBadge({ providers }: { providers: ProviderUsage[] }) {
             : `${labelOf(p)} (${p.host}): idle`)
         .join("\n");
     return (
-        <span className="badge badge-dash badge-ghost badge-sm inline-flex max-w-[240px] cursor-help items-baseline gap-1 truncate max-[899px]:max-w-full" title={tooltip}>
+        <span className="badge badge-dash badge-ghost badge-sm inline-flex max-w-full min-w-0 cursor-help items-baseline gap-1 overflow-hidden max-[899px]:max-w-full" title={tooltip}>
             {visible.map((p, i) => (
-                <span key={p.host} className="inline-flex items-baseline">
-                    {i > 0 && <span className="text-base-content/20 mx-0.5">·</span>}
-                    <span>{labelOf(p)}</span>
+                <span key={p.host} className="inline-flex min-w-0 shrink items-baseline overflow-hidden">
+                    {i > 0 && <span className="text-base-content/20 mx-0.5 shrink-0">·</span>}
+                    <span className="truncate">{labelOf(p)}</span>
                     {total > 0 && (
-                        <span className="text-base-content/50 ml-0.5 tabular-nums">
+                        <span className="text-base-content/50 ml-0.5 shrink-0 tabular-nums">
                             {Math.round((p.segments / total) * 100)}%
                         </span>
                     )}
                 </span>
             ))}
-            {hidden > 0 && <span className="text-base-content/50 ml-1">+{hidden}</span>}
+            {hidden > 0 && <span className="text-base-content/50 ml-1 shrink-0">+{hidden}</span>}
         </span>
     );
 }

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsRequestTests.cs
@@ -35,6 +35,7 @@ public class GetOverviewStatsRequestTests
     }
 
     [Theory]
+    [InlineData("1h", GetOverviewStatsRequest.OverviewWindow.Last1Hour)]
     [InlineData("24h", GetOverviewStatsRequest.OverviewWindow.Last24Hours)]
     [InlineData("7d", GetOverviewStatsRequest.OverviewWindow.Last7Days)]
     [InlineData("30d", GetOverviewStatsRequest.OverviewWindow.Last30Days)]


### PR DESCRIPTION
## Summary
- Add a 1-hour Overview activity window with per-minute buckets for throughput and related windowed stats
- Fix the queue Provider column so idle (0%) hosts stay out of the inline badge and no longer spill into Status
- Widen the top-nav version button and prevent wrapping so long build numbers stay on one line

## Test plan
- [ ] Overview: switch activity window to 1h and confirm chart/stats use finer buckets and look correct
- [ ] Queue: with an active download across multiple providers, Provider shows only used hosts (e.g. `newshosting 100%`) and Status stays aligned
- [ ] Hover Provider badge and confirm idle hosts still appear in the tooltip
- [ ] Top nav: with a long build/version string, version label stays on one line without wrapping