### PR TITLE
fix(queue): accept split-RAR sets with colliding header volume numbers

### DIFF
--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Queue.FileProcessors;
 using NzbWebDAV.Utils;
+using Serilog;
 
 namespace NzbWebDAV.Queue.FileAggregators;
 
@@ -135,25 +136,118 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
         }
     }
 
+    internal enum PartNumberSource
+    {
+        Header,
+        Filename,
+        Mixed
+    }
+
+    internal static PartNumberSource SelectPartNumberSource(
+        List<RarProcessor.StoredFileSegment> storedFileSegments)
+    {
+        var headerNumbers = storedFileSegments
+            .Select(x => x.PartNumber.PartNumberFromHeader)
+            .Where(n => n is >= 0)
+            .Select(n => n!.Value)
+            .ToList();
+        var filenameNumbers = storedFileSegments
+            .Select(x => x.PartNumber.PartNumberFromFilename)
+            .Where(n => n is >= 0)
+            .Select(n => n!.Value)
+            .ToList();
+
+        var headerPresentForAll = storedFileSegments.All(x => x.PartNumber.PartNumberFromHeader is >= 0);
+        var filenamePresentForAll = storedFileSegments.All(x => x.PartNumber.PartNumberFromFilename is >= 0);
+        var headerDistinct = headerNumbers.Count > 0
+                             && headerNumbers.Distinct().Count() == headerNumbers.Count;
+        var filenameDistinct = filenameNumbers.Count > 0
+                               && filenameNumbers.Distinct().Count() == filenameNumbers.Count;
+
+        if (headerPresentForAll && headerDistinct)
+            return PartNumberSource.Header;
+
+        if (filenamePresentForAll && filenameDistinct)
+        {
+            if (headerNumbers.Count > 0 && !headerDistinct)
+            {
+                Log.Debug(
+                    "RAR header volume numbers are not distinct; using filename-derived part numbers instead");
+            }
+
+            return PartNumberSource.Filename;
+        }
+
+        return PartNumberSource.Mixed;
+    }
+
     internal static RarProcessor.StoredFileSegment[] SortByPartNumber(
         List<RarProcessor.StoredFileSegment> storedFileSegments)
     {
-        // Find delta between part number from headers and filenames.
-        var delta = storedFileSegments
-            .Select(x => x.PartNumber)
-            .Where(x => x is { PartNumberFromHeader: >= 0, PartNumberFromFilename: >= 0 })
-            .Select(x => x.PartNumberFromHeader - x.PartNumberFromFilename)
-            .GroupBy(x => x)
-            .MaxBy(x => x.Count())?.Key;
+        var source = SelectPartNumberSource(storedFileSegments);
 
-        // Ensure there are no duplicate part numbers.
-        var allPartNumbers = storedFileSegments.Select(x => GetNormalizedPartNumber(x.PartNumber, delta));
-        ValidatePartNumbers(allPartNumbers);
+        int? delta = null;
+        if (source == PartNumberSource.Mixed)
+        {
+            // Find delta between part number from headers and filenames.
+            delta = storedFileSegments
+                .Select(x => x.PartNumber)
+                .Where(x => x is { PartNumberFromHeader: >= 0, PartNumberFromFilename: >= 0 })
+                .Select(x => x.PartNumberFromHeader - x.PartNumberFromFilename)
+                .GroupBy(x => x)
+                .MaxBy(x => x.Count())?.Key;
+        }
 
-        // Sort by part numbers and return.
-        return storedFileSegments
-            .OrderBy(x => GetNormalizedPartNumber(x.PartNumber, delta))
+        var withNumbers = storedFileSegments
+            .Select(x => (Segment: x, Part: GetNormalizedPartNumber(x.PartNumber, delta, source)))
+            .ToList();
+
+        // Drop identical physical duplicates before uniqueness validation.
+        var deduped = DeduplicateIdenticalVolumes(withNumbers);
+
+        ValidatePartNumbers(deduped.Select(x => x.Part));
+
+        return deduped
+            .OrderBy(x => x.Part)
+            .Select(x => x.Segment)
             .ToArray();
+    }
+
+    private static List<(RarProcessor.StoredFileSegment Segment, int Part)> DeduplicateIdenticalVolumes(
+        List<(RarProcessor.StoredFileSegment Segment, int Part)> parts)
+    {
+        var result = new List<(RarProcessor.StoredFileSegment Segment, int Part)>();
+        foreach (var group in parts.GroupBy(x => x.Part))
+        {
+            var entries = group.ToList();
+            if (entries.Count == 1)
+            {
+                result.Add(entries[0]);
+                continue;
+            }
+
+            var first = entries[0].Segment;
+            var allIdentical = entries.All(e =>
+                e.Segment.PartSize == first.PartSize
+                && e.Segment.ByteRangeWithinPart == first.ByteRangeWithinPart
+                && e.Segment.PathWithinArchive == first.PathWithinArchive
+                && e.Segment.FileUncompressedSize == first.FileUncompressedSize);
+
+            if (allIdentical)
+            {
+                Log.Warning(
+                    "Dropping duplicate RAR volume {Part} for {Archive}",
+                    group.Key, first.ArchiveName);
+                result.Add(entries[0]);
+            }
+            else
+            {
+                // Leave ambiguous group intact so ValidatePartNumbers throws.
+                result.AddRange(entries);
+            }
+        }
+
+        return result;
     }
 
     internal static void ValidateVolumes(List<RarProcessor.StoredFileSegment> storedFileSegments)
