### PR TITLE
fix(nntp): route pipelined queue fetches through per-segment failover

### DIFF
--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -188,7 +188,7 @@ public class MultiConnectionNntpClient(
             try
             {
                 connectionLock = await connectionPool
-                    .GetConnectionLockAsync(SemaphorePriority.High, ct)
+                    .GetConnectionLockAsync(GetDownloadPriority(ct), ct)
                     .ConfigureAwait(false);
                 var batch = await connectionLock.Connection.DecodedBodiesAsync(
                     segmentIds, deferredCallback.Invoke, ct).ConfigureAwait(false);

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -781,73 +781,23 @@ public class MultiProviderNntpClient(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         if (segmentIds.Count == 0) yield break;
-        var orderedProviders = SelectOrderedProviders(out var reserved);
-        using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
-        var primary = orderedProviders.Count > 0 ? orderedProviders[0] : null;
-        if (primary == null) yield break;
-        var effectiveDepth = ResolveDepth(primary, depth);
-        var stopwatch = Stopwatch.StartNew();
 
-        await foreach (var result in primary.DecodedBodiesPipelinedAsync(segmentIds, effectiveDepth, cancellationToken)
-                           .WithCancellation(cancellationToken).ConfigureAwait(false))
+        // Resolve per-provider depth without holding a reservation across the whole
+        // enumeration — each DecodedBodiesAsync batch selects providers itself and
+        // already records metrics / wraps streams for byte counting.
+        int effectiveDepth;
         {
-            stopwatch.Stop();
-            if (result.Found)
-            {
-                _usageTracker.RecordSuccess(primary.Host);
-                RecordFetch(primary.Host, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, 0);
-                yield return WrapPipelinedBody(result, primary.Host);
-            }
-            else
-            {
-                RecordFetch(primary.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, 0);
-                yield return result;
-            }
-            stopwatch.Restart();
+            var orderedProviders = SelectOrderedProviders(out var reserved);
+            using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
+            var primary = orderedProviders.Count > 0 ? orderedProviders[0] : null;
+            if (primary == null) yield break;
+            effectiveDepth = ResolveDepth(primary, depth);
         }
-    }
 
-    public override async IAsyncEnumerable<PipelinedArticleResult> DecodedArticlesPipelinedAsync(
-        IReadOnlyList<string> segmentIds, int depth,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        if (segmentIds.Count == 0) yield break;
-        var orderedProviders = SelectOrderedProviders(out var reserved);
-        using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
-        var primary = orderedProviders.Count > 0 ? orderedProviders[0] : null;
-        if (primary == null) yield break;
-        var effectiveDepth = ResolveDepth(primary, depth);
-        var stopwatch = Stopwatch.StartNew();
-
-        await foreach (var result in primary.DecodedArticlesPipelinedAsync(segmentIds, effectiveDepth, cancellationToken)
+        await foreach (var result in base.DecodedBodiesPipelinedAsync(
+                           segmentIds, effectiveDepth, cancellationToken)
                            .WithCancellation(cancellationToken).ConfigureAwait(false))
-        {
-            stopwatch.Stop();
-            if (result.Found)
-            {
-                _usageTracker.RecordSuccess(primary.Host);
-                RecordFetch(primary.Host, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, 0);
-                yield return WrapPipelinedArticle(result, primary.Host);
-            }
-            else
-            {
-                RecordFetch(primary.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, 0);
-                yield return result;
-            }
-            stopwatch.Restart();
-        }
-    }
-
-    private PipelinedBodyResult WrapPipelinedBody(PipelinedBodyResult result, string host)
-    {
-        if (bytesTracker == null || result.Stream == null) return result;
-        return result with { Stream = new CountingYencStream(result.Stream, bytesTracker, host) };
-    }
-
-    private PipelinedArticleResult WrapPipelinedArticle(PipelinedArticleResult result, string host)
-    {
-        if (bytesTracker == null || result.Stream == null) return result;
-        return result with { Stream = new CountingYencStream(result.Stream, bytesTracker, host) };
+            yield return result;
     }
 
     private static void InvokeCompletionCallback(

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Streams;
+using Serilog;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
@@ -309,6 +310,26 @@ public abstract class NntpClient : INntpClient
                 throw new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage);
             }
 
+            if (HasSegmentIdMismatch(segmentId, response.SegmentId, response.ResponseMessage, out var actualId))
+            {
+                Log.Warning(
+                    "Pipelined BODY SegmentId mismatch: expected {Expected}, got {Actual} (message: {Message}). " +
+                    "Treating as not found so queue rescue can refetch.",
+                    NormalizeSegmentId(segmentId), actualId, response.ResponseMessage);
+                if (response.Stream != null)
+                {
+                    try { await response.Stream.DisposeAsync().ConfigureAwait(false); }
+                    catch (Exception e) { Log.Debug(e, "Failed to dispose mismatched pipelined BODY stream"); }
+                }
+
+                return new PipelinedBodyResult
+                {
+                    SegmentId = segmentId,
+                    Found = false,
+                    Stream = null,
+                };
+            }
+
             return new PipelinedBodyResult
             {
                 SegmentId = segmentId,
@@ -325,6 +346,60 @@ public abstract class NntpClient : INntpClient
                 Stream = null,
             };
         }
+    }
+
+    /// <summary>
+    /// Returns true when the response carries a different message-id than requested.
+    /// Prefers <see cref="UsenetDecodedBodyResponse.SegmentId"/> when set; also checks
+    /// a <c>&lt;mid&gt;</c> echoed in <c>ResponseMessage</c> (typical 222 form). Cache /
+    /// synthetic responses without a wire id are treated as matching.
+    /// </summary>
+    internal static bool HasSegmentIdMismatch(
+        string requestedSegmentId,
+        string? responseSegmentId,
+        string? responseMessage,
+        out string actualId)
+    {
+        var expected = NormalizeSegmentId(requestedSegmentId);
+        actualId = "";
+
+        var responseId = NormalizeSegmentId(responseSegmentId);
+        if (responseId.Length > 0 &&
+            !string.Equals(responseId, expected, StringComparison.OrdinalIgnoreCase))
+        {
+            actualId = responseId;
+            return true;
+        }
+
+        if (TryExtractMessageIdFromResponseMessage(responseMessage, out var wireId) &&
+            !string.Equals(NormalizeSegmentId(wireId), expected, StringComparison.OrdinalIgnoreCase))
+        {
+            actualId = NormalizeSegmentId(wireId);
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static string NormalizeSegmentId(string? id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) return "";
+        var trimmed = id.Trim();
+        if (trimmed.Length >= 2 && trimmed[0] == '<' && trimmed[^1] == '>')
+            trimmed = trimmed[1..^1];
+        return trimmed;
+    }
+
+    internal static bool TryExtractMessageIdFromResponseMessage(string? message, out string messageId)
+    {
+        messageId = "";
+        if (string.IsNullOrEmpty(message)) return false;
+        var start = message.IndexOf('<');
+        if (start < 0) return false;
+        var end = message.IndexOf('>', start + 1);
+        if (end < 0) return false;
+        messageId = message[(start + 1)..end];
+        return messageId.Length > 0;
     }
 
     public virtual async Task CheckAllSegmentsPipelinedAsync

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -48,20 +48,44 @@ public static class FetchFirstSegmentsStep
         var depth = configManager.GetPipeliningDepth();
         var segmentIds = files.Select(x => x.Segments[0].MessageId).ToList();
         var results = new NzbFileWithFirstSegment?[files.Count];
+        var indexBySegmentId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < files.Count; i++)
+        {
+            var key = NntpClient.NormalizeSegmentId(files[i].Segments[0].MessageId);
+            if (key.Length > 0)
+                indexBySegmentId.TryAdd(key, i);
+        }
         var completed = 0;
