### PR TITLE
fix(nntp): stop invalid segment-id loops with 404 + repair

### DIFF
--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -57,11 +57,12 @@ public class BaseNntpClient : NntpClient
 
     public override Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
-        return _client.StatAsync(segmentId, cancellationToken);
+        return _client.StatAsync(PrepareSegmentId(segmentId), cancellationToken);
     }
 
     public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
+        segmentId = PrepareSegmentId(segmentId);
         var headResponse = await _client.HeadAsync(segmentId, cancellationToken);
 
         if (headResponse.ResponseType != UsenetResponseType.ArticleRetrievedHeadFollows)
@@ -92,6 +93,7 @@ public class BaseNntpClient : NntpClient
         CancellationToken cancellationToken
     )
     {
+        segmentId = PrepareSegmentId(segmentId);
         var bodyResponse = await _client.DecodedBodyAsync(
             segmentId, onConnectionReadyAgain, cancellationToken);
 
@@ -115,7 +117,7 @@ public class BaseNntpClient : NntpClient
     )
     {
         return _client.DecodedBodiesAsync(
-            segmentIds, onConnectionReadyAgain, cancellationToken);
+            PrepareSegmentIds(segmentIds), onConnectionReadyAgain, cancellationToken);
     }
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync
@@ -134,6 +136,7 @@ public class BaseNntpClient : NntpClient
         CancellationToken cancellationToken
     )
     {
+        segmentId = PrepareSegmentId(segmentId);
         var articleResponse = await _client.ArticleAsync(segmentId, onConnectionReadyAgain, cancellationToken);
 
         if (articleResponse.ResponseType != UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
@@ -147,6 +150,14 @@ public class BaseNntpClient : NntpClient
             ArticleHeaders = articleResponse.ArticleHeaders!,
             Stream = new YencStream(articleResponse.Stream!),
         };
+    }
+
+    private static SegmentId[] PrepareSegmentIds(IReadOnlyList<SegmentId> segmentIds)
+    {
+        var prepared = new SegmentId[segmentIds.Count];
+        for (var index = 0; index < segmentIds.Count; index++)
+            prepared[index] = PrepareSegmentId(segmentIds[index]);
+        return prepared;
     }
 
     public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken)

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -233,6 +233,14 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
+            catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
+            {
+                // Permanently missing / invalid segment ids are not connection failures.
+                deferredCallback.Discard();
+                LogException(() => connectionLock?.Dispose());
+                LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
+                throw;
+            }
             catch (Exception e)
             {
                 deferredCallback.Discard();

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -157,6 +157,14 @@ public class MultiProviderNntpClient(
                 }
                 return new UsenetDecodedBodyBatch { Responses = responses };
             }
+            catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
+            {
+                // Invalid / permanently missing segment ids are invalid on every provider.
+                deferredCallback.Discard();
+                InvokeCompletionCallback(
+                    onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
+                throw;
+            }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken))
             {
                 deferredCallback.Discard();

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -384,10 +384,47 @@ public abstract class NntpClient : INntpClient
     internal static string NormalizeSegmentId(string? id)
     {
         if (string.IsNullOrWhiteSpace(id)) return "";
+        // Strip the angle brackets independently: an upstream SegmentId conversion
+        // may have already removed one bracket while whitespace shielded the other
+        // (e.g. "<id@host>\n" arrives here as "id@host>\n").
         var trimmed = id.Trim();
-        if (trimmed.Length >= 2 && trimmed[0] == '<' && trimmed[^1] == '>')
-            trimmed = trimmed[1..^1];
-        return trimmed;
+        if (trimmed.Length > 0 && trimmed[0] == '<')
+            trimmed = trimmed[1..];
+        if (trimmed.Length > 0 && trimmed[^1] == '>')
+            trimmed = trimmed[..^1];
+        return trimmed.Trim();
+    }
+
+    /// <summary>
+    /// Mirrors UsenetSharp's message-id shape rules so invalid ids fail as
+    /// <see cref="UsenetArticleNotFoundException"/> instead of ArgumentException.
+    /// </summary>
+    internal static bool IsValidSegmentId(string? id)
+    {
+        var value = NormalizeSegmentId(id);
+        if (value.Length is < 3 or > 497) return false;
+        if (value[0] == '@' || value[^1] == '@' || !value.Contains('@')) return false;
+        if (value.Contains('<') || value.Contains('>')) return false;
+        foreach (var character in value)
+        {
+            if (char.IsWhiteSpace(character) || char.IsControl(character))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Normalize and validate a segment id before handing it to UsenetSharp.
+    /// Permanently-invalid ids throw <see cref="UsenetArticleNotFoundException"/>.
+    /// </summary>
+    internal static SegmentId PrepareSegmentId(SegmentId segmentId)
+    {
+        var normalized = NormalizeSegmentId(segmentId);
+        if (!IsValidSegmentId(normalized))
+            throw new UsenetArticleNotFoundException(normalized);
+
+        return normalized;
     }
 
     internal static bool TryExtractMessageIdFromResponseMessage(string? message, out string messageId)

--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -110,7 +110,7 @@ public class NzbDocument
                 var segment = new NzbSegment
                 {
                     Bytes = long.TryParse(bytesAttr, out var bytes) ? bytes : 0,
-                    MessageId = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false)
+                    MessageId = (await reader.ReadElementContentAsStringAsync().ConfigureAwait(false)).Trim()
                 };
                 file.Segments.Add(segment);
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -484,6 +484,32 @@ public class MultiProviderNntpClientTests
         await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() => batch.Responses[0]);
     }
 
