### PR TITLE
fix(usenet): key provider usage metrics by ProviderId

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -54,10 +54,8 @@ public class GetOverviewStatsController(
             window == GetOverviewStatsRequest.OverviewWindow.Last30Days ||
             window == GetOverviewStatsRequest.OverviewWindow.AllTime;
 
-        var nicknamesByHost = configManager.GetUsenetProviderConfig().Providers
-            .Where(p => !string.IsNullOrWhiteSpace(p.Nickname))
-            .GroupBy(p => p.Host, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First().Nickname, StringComparer.OrdinalIgnoreCase);
+        var labelsByMetricsKey = ProviderUsageHelper
+            .BuildLabelsByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
 
         var included = new List<string>();
         var tiles = new GetOverviewStatsResponse.LiveTiles();
@@ -80,7 +78,7 @@ public class GetOverviewStatsController(
         Task<StaticSectionResult>? staticTask = null;
 
         if (wantWindow)
-            windowTask = BuildWindowSectionAsync(window, windowStart, windowMs, bucketSize, nowMs, useRollups, nicknamesByHost);
+            windowTask = BuildWindowSectionAsync(window, windowStart, windowMs, bucketSize, nowMs, useRollups, labelsByMetricsKey);
         if (wantDetail && !useRollups)
             detailTask = BuildDetailSectionAsync(windowStart);
         if (wantStatic)
@@ -188,7 +186,7 @@ public class GetOverviewStatsController(
         long bucketSize,
         long nowMs,
         bool useRollups,
-        IReadOnlyDictionary<string, string?> nicknamesByHost)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
     {
         await using var metricsSessions = new MetricsDbContext();
         await using var metricsHeatmap = new MetricsDbContext();
@@ -245,7 +243,7 @@ public class GetOverviewStatsController(
                 hours.Select(h => (h.Hour, h.Articles, h.Misses, h.Errors, h.BytesFetched)),
                 sessions.Select(s => (s.EndedAt, s.BytesServed)),
                 bucketSize);
-            providers = BuildProvidersFromHourly(hours, windowStart, bucketSize, nowMs, nicknamesByHost);
+            providers = BuildProvidersFromHourly(hours, windowStart, bucketSize, nowMs, labelsByMetricsKey);
             totalArticles = hours.Sum(h => h.Articles);
             totalMisses = hours.Sum(h => h.Misses);
             totalErrors = hours.Sum(h => h.Errors);
@@ -297,7 +295,7 @@ public class GetOverviewStatsController(
                 bucketSize);
             providers = BuildProvidersFromMinutes(
                 minutes.Select(m => (m.Minute, m.Provider, m.Articles, m.BytesFetched, m.Errors, m.Retries, m.SumDurationMs)),
-                windowStart, window, nicknamesByHost);
+                windowStart, window, labelsByMetricsKey);
             totalArticles = minutes.Sum(m => m.Articles);
             totalMisses = minutes.Sum(m => m.Misses);
             totalErrors = minutes.Sum(m => m.Errors);
@@ -322,7 +320,7 @@ public class GetOverviewStatsController(
             readsSaved,
             previousSaves,
             ResolveFailoverBucket(window),
-            nicknamesByHost);
+            labelsByMetricsKey);
 
         var tiles = BuildLiveTiles(liveCounts?.Articles ?? 0, liveCounts?.Errors ?? 0);
         var sessionsBlock = BuildSessionsBlock(sessionsRows.Select(s => (s.DurationMs, s.BytesServed)));
@@ -471,7 +469,7 @@ public class GetOverviewStatsController(
         long readsSaved,
         long? previousSaves,
         long chartBucketSize,
-        IReadOnlyDictionary<string, string?> nicknamesByHost)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
     {
         var totalsByProvider = new Dictionary<string, long>();
         var byBucket = new SortedDictionary<long, Dictionary<string, long>>();
@@ -523,7 +521,7 @@ public class GetOverviewStatsController(
                 .Select(p => new GetOverviewStatsResponse.FailoverProvider
                 {
                     Provider = p,
-                    Nickname = nicknamesByHost.GetValueOrDefault(p),
+                    Nickname = labelsByMetricsKey.GetValueOrDefault(p),
                     Saves = totalsByProvider[p],
                 })
                 .ToList(),
@@ -533,7 +531,7 @@ public class GetOverviewStatsController(
                 .Select(kv => new GetOverviewStatsResponse.FailoverFrom
                 {
                     Provider = kv.Key,
-                    Nickname = nicknamesByHost.GetValueOrDefault(kv.Key),
+                    Nickname = labelsByMetricsKey.GetValueOrDefault(kv.Key),
                     Misses = kv.Value,
                 })
                 .ToList(),
@@ -642,7 +640,7 @@ public class GetOverviewStatsController(
         IEnumerable<(long Minute, string Provider, long Articles, long BytesFetched, long Errors, long Retries, long SumDurationMs)> minutes,
         long windowStart,
         GetOverviewStatsRequest.OverviewWindow window,
-        IReadOnlyDictionary<string, string?> nicknamesByHost)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
     {
         var (sparkBuckets, sparkSize) = window switch
         {
@@ -671,7 +669,7 @@ public class GetOverviewStatsController(
             .Select(kv => new GetOverviewStatsResponse.ProviderRow
             {
                 Provider = kv.Key,
-                Nickname = nicknamesByHost.GetValueOrDefault(kv.Key),
+                Nickname = labelsByMetricsKey.GetValueOrDefault(kv.Key),
                 Articles = kv.Value.Articles,
                 BytesFetched = kv.Value.Bytes,
                 Errors = kv.Value.Errors,
@@ -689,7 +687,7 @@ public class GetOverviewStatsController(
         long windowStart,
         long bucketSize,
         long nowMs,
-        IReadOnlyDictionary<string, string?> nicknamesByHost)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
     {
         var totalSpan = nowMs - windowStart;
         var sparkSize = OneDay;
@@ -716,7 +714,7 @@ public class GetOverviewStatsController(
             .Select(kv => new GetOverviewStatsResponse.ProviderRow
             {
                 Provider = kv.Key,
-                Nickname = nicknamesByHost.GetValueOrDefault(kv.Key),
+                Nickname = labelsByMetricsKey.GetValueOrDefault(kv.Key),
                 Articles = kv.Value.Articles,
                 BytesFetched = kv.Value.Bytes,
                 Errors = kv.Value.Errors,

--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
@@ -14,15 +14,19 @@ public class GetProviderUsageController(
     private async Task<GetProviderUsageResponse> GetUsageAsync()
     {
         var providerConfig = configManager.GetUsenetProviderConfig();
-        var recentHoursByHost = await ProviderUsageHelper
-            .ReadRecentHoursAsync(providerConfig.Providers.Select(p => p.Host))
+        var recentHoursByKey = await ProviderUsageHelper
+            .ReadRecentHoursAsync(providerConfig.Providers
+                .Where(p => p.ProviderId != Guid.Empty)
+                .Select(UsenetProviderIdentity.MetricsKey))
             .ConfigureAwait(false);
 
         var items = providerConfig.Providers
             .Select((provider, index) =>
             {
                 var used = ProviderUsageHelper.ComputeUsage(bytesTracker, provider);
-                recentHoursByHost.TryGetValue(provider.Host, out var recentHours);
+                List<(long Hour, long Bytes)>? recentHours = null;
+                if (provider.ProviderId != Guid.Empty)
+                    recentHoursByKey.TryGetValue(UsenetProviderIdentity.MetricsKey(provider), out recentHours);
                 var (bytesPerDay, daysRemaining) = ProviderUsageHelper.ComputeBurnRate(provider, used, recentHours);
                 return new GetProviderUsageResponse.ProviderUsageItem
                 {

--- a/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
+++ b/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -38,6 +39,9 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
                 !ConfigSecretMasker.IsMaskToken(item.ConfigValue))
                 resolvedValue = PasswordUtil.Hash(resolvedValue);
 
+            if (item.ConfigName == ConfigKeys.UsenetProviders)
+                resolvedValue = NormalizeUsenetProviderIds(resolvedValue, existingValue);
+
             return new ConfigItem
             {
                 ConfigName = item.ConfigName,
@@ -68,6 +72,31 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
         configManager.UpdateValues(resolvedItems);
 
         return new UpdateConfigResponse { Status = true };
+    }
+
+    /// <summary>
+    /// Preserve ProviderIds across config saves even when a client omits them
+    /// (e.g. older UI that rebuilds ConnectionDetails without the field).
+    /// </summary>
+    private static string NormalizeUsenetProviderIds(string incomingJson, string? existingJson)
+    {
+        var incoming = JsonSerializer.Deserialize<UsenetProviderConfig>(incomingJson)
+                       ?? new UsenetProviderConfig();
+        UsenetProviderConfig? existing = null;
+        if (!string.IsNullOrWhiteSpace(existingJson))
+        {
+            try
+            {
+                existing = JsonSerializer.Deserialize<UsenetProviderConfig>(existingJson);
+            }
+            catch (JsonException)
+            {
+                existing = null;
+            }
+        }
+
+        UsenetProviderIdentity.NormalizeProviderIdsOnSave(incoming, existing);
+        return JsonSerializer.Serialize(incoming);
     }
 
     protected override async Task<IActionResult> HandleRequest()

--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
 
 namespace NzbWebDAV.Api.SabControllers.GetHistory;
 
@@ -49,10 +50,8 @@ public class GetHistoryController(
 
         // get slots (in-memory provider counts only survive until app restart)
         var providerUsages = providerUsageTracker.SnapshotMany(historyItems.Select(x => x.Id));
-        var nicknamesByHost = configManager.GetUsenetProviderConfig().Providers
-            .Where(p => !string.IsNullOrWhiteSpace(p.Nickname))
-            .GroupBy(p => p.Host, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First().Nickname, StringComparer.OrdinalIgnoreCase);
+        var displayByMetricsKey = ProviderUsageHelper
+            .BuildDisplayByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
         var slots = historyItems
             .Select(x =>
                 GetHistoryResponse.HistorySlot.FromHistoryItem(
@@ -60,7 +59,7 @@ public class GetHistoryController(
                     x.DownloadDirId != null ? davItemsDict.GetValueOrDefault(x.DownloadDirId.Value) : null,
                     configManager,
                     providerUsages.GetValueOrDefault(x.Id),
-                    nicknamesByHost
+                    displayByMetricsKey
                 )
             )
             .ToList();

--- a/backend/Api/SabControllers/GetHistory/GetHistoryResponse.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryResponse.cs
@@ -66,7 +66,7 @@ public class GetHistoryResponse : SabBaseResponse
             DavItem? downloadFolder,
             ConfigManager configManager,
             IReadOnlyDictionary<string, long>? providerUsage = null,
-            IReadOnlyDictionary<string, string?>? nicknamesByHost = null
+            IReadOnlyDictionary<string, (string Host, string? Nickname)>? displayByMetricsKey = null
         )
         {
             return new HistorySlot()
@@ -86,11 +86,22 @@ public class GetHistoryResponse : SabBaseResponse
                 Providers = providerUsage is { Count: > 0 }
                     ? providerUsage
                         .OrderByDescending(kv => kv.Value)
-                        .Select(kv => new ProviderUsage
+                        .Select(kv =>
                         {
-                            Host = kv.Key,
-                            Nickname = nicknamesByHost is not null && nicknamesByHost.TryGetValue(kv.Key, out var n) ? n : null,
-                            Segments = kv.Value,
+                            var host = kv.Key;
+                            string? nickname = null;
+                            if (displayByMetricsKey is not null &&
+                                displayByMetricsKey.TryGetValue(kv.Key, out var display))
+                            {
+                                host = display.Host;
+                                nickname = display.Nickname;
+                            }
+                            return new ProviderUsage
+                            {
+                                Host = host,
+                                Nickname = nickname,
+                                Segments = kv.Value,
+                            };
                         })
                         .ToList()
                     : null,

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
 
 namespace NzbWebDAV.Api.SabControllers.GetQueue;
 
@@ -30,18 +31,15 @@ public class GetQueueController(
             .Where(x => x.Id != inProgressQueueItem?.Id)
             .ToArray();
 
-        // hosts of every configured Usenet provider — used to show idle providers
-        // alongside active ones for the in-progress download
+        // Metrics keys of every configured Usenet provider — used to show idle providers
+        // alongside active ones for the in-progress download.
         var configuredProviders = configManager.GetUsenetProviderConfig().Providers;
-        var configuredHosts = configuredProviders
-            .Select(p => p.Host)
-            .Where(h => !string.IsNullOrEmpty(h))
+        var configuredKeys = configuredProviders
+            .Where(p => p.ProviderId != Guid.Empty)
+            .Select(UsenetProviderIdentity.MetricsKey)
             .Distinct()
             .ToList();
-        var nicknamesByHost = configuredProviders
-            .Where(p => !string.IsNullOrWhiteSpace(p.Nickname))
-            .GroupBy(p => p.Host, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First().Nickname, StringComparer.OrdinalIgnoreCase);
+        var displayByMetricsKey = ProviderUsageHelper.BuildDisplayByMetricsKey(configuredProviders);
 
         // get slots
         var slots = queueItems
@@ -53,14 +51,14 @@ public class GetQueueController(
                 var percentage = (isInProgress ? progressPercentage : 0)!.Value;
                 var status = isInProgress ? "Downloading" : "Queued";
                 var providerUsage = providerUsageTracker.Snapshot(queueItem!.Id);
-                if (isInProgress && configuredHosts.Count > 0)
+                if (isInProgress && configuredKeys.Count > 0)
                 {
                     var merged = new Dictionary<string, long>();
-                    foreach (var host in configuredHosts) merged[host] = 0;
+                    foreach (var key in configuredKeys) merged[key] = 0;
                     foreach (var kv in providerUsage) merged[kv.Key] = kv.Value;
                     providerUsage = merged;
                 }
-                return GetQueueResponse.QueueSlot.FromQueueItem(queueItem!, index, percentage, status, providerUsage, nicknamesByHost);
+                return GetQueueResponse.QueueSlot.FromQueueItem(queueItem!, index, percentage, status, providerUsage, displayByMetricsKey);
             })
             .ToList();
 

--- a/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
@@ -70,7 +70,7 @@ public class GetQueueResponse : SabBaseResponse
             int progressPercentage = 0,
             string status = "Queued",
             IReadOnlyDictionary<string, long>? providerUsage = null,
-            IReadOnlyDictionary<string, string?>? nicknamesByHost = null
+            IReadOnlyDictionary<string, (string Host, string? Nickname)>? displayByMetricsKey = null
         )
         {
             return new QueueSlot
@@ -90,11 +90,22 @@ public class GetQueueResponse : SabBaseResponse
                 Providers = providerUsage is { Count: > 0 }
                     ? providerUsage
                         .OrderByDescending(kv => kv.Value)
-                        .Select(kv => new ProviderUsage
+                        .Select(kv =>
                         {
-                            Host = kv.Key,
-                            Nickname = nicknamesByHost is not null && nicknamesByHost.TryGetValue(kv.Key, out var n) ? n : null,
-                            Segments = kv.Value,
+                            var host = kv.Key;
+                            string? nickname = null;
+                            if (displayByMetricsKey is not null &&
+                                displayByMetricsKey.TryGetValue(kv.Key, out var display))
+                            {
+                                host = display.Host;
+                                nickname = display.Nickname;
+                            }
+                            return new ProviderUsage
+                            {
+                                Host = host,
+                                Nickname = nickname,
+                                Segments = kv.Value,
+                            };
                         })
                         .ToList()
                     : null,

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -24,7 +24,8 @@ namespace NzbWebDAV.Clients.Usenet;
 /// <param name="connectionPool"></param>
 /// <param name="type"></param>
 /// <param name="circuitBreaker"></param>
-/// <param name="providerName"></param>
+/// <param name="providerName">NNTP hostname used for connection/logging.</param>
+/// <param name="metricsKey">Stable per-account metrics key (ProviderId).</param>
 [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
 public class MultiConnectionNntpClient(
     ConnectionPool<INntpClient> connectionPool,
@@ -35,12 +36,18 @@ public class MultiConnectionNntpClient(
     long bytesUsedOffset = 0,
     int priority = 0,
     int? pipeliningDepth = null,
-    string storageGroup = ""
+    string storageGroup = "",
+    string? metricsKey = null
 ) : NntpClient
 {
     public ProviderType ProviderType { get; } = type;
     public int Priority { get; } = priority;
     public string Host { get; } = providerName;
+    /// <summary>
+    /// Stable per-account key for bandwidth/usage metrics. Distinct from
+    /// <see cref="Host"/> so multiple accounts on the same NNTP host do not share counters.
+    /// </summary>
+    public string MetricsKey { get; } = string.IsNullOrEmpty(metricsKey) ? providerName : metricsKey;
     public string StorageGroup { get; } = storageGroup;
 
     private static readonly ConcurrentDictionary<string, int> TimeoutCounts = new();

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -204,26 +204,26 @@ public class MultiProviderNntpClient(
             {
                 primaryStopwatch.Stop();
                 var reason = ClassifyException(e);
-                RecordFetch(primaryProvider.Host, reason, primaryStopwatch.ElapsedMilliseconds, 0);
-                (priorMisses ??= []).Add((primaryProvider.Host, reason));
+                RecordFetch(primaryProvider.MetricsKey, reason, primaryStopwatch.ElapsedMilliseconds, 0);
+                (priorMisses ??= []).Add((primaryProvider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
             }
 
             if (response?.ResponseType == UsenetResponseType.ArticleRetrievedBodyFollows)
             {
                 primaryStopwatch.Stop();
-                _usageTracker.RecordSuccess(primaryProvider.Host);
-                RecordFetch(primaryProvider.Host, SegmentFetch.FetchStatus.Ok,
+                _usageTracker.RecordSuccess(primaryProvider.MetricsKey);
+                RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Ok,
                     primaryStopwatch.ElapsedMilliseconds, 0);
-                return WrapStreamForByteCounting(response, primaryProvider.Host);
+                return WrapStreamForByteCounting(response, primaryProvider.MetricsKey);
             }
 
             if (response != null && UsenetArticleAvailability.IsDefinitiveMissing(response))
             {
                 primaryStopwatch.Stop();
-                RecordFetch(primaryProvider.Host, SegmentFetch.FetchStatus.Missing,
+                RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                     primaryStopwatch.ElapsedMilliseconds, 0);
-                (priorMisses ??= []).Add((primaryProvider.Host, SegmentFetch.FetchStatus.Missing));
+                (priorMisses ??= []).Add((primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing));
             }
 
             // Retry the primary provider once before falling back. Even a definitive miss
@@ -267,15 +267,15 @@ public class MultiProviderNntpClient(
                     var responseType = response.ResponseType;
                     if (responseType == UsenetResponseType.ArticleRetrievedBodyFollows)
                     {
-                        _usageTracker.RecordSuccess(provider.Host);
-                        RecordFetch(provider.Host, SegmentFetch.FetchStatus.Ok,
+                        _usageTracker.RecordSuccess(provider.MetricsKey);
+                        RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
                             stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0);
                         if (priorMisses is { Count: > 0 })
                         {
                             _usageTracker.RecordFailoverSave();
-                            RecordFailoverMisses(priorMisses, provider.Host);
+                            RecordFailoverMisses(priorMisses, provider.MetricsKey);
                         }
-                        response = WrapStreamForByteCounting(response, provider.Host);
+                        response = WrapStreamForByteCounting(response, provider.MetricsKey);
                         fallbackCompletionOwnedByTransfer = true;
                         deferredCallback.Activate(result =>
                         {
@@ -291,9 +291,9 @@ public class MultiProviderNntpClient(
                     }
                     else
                     {
-                        RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
+                        RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                             stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0);
-                        (priorMisses ??= []).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
+                        (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                         if (UsenetArticleAvailability.IsDefinitiveMissing(response) &&
                             group.Length > 0)
                         {
@@ -309,9 +309,9 @@ public class MultiProviderNntpClient(
                 {
                     stopwatch.Stop();
                     var reason = ClassifyException(e);
-                    RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds,
+                    RecordFetch(provider.MetricsKey, reason, stopwatch.ElapsedMilliseconds,
                         priorMisses?.Count ?? 0);
-                    (priorMisses ??= []).Add((provider.Host, reason));
+                    (priorMisses ??= []).Add((provider.MetricsKey, reason));
                     deferredCallback.Discard();
                     coordinator.CompleteAttempt();
                     lastException = ExceptionDispatchInfo.Capture(e);
@@ -464,15 +464,15 @@ public class MultiProviderNntpClient(
                 if (result.ResponseType == successResponseType)
                 {
                     if (attribution != null) attribution.Host = provider.Host;
-                    _usageTracker.RecordSuccess(provider.Host);
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Ok,
+                    _usageTracker.RecordSuccess(provider.MetricsKey);
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
                         stopwatch.ElapsedMilliseconds, attemptIndex);
                     if (attemptIndex > 0)
                     {
                         _usageTracker.RecordFailoverSave();
-                        RecordFailoverMisses(priorMisses, provider.Host);
+                        RecordFailoverMisses(priorMisses, provider.MetricsKey);
                     }
-                    result = WrapStreamForByteCounting(result, provider.Host);
+                    result = WrapStreamForByteCounting(result, provider.MetricsKey);
                     deferredCallback.Activate(onConnectionReadyAgain ?? (_ => { }));
                     return result;
                 }
@@ -480,9 +480,9 @@ public class MultiProviderNntpClient(
                 deferredCallback.Discard();
                 if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                         stopwatch.ElapsedMilliseconds, attemptIndex);
-                    (priorMisses ??= []).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
+                    (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                     lastNoArticleResult = result;
                     lastOutcomeWasException = false;
                     if (group.Length > 0) missingGroups.Add(group);
@@ -490,7 +490,7 @@ public class MultiProviderNntpClient(
                     continue;
                 }
 
-                RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing,
+                RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                     stopwatch.ElapsedMilliseconds, attemptIndex);
                 InvokeCompletionCallback(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
@@ -500,8 +500,8 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 var reason = ClassifyException(e);
-                RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds, attemptIndex);
-                (priorMisses ??= []).Add((provider.Host, reason));
+                RecordFetch(provider.MetricsKey, reason, stopwatch.ElapsedMilliseconds, attemptIndex);
+                (priorMisses ??= []).Add((provider.MetricsKey, reason));
                 deferredCallback.Discard();
                 lastException = ExceptionDispatchInfo.Capture(e);
                 lastOutcomeWasException = true;
@@ -575,8 +575,8 @@ public class MultiProviderNntpClient(
                 // never a connection error.
                 if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
-                    (priorMisses ??= new()).Add((provider.Host, SegmentFetch.FetchStatus.Missing));
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    (priorMisses ??= new()).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                     lastNoArticleResult = result;
                     lastOutcomeWasException = false;
                     if (group.Length > 0) missingGroups.Add(group);
@@ -594,18 +594,18 @@ public class MultiProviderNntpClient(
                     && result.ResponseType is UsenetResponseType.ArticleRetrievedBodyFollows
                                           or UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
                 {
-                    _usageTracker.RecordSuccess(provider.Host);
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    _usageTracker.RecordSuccess(provider.MetricsKey);
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, attemptIndex);
                     if (attemptIndex > 0)
                     {
                         _usageTracker.RecordFailoverSave();
-                        RecordFailoverMisses(priorMisses, rescuer: provider.Host);
+                        RecordFailoverMisses(priorMisses, rescuer: provider.MetricsKey);
                     }
-                    result = WrapStreamForByteCounting(result, provider.Host);
+                    result = WrapStreamForByteCounting(result, provider.MetricsKey);
                 }
                 else
                 {
-                    RecordFetch(provider.Host, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
                 }
 
                 return result;
@@ -614,8 +614,8 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 var reason = ClassifyException(e);
-                RecordFetch(provider.Host, reason, stopwatch.ElapsedMilliseconds, attemptIndex);
-                (priorMisses ??= new()).Add((provider.Host, reason));
+                RecordFetch(provider.MetricsKey, reason, stopwatch.ElapsedMilliseconds, attemptIndex);
+                (priorMisses ??= new()).Add((provider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
                 lastOutcomeWasException = true;
                 attemptIndex++;
@@ -637,13 +637,13 @@ public class MultiProviderNntpClient(
         throw new Exception("There are no usenet providers configured.");
     }
 
-    private void RecordFetch(string host, SegmentFetch.FetchStatus status, long durationMs, int retries)
+    private void RecordFetch(string metricsKey, SegmentFetch.FetchStatus status, long durationMs, int retries)
     {
         if (metricsWriter == null) return;
         metricsWriter.RecordFetch(new SegmentFetch
         {
             At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            Provider = host,
+            Provider = metricsKey,
             ReadSessionId = ReadSessionScope.Value,
             Bytes = 0, // bytes flow lazily through CountingYencStream → ProviderBytesTracker
             DurationMs = (int)Math.Min(int.MaxValue, durationMs),
@@ -670,15 +670,15 @@ public class MultiProviderNntpClient(
         }
     }
 
-    private T WrapStreamForByteCounting<T>(T result, string host) where T : UsenetResponse
+    private T WrapStreamForByteCounting<T>(T result, string metricsKey) where T : UsenetResponse
     {
         if (bytesTracker == null) return result;
         return result switch
         {
             UsenetDecodedBodyResponse b
-                => (T)(object)(b with { Stream = new CountingYencStream(b.Stream!, bytesTracker, host) }),
+                => (T)(object)(b with { Stream = new CountingYencStream(b.Stream!, bytesTracker, metricsKey) }),
             UsenetDecodedArticleResponse a
-                => (T)(object)(a with { Stream = new CountingYencStream(a.Stream!, bytesTracker, host) }),
+                => (T)(object)(a with { Stream = new CountingYencStream(a.Stream!, bytesTracker, metricsKey) }),
             _ => result,
         };
     }
@@ -729,7 +729,7 @@ public class MultiProviderNntpClient(
     private double EstimatedDeliveryScore(MultiConnectionNntpClient provider)
     {
         var inFlight = provider.ActiveConnections + provider.PendingSelections + 1;
-        var bytesPerMs = bytesTracker?.GetBytesPerMs(provider.Host) ?? 0d;
+        var bytesPerMs = bytesTracker?.GetBytesPerMs(provider.MetricsKey) ?? 0d;
         return bytesPerMs > 0 ? inFlight / bytesPerMs : inFlight;
     }
 
@@ -737,7 +737,7 @@ public class MultiProviderNntpClient(
     {
         var limit = client.ByteLimit;
         if (bytesTracker == null || !limit.HasValue || limit.Value <= 0) return false;
-        var used = bytesTracker.GetLifetime(client.Host) + client.BytesUsedOffset;
+        var used = bytesTracker.GetLifetime(client.MetricsKey) + client.BytesUsedOffset;
         // Stop at the effective cutoff (95% of cap) so in-flight fetches that
         // already passed this check can't push the actual count past the cap.
         // See ProviderUsageHelper.EffectiveLimitFraction for the rationale.
@@ -749,7 +749,7 @@ public class MultiProviderNntpClient(
     {
         var limit = client.ByteLimit;
         if (bytesTracker == null || !limit.HasValue || limit.Value <= 0) return long.MaxValue;
-        var used = bytesTracker.GetLifetime(client.Host) + client.BytesUsedOffset;
+        var used = bytesTracker.GetLifetime(client.MetricsKey) + client.BytesUsedOffset;
         return Math.Max(0, limit.Value - used);
     }
 

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -105,6 +105,9 @@ public class UsenetStreamingClient : WrappingNntpClient
             onConnectionPoolChanged
         );
         var circuitBreaker = new ProviderCircuitBreaker(connectionDetails.Host);
+        // Ensure a metrics key even if startup backfill was skipped somehow.
+        if (connectionDetails.ProviderId == Guid.Empty)
+            connectionDetails.ProviderId = Guid.NewGuid();
         return new MultiConnectionNntpClient(
             connectionPool,
             connectionDetails.Type,
@@ -114,7 +117,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             connectionDetails.BytesUsedOffset,
             connectionDetails.Priority,
             connectionDetails.PipeliningDepth,
-            connectionDetails.StorageGroup
+            connectionDetails.StorageGroup,
+            UsenetProviderIdentity.MetricsKey(connectionDetails)
         );
     }
 

--- a/backend/Config/UsenetProviderConfig.cs
+++ b/backend/Config/UsenetProviderConfig.cs
@@ -13,6 +13,13 @@ public class UsenetProviderConfig
 
     public class ConnectionDetails
     {
+        /// <summary>
+        /// Stable per-account identity used as the metrics/usage key. Distinct from
+        /// <see cref="Host"/> so two accounts on the same NNTP host keep independent
+        /// bandwidth counters, caps, and scoreboard rows.
+        /// </summary>
+        public Guid ProviderId { get; set; }
+
         public required ProviderType Type { get; set; }
         public required string Host { get; set; }
         public required int Port { get; set; }
@@ -26,7 +33,7 @@ public class UsenetProviderConfig
         public int? PipeliningDepth { get; set; }
 
         // Optional user-friendly label shown in the UI in place of Host. Host is
-        // still the real NNTP target and the stable key used for metrics/logs.
+        // still the real NNTP target; ProviderId is the stable metrics/logs key.
         public string? Nickname { get; set; }
 
         /// <summary>

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using Serilog;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Ensures each configured Usenet account has a stable <see cref="UsenetProviderConfig.ConnectionDetails.ProviderId"/>
+/// and remaps legacy host-keyed metrics rows onto those ids once at startup.
+/// </summary>
+public static class UsenetProviderIdentity
+{
+    public static string MetricsKey(Guid providerId) => providerId.ToString("N");
+
+    public static string MetricsKey(UsenetProviderConfig.ConnectionDetails provider)
+    {
+        if (provider.ProviderId == Guid.Empty)
+            throw new InvalidOperationException("ProviderId must be assigned before use as a metrics key.");
+        return MetricsKey(provider.ProviderId);
+    }
+
+    /// <summary>
+    /// Assigns missing ProviderIds, persists them to the main config DB, and remaps
+    /// legacy host-keyed metrics rows. Must run after config load and metrics DB
+    /// migration, before UsenetStreamingClient is constructed.
+    /// </summary>
+    public static async Task EnsureAsync(ConfigManager configManager, CancellationToken ct = default)
+    {
+        var providerConfig = configManager.GetUsenetProviderConfig();
+        var assigned = EnsureProviderIds(providerConfig);
+        if (assigned)
+            await PersistProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);
+
+        await RemapHostKeyedMetricsAsync(providerConfig, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Assigns a Guid to every provider missing one. Returns true when any id was created.
+    /// </summary>
+    public static bool EnsureProviderIds(UsenetProviderConfig config)
+    {
+        var assigned = false;
+        foreach (var provider in config.Providers)
+        {
+            if (provider.ProviderId != Guid.Empty) continue;
+            provider.ProviderId = Guid.NewGuid();
+            assigned = true;
+        }
+        return assigned;
+    }
+
+    /// <summary>
+    /// When saving usenet.providers, preserve ProviderIds from the stored config for
+    /// entries that omit them (match by Host+Port+User). Generates a new Guid when
+    /// no match exists. Mutates <paramref name="incoming"/> in place.
+    /// </summary>
+    public static void NormalizeProviderIdsOnSave(
+        UsenetProviderConfig incoming,
+        UsenetProviderConfig? existing)
+    {
+        var unusedExisting = existing?.Providers
+            .Where(p => p.ProviderId != Guid.Empty)
+            .ToList() ?? [];
+
+        foreach (var provider in incoming.Providers)
+        {
+            if (provider.ProviderId != Guid.Empty) continue;
+
+            var matchIndex = unusedExisting.FindIndex(p =>
+                string.Equals(p.Host, provider.Host, StringComparison.OrdinalIgnoreCase)
+                && p.Port == provider.Port
+                && string.Equals(p.User, provider.User, StringComparison.Ordinal));
+
+            if (matchIndex >= 0)
+            {
+                provider.ProviderId = unusedExisting[matchIndex].ProviderId;
+                unusedExisting.RemoveAt(matchIndex);
+            }
+            else
+            {
+                provider.ProviderId = Guid.NewGuid();
+            }
+        }
+    }
+
+    private static async Task PersistProvidersAsync(
+        ConfigManager configManager,
+        UsenetProviderConfig providerConfig,
+        CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(providerConfig);
+        await using var db = new DavDatabaseContext();
+        var item = await db.ConfigItems
+            .FirstOrDefaultAsync(c => c.ConfigName == ConfigKeys.UsenetProviders, ct)
+            .ConfigureAwait(false);
+        if (item == null)
+        {
+            item = new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = json,
+            };
+            db.ConfigItems.Add(item);
+        }
+        else
+        {
+            item.ConfigValue = json;
+        }
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        configManager.UpdateValues([item]);
+        Log.Information("Assigned and persisted ProviderId for {Count} usenet provider(s).",
+            providerConfig.Providers.Count);
+    }
+
+    public static async Task RemapHostKeyedMetricsAsync(
+        UsenetProviderConfig config,
+        CancellationToken ct = default)
+    {
+        await using var db = new MetricsDbContext();
+        await RemapHostKeyedMetricsAsync(config, db, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Remaps legacy host-keyed metrics onto ProviderId keys. When multiple config
+    /// entries share a host, only the first inherits the historical rows.
+    /// </summary>
+    public static async Task RemapHostKeyedMetricsAsync(
+        UsenetProviderConfig config,
+        MetricsDbContext db,
+        CancellationToken ct = default)
+    {
+        if (config.Providers.Count == 0) return;
+
+        var seenHosts = new HashSet<string>(StringComparer.Ordinal);
+        await using var tx = await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var remapped = 0;
+            foreach (var provider in config.Providers)
+            {
+                var host = provider.Host;
+                if (string.IsNullOrEmpty(host) || provider.ProviderId == Guid.Empty)
+                    continue;
+                if (!seenHosts.Add(host))
+                    continue;
+
+                var metricsKey = MetricsKey(provider);
+                var hasHostHourly = await db.ProviderHourly
+                    .AnyAsync(x => x.Provider == host, ct)
+                    .ConfigureAwait(false);
+                var hasAnyHostKeyed = hasHostHourly
+                    || await db.ProviderMinutes
+                        .AnyAsync(x => x.Provider == host, ct).ConfigureAwait(false)
+                    || await db.SegmentFetches
+                        .AnyAsync(x => x.Provider == host, ct).ConfigureAwait(false)
+                    || await db.FailoverMisses
+                        .AnyAsync(x => x.FromProvider == host || x.ToProvider == host, ct)
+                        .ConfigureAwait(false)
+                    || await db.FailoverHourly
+                        .AnyAsync(x => x.FromProvider == host || x.ToProvider == host, ct)
+                        .ConfigureAwait(false);
+                if (!hasAnyHostKeyed) continue;
+
+                await MergeProviderMinutesAsync(db, host, metricsKey, ct).ConfigureAwait(false);
+                await MergeProviderHourlyAsync(db, host, metricsKey, ct).ConfigureAwait(false);
+                await RemapSegmentFetchesAsync(db, host, metricsKey, ct).ConfigureAwait(false);
+                await RemapFailoverMissesAsync(db, host, metricsKey, ct).ConfigureAwait(false);
+                await MergeFailoverHourlyAsync(db, host, metricsKey, ct).ConfigureAwait(false);
+                remapped++;
+            }
+
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            await tx.CommitAsync(ct).ConfigureAwait(false);
+            if (remapped > 0)
+                Log.Information("Remapped host-keyed metrics rows onto ProviderId for {Count} provider(s).", remapped);
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync(ct).ConfigureAwait(false);
+            Log.Warning(ex, "Failed to remap host-keyed provider metrics; continuing with ProviderId keys going forward.");
+        }
+    }
+
+    private static async Task MergeProviderMinutesAsync(
+        MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
+    {
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+            SELECT Minute, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
+            FROM ProviderMinutes WHERE Provider = {1}
+            ON CONFLICT(Minute, Provider) DO UPDATE SET
+                Articles = ProviderMinutes.Articles + excluded.Articles,
+                BytesFetched = ProviderMinutes.BytesFetched + excluded.BytesFetched,
+                Misses = ProviderMinutes.Misses + excluded.Misses,
+                Errors = ProviderMinutes.Errors + excluded.Errors,
+                Retries = ProviderMinutes.Retries + excluded.Retries,
+                FailoverSaves = ProviderMinutes.FailoverSaves + excluded.FailoverSaves,
+                SumDurationMs = ProviderMinutes.SumDurationMs + excluded.SumDurationMs;
+            """,
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM ProviderMinutes WHERE Provider = {0}",
+            new object[] { host }, ct).ConfigureAwait(false);
+    }
+
+    private static async Task MergeProviderHourlyAsync(
+        MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
+    {
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO ProviderHourly (Hour, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
+            SELECT Hour, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs
+            FROM ProviderHourly WHERE Provider = {1}
+            ON CONFLICT(Hour, Provider) DO UPDATE SET
+                Articles = ProviderHourly.Articles + excluded.Articles,
+                BytesFetched = ProviderHourly.BytesFetched + excluded.BytesFetched,
+                Misses = ProviderHourly.Misses + excluded.Misses,
+                Errors = ProviderHourly.Errors + excluded.Errors,
+                Retries = ProviderHourly.Retries + excluded.Retries,
+                FailoverSaves = ProviderHourly.FailoverSaves + excluded.FailoverSaves,
+                SumDurationMs = ProviderHourly.SumDurationMs + excluded.SumDurationMs;
+            """,
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM ProviderHourly WHERE Provider = {0}",
+            new object[] { host }, ct).ConfigureAwait(false);
+    }
+
+    private static async Task RemapSegmentFetchesAsync(
+        MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
+    {
+        await db.Database.ExecuteSqlRawAsync(
+            "UPDATE SegmentFetches SET Provider = {0} WHERE Provider = {1}",
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+    }
+
+    private static async Task RemapFailoverMissesAsync(
+        MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
+    {
+        await db.Database.ExecuteSqlRawAsync(
+            "UPDATE FailoverMisses SET FromProvider = {0} WHERE FromProvider = {1}",
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "UPDATE FailoverMisses SET ToProvider = {0} WHERE ToProvider = {1}",
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+    }
+
+    private static async Task MergeFailoverHourlyAsync(
+        MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
+    {
+        // Remap FromProvider first, then ToProvider, merging on conflict.
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO FailoverHourly (Hour, FromProvider, ToProvider, Reason, Count)
+            SELECT Hour, {0}, ToProvider, Reason, Count
+            FROM FailoverHourly WHERE FromProvider = {1}
+            ON CONFLICT(Hour, FromProvider, ToProvider, Reason) DO UPDATE SET
+                Count = FailoverHourly.Count + excluded.Count;
+            """,
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM FailoverHourly WHERE FromProvider = {0}",
+            new object[] { host }, ct).ConfigureAwait(false);
+
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO FailoverHourly (Hour, FromProvider, ToProvider, Reason, Count)
+            SELECT Hour, FromProvider, {0}, Reason, Count
+            FROM FailoverHourly WHERE ToProvider = {1}
+            ON CONFLICT(Hour, FromProvider, ToProvider, Reason) DO UPDATE SET
+                Count = FailoverHourly.Count + excluded.Count;
+            """,
+            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM FailoverHourly WHERE ToProvider = {0}",
+            new object[] { host }, ct).ConfigureAwait(false);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -102,6 +102,12 @@ class Program
             var configManager = new ConfigManager();
             await configManager.LoadConfig().ConfigureAwait(false);
 
+            // Assign stable ProviderIds (persisting if needed) and remap legacy
+            // host-keyed metrics rows before the streaming client is built.
+            await UsenetProviderIdentity
+                .EnsureAsync(configManager, SigtermUtil.GetCancellationToken())
+                .ConfigureAwait(false);
+
             // initialize rclone client
             RcloneClient.Initialize(configManager);
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -18,6 +18,7 @@ using NzbWebDAV.Queue.FileAggregators;
 using NzbWebDAV.Queue.FileProcessors;
 using NzbWebDAV.Queue.PostProcessors;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -485,7 +486,10 @@ public class QueueItemProcessor(
         var mountFolder = databaseOperations != null ? await databaseOperations.Invoke().ConfigureAwait(false) : null;
         var historyItem = CreateHistoryItem(mountFolder, startTime, error);
         var providerUsage = providerUsageTracker.Snapshot(queueItem.Id);
-        var historySlot = GetHistoryResponse.HistorySlot.FromHistoryItem(historyItem, mountFolder, configManager, providerUsage);
+        var displayByMetricsKey = ProviderUsageHelper
+            .BuildDisplayByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
+        var historySlot = GetHistoryResponse.HistorySlot.FromHistoryItem(
+            historyItem, mountFolder, configManager, providerUsage, displayByMetricsKey);
         dbClient.Ctx.QueueItems.Remove(queueItem);
         dbClient.Ctx.HistoryItems.Add(historyItem);
         await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
@@ -532,7 +536,7 @@ public class QueueItemProcessor(
         var outcome = error == null
             ? WatchdogEntry.Outcome.QueueCompleted
             : WatchdogEntry.Outcome.QueueFailed;
-        var providerHost = FormatProviders(providerUsage);
+        var providerHost = FormatProviders(providerUsage, configManager);
 
         watchdogLog.Record(new WatchdogEntry
         {
@@ -554,14 +558,21 @@ public class QueueItemProcessor(
         });
     }
 
-    private static string? FormatProviders(IReadOnlyDictionary<string, long> usage)
+    private static string? FormatProviders(
+        IReadOnlyDictionary<string, long> usage,
+        ConfigManager configManager)
     {
         if (usage.Count == 0) return null;
+        var labels = ProviderUsageHelper.BuildLabelsByMetricsKey(
+            configManager.GetUsenetProviderConfig().Providers);
+        string Label(string key) =>
+            labels.TryGetValue(key, out var label) && !string.IsNullOrEmpty(label) ? label! : key;
+
         var total = usage.Values.Sum();
-        if (total == 0) return string.Join(", ", usage.Keys);
+        if (total == 0) return string.Join(", ", usage.Keys.Select(Label));
         return string.Join(", ", usage
             .OrderByDescending(kv => kv.Value)
-            .Select(kv => $"{kv.Key} ({(int)Math.Round(100.0 * kv.Value / total)}%)"));
+            .Select(kv => $"{Label(kv.Key)} ({(int)Math.Round(100.0 * kv.Value / total)}%)"));
     }
 
     private async Task RefreshMonitoredDownloads()

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -228,11 +229,23 @@ public class QueueManager : IDisposable
     private string BuildProvidersMessage(Guid queueItemId)
     {
         var snapshot = _providerUsageTracker.Snapshot(queueItemId);
-        var configured = _configManager.GetUsenetProviderConfig().Providers
+        var providers = _configManager.GetUsenetProviderConfig().Providers;
+        var displayByMetricsKey = ProviderUsageHelper.BuildDisplayByMetricsKey(providers);
+
+        // The wire format is host-based; resolve metrics keys to display hosts so
+        // Guids never reach the UI, aggregating same-host accounts into one entry.
+        var merged = new Dictionary<string, long>();
+        foreach (var kv in snapshot)
+        {
+            var host = displayByMetricsKey.TryGetValue(kv.Key, out var display) ? display.Host : kv.Key;
+            merged.TryGetValue(host, out var existing);
+            merged[host] = existing + kv.Value;
+        }
+
+        var configured = providers
             .Select(p => p.Host)
             .Where(h => !string.IsNullOrEmpty(h))
             .Distinct();
-        var merged = new Dictionary<string, long>(snapshot);
         foreach (var host in configured)
             if (!merged.ContainsKey(host)) merged[host] = 0;
         var payload = string.Join(",", merged.Select(kv => $"{kv.Key}={kv.Value}"));

--- a/backend/Services/ActiveReadsBroadcaster.cs
+++ b/backend/Services/ActiveReadsBroadcaster.cs
@@ -82,10 +82,8 @@ public class ActiveReadsBroadcaster(
         if (entries.Count == 0 && _wasEmpty) return;
 
         var usage = usageTracker.SnapshotMany(entries.Select(e => e.Id));
-        var nicknamesByHost = configManager.GetUsenetProviderConfig().Providers
-            .Where(p => !string.IsNullOrWhiteSpace(p.Nickname))
-            .GroupBy(p => p.Host, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First().Nickname, StringComparer.OrdinalIgnoreCase);
+        var displayByMetricsKey = ProviderUsageHelper
+            .BuildDisplayByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
         var snapshot = new
         {
             reads = entries.Select(e => new
@@ -99,11 +97,15 @@ public class ActiveReadsBroadcaster(
                 currentOffset = Interlocked.Read(ref e.CurrentOffset),
                 fileSize = e.FileSize,
                 providers = (usage.GetValueOrDefault(e.Id) ?? new Dictionary<string, long>())
-                    .Select(kv => new
+                    .Select(kv =>
                     {
-                        host = kv.Key,
-                        nickname = nicknamesByHost.GetValueOrDefault(kv.Key),
-                        segments = kv.Value,
+                        displayByMetricsKey.TryGetValue(kv.Key, out var display);
+                        return new
+                        {
+                            host = display.Host ?? kv.Key,
+                            nickname = display.Nickname,
+                            segments = kv.Value,
+                        };
                     })
                     .OrderByDescending(p => p.segments)
                     .ToList()

--- a/backend/Services/Metrics/MetricsRollupService.cs
+++ b/backend/Services/Metrics/MetricsRollupService.cs
@@ -78,7 +78,7 @@ public class MetricsRollupService(ProviderBytesTracker bytesTracker) : Backgroun
         var drained = bytesTracker.DrainClosed(currentMinute);
         if (drained.Count == 0) return;
 
-        foreach (var (minute, host, bytes) in drained)
+        foreach (var (minute, providerKey, bytes) in drained)
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
@@ -88,7 +88,7 @@ public class MetricsRollupService(ProviderBytesTracker bytesTracker) : Backgroun
                 ON CONFLICT(Minute, Provider) DO UPDATE SET
                     BytesFetched = ProviderMinutes.BytesFetched + excluded.BytesFetched;
                 """,
-                minute, host, bytes).ConfigureAwait(false);
+                minute, providerKey, bytes).ConfigureAwait(false);
 
             var hour = FloorTo(minute, OneHour);
             await db.Database.ExecuteSqlRawAsync(
@@ -99,7 +99,7 @@ public class MetricsRollupService(ProviderBytesTracker bytesTracker) : Backgroun
                 ON CONFLICT(Hour, Provider) DO UPDATE SET
                     BytesFetched = ProviderHourly.BytesFetched + excluded.BytesFetched;
                 """,
-                hour, host, bytes).ConfigureAwait(false);
+                hour, providerKey, bytes).ConfigureAwait(false);
 
             await db.Database.ExecuteSqlRawAsync(
                 """

--- a/backend/Services/Metrics/ProviderBytesTracker.cs
+++ b/backend/Services/Metrics/ProviderBytesTracker.cs
@@ -9,77 +9,79 @@ namespace NzbWebDAV.Services.Metrics;
 /// stream is read and folds them into ProviderMinute on the next rollup tick.
 ///
 /// Two pieces of state:
-///   - _buckets keyed by (minute, host) -> bytes, drained by the rollup service
-///   - _lifetime keyed by host -> total bytes, exposed for "all-time" tiles
+///   - _buckets keyed by (minute, providerKey) -> bytes, drained by the rollup service
+///   - _lifetime keyed by providerKey -> total bytes, exposed for "all-time" tiles
+///
+/// providerKey is the stable per-account identity (<c>ProviderId</c>), not the NNTP host.
 /// </summary>
 public sealed class ProviderBytesTracker
 {
     private const long OneMinute = 60_000;
 
-    private readonly ConcurrentDictionary<(long Minute, string Host), long> _buckets = new();
+    private readonly ConcurrentDictionary<(long Minute, string ProviderKey), long> _buckets = new();
     private readonly ConcurrentDictionary<string, long> _lifetime = new();
     private long _lifetimeAll;
 
     private readonly ConcurrentDictionary<string, double> _bytesPerMs = new();
     private const double SpeedEwmaAlpha = 0.3;
 
-    public void Add(string host, long bytes)
+    public void Add(string providerKey, long bytes)
     {
-        if (bytes <= 0 || string.IsNullOrEmpty(host)) return;
+        if (bytes <= 0 || string.IsNullOrEmpty(providerKey)) return;
         var minute = NowMinute();
-        _buckets.AddOrUpdate((minute, host), bytes, (_, prev) => prev + bytes);
-        _lifetime.AddOrUpdate(host, bytes, (_, prev) => prev + bytes);
+        _buckets.AddOrUpdate((minute, providerKey), bytes, (_, prev) => prev + bytes);
+        _lifetime.AddOrUpdate(providerKey, bytes, (_, prev) => prev + bytes);
         Interlocked.Add(ref _lifetimeAll, bytes);
     }
 
     public long LifetimeAll => Interlocked.Read(ref _lifetimeAll);
 
-    public IReadOnlyDictionary<string, long> LifetimeByHost => _lifetime;
+    public IReadOnlyDictionary<string, long> LifetimeByProvider => _lifetime;
 
     /// <summary>
-    /// Overwrites the in-memory lifetime counter for a host. Used at startup to
+    /// Overwrites the in-memory lifetime counter for a provider key. Used at startup to
     /// hydrate from ProviderHourly and after a counter reset to drop back to
     /// zero. Does not touch <see cref="LifetimeAll"/> since that reflects the
     /// total bytes observed by this process; rewriting it on every config
     /// change would make the overview tile jump around for unrelated reasons.
     /// </summary>
-    public void SetLifetime(string host, long bytes)
+    public void SetLifetime(string providerKey, long bytes)
     {
-        if (string.IsNullOrEmpty(host)) return;
-        _lifetime[host] = Math.Max(0, bytes);
+        if (string.IsNullOrEmpty(providerKey)) return;
+        _lifetime[providerKey] = Math.Max(0, bytes);
     }
 
-    public long GetLifetime(string host)
+    public long GetLifetime(string providerKey)
     {
-        if (string.IsNullOrEmpty(host)) return 0;
-        return _lifetime.TryGetValue(host, out var v) ? v : 0;
+        if (string.IsNullOrEmpty(providerKey)) return 0;
+        return _lifetime.TryGetValue(providerKey, out var v) ? v : 0;
     }
 
-    public void RecordSegmentThroughput(string host, long bytes, double activeMs)
+    public void RecordSegmentThroughput(string providerKey, long bytes, double activeMs)
     {
-        if (string.IsNullOrEmpty(host) || bytes <= 0 || activeMs <= 0) return;
+        if (string.IsNullOrEmpty(providerKey) || bytes <= 0 || activeMs <= 0) return;
         var sample = bytes / activeMs;
-        _bytesPerMs.AddOrUpdate(host, sample, (_, prev) => prev + SpeedEwmaAlpha * (sample - prev));
+        _bytesPerMs.AddOrUpdate(providerKey, sample, (_, prev) => prev + SpeedEwmaAlpha * (sample - prev));
     }
 
-    public double GetBytesPerMs(string host)
+    public double GetBytesPerMs(string providerKey)
     {
-        if (string.IsNullOrEmpty(host)) return 0;
-        return _bytesPerMs.TryGetValue(host, out var v) ? v : 0;
+        if (string.IsNullOrEmpty(providerKey)) return 0;
+        return _bytesPerMs.TryGetValue(providerKey, out var v) ? v : 0;
     }
 
     /// <summary>
     /// Pop all buckets whose minute is strictly older than <paramref name="cutoffMinute"/>.
     /// Returned in stable order so callers can apply them transactionally.
     /// </summary>
-    public List<(long Minute, string Host, long Bytes)> DrainClosed(long cutoffMinute)
+    public List<(long Minute, string ProviderKey, long Bytes)> DrainClosed(long cutoffMinute)
     {
         var drained = new List<(long, string, long)>();
         foreach (var key in _buckets.Keys)
         {
             if (key.Minute >= cutoffMinute) continue;
             if (_buckets.TryRemove(key, out var bytes))
-                drained.Add((key.Minute, key.Host, bytes));
+                drained.Add((key.Minute, key.ProviderKey, bytes));
         }
         return drained;
     }

--- a/backend/Services/Metrics/ProviderUsageHelper.cs
+++ b/backend/Services/Metrics/ProviderUsageHelper.cs
@@ -20,6 +20,8 @@ namespace NzbWebDAV.Services.Metrics;
 /// rewinds. Offset is added on top so a user migrating from another client can
 /// pre-seed "I've already burned 300 GB on this account" without faking events
 /// into the metrics tables.
+///
+/// Metrics keys are stable per-account <c>ProviderId</c> strings, not NNTP hosts.
 /// </summary>
 public static class ProviderUsageHelper
 {
@@ -39,27 +41,27 @@ public static class ProviderUsageHelper
     /// summed from ProviderHourly. The caller adds <see cref="UsenetProviderConfig.ConnectionDetails.BytesUsedOffset"/>
     /// if it wants the user-facing total.
     /// </summary>
-    public static async Task<long> ReadDbBytesSinceResetAsync(string host, long resetAt)
+    public static async Task<long> ReadDbBytesSinceResetAsync(string providerKey, long resetAt)
     {
-        if (string.IsNullOrEmpty(host)) return 0;
+        if (string.IsNullOrEmpty(providerKey)) return 0;
         await using var db = new MetricsDbContext();
         // SumAsync over nothing returns 0; no need to guard for empty.
         return await db.ProviderHourly
-            .Where(x => x.Provider == host && x.Hour >= resetAt)
+            .Where(x => x.Provider == providerKey && x.Hour >= resetAt)
             .SumAsync(x => x.BytesFetched)
             .ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Raw ProviderHourly rows over the last 7 days for the supplied hosts,
-    /// grouped by host. Returning rows rather than a pre-aggregated sum lets
+    /// Raw ProviderHourly rows over the last 7 days for the supplied provider keys,
+    /// grouped by key. Returning rows rather than a pre-aggregated sum lets
     /// the caller apply each provider's own ResetAt cutoff in memory without
     /// firing N queries — the settings page polls every 10s.
     /// </summary>
     public static async Task<Dictionary<string, List<(long Hour, long Bytes)>>> ReadRecentHoursAsync(
-        IEnumerable<string> hosts)
+        IEnumerable<string> providerKeys)
     {
-        var distinct = hosts.Where(h => !string.IsNullOrEmpty(h)).Distinct().ToArray();
+        var distinct = providerKeys.Where(k => !string.IsNullOrEmpty(k)).Distinct().ToArray();
         if (distinct.Length == 0) return new Dictionary<string, List<(long, long)>>();
 
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -139,22 +141,27 @@ public static class ProviderUsageHelper
     /// </summary>
     public static async Task SeedTrackerAsync(ProviderBytesTracker tracker, UsenetProviderConfig config)
     {
+        await SeedTrackerAsync(tracker, config, () => new MetricsDbContext()).ConfigureAwait(false);
+    }
+
+    public static async Task SeedTrackerAsync(
+        ProviderBytesTracker tracker,
+        UsenetProviderConfig config,
+        Func<MetricsDbContext> dbFactory)
+    {
         if (config.Providers.Count == 0) return;
         try
         {
-            await using var db = new MetricsDbContext();
-            // Distinct host so we don't issue duplicate queries for the unusual
-            // case where two ConnectionDetails entries share a Host.
-            var seen = new HashSet<string>(StringComparer.Ordinal);
+            await using var db = dbFactory();
             foreach (var provider in config.Providers)
             {
-                var host = provider.Host;
-                if (string.IsNullOrEmpty(host) || !seen.Add(host)) continue;
+                if (provider.ProviderId == Guid.Empty) continue;
+                var key = UsenetProviderIdentity.MetricsKey(provider);
                 var bytes = await db.ProviderHourly
-                    .Where(x => x.Provider == host && x.Hour >= provider.BytesUsedResetAt)
+                    .Where(x => x.Provider == key && x.Hour >= provider.BytesUsedResetAt)
                     .SumAsync(x => x.BytesFetched)
                     .ConfigureAwait(false);
-                tracker.SetLifetime(host, bytes);
+                tracker.SetLifetime(key, bytes);
             }
         }
         catch (Exception ex)
@@ -170,7 +177,8 @@ public static class ProviderUsageHelper
     /// </summary>
     public static long ComputeUsage(ProviderBytesTracker tracker, UsenetProviderConfig.ConnectionDetails provider)
     {
-        var live = tracker.GetLifetime(provider.Host);
+        if (provider.ProviderId == Guid.Empty) return Math.Max(0, provider.BytesUsedOffset);
+        var live = tracker.GetLifetime(UsenetProviderIdentity.MetricsKey(provider));
         return Math.Max(0, live + provider.BytesUsedOffset);
     }
 
@@ -185,5 +193,45 @@ public static class ProviderUsageHelper
         if (!limit.HasValue || limit.Value <= 0) return false;
         var effective = (long)(limit.Value * EffectiveLimitFraction);
         return ComputeUsage(tracker, provider) >= effective;
+    }
+
+    /// <summary>
+    /// Builds a metrics-key → display-label map (nickname, else host).
+    /// Used by overview/queue/history/live-reads so Guids never render.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string?> BuildLabelsByMetricsKey(
+        IEnumerable<UsenetProviderConfig.ConnectionDetails> providers)
+    {
+        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var group in providers
+                     .Where(p => p.ProviderId != Guid.Empty)
+                     .GroupBy(p => UsenetProviderIdentity.MetricsKey(p), StringComparer.Ordinal))
+        {
+            var p = group.First();
+            var nick = p.Nickname?.Trim();
+            result[group.Key] = string.IsNullOrEmpty(nick) ? p.Host : nick;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Builds a metrics-key → (Host, Nickname) map for API payloads that still
+    /// expose a host field for display (queue/history/live-reads).
+    /// </summary>
+    public static IReadOnlyDictionary<string, (string Host, string? Nickname)> BuildDisplayByMetricsKey(
+        IEnumerable<UsenetProviderConfig.ConnectionDetails> providers)
+    {
+        return providers
+            .Where(p => p.ProviderId != Guid.Empty)
+            .GroupBy(p => UsenetProviderIdentity.MetricsKey(p), StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g =>
+                {
+                    var p = g.First();
+                    var nick = p.Nickname?.Trim();
+                    return (p.Host, string.IsNullOrEmpty(nick) ? null : nick);
+                },
+                StringComparer.Ordinal);
     }
 }

--- a/backend/Streams/CountingYencStream.cs
+++ b/backend/Streams/CountingYencStream.cs
@@ -15,15 +15,15 @@ public sealed class CountingYencStream : YencStream
 {
     private readonly YencStream _inner;
     private readonly ProviderBytesTracker _tracker;
-    private readonly string _host;
+    private readonly string _providerKey;
     private long _bytes;
     private long _activeReadTicks;
 
-    public CountingYencStream(YencStream inner, ProviderBytesTracker tracker, string host) : base(Null)
+    public CountingYencStream(YencStream inner, ProviderBytesTracker tracker, string providerKey) : base(Null)
     {
         _inner = inner;
         _tracker = tracker;
-        _host = host;
+        _providerKey = providerKey;
     }
 
     public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(CancellationToken cancellationToken = default)
@@ -36,7 +36,7 @@ public sealed class CountingYencStream : YencStream
         _activeReadTicks += Stopwatch.GetTimestamp() - start;
         if (n > 0)
         {
-            _tracker.Add(_host, n);
+            _tracker.Add(_providerKey, n);
             _bytes += n;
         }
         return n;
@@ -49,7 +49,7 @@ public sealed class CountingYencStream : YencStream
             if (_bytes > 0 && _activeReadTicks > 0)
             {
                 var activeMs = _activeReadTicks * 1000.0 / Stopwatch.Frequency;
-                _tracker.RecordSegmentThroughput(_host, _bytes, activeMs);
+                _tracker.RecordSegmentThroughput(_providerKey, _bytes, activeMs);
             }
 
             _inner.Dispose();

--- a/frontend/app/routes/_index/components/live-reads/live-reads.tsx
+++ b/frontend/app/routes/_index/components/live-reads/live-reads.tsx
@@ -88,7 +88,7 @@ function ReadRow({ item }: { item: Read }) {
                 {item.providers.length === 0
                     ? <span className="italic text-base-content/40">buffering…</span>
                     : item.providers.map((p, i) => (
-                        <span key={p.host} className="inline-flex items-baseline gap-1">
+                        <span key={`${p.host}-${i}`} className="inline-flex items-baseline gap-1">
                             {i > 0 && <span className="text-base-content/30">·</span>}
                             <span className="text-base-content/70" title={p.host}>{p.nickname?.trim() || stripHost(p.host)}</span>
                             {totalSegments > 0 && (

--- a/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
+++ b/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
@@ -153,7 +153,7 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                                     const width = (p.misses / maxMisses) * 100;
                                     const share = segmentsCovered > 0 ? (p.misses / segmentsCovered) * 100 : 0;
                                     return (
-                                        <div key={p.provider} className={styles.row} title={p.provider}>
+                                        <div key={p.provider} className={styles.row} title={p.nickname?.trim() || p.provider}>
                                             <span className={styles.name}>{p.nickname?.trim() || p.provider}</span>
                                             <span className={styles.barTrack}>
                                                 <span className={`${styles.barFill} ${styles.barFillBad}`} style={{ width: `${width.toFixed(1)}%` }} />
@@ -178,7 +178,7 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                                     const width = (p.saves / maxSaves) * 100;
                                     const share = articlesRecovered > 0 ? (p.saves / articlesRecovered) * 100 : 0;
                                     return (
-                                        <div key={p.provider} className={styles.row} title={p.provider}>
+                                        <div key={p.provider} className={styles.row} title={p.nickname?.trim() || p.provider}>
                                             <span className={styles.name}>{p.nickname?.trim() || p.provider}</span>
                                             <span className={styles.barTrack}>
                                                 <span className={styles.barFill} style={{ width: `${width.toFixed(1)}%` }} />

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -106,7 +106,7 @@ export function LiveReadsPanel() {
                                         const label = p.nickname?.trim() || p.host;
                                         return (
                                             <span
-                                                key={p.host}
+                                                key={`${p.host}-${i}`}
                                                 className={`${styles.providerChip} ${i === 0 ? styles.providerChipPrimary : ""}`}
                                                 title={`${label} (${p.host}): ${p.segments} segments`}
                                             >

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -40,7 +40,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                             return (
                                 <tr key={p.provider}>
                                     <td>
-                                        <div className={styles.providerCell} title={p.provider}>
+                                        <div className={styles.providerCell} title={p.nickname?.trim() || p.provider}>
                                             <span className={styles.dot} />
                                             <span className={styles.providerName}>{p.nickname?.trim() || p.provider}</span>
                                         </div>

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -175,7 +175,7 @@ export function ProvidersBadge({ providers }: { providers: ProviderUsage[] }) {
     return (
         <span className="badge badge-dash badge-ghost badge-sm inline-flex max-w-full min-w-0 cursor-help items-baseline gap-1 overflow-hidden max-[899px]:max-w-full" title={tooltip}>
             {visible.map((p, i) => (
-                <span key={p.host} className="inline-flex min-w-0 shrink items-baseline overflow-hidden">
+                <span key={`${p.host}-${i}`} className="inline-flex min-w-0 shrink items-baseline overflow-hidden">
                     {i > 0 && <span className="text-base-content/20 mx-0.5 shrink-0">·</span>}
                     <span className="truncate">{labelOf(p)}</span>
                     {total > 0 && (

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -71,6 +71,7 @@ enum ProviderType {
 }
 
 type ConnectionDetails = {
+    ProviderId?: string;
     Type: ProviderType;
     Host: string;
     Port: number;
@@ -81,7 +82,7 @@ type ConnectionDetails = {
     Priority?: number;
     PipeliningDepth?: number | null;
     // Optional user-set label. Shown in the UI in place of Host when present;
-    // Host stays the real NNTP target.
+    // Host stays the real NNTP target. ProviderId is the stable metrics key.
     Nickname?: string;
     // Optional label for providers that share upstream storage. When one reports
     // an article missing (NNTP 430), siblings with the same label are skipped
@@ -301,7 +302,11 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
         if (editingIndex !== null) {
             providers[editingIndex] = provider;
         } else {
-            providers.push({ ...provider, Priority: providers.length });
+            providers.push({
+                ...provider,
+                ProviderId: provider.ProviderId || crypto.randomUUID(),
+                Priority: providers.length,
+            });
         }
         setNewConfig({ ...config, "usenet.providers": serializeProviderConfig({ ...providerConfig, Providers: providers }) });
         handleCloseModal();
@@ -966,6 +971,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
         const trimmedNickname = nickname.trim();
         const trimmedStorageGroup = storageGroup.trim();
         onSave({
+            ProviderId: provider?.ProviderId,
             Type: type,
             Host: host,
             Port: parseInt(port, 10),

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -199,6 +199,20 @@ function providerKey(p: ConnectionDetails): string {
     return `${p.Host}::${p.Port}::${p.User}`;
 }
 
+// crypto.randomUUID requires a secure context, but self-hosted UIs are often
+// served over plain http on a LAN; fall back to a manual v4 from getRandomValues.
+function generateProviderId(): string {
+    if (typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 type DragBits = {
     setNodeRef: (node: HTMLElement | null) => void;
     setActivatorNodeRef: (node: HTMLElement | null) => void;
@@ -304,7 +318,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
         } else {
             providers.push({
                 ...provider,
-                ProviderId: provider.ProviderId || crypto.randomUUID(),
+                ProviderId: provider.ProviderId || generateProviderId(),
                 Priority: providers.length,
             });
         }

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
@@ -1,0 +1,224 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+public class ProviderMetricsKeyTests
+{
+    [Fact]
+    public void Tracker_IsolatesSameHostAccountsByProviderKey()
+    {
+        var tracker = new ProviderBytesTracker();
+        var a = Guid.NewGuid().ToString("N");
+        var b = Guid.NewGuid().ToString("N");
+
+        tracker.Add(a, 1000);
+        tracker.Add(b, 250);
+
+        Assert.Equal(1000, tracker.GetLifetime(a));
+        Assert.Equal(250, tracker.GetLifetime(b));
+        Assert.Equal(1250, tracker.LifetimeAll);
+    }
+
+    [Fact]
+    public void ComputeUsage_AndIsOverLimit_AreIndependentPerProviderId()
+    {
+        var tracker = new ProviderBytesTracker();
+        var providerA = MakeProvider("news.example.com", "user-a", byteLimit: 1000);
+        var providerB = MakeProvider("news.example.com", "user-b", byteLimit: 1000);
+        var keyA = UsenetProviderIdentity.MetricsKey(providerA);
+        var keyB = UsenetProviderIdentity.MetricsKey(providerB);
+
+        tracker.SetLifetime(keyA, 960); // over 95% effective limit
+        tracker.SetLifetime(keyB, 100);
+
+        Assert.Equal(960, ProviderUsageHelper.ComputeUsage(tracker, providerA));
+        Assert.Equal(100, ProviderUsageHelper.ComputeUsage(tracker, providerB));
+        Assert.True(ProviderUsageHelper.IsOverLimit(tracker, providerA));
+        Assert.False(ProviderUsageHelper.IsOverLimit(tracker, providerB));
+    }
+
+    [Fact]
+    public void EnsureProviderIds_AssignsMissingGuidsOnly()
+    {
+        var existing = Guid.NewGuid();
+        var config = new UsenetProviderConfig
+        {
+            Providers =
+            [
+                MakeProvider("news.example.com", "a", providerId: existing),
+                MakeProvider("news.example.com", "b", providerId: Guid.Empty),
+            ],
+        };
+
+        Assert.True(UsenetProviderIdentity.EnsureProviderIds(config));
+        Assert.Equal(existing, config.Providers[0].ProviderId);
+        Assert.NotEqual(Guid.Empty, config.Providers[1].ProviderId);
+        Assert.False(UsenetProviderIdentity.EnsureProviderIds(config));
+    }
+
+    [Fact]
+    public void NormalizeProviderIdsOnSave_PreservesMatchAndCreatesMissing()
+    {
+        var existingId = Guid.NewGuid();
+        var existing = new UsenetProviderConfig
+        {
+            Providers = [MakeProvider("news.example.com", "alice", port: 563, providerId: existingId)],
+        };
+        var incoming = new UsenetProviderConfig
+        {
+            Providers =
+            [
+                MakeProvider("news.example.com", "alice", port: 563, providerId: Guid.Empty),
+                MakeProvider("news.example.com", "bob", port: 563, providerId: Guid.Empty),
+            ],
+        };
+
+        UsenetProviderIdentity.NormalizeProviderIdsOnSave(incoming, existing);
+
+        Assert.Equal(existingId, incoming.Providers[0].ProviderId);
+        Assert.NotEqual(Guid.Empty, incoming.Providers[1].ProviderId);
+        Assert.NotEqual(existingId, incoming.Providers[1].ProviderId);
+    }
+
+    [Fact]
+    public async Task SeedTrackerAsync_SeedsEveryProviderWithoutHostDedup()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var providerA = MakeProvider("news.example.com", "a");
+        var providerB = MakeProvider("news.example.com", "b");
+        var keyA = UsenetProviderIdentity.MetricsKey(providerA);
+        var keyB = UsenetProviderIdentity.MetricsKey(providerB);
+        var hour = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        hour -= hour % 3_600_000;
+
+        harness.Context.ProviderHourly.AddRange(
+            new ProviderHourly { Hour = hour, Provider = keyA, BytesFetched = 111 },
+            new ProviderHourly { Hour = hour, Provider = keyB, BytesFetched = 222 });
+        await harness.Context.SaveChangesAsync();
+
+        var tracker = new ProviderBytesTracker();
+        await ProviderUsageHelper.SeedTrackerAsync(
+            tracker,
+            new UsenetProviderConfig { Providers = [providerA, providerB] },
+            () => harness.CreateContext());
+
+        Assert.Equal(111, tracker.GetLifetime(keyA));
+        Assert.Equal(222, tracker.GetLifetime(keyB));
+    }
+
+    [Fact]
+    public async Task Remap_AttributesHostRowsToFirstSameHostProvider()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var first = MakeProvider("news.example.com", "first");
+        var second = MakeProvider("news.example.com", "second");
+        var firstKey = UsenetProviderIdentity.MetricsKey(first);
+        var secondKey = UsenetProviderIdentity.MetricsKey(second);
+        var hour = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        hour -= hour % 3_600_000;
+
+        harness.Context.ProviderHourly.Add(new ProviderHourly
+        {
+            Hour = hour,
+            Provider = "news.example.com",
+            BytesFetched = 5000,
+            Articles = 10,
+        });
+        // Pre-existing id-keyed row in the same hour to exercise merge-on-conflict.
+        harness.Context.ProviderHourly.Add(new ProviderHourly
+        {
+            Hour = hour,
+            Provider = firstKey,
+            BytesFetched = 100,
+            Articles = 1,
+        });
+        await harness.Context.SaveChangesAsync();
+
+        await UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
+            new UsenetProviderConfig { Providers = [first, second] },
+            harness.Context);
+
+        await using var verify = harness.CreateContext();
+        var firstRow = await verify.ProviderHourly.SingleAsync(x => x.Provider == firstKey && x.Hour == hour);
+        Assert.Equal(5100, firstRow.BytesFetched);
+        Assert.Equal(11, firstRow.Articles);
+        Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == "news.example.com"));
+        Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == secondKey));
+    }
+
+    private static UsenetProviderConfig.ConnectionDetails MakeProvider(
+        string host,
+        string user,
+        int port = 563,
+        long? byteLimit = null,
+        Guid? providerId = null)
+    {
+        return new UsenetProviderConfig.ConnectionDetails
+        {
+            ProviderId = providerId ?? Guid.NewGuid(),
+            Type = ProviderType.Pooled,
+            Host = host,
+            Port = port,
+            UseSsl = true,
+            User = user,
+            Pass = "pass",
+            MaxConnections = 10,
+            ByteLimit = byteLimit,
+        };
+    }
+
+    private sealed class MetricsHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+        private readonly DbContextOptions<MetricsDbContext> _options;
+
+        private MetricsHarness(string dir, DbContextOptions<MetricsDbContext> options, MetricsDbContext context)
+        {
+            _dir = dir;
+            _options = options;
+            Context = context;
+        }
+
+        public MetricsDbContext Context { get; }
+
+        public MetricsDbContext CreateContext() => new(_options);
+
+        public static async Task<MetricsHarness> CreateAsync()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"nzbdav-metrics-key-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "metrics.sqlite");
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            return new MetricsHarness(dir, options, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #284: provider bandwidth/usage metrics are now keyed by a stable per-account `ProviderId` instead of NNTP host, so multiple accounts on the same host keep independent counters, caps, and scoreboard rows.
- Startup backfills missing ProviderIds, remaps legacy host-keyed metrics rows (first same-host account inherits history), and `UpdateConfig` preserves ids even when the UI omits them.
- Queue/history/live-reads/watchdog resolve metrics keys to `nickname || host` so Guids never render.

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~ProviderMetricsKeyTests` (6 passing)
- [x] Related usenet/config unit tests (49 passing)
- [x] `cd frontend && npm run typecheck`
- [ ] Configure two providers with the same Host / different User; confirm Settings gauges and Overview scoreboard show independent totals
- [ ] Reset usage on one account; confirm the other is unaffected
- [ ] After upgrade, confirm prior single-account host-keyed history appears under the remapped ProviderId