-        var index = 0;
 
         try
         {
             await foreach (var article in usenetClient.DecodedArticlesPipelinedAsync(segmentIds, depth, cancellationToken)
                                .WithCancellation(cancellationToken).ConfigureAwait(false))
             {
-                var i = index++;
+                var key = NntpClient.NormalizeSegmentId(article.SegmentId);
+                if (key.Length == 0 || !indexBySegmentId.TryGetValue(key, out var i))
+                {
+                    Log.Warning(
+                        "Pipelined first-segment result SegmentId {SegmentId} did not match any pending file; leaving for rescue",
+                        article.SegmentId);
+                    if (article.Stream != null)
+                    {
+                        try { await article.Stream.DisposeAsync().ConfigureAwait(false); }
+                        catch (Exception e) { Log.Debug(e, "Failed to dispose unmatched first-segment stream"); }
+                    }
+                    continue;
+                }
+
                 if (article.Found && article.Stream != null)
                 {
                     results[i] = await BuildFirstSegment(files[i], article.Stream, article.ArticleHeaders, cancellationToken)
                         .ConfigureAwait(false);
                     progress?.Report(++completed);
+                }
+                else if (article.Stream != null)
+                {
+                    try { await article.Stream.DisposeAsync().ConfigureAwait(false); }
+                    catch (Exception e) { Log.Debug(e, "Failed to dispose missing first-segment stream"); }
                 }
             }
         }
