### PR TITLE
feat(db): integrated database backup and restore

### DIFF
--- a/backend/Api/Controllers/DbBackupCreate/DbBackupCreateController.cs
+++ b/backend/Api/Controllers/DbBackupCreate/DbBackupCreateController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.DbBackupCreate;
+
+[ApiController]
+[Route("api/db-backup-create")]
+public class DbBackupCreateController(
+    ConfigManager configManager,
+    WebsocketManager websocketManager,
+    DatabaseBackupStore store
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var notes = HttpContext.Request.HasFormContentType
+            ? HttpContext.Request.Form["notes"].ToString()
+            : "";
+
+        var task = new DatabaseBackupTask(
+            configManager,
+            websocketManager,
+            store,
+            DatabaseBackupKinds.Manual,
+            notes: string.IsNullOrWhiteSpace(notes) ? null : notes);
+
+        var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed)
+            return Conflict(new { error = "A database backup or restore task is already running." });
+
+        return Ok(new BaseApiResponse { Status = true });
+    }
+}

--- a/backend/Api/Controllers/DbBackupDelete/DbBackupDeleteController.cs
+++ b/backend/Api/Controllers/DbBackupDelete/DbBackupDeleteController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.DbBackupDelete;
+
+[ApiController]
+[Route("api/db-backup-delete")]
+public class DbBackupDeleteController(DatabaseBackupStore store) : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        if (!HttpContext.Request.HasFormContentType)
+            throw new BadHttpRequestException("Expected form body.");
+
+        var id = HttpContext.Request.Form["id"].ToString();
+        if (string.IsNullOrWhiteSpace(id))
+            throw new BadHttpRequestException("Backup id is required.");
+
+        store.Delete(id);
+        return Task.FromResult<IActionResult>(Ok(new BaseApiResponse { Status = true }));
+    }
+}

--- a/backend/Api/Controllers/DbBackupDownload/DbBackupDownloadController.cs
+++ b/backend/Api/Controllers/DbBackupDownload/DbBackupDownloadController.cs
@@ -1,0 +1,41 @@
+using System.IO.Compression;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.DbBackupDownload;
+
+[ApiController]
+[Route("api/db-backup-download")]
+public class DbBackupDownloadController(DatabaseBackupStore store) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var id = HttpContext.Request.Query["id"].ToString();
+        if (string.IsNullOrWhiteSpace(id))
+            throw new BadHttpRequestException("Backup id is required.");
+
+        DatabaseBackupStore.ValidateBackupId(id);
+        var backupDir = store.GetBackupDirectory(id);
+        if (!Directory.Exists(backupDir) || store.Get(id) is null)
+            return NotFound(new BaseApiResponse { Status = false, Error = $"Backup not found: {id}" });
+
+        Response.ContentType = "application/zip";
+        Response.Headers.ContentDisposition = $"attachment; filename=\"nzbdav-backup-{id}.zip\"";
+
+        await using var archive = new ZipArchive(Response.Body, ZipArchiveMode.Create, leaveOpen: true);
+        foreach (var file in Directory.EnumerateFiles(backupDir, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(backupDir, file).Replace('\\', '/');
+            if (relative.StartsWith(DatabaseBackupStore.RollbackFolderName + "/", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var entry = archive.CreateEntry(relative, CompressionLevel.Fastest);
+            await using var entryStream = entry.Open();
+            await using var fileStream = System.IO.File.OpenRead(file);
+            await fileStream.CopyToAsync(entryStream, HttpContext.RequestAborted).ConfigureAwait(false);
+        }
+
+        return new EmptyResult();
+    }
+}

--- a/backend/Api/Controllers/DbBackupList/DbBackupListController.cs
+++ b/backend/Api/Controllers/DbBackupList/DbBackupListController.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tasks;
+
+namespace NzbWebDAV.Api.Controllers.DbBackupList;
+
+[ApiController]
+[Route("api/db-backup-list")]
+public class DbBackupListController(DatabaseBackupStore store) : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        store.EnsureInitialized();
+        var response = new DbBackupListResponse
+        {
+            Status = true,
+            Backups = store.List().ToList(),
+            TaskRunning = BaseTask.IsRunning,
+            PendingRestore = store.HasPendingRestore(),
+            LastRestoreReport = store.ReadLastRestoreReport(),
+        };
+        return Task.FromResult<IActionResult>(Ok(response));
+    }
+}
+
+public class DbBackupListResponse : BaseApiResponse
+{
+    [JsonPropertyName("backups")]
+    public required List<DatabaseBackupManifest> Backups { get; init; }
+
+    [JsonPropertyName("taskRunning")]
+    public bool TaskRunning { get; init; }
+
+    [JsonPropertyName("pendingRestore")]
+    public bool PendingRestore { get; init; }
+
+    [JsonPropertyName("lastRestoreReport")]
+    public LastRestoreReport? LastRestoreReport { get; init; }
+}

--- a/backend/Api/Controllers/DbBackupUpdate/DbBackupUpdateController.cs
+++ b/backend/Api/Controllers/DbBackupUpdate/DbBackupUpdateController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.DbBackupUpdate;
+
+[ApiController]
+[Route("api/db-backup-update")]
+public class DbBackupUpdateController(DatabaseBackupStore store) : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        if (!HttpContext.Request.HasFormContentType)
+            throw new BadHttpRequestException("Expected form body.");
+
+        var id = HttpContext.Request.Form["id"].ToString();
+        if (string.IsNullOrWhiteSpace(id))
+            throw new BadHttpRequestException("Backup id is required.");
+
+        bool? preserved = null;
+        var preservedRaw = HttpContext.Request.Form["preserved"].ToString();
+        if (!string.IsNullOrWhiteSpace(preservedRaw))
+        {
+            if (!bool.TryParse(preservedRaw, out var parsed))
+                throw new BadHttpRequestException("preserved must be true or false.");
+            preserved = parsed;
+        }
+
+        string? notes = null;
+        if (HttpContext.Request.Form.ContainsKey("notes"))
+            notes = HttpContext.Request.Form["notes"].ToString();
+
+        var manifest = store.UpdateManifest(id, preserved, notes);
+        return Task.FromResult<IActionResult>(Ok(new { status = true, backup = manifest }));
+    }
+}

--- a/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
+++ b/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
@@ -1,0 +1,133 @@
+using System.IO.Compression;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.DbBackupUpload;
+
+[ApiController]
+[Route("api/db-backup-upload")]
+[RequestSizeLimit(4L * 1024 * 1024 * 1024)]
+[RequestFormLimits(MultipartBodyLengthLimit = 4L * 1024 * 1024 * 1024)]
+public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        // Allow large backup uploads regardless of the global Kestrel body limit.
+        var sizeFeature = HttpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpMaxRequestBodySizeFeature>();
+        if (sizeFeature is { IsReadOnly: false })
+            sizeFeature.MaxRequestBodySize = null;
+
+        if (!HttpContext.Request.HasFormContentType)
+            throw new BadHttpRequestException("Expected multipart form body.");
+
+        var file = HttpContext.Request.Form.Files.FirstOrDefault();
+        if (file is null || file.Length == 0)
+            throw new BadHttpRequestException("No backup file was uploaded.");
+
+        store.EnsureInitialized();
+        var stagingPath = store.CreateStaging(DatabaseBackupKinds.Uploaded);
+        try
+        {
+            var fileName = file.FileName ?? "upload.zip";
+            if (fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                await ExtractZipAsync(file, stagingPath, HttpContext.RequestAborted).ConfigureAwait(false);
+            }
+            else if (fileName.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
+            {
+                var target = Path.Combine(stagingPath, DatabaseBackupStore.DbSqlName);
+                await using var stream = file.OpenReadStream();
+                await using var output = System.IO.File.Create(target);
+                await stream.CopyToAsync(output, HttpContext.RequestAborted).ConfigureAwait(false);
+            }
+            else
+            {
+                throw new BadHttpRequestException("Upload must be a .zip backup or a .sql dump.");
+            }
+
+            ValidateSqlFiles(stagingPath);
+
+            var notes = HttpContext.Request.Form["notes"].ToString();
+            var manifest = store.CommitStaging(
+                stagingPath,
+                DatabaseBackupKinds.Uploaded,
+                string.IsNullOrWhiteSpace(notes) ? $"Uploaded from {Path.GetFileName(fileName)}" : notes,
+                preserved: false,
+                appVersion: ConfigManager.AppVersion,
+                lastMainMigration: null);
+            stagingPath = null;
+
+            return Ok(new { status = true, backup = manifest });
+        }
+        finally
+        {
+            store.DiscardStaging(stagingPath);
+        }
+    }
+
+    private static async Task ExtractZipAsync(IFormFile file, string stagingPath, CancellationToken ct)
+    {
+        await using var upload = file.OpenReadStream();
+        using var archive = new ZipArchive(upload, ZipArchiveMode.Read, leaveOpen: false);
+        foreach (var entry in archive.Entries)
+        {
+            if (string.IsNullOrEmpty(entry.Name))
+                continue;
+
+            var relative = entry.FullName.Replace('\\', '/');
+            if (relative.Contains("..", StringComparison.Ordinal) || Path.IsPathRooted(relative))
+                throw new BadHttpRequestException("Zip entry path is invalid.");
+
+            var fileName = Path.GetFileName(relative);
+            if (fileName is not (DatabaseBackupStore.DbSqlName
+                or DatabaseBackupStore.MetricsSqlName
+                or DatabaseBackupStore.WardenSqlName
+                or DatabaseBackupStore.ManifestFileName))
+                continue;
+
+            var dest = Path.Combine(stagingPath, fileName);
+            await using var entryStream = entry.Open();
+            await using var output = System.IO.File.Create(dest);
+            await entryStream.CopyToAsync(output, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static void ValidateSqlFiles(string stagingPath)
+    {
+        var sqlFiles = new[]
+        {
+            DatabaseBackupStore.DbSqlName,
+            DatabaseBackupStore.MetricsSqlName,
+            DatabaseBackupStore.WardenSqlName,
+        };
+
+        var found = false;
+        foreach (var name in sqlFiles)
+        {
+            var path = Path.Combine(stagingPath, name);
+            if (!System.IO.File.Exists(path))
+                continue;
+            found = true;
+            using var reader = new StreamReader(path);
+            var header = reader.ReadLine() ?? "";
+            if (!header.Contains("PRAGMA foreign_keys", StringComparison.OrdinalIgnoreCase)
+                && !header.Contains("BEGIN", StringComparison.OrdinalIgnoreCase)
+                && !header.Contains("CREATE", StringComparison.OrdinalIgnoreCase))
+            {
+                // Soft check — dumps may start with blank lines; read a bit more.
+                var sample = header + "\n" + reader.ReadToEnd();
+                if (sample.Length > 4096)
+                    sample = sample[..4096];
+                if (!sample.Contains("CREATE TABLE", StringComparison.OrdinalIgnoreCase)
+                    && !sample.Contains("BEGIN", StringComparison.OrdinalIgnoreCase))
+                    throw new BadHttpRequestException($"{name} does not look like a SQLite SQL dump.");
+            }
+        }
+
+        if (!found)
+            throw new BadHttpRequestException("Upload did not contain any recognized .sql dump files.");
+    }
+}

--- a/backend/Api/Controllers/DbRestore/DbRestoreController.cs
+++ b/backend/Api/Controllers/DbRestore/DbRestoreController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.DbRestore;
+
+[ApiController]
+[Route("api/db-restore")]
+public class DbRestoreController(
+    ConfigManager configManager,
+    WebsocketManager websocketManager,
+    DatabaseBackupStore store,
+    RestartService restartService
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        if (!HttpContext.Request.HasFormContentType)
+            throw new BadHttpRequestException("Expected form body.");
+
+        var id = HttpContext.Request.Form["id"].ToString();
+        if (string.IsNullOrWhiteSpace(id))
+            throw new BadHttpRequestException("Backup id is required.");
+
+        var task = new DatabaseRestoreStageTask(
+            configManager,
+            websocketManager,
+            store,
+            restartService,
+            id);
+
+        try
+        {
+            var executed = await task.Execute().ConfigureAwait(false);
+            if (!executed)
+                return Conflict(new { error = "A database backup or restore task is already running." });
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or InvalidOperationException or ArgumentException)
+        {
+            return BadRequest(new BaseApiResponse { Status = false, Error = ex.Message });
+        }
+
+        return Ok(new { status = true, restarting = true });
+    }
+}

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -70,6 +70,11 @@ public static class ConfigKeys
     public const string MaintenanceRemoveOrphanedScheduleEnabled = "maintenance.remove-orphaned-schedule-enabled";
     public const string MaintenanceRemoveOrphanedScheduleTime = "maintenance.remove-orphaned-schedule-time";
 
+    // database backups
+    public const string BackupScheduleEnabled = "backup.schedule-enabled";
+    public const string BackupScheduleTime = "backup.schedule-time";
+    public const string BackupRetentionCount = "backup.retention-count";
+
     // play
     public const string PlayCandidateNegativeCacheMinutes = "play.candidate-negative-cache-minutes";
     public const string PlayExcludePatterns = "play.exclude-patterns";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -192,6 +192,8 @@ public class ConfigManager
                 case ConfigKeys.DatabaseHistoryRetentionDays:
                 case ConfigKeys.DatabaseHealthcheckRetentionDays:
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleTime:
+                case ConfigKeys.BackupScheduleTime:
+                case ConfigKeys.BackupRetentionCount:
                     RequireLong(item.ConfigName, value);
                     break;
 
@@ -222,6 +224,7 @@ public class ConfigManager
                 case ConfigKeys.RcloneRcEnabled:
                 case ConfigKeys.DbIsStartupVacuumEnabled:
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled:
+                case ConfigKeys.BackupScheduleEnabled:
                     RequireBool(item.ConfigName, value);
                     break;
 
@@ -1150,6 +1153,32 @@ public class ConfigManager
         if (!int.TryParse(configValue, out var totalMinutes)) return defaultValue;
         if (totalMinutes < 0 || totalMinutes >= 24 * 60) return defaultValue;
         return TimeSpan.FromMinutes(totalMinutes);
+    }
+
+    public bool IsDatabaseBackupScheduleEnabled()
+    {
+        var defaultValue = false;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.BackupScheduleEnabled));
+        return configValue != null ? bool.Parse(configValue) : defaultValue;
+    }
+
+    public TimeSpan DatabaseBackupSchedule()
+    {
+        var defaultValue = TimeSpan.Zero;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.BackupScheduleTime));
+        if (configValue == null) return defaultValue;
+        if (!int.TryParse(configValue, out var totalMinutes)) return defaultValue;
+        if (totalMinutes < 0 || totalMinutes >= 24 * 60) return defaultValue;
+        return TimeSpan.FromMinutes(totalMinutes);
+    }
+
+    public int GetDatabaseBackupRetentionCount()
+    {
+        var defaultValue = 5;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.BackupRetentionCount));
+        if (configValue == null) return defaultValue;
+        if (!int.TryParse(configValue, out var count) || count < 0) return defaultValue;
+        return count;
     }
 
     public class ConfigEventArgs : EventArgs

--- a/backend/Database/Backup/DatabaseBackupModels.cs
+++ b/backend/Database/Backup/DatabaseBackupModels.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Database.Backup;
+
+public sealed class DatabaseBackupManifest
+{
+    public required string Id { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public required string Kind { get; set; }
+    public string Notes { get; set; } = "";
+    public bool Preserved { get; set; }
+    public string? AppVersion { get; set; }
+    public string? LastMainMigration { get; set; }
+    public List<DatabaseBackupFileEntry> Files { get; set; } = [];
+}
+
+public sealed class DatabaseBackupFileEntry
+{
+    public required string Name { get; set; }
+    public long Bytes { get; set; }
+}
+
+public sealed class PendingRestoreIntent
+{
+    public required string BackupId { get; set; }
+    public required string PreRestoreBackupId { get; set; }
+    public List<string> StagedFiles { get; set; } = [];
+    public DateTimeOffset CreatedAt { get; set; }
+}
+
+public sealed class LastRestoreReport
+{
+    public required string BackupId { get; set; }
+    public DateTimeOffset RestoredAt { get; set; }
+    public long MissingBlobRefs { get; set; }
+    public long CheckedRefs { get; set; }
+}
+
+public static class DatabaseBackupKinds
+{
+    public const string Manual = "manual";
+    public const string Scheduled = "scheduled";
+    public const string Uploaded = "uploaded";
+    public const string PreRestore = "pre-restore";
+}
+
+public static class DatabaseBackupJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}

