### PR TITLE
fix(ui): resolve frontend startup crash from extensionless proxy-path import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
         working-directory: frontend
         run: npm run build && npm run build:server
 
+      # Node ESM requires explicit .js extensions in emitted dist-node imports.
+      - name: Smoke-import dist-node server modules
+        working-directory: frontend
+        run: node --input-type=module -e "import('./dist-node/server/security-headers.js')"
+
       - name: Test frontend with coverage
         working-directory: frontend
         run: npm run test:coverage

--- a/frontend/server/security-headers.ts
+++ b/frontend/server/security-headers.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import { shouldProxyToBackend } from "./proxy-path";
+import { shouldProxyToBackend } from "./proxy-path.js";
 
 /**
  * Defensive UI response headers. Skipped on proxied WebDAV/API paths so


### PR DESCRIPTION
## Summary
- `frontend/server/security-headers.ts` (added in a42292a) imported `./proxy-path` without a `.js` extension; the compiled `dist-node` output crashed the production frontend at startup with `ERR_MODULE_NOT_FOUND` (image `main-0c89f9cf`).
- Adds the `.js` extension, matching the existing convention in `server.ts` and `logger.ts`.
- Adds a CI smoke-import of the compiled `dist-node/server/security-headers.js` after `build:server`, since Vitest runs sources through tsx and never exercises the emitted ESM graph.

## Test plan
- [x] `npm run build:server` then `node --input-type=module -e "import('./dist-node/server/security-headers.js')"` succeeds (previously failed with ERR_MODULE_NOT_FOUND)
- [x] Verified the smoke command exits non-zero against the broken import
- [x] `npm run typecheck`, `npm run lint`, `npm run build` pass
- [x] Full frontend suite passes (148 tests, 15 files)
- [x] Clean `dist-node` rebuild contains no extensionless relative imports
- [ ] After merge: rebuild/redeploy the Docker image so the container picks up the fixed output