### PR TITLE
fix(queue): dedupe and order NZB segments by number at parse time

### DIFF
--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -91,6 +91,7 @@ public class NzbDocument
             }
         }
 
+        file.CanonicalizeSegments();
         return file;
     }
 
@@ -107,9 +108,11 @@ public class NzbDocument
             if (reader is { NodeType: XmlNodeType.Element, Name: "segment" })
             {
                 var bytesAttr = reader.GetAttribute("bytes");
+                var numberAttr = reader.GetAttribute("number");
                 var segment = new NzbSegment
                 {
                     Bytes = long.TryParse(bytesAttr, out var bytes) ? bytes : 0,
+                    Number = int.TryParse(numberAttr, out var number) ? number : null,
                     MessageId = (await reader.ReadElementContentAsStringAsync().ConfigureAwait(false)).Trim()
                 };
                 file.Segments.Add(segment);

--- a/backend/Models/Nzb/NzbFile.cs
+++ b/backend/Models/Nzb/NzbFile.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Serilog;
 
 namespace NzbWebDAV.Models.Nzb;
 
@@ -6,6 +7,73 @@ public class NzbFile
 {
     public required string Subject { get; init; }
     public List<NzbSegment> Segments { get; } = [];
+
+    /// <summary>
+    /// Sort by segment number (when all present) and drop duplicates so every
+    /// consumer sees one logical segment per ordinal / message-id.
+    /// </summary>
+    public void CanonicalizeSegments()
+    {
+        if (Segments.Count <= 1) return;
+
+        var allNumbered = Segments.All(s => s.Number is not null);
+        if (allNumbered)
+        {
+            var ordered = Segments
+                .OrderBy(s => s.Number!.Value)
+                .ToList();
+
+            var deduped = new List<NzbSegment>(ordered.Count);
+            var duplicateCount = 0;
+            int? lastNumber = null;
+            foreach (var segment in ordered)
+            {
+                if (lastNumber == segment.Number)
+                {
+                    duplicateCount++;
+                    continue;
+                }
+
+                deduped.Add(segment);
+                lastNumber = segment.Number;
+            }
+
+            if (duplicateCount > 0)
+            {
+                Log.Warning(
+                    "NZB file {Subject} contained {Count} duplicate segment(s); deduplicated",
+                    Subject, duplicateCount);
+            }
+
+            Segments.Clear();
+            Segments.AddRange(deduped);
+            return;
+        }
+
+        // Numbers missing/partial: drop exact duplicate MessageIds only.
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        var kept = new List<NzbSegment>(Segments.Count);
+        var droppedIds = 0;
+        foreach (var segment in Segments)
+        {
+            if (!seenIds.Add(segment.MessageId))
+            {
+                droppedIds++;
+                continue;
+            }
+
+            kept.Add(segment);
+        }
+
+        if (droppedIds > 0)
+        {
+            Log.Warning(
+                "NZB file {Subject} contained {Count} duplicate segment(s); deduplicated",
+                Subject, droppedIds);
+            Segments.Clear();
+            Segments.AddRange(kept);
+        }
+    }
 
     public string[] GetSegmentIds()
     {

--- a/backend/Models/Nzb/NzbSegment.cs
+++ b/backend/Models/Nzb/NzbSegment.cs
@@ -6,5 +6,9 @@ public class NzbSegment
 {
     public required long Bytes { get; init; }
     public required string MessageId { get; init; }
+    /// <summary>
+    /// NZB segment ordinal from the <c>number</c> attribute, when present.
+    /// </summary>
+    public int? Number { get; init; }
     public LongRange? ByteRange { get; set; }
 }

--- a/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
+++ b/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 
 namespace NzbWebDAV.Tests.Models;
@@ -91,5 +92,91 @@ public class NzbDocumentTests
 
         Assert.Equal("Could not parse the nzb document (malformed nzb)", exception.Message);
         Assert.IsType<System.Xml.XmlException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task LoadAsync_DedupesDuplicateSegmentNumbersKeepingFirst()
+    {
+        const string xml = """
+            <nzb><file subject="dup"><segments>
+              <segment bytes="10" number="1">a@example</segment>
+              <segment bytes="20" number="2">b-first@example</segment>
+              <segment bytes="21" number="2">b-second@example</segment>
+              <segment bytes="30" number="3">c@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        var document = await NzbDocument.LoadAsync(stream);
+        var file = Assert.Single(document.Files);
+
+        Assert.Equal(3, file.Segments.Count);
+        Assert.Equal(["a@example", "b-first@example", "c@example"], file.GetSegmentIds());
+        Assert.Equal([1, 2, 3], file.Segments.Select(s => s.Number!.Value).ToArray());
+    }
+
+    [Fact]
+    public async Task LoadAsync_SortsSegmentsByNumber()
+    {
+        const string xml = """
+            <nzb><file subject="shuffled"><segments>
+              <segment bytes="30" number="3">c@example</segment>
+              <segment bytes="10" number="1">a@example</segment>
+              <segment bytes="20" number="2">b@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        var document = await NzbDocument.LoadAsync(stream);
+
+        Assert.Equal(["a@example", "b@example", "c@example"],
+            Assert.Single(document.Files).GetSegmentIds());
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithoutNumbers_DedupesDuplicateMessageIds()
+    {
+        const string xml = """
+            <nzb><file subject="ids"><segments>
+              <segment bytes="10">a@example</segment>
+              <segment bytes="20">b@example</segment>
+              <segment bytes="20">b@example</segment>
+              <segment bytes="30">c@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        var document = await NzbDocument.LoadAsync(stream);
+
+        Assert.Equal(["a@example", "b@example", "c@example"],
+            Assert.Single(document.Files).GetSegmentIds());
+    }
+
+    [Fact]
+    public async Task GetSegmentByteRanges_RemainsContiguousAfterDedup()
+    {
+        const string xml = """
+            <nzb><file subject="ranges"><segments>
+              <segment bytes="100" number="1">a@example</segment>
+              <segment bytes="100" number="2">b-dup1@example</segment>
+              <segment bytes="100" number="2">b-dup2@example</segment>
+              <segment bytes="100" number="3">c@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var file = Assert.Single((await NzbDocument.LoadAsync(stream)).Files);
+
+        file.Segments[0].ByteRange = new LongRange(0, 100);
+        file.Segments[^1].ByteRange = new LongRange(200, 300);
+
+        var ranges = file.GetSegmentByteRanges();
+        Assert.NotNull(ranges);
+        Assert.Equal(3, ranges.Length);
+        Assert.Equal(0, ranges[0].StartInclusive);
+        Assert.Equal(100, ranges[0].EndExclusive);
+        Assert.Equal(100, ranges[1].StartInclusive);
+        Assert.Equal(200, ranges[1].EndExclusive);
+        Assert.Equal(200, ranges[2].StartInclusive);
+        Assert.Equal(300, ranges[2].EndExclusive);
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `Number` on `NzbSegment` and parse the NZB `number` attribute.
- After each file is parsed, canonicalize segments: sort by number when all present (stable LINQ `OrderBy`), keep first of duplicate ordinals; otherwise drop duplicate `MessageId`s only.
- Ensures streaming, health checks, and byte-range inference all see the same list.

**Follow-up (not in this PR):** ordered fallback candidates when a primary duplicate article is missing.

Closes #113

## Test plan
- [x] Duplicate numbers → keep first, order 1,2,3
- [x] Shuffled document order → sorted by number
- [x] No numbers + duplicate MessageId → deduped
- [x] Byte-range inference contiguous after dedup
- [x] Existing well-formed NZB fixtures unchanged