@@ -147,6 +171,9 @@ public static class FetchFirstSegmentsStep
 
         var first16KB = totalRead < buffer.Length ? buffer.AsSpan(0, totalRead).ToArray() : buffer;
         var yencHeaders = await stream.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
+        if (yencHeaders is not null)
+            nzbFile.Segments[0].ByteRange =
+                LongRange.FromStartAndSize(yencHeaders.PartOffset, yencHeaders.PartSize);
 
         return new NzbFileWithFirstSegment
         {

--- a/docs/nntp-pipelining.md
+++ b/docs/nntp-pipelining.md
@@ -53,10 +53,12 @@ pipelining helps at your connection count.
 
 ## Limitations
 
-- **Cross-provider failover mid-batch is limited.** A batch runs on the selected
-  provider; per-segment failover to a backup provider mid-batch is not performed.
-  Misses degrade gracefully per consumer:
-  - queue first-segment → marked `MissingFirstSegment` (name still recoverable via par2)
-  - streaming → handled by the WebDAV batch path and provider failover logic
-  - health check → concurrent per-segment failover across providers
-- The segment cache bypasses pipelined queue paths when caching is enabled.
+- **Queue / WebDAV pipelined BODY batches use the same per-segment failover as
+  `DecodedBodiesAsync`.** Each depth-sized chunk selects an ordered provider list
+  and retries individual misses on the primary (then backups) before yielding
+  `Found = false`. Queue first-segment rescue still re-fetches any remaining null
+  slots with full per-article failover.
+- **`StatsPipelinedAsync` remains primary-only.** Health checks use concurrent
+  per-segment `STAT` with failover elsewhere, so this does not affect correctness.
+- The per-queue-item article cache bypasses pipelined queue paths when caching is
+  enabled (pre-existing; first segments may be re-fetched during RAR header parse).

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -113,28 +113,102 @@ public class MultiProviderNntpClientTests
         Assert.Equal(1, connection.BatchRequests);
     }
 
