### PR TITLE
fix(ui): frontend audit and UX batch

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -121,6 +121,8 @@ The image runs two processes: the frontend and public proxy on port `3000`, and 
 > Port `3000` serves plain HTTP. If NzbDav will be reachable outside your trusted network, put it behind an HTTPS reverse proxy and do not expose the container port directly to the internet. WebDAV uses Basic authentication, so remote access without TLS exposes credentials. When the proxy runs on the Docker host, bind the port to localhost with `127.0.0.1:3000:3000`.
 >
 > For adapter/Newznab absolute links and STRM URLs, set an explicit **Base URL** under Settings (preferred). Without it, public scheme/host come only from trusted forwarded headers: the frontend strips client `X-Forwarded-*` and rewrites canonical values for the backend (which trusts loopback by default). TLS-terminating reverse proxies should set `TRUST_PROXY=1` on the container so Express honors the proxy’s forwarded headers when rewriting, **or** set Base URL explicitly — otherwise generated links may stay `http://`. Split-container topologies can widen backend trust with `TRUSTED_PROXY_CIDRS` (comma-separated IPs or CIDRs).
+>
+> Frontend session cookies: set `SECURE_COOKIES=true` when the UI is only served over HTTPS. Optionally set `SESSION_KEY` to a long random secret (otherwise a stable key is persisted under `CONFIG_PATH/session.key` so restarts do not log everyone out). Optionally set `SESSION_MAX_AGE` in seconds (default one year).
 
 ### 2. Core configuration
 

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "material-symbols/rounded.css";
+@import "@fontsource-variable/inter";
 
 @plugin "daisyui" {
   themes: false;
@@ -91,7 +92,7 @@
     --radius-sm: 6px;
     --radius-md: 10px;
     --radius-lg: 14px;
-    --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
+    --font-sans: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
     --font-mono: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
     --body-background-color: var(--app-bg);
     --top-nav-background-color: var(--app-bg);
@@ -105,7 +106,7 @@
   html,
   body {
     @apply bg-base-300 text-base-content m-0 min-h-full min-w-full antialiased;
-    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Inter Variable", Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 
   body {

--- a/frontend/app/auth/authentication.server.ts
+++ b/frontend/app/auth/authentication.server.ts
@@ -1,5 +1,7 @@
 import { createCookieSessionStorage } from "react-router";
-import crypto from "crypto"
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
 import { backendClient } from "~/clients/backend-client.server";
 import type { IncomingMessage } from "http";
 
@@ -10,7 +12,53 @@ type User = {
 };
 
 const oneYear = 60 * 60 * 24 * 365; // seconds
-const sessionKey = process.env.SESSION_KEY ||= crypto.randomBytes(64).toString("hex");
+
+function resolveSessionMaxAgeSeconds(): number {
+  const raw = process.env.SESSION_MAX_AGE?.trim();
+  if (!raw) return oneYear;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return oneYear;
+  return parsed;
+}
+
+function resolveSessionKey(): string {
+  if (process.env.SESSION_KEY) return process.env.SESSION_KEY;
+
+  const configPath = process.env.CONFIG_PATH;
+  if (configPath) {
+    const keyPath = path.join(configPath, "session.key");
+    try {
+      if (fs.existsSync(keyPath)) {
+        const existing = fs.readFileSync(keyPath, "utf8").trim();
+        if (existing.length > 0) {
+          process.env.SESSION_KEY = existing;
+          return existing;
+        }
+      }
+      const generated = crypto.randomBytes(64).toString("hex");
+      fs.mkdirSync(configPath, { recursive: true });
+      fs.writeFileSync(keyPath, generated, { encoding: "utf8", mode: 0o600 });
+      process.env.SESSION_KEY = generated;
+      return generated;
+    } catch {
+      // Fall through to ephemeral key if CONFIG_PATH is unwritable.
+    }
+  }
+
+  const ephemeral = crypto.randomBytes(64).toString("hex");
+  process.env.SESSION_KEY = ephemeral;
+  return ephemeral;
+}
+
+const sessionKey = resolveSessionKey();
+const sessionMaxAge = resolveSessionMaxAgeSeconds();
+const secureCookiesExplicit = process.env.SECURE_COOKIES !== undefined && process.env.SECURE_COOKIES !== "";
+if (!secureCookiesExplicit && !IS_FRONTEND_AUTH_DISABLED) {
+  console.warn(
+    "SECURE_COOKIES is unset; session cookies will be sent over HTTP. Set SECURE_COOKIES=true behind HTTPS.",
+  );
+}
+
 const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: "__session",
@@ -19,7 +67,7 @@ const sessionStorage = createCookieSessionStorage({
     sameSite: "strict",
     secrets: [sessionKey],
     secure: ["true", "yes"].includes(process?.env?.SECURE_COOKIES || ""),
-    maxAge: oneYear,
+    maxAge: sessionMaxAge,
   },
 });
 

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -51,13 +51,27 @@ export async function loader({ request }: Route.LoaderArgs) {
   };
 }
 
-/** Only re-fetch layout config after settings/onboarding mutations. */
+/** True for pages the root loader renders without the app layout. */
+function isLayoutlessPath(pathname: string): boolean {
+  const path = pathname.replace(/\.data$/, "");
+  return path === "/login" || path === "/onboarding";
+}
+
+/**
+ * Skip root config re-fetches for routine mutations (queue deletes, toggles),
+ * but always revalidate when crossing the login/onboarding layout boundary
+ * (login/logout redirects change `useLayout`) and after settings/onboarding
+ * saves (which can change providers/watchdog config).
+ */
 export function shouldRevalidate({
   currentUrl,
   nextUrl,
   formMethod,
   defaultShouldRevalidate,
 }: ShouldRevalidateFunctionArgs) {
+  if (isLayoutlessPath(currentUrl.pathname) !== isLayoutlessPath(nextUrl.pathname)) {
+    return true;
+  }
   if (formMethod && formMethod !== "GET") {
     const fromSettingsOrOnboarding =
       currentUrl.pathname.startsWith("/settings")

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -8,6 +8,7 @@ import {
   useLocation,
   useNavigation,
   useRouteError,
+  type ShouldRevalidateFunctionArgs,
 } from "react-router";
 
 import "./app.css";
@@ -48,6 +49,25 @@ export async function loader({ request }: Route.LoaderArgs) {
     isWatchdogEnabled:
       config.find(item => item.configName === "play.watchdog-enabled")?.configValue?.toLowerCase() !== "false",
   };
+}
+
+/** Only re-fetch layout config after settings/onboarding mutations. */
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (formMethod && formMethod !== "GET") {
+    const fromSettingsOrOnboarding =
+      currentUrl.pathname.startsWith("/settings")
+      || currentUrl.pathname.startsWith("/onboarding");
+    const toSettingsOrOnboarding =
+      nextUrl.pathname.startsWith("/settings")
+      || nextUrl.pathname.startsWith("/onboarding");
+    return fromSettingsOrOnboarding || toSettingsOrOnboarding;
+  }
+  return defaultShouldRevalidate;
 }
 
 function hasConfiguredUsenetProviders(configValue?: string): boolean {

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -69,9 +69,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/logo.svg" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
         <Meta />
         <Links />
       </head>

--- a/frontend/app/routes/_index/components/live-reads/live-reads.tsx
+++ b/frontend/app/routes/_index/components/live-reads/live-reads.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
+import { useState } from "react";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
 import { Icon } from "~/components/ui";
-
-const activeReadsTopic = { ar: 'state' };
 
 type ProviderUsage = { host: string; nickname?: string | null; segments: number };
 type Read = {
@@ -38,30 +36,12 @@ function shortName(name: string): string {
 export function LiveReads() {
     const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
 
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage((_, message) => {
-                try { setSnapshot(JSON.parse(message)); }
-                catch { /* ignore malformed frames */ }
-            });
-            ws.onopen = () => ws.send(JSON.stringify(activeReadsTopic));
-            ws.onerror = () => { ws.close() };
-            ws.onclose = onClose;
-            return () => { disposed = true; ws.close(); }
-        }
-        function onClose(e: CloseEvent) {
-            if (e.code === 1008) {
-                globalThis.location.assign("/login");
-                return;
-            }
-            !disposed && setTimeout(() => connect(), 1000);
-            setSnapshot(null);
-        }
-        return connect();
-    }, []);
+    useWebsocketTopic("ar", "state", (message) => {
+        try { setSnapshot(JSON.parse(message)); }
+        catch { /* ignore malformed frames */ }
+    }, {
+        onClose: () => setSnapshot(null),
+    });
 
     const reads = snapshot?.reads ?? [];
     if (reads.length === 0) return null;

--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
-
-const usenetConnectionsTopic = {'cxs': 'state'};
+import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type LiveUsenetConnectionsProps = {
     hasUsenetProviders: boolean,
@@ -13,31 +11,18 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
     const [_0, _1, _2, live, max, idle] = parts.map(x => Number(x));
     const active = live - idle;
 
-    useEffect(() => {
-        if (!hasUsenetProviders) {
-            setConnections(null);
-            return;
-        }
+    useWebsocketTopic(
+        "cxs",
+        "state",
+        setConnections,
+        {
+            enabled: hasUsenetProviders,
+            onClose: () => setConnections(null),
+        },
+    );
 
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage((_, message) => setConnections(message));
-            ws.onopen = () => ws.send(JSON.stringify(usenetConnectionsTopic));
-            ws.onerror = () => { ws.close() };
-            ws.onclose = onClose;
-            return () => { disposed = true; ws.close(); }
-        }
-        function onClose(e: CloseEvent) {
-            if (e.code == 1008) {
-                globalThis.location.assign("/login");
-                return;
-            }
-            !disposed && setTimeout(() => connect(), 1000);
-            setConnections(null);
-        }
-        return connect();
+    useEffect(() => {
+        if (!hasUsenetProviders) setConnections(null);
     }, [hasUsenetProviders]);
 
     return (

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -279,7 +279,7 @@ function Body(props: ExplorePageData) {
                             This WebDAV directory does not exist, may have moved, or is still initializing.
                         </p>
                         <div className="card-actions justify-center">
-                                <Link to="/explore" prefetch="none" className="btn btn-primary btn-sm">
+                                <Link to="/explore" discover="none" className="btn btn-primary btn-sm">
                                 WebDAV root
                             </Link>
                         </div>
@@ -330,7 +330,7 @@ function Body(props: ExplorePageData) {
                                         onToggle={toggleSelect}
                                     />
                                 )}
-                                <Link to={getDirectoryPath(x.name)} prefetch="none">
+                                <Link to={getDirectoryPath(x.name)} discover="none">
                                     <div className={styles["item-content"]}>
                                         <div className={styles["directory-icon"]} />
                                         <div className={styles["item-name"]}>{x.name}</div>

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -279,7 +279,7 @@ function Body(props: ExplorePageData) {
                             This WebDAV directory does not exist, may have moved, or is still initializing.
                         </p>
                         <div className="card-actions justify-center">
-                            <Link to="/explore" className="btn btn-primary btn-sm">
+                                <Link to="/explore" prefetch="none" className="btn btn-primary btn-sm">
                                 WebDAV root
                             </Link>
                         </div>
@@ -330,7 +330,7 @@ function Body(props: ExplorePageData) {
                                         onToggle={toggleSelect}
                                     />
                                 )}
-                                <Link to={getDirectoryPath(x.name)}>
+                                <Link to={getDirectoryPath(x.name)} prefetch="none">
                                     <div className={styles["item-content"]}>
                                         <div className={styles["directory-icon"]} />
                                         <div className={styles["item-name"]}>{x.name}</div>

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -3,7 +3,7 @@ import { backendClient } from "~/clients/backend-client.server";
 import { HealthTable } from "./components/health-table/health-table";
 import { HealthStats } from "./components/health-stats/health-stats";
 import { useCallback, useEffect, useState } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
+import { useWebsocketTopics } from "~/utils/shared-websocket";
 import { Alert, Icon } from "~/components/ui";
 
 const topicNames = {
@@ -13,7 +13,7 @@ const topicNames = {
 const topicSubscriptions = {
     [topicNames.healthItemStatus]: 'event',
     [topicNames.healthItemProgress]: 'event',
-}
+} as const;
 
 export async function loader() {
     const enabledKey = 'repair.enable';
@@ -117,20 +117,7 @@ export default function Health({ loaderData }: Route.ComponentProps) {
         onHealthItemProgress
     ]);
 
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage(onWebsocketMessage);
-            ws.onopen = () => { ws.send(JSON.stringify(topicSubscriptions)); }
-            ws.onclose = () => { !disposed && setTimeout(() => connect(), 1000); };
-            ws.onerror = () => { ws.close() };
-            return () => { disposed = true; ws.close(); }
-        }
-
-        return connect();
-    }, [onWebsocketMessage]);
+    useWebsocketTopics(topicSubscriptions, onWebsocketMessage);
 
     return (
         <div className="flex min-h-full min-w-full flex-col gap-8 px-4 py-4 text-sm text-slate-300 md:px-8">

--- a/frontend/app/routes/logs/controllers/websocket-controller.ts
+++ b/frontend/app/routes/logs/controllers/websocket-controller.ts
@@ -1,9 +1,8 @@
-import { useEffect } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
+import { useWebsocketTopics } from "~/utils/shared-websocket";
 import type { LogBroadcastMessage, LogEntry } from "~/clients/backend-client.server";
 
 const LOG_TOPIC = "log";
-const topicSubscriptions = { [LOG_TOPIC]: "event" };
+const topicSubscriptions = { [LOG_TOPIC]: "event" } as const;
 
 export type ConnectionStatus = "connecting" | "live" | "reconnecting" | "disconnected";
 
@@ -11,41 +10,20 @@ export function useLogsWebsocket(
     onBatch: (entries: LogEntry[]) => void,
     onStatus: (status: ConnectionStatus) => void,
 ) {
-    useEffect(() => {
-        let ws: WebSocket | null = null;
-        let disposed = false;
-        let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-
-        const connect = () => {
-            onStatus("connecting");
-            ws = new WebSocket(window.location.origin.replace(/^http/, "ws"));
-            ws.onmessage = receiveMessage((topic, message) => {
-                if (topic !== LOG_TOPIC) return;
-                try {
-                    const parsed = JSON.parse(message) as LogBroadcastMessage;
-                    if (parsed?.entries?.length) onBatch(parsed.entries);
-                } catch {
-                    // ignore malformed payloads
-                }
-            });
-            ws.onopen = () => {
-                ws?.send(JSON.stringify(topicSubscriptions));
-                onStatus("live");
-            };
-            ws.onclose = () => {
-                if (disposed) return;
-                onStatus("reconnecting");
-                reconnectTimer = setTimeout(connect, 1000);
-            };
-            ws.onerror = () => ws?.close();
-        };
-
-        connect();
-        return () => {
-            disposed = true;
-            if (reconnectTimer) clearTimeout(reconnectTimer);
-            ws?.close();
-            onStatus("disconnected");
-        };
-    }, [onBatch, onStatus]);
+    useWebsocketTopics(
+        topicSubscriptions,
+        (topic, message) => {
+            if (topic !== LOG_TOPIC) return;
+            try {
+                const parsed = JSON.parse(message) as LogBroadcastMessage;
+                if (parsed?.entries?.length) onBatch(parsed.entries);
+            } catch {
+                // ignore malformed payloads
+            }
+        },
+        {
+            onOpen: () => onStatus("live"),
+            onClose: () => onStatus("reconnecting"),
+        },
+    );
 }

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import styles from "./live-reads-panel.module.css";
 import type { ActiveRead, ActiveReadsMessage } from "~/clients/backend-client.server";
 import { formatBytes } from "../../utils/format";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 const TOPIC_ACTIVE_READS = "ar";
-const SUBSCRIPTION = { [TOPIC_ACTIVE_READS]: "state" };
 
 /**
  * Live "right now" panel — reads cards refreshed via the ActiveReads WS topic.
@@ -15,49 +15,29 @@ export function LiveReadsPanel() {
     // Track previous bytesRead per session for live MiB/s computation.
     const prevRef = useRef<Map<string, { bytes: number, at: number, rate: number }>>(new Map());
 
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(globalThis.location.origin.replace(/^http/, "ws"));
-            ws.onmessage = (event) => {
-                try {
-                    const parsed = JSON.parse(event.data);
-                    if (parsed.Topic !== TOPIC_ACTIVE_READS) return;
-                    const payload: ActiveReadsMessage = JSON.parse(parsed.Message);
-                    const now = Date.now();
-                    const prev = prevRef.current;
-                    const next = new Map<string, { bytes: number, at: number, rate: number }>();
-                    for (const r of payload.reads ?? []) {
-                        const old = prev.get(r.id);
-                        let rate = old?.rate ?? 0;
-                        if (old && now > old.at) {
-                            const dt = (now - old.at) / 1000;
-                            const db = r.bytesRead - old.bytes;
-                            if (dt > 0 && db >= 0) {
-                                const instant = db / dt;
-                                rate = old.rate * 0.4 + instant * 0.6;
-                            }
-                        }
-                        next.set(r.id, { bytes: r.bytesRead, at: now, rate });
+    useWebsocketTopic(TOPIC_ACTIVE_READS, "state", (message) => {
+        try {
+            const payload: ActiveReadsMessage = JSON.parse(message);
+            const now = Date.now();
+            const prev = prevRef.current;
+            const next = new Map<string, { bytes: number, at: number, rate: number }>();
+            for (const r of payload.reads ?? []) {
+                const old = prev.get(r.id);
+                let rate = old?.rate ?? 0;
+                if (old && now > old.at) {
+                    const dt = (now - old.at) / 1000;
+                    const db = r.bytesRead - old.bytes;
+                    if (dt > 0 && db >= 0) {
+                        const instant = db / dt;
+                        rate = old.rate * 0.4 + instant * 0.6;
                     }
-                    prevRef.current = next;
-                    setReads(payload.reads ?? []);
-                } catch { /* ignore */ }
-            };
-            ws.onopen = () => { ws.send(JSON.stringify(SUBSCRIPTION)); };
-            ws.onclose = (event) => {
-                if (event.code === 1008) {
-                    globalThis.location.assign("/login");
-                    return;
                 }
-                if (!disposed) setTimeout(connect, 1000);
-            };
-            ws.onerror = () => { ws.close(); };
-        }
-        connect();
-        return () => { disposed = true; ws?.close(); };
-    }, []);
+                next.set(r.id, { bytes: r.bytesRead, at: now, rate });
+            }
+            prevRef.current = next;
+            setReads(payload.reads ?? []);
+        } catch { /* ignore */ }
+    });
 
     if (reads.length === 0) return null;
 

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/route";
 import styles from "./route.module.css";
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
+import { useWebsocketTopics } from "~/utils/shared-websocket";
 import { DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCenter, type DragEndEvent } from "@dnd-kit/core";
 import { SortableContext, arrayMove, verticalListSortingStrategy, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { LiveTiles } from "./components/live-tiles/live-tiles";
@@ -33,7 +33,7 @@ const topicNames = {
 };
 const topicSubscriptions = {
     [topicNames.liveStats]: 'state',
-};
+} as const;
 
 const WINDOWS: { value: OverviewWindow, label: string }[] = [
     { value: "1h", label: "1h" },
@@ -179,30 +179,13 @@ export default function Overview(_props: Route.ComponentProps) {
         return () => clearInterval(interval);
     }, []);
 
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(globalThis.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage(onWsMessage);
-            ws.onopen = () => {
-                setConnectedAt(Date.now());
-                ws.send(JSON.stringify(topicSubscriptions));
-            };
-            ws.onclose = (event) => {
-                setConnectedAt(null);
-                setTransportFailed(true);
-                if (event.code === 1008) {
-                    globalThis.location.assign("/login");
-                    return;
-                }
-                if (!disposed) setTimeout(connect, 1000);
-            };
-            ws.onerror = () => { ws.close(); };
-        }
-        connect();
-        return () => { disposed = true; ws?.close(); };
-    }, [onWsMessage]);
+    useWebsocketTopics(topicSubscriptions, onWsMessage, {
+        onOpen: () => setConnectedAt(Date.now()),
+        onClose: () => {
+            setConnectedAt(null);
+            setTransportFailed(true);
+        },
+    });
 
     const heartbeatAge = liveClock - (lastLiveStatsAt ?? connectedAt ?? liveClock);
     const liveStatsStale = transportFailed || (connectedAt !== null && heartbeatAge > 15_000);

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -205,7 +205,7 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
     return (
         <>
             {!isFolderDisabled && folderLink &&
-                <Link to={folderLink} prefetch="none">
+                <Link to={folderLink} discover="none">
                     <ActionButton type="explore" />
                 </Link>
             }

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -205,7 +205,7 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
     return (
         <>
             {!isFolderDisabled && folderLink &&
-                <Link to={folderLink} >
+                <Link to={folderLink} prefetch="none">
                     <ActionButton type="explore" />
                 </Link>
             }

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -69,7 +69,7 @@ export type PageRowProps = {
 }
 export function PageRow(props: PageRowProps) {
     const nameContent = props.nameHref
-        ? <Link to={props.nameHref} className="text-base-content hover:text-primary hover:underline" onClick={e => e.stopPropagation()}>{props.name}</Link>
+        ? <Link to={props.nameHref} prefetch="none" className="text-base-content hover:text-primary hover:underline" onClick={e => e.stopPropagation()}>{props.name}</Link>
         : props.name;
     const completedLabel = formatCompleted(props.completed);
 

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -69,7 +69,7 @@ export type PageRowProps = {
 }
 export function PageRow(props: PageRowProps) {
     const nameContent = props.nameHref
-        ? <Link to={props.nameHref} prefetch="none" className="text-base-content hover:text-primary hover:underline" onClick={e => e.stopPropagation()}>{props.name}</Link>
+        ? <Link to={props.nameHref} discover="none" className="text-base-content hover:text-primary hover:underline" onClick={e => e.stopPropagation()}>{props.name}</Link>
         : props.name;
     const completedLabel = formatCompleted(props.completed);
 

--- a/frontend/app/routes/queue/controllers/dropzone-controller.ts
+++ b/frontend/app/routes/queue/controllers/dropzone-controller.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent } from "react";
 import type { UploadingFile } from "../route";
 
@@ -21,6 +21,14 @@ export function useQueueDropzone(
     const dragDepthRef = useRef(0);
     const [isDragActive, setIsDragActive] = useState(false);
     const [rejectMessage, setRejectMessage] = useState<string | null>(null);
+
+    // iOS Safari greys out files whose extension/MIME it doesn't recognize
+    // (like .nzb) when `accept` is set. Strip the attribute after mount on
+    // iOS instead of branching during render, which would mismatch the SSR
+    // markup and trigger a hydration error.
+    useEffect(() => {
+        if (isIosUserAgent()) inputRef.current?.removeAttribute("accept");
+    }, []);
 
     const enqueueFiles = useCallback((acceptedFiles: File[]) => {
         const newFiles: UploadingFile[] = acceptedFiles.map(file => ({
@@ -94,19 +102,13 @@ export function useQueueDropzone(
             onDragLeave,
             onDrop,
         }),
-        getInputProps: () => {
-            // iOS Safari greys out unrecognized extensions in `accept`; omit it there.
-            const props: Record<string, unknown> = {
-                ref: inputRef,
-                type: "file",
-                multiple: true,
-                hidden: true,
-                onChange: onInputChange,
-            };
-            if (!isIosUserAgent()) {
-                props.accept = ".nzb,application/x-nzb";
-            }
-            return props;
-        },
+        getInputProps: () => ({
+            ref: inputRef,
+            type: "file",
+            accept: ".nzb,application/x-nzb",
+            multiple: true,
+            hidden: true,
+            onChange: onInputChange,
+        }),
     };
 }

--- a/frontend/app/routes/queue/controllers/dropzone-controller.ts
+++ b/frontend/app/routes/queue/controllers/dropzone-controller.ts
@@ -2,6 +2,16 @@ import { useCallback, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent } from "react";
 import type { UploadingFile } from "../route";
 
+function isIosUserAgent(): boolean {
+    if (typeof navigator === "undefined") return false;
+    return /iPad|iPhone|iPod/i.test(navigator.userAgent)
+        || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+}
+
+function isNzbFile(file: File): boolean {
+    return file.name.toLowerCase().endsWith(".nzb");
+}
+
 export function useQueueDropzone(
     setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void,
     uploadQueueRef: React.RefObject<UploadingFile[]>,
@@ -10,6 +20,7 @@ export function useQueueDropzone(
     const inputRef = useRef<HTMLInputElement>(null);
     const dragDepthRef = useRef(0);
     const [isDragActive, setIsDragActive] = useState(false);
+    const [rejectMessage, setRejectMessage] = useState<string | null>(null);
 
     const enqueueFiles = useCallback((acceptedFiles: File[]) => {
         const newFiles: UploadingFile[] = acceptedFiles.map(file => ({
@@ -53,19 +64,29 @@ export function useQueueDropzone(
         event.preventDefault();
         dragDepthRef.current = 0;
         setIsDragActive(false);
+        setRejectMessage(null);
         enqueueFiles(
-            Array.from(event.dataTransfer.files)
-                .filter(file => file.name.toLowerCase().endsWith(".nzb"))
+            Array.from(event.dataTransfer.files).filter(isNzbFile)
         );
     }, [enqueueFiles]);
 
     const onInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-        enqueueFiles(Array.from(event.target.files ?? []));
+        const selected = Array.from(event.target.files ?? []);
+        const nzbFiles = selected.filter(isNzbFile);
+        const rejected = selected.length - nzbFiles.length;
+        setRejectMessage(
+            rejected > 0
+                ? `Skipped ${rejected} non-.nzb file${rejected === 1 ? "" : "s"}.`
+                : null,
+        );
+        enqueueFiles(nzbFiles);
         event.target.value = "";
     }, [enqueueFiles]);
 
     return {
         isDragActive,
+        rejectMessage,
+        clearRejectMessage: () => setRejectMessage(null),
         open: () => inputRef.current?.click(),
         getRootProps: () => ({
             onDragEnter,
@@ -73,13 +94,19 @@ export function useQueueDropzone(
             onDragLeave,
             onDrop,
         }),
-        getInputProps: () => ({
-            ref: inputRef,
-            type: "file",
-            accept: ".nzb,application/x-nzb",
-            multiple: true,
-            hidden: true,
-            onChange: onInputChange,
-        }),
+        getInputProps: () => {
+            // iOS Safari greys out unrecognized extensions in `accept`; omit it there.
+            const props: Record<string, unknown> = {
+                ref: inputRef,
+                type: "file",
+                multiple: true,
+                hidden: true,
+                onChange: onInputChange,
+            };
+            if (!isIosUserAgent()) {
+                props.accept = ".nzb,application/x-nzb";
+            }
+            return props;
+        },
     };
 }

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 import type { HistoryEvents, QueueEvents } from "./events-controller";
-import { receiveMessage } from "~/utils/websocket-util";
+import { useWebsocketTopics } from "~/utils/shared-websocket";
 
 const topicNames = {
     queueItemStatus: 'qs',
@@ -20,7 +20,7 @@ const topicSubscriptions = {
     [topicNames.queueItemRemoved]: 'event',
     [topicNames.historyItemAdded]: 'event',
     [topicNames.historyItemRemoved]: 'event',
-};
+} as const;
 
 export function initializeQueueHistoryWebsocket(
     queueEvents: QueueEvents,
@@ -54,18 +54,5 @@ export function initializeQueueHistoryWebsocket(
         isHistoryLive
     ]);
 
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage(onWebsocketMessage);
-            ws.onopen = () => { ws.send(JSON.stringify(topicSubscriptions)); }
-            ws.onclose = () => { !disposed && setTimeout(() => connect(), 1000); };
-            ws.onerror = () => { ws.close() };
-            return () => { disposed = true; ws.close(); }
-        }
-
-        return connect();
-    }, [onWebsocketMessage]);
+    useWebsocketTopics(topicSubscriptions, onWebsocketMessage);
 }

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -8,6 +8,7 @@ import { useHistoryEvents, useQueueEvents } from "./controllers/events-controlle
 import { initializeQueueHistoryWebsocket } from "./controllers/websocket-controller";
 import { initializeUploadController } from "./controllers/nzb-upload-controller";
 import { useQueueDropzone } from "./controllers/dropzone-controller";
+import { Alert } from "~/components/ui";
 
 const pageSize = 100;
 
@@ -96,6 +97,12 @@ export default function Queue(props: Route.ComponentProps) {
     // view
     return (
         <div className="min-h-full min-w-full px-4 py-4 text-sm text-slate-300 md:px-8">
+
+            {dropzone.rejectMessage && (
+                <Alert className="mb-4" variant="warning">
+                    {dropzone.rejectMessage}
+                </Alert>
+            )}
 
             {/* queue */}
             <div className="mb-12 min-h-[413.9px] min-[450px]:min-h-[382.9px]">

--- a/frontend/app/routes/settings/maintenance/migrate-database-files-to-blobstore/migrate-database-files-to-blobstore.tsx
+++ b/frontend/app/routes/settings/maintenance/migrate-database-files-to-blobstore/migrate-database-files-to-blobstore.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
-
-const TaskTopic = { 'uftbmp': 'state' };
+import { useState } from "react";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type ConvertStrmToSymlinksProps = {
     savedConfig: Record<string, string>
@@ -12,20 +10,10 @@ export function MigrateDatabaseFilesToBlobstore({ savedConfig }: ConvertStrmToSy
     const [connected, setConnected] = useState<boolean>(false);
     const [progress, setProgress] = useState<string | null>(null);
 
-    // effects
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage((_, message) => setProgress(message));
-            ws.onopen = () => { setConnected(true); ws.send(JSON.stringify(TaskTopic)); }
-            ws.onclose = () => { !disposed && setTimeout(() => connect(), 1000); setProgress(null) };
-            ws.onerror = () => { ws.close() };
-            return () => { disposed = true; ws.close(); }
-        }
-        return connect();
-    }, [setProgress, setConnected]);
+    useWebsocketTopic("uftbmp", "state", setProgress, {
+        onOpen: () => setConnected(true),
+        onClose: () => setProgress(null),
+    });
 
     return (
         <div className={'space-y-3'}>

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -2,9 +2,7 @@ import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useEffect, useState } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
-
-const cleanupTaskTopic = { 'ctp': 'state' };
+import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type RemoveUnlinkedFilesProps = {
     savedConfig: Record<string, string>
@@ -29,20 +27,10 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
     const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
     const runButtonLabel = isRunning ? "Running..." : "Run Task";
 
-    // effects
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage((_, message) => setProgress(message));
-            ws.onopen = () => { setConnected(true); ws.send(JSON.stringify(cleanupTaskTopic)); }
-            ws.onclose = () => { !disposed && setTimeout(() => connect(), 1000); setProgress(null) };
-            ws.onerror = () => { ws.close() };
-            return () => { disposed = true; ws.close(); }
-        }
-        return connect();
-    }, [setProgress, setConnected]);
+    useWebsocketTopic("ctp", "state", setProgress, {
+        onOpen: () => setConnected(true),
+        onClose: () => setProgress(null),
+    });
 
     useEffect(() => {
         if (isFinished)

--- a/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
+++ b/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
@@ -1,7 +1,7 @@
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type ConvertStrmToSymlinksProps = {

--- a/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
+++ b/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
@@ -2,9 +2,7 @@ import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useEffect, useState } from "react";
-import { receiveMessage } from "~/utils/websocket-util";
-
-const cleanupTaskTopic = { 'st2sy': 'state' };
+import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type ConvertStrmToSymlinksProps = {
     savedConfig: Record<string, string>
@@ -25,20 +23,10 @@ export function ConvertStrmToSymlinks({ savedConfig }: ConvertStrmToSymlinksProp
     const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
     const runButtonLabel = isRunning ? "Running..." : "Run Task";
 
-    // effects
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage((_, message) => setProgress(message));
-            ws.onopen = () => { setConnected(true); ws.send(JSON.stringify(cleanupTaskTopic)); }
-            ws.onclose = () => { !disposed && setTimeout(() => connect(), 1000); setProgress(null) };
-            ws.onerror = () => { ws.close() };
-            return () => { disposed = true; ws.close(); }
-        }
-        return connect();
-    }, [setProgress, setConnected]);
+    useWebsocketTopic("st2sy", "state", setProgress, {
+        onOpen: () => setConnected(true),
+        onClose: () => setProgress(null),
+    });
 
     // events
     const onRun = useCallback(async () => {

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -955,9 +955,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
         // history for the same hostname twice. On edit, leave ResetAt alone
         // (the dedicated Reset button is the right surface for that).
         const isNew = !isEditing;
-        const offsetToPersist = isNew
-            ? (initialUsedBytes ?? 0)
-            : (provider?.BytesUsedOffset ?? 0);
+        const offsetToPersist = initialUsedBytes ?? (isNew ? 0 : (provider?.BytesUsedOffset ?? 0));
         const resetAtToPersist = isNew && initialUsedBytes !== null
             ? Date.now()
             : (provider?.BytesUsedResetAt ?? 0);
@@ -1225,8 +1223,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                             </div>
                         </div>
 
-                        {!isEditing && (
-                            <div className={`${styles["form-group"]} ${styles["full-width"]}`}>
+                        <div className={`${styles["form-group"]} ${styles["full-width"]}`}>
                                 <label className={styles["form-label"]}>
                                     Already Used (optional)
                                 </label>
@@ -1253,7 +1250,6 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                                     Seed the counter when migrating a partially-used block from another client. Leave empty for a fresh block.
                                 </div>
                             </div>
-                        )}
                     </div>
 
                     {testError && (

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -2,7 +2,7 @@ import styles from "./usenet.module.css"
 import { type Dispatch, type SetStateAction, type ReactNode, type CSSProperties, useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { Button } from "~/components/ui/button";
 import { Icon, SettingsPage } from "~/components/ui";
-import { receiveMessage } from "~/utils/websocket-util";
+import { subscribeWebsocketTopics, useWebsocketTopic } from "~/utils/shared-websocket";
 import { isMaskedSecret } from "~/utils/config-mask";
 import {
     DndContext,
@@ -22,8 +22,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-const usenetConnectionsTopic = {'cxs': 'state'};
-const benchmarkTopic = {'bench': 'state'};
 const USAGE_POLL_INTERVAL_MS = 10_000;
 
 // Mirrors the camelCase JSON the backend benchmark endpoint + websocket emit.
@@ -366,24 +364,9 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
         }}));
     }, [setConnections]);
 
-    // effects
-    useEffect(() => {
-        let ws: WebSocket;
-        let disposed = false;
-        function connect() {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onmessage = receiveMessage((_, message) => handleConnectionsMessage(message));
-            ws.onopen = () => ws.send(JSON.stringify(usenetConnectionsTopic));
-            ws.onerror = () => { ws.close() };
-            ws.onclose = onClose;
-            return () => { disposed = true; ws.close(); }
-        }
-        function onClose(e: CloseEvent) {
-            !disposed && setTimeout(() => connect(), 1000);
-            setConnections({});
-        }
-        return connect();
-    }, [setConnections, handleConnectionsMessage]);
+    useWebsocketTopic("cxs", "state", handleConnectionsMessage, {
+        onClose: () => setConnections({}),
+    });
 
     // Poll provider usage. Backend computes "bytes since reset + offset" from
     // the persisted hourly rollup plus the in-memory tracker; cheap enough to
@@ -894,21 +877,18 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
 
         // Live progress over the websocket — best-effort eye-candy; the POST
         // below returns the authoritative result regardless.
-        let ws: WebSocket | null = null;
-        try {
-            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
-            ws.onopen = () => ws?.send(JSON.stringify(benchmarkTopic));
-            ws.onmessage = receiveMessage((topic, message) => {
-                if (topic !== 'bench') return;
+        const unsubscribeProgress = subscribeWebsocketTopics(
+            { bench: "state" },
+            (topic, message) => {
+                if (topic !== "bench") return;
                 try {
                     const update = JSON.parse(message) as BenchmarkProgress;
                     // Ignore the terminal "done" frame (incl. any replayed from a
                     // previous run) so the bar doesn't flash to 100% then restart.
-                    if (update.phase !== 'done') setBenchmarkProgress(update);
+                    if (update.phase !== "done") setBenchmarkProgress(update);
                 } catch { /* ignore malformed progress */ }
-            });
-            ws.onerror = () => ws?.close();
-        } catch { /* progress is optional */ }
+            },
+        );
 
         try {
             const formData = new FormData();
@@ -945,7 +925,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
         } finally {
             setIsBenchmarking(false);
             if (benchmarkAbortRef.current === controller) benchmarkAbortRef.current = null;
-            ws?.close();
+            unsubscribeProgress();
         }
     }, [host, port, useSsl, user, pass, maxConnections, intensity, pipeliningOnly]);
 

--- a/frontend/app/utils/shared-websocket.ts
+++ b/frontend/app/utils/shared-websocket.ts
@@ -1,0 +1,182 @@
+import { useEffect, useRef } from "react";
+import { receiveMessage } from "~/utils/websocket-util";
+
+export type TopicKind = "state" | "stream" | "event";
+
+type MessageListener = (topic: string, message: string) => void;
+
+type Subscriber = {
+    topics: Record<string, TopicKind>;
+    onMessage: MessageListener;
+    onOpen?: () => void;
+    onClose?: (event: CloseEvent) => void;
+};
+
+const RECONNECT_MS = 1000;
+
+function websocketUrl(): string {
+    return globalThis.location.origin.replace(/^http/, "ws");
+}
+
+/**
+ * One multiplexed WebSocket per browser tab. Components subscribe by topic;
+ * the hub already fans out by topic — this client merges subscription maps
+ * and shares a single connection.
+ */
+class SharedWebsocketClient {
+    private ws: WebSocket | null = null;
+    private subscribers = new Set<Subscriber>();
+    private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    private intentionalClose = false;
+
+    subscribe(subscriber: Subscriber): () => void {
+        this.subscribers.add(subscriber);
+        this.ensureConnected();
+        if (this.ws?.readyState === WebSocket.OPEN) {
+            this.sendMergedSubscriptions();
+            subscriber.onOpen?.();
+        }
+        return () => {
+            this.subscribers.delete(subscriber);
+            if (this.subscribers.size === 0) {
+                this.teardown();
+            } else if (this.ws?.readyState === WebSocket.OPEN) {
+                this.sendMergedSubscriptions();
+            }
+        };
+    }
+
+    private mergedTopics(): Record<string, TopicKind> {
+        const merged: Record<string, TopicKind> = {};
+        for (const subscriber of this.subscribers) {
+            for (const [topic, kind] of Object.entries(subscriber.topics)) {
+                // Prefer "state" so late subscribers still get lastMessage replay.
+                if (merged[topic] === "state") continue;
+                merged[topic] = kind === "state" ? "state" : (merged[topic] ?? kind);
+            }
+        }
+        return merged;
+    }
+
+    private sendMergedSubscriptions() {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        this.ws.send(JSON.stringify(this.mergedTopics()));
+    }
+
+    private ensureConnected() {
+        if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+            return;
+        }
+        this.intentionalClose = false;
+        const ws = new WebSocket(websocketUrl());
+        this.ws = ws;
+
+        ws.onopen = () => {
+            this.sendMergedSubscriptions();
+            for (const subscriber of this.subscribers) {
+                subscriber.onOpen?.();
+            }
+        };
+
+        ws.onmessage = receiveMessage((topic, message) => {
+            for (const subscriber of this.subscribers) {
+                if (topic in subscriber.topics) {
+                    subscriber.onMessage(topic, message);
+                }
+            }
+        });
+
+        ws.onerror = () => {
+            ws.close();
+        };
+
+        ws.onclose = (event) => {
+            if (this.ws === ws) this.ws = null;
+            for (const subscriber of this.subscribers) {
+                subscriber.onClose?.(event);
+            }
+            if (event.code === 1008) {
+                globalThis.location.assign("/login");
+                return;
+            }
+            if (!this.intentionalClose && this.subscribers.size > 0) {
+                this.reconnectTimer = setTimeout(() => this.ensureConnected(), RECONNECT_MS);
+            }
+        };
+    }
+
+    private teardown() {
+        this.intentionalClose = true;
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        this.ws?.close();
+        this.ws = null;
+    }
+}
+
+const sharedClient = new SharedWebsocketClient();
+
+export type UseWebsocketTopicsOptions = {
+    enabled?: boolean;
+    onOpen?: () => void;
+    onClose?: (event: CloseEvent) => void;
+};
+
+/** Subscribe to one or more topics on the shared per-tab WebSocket. */
+export function useWebsocketTopics(
+    topics: Record<string, TopicKind>,
+    onMessage: MessageListener,
+    options: UseWebsocketTopicsOptions = {},
+) {
+    const { enabled = true, onOpen, onClose } = options;
+    const onMessageRef = useRef(onMessage);
+    const onOpenRef = useRef(onOpen);
+    const onCloseRef = useRef(onClose);
+    onMessageRef.current = onMessage;
+    onOpenRef.current = onOpen;
+    onCloseRef.current = onClose;
+
+    const topicsKey = JSON.stringify(topics);
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        const parsedTopics = JSON.parse(topicsKey) as Record<string, TopicKind>;
+        return sharedClient.subscribe({
+            topics: parsedTopics,
+            onMessage: (topic, message) => onMessageRef.current(topic, message),
+            onOpen: () => onOpenRef.current?.(),
+            onClose: (event) => onCloseRef.current?.(event),
+        });
+    }, [enabled, topicsKey]);
+}
+
+/** Convenience for a single topic. */
+export function useWebsocketTopic(
+    topic: string,
+    kind: TopicKind,
+    onMessage: (message: string) => void,
+    options: UseWebsocketTopicsOptions = {},
+) {
+    useWebsocketTopics(
+        { [topic]: kind },
+        (_topic, message) => onMessage(message),
+        options,
+    );
+}
+
+/** Imperative subscribe for non-hook contexts (e.g. one-shot benchmark progress). */
+export function subscribeWebsocketTopics(
+    topics: Record<string, TopicKind>,
+    onMessage: MessageListener,
+    options: Omit<UseWebsocketTopicsOptions, "enabled"> = {},
+): () => void {
+    return sharedClient.subscribe({
+        topics,
+        onMessage,
+        onOpen: options.onOpen,
+        onClose: options.onClose,
+    });
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fontsource-variable/inter": "^5.2.8",
         "@react-router/express": "~8.1.0",
         "@react-router/fs-routes": "~8.1.0",
         "@react-router/node": "~8.1.0",
@@ -1122,6 +1123,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource-variable/inter": "^5.2.8",
     "@react-router/express": "~8.1.0",
     "@react-router/fs-routes": "~8.1.0",
     "@react-router/node": "~8.1.0",

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -5,6 +5,7 @@ import { WebSocketServer } from "ws";
 import { logger, requestLogger } from "./server/logger.js";
 import { shouldSkipCompression } from "./server/proxy-path.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
+import { MAX_WEBSOCKET_PAYLOAD_BYTES } from "./server/websocket.server.js";
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = "../build/server/index.js";
@@ -98,7 +99,7 @@ if (DEVELOPMENT) {
 
 // Create both the http and websocket servers
 const server = http.createServer(app);
-setWebsocketServer(new WebSocketServer({ server }));
+setWebsocketServer(new WebSocketServer({ server, maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES }));
 
 // Begin listening for connections
 server.listen(PORT, () => {

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -4,6 +4,7 @@ import http from "http";
 import { WebSocketServer } from "ws";
 import { logger, requestLogger } from "./server/logger.js";
 import { shouldSkipCompression } from "./server/proxy-path.js";
+import { securityHeadersMiddleware } from "./server/security-headers.js";
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = "../build/server/index.js";
@@ -37,6 +38,7 @@ app.use(
   }),
 );
 app.disable("x-powered-by");
+app.use(securityHeadersMiddleware);
 
 // Frontend-local healthcheck. Registered BEFORE request logging and the React
 // Router catch-all so probes bypass SSR and stay quiet in access logs.

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -5,7 +5,6 @@ import { WebSocketServer } from "ws";
 import { logger, requestLogger } from "./server/logger.js";
 import { shouldSkipCompression } from "./server/proxy-path.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
-import { MAX_WEBSOCKET_PAYLOAD_BYTES } from "./server/websocket.server.js";
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = "../build/server/index.js";
@@ -99,7 +98,7 @@ if (DEVELOPMENT) {
 
 // Create both the http and websocket servers
 const server = http.createServer(app);
-setWebsocketServer(new WebSocketServer({ server, maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES }));
+setWebsocketServer(new WebSocketServer({ server, maxPayload: 64 * 1024 }));
 
 // Begin listening for connections
 server.listen(PORT, () => {

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -16,6 +16,7 @@ import {
 import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
 
 export const app = express();
+app.disable("x-powered-by");
 export const initializeWebsocketServer = websocketServer.initialize;
 
 const trustProxy =

--- a/frontend/server/security-headers.test.ts
+++ b/frontend/server/security-headers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { securityHeadersMiddleware } from "./security-headers";
+
+function mockRes() {
+  const headers = new Map<string, string>();
+  return {
+    headers,
+    setHeader: (name: string, value: string) => {
+      headers.set(name, value);
+    },
+  };
+}
+
+describe("securityHeadersMiddleware", () => {
+  it("sets defensive headers on UI paths", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    securityHeadersMiddleware(
+      { method: "GET", path: "/queue" } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBe("same-origin");
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("skips headers on proxied backend paths", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    securityHeadersMiddleware(
+      { method: "GET", path: "/view/foo.mkv" } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.headers.size).toBe(0);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("skips headers on WebDAV methods", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    securityHeadersMiddleware(
+      { method: "PROPFIND", path: "/" } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.headers.size).toBe(0);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/server/security-headers.ts
+++ b/frontend/server/security-headers.ts
@@ -1,0 +1,18 @@
+import type { NextFunction, Request, Response } from "express";
+import { shouldProxyToBackend } from "./proxy-path";
+
+/**
+ * Defensive UI response headers. Skipped on proxied WebDAV/API paths so
+ * non-browser clients are not affected. CSP is deferred (report-only later).
+ */
+export function securityHeadersMiddleware(req: Request, res: Response, next: NextFunction) {
+  if (shouldProxyToBackend(req.method, req.path || "")) {
+    next();
+    return;
+  }
+
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "same-origin");
+  res.setHeader("X-Frame-Options", "SAMEORIGIN");
+  next();
+}

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
-import { disconnectBrowserClients } from "./websocket.server";
+import {
+    disconnectBrowserClients,
+    MAX_TOPICS_PER_SOCKET,
+    parseSubscriptionTopics,
+} from "./websocket.server";
+
+describe("parseSubscriptionTopics", () => {
+    it("accepts a flat state/stream map", () => {
+        expect(parseSubscriptionTopics(JSON.stringify({ ls: "state", cxs: "stream" }))).toEqual({
+            ls: "state",
+            cxs: "stream",
+        });
+    });
+
+    it("rejects arrays, non-objects, and invalid kinds", () => {
+        expect(parseSubscriptionTopics("[]")).toBeNull();
+        expect(parseSubscriptionTopics('"ls"')).toBeNull();
+        expect(parseSubscriptionTopics(JSON.stringify({ ls: "wat" }))).toBeNull();
+        expect(parseSubscriptionTopics("{")).toBeNull();
+    });
+
+    it("rejects more than MAX_TOPICS_PER_SOCKET topics", () => {
+        const topics: Record<string, "state"> = {};
+        for (let i = 0; i < MAX_TOPICS_PER_SOCKET + 1; i++) {
+            topics[`t${i}`] = "state";
+        }
+        expect(parseSubscriptionTopics(JSON.stringify(topics))).toBeNull();
+    });
+});
 
 describe("disconnectBrowserClients", () => {
     it("clears stale state and reconnects each browser once", () => {

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import {
     disconnectBrowserClients,
+    MAX_CLIENT_BUFFERED_AMOUNT,
     MAX_TOPICS_PER_SOCKET,
     parseSubscriptionTopics,
+    sendToBrowserClient,
 } from "./websocket.server";
 
 describe("parseSubscriptionTopics", () => {
@@ -27,6 +29,32 @@ describe("parseSubscriptionTopics", () => {
             topics[`t${i}`] = "state";
         }
         expect(parseSubscriptionTopics(JSON.stringify(topics))).toBeNull();
+    });
+});
+
+describe("sendToBrowserClient", () => {
+    it("skips sends when the client buffer is too full", () => {
+        const send = vi.fn();
+        const client = {
+            readyState: WebSocket.OPEN,
+            bufferedAmount: MAX_CLIENT_BUFFERED_AMOUNT + 1,
+            send,
+        } as unknown as WebSocket;
+
+        sendToBrowserClient(client, "msg");
+        expect(send).not.toHaveBeenCalled();
+    });
+
+    it("sends when the client is open and not back-pressured", () => {
+        const send = vi.fn();
+        const client = {
+            readyState: WebSocket.OPEN,
+            bufferedAmount: 0,
+            send,
+        } as unknown as WebSocket;
+
+        sendToBrowserClient(client, "msg");
+        expect(send).toHaveBeenCalledWith("msg");
     });
 });
 

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -3,9 +3,35 @@ import { isAuthenticated } from "../app/auth/authentication.server";
 import type { IncomingMessage } from 'http';
 import { logger } from "./logger";
 
+export const MAX_WEBSOCKET_PAYLOAD_BYTES = 64 * 1024;
+export const MAX_TOPICS_PER_SOCKET = 100;
+
+const TOPIC_KINDS = new Set(["state", "stream"]);
+
+/** Validate browser subscription payloads: flat Record<string, "state" | "stream">. */
+export function parseSubscriptionTopics(raw: string): Record<string, "state" | "stream"> | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+    const topics: Record<string, "state" | "stream"> = {};
+    for (const [topic, kind] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof topic !== "string" || topic.length === 0) return null;
+        if (kind !== "state" && kind !== "stream") return null;
+        if (!TOPIC_KINDS.has(kind)) return null;
+        topics[topic] = kind;
+    }
+    if (Object.keys(topics).length > MAX_TOPICS_PER_SOCKET) return null;
+    return topics;
+}
+
 function initializeWebsocketServer(wss: WebSocketServer) {
     // keep track of socket subscriptions
-    const websockets = new Map<WebSocket, any>();
+    const websockets = new Map<WebSocket, Record<string, "state" | "stream">>();
     const subscriptions = new Map<string, Set<WebSocket>>();
     const lastMessage = new Map<string, string>();
     initializeWebsocketClient(subscriptions, lastMessage);
@@ -19,20 +45,28 @@ function initializeWebsocketServer(wss: WebSocketServer) {
         const pendingMessages: WebSocket.MessageEvent[] = [];
 
         const applySubscription = (event: WebSocket.MessageEvent) => {
-            try {
-                const topics = JSON.parse(event.data.toString());
-                websockets.set(ws, topics);
-                for (const topic in topics) {
-                    const topicSubscriptions = subscriptions.get(topic);
-                    if (topicSubscriptions) topicSubscriptions.add(ws);
-                    else subscriptions.set(topic, new Set<WebSocket>([ws]));
-                    if (topics[topic] === 'state') {
-                        const messageToSend = lastMessage.get(topic);
-                        if (messageToSend) ws.send(messageToSend);
-                    }
-                }
-            } catch {
+            const topics = parseSubscriptionTopics(event.data.toString());
+            if (!topics) {
                 ws.close(1003, "Could not process topic subscription. If recently updated, try refreshing the page.");
+                return;
+            }
+
+            const previous = websockets.get(ws);
+            if (previous) {
+                for (const topic of Object.keys(previous)) {
+                    subscriptions.get(topic)?.delete(ws);
+                }
+            }
+
+            websockets.set(ws, topics);
+            for (const topic of Object.keys(topics)) {
+                const topicSubscriptions = subscriptions.get(topic);
+                if (topicSubscriptions) topicSubscriptions.add(ws);
+                else subscriptions.set(topic, new Set<WebSocket>([ws]));
+                if (topics[topic] === 'state') {
+                    const messageToSend = lastMessage.get(topic);
+                    if (messageToSend) ws.send(messageToSend);
+                }
             }
         };
 
@@ -50,7 +84,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
             const topics = websockets.get(ws);
             if (topics) {
                 websockets.delete(ws);
-                for (const topic in topics) {
+                for (const topic of Object.keys(topics)) {
                     const topicSubscriptions = subscriptions.get(topic);
                     if (topicSubscriptions) topicSubscriptions.delete(ws);
                 }

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -8,12 +8,14 @@ export const MAX_TOPICS_PER_SOCKET = 100;
 export const WEBSOCKET_HEARTBEAT_INTERVAL_MS = 30_000;
 export const MAX_CLIENT_BUFFERED_AMOUNT = 1024 * 1024;
 
-const TOPIC_KINDS = new Set(["state", "stream"]);
+export type TopicKind = "state" | "stream" | "event";
+
+const TOPIC_KINDS = new Set<TopicKind>(["state", "stream", "event"]);
 
 type TrackedSocket = WebSocket & { isAlive?: boolean };
 
-/** Validate browser subscription payloads: flat Record<string, "state" | "stream">. */
-export function parseSubscriptionTopics(raw: string): Record<string, "state" | "stream"> | null {
+/** Validate browser subscription payloads: flat Record<string, TopicKind>. */
+export function parseSubscriptionTopics(raw: string): Record<string, TopicKind> | null {
     let parsed: unknown;
     try {
         parsed = JSON.parse(raw);
@@ -22,12 +24,11 @@ export function parseSubscriptionTopics(raw: string): Record<string, "state" | "
     }
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
 
-    const topics: Record<string, "state" | "stream"> = {};
+    const topics: Record<string, TopicKind> = {};
     for (const [topic, kind] of Object.entries(parsed as Record<string, unknown>)) {
         if (typeof topic !== "string" || topic.length === 0) return null;
-        if (kind !== "state" && kind !== "stream") return null;
-        if (!TOPIC_KINDS.has(kind)) return null;
-        topics[topic] = kind;
+        if (typeof kind !== "string" || !TOPIC_KINDS.has(kind as TopicKind)) return null;
+        topics[topic] = kind as TopicKind;
     }
     if (Object.keys(topics).length > MAX_TOPICS_PER_SOCKET) return null;
     return topics;
@@ -41,7 +42,7 @@ export function sendToBrowserClient(client: WebSocket, rawMessage: string): void
 
 function initializeWebsocketServer(wss: WebSocketServer) {
     // keep track of socket subscriptions
-    const websockets = new Map<TrackedSocket, Record<string, "state" | "stream">>();
+    const websockets = new Map<TrackedSocket, Record<string, TopicKind>>();
     const subscriptions = new Map<string, Set<TrackedSocket>>();
     const lastMessage = new Map<string, string>();
     initializeWebsocketClient(subscriptions, lastMessage);

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -5,8 +5,12 @@ import { logger } from "./logger";
 
 export const MAX_WEBSOCKET_PAYLOAD_BYTES = 64 * 1024;
 export const MAX_TOPICS_PER_SOCKET = 100;
+export const WEBSOCKET_HEARTBEAT_INTERVAL_MS = 30_000;
+export const MAX_CLIENT_BUFFERED_AMOUNT = 1024 * 1024;
 
 const TOPIC_KINDS = new Set(["state", "stream"]);
+
+type TrackedSocket = WebSocket & { isAlive?: boolean };
 
 /** Validate browser subscription payloads: flat Record<string, "state" | "stream">. */
 export function parseSubscriptionTopics(raw: string): Record<string, "state" | "stream"> | null {
@@ -29,20 +33,44 @@ export function parseSubscriptionTopics(raw: string): Record<string, "state" | "
     return topics;
 }
 
+export function sendToBrowserClient(client: WebSocket, rawMessage: string): void {
+    if (client.readyState !== WebSocket.OPEN) return;
+    if (client.bufferedAmount > MAX_CLIENT_BUFFERED_AMOUNT) return;
+    client.send(rawMessage);
+}
+
 function initializeWebsocketServer(wss: WebSocketServer) {
     // keep track of socket subscriptions
-    const websockets = new Map<WebSocket, Record<string, "state" | "stream">>();
-    const subscriptions = new Map<string, Set<WebSocket>>();
+    const websockets = new Map<TrackedSocket, Record<string, "state" | "stream">>();
+    const subscriptions = new Map<string, Set<TrackedSocket>>();
     const lastMessage = new Map<string, string>();
     initializeWebsocketClient(subscriptions, lastMessage);
 
+    const heartbeat = setInterval(() => {
+        for (const client of wss.clients) {
+            const tracked = client as TrackedSocket;
+            if (tracked.isAlive === false) {
+                tracked.terminate();
+                continue;
+            }
+            tracked.isAlive = false;
+            tracked.ping();
+        }
+    }, WEBSOCKET_HEARTBEAT_INTERVAL_MS);
+    heartbeat.unref?.();
+    wss.on("close", () => clearInterval(heartbeat));
+
     // authenticate new websocket sessions
-    wss.on("connection", (ws: WebSocket, request: IncomingMessage) => {
+    wss.on("connection", (ws: TrackedSocket, request: IncomingMessage) => {
         // Buffer early frames and attach handlers before awaiting auth so the
         // browser's immediate onopen subscription is not dropped.
         let authenticated = false;
         let closed = false;
         const pendingMessages: WebSocket.MessageEvent[] = [];
+        ws.isAlive = true;
+        ws.on("pong", () => {
+            ws.isAlive = true;
+        });
 
         const applySubscription = (event: WebSocket.MessageEvent) => {
             const topics = parseSubscriptionTopics(event.data.toString());
@@ -62,10 +90,10 @@ function initializeWebsocketServer(wss: WebSocketServer) {
             for (const topic of Object.keys(topics)) {
                 const topicSubscriptions = subscriptions.get(topic);
                 if (topicSubscriptions) topicSubscriptions.add(ws);
-                else subscriptions.set(topic, new Set<WebSocket>([ws]));
+                else subscriptions.set(topic, new Set<TrackedSocket>([ws]));
                 if (topics[topic] === 'state') {
                     const messageToSend = lastMessage.get(topic);
-                    if (messageToSend) ws.send(messageToSend);
+                    if (messageToSend) sendToBrowserClient(ws, messageToSend);
                 }
             }
         };
@@ -181,9 +209,7 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
                 lastMessage.set(topic, rawMessage);
                 const subscribed = subscriptions.get(topic) || [];
                 subscribed.forEach(client => {
-                    if (client.readyState === client.OPEN) {
-                        client.send(rawMessage);
-                    }
+                    sendToBrowserClient(client, rawMessage);
                 });
             } catch (error) {
                 logger.error("Ignoring malformed backend websocket message", error);

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/startup-grace.ts", "vite.config.ts", "vitest.config.ts"],
+  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/startup-grace.ts", "server/security-headers.ts", "vite.config.ts", "vitest.config.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,15 @@ import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
+function resolveAllowedHosts(): string[] {
+  const raw = process.env.VITE_ALLOWED_HOSTS?.trim();
+  if (!raw) return [".net"];
+  return raw.split(",").map((host) => host.trim()).filter(Boolean);
+}
+
 export default defineConfig({
   server: {
-    allowedHosts: [".net"],
+    allowedHosts: resolveAllowedHosts(),
   },
   resolve: {
     tsconfigPaths: true,


### PR DESCRIPTION
## Summary
- Harden the frontend Express/SSR layer: security headers, X-Powered-By disable, websocket payload bounds + heartbeat, shared per-tab WebSocket client, session key/cookie hardening, self-hosted Inter, root `shouldRevalidate`, and configurable Vite `allowedHosts`.
- UX fixes: editable provider Already Used offset, iOS NZB upload accept workaround, explore Link `prefetch="none"` to avoid HTTP 431.
- Closes already-resolved #216 (TRUST_PROXY shipped in #294) and #227 (Express etag/lastModified defaults confirmed).

Fixes #215
Fixes #219
Fixes #220
Fixes #221
Fixes #222
Fixes #224
Fixes #225
Fixes #226
Fixes #228
Fixes #256
Fixes #140
Fixes #135
Closes #216
Closes #227

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test` (148 tests)
- [x] `cd frontend && npm run build`
- [ ] Manual: Overview/queue page should use one WS (DevTools → Network)
- [ ] Manual: explore a large directory folder behind nginx (no 431)
- [ ] Manual: Usenet provider edit → change Already Used → save
- [ ] Manual (optional): iOS Safari NZB file picker select