### PR TITLE
perf(webdav): stream and order large directory listings

### DIFF
--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database.Models;
 
@@ -28,13 +29,34 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     // directory
     public Task<List<DavItem>> GetDirectoryChildrenAsync(Guid dirId, CancellationToken ct = default)
     {
-        return ctx.Items.AsNoTracking().Where(x => x.ParentId == dirId).ToListAsync(ct);
+        return GetDirectoryChildrenQuery(dirId).ToListAsync(ct);
+    }
+
+    public async IAsyncEnumerable<DavItem> GetDirectoryChildrenEnumerableAsync(
+        Guid dirId,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var child in GetDirectoryChildrenQuery(dirId)
+                           .AsAsyncEnumerable()
+                           .WithCancellation(ct)
+                           .ConfigureAwait(false))
+        {
+            yield return child;
+        }
     }
 
     public Task<DavItem?> GetDirectoryChildAsync(Guid dirId, string childName, CancellationToken ct = default)
     {
         return ctx.Items.AsNoTracking()
             .FirstOrDefaultAsync(x => x.ParentId == dirId && x.Name == childName, ct);
+    }
+
+    private IQueryable<DavItem> GetDirectoryChildrenQuery(Guid dirId)
+    {
+        return ctx.Items
+            .AsNoTracking()
+            .Where(x => x.ParentId == dirId)
+            .OrderBy(x => x.Name);
     }
 
     // Resolves a persisted item by its absolute virtual path in a single indexed lookup,
@@ -353,8 +375,26 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     }
 
     // completed-symlinks
-    public async Task<List<DavItem>> GetCompletedSymlinkCategoryChildren(string category,
+    public Task<List<DavItem>> GetCompletedSymlinkCategoryChildren(string category,
         CancellationToken ct = default)
+    {
+        return GetCompletedSymlinkCategoryChildrenQuery(category).ToListAsync(ct);
+    }
+
+    public async IAsyncEnumerable<DavItem> GetCompletedSymlinkCategoryChildrenEnumerableAsync(
+        string category,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var child in GetCompletedSymlinkCategoryChildrenQuery(category)
+                           .AsAsyncEnumerable()
+                           .WithCancellation(ct)
+                           .ConfigureAwait(false))
+        {
+            yield return child;
+        }
+    }
+
+    private IQueryable<DavItem> GetCompletedSymlinkCategoryChildrenQuery(string category)
     {
         var query = from historyItem in Ctx.HistoryItems
             .AsNoTracking()
@@ -364,6 +404,6 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
                     join davItem in Ctx.Items.AsNoTracking() on historyItem.DownloadDirId equals davItem.Id
                     where davItem.Type == DavItem.ItemType.Directory
                     select davItem;
-        return await query.Distinct().ToListAsync(ct).ConfigureAwait(false);
+        return query.Distinct().OrderBy(x => x.Name);
     }
 }

--- a/backend/WebDav/Base/BaseStoreCollection.cs
+++ b/backend/WebDav/Base/BaseStoreCollection.cs
@@ -28,7 +28,12 @@ public abstract class BaseStoreCollection : IStoreCollection
 
     // interface implementation
     public IPropertyManager? PropertyManager => BaseStoreCollectionPropertyManager.Instance;
-    public InfiniteDepthMode InfiniteDepthMode => InfiniteDepthMode.Allowed;
+
+    // Depth > 1 PROPFIND would recurse into child collections while the parent's
+    // streamed EF query is still open, starting a second operation on the same scoped
+    // DbContext. It also materializes the entire subtree in memory. Clamp to depth 1;
+    // WebDAV clients (rclone included) traverse one directory per request anyway.
+    public InfiniteDepthMode InfiniteDepthMode => InfiniteDepthMode.Assume1;
 
     public Task<StoreItemResult> CopyAsync
     (

--- a/backend/WebDav/Base/BaseStoreCollection.cs
+++ b/backend/WebDav/Base/BaseStoreCollection.cs
@@ -1,4 +1,5 @@
-﻿using NWebDav.Server;
+﻿using System.Runtime.CompilerServices;
+using NWebDav.Server;
 using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Streams;
@@ -15,7 +16,7 @@ public abstract class BaseStoreCollection : IStoreCollection
 
     protected abstract Task<StoreItemResult> CopyAsync(CopyRequest request);
     protected abstract Task<IStoreItem?> GetItemAsync(GetItemRequest request);
-    protected abstract Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken);
+    protected abstract IAsyncEnumerable<IStoreItem> GetAllItemsAsync(CancellationToken cancellationToken);
     protected abstract Task<StoreItemResult> CreateItemAsync(CreateItemRequest request);
     protected abstract Task<StoreCollectionResult> CreateCollectionAsync(CreateCollectionRequest request);
     protected abstract bool SupportsFastMove(SupportsFastMoveRequest request);