--- a/backend/Database/Backup/SqliteDumper.cs
+++ b/backend/Database/Backup/SqliteDumper.cs
@@ -1,0 +1,261 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Data.Sqlite;
+
+namespace NzbWebDAV.Database.Backup;
+
+/// <summary>
+/// Streams a logical <c>.sql</c> dump of a SQLite database in a format compatible
+/// with <c>sqlite3 .dump</c>. Safe to run against a live WAL database — uses a
+/// deferred read transaction for snapshot isolation.
+/// </summary>
+public static class SqliteDumper
+{
+    public static async Task DumpAsync(
+        string databaseFilePath,
+        Stream output,
+        Action<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(databaseFilePath);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (!File.Exists(databaseFilePath))
+            throw new FileNotFoundException("SQLite database file not found.", databaseFilePath);
+
+        await using var connection = await OpenConnectionAsync(databaseFilePath, cancellationToken).ConfigureAwait(false);
+
+        await using var begin = connection.CreateCommand();
+        begin.CommandText = "BEGIN;";
+        await begin.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await using var writer = new StreamWriter(output, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true);
+            await writer.WriteLineAsync("PRAGMA foreign_keys=OFF;").ConfigureAwait(false);
+            await writer.WriteLineAsync("BEGIN TRANSACTION;").ConfigureAwait(false);
+
+            var tables = await ListMasterObjectsAsync(connection, "table", cancellationToken).ConfigureAwait(false);
+            var userTables = tables
+                .Where(t => !t.Name.StartsWith("sqlite_", StringComparison.Ordinal))
+                .ToList();
+
+            for (var i = 0; i < userTables.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var table = userTables[i];
+                progress?.Invoke($"Dumping table {table.Name} ({i + 1}/{userTables.Count})");
+
+                if (!string.IsNullOrWhiteSpace(table.Sql))
+                    await writer.WriteLineAsync(EnsureTrailingSemicolon(table.Sql)).ConfigureAwait(false);
+
+                await DumpTableDataAsync(connection, writer, table.Name, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (tables.Any(t => t.Name == "sqlite_sequence"))
+            {
+                progress?.Invoke("Dumping sqlite_sequence");
+                await writer.WriteLineAsync("DELETE FROM sqlite_sequence;").ConfigureAwait(false);
+                await DumpTableDataAsync(connection, writer, "sqlite_sequence", cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var type in new[] { "index", "trigger", "view" })
+            {
+                var objects = await ListMasterObjectsAsync(connection, type, cancellationToken).ConfigureAwait(false);
+                foreach (var obj in objects)
+                {
+                    if (string.IsNullOrWhiteSpace(obj.Sql))
+                        continue; // skip autoindexes
+
+                    progress?.Invoke($"Dumping {type} {obj.Name}");
+                    await writer.WriteLineAsync(EnsureTrailingSemicolon(obj.Sql)).ConfigureAwait(false);
+                }
+            }
+
+            await writer.WriteLineAsync("COMMIT;").ConfigureAwait(false);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await using var end = connection.CreateCommand();
+            end.CommandText = "COMMIT;";
+            await end.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    public static async Task DumpToFileAsync(
+        string databaseFilePath,
+        string sqlFilePath,
+        Action<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(sqlFilePath);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        await using var stream = new FileStream(
+            sqlFilePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 64 * 1024,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        await DumpAsync(databaseFilePath, stream, progress, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<SqliteConnection> OpenConnectionAsync(
+        string databaseFilePath,
+        CancellationToken cancellationToken)
+    {
+        var readOnly = new SqliteConnectionStringBuilder
+        {
+            DataSource = databaseFilePath,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false,
+            DefaultTimeout = 30,
+        }.ToString();
+
+        var connection = new SqliteConnection(readOnly);
+        try
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            return connection;
+        }
+        catch
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
+
+        // Readonly open can fail when a WAL DB needs -shm created; fall back to read-write.
+        var readWrite = new SqliteConnectionStringBuilder
+        {
+            DataSource = databaseFilePath,
+            Mode = SqliteOpenMode.ReadWrite,
+            Pooling = false,
+            DefaultTimeout = 30,
+        }.ToString();
+
+        connection = new SqliteConnection(readWrite);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    private static async Task<List<MasterObject>> ListMasterObjectsAsync(
+        SqliteConnection connection,
+        string type,
+        CancellationToken cancellationToken)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT name, sql
+            FROM sqlite_master
+            WHERE type = $type
+            ORDER BY rowid;
+            """;
+        cmd.Parameters.AddWithValue("$type", type);
+
+        var results = new List<MasterObject>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(new MasterObject(
+                reader.GetString(0),
+                reader.IsDBNull(1) ? null : reader.GetString(1)));
+        }
+
+        return results;
+    }
+
+    private static async Task DumpTableDataAsync(
+        SqliteConnection connection,
+        StreamWriter writer,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        var quotedTable = QuoteIdent(tableName);
+        var columns = await GetColumnNamesAsync(connection, tableName, cancellationToken).ConfigureAwait(false);
+        if (columns.Count == 0)
+            return;
+
+        var quotedColumns = string.Join(",", columns.Select(QuoteIdent));
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT * FROM {quotedTable};";
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        var valueBuffer = new object[columns.Count];
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            reader.GetValues(valueBuffer);
+            var sb = new StringBuilder();
+            sb.Append("INSERT INTO ").Append(quotedTable)
+                .Append(" (").Append(quotedColumns).Append(") VALUES (");
+
+            for (var i = 0; i < valueBuffer.Length; i++)
+            {
+                if (i > 0) sb.Append(',');
+                sb.Append(FormatValue(valueBuffer[i]));
+            }
+
+            sb.Append(");");
+            await writer.WriteLineAsync(sb.ToString()).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<List<string>> GetColumnNamesAsync(
+        SqliteConnection connection,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        await using var cmd = connection.CreateCommand();
+        // PRAGMA table_info does not accept bound parameters for the table name.
+        cmd.CommandText = $"PRAGMA table_info({QuoteIdent(tableName)});";
+
+        var columns = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            columns.Add(reader.GetString(1));
+
+        return columns;
+    }
+
+    internal static string FormatValue(object? value) => value switch
+    {
+        null or DBNull => "NULL",
+        long l => l.ToString(CultureInfo.InvariantCulture),
+        int i => i.ToString(CultureInfo.InvariantCulture),
+        short s => s.ToString(CultureInfo.InvariantCulture),
+        byte b => b.ToString(CultureInfo.InvariantCulture),
+        double d => d.ToString("G17", CultureInfo.InvariantCulture),
+        float f => ((double)f).ToString("G17", CultureInfo.InvariantCulture),
+        decimal m => ((double)m).ToString("G17", CultureInfo.InvariantCulture),
+        string s => QuoteString(s),
+        byte[] bytes => FormatBlob(bytes),
+        bool boolean => boolean ? "1" : "0",
+        DateTime dt => QuoteString(dt.ToString("O", CultureInfo.InvariantCulture)),
+        Guid guid => QuoteString(guid.ToString()),
+        _ => QuoteString(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty),
+    };
+
+    private static string FormatBlob(byte[] bytes)
+    {
+        var sb = new StringBuilder(bytes.Length * 2 + 3);
+        sb.Append("X'");
+        foreach (var b in bytes)
+            sb.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+        sb.Append('\'');
+        return sb.ToString();
+    }
+
+    private static string QuoteString(string value) =>
+        "'" + value.Replace("'", "''", StringComparison.Ordinal) + "'";
+
+    private static string QuoteIdent(string name) =>
+        "\"" + name.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+
+    private static string EnsureTrailingSemicolon(string sql) =>
+        sql.TrimEnd().EndsWith(';') ? sql.TrimEnd() : sql.TrimEnd() + ";";
+
+    private sealed record MasterObject(string Name, string? Sql);
+}

--- a/backend/Database/Backup/SqliteSqlImporter.cs
+++ b/backend/Database/Backup/SqliteSqlImporter.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using Microsoft.Data.Sqlite;
+using SQLitePCL;
+
+namespace NzbWebDAV.Database.Backup;
+
+/// <summary>
+/// Imports a <c>.sql</c> dump produced by <see cref="SqliteDumper"/> into a fresh
+/// SQLite database file. Uses <c>sqlite3_complete</c> for statement splitting so
+/// semicolons inside string literals are handled correctly.
+/// </summary>
+public static class SqliteSqlImporter
+{
+    private static int _batteriesInitialized;
+
+    public static async Task ImportAsync(
+        string sqlFilePath,
+        string targetDatabaseFilePath,
+        bool requireMigrationsHistory = false,
+        Action<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sqlFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetDatabaseFilePath);
+
+        if (!File.Exists(sqlFilePath))
+            throw new FileNotFoundException("SQL dump file not found.", sqlFilePath);
+
+        if (File.Exists(targetDatabaseFilePath))
+            throw new InvalidOperationException($"Target database already exists: {targetDatabaseFilePath}");
+
+        EnsureBatteriesInitialized();
+
+        var directory = Path.GetDirectoryName(targetDatabaseFilePath);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        try
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = targetDatabaseFilePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = false,
+                DefaultTimeout = 30,
+            }.ToString();
+
+            await using var connection = new SqliteConnection(connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            progress?.Invoke("Importing SQL dump");
+            await ExecuteStatementsAsync(sqlFilePath, connection, progress, cancellationToken).ConfigureAwait(false);
+
+            progress?.Invoke("Running integrity check");
+            await using (var check = connection.CreateCommand())
+            {
+                check.CommandText = "PRAGMA quick_check;";
+                var result = (string?)await check.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                if (!string.Equals(result, "ok", StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException($"SQLite quick_check failed: {result}");
+            }
+
+            if (requireMigrationsHistory)
+            {
+                await using var history = connection.CreateCommand();
+                history.CommandText = """
+                    SELECT COUNT(*) FROM sqlite_master
+                    WHERE type = 'table' AND name = '__EFMigrationsHistory';
+                    """;
+                var count = Convert.ToInt64(await history.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
+                if (count == 0)
+                    throw new InvalidOperationException("Restored main database is missing __EFMigrationsHistory.");
+            }
+        }
+        catch
+        {
+            TryDeleteDatabaseFiles(targetDatabaseFilePath);
+            throw;
+        }
+    }
+
+    private static async Task ExecuteStatementsAsync(
+        string sqlFilePath,
+        SqliteConnection connection,
+        Action<string>? progress,
+        CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(
+            sqlFilePath,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 64 * 1024);
+
+        var buffer = new StringBuilder();
+        var statementCount = 0;
+        string? line;
+        while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (buffer.Length > 0)
+                buffer.Append('\n');
+            buffer.Append(line);
+
+            var candidate = buffer.ToString();
+            if (!IsCompleteStatement(candidate))
+                continue;
+
+            var sql = candidate.Trim();
+            buffer.Clear();
+            if (sql.Length == 0)
+                continue;
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            statementCount++;
+            if (statementCount % 500 == 0)
+                progress?.Invoke($"Imported {statementCount} SQL statements");
+        }
+
+        var trailing = buffer.ToString().Trim();
+        if (trailing.Length > 0)
+        {
+            if (!IsCompleteStatement(trailing) && !trailing.EndsWith(';'))
+                trailing += ";";
+
+            if (!IsCompleteStatement(trailing))
+                throw new InvalidOperationException("SQL dump ended with an incomplete statement.");
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = trailing;
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal static bool IsCompleteStatement(string sql)
+    {
+        EnsureBatteriesInitialized();
+        return raw.sqlite3_complete(sql) != 0;
+    }
+
+    private static void EnsureBatteriesInitialized()
+    {
+        if (Interlocked.CompareExchange(ref _batteriesInitialized, 1, 0) == 0)
+            Batteries_V2.Init();
+    }
+
+    private static void TryDeleteDatabaseFiles(string databaseFilePath)
+    {
+        foreach (var path in new[]
+                 {
+                     databaseFilePath,
+                     databaseFilePath + "-wal",
+                     databaseFilePath + "-shm",
+                     databaseFilePath + "-journal",
+                 })
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+            catch
+            {
+                // Best-effort cleanup after a failed import.
+            }
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -79,6 +79,15 @@ class Program
             // Block upgrades to version 0.6.x
             BlockUpgradesToV06X();
 
+            // run database migration / restore, if necessary.
+            // Restore must run before opening the live DavDatabaseContext so pending
+            // migrations are computed against the restored schema.
+            if (args.Contains("--db-migration"))
+            {
+                await RunDatabaseMigrationsAsync(args).ConfigureAwait(false);
+                return;
+            }
+
             // initialize database
             await using var databaseContext = new DavDatabaseContext();
             await databaseContext.Database
@@ -86,12 +95,6 @@ class Program
                     "PRAGMA journal_mode = WAL;",
                     SigtermUtil.GetCancellationToken())
                 .ConfigureAwait(false);
-            // run database migration, if necessary.
-            if (args.Contains("--db-migration"))
-            {
-                await RunDatabaseMigrationsAsync(databaseContext, args).ConfigureAwait(false);
-                return;
-            }
 
             // The metrics database has its own schema and must also be current on
             // normal startup, where the operational migration runner is skipped.
@@ -167,6 +170,9 @@ class Program
                 .AddHostedService(sp => sp.GetRequiredService<WardenRemoteSourceService>())
                 .AddSingleton<WardenBackupService>()
                 .AddHostedService(sp => sp.GetRequiredService<WardenBackupService>())
+                .AddSingleton<DatabaseBackupStore>()
+                .AddSingleton<RestartService>()
+                .AddHostedService<DatabaseBackupSchedulerService>()
                 .AddSingleton<SearchExcludeSyncService>()
                 .AddHostedService(sp => sp.GetRequiredService<SearchExcludeSyncService>())
                 .AddSingleton<PlaybackFastVerifier>()
@@ -312,17 +318,47 @@ class Program
         Environment.Exit(1);
     }
 
-    private static async Task RunDatabaseMigrationsAsync(DavDatabaseContext databaseContext, string[] args)
+    private static async Task RunDatabaseMigrationsAsync(string[] args)
     {
         var ct = SigtermUtil.GetCancellationToken();
         var argIndex = args.ToList().IndexOf("--db-migration");
         var targetMigration = args.Length > argIndex + 1 ? args[argIndex + 1] : null;
+        var backupStore = new DatabaseBackupStore();
+        backupStore.EnsureInitialized();
+        var pendingRestore = backupStore.ReadPendingRestore();
+        var hasPendingRestore = pendingRestore is not null
+            && pendingRestore.StagedFiles.Count > 0
+            && pendingRestore.StagedFiles.All(name =>
+                File.Exists(Path.Combine(backupStore.RestoreStagingRoot, name)));
+        if (pendingRestore is not null && !hasPendingRestore)
+        {
+            Log.Warning(
+                "Discarding incomplete pending restore for backup {BackupId}",
+                pendingRestore.BackupId);
+            backupStore.ClearPendingRestore();
+            backupStore.ClearRestoreStaging();
+            pendingRestore = null;
+        }
 
         // An explicit target (design-time tooling / tests) uses the simple,
         // single-call path. Progress tracking only covers the common upgrade
         // path where all pending migrations are applied.
         if (targetMigration is not null)
         {
+            if (hasPendingRestore)
+            {
+                var progress = new MigrationProgress();
+                progress.Initialize(DatabaseRestoreRunner.GetRestoreSteps(pendingRestore!));
+                await using var statusServer = await MigrationStatusServer.StartAsync(progress, ct).ConfigureAwait(false);
+                await DatabaseRestoreRunner.ApplyPendingRestoreAsync(progress, ct).ConfigureAwait(false);
+                if (statusServer is not null)
+                    await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+            }
+
+            await using var databaseContext = new DavDatabaseContext();
+            await databaseContext.Database
+                .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
+                .ConfigureAwait(false);
             Log.Information("Applying database migrations through {Target}", targetMigration);
             await databaseContext.Database.MigrateAsync(targetMigration, ct).ConfigureAwait(false);
             Log.Information("Database migrations completed");
@@ -332,47 +368,93 @@ class Program
             return;
         }
 
-        var pending = (await databaseContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
-        var vacuumEnabled = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);
-
-        // Routine restarts with nothing to do: skip the status server and its
-        // grace delay so Docker does not bind/unbind :8080 just to say "idle".
-        if (MigrationProgress.IsIdleMaintenance(pending.Count, vacuumEnabled))
+        // When a restore is pending we always show the status page, even if there
+        // are no pending EF migrations after the swap.
+        if (!hasPendingRestore)
         {
-            Log.Information("No pending database migrations");
-            await using var metricsContext = new MetricsDbContext();
-            await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
-            Log.Information("Database migrations completed");
-            return;
+            await using var probeContext = new DavDatabaseContext();
+            await probeContext.Database
+                .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
+                .ConfigureAwait(false);
+            var pendingProbe = (await probeContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
+            var vacuumEnabledProbe = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);
+
+            // Routine restarts with nothing to do: skip the status server and its
+            // grace delay so Docker does not bind/unbind :8080 just to say "idle".
+            if (MigrationProgress.IsIdleMaintenance(pendingProbe.Count, vacuumEnabledProbe))
+            {
+                Log.Information("No pending database migrations");
+                await using var metricsContext = new MetricsDbContext();
+                await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
+                Log.Information("Database migrations completed");
+                return;
+            }
         }
 
-        // Build the ordered list of maintenance steps: each pending migration,
-        // then the metrics database, then the optional vacuum.
+        // Build the ordered list of maintenance steps: optional restore, then each
+        // pending migration (computed AFTER restore), then metrics, then optional vacuum.
         var steps = new List<MigrationProgress.MigrationStep>();
-        foreach (var id in pending)
-            steps.Add(new MigrationProgress.MigrationStep(id, MigrationProgress.FriendlyName(id), MigrationProgress.IsSlow(id)));
-        steps.Add(new MigrationProgress.MigrationStep(MigrationProgress.MetricsStepId, "Metrics database", false));
-        if (vacuumEnabled)
-            steps.Add(new MigrationProgress.MigrationStep(MigrationProgress.VacuumStepId, "Optimizing database (vacuum)", true));
+        if (hasPendingRestore)
+            steps.AddRange(DatabaseRestoreRunner.GetRestoreSteps(pendingRestore!));
 
-        var progress = new MigrationProgress();
-        progress.Initialize(steps);
+        var progressFull = new MigrationProgress();
+        // Restore steps are registered first; migration steps are appended after
+        // the swap so GetPendingMigrations reflects the restored schema.
+        progressFull.Initialize(steps);
 
-        // Serve live progress on the backend port for the duration of the migration.
-        await using var statusServer = await MigrationStatusServer.StartAsync(progress, ct).ConfigureAwait(false);
+        await using var statusServerFull = await MigrationStatusServer.StartAsync(progressFull, ct).ConfigureAwait(false);
 
         try
         {
+            if (hasPendingRestore)
+            {
+                Log.Information("Applying staged database restore for backup {BackupId}", pendingRestore!.BackupId);
+                await DatabaseRestoreRunner.ApplyPendingRestoreAsync(progressFull, ct).ConfigureAwait(false);
+            }
+
+            await using var databaseContext = new DavDatabaseContext();
+            await databaseContext.Database
+                .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
+                .ConfigureAwait(false);
+
+            var pending = (await databaseContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
+            var vacuumEnabled = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);
+
+            var remainingSteps = new List<MigrationProgress.MigrationStep>();
+            foreach (var id in pending)
+                remainingSteps.Add(new MigrationProgress.MigrationStep(id, MigrationProgress.FriendlyName(id), MigrationProgress.IsSlow(id)));
+            remainingSteps.Add(new MigrationProgress.MigrationStep(MigrationProgress.MetricsStepId, "Metrics database", false));
+            if (vacuumEnabled)
+                remainingSteps.Add(new MigrationProgress.MigrationStep(MigrationProgress.VacuumStepId, "Optimizing database (vacuum)", true));
+
+            // Re-initialize with restore steps (already completed) + remaining work so
+            // the UI shows the full plan. Completed restore steps keep their status via
+            // a fresh Initialize — instead append by re-init with all steps and mark
+            // restore steps completed again.
+            var allSteps = new List<MigrationProgress.MigrationStep>();
+            if (hasPendingRestore)
+                allSteps.AddRange(DatabaseRestoreRunner.GetRestoreSteps(pendingRestore!));
+            allSteps.AddRange(remainingSteps);
+            progressFull.Initialize(allSteps);
+            if (hasPendingRestore)
+            {
+                foreach (var step in DatabaseRestoreRunner.GetRestoreSteps(pendingRestore!))
+                {
+                    progressFull.BeginStep(step.Id);
+                    progressFull.CompleteStep(step.Id);
+                }
+            }
+
             if (pending.Count == 0)
                 Log.Information("No pending database migrations");
 
-            for (var i = 0; i < steps.Count; i++)
+            for (var i = 0; i < remainingSteps.Count; i++)
             {
-                var step = steps[i];
+                var step = remainingSteps[i];
                 Log.Information(
                     "Database maintenance step {Index}/{Total}: {Name}",
-                    i + 1, steps.Count, step.Name);
-                progress.BeginStep(step.Id);
+                    i + 1, remainingSteps.Count, step.Name);
+                progressFull.BeginStep(step.Id);
 
                 if (step.Id == MigrationProgress.MetricsStepId)
                 {
@@ -388,24 +470,24 @@ class Program
                     await databaseContext.Database.MigrateAsync(step.Id, ct).ConfigureAwait(false);
                 }
 
-                progress.CompleteStep(step.Id);
+                progressFull.CompleteStep(step.Id);
             }
 
-            progress.Complete();
+            progressFull.Complete();
             Log.Information("Database migrations completed");
 
             // Brief grace so the status page can render the final state before
             // this process exits and the port goes dark.
-            if (statusServer is not null)
+            if (statusServerFull is not null)
                 await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            progress.Fail(ex.Message);
+            progressFull.Fail(ex.Message);
             Log.Error(ex, "Database migration failed");
 
             // Keep the failure visible on the status page briefly before exiting.
-            if (statusServer is not null)
+            if (statusServerFull is not null)
             {
                 try { await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false); }
                 catch { /* ignore */ }

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Utils;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Runs a database backup daily at the configured local time when scheduling is enabled.
+/// </summary>
+public class DatabaseBackupSchedulerService : BackgroundService
+{
+    private readonly ConfigManager _configManager;
+    private readonly WebsocketManager _websocketManager;
+    private readonly DatabaseBackupStore _store;
+    private CancellationTokenSource _rescheduleCts = new();
+
+    private static readonly TimeSpan MaxSleepSlice = TimeSpan.FromMinutes(30);
+    private DateTime? _lastLoggedNextRun;
+    private DateTime? _lastRun;
+
+    public DatabaseBackupSchedulerService(
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        DatabaseBackupStore store)
+    {
+        _configManager = configManager;
+        _websocketManager = websocketManager;
+        _store = store;
+
+        _configManager.OnConfigChanged += (_, args) =>
+        {
+            if (!args.ChangedConfig.ContainsKey(ConfigKeys.BackupScheduleEnabled) &&
+                !args.ChangedConfig.ContainsKey(ConfigKeys.BackupScheduleTime))
+                return;
+
+            var old = Interlocked.Exchange(ref _rescheduleCts, new CancellationTokenSource());
+            old.Cancel();
+        };
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _store.EnsureInitialized();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var reschedule = Volatile.Read(ref _rescheduleCts);
+
+                if (!_configManager.IsDatabaseBackupScheduleEnabled())
+                {
+                    _lastLoggedNextRun = null;
+                    using var disabledLinked = CancellationTokenSource
+                        .CreateLinkedTokenSource(stoppingToken, reschedule.Token);
+                    await Task.Delay(Timeout.Infinite, disabledLinked.Token).ConfigureAwait(false);
+                    continue;
+                }
+
+                var scheduleTime = _configManager.DatabaseBackupSchedule();
+                var now = DateTime.Now;
+                var todayRun = now.Date + scheduleTime;
+                var lastRun = _lastRun ?? DateTime.MinValue;
+                var nextRun = todayRun > now && todayRun > lastRun ? todayRun : todayRun.AddDays(1);
+                var delay = nextRun - now;
+
+                if (_lastLoggedNextRun != nextRun)
+                {
+                    Log.Information("DatabaseBackupScheduler: next run scheduled at {NextRun}", nextRun);
+                    _lastLoggedNextRun = nextRun;
+                }
+
+                using var delayLinked = CancellationTokenSource
+                    .CreateLinkedTokenSource(stoppingToken, reschedule.Token);
+                await Task.Delay(delay < MaxSleepSlice ? delay : MaxSleepSlice, delayLinked.Token)
+                    .ConfigureAwait(false);
+
+                if (DateTime.Now < nextRun) continue;
+
+                Log.Information("DatabaseBackupScheduler: running scheduled database backup");
+                var task = new DatabaseBackupTask(
+                    _configManager,
+                    _websocketManager,
+                    _store,
+                    DatabaseBackupKinds.Scheduled);
+                await task.Execute().ConfigureAwait(false);
+                _lastRun = nextRun;
+            }
+            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+            {
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                // Config changed — loop and recompute the next run time
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "DatabaseBackupScheduler: error running scheduled task: {Message}", e.Message);
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/backend/Services/DatabaseBackupStore.cs
+++ b/backend/Services/DatabaseBackupStore.cs
@@ -1,0 +1,332 @@
+using System.Text.Json;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Backup;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Manages on-disk database backups under <c>{CONFIG_PATH}/backups/</c>.
+/// Manifests live next to the <c>.sql</c> dumps so metadata survives a restore.
+/// </summary>
+public sealed class DatabaseBackupStore
+{
+    public const string DbSqlName = "db.sql";
+    public const string MetricsSqlName = "metrics.sql";
+    public const string WardenSqlName = "warden.sql";
+    public const string ManifestFileName = "manifest.json";
+    public const string RollbackFolderName = "rollback";
+    public const string LastRestoreReportFileName = "last-restore-report.json";
+    public const string PendingRestoreFileName = "pending-restore.json";
+    public const string RestoreStagingFolderName = "restore-staging";
+
+    private readonly object _gate = new();
+
+    public string BackupsRoot => Path.Combine(DavDatabaseContext.ConfigPath, "backups");
+    public string RestoreStagingRoot => Path.Combine(DavDatabaseContext.ConfigPath, RestoreStagingFolderName);
+    public string PendingRestorePath => Path.Combine(DavDatabaseContext.ConfigPath, PendingRestoreFileName);
+    public string LastRestoreReportPath => Path.Combine(BackupsRoot, LastRestoreReportFileName);
+
+    public void EnsureInitialized()
+    {
+        Directory.CreateDirectory(BackupsRoot);
+        CleanupTempFolders();
+    }
+
+    public IReadOnlyList<DatabaseBackupManifest> List()
+    {
+        EnsureInitialized();
+
+        var results = new List<DatabaseBackupManifest>();
+        foreach (var dir in Directory.EnumerateDirectories(BackupsRoot))
+        {
+            var name = Path.GetFileName(dir);
+            if (name.StartsWith(".tmp-", StringComparison.Ordinal))
+                continue;
+
+            try
+            {
+                var manifest = ReadManifest(name);
+                if (manifest is not null)
+                    results.Add(manifest);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Skipping unreadable database backup {BackupId}", name);
+            }
+        }
+
+        return results
+            .OrderByDescending(x => x.CreatedAt)
+            .ThenByDescending(x => x.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public DatabaseBackupManifest? Get(string backupId)
+    {
+        ValidateBackupId(backupId);
+        return ReadManifest(backupId);
+    }
+
+    public string GetBackupDirectory(string backupId)
+    {
+        ValidateBackupId(backupId);
+        return Path.Combine(BackupsRoot, backupId);
+    }
+
+    public string CreateStaging(string kind)
+    {
+        EnsureInitialized();
+        var id = $"{DateTime.UtcNow:yyyyMMdd-HHmmssfff}-{SanitizeKind(kind)}-{Guid.NewGuid().ToString("N")[..6]}";
+        var stagingPath = Path.Combine(BackupsRoot, $".tmp-{id}");
+        if (Directory.Exists(stagingPath))
+            Directory.Delete(stagingPath, recursive: true);
+        Directory.CreateDirectory(stagingPath);
+        return stagingPath;
+    }
+
+    public string GetStagingBackupId(string stagingPath)
+    {
+        var name = Path.GetFileName(stagingPath);
+        if (!name.StartsWith(".tmp-", StringComparison.Ordinal))
+            throw new ArgumentException("Not a staging path.", nameof(stagingPath));
+        return name[".tmp-".Length..];
+    }
+
+    public DatabaseBackupManifest CommitStaging(
+        string stagingPath,
+        string kind,
+        string? notes,
+        bool preserved,
+        string? appVersion,
+        string? lastMainMigration)
+    {
+        var backupId = GetStagingBackupId(stagingPath);
+        var files = new List<DatabaseBackupFileEntry>();
+        foreach (var sqlName in new[] { DbSqlName, MetricsSqlName, WardenSqlName })
+        {
+            var path = Path.Combine(stagingPath, sqlName);
+            if (!File.Exists(path))
+                continue;
+            files.Add(new DatabaseBackupFileEntry
+            {
+                Name = sqlName,
+                Bytes = new FileInfo(path).Length,
+            });
+        }
+
+        if (files.Count == 0)
+            throw new InvalidOperationException("Backup staging folder contains no .sql dumps.");
+
+        var manifest = new DatabaseBackupManifest
+        {
+            Id = backupId,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Kind = SanitizeKind(kind),
+            Notes = notes ?? "",
+            Preserved = preserved,
+            AppVersion = appVersion,
+            LastMainMigration = lastMainMigration,
+            Files = files,
+        };
+
+        WriteManifestAtomic(stagingPath, manifest);
+
+        var finalPath = Path.Combine(BackupsRoot, backupId);
+        if (Directory.Exists(finalPath))
+            throw new InvalidOperationException($"Backup id already exists: {backupId}");
+
+        Directory.Move(stagingPath, finalPath);
+        return manifest;
+    }
+
+    public void DiscardStaging(string? stagingPath)
+    {
+        if (string.IsNullOrWhiteSpace(stagingPath))
+            return;
+        try
+        {
+            if (Directory.Exists(stagingPath))
+                Directory.Delete(stagingPath, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to discard backup staging folder {Path}", stagingPath);
+        }
+    }
+
+    public DatabaseBackupManifest UpdateManifest(string backupId, bool? preserved = null, string? notes = null)
+    {
+        ValidateBackupId(backupId);
+        var manifest = ReadManifest(backupId)
+            ?? throw new FileNotFoundException($"Backup not found: {backupId}");
+
+        if (preserved.HasValue)
+            manifest.Preserved = preserved.Value;
+        if (notes is not null)
+            manifest.Notes = notes;
+
+        WriteManifestAtomic(GetBackupDirectory(backupId), manifest);
+        return manifest;
+    }
+
+    public void SaveManifest(DatabaseBackupManifest manifest)
+    {
+        ValidateBackupId(manifest.Id);
+        WriteManifestAtomic(GetBackupDirectory(manifest.Id), manifest);
+    }
+
+    public void Delete(string backupId)
+    {
+        ValidateBackupId(backupId);
+        var path = GetBackupDirectory(backupId);
+        if (!Directory.Exists(path))
+            throw new FileNotFoundException($"Backup not found: {backupId}");
+        Directory.Delete(path, recursive: true);
+    }
+
+    public int Prune(int retentionCount)
+    {
+        if (retentionCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(retentionCount));
+        if (retentionCount == 0)
+            return 0;
+
+        var candidates = List()
+            .Where(x => !x.Preserved)
+            .OrderByDescending(x => x.CreatedAt)
+            .ThenByDescending(x => x.Id, StringComparer.Ordinal)
+            .ToList();
+
+        var removed = 0;
+        for (var i = retentionCount; i < candidates.Count; i++)
+        {
+            try
+            {
+                Delete(candidates[i].Id);
+                removed++;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to prune database backup {BackupId}", candidates[i].Id);
+            }
+        }
+
+        return removed;
+    }
+
+    public bool HasPendingRestore() => File.Exists(PendingRestorePath);
+
+    public PendingRestoreIntent? ReadPendingRestore()
+    {
+        if (!File.Exists(PendingRestorePath))
+            return null;
+
+        var json = File.ReadAllText(PendingRestorePath);
+        return JsonSerializer.Deserialize<PendingRestoreIntent>(json, DatabaseBackupJson.Options);
+    }
+
+    public void WritePendingRestore(PendingRestoreIntent intent)
+    {
+        Directory.CreateDirectory(DavDatabaseContext.ConfigPath);
+        var json = JsonSerializer.Serialize(intent, DatabaseBackupJson.Options);
+        var temp = PendingRestorePath + ".tmp";
+        File.WriteAllText(temp, json);
+        File.Move(temp, PendingRestorePath, overwrite: true);
+    }
+
+    public void ClearPendingRestore()
+    {
+        if (File.Exists(PendingRestorePath))
+            File.Delete(PendingRestorePath);
+    }
+
+    public LastRestoreReport? ReadLastRestoreReport()
+    {
+        if (!File.Exists(LastRestoreReportPath))
+            return null;
+        var json = File.ReadAllText(LastRestoreReportPath);
+        return JsonSerializer.Deserialize<LastRestoreReport>(json, DatabaseBackupJson.Options);
+    }
+
+    public void WriteLastRestoreReport(LastRestoreReport report)
+    {
+        EnsureInitialized();
+        var json = JsonSerializer.Serialize(report, DatabaseBackupJson.Options);
+        var temp = LastRestoreReportPath + ".tmp";
+        File.WriteAllText(temp, json);
+        File.Move(temp, LastRestoreReportPath, overwrite: true);
+    }
+
+    public void ClearRestoreStaging()
+    {
+        if (Directory.Exists(RestoreStagingRoot))
+            Directory.Delete(RestoreStagingRoot, recursive: true);
+    }
+
+    public void PrepareRestoreStaging()
+    {
+        ClearRestoreStaging();
+        Directory.CreateDirectory(RestoreStagingRoot);
+    }
+
+    private DatabaseBackupManifest? ReadManifest(string backupId)
+    {
+        var path = Path.Combine(GetBackupDirectory(backupId), ManifestFileName);
+        if (!File.Exists(path))
+            return null;
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<DatabaseBackupManifest>(json, DatabaseBackupJson.Options);
+    }
+
+    private void WriteManifestAtomic(string backupDirectory, DatabaseBackupManifest manifest)
+    {
+        Directory.CreateDirectory(backupDirectory);
+        var path = Path.Combine(backupDirectory, ManifestFileName);
+        var temp = path + ".tmp";
+        var json = JsonSerializer.Serialize(manifest, DatabaseBackupJson.Options);
+        lock (_gate)
+        {
+            File.WriteAllText(temp, json);
+            File.Move(temp, path, overwrite: true);
+        }
+    }
+
+    private void CleanupTempFolders()
+    {
+        if (!Directory.Exists(BackupsRoot))
+            return;
+
+        foreach (var dir in Directory.EnumerateDirectories(BackupsRoot, ".tmp-*"))
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to clean leftover backup staging folder {Path}", dir);
+            }
+        }
+    }
+
+    private static string SanitizeKind(string kind)
+    {
+        var cleaned = new string(kind.Trim().ToLowerInvariant()
+            .Select(ch => char.IsLetterOrDigit(ch) ? ch : '-')
+            .ToArray());
+        while (cleaned.Contains("--", StringComparison.Ordinal))
+            cleaned = cleaned.Replace("--", "-", StringComparison.Ordinal);
+        return string.IsNullOrWhiteSpace(cleaned) ? DatabaseBackupKinds.Manual : cleaned.Trim('-');
+    }
+
+    public static void ValidateBackupId(string backupId)
+    {
+        if (string.IsNullOrWhiteSpace(backupId))
+            throw new ArgumentException("Backup id is required.", nameof(backupId));
+        if (backupId.Contains('/') || backupId.Contains('\\') || backupId.Contains("..", StringComparison.Ordinal))
+            throw new ArgumentException("Invalid backup id.", nameof(backupId));
+        if (backupId.StartsWith('.'))
+            throw new ArgumentException("Invalid backup id.", nameof(backupId));
+    }
+}

--- a/backend/Services/DatabaseRestoreRunner.cs
+++ b/backend/Services/DatabaseRestoreRunner.cs
@@ -1,0 +1,308 @@
+using Microsoft.Data.Sqlite;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Backup;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Applies a staged database restore during the <c>--db-migration</c> maintenance
+/// phase: checkpoint/VACUUM current DBs, move them into a rollback folder, swap
+/// in the staged files, then scan for missing blob references.
+/// </summary>
+public static class DatabaseRestoreRunner
+{
+    public const string RollbackStepId = "__restore_rollback__";
+    public const string SwapStepId = "__restore_swap__";
+    public const string BlobScanStepId = "__restore_blobscan__";
+
+    public static bool HasPendingRestore(DatabaseBackupStore? store = null)
+    {
+        store ??= new DatabaseBackupStore();
+        return store.HasPendingRestore();
+    }
+
+    public static List<MigrationProgress.MigrationStep> GetRestoreSteps(PendingRestoreIntent intent)
+    {
+        return
+        [
+            new MigrationProgress.MigrationStep(RollbackStepId, "Preparing current databases for rollback", true),
+            new MigrationProgress.MigrationStep(SwapStepId, $"Restoring backup {intent.BackupId}", true),
+            new MigrationProgress.MigrationStep(BlobScanStepId, "Scanning for missing blob files", false),
+        ];
+    }
+
+    public static async Task ApplyPendingRestoreAsync(
+        MigrationProgress progress,
+        CancellationToken cancellationToken = default)
+    {
+        var store = new DatabaseBackupStore();
+        var intent = store.ReadPendingRestore();
+        if (intent is null)
+            return;
+
+        if (intent.StagedFiles.Count == 0 ||
+            !intent.StagedFiles.All(name => File.Exists(Path.Combine(store.RestoreStagingRoot, name))))
+        {
+            Log.Warning(
+                "Pending restore intent {BackupId} is missing staged files; discarding and continuing startup",
+                intent.BackupId);
+            store.ClearPendingRestore();
+            store.ClearRestoreStaging();
+            return;
+        }
+
+        var movedAway = new List<(string originalPath, string rollbackPath)>();
+        try
+        {
+            progress.BeginStep(RollbackStepId);
+            var rollbackDir = Path.Combine(
+                store.GetBackupDirectory(intent.PreRestoreBackupId),
+                DatabaseBackupStore.RollbackFolderName);
+            Directory.CreateDirectory(rollbackDir);
+
+            foreach (var stagedName in intent.StagedFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var livePath = ResolveLivePath(stagedName);
+                if (!File.Exists(livePath) && !File.Exists(livePath + "-wal") && !File.Exists(livePath + "-shm"))
+                    continue;
+
+                await CheckpointAndVacuumAsync(livePath, cancellationToken).ConfigureAwait(false);
+                SqliteConnection.ClearAllPools();
+
+                var rollbackPath = Path.Combine(rollbackDir, Path.GetFileName(livePath));
+                MoveDatabaseFiles(livePath, rollbackPath);
+                movedAway.Add((livePath, rollbackPath));
+            }
+
+            progress.CompleteStep(RollbackStepId);
+
+            progress.BeginStep(SwapStepId);
+            foreach (var stagedName in intent.StagedFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var stagedPath = Path.Combine(store.RestoreStagingRoot, stagedName);
+                var livePath = ResolveLivePath(stagedName);
+                Directory.CreateDirectory(Path.GetDirectoryName(livePath)!);
+                File.Move(stagedPath, livePath, overwrite: false);
+            }
+
+            progress.CompleteStep(SwapStepId);
+
+            // Update pre-restore manifest with rollback file sizes.
+            try
+            {
+                var pre = store.Get(intent.PreRestoreBackupId);
+                if (pre is not null)
+                {
+                    pre.Files.RemoveAll(f => f.Name.StartsWith(DatabaseBackupStore.RollbackFolderName + "/", StringComparison.Ordinal)
+                                             || f.Name.StartsWith(DatabaseBackupStore.RollbackFolderName + "\\", StringComparison.Ordinal));
+                    foreach (var file in Directory.EnumerateFiles(rollbackDir))
+                    {
+                        pre.Files.Add(new DatabaseBackupFileEntry
+                        {
+                            Name = Path.Combine(DatabaseBackupStore.RollbackFolderName, Path.GetFileName(file))
+                                .Replace('\\', '/'),
+                            Bytes = new FileInfo(file).Length,
+                        });
+                    }
+
+                    store.SaveManifest(pre);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Could not update pre-restore backup manifest with rollback files");
+            }
+
+            store.ClearPendingRestore();
+            store.ClearRestoreStaging();
+
+            progress.BeginStep(BlobScanStepId);
+            var report = await ScanMissingBlobsAsync(intent.BackupId, cancellationToken).ConfigureAwait(false);
+            store.WriteLastRestoreReport(report);
+            if (report.MissingBlobRefs > 0)
+            {
+                Log.Warning(
+                    "Restore {BackupId}: {Missing}/{Checked} blob references point to missing files under blobs/",
+                    report.BackupId, report.MissingBlobRefs, report.CheckedRefs);
+            }
+            else
+            {
+                Log.Information(
+                    "Restore {BackupId}: all {Checked} blob references resolved on disk",
+                    report.BackupId, report.CheckedRefs);
+            }
+
+            progress.CompleteStep(BlobScanStepId);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Database restore swap failed; attempting to restore pre-swap databases");
+            try
+            {
+                SqliteConnection.ClearAllPools();
+                foreach (var (originalPath, rollbackPath) in movedAway)
+                {
+                    if (File.Exists(rollbackPath))
+                        MoveDatabaseFiles(rollbackPath, originalPath);
+                }
+            }
+            catch (Exception rollbackEx)
+            {
+                Log.Error(rollbackEx, "Failed to roll back database files after a failed restore swap");
+            }
+
+            progress.Fail(ex.Message);
+            throw;
+        }
+    }
+
+    private static string ResolveLivePath(string stagedFileName) => stagedFileName switch
+    {
+        "db.sqlite" => DavDatabaseContext.DatabaseFilePath,
+        "metrics.sqlite" => MetricsDbContext.DatabaseFilePath,
+        "warden.db" => Path.Combine(DavDatabaseContext.ConfigPath, "warden.db"),
+        _ => throw new InvalidOperationException($"Unknown staged database file: {stagedFileName}"),
+    };
+
+    private static async Task CheckpointAndVacuumAsync(string databasePath, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(databasePath))
+            return;
+
+        var cs = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWrite,
+            Pooling = false,
+            DefaultTimeout = 60,
+        }.ToString();
+
+        await using var connection = new SqliteConnection(cs);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await using (var checkpoint = connection.CreateCommand())
+        {
+            checkpoint.CommandText = "PRAGMA wal_checkpoint(TRUNCATE);";
+            await checkpoint.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await using (var vacuum = connection.CreateCommand())
+        {
+            vacuum.CommandText = "VACUUM;";
+            await vacuum.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static void MoveDatabaseFiles(string fromDbPath, string toDbPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(toDbPath)!);
+        foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+        {
+            var from = fromDbPath + suffix;
+            var to = toDbPath + suffix;
+            if (!File.Exists(from))
+                continue;
+            if (File.Exists(to))
+                File.Delete(to);
+            File.Move(from, to);
+        }
+    }
+
+    private static async Task<LastRestoreReport> ScanMissingBlobsAsync(
+        string backupId,
+        CancellationToken cancellationToken)
+    {
+        long checkedRefs = 0;
+        long missing = 0;
+
+        if (!File.Exists(DavDatabaseContext.DatabaseFilePath))
+        {
+            return new LastRestoreReport
+            {
+                BackupId = backupId,
+                RestoredAt = DateTimeOffset.UtcNow,
+                MissingBlobRefs = 0,
+                CheckedRefs = 0,
+            };
+        }
+
+        var cs = new SqliteConnectionStringBuilder
+        {
+            DataSource = DavDatabaseContext.DatabaseFilePath,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false,
+        }.ToString();
+
+        await using var connection = new SqliteConnection(cs);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await CollectBlobIdsAsync(connection, """
+            SELECT DISTINCT FileBlobId FROM DavItems WHERE FileBlobId IS NOT NULL AND FileBlobId != ''
+            """, ids, cancellationToken).ConfigureAwait(false);
+        await CollectBlobIdsAsync(connection, """
+            SELECT DISTINCT NzbBlobId FROM DavItems WHERE NzbBlobId IS NOT NULL AND NzbBlobId != ''
+            """, ids, cancellationToken).ConfigureAwait(false);
+        await CollectBlobIdsAsync(connection, """
+            SELECT DISTINCT NzbBlobId FROM HistoryItems WHERE NzbBlobId IS NOT NULL AND NzbBlobId != ''
+            """, ids, cancellationToken).ConfigureAwait(false);
+
+        foreach (var idText in ids)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            checkedRefs++;
+            if (!Guid.TryParse(idText, out var id))
+            {
+                missing++;
+                continue;
+            }
+
+            if (!File.Exists(GetBlobPath(id)))
+                missing++;
+        }
+
+        return new LastRestoreReport
+        {
+            BackupId = backupId,
+            RestoredAt = DateTimeOffset.UtcNow,
+            MissingBlobRefs = missing,
+            CheckedRefs = checkedRefs,
+        };
+    }
+
+    private static async Task CollectBlobIdsAsync(
+        SqliteConnection connection,
+        string sql,
+        HashSet<string> ids,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (!reader.IsDBNull(0))
+                    ids.Add(reader.GetString(0));
+            }
+        }
+        catch (SqliteException ex)
+        {
+            // Older schemas may lack a column — treat as no refs.
+            Log.Debug(ex, "Skipping blob-id query during restore scan: {Sql}", sql);
+        }
+    }
+
+    private static string GetBlobPath(Guid id)
+    {
+        var guidStr = id.ToString("N");
+        var firstTwo = guidStr[..2];
+        var nextTwo = guidStr.Substring(2, 2);
+        var fileName = id.ToString();
+        return Path.Combine(DavDatabaseContext.ConfigPath, "blobs", firstTwo, nextTwo, fileName);
+    }
+}

--- a/backend/Services/RestartService.cs
+++ b/backend/Services/RestartService.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Schedules a graceful process exit after a restore has been staged so the
+/// Docker/local restart loop can re-enter the maintenance phase.
+/// </summary>
+public sealed class RestartService(IHostApplicationLifetime lifetime)
+{
+    public void RequestRestartForRestore()
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                Environment.ExitCode = RestartUtil.RestartForRestoreExitCode;
+                Log.Information(
+                    "Exiting with code {ExitCode} to apply staged database restore",
+                    RestartUtil.RestartForRestoreExitCode);
+                lifetime.StopApplication();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to request restart for database restore");
+            }
+        });
+    }
+}

--- a/backend/Tasks/BaseTask.cs
+++ b/backend/Tasks/BaseTask.cs
@@ -11,6 +11,15 @@ public abstract class BaseTask
 
     protected readonly CancellationToken CancellationToken = SigtermUtil.GetCancellationToken();
 
+    public static bool IsRunning
+    {
+        get
+        {
+            var task = Volatile.Read(ref _runningTask);
+            return task is { IsCompleted: false };
+        }
+    }
+
     public async Task<bool> Execute()
     {
         await Semaphore.WaitAsync(CancellationToken).ConfigureAwait(false);

--- a/backend/Tasks/DatabaseBackupTask.cs
+++ b/backend/Tasks/DatabaseBackupTask.cs
@@ -1,0 +1,150 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+public class DatabaseBackupTask(
+    ConfigManager configManager,
+    WebsocketManager websocketManager,
+    DatabaseBackupStore store,
+    string kind,
+    string? notes = null,
+    bool preserved = false
+) : BaseTask
+{
+    protected override Task ExecuteInternal() => RunInternalAsync();
+
+    /// <summary>
+    /// Runs the backup body without acquiring <see cref="BaseTask"/>'s global
+    /// single-flight slot. Used by the restore stager for the pre-restore dump.
+    /// </summary>
+    internal Task<DatabaseBackupManifest> RunInternalAsync() => ExecuteBodyAsync();
+
+    private async Task<DatabaseBackupManifest> ExecuteBodyAsync()
+    {
+        string? stagingPath = null;
+        try
+        {
+            if (store.HasPendingRestore())
+            {
+                Report("Failed: a restore is already pending. Wait for the restart to finish.");
+                throw new InvalidOperationException("A database restore is already pending.");
+            }
+
+            store.EnsureInitialized();
+            stagingPath = store.CreateStaging(kind);
+            var backupId = store.GetStagingBackupId(stagingPath);
+            Report($"Creating backup {backupId}");
+
+            await DumpIfExistsAsync(
+                DavDatabaseContext.DatabaseFilePath,
+                Path.Combine(stagingPath, DatabaseBackupStore.DbSqlName),
+                "main database").ConfigureAwait(false);
+
+            await DumpIfExistsAsync(
+                MetricsDbContext.DatabaseFilePath,
+                Path.Combine(stagingPath, DatabaseBackupStore.MetricsSqlName),
+                "metrics database").ConfigureAwait(false);
+
+            var wardenPath = Path.Combine(DavDatabaseContext.ConfigPath, "warden.db");
+            await DumpIfExistsAsync(
+                wardenPath,
+                Path.Combine(stagingPath, DatabaseBackupStore.WardenSqlName),
+                "warden database").ConfigureAwait(false);
+
+            var lastMigration = await ReadLastMainMigrationAsync().ConfigureAwait(false);
+            var isPreRestore = string.Equals(kind, DatabaseBackupKinds.PreRestore, StringComparison.Ordinal);
+            var manifest = store.CommitStaging(
+                stagingPath,
+                kind,
+                notes,
+                preserved: preserved || isPreRestore,
+                appVersion: ConfigManager.AppVersion,
+                lastMainMigration: lastMigration);
+            stagingPath = null;
+
+            var retention = configManager.GetDatabaseBackupRetentionCount();
+            var pruned = store.Prune(retention);
+            if (pruned > 0)
+                Report($"Pruned {pruned} old backup(s)");
+
+            Report($"Completed backup {manifest.Id}");
+            return manifest;
+        }
+        catch (Exception ex)
+        {
+            store.DiscardStaging(stagingPath);
+            Report($"Failed: {ex.Message}");
+            Log.Error(ex, "Database backup failed");
+            throw;
+        }
+    }
+
+    private async Task DumpIfExistsAsync(string databasePath, string sqlPath, string label)
+    {
+        if (!File.Exists(databasePath))
+        {
+            Report($"Skipping {label} (file not found)");
+            return;
+        }
+
+        Report($"Dumping {label}");
+        await SqliteDumper.DumpToFileAsync(
+            databasePath,
+            sqlPath,
+            message => Report($"Dumping {label} — {message}"),
+            CancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ReadLastMainMigrationAsync()
+    {
+        if (!File.Exists(DavDatabaseContext.DatabaseFilePath))
+            return null;
+
+        try
+        {
+            await using var ctx = new DavDatabaseContext();
+            var applied = await ctx.Database.GetAppliedMigrationsAsync().ConfigureAwait(false);
+            return applied.LastOrDefault();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not read last applied main-database migration for backup manifest");
+
+            // Fallback: query sqlite_master / __EFMigrationsHistory directly.
+            try
+            {
+                var cs = new SqliteConnectionStringBuilder
+                {
+                    DataSource = DavDatabaseContext.DatabaseFilePath,
+                    Mode = SqliteOpenMode.ReadOnly,
+                    Pooling = false,
+                }.ToString();
+                await using var connection = new SqliteConnection(cs);
+                await connection.OpenAsync().ConfigureAwait(false);
+                await using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                    SELECT MigrationId FROM "__EFMigrationsHistory"
+                    ORDER BY MigrationId DESC LIMIT 1;
+                    """;
+                return (string?)await cmd.ExecuteScalarAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    private void Report(string message)
+    {
+        _ = websocketManager.SendMessage(WebsocketTopic.DatabaseBackupTaskProgress, message);
+        Log.Information("DatabaseBackupTask: {Message}", message);
+    }
+}

--- a/backend/Tasks/DatabaseRestoreStageTask.cs
+++ b/backend/Tasks/DatabaseRestoreStageTask.cs
@@ -1,0 +1,145 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+/// <summary>
+/// Validates a backup, creates a pre-restore safety dump, imports dumps into
+/// restore-staging, writes the pending-restore intent, then requests a restart
+/// so the maintenance phase can swap databases safely.
+/// </summary>
+public class DatabaseRestoreStageTask(
+    ConfigManager configManager,
+    WebsocketManager websocketManager,
+    DatabaseBackupStore store,
+    RestartService restartService,
+    string backupId
+) : BaseTask
+{
+    protected override async Task ExecuteInternal()
+    {
+        try
+        {
+            DatabaseBackupStore.ValidateBackupId(backupId);
+            if (store.HasPendingRestore())
+            {
+                Report("Failed: a restore is already pending.");
+                throw new InvalidOperationException("A database restore is already pending.");
+            }
+
+            var manifest = store.Get(backupId)
+                ?? throw new FileNotFoundException($"Backup not found: {backupId}");
+            var backupDir = store.GetBackupDirectory(backupId);
+            var dbSql = Path.Combine(backupDir, DatabaseBackupStore.DbSqlName);
+            if (!File.Exists(dbSql))
+                throw new InvalidOperationException("Backup is missing db.sql and cannot be restored.");
+
+            await ValidateMigrationCompatibilityAsync(manifest).ConfigureAwait(false);
+
+            Report($"Creating pre-restore safety backup before restoring {backupId}");
+            var safetyTask = new DatabaseBackupTask(
+                configManager,
+                websocketManager,
+                store,
+                DatabaseBackupKinds.PreRestore,
+                notes: $"Automatic backup before restoring {backupId}",
+                preserved: true);
+            var preRestore = await safetyTask.RunInternalAsync().ConfigureAwait(false);
+
+            Report("Importing dumps into restore staging");
+            store.PrepareRestoreStaging();
+            var stagedFiles = new List<string>();
+
+            await ImportOptionalAsync(
+                Path.Combine(backupDir, DatabaseBackupStore.DbSqlName),
+                Path.Combine(store.RestoreStagingRoot, "db.sqlite"),
+                requireMigrationsHistory: true,
+                "main database",
+                stagedFiles).ConfigureAwait(false);
+
+            await ImportOptionalAsync(
+                Path.Combine(backupDir, DatabaseBackupStore.MetricsSqlName),
+                Path.Combine(store.RestoreStagingRoot, "metrics.sqlite"),
+                requireMigrationsHistory: false,
+                "metrics database",
+                stagedFiles).ConfigureAwait(false);
+
+            await ImportOptionalAsync(
+                Path.Combine(backupDir, DatabaseBackupStore.WardenSqlName),
+                Path.Combine(store.RestoreStagingRoot, "warden.db"),
+                requireMigrationsHistory: false,
+                "warden database",
+                stagedFiles).ConfigureAwait(false);
+
+            if (stagedFiles.Count == 0)
+                throw new InvalidOperationException("No database dumps were imported into restore staging.");
+
+            store.WritePendingRestore(new PendingRestoreIntent
+            {
+                BackupId = backupId,
+                PreRestoreBackupId = preRestore.Id,
+                StagedFiles = stagedFiles,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+            Report("Restore staged. Restarting into maintenance mode…");
+            restartService.RequestRestartForRestore();
+        }
+        catch (Exception ex)
+        {
+            store.ClearPendingRestore();
+            store.ClearRestoreStaging();
+            Report($"Failed: {ex.Message}");
+            Log.Error(ex, "Database restore staging failed");
+            throw;
+        }
+    }
+
+    private async Task ImportOptionalAsync(
+        string sqlPath,
+        string targetPath,
+        bool requireMigrationsHistory,
+        string label,
+        List<string> stagedFiles)
+    {
+        if (!File.Exists(sqlPath))
+        {
+            Report($"Skipping {label} (dump not present in backup)");
+            return;
+        }
+
+        Report($"Importing {label}");
+        await SqliteSqlImporter.ImportAsync(
+            sqlPath,
+            targetPath,
+            requireMigrationsHistory,
+            message => Report($"Importing {label} — {message}"),
+            CancellationToken).ConfigureAwait(false);
+        stagedFiles.Add(Path.GetFileName(targetPath));
+    }
+
+    private static async Task ValidateMigrationCompatibilityAsync(DatabaseBackupManifest manifest)
+    {
+        if (string.IsNullOrWhiteSpace(manifest.LastMainMigration))
+            return;
+
+        await using var ctx = new DavDatabaseContext();
+        var known = ctx.Database.GetMigrations();
+        if (!known.Contains(manifest.LastMainMigration, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "This backup was created by a newer version of nzbdav and cannot be restored here.");
+        }
+    }
+
+    private void Report(string message)
+    {
+        _ = websocketManager.SendMessage(WebsocketTopic.DatabaseRestoreTaskProgress, message);
+        Log.Information("DatabaseRestoreStageTask: {Message}", message);
+    }
+}

--- a/backend/Utils/RestartUtil.cs
+++ b/backend/Utils/RestartUtil.cs
@@ -1,0 +1,14 @@
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Exit codes used by the Docker/local restart loops when the backend needs to
+/// re-enter the <c>--db-migration</c> maintenance phase.
+/// </summary>
+public static class RestartUtil
+{
+    /// <summary>
+    /// Backend staged a database restore and needs the entrypoint to re-run
+    /// maintenance so the swap can happen with WebDAV/SAB offline.
+    /// </summary>
+    public const int RestartForRestoreExitCode = 86;
+}

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -26,6 +26,10 @@ public class WebsocketTopic
     // Migration progress topic
     public static readonly WebsocketTopic UsenetFileToBlobstoreMigrationProgress = new("uftbmp", TopicType.State);
 
+    // Database backup / restore progress
+    public static readonly WebsocketTopic DatabaseBackupTaskProgress = new("dbbk", TopicType.State);
+    public static readonly WebsocketTopic DatabaseRestoreTaskProgress = new("dbrs", TopicType.State);
+
     public readonly string Name;
     public readonly TopicType Type;
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -540,7 +540,17 @@ These can also be set under **Settings → Maintenance** (`database.history-rete
 
 ### Back up NzbDav
 
-Back up the host directory mapped to `/config` (shown as `./config` in this guide). It contains the database, settings, credentials, and persisted application data, so store the backup securely. Stop the container or use a filesystem snapshot to get a consistent backup:
+NzbDav includes an in-app **Settings → Backup & Restore** flow that dumps all SQLite databases (`db.sqlite`, `metrics.sqlite`, and `warden.db`) to portable `.sql` files under `{CONFIG_PATH}/backups/`. You can:
+
+- create a backup on demand
+- schedule a daily backup and set a retention count
+- preserve important backups so retention never deletes them
+- download a backup as a zip, or upload a previously downloaded zip / `.sql` dump
+- restore through a guided flow that creates a pre-restore safety backup, stages the import, then restarts into maintenance mode to swap databases safely
+
+The `blobs/` folder is **not** included in these dumps. After a restore, the UI reports how many blob references point to missing files. Affected WebDAV items may fail to stream until they are re-downloaded.
+
+For a full filesystem-level backup (including blobs and data-protection keys), stop the container or use a filesystem snapshot and archive the host directory mapped to `/config`:
 
 ```bash
 docker compose stop nzbdav

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,66 +113,80 @@ cd /app/frontend
 su-exec "$USER_NAME" npm run start &
 FRONTEND_PID=$!
 
-# Run backend database migration
-cd /app/backend
-echo "Running database maintenance."
-su-exec "$USER_NAME" ./NzbWebDAV --db-migration
-MIGRATION_EXIT_CODE=$?
-if [ "$MIGRATION_EXIT_CODE" -ne 0 ]; then
-    echo "Database migration failed. Exiting with error code $MIGRATION_EXIT_CODE."
-    if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
-        kill "$FRONTEND_PID"
-        wait "$FRONTEND_PID" 2>/dev/null
-    fi
-    exit "$MIGRATION_EXIT_CODE"
-fi
-echo "Done with database maintenance."
+# Exit code 86 means the backend staged a database restore and needs the
+# maintenance phase to run again (swap DBs with WebDAV/SAB offline). Keep the
+# frontend alive and loop.
+RESTORE_RESTART_EXIT_CODE=86
 
-# Run backend as "$USER_NAME" in background
-su-exec "$USER_NAME" ./NzbWebDAV &
-BACKEND_PID=$!
-
-# Wait for backend health check
-echo "Waiting for backend to start."
-MAX_BACKEND_HEALTH_RETRIES=${MAX_BACKEND_HEALTH_RETRIES:-30}
-MAX_BACKEND_HEALTH_RETRY_DELAY=${MAX_BACKEND_HEALTH_RETRY_DELAY:-1}
-i=0
 while true; do
-    echo "Checking backend health: $BACKEND_URL/health ..."
-    if curl -s -o /dev/null -w "%{http_code}" "$BACKEND_URL/health" | grep -q "^200$"; then
-        echo "Backend is healthy."
-        break
-    fi
-
-    i=$((i+1))
-    if [ "$i" -ge "$MAX_BACKEND_HEALTH_RETRIES" ]; then
-        echo "Backend failed health check after $MAX_BACKEND_HEALTH_RETRIES retries. Exiting."
-        kill "$BACKEND_PID"
-        wait "$BACKEND_PID"
+    # Run backend database migration / restore swap
+    cd /app/backend
+    echo "Running database maintenance."
+    su-exec "$USER_NAME" ./NzbWebDAV --db-migration
+    MIGRATION_EXIT_CODE=$?
+    if [ "$MIGRATION_EXIT_CODE" -ne 0 ]; then
+        echo "Database migration failed. Exiting with error code $MIGRATION_EXIT_CODE."
         if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
             kill "$FRONTEND_PID"
             wait "$FRONTEND_PID" 2>/dev/null
         fi
-        exit 1
+        exit "$MIGRATION_EXIT_CODE"
+    fi
+    echo "Done with database maintenance."
+
+    # Run backend as "$USER_NAME" in background
+    su-exec "$USER_NAME" ./NzbWebDAV &
+    BACKEND_PID=$!
+
+    # Wait for backend health check
+    echo "Waiting for backend to start."
+    MAX_BACKEND_HEALTH_RETRIES=${MAX_BACKEND_HEALTH_RETRIES:-30}
+    MAX_BACKEND_HEALTH_RETRY_DELAY=${MAX_BACKEND_HEALTH_RETRY_DELAY:-1}
+    i=0
+    while true; do
+        echo "Checking backend health: $BACKEND_URL/health ..."
+        if curl -s -o /dev/null -w "%{http_code}" "$BACKEND_URL/health" | grep -q "^200$"; then
+            echo "Backend is healthy."
+            break
+        fi
+
+        i=$((i+1))
+        if [ "$i" -ge "$MAX_BACKEND_HEALTH_RETRIES" ]; then
+            echo "Backend failed health check after $MAX_BACKEND_HEALTH_RETRIES retries. Exiting."
+            kill "$BACKEND_PID"
+            wait "$BACKEND_PID"
+            if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
+                kill "$FRONTEND_PID"
+                wait "$FRONTEND_PID" 2>/dev/null
+            fi
+            exit 1
+        fi
+
+        sleep "$MAX_BACKEND_HEALTH_RETRY_DELAY"
+    done
+
+    # Wait for either to exit
+    wait_either "$BACKEND_PID" "$FRONTEND_PID"
+    EXIT_CODE=$?
+
+    # Staged restore: backend asked to re-enter maintenance. Keep frontend and loop.
+    if [ "$EXITED_PID" -eq "$BACKEND_PID" ] && [ "$EXIT_CODE" -eq "$RESTORE_RESTART_EXIT_CODE" ]; then
+        echo "Backend requested restore restart (exit $RESTORE_RESTART_EXIT_CODE). Re-running database maintenance."
+        BACKEND_PID=""
+        continue
     fi
 
-    sleep "$MAX_BACKEND_HEALTH_RETRY_DELAY"
+    # Determine which process exited
+    if [ "$EXITED_PID" -eq "$FRONTEND_PID" ]; then
+        echo "The web-frontend has exited. Shutting down the web-backend..."
+    else
+        echo "The web-backend has exited. Shutting down the web-frontend..."
+    fi
+
+    # Kill the remaining process
+    kill "$REMAINING_PID"
+    wait "$REMAINING_PID" 2>/dev/null
+
+    # Exit with the code of the process that died first
+    exit $EXIT_CODE
 done
-
-# Wait for either to exit
-wait_either "$BACKEND_PID" "$FRONTEND_PID"
-EXIT_CODE=$?
-
-# Determine which process exited
-if [ "$EXITED_PID" -eq "$FRONTEND_PID" ]; then
-    echo "The web-frontend has exited. Shutting down the web-backend..."
-else
-    echo "The web-backend has exited. Shutting down the web-frontend..."
-fi
-
-# Kill the remaining process
-kill "$REMAINING_PID"
-wait "$REMAINING_PID" 2>/dev/null
-
-# Exit with the code of the process that died first
-exit $EXIT_CODE

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -193,7 +193,7 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
   );
 }
 
-function MigrationProgressView({ status }: { status: MigrationStatus }) {
+export function MigrationProgressView({ status }: { status: MigrationStatus }) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const interval = window.setInterval(() => setNow(Date.now()), 1000);
@@ -295,7 +295,7 @@ function MigrationProgressView({ status }: { status: MigrationStatus }) {
   );
 }
 
-function MigrationShell({
+export function MigrationShell({
   title,
   subtitle,
   children,

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -1,0 +1,658 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
+import {
+    decideMigrationStatusPoll,
+    MigrationProgressView,
+    MigrationShell,
+    type MigrationStatus,
+} from "~/components/migration-progress";
+import { Button } from "~/components/ui/button";
+import { Alert, Badge, Spinner } from "~/components/ui/feedback";
+import { Checkbox, Input, Select } from "~/components/ui/form";
+import { Icon } from "~/components/ui/icon";
+import { SettingsPage } from "~/components/ui";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
+
+type BackupSettingsProps = {
+    config: Record<string, string>;
+    setNewConfig: Dispatch<SetStateAction<Record<string, string>>>;
+};
+
+type BackupFileEntry = { name: string; bytes: number };
+
+type BackupManifest = {
+    id: string;
+    createdAt: string;
+    kind: string;
+    notes: string;
+    preserved: boolean;
+    appVersion?: string | null;
+    lastMainMigration?: string | null;
+    files: BackupFileEntry[];
+};
+
+type LastRestoreReport = {
+    backupId: string;
+    restoredAt: string;
+    missingBlobRefs: number;
+    checkedRefs: number;
+};
+
+type BackupListResponse = {
+    status?: boolean;
+    backups?: BackupManifest[];
+    taskRunning?: boolean;
+    pendingRestore?: boolean;
+    lastRestoreReport?: LastRestoreReport | null;
+    error?: string;
+};
+
+export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
+    const [backups, setBackups] = useState<BackupManifest[]>([]);
+    const [taskRunning, setTaskRunning] = useState(false);
+    const [lastRestoreReport, setLastRestoreReport] = useState<LastRestoreReport | null>(null);
+    const [reportDismissed, setReportDismissed] = useState(false);
+    const [listError, setListError] = useState<string | null>(null);
+    const [busy, setBusy] = useState<string | null>(null);
+    const [message, setMessage] = useState<{ text: string; variant: "success" | "danger" | "warning" } | null>(null);
+    const [notes, setNotes] = useState("");
+    const [backupProgress, setBackupProgress] = useState<string | null>(null);
+    const [restoreProgress, setRestoreProgress] = useState<string | null>(null);
+    const [wsConnected, setWsConnected] = useState(false);
+    const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+    const [confirmRestoreId, setConfirmRestoreId] = useState<string | null>(null);
+    const [restoring, setRestoring] = useState(false);
+    const [migrationStatus, setMigrationStatus] = useState<MigrationStatus | null>(null);
+    const [restorePhase, setRestorePhase] = useState<"idle" | "staging" | "restarting" | "migrating">("idle");
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const reloadScheduled = useRef(false);
+
+    const refreshList = useCallback(async () => {
+        try {
+            const res = await fetch("/api/db-backup-list", { cache: "no-store" });
+            const data = (await res.json().catch(() => null)) as BackupListResponse | null;
+            if (!res.ok) {
+                setListError(data?.error || `Failed to load backups (${res.status})`);
+                return;
+            }
+            setBackups(data?.backups ?? []);
+            setTaskRunning(!!data?.taskRunning);
+            setLastRestoreReport(data?.lastRestoreReport ?? null);
+            setListError(null);
+        } catch {
+            setListError("Failed to load backups.");
+        }
+    }, []);
+
+    useEffect(() => {
+        void refreshList();
+    }, [refreshList]);
+
+    useWebsocketTopic("dbbk", "state", setBackupProgress, {
+        onOpen: () => setWsConnected(true),
+        onClose: () => setWsConnected(false),
+    });
+
+    useWebsocketTopic("dbrs", "state", setRestoreProgress, {
+        onOpen: () => setWsConnected(true),
+    });
+
+    useEffect(() => {
+        if (!message || message.variant !== "success") return;
+        const timer = window.setTimeout(() => setMessage(null), 4000);
+        return () => window.clearTimeout(timer);
+    }, [message]);
+
+    useEffect(() => {
+        if (!backupProgress) return;
+        if (backupProgress.startsWith("Completed") || backupProgress.startsWith("Failed")) {
+            void refreshList();
+            setBusy(null);
+        }
+    }, [backupProgress, refreshList]);
+
+    // Poll migration status while a restore restart is in flight.
+    useEffect(() => {
+        if (restorePhase !== "restarting" && restorePhase !== "migrating") return;
+
+        let cancelled = false;
+        const poll = async () => {
+            try {
+                const res = await fetch("/api/migration-status", {
+                    headers: { accept: "application/json" },
+                    cache: "no-store",
+                });
+                if (cancelled) return;
+                const body = res.ok ? await res.json().catch(() => null) : null;
+                const decision = decideMigrationStatusPoll(res.status, body);
+                if (decision.action === "migrating") {
+                    setMigrationStatus(decision.status);
+                    setRestorePhase("migrating");
+                    if (decision.reloadMs !== undefined && !reloadScheduled.current) {
+                        reloadScheduled.current = true;
+                        window.setTimeout(() => window.location.reload(), decision.reloadMs);
+                    }
+                    return;
+                }
+                if (decision.action === "connecting") {
+                    setRestorePhase("restarting");
+                }
+            } catch {
+                if (!cancelled) setRestorePhase("restarting");
+            }
+        };
+
+        void poll();
+        const interval = window.setInterval(poll, 2000);
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+        };
+    }, [restorePhase]);
+
+    const createBackup = useCallback(async () => {
+        setBusy("create");
+        setMessage(null);
+        setBackupProgress(null);
+        try {
+            const form = new FormData();
+            if (notes.trim()) form.append("notes", notes.trim());
+            const res = await fetch("/api/db-backup-create", { method: "POST", body: form });
+            if (res.status === 409) {
+                setMessage({ text: "A backup or restore task is already running.", variant: "warning" });
+                return;
+            }
+            if (!res.ok) {
+                const data = await res.json().catch(() => null);
+                setMessage({ text: data?.error || `Backup failed (${res.status})`, variant: "danger" });
+                return;
+            }
+            setNotes("");
+            setMessage({ text: "Backup started.", variant: "success" });
+            await refreshList();
+        } catch {
+            setMessage({ text: "Backup request failed.", variant: "danger" });
+        } finally {
+            setBusy(null);
+        }
+    }, [notes, refreshList]);
+
+    const updateBackup = useCallback(async (id: string, patch: { preserved?: boolean; notes?: string }) => {
+        const form = new FormData();
+        form.append("id", id);
+        if (patch.preserved !== undefined) form.append("preserved", String(patch.preserved));
+        if (patch.notes !== undefined) form.append("notes", patch.notes);
+        const res = await fetch("/api/db-backup-update", { method: "POST", body: form });
+        if (!res.ok) {
+            const data = await res.json().catch(() => null);
+            setMessage({ text: data?.error || `Update failed (${res.status})`, variant: "danger" });
+            return;
+        }
+        await refreshList();
+    }, [refreshList]);
+
+    const deleteBackup = useCallback(async (id: string) => {
+        setConfirmDeleteId(null);
+        setBusy(`delete-${id}`);
+        try {
+            const form = new FormData();
+            form.append("id", id);
+            const res = await fetch("/api/db-backup-delete", { method: "POST", body: form });
+            if (!res.ok) {
+                const data = await res.json().catch(() => null);
+                setMessage({ text: data?.error || `Delete failed (${res.status})`, variant: "danger" });
+                return;
+            }
+            setMessage({ text: "Backup deleted.", variant: "success" });
+            await refreshList();
+        } catch {
+            setMessage({ text: "Delete failed.", variant: "danger" });
+        } finally {
+            setBusy(null);
+        }
+    }, [refreshList]);
+
+    const downloadBackup = useCallback((id: string) => {
+        const a = document.createElement("a");
+        a.href = `/api/db-backup-download?id=${encodeURIComponent(id)}`;
+        a.download = `nzbdav-backup-${id}.zip`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+    }, []);
+
+    const uploadBackup = useCallback(async (file: File) => {
+        setBusy("upload");
+        setMessage(null);
+        try {
+            const form = new FormData();
+            form.append("file", file);
+            const res = await fetch("/api/db-backup-upload", { method: "POST", body: form });
+            const data = await res.json().catch(() => null);
+            if (!res.ok) {
+                setMessage({ text: data?.error || `Upload failed (${res.status})`, variant: "danger" });
+                return;
+            }
+            setMessage({ text: "Backup uploaded.", variant: "success" });
+            await refreshList();
+        } catch {
+            setMessage({ text: "Upload failed.", variant: "danger" });
+        } finally {
+            setBusy(null);
+            if (fileInputRef.current) fileInputRef.current.value = "";
+        }
+    }, [refreshList]);
+
+    const startRestore = useCallback(async (id: string, acknowledged?: boolean) => {
+        if (!acknowledged) {
+            setMessage({ text: "You must acknowledge the restore warning.", variant: "warning" });
+            return;
+        }
+        setConfirmRestoreId(null);
+        setBusy(`restore-${id}`);
+        setRestoreProgress(null);
+        setRestoring(true);
+        setRestorePhase("staging");
+        setMessage(null);
+        try {
+            const form = new FormData();
+            form.append("id", id);
+            const res = await fetch("/api/db-restore", { method: "POST", body: form });
+            const data = await res.json().catch(() => null);
+            if (res.status === 409) {
+                setMessage({ text: "A backup or restore task is already running.", variant: "warning" });
+                setRestoring(false);
+                setRestorePhase("idle");
+                return;
+            }
+            if (!res.ok) {
+                setMessage({ text: data?.error || `Restore failed (${res.status})`, variant: "danger" });
+                setRestoring(false);
+                setRestorePhase("idle");
+                return;
+            }
+            setRestorePhase("restarting");
+        } catch {
+            // Expected once the backend exits for restart.
+            setRestorePhase("restarting");
+        } finally {
+            setBusy(null);
+        }
+    }, []);
+
+    if (restoring && (restorePhase === "restarting" || restorePhase === "migrating")) {
+        if (restorePhase === "migrating" && migrationStatus) {
+            return (
+                <div className="fixed inset-0 z-50 overflow-auto bg-base-300">
+                    <MigrationProgressView status={migrationStatus} />
+                </div>
+            );
+        }
+        return (
+            <div className="fixed inset-0 z-50 overflow-auto bg-base-300">
+                <MigrationShell
+                    title="Applying database restore"
+                    subtitle="The backend is restarting into maintenance mode to swap databases. This page will update automatically."
+                >
+                    <div className="flex items-center gap-3 text-sm text-base-content/70">
+                        <span className="loading loading-spinner loading-sm text-primary" />
+                        <span>{restoreProgress || "Waiting for maintenance status…"}</span>
+                    </div>
+                </MigrationShell>
+            </div>
+        );
+    }
+
+    const scheduleEnabled = config["backup.schedule-enabled"] === "true";
+    const scheduleTime = getScheduledTime(config);
+
+    return (
+        <SettingsPage>
+            {!reportDismissed && lastRestoreReport && lastRestoreReport.missingBlobRefs > 0 && (
+                <Alert variant="warning" className="mb-4 text-sm">
+                    <div className="flex items-start justify-between gap-3">
+                        <div>
+                            Last restore of <span className="font-mono">{lastRestoreReport.backupId}</span> found{" "}
+                            <strong>{lastRestoreReport.missingBlobRefs}</strong> of{" "}
+                            {lastRestoreReport.checkedRefs} blob references pointing to missing files under{" "}
+                            <code className="font-mono">blobs/</code>. Affected items may fail to stream until
+                            re-downloaded.
+                        </div>
+                        <Button variant="ghost" size="small" onClick={() => setReportDismissed(true)}>
+                            Dismiss
+                        </Button>
+                    </div>
+                </Alert>
+            )}
+
+            <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <Checkbox
+                        id="backup-schedule-enabled"
+                        checked={scheduleEnabled}
+                        onChange={(e) =>
+                            setNewConfig({
+                                ...config,
+                                "backup.schedule-enabled": "" + e.target.checked,
+                            })
+                        }
+                    />
+                    <span>Schedule database backup daily</span>
+                </label>
+                <div className="mt-4 flex w-full gap-2">
+                    <Select
+                        disabled={!scheduleEnabled}
+                        value={scheduleTime.hour}
+                        onChange={(e) =>
+                            setNewConfig({
+                                ...config,
+                                "backup.schedule-time": buildScheduledTime(
+                                    parseInt(e.target.value),
+                                    scheduleTime.minute,
+                                    scheduleTime.period,
+                                ),
+                            })
+                        }
+                    >
+                        {Array.from({ length: 12 }, (_, i) => i + 1).map((h) => (
+                            <option key={h} value={h}>
+                                {h}
+                            </option>
+                        ))}
+                    </Select>
+                    <Select
+                        disabled={!scheduleEnabled}
+                        value={scheduleTime.minute}
+                        onChange={(e) =>
+                            setNewConfig({
+                                ...config,
+                                "backup.schedule-time": buildScheduledTime(
+                                    scheduleTime.hour,
+                                    parseInt(e.target.value),
+                                    scheduleTime.period,
+                                ),
+                            })
+                        }
+                    >
+                        <option value={0}>00</option>
+                        <option value={15}>15</option>
+                        <option value={30}>30</option>
+                        <option value={45}>45</option>
+                    </Select>
+                    <Select
+                        disabled={!scheduleEnabled}
+                        value={scheduleTime.period}
+                        onChange={(e) =>
+                            setNewConfig({
+                                ...config,
+                                "backup.schedule-time": buildScheduledTime(
+                                    scheduleTime.hour,
+                                    scheduleTime.minute,
+                                    e.target.value as "am" | "pm",
+                                ),
+                            })
+                        }
+                    >
+                        <option value="am">am</option>
+                        <option value="pm">pm</option>
+                    </Select>
+                </div>
+                <p className="text-[11px] leading-relaxed text-base-content/45">
+                    Creates a logical <code className="font-mono">.sql</code> dump of all databases under the config
+                    volume. Set the <code className="font-mono">TZ</code> env variable for the correct timezone.
+                </p>
+            </div>
+
+            <hr />
+
+            <div className="space-y-2">
+                <label className="block text-sm text-slate-300" htmlFor="backup-retention-count">
+                    Retention count (non-preserved backups)
+                </label>
+                <Input
+                    id="backup-retention-count"
+                    type="number"
+                    min={0}
+                    value={config["backup.retention-count"] ?? "5"}
+                    onChange={(e) =>
+                        setNewConfig({
+                            ...config,
+                            "backup.retention-count": e.target.value,
+                        })
+                    }
+                    className="max-w-xs"
+                />
+                <p className="text-[11px] leading-relaxed text-base-content/45">
+                    Keep the newest N backups that are not preserved. Set to 0 to disable pruning. Preserved backups
+                    are never deleted by retention.
+                </p>
+            </div>
+
+            <hr />
+
+            <div className="space-y-3">
+                <h2 className="text-sm font-semibold text-white">Create backup now</h2>
+                <Input
+                    placeholder="Optional notes"
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                />
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                        variant="success"
+                        disabled={busy === "create" || taskRunning}
+                        onClick={() => void createBackup()}
+                    >
+                        {busy === "create" ? <Spinner className="h-4 w-4" /> : <Icon name="backup" className="!text-[18px]" />}
+                        Create Backup
+                    </Button>
+                    <Button
+                        variant="outline"
+                        disabled={busy === "upload"}
+                        onClick={() => fileInputRef.current?.click()}
+                    >
+                        {busy === "upload" ? <Spinner className="h-4 w-4" /> : <Icon name="upload" className="!text-[18px]" />}
+                        Upload Backup
+                    </Button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".zip,.sql,application/zip,text/plain"
+                        className="hidden"
+                        onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (file) void uploadBackup(file);
+                        }}
+                    />
+                    {!wsConnected && (
+                        <span className="text-[11px] text-base-content/45">Connecting for live progress…</span>
+                    )}
+                </div>
+                {backupProgress && (
+                    <p className="font-mono text-xs text-base-content/70">{backupProgress}</p>
+                )}
+                {restoreProgress && restorePhase === "staging" && (
+                    <p className="font-mono text-xs text-base-content/70">{restoreProgress}</p>
+                )}
+            </div>
+
+            {message && (
+                <Alert variant={message.variant === "danger" ? "danger" : message.variant === "warning" ? "warning" : "success"} className="text-sm">
+                    {message.text}
+                </Alert>
+            )}
+            {listError && (
+                <Alert variant="danger" className="text-sm">
+                    {listError}
+                </Alert>
+            )}
+
+            <hr />
+
+            <div className="space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                    <h2 className="text-sm font-semibold text-white">Backups</h2>
+                    <Button variant="ghost" size="small" onClick={() => void refreshList()}>
+                        <Icon name="refresh" className="!text-[16px]" />
+                        Refresh
+                    </Button>
+                </div>
+
+                {backups.length === 0 ? (
+                    <p className="text-sm text-base-content/50">No backups yet.</p>
+                ) : (
+                    <ul className="space-y-3">
+                        {backups.map((backup) => {
+                            const totalBytes = backup.files.reduce((sum, f) => sum + (f.bytes || 0), 0);
+                            return (
+                                <li
+                                    key={backup.id}
+                                    className="rounded border border-slate-700/70 bg-base-200/40 p-3 space-y-3"
+                                >
+                                    <div className="flex flex-wrap items-start justify-between gap-2">
+                                        <div className="space-y-1">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <span className="font-mono text-sm text-white">{backup.id}</span>
+                                                <Badge className="badge-sm">{backup.kind}</Badge>
+                                                {backup.preserved && <Badge className="badge-sm badge-warning">preserved</Badge>}
+                                            </div>
+                                            <p className="text-[11px] text-base-content/50">
+                                                {formatDate(backup.createdAt)} · {formatBytes(totalBytes)}
+                                                {backup.appVersion ? ` · v${backup.appVersion}` : ""}
+                                            </p>
+                                        </div>
+                                        <label className="flex items-center gap-2 text-xs text-slate-300">
+                                            <Checkbox
+                                                checked={backup.preserved}
+                                                onChange={(e) =>
+                                                    void updateBackup(backup.id, { preserved: e.target.checked })
+                                                }
+                                            />
+                                            Preserve
+                                        </label>
+                                    </div>
+                                    <Input
+                                        defaultValue={backup.notes ?? ""}
+                                        placeholder="Notes"
+                                        onBlur={(e) => {
+                                            if (e.target.value !== (backup.notes ?? "")) {
+                                                void updateBackup(backup.id, { notes: e.target.value });
+                                            }
+                                        }}
+                                    />
+                                    <div className="flex flex-wrap gap-2">
+                                        <Button
+                                            variant="outline"
+                                            size="small"
+                                            onClick={() => downloadBackup(backup.id)}
+                                        >
+                                            <Icon name="download" className="!text-[16px]" />
+                                            Download
+                                        </Button>
+                                        <Button
+                                            variant="warning"
+                                            size="small"
+                                            disabled={!!busy || taskRunning}
+                                            onClick={() => setConfirmRestoreId(backup.id)}
+                                        >
+                                            <Icon name="restore" className="!text-[16px]" />
+                                            Restore
+                                        </Button>
+                                        <Button
+                                            variant="danger"
+                                            size="small"
+                                            disabled={busy === `delete-${backup.id}`}
+                                            onClick={() => setConfirmDeleteId(backup.id)}
+                                        >
+                                            <Icon name="delete" className="!text-[16px]" />
+                                            Delete
+                                        </Button>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
+
+            <p className="text-[11px] leading-relaxed text-base-content/45">
+                Backups include <code className="font-mono">db.sqlite</code>,{" "}
+                <code className="font-mono">metrics.sqlite</code>, and <code className="font-mono">warden.db</code> as
+                logical SQL dumps. The <code className="font-mono">blobs/</code> folder is not included — restoring an
+                older dump may leave some items with missing blob files.
+            </p>
+
+            <ConfirmModal
+                show={confirmDeleteId !== null}
+                title="Delete backup"
+                message={<>Delete backup <span className="font-mono">{confirmDeleteId}</span>? This cannot be undone.</>}
+                cancelText="Cancel"
+                confirmText="Delete"
+                onCancel={() => setConfirmDeleteId(null)}
+                onConfirm={() => {
+                    if (confirmDeleteId) void deleteBackup(confirmDeleteId);
+                }}
+            />
+
+            <ConfirmModal
+                show={confirmRestoreId !== null}
+                title="Restore database backup"
+                message={
+                    <>
+                        Restoring <span className="font-mono">{confirmRestoreId}</span> replaces all settings, queue,
+                        history, and the WebDAV file tree. A pre-restore safety backup is created automatically. The
+                        server will restart into maintenance mode to apply the swap.
+                    </>
+                }
+                checkboxMessage="I understand this will replace the current databases"
+                cancelText="Cancel"
+                confirmText="Restore"
+                onCancel={() => setConfirmRestoreId(null)}
+                onConfirm={(checked) => {
+                    if (confirmRestoreId) void startRestore(confirmRestoreId, checked);
+                }}
+            />
+        </SettingsPage>
+    );
+}
+
+export function isBackupSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
+    return (
+        config["backup.schedule-enabled"] !== newConfig["backup.schedule-enabled"] ||
+        config["backup.schedule-time"] !== newConfig["backup.schedule-time"] ||
+        config["backup.retention-count"] !== newConfig["backup.retention-count"]
+    );
+}
+
+function getScheduledTime(config: Record<string, string>): { hour: number; minute: number; period: "am" | "pm" } {
+    const totalMinutes = parseInt(config["backup.schedule-time"] || "0");
+    const hour24 = Math.floor(totalMinutes / 60);
+    return {
+        hour: hour24 % 12 || 12,
+        minute: totalMinutes % 60,
+        period: Math.floor(totalMinutes / 60) >= 12 ? "pm" : "am",
+    };
+}
+
+function buildScheduledTime(hour: number, minute: number, period: "am" | "pm"): string {
+    const hour24 = (hour % 12) + (period === "pm" ? 12 : 0);
+    return "" + (hour24 * 60 + minute);
+}
+
+function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+    const units = ["B", "KB", "MB", "GB"];
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+    }
+    return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function formatDate(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString();
+}

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -10,6 +10,7 @@ import { isArrsSettingsUpdated, isArrsSettingsValid, ArrsSettings } from "./arrs
 import { isIndexersSettingsUpdated, isIndexersSettingsValid, IndexersSettings } from "./indexers/indexers";
 import { isProfilesSettingsUpdated, isProfilesSettingsValid, ProfilesSettings } from "./profiles/profiles";
 import { isMaintenanceSettingsUpdated, Maintenance } from "./maintenance/maintenance";
+import { isBackupSettingsUpdated, BackupSettings } from "./backup/backup";
 import { isRepairsSettingsUpdated, RepairsSettings } from "./repairs/repairs";
 import { isWatchdogSettingsUpdated, WatchdogSettings } from "./watchdog/watchdog";
 import { isPreflightSettingsUpdated, PreflightSettings } from "./preflight/preflight";
@@ -97,6 +98,9 @@ const defaultConfig = {
     "database.healthcheck-retention-days": "30",
     "maintenance.remove-orphaned-schedule-enabled": "false",
     "maintenance.remove-orphaned-schedule-time": "0",
+    "backup.schedule-enabled": "false",
+    "backup.schedule-time": "0",
+    "backup.retention-count": "5",
     "api.nzb-backup-enabled": "false",
     "api.nzb-backup-location": "",
     "watchtower.enabled": "false",
@@ -177,9 +181,10 @@ function Body(props: BodyProps) {
     const isPreflightUpdated = isPreflightSettingsUpdated(config, newConfig);
     const isRcloneUpdated = isRcloneSettingsUpdated(config, newConfig);
     const isMaintenanceUpdated = isMaintenanceSettingsUpdated(config, newConfig);
+    const isBackupUpdated = isBackupSettingsUpdated(config, newConfig);
     const isWatchtowerUpdated = isWatchtowerSettingsUpdated(config, newConfig);
     const isWardenUpdated = isWardenSettingsUpdated(config, newConfig);
-    const isUpdated = iseUsenetUpdated || isSabnzbdUpdated || isWebdavUpdated || isArrsUpdated || isIndexersUpdated || isProfilesUpdated || isRepairsUpdated || isWatchdogUpdated || isPreflightUpdated || isRcloneUpdated || isMaintenanceUpdated || isWatchtowerUpdated || isWardenUpdated;
+    const isUpdated = iseUsenetUpdated || isSabnzbdUpdated || isWebdavUpdated || isArrsUpdated || isIndexersUpdated || isProfilesUpdated || isRepairsUpdated || isWatchdogUpdated || isPreflightUpdated || isRcloneUpdated || isMaintenanceUpdated || isBackupUpdated || isWatchtowerUpdated || isWardenUpdated;
     const navigationBlocker = useNavigationBlocker(isUpdated);
 
     const saveButtonLabel = isSaving ? "Saving..."
@@ -250,6 +255,7 @@ function Body(props: BodyProps) {
                 {activeTab === "repairs" && <RepairsSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "rclone" && <RcloneSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "maintenance" && <Maintenance savedConfig={config} config={newConfig} setNewConfig={setNewConfig} />}
+                {activeTab === "backup" && <BackupSettings config={newConfig} setNewConfig={setNewConfig} />}
             </SettingsPanel>
 
             {saveError && (

--- a/frontend/app/routes/settings/settings-tabs.ts
+++ b/frontend/app/routes/settings/settings-tabs.ts
@@ -11,7 +11,8 @@ export type SettingsTab =
     | "arrs"
     | "repairs"
     | "rclone"
-    | "maintenance";
+    | "maintenance"
+    | "backup";
 
 export type SettingsTabItem = {
     id: SettingsTab;
@@ -56,6 +57,7 @@ export const SETTINGS_TAB_GROUPS: SettingsTabGroup[] = [
         items: [
             { id: "repairs", label: "Repairs", icon: "build" },
             { id: "maintenance", label: "Maintenance", icon: "settings_suggest" },
+            { id: "backup", label: "Backup & Restore", icon: "settings_backup_restore" },
         ],
     },
 ];

--- a/scripts/run-backend.sh
+++ b/scripts/run-backend.sh
@@ -109,9 +109,24 @@ if [[ "$MIGRATE_ONLY" -eq 1 ]]; then
   exit 0
 fi
 
-if [[ "$SKIP_MIGRATE" -eq 0 ]]; then
-  run_migration
-fi
+RESTORE_RESTART_EXIT_CODE=86
 
-echo "Starting backend at $BACKEND_URL (config: $CONFIG_PATH)"
-exec "$BINARY"
+while true; do
+  if [[ "$SKIP_MIGRATE" -eq 0 ]]; then
+    run_migration
+  fi
+
+  echo "Starting backend at $BACKEND_URL (config: $CONFIG_PATH)"
+  set +e
+  "$BINARY"
+  EXIT_CODE=$?
+  set -e
+
+  if [[ "$EXIT_CODE" -eq "$RESTORE_RESTART_EXIT_CODE" ]]; then
+    echo "Backend requested restore restart (exit $RESTORE_RESTART_EXIT_CODE). Re-running migration."
+    SKIP_MIGRATE=0
+    continue
+  fi
+
+  exit "$EXIT_CODE"
+done

--- a/tests/NzbWebDAV.Tests/Database/ConfigPathCollection.cs
+++ b/tests/NzbWebDAV.Tests/Database/ConfigPathCollection.cs
@@ -1,0 +1,7 @@
+namespace NzbWebDAV.Tests.Database;
+
+/// <summary>
+/// Serializes tests that mutate the process-wide <c>CONFIG_PATH</c> environment variable.
+/// </summary>
+[CollectionDefinition(nameof(ConfigPathCollection), DisableParallelization = true)]
+public sealed class ConfigPathCollection;

--- a/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
@@ -1,0 +1,500 @@
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Backup;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Database;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class SqliteDumpImportTests
+{
+    [Fact]
+    public async Task DumpAndImport_RoundTripsRepresentativeContent()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-dump-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var sourcePath = Path.Combine(root, "source.sqlite");
+            var dumpPath = Path.Combine(root, "dump.sql");
+            var restoredPath = Path.Combine(root, "restored.sqlite");
+            var redumpPath = Path.Combine(root, "redump.sql");
+
+            await CreateRepresentativeDatabaseAsync(sourcePath);
+
+            await SqliteDumper.DumpToFileAsync(sourcePath, dumpPath);
+            await SqliteSqlImporter.ImportAsync(dumpPath, restoredPath);
+
+            await using (var connection = Open(restoredPath))
+            {
+                await connection.OpenAsync();
+
+                await using (var countCmd = connection.CreateCommand())
+                {
+                    countCmd.CommandText = "SELECT COUNT(*) FROM Notes;";
+                    Assert.Equal(3L, (long)(await countCmd.ExecuteScalarAsync())!);
+                }
+
+                await using (var textCmd = connection.CreateCommand())
+                {
+                    textCmd.CommandText = "SELECT Body FROM Notes WHERE Id = 2;";
+                    Assert.Equal("line1; still one value\nwith 'quotes'", (string)(await textCmd.ExecuteScalarAsync())!);
+                }
+
+                await using (var realCmd = connection.CreateCommand())
+                {
+                    realCmd.CommandText = "SELECT Amount FROM Payments WHERE Id = 1;";
+                    Assert.Equal(0.1, (double)(await realCmd.ExecuteScalarAsync())!);
+                }
+
+                await using (var blobCmd = connection.CreateCommand())
+                {
+                    blobCmd.CommandText = "SELECT Payload FROM Blobs WHERE Id = 1;";
+                    var bytes = (byte[])(await blobCmd.ExecuteScalarAsync())!;
+                    Assert.Equal(new byte[] { 0x00, 0xFF, 0x10 }, bytes);
+                }
+
+                await using (var auditBefore = connection.CreateCommand())
+                {
+                    auditBefore.CommandText = "SELECT COUNT(*) FROM AuditLog;";
+                    var before = (long)(await auditBefore.ExecuteScalarAsync())!;
+                    await using (var triggerCmd = connection.CreateCommand())
+                    {
+                        triggerCmd.CommandText = "INSERT INTO Notes (Body) VALUES ('trigger-me');";
+                        await triggerCmd.ExecuteNonQueryAsync();
+                    }
+
+                    await using var auditAfter = connection.CreateCommand();
+                    auditAfter.CommandText = "SELECT COUNT(*) FROM AuditLog;";
+                    Assert.Equal(before + 1, (long)(await auditAfter.ExecuteScalarAsync())!);
+                }
+
+                await using (var viewCmd = connection.CreateCommand())
+                {
+                    viewCmd.CommandText = "SELECT COUNT(*) FROM NotesView;";
+                    Assert.True((long)(await viewCmd.ExecuteScalarAsync())! >= 4);
+                }
+            }
+
+            await SqliteDumper.DumpToFileAsync(restoredPath, redumpPath);
+            // Second dump of an imported DB should contain the same schema objects.
+            var dumpText = await File.ReadAllTextAsync(dumpPath);
+            var redumpText = await File.ReadAllTextAsync(redumpPath);
+            Assert.Contains("CREATE TABLE", dumpText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("CREATE TRIGGER", redumpText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("CREATE VIEW", redumpText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("CREATE INDEX", redumpText, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task Importer_HandlesSemicolonsCommentsAndMultilineStatements()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-import-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var sqlPath = Path.Combine(root, "special.sql");
+            var dbPath = Path.Combine(root, "special.sqlite");
+            await File.WriteAllTextAsync(sqlPath, """
+                PRAGMA foreign_keys=OFF;
+                BEGIN TRANSACTION;
+                -- this is a comment; with a semicolon
+                CREATE TABLE Items (
+                  Id INTEGER PRIMARY KEY,
+                  Name TEXT
+                );
+                /* multi-line
+                   comment; still ignored */
+                INSERT INTO Items (Id, Name) VALUES (1, 'a;b');
+                INSERT INTO Items (Id, Name) VALUES (2, 'line1
+                line2');
+                COMMIT;
+                """);
+
+            Assert.True(SqliteSqlImporter.IsCompleteStatement("SELECT 1;"));
+            Assert.False(SqliteSqlImporter.IsCompleteStatement("INSERT INTO t VALUES ('a;"));
+            Assert.True(SqliteSqlImporter.IsCompleteStatement("INSERT INTO t VALUES ('a;b');"));
+
+            await SqliteSqlImporter.ImportAsync(sqlPath, dbPath);
+
+            await using var connection = Open(dbPath);
+            await connection.OpenAsync();
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT Name FROM Items ORDER BY Id;";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal("a;b", reader.GetString(0));
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal("line1\nline2", reader.GetString(0));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task DumpAndImport_RoundTripsRealDavSchema()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-schema-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var sourceDb = Path.Combine(root, "source.sqlite");
+        var dumpPath = Path.Combine(root, "db.sql");
+        var restoredDb = Path.Combine(root, "restored-db.sqlite");
+        try
+        {
+            var sourceOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={sourceDb};Pooling=False")
+                .AddInterceptors(new NzbWebDAV.Database.Interceptors.SqliteMainDbPragmas())
+                .ReplaceService<
+                    Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator,
+                    NzbWebDAV.Database.MigrationHelpers.SqliteMigrationsSqlGenerator<
+                        Microsoft.EntityFrameworkCore.Migrations.SqliteMigrationsSqlGenerator>>()
+                .Options;
+
+            await using (var ctx = new DavDatabaseContext(sourceOptions))
+            {
+                await ctx.Database.MigrateAsync();
+                ctx.ConfigItems.Add(new NzbWebDAV.Database.Models.ConfigItem
+                {
+                    ConfigName = "test.key",
+                    ConfigValue = "test-value",
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await SqliteDumper.DumpToFileAsync(sourceDb, dumpPath);
+            await SqliteSqlImporter.ImportAsync(dumpPath, restoredDb, requireMigrationsHistory: true);
+
+            var restoredOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={restoredDb};Pooling=False")
+                .AddInterceptors(new NzbWebDAV.Database.Interceptors.SqliteMainDbPragmas())
+                .ReplaceService<
+                    Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator,
+                    NzbWebDAV.Database.MigrationHelpers.SqliteMigrationsSqlGenerator<
+                        Microsoft.EntityFrameworkCore.Migrations.SqliteMigrationsSqlGenerator>>()
+                .Options;
+            await using (var restored = new DavDatabaseContext(restoredOptions))
+            {
+                var pending = await restored.Database.GetPendingMigrationsAsync();
+                Assert.Empty(pending);
+
+                var value = await restored.ConfigItems
+                    .Where(x => x.ConfigName == "test.key")
+                    .Select(x => x.ConfigValue)
+                    .SingleAsync();
+                Assert.Equal("test-value", value);
+
+                await using var connection = restored.Database.GetDbConnection();
+                await connection.OpenAsync();
+                await using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                    SELECT COUNT(*) FROM sqlite_master
+                    WHERE type = 'trigger' AND name LIKE 'TR_%';
+                    """;
+                var triggerCount = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+                Assert.True(triggerCount > 0);
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static async Task CreateRepresentativeDatabaseAsync(string path)
+    {
+        await using var connection = Open(path, create: true);
+        await connection.OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE Notes (
+              Id INTEGER PRIMARY KEY AUTOINCREMENT,
+              Body TEXT,
+              Flag INTEGER
+            );
+            CREATE TABLE Payments (
+              Id INTEGER PRIMARY KEY,
+              Amount REAL
+            );
+            CREATE TABLE Blobs (
+              Id INTEGER PRIMARY KEY,
+              Payload BLOB
+            );
+            CREATE TABLE AuditLog (
+              Id INTEGER PRIMARY KEY AUTOINCREMENT,
+              NoteId INTEGER
+            );
+            CREATE INDEX IX_Notes_Body ON Notes(Body);
+            CREATE TRIGGER TR_Notes_Insert
+            AFTER INSERT ON Notes
+            BEGIN
+              INSERT INTO AuditLog(NoteId) VALUES (NEW.Id);
+            END;
+            CREATE VIEW NotesView AS SELECT Id, Body FROM Notes;
+            INSERT INTO Notes (Body, Flag) VALUES ('plain', NULL);
+            INSERT INTO Notes (Body, Flag) VALUES ('line1; still one value
+            with ''quotes''', 1);
+            INSERT INTO Notes (Body, Flag) VALUES (NULL, 0);
+            INSERT INTO Payments (Id, Amount) VALUES (1, 0.1);
+            INSERT INTO Blobs (Id, Payload) VALUES (1, X'00FF10');
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static SqliteConnection Open(string path, bool create = false)
+    {
+        var cs = new SqliteConnectionStringBuilder
+        {
+            DataSource = path,
+            Mode = create ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite,
+            Pooling = false,
+        }.ToString();
+        return new SqliteConnection(cs);
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+}
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class DatabaseBackupStoreTests
+{
+    [Fact]
+    public void Retention_RespectsPreservedAndZeroDisablesPruning()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-store-{Guid.NewGuid():N}");
+        var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", root);
+        try
+        {
+            Directory.CreateDirectory(root);
+            var store = new DatabaseBackupStore();
+            store.EnsureInitialized();
+
+            CreateCommittedBackup(store, "manual", preserved: false);
+            CreateCommittedBackup(store, "manual", preserved: false);
+            CreateCommittedBackup(store, "manual", preserved: true);
+            CreateCommittedBackup(store, "manual", preserved: false);
+
+            Assert.Equal(4, store.List().Count);
+            Assert.Equal(0, store.Prune(0));
+            Assert.Equal(4, store.List().Count);
+
+            var pruned = store.Prune(1);
+            Assert.Equal(2, pruned);
+            var remaining = store.List();
+            Assert.Equal(2, remaining.Count);
+            Assert.Contains(remaining, x => x.Preserved);
+            Assert.DoesNotContain(remaining, x => Path.GetFileName(store.GetBackupDirectory(x.Id)).StartsWith(".tmp-"));
+
+            var preserved = remaining.Single(x => x.Preserved);
+            store.UpdateManifest(preserved.Id, notes: "pinned");
+            Assert.Equal("pinned", store.Get(preserved.Id)!.Notes);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void IncompletePendingRestore_IsReadableAndClearable()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-intent-{Guid.NewGuid():N}");
+        var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", root);
+        try
+        {
+            var store = new DatabaseBackupStore();
+            store.EnsureInitialized();
+            store.WritePendingRestore(new PendingRestoreIntent
+            {
+                BackupId = "20260101-000000-manual",
+                PreRestoreBackupId = "20260101-000001-pre-restore",
+                StagedFiles = ["db.sqlite"],
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            Assert.True(store.HasPendingRestore());
+            Assert.NotNull(store.ReadPendingRestore());
+            store.ClearPendingRestore();
+            Assert.False(store.HasPendingRestore());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
+            TryDelete(root);
+        }
+    }
+
+    private static void CreateCommittedBackup(DatabaseBackupStore store, string kind, bool preserved)
+    {
+        var staging = store.CreateStaging(kind);
+        File.WriteAllText(Path.Combine(staging, DatabaseBackupStore.DbSqlName), "PRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\nCOMMIT;\n");
+        store.CommitStaging(staging, kind, notes: null, preserved: preserved, appVersion: "test", lastMainMigration: null);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+}
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class DatabaseRestoreRunnerTests
+{
+    [Fact]
+    public async Task ApplyPendingRestore_DiscardsMissingStagingFiles()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-restore-{Guid.NewGuid():N}");
+        var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", root);
+        try
+        {
+            Directory.CreateDirectory(root);
+            var store = new DatabaseBackupStore();
+            store.EnsureInitialized();
+            store.WritePendingRestore(new PendingRestoreIntent
+            {
+                BackupId = "missing-staging",
+                PreRestoreBackupId = "pre",
+                StagedFiles = ["db.sqlite"],
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+            var progress = new MigrationProgress();
+            progress.Initialize(DatabaseRestoreRunner.GetRestoreSteps(store.ReadPendingRestore()!));
+            await DatabaseRestoreRunner.ApplyPendingRestoreAsync(progress);
+
+            Assert.False(store.HasPendingRestore());
+            Assert.False(Directory.Exists(store.RestoreStagingRoot));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
+            SqliteConnection.ClearAllPools();
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ApplyPendingRestore_SwapsStagedDatabaseAndWritesReport()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-swap-{Guid.NewGuid():N}");
+        var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", root);
+        try
+        {
+            Directory.CreateDirectory(root);
+            var store = new DatabaseBackupStore();
+            store.EnsureInitialized();
+
+            // Live DB
+            await using (var live = new SqliteConnection($"Data Source={DavDatabaseContext.DatabaseFilePath};Pooling=False"))
+            {
+                await live.OpenAsync();
+                await using var cmd = live.CreateCommand();
+                cmd.CommandText = "CREATE TABLE Marker(Value TEXT); INSERT INTO Marker VALUES ('live');";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            // Pre-restore backup folder for rollback target
+            var preStaging = store.CreateStaging(DatabaseBackupKinds.PreRestore);
+            File.WriteAllText(Path.Combine(preStaging, DatabaseBackupStore.DbSqlName), "PRAGMA foreign_keys=OFF;\nBEGIN;\nCOMMIT;\n");
+            var pre = store.CommitStaging(preStaging, DatabaseBackupKinds.PreRestore, "safety", preserved: true, "test", null);
+
+            // Staged restored DB
+            store.PrepareRestoreStaging();
+            var stagedPath = Path.Combine(store.RestoreStagingRoot, "db.sqlite");
+            await using (var staged = new SqliteConnection($"Data Source={stagedPath};Pooling=False"))
+            {
+                await staged.OpenAsync();
+                await using var cmd = staged.CreateCommand();
+                cmd.CommandText = """
+                    CREATE TABLE Marker(Value TEXT);
+                    CREATE TABLE DavItems(FileBlobId TEXT, NzbBlobId TEXT);
+                    CREATE TABLE HistoryItems(NzbBlobId TEXT);
+                    INSERT INTO Marker VALUES ('restored');
+                    """;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            store.WritePendingRestore(new PendingRestoreIntent
+            {
+                BackupId = "swap-test",
+                PreRestoreBackupId = pre.Id,
+                StagedFiles = ["db.sqlite"],
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+            var progress = new MigrationProgress();
+            progress.Initialize(DatabaseRestoreRunner.GetRestoreSteps(store.ReadPendingRestore()!));
+            await DatabaseRestoreRunner.ApplyPendingRestoreAsync(progress);
+
+            Assert.False(store.HasPendingRestore());
+            await using (var live = new SqliteConnection($"Data Source={DavDatabaseContext.DatabaseFilePath};Pooling=False"))
+            {
+                await live.OpenAsync();
+                await using var cmd = live.CreateCommand();
+                cmd.CommandText = "SELECT Value FROM Marker;";
+                Assert.Equal("restored", (string)(await cmd.ExecuteScalarAsync())!);
+            }
+
+            var rollbackDb = Path.Combine(store.GetBackupDirectory(pre.Id), DatabaseBackupStore.RollbackFolderName, "db.sqlite");
+            Assert.True(File.Exists(rollbackDb));
+
+            var report = store.ReadLastRestoreReport();
+            Assert.NotNull(report);
+            Assert.Equal("swap-test", report!.BackupId);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
+            SqliteConnection.ClearAllPools();
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #255

Implements in-app SQLite backup/restore:

- Dump all three databases (`db.sqlite`, `metrics.sqlite`, `warden.db`) to portable `.sql` files under `{CONFIG_PATH}/backups/`
- On-demand + daily scheduled backups with retention, preserve flags, notes, download (zip) and upload
- Guided restore: stage import live → exit code 86 → entrypoint re-enters `--db-migration` maintenance → checkpoint/VACUUM + rollback copies + swap → missing-blob report
- New **Settings → Backup & Restore** tab with live progress and maintenance-status overlay

Blobs are intentionally not included; post-restore UI reports missing blob references.

## Test plan

- [x] `dotnet test` focused backup/restore suite (7/7 passed)
- [x] `frontend` typecheck + build + vitest (173/173 passed)
- [ ] Manual smoke: create backup → download → delete → upload → restore → observe maintenance page → verify settings/queue after reload
- [ ] Confirm scheduled backup + retention pruning
- [ ] Confirm preserve flag prevents pruning