### PR TITLE
fix(webdav): handle lowercase GUIDs in DAV cleanup queue

### DIFF
--- a/backend/Services/DavCleanupService.cs
+++ b/backend/Services/DavCleanupService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
@@ -17,35 +18,12 @@ public class DavCleanupService : BackgroundService
             {
                 await using var dbContext = new DavDatabaseContext();
 
-                // Get the first item from the queue
-                var cleanupItem = await dbContext.DavCleanupItems
-                    .FirstOrDefaultAsync(stoppingToken)
-                    .ConfigureAwait(false);
-
                 // If no items in queue, wait 10 seconds before checking again
-                if (cleanupItem == null)
+                if (!await ProcessNextItemAsync(dbContext, stoppingToken).ConfigureAwait(false))
                 {
                     await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
                     continue;
                 }
-
-                // Collect children to delete for vfs/forget
-                var deletedItems = await dbContext.Items
-                    .Where(x => x.ParentId == cleanupItem.Id)
-                    .Select(x => new DavItem { Id = x.Id, Type = x.Type, Path = x.Path })
-                    .ToListAsync(stoppingToken);
-
-                // Delete any children
-                await dbContext.Items
-                    .Where(x => x.ParentId == cleanupItem.Id)
-                    .ExecuteDeleteAsync(stoppingToken);
-
-                // Trigger rclone vfs/forget for deleted children
-                _ = DavDatabaseContext.RcloneVfsForget(deletedItems);
-
-                // Remove the queue item from database
-                dbContext.DavCleanupItems.Remove(cleanupItem);
-                await dbContext.SaveChangesAsync(stoppingToken).ConfigureAwait(false);
 
                 // Continue immediately to next iteration to process more items
             }
@@ -63,4 +41,59 @@ public class DavCleanupService : BackgroundService
             }
         }
     }
+
+    internal static async Task<bool> ProcessNextItemAsync(
+        DavDatabaseContext dbContext,
+        CancellationToken cancellationToken = default)
+    {
+        // Preserve the stored text casing: materializing as Guid would normalize it to
+        // uppercase when bound again and miss lowercase rows in SQLite.
+        var cleanupItemId = await dbContext.Database
+            .SqlQueryRaw<string>("SELECT Id AS Value FROM DavCleanupItems LIMIT 1")
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (cleanupItemId == null)
+            return false;
+
+        // Children can use either casing: migrations can preserve lowercase ParentIds,
+        // while EF always writes Guid parameters as uppercase text.
+        var deletedItems = await dbContext.Items
+            .FromSqlRaw(
+                """
+                SELECT * FROM DavItems
+                WHERE ParentId IN (@exactParentId, @upperParentId, @lowerParentId)
+                """,
+                CreateParentIdParameters(cleanupItemId))
+            .AsNoTracking()
+            .Select(x => new DavItem { Id = x.Id, Type = x.Type, Path = x.Path })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            """
+            DELETE FROM DavItems
+            WHERE ParentId IN (@exactParentId, @upperParentId, @lowerParentId)
+            """,
+            CreateParentIdParameters(cleanupItemId),
+            cancellationToken).ConfigureAwait(false);
+
+        _ = DavDatabaseContext.RcloneVfsForget(deletedItems);
+
+        // Delete by the exact text selected above. A concurrent or repeated delete
+        // affects zero rows without raising an optimistic-concurrency exception.
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "DELETE FROM DavCleanupItems WHERE Id = @cleanupItemId",
+            [new SqliteParameter("@cleanupItemId", cleanupItemId)],
+            cancellationToken).ConfigureAwait(false);
+
+        return true;
+    }
+
+    private static SqliteParameter[] CreateParentIdParameters(string cleanupItemId) =>
+    [
+        new("@exactParentId", cleanupItemId),
+        new("@upperParentId", cleanupItemId.ToUpperInvariant()),
+        new("@lowerParentId", cleanupItemId.ToLowerInvariant()),
+    ];
 }

