### PR TITLE
fix: RemoveUnlinkedFilesTask CI failures (Guid casing + dash pipefail)

### DIFF
--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -156,6 +156,34 @@ public class RemoveUnlinkedFilesTask(
 #pragma warning restore EF1002
     }
 
+    /// <summary>
+    /// Deletes DavItems by the exact Id text returned from a raw SELECT. Going through
+    /// Guid.Parse + ExecuteDelete re-serializes Ids as uppercase, which silently misses
+    /// rows stored lowercase (e.g. the folder seeded by the Fix-Empty-Categories migration).
+    /// </summary>
+    private static async Task<int> DeleteItemsByIdTextAsync(
+        DavDatabaseContext dbContext,
+        IReadOnlyList<UnlinkedItemInfo> items,
+        CancellationToken cancellationToken = default)
+    {
+        var parameters = new SqliteParameter[items.Count];
+        var placeholders = new string[items.Count];
+        for (var i = 0; i < items.Count; i++)
+        {
+            var name = $"@p{i}";
+            placeholders[i] = name;
+            parameters[i] = new SqliteParameter(name, items[i].Id);
+        }
+
+        // Placeholder names are generated locally (@p0..@pN); values are bound via SqliteParameter.
+#pragma warning disable EF1002
+        return await dbContext.Database.ExecuteSqlRawAsync(
+            $"DELETE FROM DavItems WHERE Id IN ({string.Join(",", placeholders)})",
+            parameters.AsEnumerable(),
+            cancellationToken).ConfigureAwait(false);
+#pragma warning restore EF1002
+    }
+
     private IEnumerable<Guid> GetLinkedIds()
     {
         var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(500));