@@ -46,10 +47,10 @@ public abstract class BaseStoreCollection : IStoreCollection
         });
     }
 
-    public async IAsyncEnumerable<IStoreItem> GetItemsAsync(CancellationToken cancellationToken)
+    public async IAsyncEnumerable<IStoreItem> GetItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var allItems = await GetAllItemsAsync(cancellationToken).ConfigureAwait(false);
-        foreach (var item in allItems)
+        await foreach (var item in GetAllItemsAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return item;
         }

--- a/backend/WebDav/Base/BaseStoreEmptyCollection.cs
+++ b/backend/WebDav/Base/BaseStoreEmptyCollection.cs
@@ -1,4 +1,5 @@
-﻿using NWebDav.Server.Stores;
+﻿using System.Runtime.CompilerServices;
+using NWebDav.Server.Stores;
 using NzbWebDAV.WebDav.Requests;
 
 namespace NzbWebDAV.WebDav.Base;
@@ -14,8 +15,11 @@ public class BaseStoreEmptyCollection(string name) : BaseStoreReadonlyCollection
         return Task.FromResult<IStoreItem?>(null);
     }
 
-    protected override Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
+    protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        return Task.FromResult<IStoreItem[]>([]);
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield break;
     }
 }

--- a/backend/WebDav/DatabaseStoreCategoryWatchFolder.cs
+++ b/backend/WebDav/DatabaseStoreCategoryWatchFolder.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
@@ -34,12 +35,15 @@ public class DatabaseStoreCategoryWatchFolder(
         return new DatabaseStoreQueueItem(queueItem, dbClient);
     }
 
-    protected override async Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
+    protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        return (await dbClient.GetQueueItems(category, 0, int.MaxValue, cancellationToken).ConfigureAwait(false))
-            .Select(x => new DatabaseStoreQueueItem(x, dbClient))
-            .Select(IStoreItem (x) => x)
-            .ToArray();
+        foreach (var queueItem in await dbClient
+                     .GetQueueItems(category, 0, int.MaxValue, cancellationToken)
+                     .ConfigureAwait(false))
+        {
+            yield return new DatabaseStoreQueueItem(queueItem, dbClient);
+        }
     }
 
     protected override async Task<StoreItemResult> CreateItemAsync(CreateItemRequest request)

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using System.Runtime.CompilerServices;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Clients.Usenet;
@@ -61,31 +62,35 @@ public class DatabaseStoreCollection(
         return null;
     }
 
-    protected override async Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
+    protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        // read DavItems from the database
-        var children = await dbClient
-            .GetDirectoryChildrenAsync(davDirectory.Id, cancellationToken)
-            .ConfigureAwait(false);
+        var isContentFolder = davDirectory.Id == DavItem.ContentFolder.Id;
+        HashSet<string>? childNames = isContentFolder ? [] : null;
 
-        // map DavItems to IStoreItems
-        var result = children.Select(child => DatabaseStoreItemFactory.Create(
-            child, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,
-            lazyRarResolver));
+        await foreach (var child in dbClient
+                           .GetDirectoryChildrenEnumerableAsync(davDirectory.Id, cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            childNames?.Add(child.Name);
+            yield return DatabaseStoreItemFactory.Create(
+                child, httpContext, dbClient, configManager, usenetClient, queueManager, websocketManager,
+                lazyRarResolver);
+        }
 
         // include the readme file
         if (davDirectory.Id == DavItem.Root.Id)
-            result = result.Append(Readme);
+            yield return Readme;
 
         // include any missing category folders
-        if (davDirectory.Id == DavItem.ContentFolder.Id)
+        if (isContentFolder)
         {
-            result = result.Concat(configManager.GetApiCategories()
-                .Except(children.Select(x => x.Name))
-                .Select(x => new BaseStoreEmptyCollection(x)));
+            foreach (var category in configManager.GetApiCategories())
+            {
+                if (!childNames!.Contains(category))
+                    yield return new BaseStoreEmptyCollection(category);
+            }
         }
-
-        return result.ToArray();
     }
 
     protected override bool SupportsFastMove(SupportsFastMoveRequest request)

--- a/backend/WebDav/DatabaseStoreIdsCollection.cs
+++ b/backend/WebDav/DatabaseStoreIdsCollection.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
@@ -47,21 +48,27 @@ public class DatabaseStoreIdsCollection(
         return item == null ? null : new DatabaseStoreIdFile(item, ctx, dbClient, usenet, config, lazy);
     }
 
-    protected override async Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
+    protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var (ctx, db, usenet, config, lazy) =
             (httpContext, dbClient, usenetClient, configManager, lazyRarResolver);
         if (_currentPathParts.Length < DavItem.IdPrefixLength)
