### PR TITLE
feat: make ThreadPool limits configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,11 @@ export FRONTEND_BACKEND_API_KEY=$(head -c 32 /dev/urandom | hexdump -ve '1/1 "%.
 export BACKEND_URL=http://localhost:5000
 ```
 
+The backend thread-pool limits can optionally be overridden with
+`THREADPOOL_MIN_THREADS` and `THREADPOOL_MAX_THREADS`. When unset, they retain
+the production defaults of `max(2 × processor count, 50)` minimum threads and
+`max(50 × processor count, 1000)` maximum threads.
+
 You need some packages in order to run the project:
 
 - dotnet-sdk

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -33,12 +33,12 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        // Update thread-pool
-        var coreCount = Environment.ProcessorCount;
-        var minThreads = Math.Max(coreCount * 2, 50); // 2x cores, minimum 50
-        var maxThreads = Math.Max(coreCount * 50, 1000); // 50x cores, minimum 1000
-        ThreadPool.SetMinThreads(minThreads, minThreads);
+        var (minThreads, maxThreads) = ThreadPoolUtil.ResolveLimits(
+            Environment.ProcessorCount,
+            EnvironmentUtil.GetLongVariable("THREADPOOL_MIN_THREADS"),
+            EnvironmentUtil.GetLongVariable("THREADPOOL_MAX_THREADS"));
         ThreadPool.SetMaxThreads(maxThreads, maxThreads);
+        ThreadPool.SetMinThreads(minThreads, minThreads);
 
         // Initialize logger
         var defaultLevel = LogEventLevel.Information;
@@ -71,6 +71,10 @@ class Program
                 ConfigManager.AppVersion,
                 DavDatabaseContext.ConfigPath,
                 level);
+            Log.Information(
+                "ThreadPool configured with minimum {MinThreads} and maximum {MaxThreads} worker and IOCP threads",
+                minThreads,
+                maxThreads);
 
             // Block upgrades to version 0.6.x
             BlockUpgradesToV06X();

--- a/backend/Utils/ThreadPoolUtil.cs
+++ b/backend/Utils/ThreadPoolUtil.cs
@@ -1,0 +1,31 @@
+namespace NzbWebDAV.Utils;
+
+public static class ThreadPoolUtil
+{
+    public const int MinimumThreadCount = 2;
+    public const int MaximumThreadCount = 32767;
+
+    public static (int MinThreads, int MaxThreads) ResolveLimits(
+        int processorCount,
+        long? configuredMinThreads,
+        long? configuredMaxThreads)
+    {
+        var effectiveProcessorCount = Math.Clamp(processorCount, 1, MaximumThreadCount);
+        var defaultMinThreads = Math.Max((long)effectiveProcessorCount * 2, 50);
+        var defaultMaxThreads = Math.Max((long)effectiveProcessorCount * 50, 1000);
+
+        var minThreads = (int)Math.Clamp(
+            configuredMinThreads ?? defaultMinThreads,
+            MinimumThreadCount,
+            MaximumThreadCount);
+        var maxThreads = (int)Math.Clamp(
+            configuredMaxThreads ?? defaultMaxThreads,
+            MinimumThreadCount,
+            MaximumThreadCount);
+
+        // ThreadPool rejects a maximum below either its minimum or the processor count.
+        maxThreads = Math.Max(maxThreads, Math.Max(minThreads, effectiveProcessorCount));
+
+        return (minThreads, maxThreads);
+    }
+}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -124,6 +124,9 @@ The image runs two processes: the frontend and public proxy on port `3000`, and 
 >
 > Frontend session cookies: set `SECURE_COOKIES=true` when the UI is only served over HTTPS. Optionally set `SESSION_KEY` to a long random secret (otherwise a stable key is persisted under `CONFIG_PATH/session.key` so restarts do not log everyone out). Optionally set `SESSION_MAX_AGE` in seconds (default one year).
 
+> [!NOTE]
+> Small, memory-constrained deployments can override the backend thread-pool limits with `THREADPOOL_MIN_THREADS` and `THREADPOOL_MAX_THREADS` in the container environment. When unset, NzbDav retains the existing defaults: `max(2 × processor count, 50)` minimum threads and `max(50 × processor count, 1000)` maximum threads. Lowering the minimum may reduce reserved stack memory but can also reduce streaming responsiveness under load; restart the container after changing either value.
+
 ### 2. Core configuration
 
 Navigate to `http://your-server-ip:3000`.

--- a/tests/NzbWebDAV.Tests/Utils/ThreadPoolUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ThreadPoolUtilTests.cs
@@ -1,0 +1,63 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ThreadPoolUtilTests
+{
+    [Theory]
+    [InlineData(1, 50, 1000)]
+    [InlineData(4, 50, 1000)]
+    [InlineData(25, 50, 1250)]
+    [InlineData(100, 200, 5000)]
+    public void ResolveLimits_UsesCurrentDefaultsWhenUnset(
+        int processorCount,
+        int expectedMinThreads,
+        int expectedMaxThreads)
+    {
+        var limits = ThreadPoolUtil.ResolveLimits(processorCount, null, null);
+
+        Assert.Equal(expectedMinThreads, limits.MinThreads);
+        Assert.Equal(expectedMaxThreads, limits.MaxThreads);
+    }
+
+    [Fact]
+    public void ResolveLimits_UsesConfiguredValues()
+    {
+        var limits = ThreadPoolUtil.ResolveLimits(4, 25, 2000);
+
+        Assert.Equal(25, limits.MinThreads);
+        Assert.Equal(2000, limits.MaxThreads);
+    }
+
+    [Fact]
+    public void ResolveLimits_UsesDefaultForEachUnsetValue()
+    {
+        var configuredMin = ThreadPoolUtil.ResolveLimits(4, 25, null);
+        var configuredMax = ThreadPoolUtil.ResolveLimits(4, null, 2000);
+
+        Assert.Equal((25, 1000), configuredMin);
+        Assert.Equal((50, 2000), configuredMax);
+    }
+
+    [Theory]
+    [InlineData(4, -1L, null, 2, 1000)]
+    [InlineData(4, 100L, 10L, 100, 100)]
+    [InlineData(8, 2L, 2L, 2, 8)]
+    [InlineData(4, long.MaxValue, long.MaxValue, 32767, 32767)]
+    [InlineData(100000, null, null, 32767, 32767)]
+    public void ResolveLimits_ClampsValuesToValidBounds(
+        int processorCount,
+        long? configuredMinThreads,
+        long? configuredMaxThreads,
+        int expectedMinThreads,
+        int expectedMaxThreads)
+    {
+        var limits = ThreadPoolUtil.ResolveLimits(
+            processorCount,
+            configuredMinThreads,
+            configuredMaxThreads);
+
+        Assert.Equal(expectedMinThreads, limits.MinThreads);
+        Assert.Equal(expectedMaxThreads, limits.MaxThreads);
+    }
+}


### PR DESCRIPTION
## Summary
- add validated `THREADPOOL_MIN_THREADS` and `THREADPOOL_MAX_THREADS` startup overrides while preserving existing defaults
- log effective limits and document the deployment settings
- cover defaults, overrides, and clamping with unit tests

Closes #239

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~ThreadPoolUtilTests'` (11 passed)
- [ ] Full backend suite attempted; unrelated streaming tests fail locally because the RapidYenc native library is absent from the test output