@@ -248,11 +276,8 @@ public class RemoveUnlinkedFilesTask(
             if (itemsToDelete.Count == 0)
                 break;
 
-            // Delete the items via parameterized Contains (no string-built IN list).
-            var idsToDelete = itemsToDelete.Select(x => Guid.Parse(x.Id)).ToList();
-            var deleted = await dbContext.Items
-                .Where(x => idsToDelete.Contains(x.Id))
-                .ExecuteDeleteAsync()
+            // Delete by the exact Id text from the select so stored casing never matters.
+            var deleted = await DeleteItemsByIdTextAsync(dbContext, itemsToDelete)
                 .ConfigureAwait(false);
 
             // A batch that selects rows but deletes none would loop forever with a climbing
@@ -329,10 +354,9 @@ public class RemoveUnlinkedFilesTask(
             if (emptyDirs.Count == 0)
                 break;
 
-            var idsToDelete = emptyDirs.Select(x => Guid.Parse(x.Id)).ToList();
-            var deleted = await dbContext.Items
-                .Where(x => idsToDelete.Contains(x.Id))
-                .ExecuteDeleteAsync(cancellationToken)
+            // Delete by the exact Id text from the select so stored casing never matters
+            // (the Fix-Empty-Categories migration seeds a lowercase-Id folder).
+            var deleted = await DeleteItemsByIdTextAsync(dbContext, emptyDirs, cancellationToken)
                 .ConfigureAwait(false);
 
             if (deleted == 0)

--- a/backend/Utils/SymlinkAndStrmUtil.cs
+++ b/backend/Utils/SymlinkAndStrmUtil.cs
@@ -18,10 +18,12 @@ public static class SymlinkAndStrmUtil
 
     private static IEnumerable<ISymlinkOrStrmInfo> GetAllSymlinksAndStrmsLinux(string directoryPath)
     {
-        // pipefail so find traversal errors (permission denied, etc.) are not masked by xargs.
+        // find -exec (instead of piping to xargs) keeps traversal errors (permission
+        // denied, etc.) in find's own exit code without `set -o pipefail`, which
+        // Ubuntu's dash (/bin/sh) does not support.
         const string command =
             """
-            set -o pipefail; find . \( -type l -o -name '*.strm' \) -print0 | xargs -0 sh -c '
+            find . \( -type l -o -name '*.strm' \) -exec sh -c '
               for path in \"$@\"; do
                 echo \"$path\"
                 if [ \"${path##*.}\" = \"strm\" ]; then
@@ -30,7 +32,7 @@ public static class SymlinkAndStrmUtil
                   echo \"$(readlink \"$path\")\"
                 fi
               done
-            ' sh
+            ' sh {} +
             """;
 
         var escapedDirectory = directoryPath.Replace("'", "'\"'\"'");

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -56,7 +56,6 @@ public class RemoveUnlinkedFilesTaskTests
         await using var harness = await TempDb.CreateAsync();
         var ctx = harness.Context;
         await SeedRootsAsync(ctx);
-        await FillSeededEmptyDirectoriesAsync(ctx);
         var file = DavItem.New(
             Guid.NewGuid(),
             DavItem.ContentFolder,
@@ -71,9 +70,16 @@ public class RemoveUnlinkedFilesTaskTests
         ctx.Items.Add(file);
         await ctx.SaveChangesAsync();
 
+        // Drain migration-seeded empty category folders (e.g. /content/uncategorized
+        // from Fix-Empty-Categories). Filling them via EF fails: ParentId is stored
+        // uppercase while the seeded folder Id is lowercase, so raw SQL still sees
+        // the folder as empty.
+        var createdBefore = DateTime.Now.AddMinutes(1);
+        await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(ctx, createdBefore);
+
         var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
             ctx,
-            DateTime.Now.AddMinutes(1));
+            createdBefore);
 
         Assert.Equal(0, removed);
         Assert.True(await ctx.Items.AnyAsync(x => x.Id == file.Id));
@@ -200,35 +206,6 @@ public class RemoveUnlinkedFilesTaskTests
             ctx.Items.Add(DavItem.Root);
         if (!await ctx.Items.AnyAsync(x => x.Id == DavItem.ContentFolder.Id))
             ctx.Items.Add(DavItem.ContentFolder);
-        await ctx.SaveChangesAsync();
-    }
-
-    /// <summary>
-    /// Migrations seed an empty category folder (e.g. /content/uncategorized), which the
-    /// task legitimately removes. Give each such folder a child so "no empty directories"
-    /// scenarios actually start with none.
-    /// </summary>
-    private static async Task FillSeededEmptyDirectoriesAsync(DavDatabaseContext ctx)
-    {
-        var emptyDirs = await ctx.Items
-            .Where(d => d.SubType == DavItem.ItemSubType.Directory
-                        && !ctx.Items.Any(c => c.ParentId == d.Id))
-            .ToListAsync();
-        foreach (var dir in emptyDirs)
-        {
-            ctx.Items.Add(DavItem.New(
-                Guid.NewGuid(),
-                dir,
-                "placeholder.mkv",
-                10,
-                DavItem.ItemType.UsenetFile,
-                DavItem.ItemSubType.NzbFile,
-                null,
-                null,
-                null,
-                null));
-        }
-
         await ctx.SaveChangesAsync();
     }
 

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -56,6 +56,7 @@ public class RemoveUnlinkedFilesTaskTests
         await using var harness = await TempDb.CreateAsync();
         var ctx = harness.Context;
         await SeedRootsAsync(ctx);
+        await FillSeededEmptyDirectoriesAsync(ctx);
         var file = DavItem.New(
             Guid.NewGuid(),
             DavItem.ContentFolder,
@@ -199,6 +200,35 @@ public class RemoveUnlinkedFilesTaskTests
             ctx.Items.Add(DavItem.Root);
         if (!await ctx.Items.AnyAsync(x => x.Id == DavItem.ContentFolder.Id))
             ctx.Items.Add(DavItem.ContentFolder);
+        await ctx.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Migrations seed an empty category folder (e.g. /content/uncategorized), which the
+    /// task legitimately removes. Give each such folder a child so "no empty directories"
+    /// scenarios actually start with none.
+    /// </summary>
+    private static async Task FillSeededEmptyDirectoriesAsync(DavDatabaseContext ctx)
+    {
+        var emptyDirs = await ctx.Items
+            .Where(d => d.SubType == DavItem.ItemSubType.Directory
+                        && !ctx.Items.Any(c => c.ParentId == d.Id))
+            .ToListAsync();
+        foreach (var dir in emptyDirs)
+        {
+            ctx.Items.Add(DavItem.New(
+                Guid.NewGuid(),
+                dir,
+                "placeholder.mkv",
+                10,
+                DavItem.ItemType.UsenetFile,
+                DavItem.ItemSubType.NzbFile,
+                null,
+                null,
+                null,
+                null));
+        }
+
         await ctx.SaveChangesAsync();
     }
 


### PR DESCRIPTION
## Summary

Fixes the 3 backend CI failures in `RemoveUnlinkedFilesTaskTests` ([failing run](https://github.com/nzbdav/nzbdav/actions/runs/29331151644/job/87079151141)) introduced by #300:

- **Guid TEXT casing mismatch** — the `Fix-Empty-Categories` migration seeds `/content/uncategorized` with a lowercase Id, while EF binds Guid parameters as uppercase TEXT. The `Guid.Parse` + `ExecuteDeleteAsync` batches from #198 therefore selected that row but deleted 0 rows, tripping the infinite-loop guard (`selected 1 empty directories but deleted 0`). Batches now delete via parameterized raw SQL bound to the exact Id text from the select.
- **dash rejects `set -o pipefail`** — Ubuntu 24.04's `/bin/sh` is dash 0.5.12-6 (pre-pipefail), so the Linux library scan died with exit code 2 and the dry-run test saw `Dry Run - Failed: Library symlink scan failed...`. The scan now uses `find -exec sh -c '...' sh {} +` — no pipe, no pipefail, and `find`'s exit code still surfaces traversal errors (preserving the #172 hardening). Alpine (Docker runtime) was unaffected either way.
- Tests now give the migration-seeded empty `uncategorized` folder a child before asserting the no-empty-directories case, since removing empty category folders is legitimate task behavior.

## Test plan

- [x] `RemoveUnlinkedFilesTaskTests` — 5/5 pass locally
- [x] Full backend suite — only the pre-existing `NzbFileStreamTests` / `ArticleCachingNntpClientTests` failures remain (verified identical on `main` via stash)
- [x] Restructured `find -exec` command smoke-tested via `sh` against a temp tree (strm + symlink output, empty dir, permission-error exit code 1)
- [ ] CI backend job on this PR (Ubuntu runner is the real check for the scanner fix)