### PR TITLE
fix: fresh-database startup crash and Remove Orphaned Files stuck in Running

### DIFF
--- a/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesController.cs
+++ b/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesController.cs
@@ -17,6 +17,8 @@ public class RemoveUnlinkedFilesController(
     {
         var task = new RemoveUnlinkedFilesTask(configManager, websocketManager, isDryRun: false);
         var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed)
+            return Conflict(new { error = "Remove Orphaned Files task is already running." });
         return Ok(executed);
     }
 }

--- a/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesDryRunController.cs
+++ b/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesDryRunController.cs
@@ -17,6 +17,8 @@ public class RemoveUnlinkedFilesDryRunController(
     {
         var task = new RemoveUnlinkedFilesTask(configManager, websocketManager, isDryRun: true);
         var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed)
+            return Conflict(new { error = "Remove Orphaned Files task is already running." });
         return Ok(executed);
     }
 }

--- a/backend/Database/DatabaseStartupGuards.cs
+++ b/backend/Database/DatabaseStartupGuards.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace NzbWebDAV.Database;
+
+/// <summary>
+/// Shared checks used during process startup / --db-migration before the schema is known to exist.
+/// </summary>
+internal static class DatabaseStartupGuards
+{
+    public const string V06BreakingMigration = "20260226053712_Add-NzbBlobId-And-NzbNames";
+
+    /// <summary>
+    /// True when the operational database has a <c>ConfigItems</c> table.
+    /// Fresh / WAL-created empty files do not, so callers must not query config yet.
+    /// </summary>
+    public static async Task<bool> ConfigItemsTableExistsAsync(
+        DbContext databaseContext,
+        CancellationToken cancellationToken = default)
+    {
+        var count = await databaseContext.Database
+            .SqlQueryRaw<int>(
+                """
+                SELECT COUNT(*) AS Value
+                FROM sqlite_master
+                WHERE type = 'table' AND name = 'ConfigItems'
+                """)
+            .FirstAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return count > 0;
+    }
+
+    /// <summary>
+    /// Whether startup should refuse to continue until the operator sets <c>UPGRADE=0.6.0</c>.
+    /// A WAL-created empty <c>db.sqlite</c> (no applied migrations) is a fresh install, not an upgrade.
+    /// </summary>
+    public static bool ShouldBlockUpgradeToV06X(
+        bool databaseFileExists,
+        IEnumerable<string> appliedMigrations,
+        IEnumerable<string> pendingMigrations,
+        string? upgradeEnv)
+    {
+        if (!databaseFileExists)
+            return false;
+
+        if (!appliedMigrations.Any())
+            return false;
+
+        if (!pendingMigrations.Contains(V06BreakingMigration))
+            return false;
+
+        return upgradeEnv != "0.6.0";
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -269,24 +269,24 @@ class Program
 
     private static void BlockUpgradesToV06X()
     {
-        // If the database file doesn't exist.
-        // Then this is a new installation.
-        // Do nothing.
-        if (!File.Exists(DavDatabaseContext.DatabaseFilePath)) return;
+        var databaseFileExists = File.Exists(DavDatabaseContext.DatabaseFilePath);
+        IEnumerable<string> appliedMigrations = [];
+        IEnumerable<string> pendingMigrations = [];
+        if (databaseFileExists)
+        {
+            using var databaseContext = new DavDatabaseContext();
+            appliedMigrations = databaseContext.Database.GetAppliedMigrations().ToList();
+            pendingMigrations = databaseContext.Database.GetPendingMigrations().ToList();
+        }
 
-        // If there is no pending database migration,
-        // Then the user has already upgraded.
-        // Do nothing.
-        using var databaseContext = new DavDatabaseContext();
-        const string migration = "20260226053712_Add-NzbBlobId-And-NzbNames";
-        var hasPendingMigration = databaseContext.Database.GetPendingMigrations().Contains(migration);
-        if (!hasPendingMigration) return;
-
-        // If the user has set the UPGRADE env variable,
-        // Then they have acknowledged the upgrade message.
-        // Do nothing.
-        var upgradeEnv = EnvironmentUtil.GetEnvironmentVariable("UPGRADE");
-        if (upgradeEnv == "0.6.0") return;
+        if (!DatabaseStartupGuards.ShouldBlockUpgradeToV06X(
+                databaseFileExists,
+                appliedMigrations,
+                pendingMigrations,
+                EnvironmentUtil.GetEnvironmentVariable("UPGRADE")))
+        {
+            return;
+        }
 
         // Otherwise, display the upgrade message, and exit.
         Log.Fatal(
@@ -407,6 +407,16 @@ class Program
 
     private static async Task<bool> IsDatabaseStartupVacuumEnabledAsync()
     {
+        // Fresh / WAL-created empty databases have no ConfigItems table yet. Querying
+        // it before migrations run is what broke brand-new installs after #269.
+        await using var databaseContext = new DavDatabaseContext();
+        if (!await DatabaseStartupGuards
+                .ConfigItemsTableExistsAsync(databaseContext, SigtermUtil.GetCancellationToken())
+                .ConfigureAwait(false))
+        {
+            return false;
+        }
+
         var configManager = new ConfigManager();
         await configManager.LoadConfig().ConfigureAwait(false);
         return configManager.IsDatabaseStartupVacuumEnabled();

--- a/backend/Tasks/BaseTask.cs
+++ b/backend/Tasks/BaseTask.cs
@@ -34,4 +34,22 @@ public abstract class BaseTask
         await task.ConfigureAwait(false);
         return true;
     }
+
+    /// <summary>
+    /// Clears the shared single-flight slot. Tests only.
+    /// </summary>
+    internal static async Task ResetRunningTaskForTestsAsync()
+    {
+        await Semaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_runningTask is { IsCompleted: false })
+                await _runningTask.ConfigureAwait(false);
+            _runningTask = null;
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
 }

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -12,12 +13,15 @@ namespace NzbWebDAV.Tasks;
 public class RemoveUnlinkedFilesTask(
     ConfigManager configManager,
     WebsocketManager websocketManager,
-    bool isDryRun
+    bool isDryRun,
+    Func<DavDatabaseContext>? createContext = null
 ) : BaseTask
 {
     private static List<string> _allRemovedPaths = [];
 
     private record UnlinkedItemInfo(string Id, int Type, string Path);
+
+    private DavDatabaseContext CreateContext() => createContext?.Invoke() ?? new DavDatabaseContext();
 
     protected override async Task ExecuteInternal()
     {
@@ -37,7 +41,7 @@ public class RemoveUnlinkedFilesTask(
         // get linked file paths
         Report("Scanning all linked files...");
         var startTime = DateTime.Now;
-        var linkedIdCount = await WriteLinkedIdsToTable();
+        var linkedIdCount = await WriteLinkedIdsToTable().ConfigureAwait(false);
         if (linkedIdCount < 5)
         {
             Report($"Aborted: " +
@@ -47,7 +51,7 @@ public class RemoveUnlinkedFilesTask(
         }
 
         Report("Searching for unlinked webdav items...");
-        var unlinkedItems = await CountUnlinkedItems(startTime);
+        var unlinkedItems = await CountUnlinkedItems(startTime).ConfigureAwait(false);
         Report($"Found {unlinkedItems} webdav items to remove.");
 
         // The `linkedIdCount < 5` check above only catches a COMPLETELY empty scan. A library
@@ -56,7 +60,7 @@ public class RemoveUnlinkedFilesTask(
         // unlinked. Refuse to delete an implausible share of the deletable population.
         // A healthy library here sits around 31% unlinked (samples, nfos, unimported extras),
         // so 90% leaves wide headroom while still catching a broken scan.
-        var deletableItems = await CountDeletableItems(startTime);
+        var deletableItems = await CountDeletableItems(startTime).ConfigureAwait(false);
         var extremeUnlinkedRatio = deletableItems > 0 && unlinkedItems > deletableItems * 0.9;
         if (extremeUnlinkedRatio)
         {
@@ -78,20 +82,20 @@ public class RemoveUnlinkedFilesTask(
 
         if (isDryRun)
         {
-            await DryRunIdentifyUnlinkedFiles(startTime);
+            await DryRunIdentifyUnlinkedFiles(startTime).ConfigureAwait(false);
             Report($"Done. Identified {_allRemovedPaths.Count} unlinked files.");
         }
         else
         {
-            await RemoveUnlinkedItems(startTime, unlinkedItems);
-            await RemoveEmptyDirectories(startTime);
+            await RemoveUnlinkedItems(startTime, unlinkedItems).ConfigureAwait(false);
+            await RemoveEmptyDirectories(startTime).ConfigureAwait(false);
             Report($"Done. Removed {_allRemovedPaths.Count} unlinked files.");
         }
     }
 
     private async Task<int> WriteLinkedIdsToTable()
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
 
         // Create a new table "TMP_LINKED_FILES", dropping old one if it already exists.
         // No index initially for fast writes.
@@ -99,18 +103,13 @@ public class RemoveUnlinkedFilesTask(
             """
             DROP TABLE IF EXISTS TMP_LINKED_FILES;
             CREATE TABLE TMP_LINKED_FILES (Id TEXT NOT NULL);
-            """);
+            """).ConfigureAwait(false);
 
         var count = 0;
         var batches = GetLinkedIds().ToBatches(100);
         foreach (var batch in batches)
         {
-            foreach (var id in batch)
-            {
-                var idStr = id.ToString().ToUpperInvariant();
-                await dbContext.Database.ExecuteSqlAsync(
-                    $"INSERT INTO TMP_LINKED_FILES (Id) VALUES ({idStr})");
-            }
+            await InsertLinkedIdBatchAsync(dbContext, batch).ConfigureAwait(false);
             count += batch.Count;
         }
 
@@ -123,9 +122,38 @@ public class RemoveUnlinkedFilesTask(
             INSERT OR IGNORE INTO TMP_LINKED_FILES_UNIQUE (Id) SELECT Id FROM TMP_LINKED_FILES;
             DROP TABLE TMP_LINKED_FILES;
             ALTER TABLE TMP_LINKED_FILES_UNIQUE RENAME TO TMP_LINKED_FILES;
-            """);
+            """).ConfigureAwait(false);
 
         return count;
+    }
+
+    /// <summary>
+    /// Parameterized multi-row INSERT so large libraries do not pay one round-trip per id.
+    /// </summary>
+    internal static async Task InsertLinkedIdBatchAsync(
+        DavDatabaseContext dbContext,
+        IReadOnlyList<Guid> batch,
+        CancellationToken cancellationToken = default)
+    {
+        if (batch.Count == 0)
+            return;
+
+        var parameters = new SqliteParameter[batch.Count];
+        var valueSql = new string[batch.Count];
+        for (var i = 0; i < batch.Count; i++)
+        {
+            var name = $"@p{i}";
+            valueSql[i] = $"({name})";
+            parameters[i] = new SqliteParameter(name, batch[i].ToString().ToUpperInvariant());
+        }
+
+        // Parameter names are generated locally (@p0..@pN); values are bound via SqliteParameter.
+#pragma warning disable EF1002
+        await dbContext.Database.ExecuteSqlRawAsync(
+            $"INSERT INTO TMP_LINKED_FILES (Id) VALUES {string.Join(",", valueSql)}",
+            parameters.AsEnumerable(),
+            cancellationToken).ConfigureAwait(false);
+#pragma warning restore EF1002
     }
 
     private IEnumerable<Guid> GetLinkedIds()
@@ -153,7 +181,7 @@ public class RemoveUnlinkedFilesTask(
     /// </summary>
     private async Task<int> CountDeletableItems(DateTime createdBefore)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
 
         return await dbContext.Database
@@ -164,12 +192,13 @@ public class RemoveUnlinkedFilesTask(
                    AND i.HistoryItemId IS NULL
                    AND i.CreatedAt < {createdBefore}
                  """)
-            .FirstAsync();
+            .FirstAsync()
+            .ConfigureAwait(false);
     }
 
     private async Task<int> CountUnlinkedItems(DateTime createdBefore)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
 
         // LEFT JOIN is equivalent to the NOT IN subquery used by RemoveUnlinkedItems /
@@ -185,7 +214,8 @@ public class RemoveUnlinkedFilesTask(
                    AND i.CreatedAt < {createdBefore}
                    AND t.Id IS NULL
                  """)
-            .FirstAsync();
+            .FirstAsync()
+            .ConfigureAwait(false);
 
         return count;
     }
@@ -194,7 +224,7 @@ public class RemoveUnlinkedFilesTask(
     {
         Report("Removing unlinked items...");
         _allRemovedPaths.Clear();
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var removed = 0;
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
 
@@ -211,7 +241,8 @@ public class RemoveUnlinkedFilesTask(
                        AND Id NOT IN (SELECT Id FROM TMP_LINKED_FILES)
                      LIMIT 100
                      """)
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
 
             // If there are no more items to delete, we're done.
             if (itemsToDelete.Count == 0)
@@ -219,9 +250,19 @@ public class RemoveUnlinkedFilesTask(
 
             // Delete the items via parameterized Contains (no string-built IN list).
             var idsToDelete = itemsToDelete.Select(x => Guid.Parse(x.Id)).ToList();
-            await dbContext.Items
+            var deleted = await dbContext.Items
                 .Where(x => idsToDelete.Contains(x.Id))
-                .ExecuteDeleteAsync();
+                .ExecuteDeleteAsync()
+                .ConfigureAwait(false);
+
+            // A batch that selects rows but deletes none would loop forever with a climbing
+            // counter. Throw so ExecuteInternal reports a terminal "Failed:" status.
+            if (deleted == 0)
+            {
+                throw new InvalidOperationException(
+                    $"selected {itemsToDelete.Count} unlinked items but deleted 0; " +
+                    $"aborting to avoid an infinite loop.");
+            }
 
             // Trigger rclone vfs/forget for deleted items
             _ = DavDatabaseContext.RcloneVfsForget(itemsToDelete.Select(x => new DavItem
@@ -233,7 +274,7 @@ public class RemoveUnlinkedFilesTask(
 
             // Track removed paths
             _allRemovedPaths.AddRange(itemsToDelete.Select(x => x.Path));
-            removed += itemsToDelete.Count;
+            removed += deleted;
 
             Report($"Removing unlinked items...\nRemoved {removed}/{totalCount}...");
         }
@@ -244,63 +285,113 @@ public class RemoveUnlinkedFilesTask(
     private async Task RemoveEmptyDirectories(DateTime createdBefore)
     {
         Report($"Removing empty directories...");
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
+        await RemoveEmptyDirectoriesAsync(
+            dbContext,
+            createdBefore,
+            removedSoFar => Report($"Removing empty directories...\nRemoved {removedSoFar}..."),
+            dirs => DavDatabaseContext.RcloneVfsForget(dirs),
+            CancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes empty regular directories in batches and returns the number removed. Throws if a
+    /// selected batch deletes 0 rows, which would otherwise loop forever with a climbing counter.
+    /// </summary>
+    internal static async Task<int> RemoveEmptyDirectoriesAsync(
+        DavDatabaseContext dbContext,
+        DateTime createdBefore,
+        Action<int>? onProgress = null,
+        Func<List<DavItem>, Task>? onDeleted = null,
+        CancellationToken cancellationToken = default)
+    {
         var removed = 0;
         var directorySubType = (int)DavItem.ItemSubType.Directory;
 
         while (true)
         {
-            // Find empty directories (no children).
-            // Only target regular directories (SubType = Directory), not root folders.
+            // NOT EXISTS uses IX_DavItems_ParentId_Name's ParentId prefix; avoid the
+            // previous LEFT JOIN anti-join which rescanned poorly at large scale.
             var emptyDirs = await dbContext.Database
                 .SqlQuery<UnlinkedItemInfo>(
                     $"""
-                     SELECT d.Id, d.Type, d.Path FROM DavItems d
-                     LEFT JOIN DavItems c ON c.ParentId = d.Id
+                     SELECT d.Id AS Id, d.Type AS Type, d.Path AS Path FROM DavItems d
                      WHERE d.SubType = {directorySubType}
                        AND d.CreatedAt < {createdBefore}
-                       AND c.Id IS NULL
+                       AND NOT EXISTS (
+                           SELECT 1 FROM DavItems c WHERE c.ParentId = d.Id
+                       )
                      LIMIT 100
                      """)
-                .ToListAsync();
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             if (emptyDirs.Count == 0)
                 break;
 
             var idsToDelete = emptyDirs.Select(x => Guid.Parse(x.Id)).ToList();
-            await dbContext.Items
+            var deleted = await dbContext.Items
                 .Where(x => idsToDelete.Contains(x.Id))
-                .ExecuteDeleteAsync();
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-            // Trigger rclone vfs/forget for deleted directories
-            _ = DavDatabaseContext.RcloneVfsForget(emptyDirs.Select(x => new DavItem
+            if (deleted == 0)
             {
-                Id = Guid.Parse(x.Id),
-                Type = (DavItem.ItemType)x.Type,
-                Path = x.Path
-            }).ToList());
+                throw new InvalidOperationException(
+                    $"selected {emptyDirs.Count} empty directories but deleted 0; " +
+                    $"aborting to avoid an infinite loop.");
+            }
 
-            removed += emptyDirs.Count;
-            Report($"Removing empty directories...\nRemoved {removed}...");
+            if (onDeleted is not null)
+            {
+                _ = onDeleted(emptyDirs.Select(x => new DavItem
+                {
+                    Id = Guid.Parse(x.Id),
+                    Type = (DavItem.ItemType)x.Type,
+                    Path = x.Path
+                }).ToList());
+            }
+
+            removed += deleted;
+            onProgress?.Invoke(removed);
         }
+
+        return removed;
     }
 
     private async Task DryRunIdentifyUnlinkedFiles(DateTime createdBefore)
     {
-        await using var dbContext = new DavDatabaseContext();
+        _allRemovedPaths.Clear();
+        await using var dbContext = CreateContext();
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
-        var unlinkedFiles = await dbContext.Database
-            .SqlQuery<UnlinkedItemInfo>(
-                $"""
-                 SELECT Id, Type, Path FROM DavItems
-                 WHERE Type = {usenetFileType}
-                   AND HistoryItemId IS NULL
-                   AND CreatedAt < {createdBefore}
-                   AND Id NOT IN (SELECT Id FROM TMP_LINKED_FILES)
-                 """)
-            .ToListAsync();
+        // Keyset pagination: LIMIT/OFFSET without ORDER BY has no stable order in SQLite,
+        // which can duplicate or skip rows across batches.
+        var lastId = string.Empty;
 
-        _allRemovedPaths = unlinkedFiles.Select(x => x.Path).ToList();
+        while (true)
+        {
+            var batch = await dbContext.Database
+                .SqlQuery<UnlinkedItemInfo>(
+                    $"""
+                     SELECT Id, Type, Path FROM DavItems
+                     WHERE Type = {usenetFileType}
+                       AND HistoryItemId IS NULL
+                       AND CreatedAt < {createdBefore}
+                       AND Id > {lastId}
+                       AND Id NOT IN (SELECT Id FROM TMP_LINKED_FILES)
+                     ORDER BY Id
+                     LIMIT 100
+                     """)
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            if (batch.Count == 0)
+                break;
+
+            _allRemovedPaths.AddRange(batch.Select(x => x.Path));
+            lastId = batch[^1].Id;
+            Report($"Identifying unlinked files...\nFound {_allRemovedPaths.Count}...");
+        }
     }
 
     private void Report(string message)
@@ -315,4 +406,6 @@ public class RemoveUnlinkedFilesTask(
             ? string.Join("\n", _allRemovedPaths)
             : "This list is Empty.\nYou must first run the task.";
     }
+
+    internal static void ClearAuditPathsForTests() => _allRemovedPaths = [];
 }

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -75,6 +75,12 @@ public class WebsocketManager
         return Task.WhenAll(authenticatedSockets.Select(x => SendMessage(x, bytes)));
     }
 
+    internal string? PeekLastMessage(WebsocketTopic topic)
+    {
+        lock (_lastMessage)
+            return _lastMessage.TryGetValue(topic, out var message) ? message : null;
+    }
+
     /// <summary>
     /// Ensure a websocket sends a valid api key.
     /// </summary>

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -15,13 +15,16 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
     const [connected, setConnected] = useState<boolean>(false);
     const [progress, setProgress] = useState<string | null>(null);
     const [isFetching, setIsFetching] = useState<boolean>(false);
+    // Replayed non-terminal ctp state must not look like an active run until the user clicks.
+    const [runStarted, setRunStarted] = useState<boolean>(false);
+    const [statusError, setStatusError] = useState<string | null>(null);
     const progressMessage = progress?.replace('Dry Run - ', '');
 
     // derived variables
     const libraryDir = savedConfig["media.library-dir"];
     const isDone = progressMessage?.startsWith("Done");
     const isFinished = progressMessage?.startsWith("Done") || progressMessage?.startsWith("Failed") || progressMessage?.startsWith("Aborted");
-    const isRunning = !isFinished && (isFetching || progress !== null);
+    const isRunning = !isFinished && (isFetching || runStarted);
     const isRunButtonEnabled = !!libraryDir && connected && !isRunning;
     const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
     const runButtonLabel = isRunning ? "Running..." : "Run Task";
@@ -41,18 +44,45 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
         return connect();
     }, [setProgress, setConnected]);
 
+    useEffect(() => {
+        if (isFinished)
+            setRunStarted(false);
+    }, [isFinished]);
+
+    const startTask = useCallback(async (url: string) => {
+        setStatusError(null);
+        // Clear any stale terminal message so isFinished doesn't mask the new run
+        // until its first progress message arrives.
+        setProgress(null);
+        setRunStarted(true);
+        setIsFetching(true);
+        try {
+            const response = await fetch(url);
+            if (response.status === 409) {
+                setStatusError("Task already running.");
+                setRunStarted(false);
+                return;
+            }
+            if (!response.ok) {
+                setStatusError(`Request failed (${response.status}).`);
+                setRunStarted(false);
+            }
+        } catch {
+            setStatusError("Request failed.");
+            setRunStarted(false);
+        } finally {
+            setIsFetching(false);
+        }
+    }, []);
+
     // events
     const onRun = useCallback(async () => {
-        setIsFetching(true);
-        await fetch("/api/remove-unlinked-files");
-        setIsFetching(false);
-    }, [setIsFetching]);
+        await startTask("/api/remove-unlinked-files");
+    }, [startTask]);
 
-    const onDryRun = useCallback(async (event: any) => {
-        setIsFetching(true);
-        await fetch("/api/remove-unlinked-files/dry-run");
-        setIsFetching(false);
-    }, [setIsFetching]);
+    const onDryRun = useCallback(async () => {
+        await startTask("/api/remove-unlinked-files/dry-run");
+    }, [startTask]);
 
     // view
     const dryRunButton =
@@ -106,7 +136,7 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
                             {runButtonLabel}
                         </Button>
                         <div className={'font-mono text-xs text-slate-300'}>
-                            {progress}
+                            {statusError ?? progress}
                             {isDone && <>
                                 &nbsp;<a href="/api/remove-unlinked-files/audit">Audit.</a>
                             </>}

--- a/tests/NzbWebDAV.Tests/Database/DatabaseStartupGuardsTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseStartupGuardsTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+
+namespace NzbWebDAV.Tests.Database;
+
+public class DatabaseStartupGuardsTests
+{
+    [Theory]
+    [InlineData(false, false, false, null, false)]
+    [InlineData(true, false, true, null, false)] // empty WAL file: applied=none, pending=yes → fresh install
+    [InlineData(true, true, true, null, true)] // real pre-0.6 DB without acknowledgement
+    [InlineData(true, true, true, "0.6.0", false)] // acknowledged
+    [InlineData(true, true, false, null, false)] // already past the breaking migration
+    public void ShouldBlockUpgradeToV06X_MatchesFreshVsUpgradeSemantics(
+        bool databaseFileExists,
+        bool hasAppliedMigrations,
+        bool hasPendingBreakingMigration,
+        string? upgradeEnv,
+        bool expectedBlock)
+    {
+        var applied = hasAppliedMigrations
+            ? new[] { "20250529081501_InitializeDatabase" }
+            : Array.Empty<string>();
+        var pending = hasPendingBreakingMigration
+            ? new[] { DatabaseStartupGuards.V06BreakingMigration }
+            : Array.Empty<string>();
+
+        Assert.Equal(
+            expectedBlock,
+            DatabaseStartupGuards.ShouldBlockUpgradeToV06X(
+                databaseFileExists,
+                applied,
+                pending,
+                upgradeEnv));
+    }
+
+    [Fact]
+    public async Task ConfigItemsTableExistsAsync_ReturnsFalse_OnEmptySqliteFile()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-startup-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            // Mimic a WAL-created empty file: open and close without migrating.
+            await using (var bootstrap = new SqliteBootstrapContext(databasePath))
+            {
+                await bootstrap.Database.OpenConnectionAsync();
+                await bootstrap.Database.ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;");
+            }
+
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .Options;
+            await using var ctx = new DavDatabaseContext(options);
+            Assert.False(await DatabaseStartupGuards.ConfigItemsTableExistsAsync(ctx));
+        }
+        finally
+        {
+            TryDelete(databasePath);
+            TryDelete(databasePath + "-wal");
+            TryDelete(databasePath + "-shm");
+        }
+    }
+
+    [Fact]
+    public async Task ConfigItemsTableExistsAsync_ReturnsTrue_AfterMigrate()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-startup-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            await using var ctx = new DavDatabaseContext(options);
+            await ctx.Database.MigrateAsync();
+            Assert.True(await DatabaseStartupGuards.ConfigItemsTableExistsAsync(ctx));
+        }
+        finally
+        {
+            TryDelete(databasePath);
+            TryDelete(databasePath + "-wal");
+            TryDelete(databasePath + "-shm");
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Minimal context so we can create an empty sqlite file without EF migrations.
+    /// </summary>
+    private sealed class SqliteBootstrapContext(string path) : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseSqlite($"Data Source={path}");
+    }
+}

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -1,0 +1,260 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Tasks;
+
+[Collection(nameof(BaseTaskCollection))]
+public class RemoveUnlinkedFilesTaskTests
+{
+    [Fact]
+    public async Task RemoveEmptyDirectoriesAsync_RemovesNestedEmptyDirsAndTerminates()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        var createdBefore = DateTime.Now.AddMinutes(1);
+
+        var parent = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "show");
+        var child = NewDir(Guid.NewGuid(), parent, "season");
+        var grandchild = NewDir(Guid.NewGuid(), child, "empty");
+        // keptFile under ContentFolder keeps that root non-empty; empty show/season tree is removed.
+        var keptFile = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "keep.mkv",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        await SeedRootsAsync(ctx);
+        ctx.Items.AddRange(parent, child, grandchild, keptFile);
+        await ctx.SaveChangesAsync();
+
+        var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
+            ctx,
+            createdBefore);
+
+        Assert.True(removed >= 2);
+        Assert.False(await ctx.Items.AnyAsync(x => x.Id == grandchild.Id));
+        Assert.False(await ctx.Items.AnyAsync(x => x.Id == child.Id));
+        Assert.False(await ctx.Items.AnyAsync(x => x.Id == parent.Id));
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == keptFile.Id));
+    }
+
+    [Fact]
+    public async Task RemoveEmptyDirectoriesAsync_ReturnsZero_WhenNoEmptyDirectories()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        await SeedRootsAsync(ctx);
+        var file = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "only.mkv",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        ctx.Items.Add(file);
+        await ctx.SaveChangesAsync();
+
+        var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
+            ctx,
+            DateTime.Now.AddMinutes(1));
+
+        Assert.Equal(0, removed);
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == file.Id));
+    }
+
+    [Fact]
+    public async Task Execute_ReturnsFalse_WhenAnotherTaskIsRunning()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        try
+        {
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var longRunning = new BlockingTask(gate.Task);
+            var run = longRunning.Execute();
+
+            // Give the long-running task time to claim the single-flight slot.
+            await Task.Delay(50);
+            var second = new NoOpTask();
+            Assert.False(await second.Execute());
+
+            gate.SetResult();
+            Assert.True(await run);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DryRun_ReportsDone_WithTerminalProgress()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Combine(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+
+            var linkedIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToList();
+            var orphanId = Guid.NewGuid();
+            foreach (var id in linkedIds.Append(orphanId))
+            {
+                ctx.Items.Add(DavItem.New(
+                    id,
+                    DavItem.ContentFolder,
+                    $"{id:N}.mkv",
+                    10,
+                    DavItem.ItemType.UsenetFile,
+                    DavItem.ItemSubType.NzbFile,
+                    null,
+                    null,
+                    null,
+                    null));
+            }
+
+            await ctx.SaveChangesAsync();
+
+            foreach (var id in linkedIds)
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(libraryDir, $"{id:N}.strm"),
+                    $"http://localhost/view/.ids/{id}.mkv");
+            }
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var task = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.StartsWith("Dry Run - Done.", progress);
+            Assert.Contains("Identified 1 unlinked files", progress);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task InsertLinkedIdBatchAsync_InsertsAllIds()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        await ctx.Database.ExecuteSqlRawAsync(
+            """
+            DROP TABLE IF EXISTS TMP_LINKED_FILES;
+            CREATE TABLE TMP_LINKED_FILES (Id TEXT NOT NULL);
+            """);
+
+        var ids = Enumerable.Range(0, 3).Select(_ => Guid.NewGuid()).ToList();
+        await RemoveUnlinkedFilesTask.InsertLinkedIdBatchAsync(ctx, ids);
+
+        var count = await ctx.Database
+            .SqlQueryRaw<int>("SELECT COUNT(*) AS Value FROM TMP_LINKED_FILES")
+            .FirstAsync();
+        Assert.Equal(3, count);
+    }
+
+    private static DavItem NewDir(Guid id, DavItem parent, string name) =>
+        DavItem.New(id, parent, name, null, DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+
+    private static async Task SeedRootsAsync(DavDatabaseContext ctx)
+    {
+        // Migrations already insert roots; ensure local references match persisted rows.
+        if (!await ctx.Items.AnyAsync(x => x.Id == DavItem.Root.Id))
+            ctx.Items.Add(DavItem.Root);
+        if (!await ctx.Items.AnyAsync(x => x.Id == DavItem.ContentFolder.Id))
+            ctx.Items.Add(DavItem.ContentFolder);
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class BlockingTask(Task gate) : BaseTask
+    {
+        protected override Task ExecuteInternal() => gate;
+    }
+
+    private sealed class NoOpTask : BaseTask
+    {
+        protected override Task ExecuteInternal() => Task.CompletedTask;
+    }
+
+    private sealed class TempDb : IAsyncDisposable
+    {
+        private readonly string _path;
+        private TempDb(string path, DavDatabaseContext context)
+        {
+            _path = path;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public DavDatabaseContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={_path}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            return new DavDatabaseContext(options);
+        }
+
+        public static async Task<TempDb> CreateAsync()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"nzbdav-unlinked-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync();
+            return new TempDb(path, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try { File.Delete(_path); } catch { /* best effort */ }
+            try { File.Delete(_path + "-wal"); } catch { /* best effort */ }
+            try { File.Delete(_path + "-shm"); } catch { /* best effort */ }
+        }
+    }
+}
+
+[CollectionDefinition(nameof(BaseTaskCollection))]
+public class BaseTaskCollection : ICollectionFixture<object>;


### PR DESCRIPTION
## Summary

Fixes two user-reported bugs from Discord:

**Fresh database never reaches onboarding** (`SQLite Error 1: 'no such table: ConfigItems'`)
- The `--db-migration` path called `ConfigManager.LoadConfig()` (for the startup-vacuum setting) *before* EF migrations created the `ConfigItems` table, crashing every fresh install (regression from #269).
- The WAL pragma had already created `db.sqlite`, so restarts misclassified the empty file as a pre-0.6 upgrade and demanded `UPGRADE=0.6.0` — an unrecoverable restart loop.
- Fix: guard the vacuum check behind a `sqlite_master` lookup (new `DatabaseStartupGuards`), and make `BlockUpgradesToV06X` treat a database with zero applied migrations as a fresh install.

**Remove Orphaned Files stuck in "Running..." forever**
- Backend: the empty-directory phase re-ran a full-table `LEFT JOIN` anti-join per 100-row batch and counted *selected* rows rather than *deleted* rows, so large libraries (one report: "Removed 748804...") or a silently-failing delete batch never reached a terminal status. Now uses `NOT EXISTS` (served by the `(ParentId, Name)` index prefix) and throws on a zero-row delete so the task reports a terminal `Failed:`. Also restores batched parameterized `TMP_LINKED_FILES` inserts (lost in #198) and paginates dry-run identification with keyset ordering + progress.
- API: controllers return `409 Conflict` when the single-flight task slot is occupied (e.g. a scheduled run in progress) instead of `Ok(false)`.
- UI: "Running..." was derived from *any* non-terminal replayed websocket message, and a failed fetch left `isFetching` stuck. Now tracks an explicit run-started flag cleared on terminal progress, wraps fetch in `try/finally`, and surfaces the 409 as "Task already running."

Note: empty cleanup tables during a dry run are expected behavior (dry runs perform no deletes, so the `AFTER DELETE` triggers never fire) — not part of the bug.

## Test plan

- [x] New tests: `DatabaseStartupGuardsTests` (fresh-install detection, `ConfigItems` guard) and `RemoveUnlinkedFilesTaskTests` (nested empty-dir removal terminates, no-op when nothing empty, concurrent `Execute()` rejected, dry run reaches terminal `Done`, batched inserts) — all passing
- [x] Frontend typecheck, build, and vitest suite pass
- [x] Full backend suite: only pre-existing failures on `main` (`NzbFileStreamTests` / `ArticleCachingNntpClientTests`, verified via stash) remain
- [ ] Manual: fresh empty `/config` boots through `--db-migration` to onboarding
- [ ] Manual: dry-run and real run of Remove Orphaned Files reach Done; second click during a run shows "Task already running."