-            return Alphabet
-                .Select(x => x.ToString())
-                .Select(x => new DatabaseStoreIdsCollection(x, Path.Join(currentPath, x), ctx, db, usenet, config, lazy))
-                .Select(x => x as IStoreItem)
-                .ToArray();
+        {
+            foreach (var segment in Alphabet)
+            {
+                yield return new DatabaseStoreIdsCollection(
+                    segment.ToString(), Path.Join(currentPath, segment.ToString()), ctx, db, usenet, config, lazy);
+            }
+
+            yield break;
+        }
 
         var idPrefix = string.Join("", _currentPathParts);
-        return (await dbClient.GetFilesByIdPrefix(idPrefix).ConfigureAwait(false))
-            .Select(x => new DatabaseStoreIdFile(x, ctx, db, usenet, config, lazy))
-            .Select(x => x as IStoreItem)
-            .ToArray();
+        foreach (var item in await dbClient.GetFilesByIdPrefix(idPrefix).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new DatabaseStoreIdFile(item, ctx, dbClient, usenet, config, lazy);
+        }
     }
 }

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Caching.Memory;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
@@ -51,31 +52,40 @@ public class DatabaseStoreSymlinkCollection(
         return null;
     }
 
-    protected override async Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
+    protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // if we are a category folder within the /completed-symlinks dir,
         // then we only want to show children that correspond to Completed History items.
         var isCategoryFolder = davDirectory.ParentId == DavItem.ContentFolder.Id;
         var children = isCategoryFolder
-            ? await dbClient.GetCompletedSymlinkCategoryChildren(davDirectory.Name, cancellationToken)
-                .ConfigureAwait(false)
-            : await dbClient.GetDirectoryChildrenAsync(TargetId, cancellationToken).ConfigureAwait(false);
-
-        // map DavItems to IStoreItems
-        var result = children.Select(GetItem);
+            ? dbClient.GetCompletedSymlinkCategoryChildrenEnumerableAsync(davDirectory.Name, cancellationToken)
+            : dbClient.GetDirectoryChildrenEnumerableAsync(TargetId, cancellationToken);
 
         // include any missing category folders
         var isSymlinkFolder = davDirectory.Id == DavItem.SymlinkFolder.Id;
-        if (isSymlinkFolder)
+        HashSet<string>? childNames = isSymlinkFolder ? [] : null;
+
+        await foreach (var child in children.ConfigureAwait(false))
         {
-            result = result.Concat(configManager.GetApiCategories()
-                .Except(children.Select(x => x.Name))
-                .Select(x => new BaseStoreEmptyCollection(x)));
+            childNames?.Add(child.Name);
+            var item = GetItem(child);
+            if (!DeletedFiles.IsDeleted(item.Name))
+                yield return item;
         }
 
-        return result
-            .Where(x => !DeletedFiles.IsDeleted(x.Name)) // must appear after Select(GetItem) for correct Name.
-            .ToArray();
+        if (isSymlinkFolder)
+        {
+            foreach (var category in configManager.GetApiCategories())
+            {
+                if (childNames!.Contains(category))
+                    continue;
+
+                var item = new BaseStoreEmptyCollection(category);
+                if (!DeletedFiles.IsDeleted(item.Name))
+                    yield return item;
+            }
+        }
     }
 
     protected override Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)

--- a/backend/WebDav/DatabaseStoreWatchFolder.cs
+++ b/backend/WebDav/DatabaseStoreWatchFolder.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Config;
@@ -30,14 +31,15 @@ public class DatabaseStoreWatchFolder(
             request.Name, dbClient, configManager, queueManager, websocketManager);
     }
 
-    protected override async Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
+    protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var categories = await GetCategoriesAsync(cancellationToken).ConfigureAwait(false);
-        return categories
-            .Select(c => new DatabaseStoreCategoryWatchFolder(
-                c, dbClient, configManager, queueManager, websocketManager))
-            .Select(IStoreItem (x) => x)
-            .ToArray();
+        foreach (var category in categories)
+        {
+            yield return new DatabaseStoreCategoryWatchFolder(
+                category, dbClient, configManager, queueManager, websocketManager);
+        }
     }
 
     private async Task<IReadOnlySet<string>> GetCategoriesAsync(CancellationToken cancellationToken)

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -60,12 +60,54 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
         var children = await _client.GetDirectoryChildrenAsync(directory.Id);
         Assert.Equal(
             new[] { "first.mkv", "science-fiction" },
-            children.Select(item => item.Name).Order());
+            children.Select(item => item.Name));
+
+        var streamedChildren = new List<DavItem>();
+        await foreach (var child in _client.GetDirectoryChildrenEnumerableAsync(directory.Id))
+            streamedChildren.Add(child);
+        Assert.Equal(
+            new[] { "first.mkv", "science-fiction" },
+            streamedChildren.Select(item => item.Name));
+
         Assert.Equal(350, await _client.GetRecursiveSize(directory.Id));
         Assert.Equal(firstFile.Id, (await _client.GetFileById(firstFile.Id.ToString()))?.Id);
         Assert.Equal(
             firstFile.Id,
             (await _client.GetFilesByIdPrefix(firstFile.IdPrefix)).Single().Id);