--- a/tests/NzbWebDAV.Tests/Services/DavCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/DavCleanupServiceTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class DavCleanupServiceTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-dav-cleanup-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        await _context.Database.ExecuteSqlRawAsync("DELETE FROM DavCleanupItems");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task ProcessNextItemAsync_CleansLowercaseQueueIdAndMixedCaseParentIds()
+    {
+        var parentId = Guid.Parse("abcdefab-cdef-4abc-8def-abcdefabcdef");
+        var lowercaseParentId = parentId.ToString().ToLowerInvariant();
+        var rawChildId = Guid.NewGuid();
+        var efChildId = Guid.NewGuid();
+
+        await InsertCleanupItemAsync(lowercaseParentId);
+        await InsertRawChildAsync(rawChildId, lowercaseParentId);
+
+        var deletedParent = new DavItem
+        {
+            Id = parentId,
+            Name = "deleted",
+            Type = DavItem.ItemType.Directory,
+            SubType = DavItem.ItemSubType.Directory,
+            Path = "/deleted",
+        };
+        _context.Items.Add(DavItem.New(
+            efChildId,
+            deletedParent,
+            "ef-child.mkv",
+            1,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var storedParentIds = await _context.Database
+            .SqlQueryRaw<string>(
+                """
+                SELECT ParentId AS Value
+                FROM DavItems
+                WHERE Path IN ('/deleted/raw-child.mkv', '/deleted/ef-child.mkv')
+                """)
+            .ToListAsync();
+        Assert.Contains(lowercaseParentId, storedParentIds);
+        Assert.Contains(parentId.ToString().ToUpperInvariant(), storedParentIds);
+
+        var processed = await DavCleanupService.ProcessNextItemAsync(
+            _context,
+            CancellationToken.None);
+
+        Assert.True(processed);
+        Assert.False(await _context.Items.AsNoTracking()
+            .AnyAsync(x => x.Id == rawChildId || x.Id == efChildId));
+        Assert.Equal(0, await CountCleanupItemsAsync());
+        Assert.False(await DavCleanupService.ProcessNextItemAsync(
+            _context,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ProcessNextItemAsync_DequeuesItemWhenChildrenAreAlreadyGone()
+    {
+        var lowercaseId = "12345678-abcd-4abc-8def-abcdefabcdef";
+        await InsertCleanupItemAsync(lowercaseId);
+
+        var processed = await DavCleanupService.ProcessNextItemAsync(
+            _context,
+            CancellationToken.None);
+
+        Assert.True(processed);
+        Assert.Equal(0, await CountCleanupItemsAsync());
+        Assert.False(await DavCleanupService.ProcessNextItemAsync(
+            _context,
+            CancellationToken.None));
+    }
+
+    private Task InsertCleanupItemAsync(string id) =>
+        _context.Database.ExecuteSqlRawAsync(
+            "INSERT INTO DavCleanupItems (Id) VALUES (@id)",
+            new SqliteParameter("@id", id));
+
+    private Task InsertRawChildAsync(Guid childId, string parentId) =>
+        _context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO DavItems
+                (Id, IdPrefix, CreatedAt, ParentId, Name, FileSize, Type, SubType, Path)
+            VALUES
+                (@id, @idPrefix, CURRENT_TIMESTAMP, @parentId, @name, @fileSize, @type, @subType, @path)
+            """,
+            new SqliteParameter("@id", childId.ToString().ToUpperInvariant()),
+            new SqliteParameter("@idPrefix", childId.ToString("N")[..DavItem.IdPrefixLength]),
+            new SqliteParameter("@parentId", parentId),
+            new SqliteParameter("@name", "raw-child.mkv"),
+            new SqliteParameter("@fileSize", 1),
+            new SqliteParameter("@type", (int)DavItem.ItemType.UsenetFile),
+            new SqliteParameter("@subType", (int)DavItem.ItemSubType.NzbFile),
+            new SqliteParameter("@path", "/deleted/raw-child.mkv"));
+
+    private Task<int> CountCleanupItemsAsync() =>
+        _context.Database
+            .SqlQueryRaw<int>("SELECT COUNT(*) AS Value FROM DavCleanupItems")
+            .SingleAsync();
+}


### PR DESCRIPTION
## Summary
- preserve cleanup queue IDs as stored SQLite text so lowercase legacy rows can be dequeued
- match both lowercase and uppercase child `ParentId` values without bypassing the existing index
- add regression coverage for lowercase queue IDs, mixed-case parent IDs, empty children, and empty queues

Follow-up database normalization is tracked in #312.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter DavCleanup` (2 passed)
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (322 passed; 11 unrelated streaming tests fail locally because `rapidyenc.dylib` is unavailable on macOS ARM)