### PR TITLE
fix(auth): invalidate webdav sessions when credentials change

### DIFF
--- a/backend/Auth/ServiceCollectionAuthExtensions.cs
+++ b/backend/Auth/ServiceCollectionAuthExtensions.cs
@@ -31,6 +31,12 @@ public static class ServiceCollectionAuthExtensions
         if (WebApplicationAuthExtensions.IsWebdavAuthDisabled())
             return services;
 
+        // Invalidate in-memory credential cache when WebDAV credentials change.
+        // Basic-auth clients resend Authorization each request; the memory cache
+        // (HMAC-keyed including password hash) already makes stale entries unreachable,
+        // but clearing keeps the invariant explicit and frees memory.
+        configManager.OnConfigChanged += OnWebdavCredentialsChanged;
+
         // otherwise configure basic auth
         services
             .AddDataProtection()
@@ -40,13 +46,41 @@ public static class ServiceCollectionAuthExtensions
             .AddBasicAuthentication(opts =>
             {
                 opts.AllowInsecureProtocol = true;
-                opts.CacheCookieName = "nzb-webdav-backend";
-                opts.CacheCookieExpiration = TimeSpan.FromHours(1);
+                // Disable NWebDav's cookie-based auth cache. Once issued, that cookie
+                // authenticates without re-running OnValidateCredentials until expiry,
+                // so password changes would otherwise leave a residual session window.
+                // The VerifiedCredentials memory cache already skips PBKDF2 on repeats.
+                opts.CacheCookieName = string.Empty;
+                opts.CacheCookieExpiration = TimeSpan.Zero;
                 opts.Events.OnValidateCredentials = (ValidateCredentialsContext context) =>
                     ValidateCredentials(context, configManager);
             });
 
         return services;
+    }
+
+    internal static void OnWebdavCredentialsChanged(object? sender, ConfigManager.ConfigEventArgs e)
+    {
+        if (e.ChangedConfig.ContainsKey(ConfigKeys.WebdavUser)
+            || e.ChangedConfig.ContainsKey(ConfigKeys.WebdavPass))
+        {
+            ClearVerifiedCredentials();
+        }
+    }
+
+    internal static void ClearVerifiedCredentials() => VerifiedCredentials.Clear();
+
+    internal static bool HasCachedCredential(string cacheKey) =>
+        VerifiedCredentials.TryGetValue(cacheKey, out _);
+
+    /// <summary>
+    /// Test helper: insert a fake verified-credential entry for a known cache key.
+    /// </summary>
+    internal static void SeedVerifiedCredential(string cacheKey)
+    {
+        VerifiedCredentials.Set(cacheKey, true, new MemoryCacheEntryOptions()
+            .SetSize(1)
+            .SetSlidingExpiration(TimeSpan.FromMinutes(5)));
     }
 
     private static Task ValidateCredentials(ValidateCredentialsContext context, ConfigManager configManager)

--- a/tests/NzbWebDAV.Tests/Auth/WebdavCredentialCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Auth/WebdavCredentialCacheTests.cs
@@ -1,0 +1,48 @@
+using NzbWebDAV.Auth;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Auth;
+
+public class WebdavCredentialCacheTests
+{
+    [Fact]
+    public void ClearVerifiedCredentials_RemovesCachedEntries()
+    {
+        const string key = "unit-test-credential-cache-key";
+        ServiceCollectionAuthExtensions.SeedVerifiedCredential(key);
+        Assert.True(ServiceCollectionAuthExtensions.HasCachedCredential(key));
+
+        ServiceCollectionAuthExtensions.ClearVerifiedCredentials();
+
+        Assert.False(ServiceCollectionAuthExtensions.HasCachedCredential(key));
+    }
+
+    [Fact]
+    public void OnWebdavCredentialsChanged_ClearsCacheWhenPasswordChanges()
+    {
+        const string key = "unit-test-credential-cache-key-pass";
+        ServiceCollectionAuthExtensions.SeedVerifiedCredential(key);
+        Assert.True(ServiceCollectionAuthExtensions.HasCachedCredential(key));
+
+        var config = new ConfigManager();
+        config.OnConfigChanged += ServiceCollectionAuthExtensions.OnWebdavCredentialsChanged;
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.WebdavPass, ConfigValue = "new-hash" }]);
+
+        Assert.False(ServiceCollectionAuthExtensions.HasCachedCredential(key));
+    }
+
+    [Fact]
+    public void OnWebdavCredentialsChanged_IgnoresUnrelatedConfigChanges()
+    {
+        const string key = "unit-test-credential-cache-key-unrelated";
+        ServiceCollectionAuthExtensions.SeedVerifiedCredential(key);
+
+        var config = new ConfigManager();
+        config.OnConfigChanged += ServiceCollectionAuthExtensions.OnWebdavCredentialsChanged;
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = "10" }]);
+
+        Assert.True(ServiceCollectionAuthExtensions.HasCachedCredential(key));
+        ServiceCollectionAuthExtensions.ClearVerifiedCredentials();
+    }
+}


### PR DESCRIPTION
## Summary
- Disable NWebDav's basic-auth cookie cache (`CacheCookieName` empty + `CacheCookieExpiration = Zero`), which previously left clients authenticated for up to 1 hour after a password change without re-running `OnValidateCredentials`.
- Clear the in-memory `VerifiedCredentials` cache when `webdav.user` or `webdav.pass` change.
- DataProtection key rotation is not needed once the cookie cache is gone; Basic-auth clients resend `Authorization` each request and the HMAC-keyed memory cache already skips PBKDF2 on repeats.

Closes #90

## Test plan
- [x] Unit tests: cache clear on password change; unrelated config ignored
- [ ] Manual: map WebDAV client, change password in settings, next request returns 401 until re-auth with new password