### PR TITLE
fix(health): hide deleted providers from overview stats

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -461,7 +461,7 @@ public class GetOverviewStatsController(
         _ => OneHour,
     };
 
-    private static GetOverviewStatsResponse.FailoverBlock BuildFailover(
+    internal static GetOverviewStatsResponse.FailoverBlock BuildFailover(
         IEnumerable<(long At, string Provider, long Saves)> rescues,
         IEnumerable<(string From, SegmentFetch.FetchStatus Reason, long Count)> misses,
         long totalArticles,
@@ -486,7 +486,10 @@ public class GetOverviewStatsController(
             perProvider[provider] = c + saves;
         }
 
+        // Chart/list series only include currently configured providers; aggregate
+        // totals below still count rescues from deleted providers.
         var orderedProviders = totalsByProvider
+            .Where(kv => IsConfiguredMetricsKey(kv.Key, labelsByMetricsKey))
             .OrderByDescending(kv => kv.Value)
             .ThenBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
             .Select(kv => kv.Key)
@@ -526,6 +529,7 @@ public class GetOverviewStatsController(
                 })
                 .ToList(),
             RescuedFrom = missesByProvider
+                .Where(kv => IsConfiguredMetricsKey(kv.Key, labelsByMetricsKey))
                 .OrderByDescending(kv => kv.Value)
                 .ThenBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(kv => new GetOverviewStatsResponse.FailoverFrom
@@ -548,7 +552,10 @@ public class GetOverviewStatsController(
                 {
                     var counts = new long[orderedProviders.Count];
                     foreach (var (provider, c) in kv.Value)
-                        counts[indexOf[provider]] = c;
+                    {
+                        if (!indexOf.TryGetValue(provider, out var i)) continue;
+                        counts[i] = c;
+                    }
                     return new GetOverviewStatsResponse.FailoverBucket
                     {
                         Bucket = kv.Key,
@@ -558,6 +565,15 @@ public class GetOverviewStatsController(
                 .ToList(),
         };
     }
+
+    /// <summary>
+    /// Metrics keys present in the current config label map. Deleted providers leave
+    /// orphaned rollup rows; those must not appear as named overview rows (GUID fallback).
+    /// </summary>
+    internal static bool IsConfiguredMetricsKey(
+        string metricsKey,
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
+        => labelsByMetricsKey.ContainsKey(metricsKey);
 
     private GetOverviewStatsResponse.LiveTiles BuildLiveTiles(long articlesLastMinute, long errorsLastMinute)
     {
@@ -636,7 +652,7 @@ public class GetOverviewStatsController(
             .ToList();
     }
 
-    private static List<GetOverviewStatsResponse.ProviderRow> BuildProvidersFromMinutes(
+    internal static List<GetOverviewStatsResponse.ProviderRow> BuildProvidersFromMinutes(
         IEnumerable<(long Minute, string Provider, long Articles, long BytesFetched, long Errors, long Retries, long SumDurationMs)> minutes,
         long windowStart,
         GetOverviewStatsRequest.OverviewWindow window,
@@ -666,6 +682,7 @@ public class GetOverviewStatsController(
         }
 
         return byProvider
+            .Where(kv => IsConfiguredMetricsKey(kv.Key, labelsByMetricsKey))
             .Select(kv => new GetOverviewStatsResponse.ProviderRow
             {
                 Provider = kv.Key,
@@ -711,6 +728,7 @@ public class GetOverviewStatsController(
         }
 
         return byProvider
+            .Where(kv => IsConfiguredMetricsKey(kv.Key, labelsByMetricsKey))
             .Select(kv => new GetOverviewStatsResponse.ProviderRow
             {
                 Provider = kv.Key,

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
@@ -1,0 +1,87 @@
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
+using NzbWebDAV.Database.Models.Metrics;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetOverviewStatsProviderFilterTests
+{
+    private static readonly string ConfiguredKey = Guid.NewGuid().ToString("N");
+    private static readonly string DeletedKey = Guid.NewGuid().ToString("N");
+
+    private static readonly IReadOnlyDictionary<string, string?> Labels =
+        new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [ConfiguredKey] = "Primary",
+        };
+
+    [Fact]
+    public void IsConfiguredMetricsKey_OnlyMatchesLabelMap()
+    {
+        Assert.True(GetOverviewStatsController.IsConfiguredMetricsKey(ConfiguredKey, Labels));
+        Assert.False(GetOverviewStatsController.IsConfiguredMetricsKey(DeletedKey, Labels));
+    }
+
+    [Fact]
+    public void BuildProvidersFromMinutes_OmitsDeletedProviderKeys()
+    {
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var windowStart = nowMs - 60_000;
+        var minutes = new[]
+        {
+            (windowStart, ConfiguredKey, 10L, 1000L, 0L, 0L, 100L),
+            (windowStart, DeletedKey, 50L, 5000L, 1L, 2L, 500L),
+        };
+
+        var rows = GetOverviewStatsController.BuildProvidersFromMinutes(
+            minutes,
+            windowStart,
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour,
+            Labels);
+
+        Assert.Single(rows);
+        Assert.Equal(ConfiguredKey, rows[0].Provider);
+        Assert.Equal("Primary", rows[0].Nickname);
+        Assert.Equal(10, rows[0].Articles);
+    }
+
+    [Fact]
+    public void BuildFailover_OmitsDeletedProvidersFromListsButKeepsAggregateTotals()
+    {
+        var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var rescues = new[]
+        {
+            (at, ConfiguredKey, 3L),
+            (at, DeletedKey, 7L),
+        };
+        var misses = new[]
+        {
+            (ConfiguredKey, SegmentFetch.FetchStatus.Missing, 2L),
+            (DeletedKey, SegmentFetch.FetchStatus.Timeout, 4L),
+        };
+
+        var block = GetOverviewStatsController.BuildFailover(
+            rescues,
+            misses,
+            totalArticles: 100,
+            readSessions: 5,
+            readsSaved: 2,
+            previousSaves: 1,
+            chartBucketSize: 60_000,
+            Labels);
+
+        Assert.Equal(10, block.ArticlesRecovered);
+        Assert.Equal(6, block.SegmentsCovered);
+
+        Assert.Single(block.RescuedBy);
+        Assert.Equal(ConfiguredKey, block.RescuedBy[0].Provider);
+        Assert.Equal("Primary", block.RescuedBy[0].Nickname);
+        Assert.Equal(3, block.RescuedBy[0].Saves);
+
+        Assert.Single(block.RescuedFrom);
+        Assert.Equal(ConfiguredKey, block.RescuedFrom[0].Provider);
+        Assert.Equal(2, block.RescuedFrom[0].Misses);
+
+        Assert.All(block.Buckets, b => Assert.Single(b.Counts));
+        Assert.Equal(3, block.Buckets.Sum(b => b.Counts.Sum()));
+    }
+}


### PR DESCRIPTION
## Summary
- Overview Providers scoreboard and failover lists now only include metrics keys present in the current Usenet provider config.
- Orphaned rollups from already-deleted providers stop showing as raw ProviderId GUIDs after upgrade (no DB purge required).
- Aggregate totals (throughput, lifetime, failover article counts) still include historical contribution from deleted providers.

## Test plan
- [x] Unit tests: configured key kept, deleted key omitted; failover lists filtered while aggregates preserved
- [ ] Delete a provider in Settings → Usenet, save, open Overview: GUID row gone from Providers table
- [ ] Failover panel no longer lists deleted provider GUIDs
- [ ] Throughput / lifetime tiles still look sane after delete