@@ -177,10 +271,22 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             throw new InvalidDataException("Rar archive has duplicate volume numbers.");
     }
 
-    private static int GetNormalizedPartNumber(RarProcessor.PartNumber partNumber, int? delta)
+    private static int GetNormalizedPartNumber(
+        RarProcessor.PartNumber partNumber, int? delta, PartNumberSource source)
     {
-        if (partNumber.PartNumberFromHeader >= 0) return partNumber.PartNumberFromHeader!.Value;
-        if (partNumber.PartNumberFromFilename >= 0) return partNumber.PartNumberFromFilename!.Value + (delta ?? 0);
-        return -1;
+        return source switch
+        {
+            PartNumberSource.Header when partNumber.PartNumberFromHeader is >= 0 or -1
+                => partNumber.PartNumberFromHeader!.Value,
+            PartNumberSource.Filename when partNumber.PartNumberFromFilename is >= 0 or -1
+                => partNumber.PartNumberFromFilename!.Value,
+            PartNumberSource.Mixed when partNumber.PartNumberFromHeader >= 0
+                => partNumber.PartNumberFromHeader!.Value,
+            PartNumberSource.Mixed when partNumber.PartNumberFromFilename >= 0
+                => partNumber.PartNumberFromFilename!.Value + (delta ?? 0),
+            _ when partNumber.PartNumberFromHeader is -1 => -1,
+            _ when partNumber.PartNumberFromFilename is -1 => -1,
+            _ => -1
+        };
     }
 }

--- a/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
@@ -19,13 +19,70 @@ public class RarAggregatorTests
     }
 
     [Fact]