+    [Fact]
+    public async Task DecodedBodiesAsync_WithInvalidSegmentId_DoesNotFailoverOrTripBreaker()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            BatchException = _ => new UsenetArticleNotFoundException("not-a-message-id"),
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+        };
+        var primaryProvider = CreateProvider(primary, host: "a.example");
+        var backupProvider = CreateProvider(backup, host: "b.example");
+        using var client = new MultiProviderNntpClient([primaryProvider, backupProvider]);
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.DecodedBodiesAsync(
+                ["not-a-message-id"], onConnectionReadyAgain: null, CancellationToken.None));
+
+        Assert.Equal(1, primary.BatchRequests);
+        Assert.Equal(0, backup.BatchRequests);
+        Assert.False(primaryProvider.IsTripped);
+        Assert.False(backupProvider.IsTripped);
+    }
+
     private static MultiConnectionNntpClient CreateProvider(
         INntpClient connection,
         string host = "test",

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Streams;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -13,9 +14,49 @@ public class NntpClientPipelinedMappingTests
     [InlineData("seg@example.com", "seg@example.com")]
     [InlineData("<seg@example.com>", "seg@example.com")]
     [InlineData(" <seg@example.com> ", "seg@example.com")]
+    [InlineData("seg@example.com>", "seg@example.com")]
+    [InlineData("<seg@example.com", "seg@example.com")]
+    [InlineData("< seg@example.com >", "seg@example.com")]
     public void NormalizeSegmentId_StripsAngleBrackets(string input, string expected)
     {
         Assert.Equal(expected, NntpClient.NormalizeSegmentId(input));
+    }
+
+    [Theory]
+    [InlineData("seg@example.com")]
+    [InlineData("<seg@example.com>")]
+    [InlineData("  seg@example.com  ")]
+    [InlineData("<seg@example.com>\n")]
+    [InlineData("\n<seg@example.com>")]
+    public void IsValidSegmentId_AcceptsNormalizedMessageIds(string input)
+    {
+        Assert.True(NntpClient.IsValidSegmentId(input));
+        Assert.Equal("seg@example.com", NntpClient.PrepareSegmentId(input).ToString());
+    }
+
+    [Theory]
+    [InlineData("<seg@example.com>\n")]
+    [InlineData("\n<seg@example.com>")]
+    public void PrepareSegmentId_NormalizesBracketAndWhitespaceCombos_AfterSegmentIdConversion(string raw)
+    {
+        // Mimic the production path: the raw DB string is converted to a SegmentId
+        // (which strips at most one bracket per end) before PrepareSegmentId runs.
+        SegmentId segmentId = raw;
+        Assert.Equal("seg@example.com", NntpClient.PrepareSegmentId(segmentId).ToString());
+    }
+
+    [Theory]
+    [InlineData("not-a-message-id")]
+    [InlineData("@example.com")]
+    [InlineData("local@")]
+    [InlineData("bad<id>@example.com")]
+    [InlineData("has space@example.com")]
+    [InlineData("")]
+    [InlineData("ab")]
+    public void PrepareSegmentId_ThrowsNotFound_ForInvalidIds(string input)
+    {
+        Assert.False(NntpClient.IsValidSegmentId(input));
+        Assert.Throws<UsenetArticleNotFoundException>(() => NntpClient.PrepareSegmentId(input));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
+++ b/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
@@ -46,6 +46,27 @@ public class NzbDocumentTests
     }
 
     [Fact]
+    public async Task LoadAsync_TrimsWhitespaceAroundSegmentMessageIds()
+    {
+        const string xml = """
+            <nzb><file subject="file"><segments>
+              <segment bytes="10">
+                padded@example.com
+              </segment>
+              <segment bytes="20">  spaced@example.com  </segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        var document = await NzbDocument.LoadAsync(stream);
+
+        Assert.Collection(
+            Assert.Single(document.Files).Segments,
+            segment => Assert.Equal("padded@example.com", segment.MessageId),
+            segment => Assert.Equal("spaced@example.com", segment.MessageId));
+    }
+
+    [Fact]
     public async Task LoadAsync_UsesZeroForInvalidSegmentSize()
     {
         const string xml = """


### PR DESCRIPTION
## Summary
- Trim NZB segment message-ids at parse time, and normalize/validate them at the UsenetSharp boundary so whitespace-padded ids work and irreparably invalid ones fail fast as `UsenetArticleNotFoundException`.
- Skip connection replace, circuit-breaker failure, and provider failover for article-not-found on batch BODY, so GET returns 404 and repair is scheduled instead of a 500 retry storm.
- Add parser and client tests for trim/normalize/invalid-id no-failover behavior (including asymmetric bracket + whitespace after `SegmentId` conversion).

## Test plan
- [x] Focused tests: `NzbDocumentTests`, `NntpClientPipelinedMappingTests`, `DecodedBodiesAsync_WithInvalidSegmentId`
- [x] Backend suite excluding local-only rapidyenc macOS native gaps (316 passed)
- [ ] CI green on Ubuntu (includes yenc-native tests)
- [ ] Manual: WebDAV GET of a DavItem with a whitespace-padded segment id succeeds; GET with a truly invalid id returns 404 and schedules repair without provider hammering