### PR TITLE
fix(ui): quiet expected BackendUnavailableError noise during startup grace

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -1,0 +1,108 @@
+import { PassThrough } from "node:stream";
+
+import type { EntryContext, HandleErrorFunction, RouterContextProvider } from "react-router";
+import { createReadableStreamFromReadable } from "@react-router/node";
+import { isRouteErrorResponse, ServerRouter } from "react-router";
+import { isbot } from "isbot";
+import type { RenderToPipeableStreamOptions } from "react-dom/server";
+import { renderToPipeableStream } from "react-dom/server";
+import {
+  isExpectedBackendUnavailableError,
+  isWithinBackendStartupGrace,
+} from "../server/startup-grace";
+
+export const streamTimeout = 5_000;
+
+/**
+ * Quiet expected BackendUnavailableError stacks during frontend-first Docker
+ * startup. Outside the grace window (or for any other error), keep default logging.
+ */
+export const handleError: HandleErrorFunction = (error, { request }) => {
+  if (request.signal.aborted) return;
+  // Unwrap route error responses the same way React Router's default handler does.
+  // The wrapped error is internal to ErrorResponseImpl, hence the cast.
+  const routeError = isRouteErrorResponse(error)
+    ? (error as { error?: unknown }).error
+    : undefined;
+  const unwrapped = routeError ?? error;
+  if (isWithinBackendStartupGrace() && isExpectedBackendUnavailableError(unwrapped)) {
+    return;
+  }
+  console.error(unwrapped);
+};
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: RouterContextProvider,
+) {
+  // https://httpwg.org/specs/rfc9110.html#HEAD
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    let userAgent = request.headers.get("user-agent");
+
+    // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+    // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+    let readyOption: keyof RenderToPipeableStreamOptions =
+      (userAgent && isbot(userAgent)) || routerContext.isSpaMode
+        ? "onAllReady"
+        : "onShellReady";
+
+    // Abort the rendering stream after the `streamTimeout` so it has time to
+    // flush down the rejected boundaries
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+      () => abort(),
+      streamTimeout + 1000,
+    );
+
+    const { pipe, abort } = renderToPipeableStream(
+      <ServerRouter context={routerContext} url={request.url} />,
+      {
+        [readyOption]() {
+          shellRendered = true;
+          const body = new PassThrough({
+            final(callback) {
+              // Clear the timeout to prevent retaining the closure and memory leak
+              clearTimeout(timeoutId);
+              timeoutId = undefined;
+              callback();
+            },
+          });
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set("Content-Type", "text/html");
+
+          pipe(body);
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      },
+    );
+  });
+}

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -5,6 +5,10 @@ import { WebSocketServer } from "ws";
 import { logger, requestLogger } from "./server/logger.js";
 import { shouldSkipCompression } from "./server/proxy-path.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
+import {
+  isExpectedBackendUnavailableError,
+  isWithinBackendStartupGrace,
+} from "./server/startup-grace.js";
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = "../build/server/index.js";
@@ -21,6 +25,12 @@ const PORT = Number.parseInt(process.env.PORT || "3000");
 // Deliberately do not hook uncaughtException: that fires for fatal errors
 // where restarting the process is the right answer.
 process.on("unhandledRejection", (reason) => {
+  if (
+    isWithinBackendStartupGrace()
+    && isExpectedBackendUnavailableError(reason)
+  ) {
+    return;
+  }
   logger.error("Unhandled promise rejection:", reason);
 });
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -34,7 +34,7 @@ let lastProxyFailureLogAt = 0;
 
 function logProxyFailure(message: string, error: unknown) {
   const now = Date.now();
-  if (isExpectedBackendConnectionError(error) && isWithinBackendStartupGrace(now)) {
+  if (isExpectedBackendConnectionError(error) && isWithinBackendStartupGrace()) {
     if (!loggedStartupWait) {
       logger.info("Waiting for backend to start...");
       loggedStartupWait = true;

--- a/frontend/server/startup-grace.test.ts
+++ b/frontend/server/startup-grace.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  BACKEND_STARTUP_GRACE_MS,
   isExpectedBackendConnectionError,
+  isExpectedBackendUnavailableError,
   isWithinBackendStartupGrace,
 } from "./startup-grace";
 
@@ -20,5 +22,20 @@ describe("startup-grace helpers", () => {
 
   it("reports within the startup grace window for a fresh process", () => {
     expect(isWithinBackendStartupGrace()).toBe(true);
+    expect(isWithinBackendStartupGrace(0)).toBe(true);
+    expect(isWithinBackendStartupGrace(BACKEND_STARTUP_GRACE_MS)).toBe(false);
+  });
+
+  it("recognizes BackendUnavailableError by name", () => {
+    const error = new Error("Failed to fetch onboarding status: fetch failed");
+    error.name = "BackendUnavailableError";
+
+    expect(isExpectedBackendUnavailableError(error)).toBe(true);
+    expect(isExpectedBackendUnavailableError(new Error("boom"))).toBe(false);
+  });
+
+  it("treats connection errors as expected backend unavailability", () => {
+    const error = Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
+    expect(isExpectedBackendUnavailableError(error)).toBe(true);
   });
 });

--- a/frontend/server/startup-grace.ts
+++ b/frontend/server/startup-grace.ts
@@ -1,10 +1,10 @@
 /** Shared frontend-process clock for expected backend-not-ready noise. */
-const startedAt = Date.now();
 export const BACKEND_STARTUP_GRACE_MS = 30_000;
 export const BACKEND_FAILURE_LOG_THROTTLE_MS = 60_000;
 
-export function isWithinBackendStartupGrace(now = Date.now()): boolean {
-  return now - startedAt < BACKEND_STARTUP_GRACE_MS;
+/** Uses process uptime so Express and SSR bundles agree even if this module is duplicated. */
+export function isWithinBackendStartupGrace(uptimeMs = process.uptime() * 1000): boolean {
+  return uptimeMs < BACKEND_STARTUP_GRACE_MS;
 }
 
 export function isExpectedBackendConnectionError(error: unknown): boolean {
@@ -20,4 +20,12 @@ export function isExpectedBackendConnectionError(error: unknown): boolean {
     const code = (candidate as { code?: string }).code;
     return code === "ECONNREFUSED" || code === "ECONNRESET" || code === "EPIPE";
   });
+}
+
+/** Match by name so callers need not import BackendUnavailableError across bundle boundaries. */
+export function isExpectedBackendUnavailableError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "BackendUnavailableError") {
+    return true;
+  }
+  return isExpectedBackendConnectionError(error);
 }


### PR DESCRIPTION
## Summary
- Docker starts the frontend before the backend; on no-migration restarts, early `/login` SSR hits `isOnboarding()` while `:8080` is still dark, and React Router's default `handleError` logs a scary `BackendUnavailableError: fetch failed` stack even though the UI recovers on its own.
- Add a custom `frontend/app/entry.server.tsx` whose `handleError` suppresses expected backend-unavailable errors during the existing 30s startup grace window (all other errors still log, with the same route-error unwrapping as the default handler).
- Extend `startup-grace.ts` with `isExpectedBackendUnavailableError()` and switch the grace check to `process.uptime()` so the Express and SSR bundles agree; also skip matching `unhandledRejection` logs in `server.ts` during grace.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build` (verified the custom `handleError` is wired into `build/server/index.js`)
- [x] `npm test` (150 tests pass, including new startup-grace helper cases)
- [ ] Container restart with no pending migrations: expect `Waiting for backend to start...` and `Backend websocket reconnected`, without the `BackendUnavailableError` stack