-    public void SortByPartNumber_RejectsDuplicateNormalizedParts()
+    public void SortByPartNumber_RejectsAmbiguousDuplicateParts()
     {
         var first = Segment(headerPart: 0, filenamePart: 1, start: 0, length: 5);
         var duplicate = Segment(headerPart: 0, filenamePart: 1, start: 5, length: 5);
 
         Assert.Throws<InvalidDataException>(
             () => RarAggregator.SortByPartNumber([first, duplicate]));
+    }
+
+    [Fact]
+    public void SortByPartNumber_UsesFilenameWhenHeadersCollide()
+    {
+        var parts = Enumerable.Range(1, 5)
+            .Select(i => Segment(headerPart: 0, filenamePart: i, start: (i - 1) * 2, length: 2))
+            .ToList();
+
+        var sorted = RarAggregator.SortByPartNumber(parts);
+
+        Assert.Equal(5, sorted.Length);
+        Assert.Equal([1, 2, 3, 4, 5], sorted.Select(x => x.PartNumber.PartNumberFromFilename).ToArray());
+        Assert.Equal(RarAggregator.PartNumberSource.Filename,
+            RarAggregator.SelectPartNumberSource(parts));
+    }
+
+    [Fact]
+    public void SortByPartNumber_ClassicSetWithFirstVolumeMarker()
+    {
+        var first = SegmentNullable(headerPart: -1, filenamePart: -1, start: 0, length: 2);
+        var r00 = SegmentNullable(headerPart: null, filenamePart: 0, start: 2, length: 2);
+        var r01 = SegmentNullable(headerPart: null, filenamePart: 1, start: 4, length: 2);
+        var r02 = SegmentNullable(headerPart: null, filenamePart: 2, start: 6, length: 2);
+        var r03 = SegmentNullable(headerPart: null, filenamePart: 3, start: 8, length: 2);
+
+        var sorted = RarAggregator.SortByPartNumber([r02, first, r03, r00, r01]);
+
+        Assert.Equal([first, r00, r01, r02, r03], sorted);
+    }
+
+    [Fact]
+    public void SortByPartNumber_DedupesIdenticalDuplicateVolumes()
+    {
+        var first = Segment(headerPart: 0, filenamePart: 1, start: 0, length: 5);
+        var duplicate = Segment(headerPart: 0, filenamePart: 1, start: 0, length: 5);
+        var second = Segment(headerPart: 1, filenamePart: 2, start: 5, length: 5);
+
+        var sorted = RarAggregator.SortByPartNumber([first, duplicate, second]);
+
+        Assert.Equal(2, sorted.Length);
+        Assert.Equal([first, second], sorted);
+    }
+
+    [Fact]
+    public void SortByPartNumber_DistinctHeadersUnchanged()
+    {
+        var parts = Enumerable.Range(0, 3)
+            .Select(i => Segment(headerPart: i, filenamePart: i + 1, start: i * 3, length: 3))
+            .Reverse()
+            .ToList();
+
+        var sorted = RarAggregator.SortByPartNumber(parts);
+
+        Assert.Equal([0, 1, 2], sorted.Select(x => x.PartNumber.PartNumberFromHeader).ToArray());
+        Assert.Equal(RarAggregator.PartNumberSource.Header,
+            RarAggregator.SelectPartNumberSource(parts));
     }
 
     [Fact]
@@ -51,6 +108,10 @@ public class RarAggregatorTests
 
     private static RarProcessor.StoredFileSegment Segment(
         int headerPart, int filenamePart, long start, long length)
+        => SegmentNullable(headerPart, filenamePart, start, length);
+
+    private static RarProcessor.StoredFileSegment SegmentNullable(
+        int? headerPart, int? filenamePart, long start, long length)
     {
         return new RarProcessor.StoredFileSegment
         {


### PR DESCRIPTION
## Summary
- Choose a part-number source for the whole archive: distinct headers → Header; else distinct filenames → Filename (ignore untrustworthy headers); else Mixed with existing delta majority-vote.
- Deduplicate identical physical volumes (same size/range/path) before uniqueness validation; still throw on genuine ambiguous collisions.
- `ValidateVolumes` size-sum check unchanged.

Closes #144

## Test plan
- [x] All headers `0` + distinct `.partNN` → sorts by filename
- [x] Classic `.rar` + `.r00`… with null headers → sorts, no throw
- [x] Identical duplicate volumes → deduped
- [x] Same normalized number, different byte ranges → still throws
- [x] Distinct headers → unchanged order