-    [Theory]
-    [InlineData(222)]
-    [InlineData(430)]
-    public async Task PipelinedBodyResponse_RecordsFetchMetric(int responseCode)
+    [Fact]
+    public async Task PipelinedBodyResponse_RecordsFetchMetric_OnSuccess()
     {
         var writer = new MetricsWriter();
         var connection = new ScriptedNntpClient
         {
-            BatchResponseCode = responseCode,
-            SingularResponseCode = responseCode,
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
         };
         using var client = new MultiProviderNntpClient(
             [CreateProvider(connection)], metricsWriter: writer);
 
-        await foreach (var result in client.DecodedBodiesPipelinedAsync(
-                           ["segment"], 1, CancellationToken.None))
-            if (result.Stream != null)
-                await result.Stream.DisposeAsync();
+        var results = await CollectPipelinedAsync(client, ["segment"], 1);
+        Assert.Single(results);
+        Assert.True(results[0].Found);
+        if (results[0].Stream != null)
+            await results[0].Stream.DisposeAsync();
 
+        // Exactly one fetch — must not double-count override metrics + DecodedBodiesAsync.
         Assert.Equal(1, writer.Stats.QueuedFetches);
         Assert.Equal(1, connection.BatchRequests);
         Assert.Equal(0, connection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task PipelinedBody_PrimaryMiss_FailsOverToBackup()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primary, host: "a.example"),
+            CreateProvider(backup, host: "b.example"),
+        ]);
+
+        var results = await CollectPipelinedAsync(client, ["segment"], depth: 2);
+
+        Assert.Single(results);
+        Assert.True(results[0].Found);
+        Assert.NotNull(results[0].Stream);
+        await results[0].Stream!.DisposeAsync();
+        Assert.True(primary.BatchRequests >= 1);
+        Assert.True(primary.SingularRequests >= 1);
+        Assert.Equal(1, backup.SingularRequests);
+    }
+
+    [Fact]
+    public async Task PipelinedBody_SuccessfulPrimary_DoesNotCallBackup()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primary, host: "a.example"),
+            CreateProvider(backup, host: "b.example"),
+        ]);
+
+        var results = await CollectPipelinedAsync(client, ["seg-a", "seg-b"], depth: 2);
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.True(r.Found));
+        foreach (var result in results)
+            if (result.Stream != null)
+                await result.Stream.DisposeAsync();
+        Assert.Equal(1, primary.BatchRequests);
+        Assert.Equal(0, primary.SingularRequests);
+        Assert.Equal(0, backup.BatchRequests);
+        Assert.Equal(0, backup.SingularRequests);
+    }
+
+    private static async Task<List<PipelinedBodyResult>> CollectPipelinedAsync(
+        MultiProviderNntpClient client,
+        IReadOnlyList<string> segmentIds,
+        int depth)
+    {
+        var results = new List<PipelinedBodyResult>();
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           segmentIds, depth, CancellationToken.None))
+            results.Add(result);
+        return results;
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -1,0 +1,179 @@
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class NntpClientPipelinedMappingTests
+{
+    [Theory]
+    [InlineData("seg@example.com", "seg@example.com")]
+    [InlineData("<seg@example.com>", "seg@example.com")]
+    [InlineData(" <seg@example.com> ", "seg@example.com")]
+    public void NormalizeSegmentId_StripsAngleBrackets(string input, string expected)
+    {
+        Assert.Equal(expected, NntpClient.NormalizeSegmentId(input));
+    }
+
+    [Fact]
+    public void HasSegmentIdMismatch_IgnoresSyntheticMessagesWithoutWireId()
+    {
+        Assert.False(NntpClient.HasSegmentIdMismatch(
+            "seg@example.com",
+            "seg@example.com",
+            "222 - Article retrieved from file cache",
+            out _));
+    }
+
+    [Fact]
+    public void HasSegmentIdMismatch_DetectsWrongResponseSegmentId()
+    {
+        Assert.True(NntpClient.HasSegmentIdMismatch(
+            "expected@example.com",
+            "wrong@example.com",
+            "222 scripted response",
+            out var actual));
+        Assert.Equal("wrong@example.com", actual);
+    }
+
+    [Fact]
+    public void HasSegmentIdMismatch_DetectsWrongWireMessageId()
+    {
+        Assert.True(NntpClient.HasSegmentIdMismatch(
+            "expected@example.com",
+            "expected@example.com", // echoed request id would hide a scramble
+            "222 0 <wrong@example.com>",
+            out var actual));
+        Assert.Equal("wrong@example.com", actual);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_MismatchedWireId_ReturnsNotFound()
+    {
+        using var client = new MismatchedSegmentNntpClient(
+            requestedId: "expected@example.com",
+            responseSegmentId: "expected@example.com",
+            responseMessage: "222 0 <wrong@example.com>");
+
+        PipelinedBodyResult? result = null;
+        await foreach (var item in client.DecodedBodiesPipelinedAsync(
+                           ["expected@example.com"], 1, CancellationToken.None))
+            result = item;
+
+        Assert.NotNull(result);
+        Assert.False(result.Found);
+        Assert.Null(result.Stream);
+        Assert.Equal("expected@example.com", result.SegmentId);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_MatchingIds_ReturnsFound()
+    {
+        using var client = new MismatchedSegmentNntpClient(
+            requestedId: "seg@example.com",
+            responseSegmentId: "seg@example.com",
+            responseMessage: "222 0 <seg@example.com>");
+
+        PipelinedBodyResult? result = null;
+        await foreach (var item in client.DecodedBodiesPipelinedAsync(
+                           ["seg@example.com"], 1, CancellationToken.None))
+            result = item;
+
+        Assert.NotNull(result);
+        Assert.True(result.Found);
+        Assert.NotNull(result.Stream);
+        await result.Stream!.DisposeAsync();
+    }
+
+    private sealed class MismatchedSegmentNntpClient(
+        string requestedId,
+        string responseSegmentId,
+        string responseMessage) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            Assert.Equal(requestedId, segmentId.ToString());
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(CreateResponse());
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            Assert.Single(segmentIds);
+            Assert.Equal(requestedId, segmentIds[0].ToString());
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch
+            {
+                Responses = [Task.FromResult(CreateResponse())],
+            });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        private UsenetDecodedBodyResponse CreateResponse()
+        {
+            var payload = Encoding.ASCII.GetBytes("payload");
+            var headers = new UsenetYencHeader
+            {
+                FileName = "fake.bin",
+                FileSize = payload.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = payload.Length,
+            };
+            return new UsenetDecodedBodyResponse
+            {
+                SegmentId = responseSegmentId,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = responseMessage,
+                Stream = new CachedYencStream(headers, new MemoryStream(payload, writable: false)),
+            };
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
@@ -1,0 +1,270 @@
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class FetchFirstSegmentsStepTests
+{
+    [Fact]
+    public async Task FetchFirstSegments_PipelinedMismatch_RescuesViaPerArticlePath()
+    {
+        var config = CreatePipeliningConfig(enabled: true, depth: 4);
+        using var client = new MismatchThenRescueNntpClient();
+        var files = new List<NzbFile>
+        {
+            CreateFile("a@example.com", "\"a.rar\" yEnc"),
+            CreateFile("b@example.com", "\"b.rar\" yEnc"),
+        };
+
+        var results = await FetchFirstSegmentsStep.FetchFirstSegments(
+            files, client, config, CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.False(r.MissingFirstSegment));
+        Assert.All(results, r => Assert.NotNull(r.First16KB));
+        Assert.Equal(2, client.ArticleFetches);
+        Assert.Equal(1, client.PipelinedEnumerations);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_PipelinedSuccess_SetsByteRangeFromYencHeaders()
+    {
+        var config = CreatePipeliningConfig(enabled: true, depth: 2);
+        var payload = Encoding.ASCII.GetBytes(new string('x', 64));
+        using var client = new MatchingPipelinedNntpClient(new Dictionary<string, byte[]>
+        {
+            ["seg@example.com"] = payload,
+        });
+        var file = CreateFile("seg@example.com", "\"movie.rar\" yEnc");
+
+        var result = Assert.Single(await FetchFirstSegmentsStep.FetchFirstSegments(
+            [file], client, config, CancellationToken.None));
+
+        Assert.False(result.MissingFirstSegment);
+        Assert.NotNull(result.Header);
+        Assert.NotNull(file.Segments[0].ByteRange);
+        Assert.Equal(result.Header!.PartOffset, file.Segments[0].ByteRange!.StartInclusive);
+        Assert.Equal(result.Header.PartSize, file.Segments[0].ByteRange!.Count);
+        Assert.Equal(0, client.ArticleFetches);
+    }
+
+    private static ConfigManager CreatePipeliningConfig(bool enabled, int depth)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetPipeliningEnabled,
+                ConfigValue = enabled ? "true" : "false",
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetPipeliningDepth,
+                ConfigValue = depth.ToString(),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetMaxQueueConnections,
+                ConfigValue = "5",
+            },
+        ]);
+        return config;
+    }
+
+    private static NzbFile CreateFile(string messageId, string subject) => new()
+    {
+        Subject = subject,
+        Segments =
+        {
+            new NzbSegment { MessageId = messageId, Bytes = 100 },
+        },
+    };
+
+    private static CachedYencStream CreateCachedStream(byte[] payload, long partOffset = 0)
+    {
+        var headers = new UsenetYencHeader
+        {
+            FileName = "fake.bin",
+            FileSize = partOffset + payload.Length,
+            LineLength = 128,
+            PartNumber = 1,
+            TotalParts = 1,
+            PartOffset = partOffset,
+            PartSize = payload.Length,
+        };
+        return new CachedYencStream(headers, new MemoryStream(payload, writable: false));
+    }
+
+    private sealed class MismatchThenRescueNntpClient : NntpClient
+    {
+        public int PipelinedEnumerations { get; private set; }
+        public int ArticleFetches { get; private set; }
+
+        public override async IAsyncEnumerable<PipelinedArticleResult> DecodedArticlesPipelinedAsync(
+            IReadOnlyList<string> segmentIds,
+            int depth,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            PipelinedEnumerations++;
+            // Wrong SegmentId → FetchFirstSegments leaves slots null for rescue.
+            foreach (var _ in segmentIds)
+            {
+                yield return new PipelinedArticleResult
+                {
+                    SegmentId = "unknown@example.com",
+                    Found = true,
+                    Stream = CreateCachedStream(Encoding.ASCII.GetBytes("wrong")),
+                    ArticleHeaders = null,
+                };
+            }
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            ArticleFetches++;
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedArticleResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220 article",
+                Stream = CreateCachedStream(Encoding.ASCII.GetBytes(segmentId.ToString())),
+                ArticleHeaders = new UsenetArticleHeader
+                {
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Date"] = DateTimeOffset.UtcNow.ToString("R"),
+                    },
+                },
+            });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class MatchingPipelinedNntpClient(IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public int ArticleFetches { get; private set; }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds.Select(id =>
+            {
+                var key = id.ToString();
+                var bytes = segments[key];
+                return Task.FromResult(new UsenetDecodedBodyResponse
+                {
+                    SegmentId = key,
+                    ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                    ResponseMessage = $"222 0 <{key}>",
+                    Stream = CreateCachedStream(bytes, partOffset: 100),
+                });
+            }).ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            ArticleFetches++;
+            throw new InvalidOperationException("Rescue path should not run for matching pipelined results");
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, cancellationToken);
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Route queue NNTP pipelined BODY/ARTICLE fetches through `DecodedBodiesAsync` so mid-batch misses get the same per-segment provider failover as non-pipelined downloads (previously primary-only).
- Guard wire-level SegmentId mismatches so bad `Found=true` bodies are discarded and rescued via the per-article path; match first-segment results by SegmentId and set yEnc `ByteRange` on the pipelined path.
- Keep queue batch connection acquires at Low priority (`GetDownloadPriority`) so imports do not compete with WebDAV streaming at High.

## Test plan
- [x] Focused tests: MultiProvider failover + single-fetch metrics, SegmentId mismatch mapping, FetchFirstSegments rescue + ByteRange (`29` passed)
- [ ] Re-enable NNTP pipelining at depth > 1 and re-queue a previously failing multi-volume RAR NZB (same blob preferred)
- [ ] Confirm queue imports still succeed with pipelining disabled / depth `1`
- [ ] Spot-check WebDAV playback under load while a queue import is running (priority separation)