### PR TITLE
fix(nntp): log known transport failures without stack dumps

### DIFF
--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -253,7 +253,7 @@ public class MultiConnectionNntpClient(
                     continue;
                 }
 
-                Log.Warning(e,
+                e.LogWarningKnownOrStack(
                     "Error executing pipelined NNTP BODY commands for provider {Provider}.",
                     providerName);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
@@ -313,7 +313,7 @@ public class MultiConnectionNntpClient(
                     continue;
                 }
 
-                Log.Warning(e, "Error getting connection-lock for provider {Provider}.", providerName);
+                e.LogWarningKnownOrStack("Error getting connection-lock for provider {Provider}.", providerName);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
@@ -379,7 +379,8 @@ public class MultiConnectionNntpClient(
                     continue;
                 }
 
-                Log.Warning(e, "Error executing nntp {Command} command for provider {Provider}.", name, providerName);
+                e.LogWarningKnownOrStack(
+                    "Error executing nntp {Command} command for provider {Provider}.", name, providerName);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using NzbWebDAV.Exceptions;
+﻿using System.Net.Sockets;
+using NzbWebDAV.Exceptions;
+using Serilog;
 
 namespace NzbWebDAV.Extensions;
 
@@ -26,6 +28,63 @@ public static class ExceptionExtensions
     {
         return exception.IsCancellationException() &&
             cancellationToken.IsCancellationRequested;
+    }
+
+    /// <summary>
+    /// Returns a human-readable message for known/expected transport and download
+    /// failures so callers can log a single line without a stack dump. Walks the
+    /// exception chain and prefers the innermost matching message. Unexpected
+    /// exceptions return false so full stack traces are preserved.
+    /// </summary>
+    public static bool TryGetKnownErrorMessage(this Exception exception, out string reason)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        string? found = null;
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (IsKnownTransportOrDownloadException(current))
+                found = current.Message;
+        }
+
+        if (found != null)
+        {
+            reason = found;
+            return true;
+        }
+
+        reason = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Logs a Warning with only the known error reason when the exception is an
+    /// expected transport/download failure; otherwise logs with the full stack.
+    /// </summary>
+    public static void LogWarningKnownOrStack(
+        this Exception exception,
+        string messageTemplate,
+        params object?[] propertyValues)
+    {
+        if (exception.TryGetKnownErrorMessage(out var reason))
+        {
+            var args = new object?[propertyValues.Length + 1];
+            propertyValues.CopyTo(args, 0);
+            args[^1] = reason;
+            Log.Warning(messageTemplate + " Reason: {Reason}", args);
+            return;
+        }
+
+        Log.Warning(exception, messageTemplate, propertyValues);
+    }
+
+    private static bool IsKnownTransportOrDownloadException(Exception exception)
+    {
+        return exception is TimeoutException
+            or SocketException
+            or IOException
+            || exception.IsRetryableDownloadException()
+            || exception.IsNonRetryableDownloadException();
     }
 
     public static bool TryGetCausingException<T>(this Exception exception, out T? exceptionType) where T : Exception

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -134,7 +134,7 @@ public static class FetchFirstSegmentsStep
         {
             // Transient provider errors must not be treated as permanent missing segments
             // (otherwise fail-fast would mark good NZBs failed — see nzbdav-dev#245).
-            Log.Warning(e,
+            e.LogWarningKnownOrStack(
                 "First segment for `{FileName}` unavailable due to provider error; not treating as permanently missing",
                 nzbFile.GetSubjectFileName());
             throw;

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
 using Serilog;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -214,7 +215,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 if (_failFastOnFirstSegment && isFirstSegment)
                 {
-                    Log.Warning(e,
+                    e.LogWarningKnownOrStack(
                         "First article {SegmentId} missing on all providers at playback start while reading {FileName}. " +
                         "Failing the stream so the player surfaces an error.",
                         segmentId, _fileName);
@@ -238,7 +239,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
                 if (_failFastOnFirstSegment && isFirstSegment)
                 {
-                    Log.Warning(e,
+                    e.LogWarningKnownOrStack(
                         "Segment {SegmentId} unavailable at playback start after {Attempts} attempts while reading {FileName}. " +
                         "Failing the stream so the player surfaces an error.",
                         segmentId, attempt + 1, _fileName);
@@ -294,8 +295,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private Stream ZeroFillSegment(string messageTemplate, string segmentId, Exception? exception = null)
     {
         var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
-        if (exception == null) Log.Warning(messageTemplate, segmentId, _fileName, fill);
-        else Log.Warning(exception, messageTemplate, segmentId, _fileName, fill);
+        if (exception == null)
+            Log.Warning(messageTemplate, segmentId, _fileName, fill);
+        else
+            exception.LogWarningKnownOrStack(messageTemplate, segmentId, _fileName, fill);
         return new MemoryStream(new byte[fill], writable: false);
     }
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -158,7 +158,7 @@ public class NzbFileStream(
                 }
                 catch (Exception e) when (articleBufferSize > 0 && !ct.IsCancellationRequested)
                 {
-                    Log.Warning(e,
+                    e.LogWarningKnownOrStack(
                         "Seek probe transient failure on segment index {Index}. Using estimated range.", guess);
                     var start = guess * avg;
                     var end = Math.Min(fileSize, start + avg);

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -1,0 +1,67 @@
+using System.Net.Sockets;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Tests.Extensions;
+
+public class ExceptionExtensionsTests
+{
+    [Fact]
+    public void TryGetKnownErrorMessage_RecognizesDirectTimeout()
+    {
+        var ex = new TimeoutException("Timeout reading from NNTP stream.");
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal("Timeout reading from NNTP stream.", reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_PrefersInnermostKnownMessage()
+    {
+        var inner = new TimeoutException("Timeout reading from NNTP stream.");
+        var outer = new Exception("wrapper", inner);
+
+        Assert.True(outer.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal("Timeout reading from NNTP stream.", reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_RecognizesUsenetUnexpectedResponse()
+    {
+        var ex = new UsenetUnexpectedResponseException("<seg@example>", "400 too much time between commands");
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Contains("Unexpected NNTP response", reason);
+        Assert.Contains("<seg@example>", reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_RecognizesSocketAndIoErrors()
+    {
+        var socket = new SocketException((int)SocketError.ConnectionReset);
+        Assert.True(socket.TryGetKnownErrorMessage(out var socketReason));
+        Assert.False(string.IsNullOrWhiteSpace(socketReason));
+
+        var io = new IOException("Unable to read data from the transport connection.");
+        Assert.True(io.TryGetKnownErrorMessage(out var ioReason));
+        Assert.Equal("Unable to read data from the transport connection.", ioReason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_RejectsUnexpectedExceptions()
+    {
+        var ex = new NullReferenceException("unexpected bug");
+
+        Assert.False(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal(string.Empty, reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_RecognizesArticleNotFound()
+    {
+        var ex = new UsenetArticleNotFoundException("<missing@example>");
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Contains("<missing@example>", reason);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TryGetKnownErrorMessage` / `LogWarningKnownOrStack` so expected NNTP transport failures (timeouts, socket/IO, typed download exceptions) log a single human-readable `Reason:` line instead of a Serilog stack dump.
- Apply at the zero-fill / fail-fast stream paths, seek-probe warnings, MultiConnectionNntpClient final-attempt warnings, and FetchFirstSegments provider-error warnings.
- Unexpected exceptions still keep full stack traces.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~ExceptionExtensionsTests`
- [ ] Reproduce a playback timeout and confirm the log is one WARNING line with `Reason: Timeout reading from NNTP stream.` and no stack frames
- [ ] Confirm an unexpected exception path still dumps a stack (regression check)