+    }
+
+    [Fact]
+    public async Task CompletedSymlinkCategoryChildren_AreDistinctAndOrdered()
+    {
+        var zetaDirectory = DavItem.New(
+            Guid.NewGuid(), DavItem.ContentFolder, "zeta", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        var alphaDirectory = DavItem.New(
+            Guid.NewGuid(), DavItem.ContentFolder, "alpha", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        var failedDirectory = DavItem.New(
+            Guid.NewGuid(), DavItem.ContentFolder, "failed", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+
+        _context.Items.AddRange(zetaDirectory, alphaDirectory, failedDirectory);
+        _context.HistoryItems.AddRange(
+            CreateHistoryItem("zeta.nzb", zetaDirectory.Id, HistoryItem.DownloadStatusOption.Completed),
+            CreateHistoryItem("zeta-duplicate.nzb", zetaDirectory.Id, HistoryItem.DownloadStatusOption.Completed),
+            CreateHistoryItem("alpha.nzb", alphaDirectory.Id, HistoryItem.DownloadStatusOption.Completed),
+            CreateHistoryItem("failed.nzb", failedDirectory.Id, HistoryItem.DownloadStatusOption.Failed));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var children = await _client.GetCompletedSymlinkCategoryChildren("movies");
+        Assert.Equal(new[] { "alpha", "zeta" }, children.Select(item => item.Name));
+
+        var streamedChildren = new List<DavItem>();
+        await foreach (var child in _client.GetCompletedSymlinkCategoryChildrenEnumerableAsync("movies"))
+            streamedChildren.Add(child);
+        Assert.Equal(new[] { "alpha", "zeta" }, streamedChildren.Select(item => item.Name));
     }
 
     [Fact]
@@ -140,6 +182,23 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
         Assert.Equal(queueItem.Id, historyItem.Id);
         Assert.Equal(HistoryItem.DownloadStatusOption.Failed, historyItem.DownloadStatus);
         Assert.Equal("The NZB file could not be found.", historyItem.FailMessage);
+    }
+
+    private static HistoryItem CreateHistoryItem(
+        string fileName,
+        Guid downloadDirId,
+        HistoryItem.DownloadStatusOption status)
+    {
+        return new HistoryItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = "movies",
+            DownloadStatus = status,
+            DownloadDirId = downloadDirId
+        };
     }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
## Summary

Resolves #238 per the [proposed resolution](https://github.com/nzbdav/nzbdav/issues/238#issuecomment-4952207519).

- `GetDirectoryChildrenAsync` and `GetCompletedSymlinkCategoryChildren` now push `ORDER BY Name` into SQL (served by the existing unique `(ParentId, Name)` index) and gain `IAsyncEnumerable` streaming variants via `AsAsyncEnumerable()`.
- `BaseStoreCollection.GetAllItemsAsync` contract changed from `Task<IStoreItem[]>` to `IAsyncEnumerable<IStoreItem>`; all collection overrides yield items instead of materializing arrays. Synthetic items (root README, missing empty category folders) are appended after the SQL-ordered DB children, preserving existing behavior.
- PROPFIND infinite depth is clamped to depth 1 (`InfiniteDepthMode.Assume1`): with streamed listings, depth > 1 recursion would start a nested query on the same scoped `DbContext` while the parent enumerator is open, and infinite depth also materialized entire subtrees in memory. rclone and typical WebDAV clients traverse one directory per request, so this is a safe clamp.

Out of scope (tracked as follow-up in the issue): `offset`/`limit` on `list-webdav-directory` / Explore pagination (#135), NWebDav `PropFindHandler` XML streaming.

## Test plan

- [x] New/updated `DavDatabaseClientTests`: SQL name ordering asserted for both list and streaming variants; completed-symlink category children are distinct, ordered, and exclude failed history items.
- [x] `dotnet test -c Release` — 319 passing; the 11 failures in `NzbFileStreamTests`/`ArticleCachingNntpClientTests` are pre-existing on `main` (verified via stash) and unrelated to this change.
- [ ] Manual smoke: PROPFIND depth:1 and Explore on a large `/completed-symlinks/<category>` tree.