### PR TITLE
fix(webdav): sanitize Dav path components for Windows-invalid names

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -50,6 +50,7 @@ public static class ConfigKeys
     public const string WebdavPreviewPar2Files = "webdav.preview-par2-files";
     public const string WebdavShowHiddenFiles = "webdav.show-hidden-files";
     public const string WebdavUser = "webdav.user";
+    public const string WebdavWindowsSafePaths = "webdav.windows-safe-paths";
 
     // media / repair / arr
     public const string MediaLibraryDir = "media.library-dir";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -38,6 +38,7 @@ public class ConfigManager
             }
         }
         lock (_excludeLock) { _compiledExcludeCache = null; }
+        SyncPathSanitizer();
     }
 
     private string? GetConfigValue(string configName)
@@ -129,8 +130,13 @@ public class ConfigManager
         }
 
         var changedConfig = configItems.ToDictionary(x => x.ConfigName, x => x.ConfigValue);
+        if (changedConfig.ContainsKey(ConfigKeys.WebdavWindowsSafePaths))
+            SyncPathSanitizer();
         OnConfigChanged?.Invoke(this, new ConfigEventArgs { ChangedConfig = changedConfig });
     }
+
+    private void SyncPathSanitizer() =>
+        PathSanitizer.SetWindowsSafePathsEnabled(IsWindowsSafePathsEnabled());
 
     /// <summary>
     /// Validates incoming config values, failing fast for anything that would otherwise throw
@@ -204,6 +210,7 @@ public class ConfigManager
                 case ConfigKeys.WebdavShowHiddenFiles:
                 case ConfigKeys.WebdavEnforceReadonly:
                 case ConfigKeys.WebdavPreviewPar2Files:
+                case ConfigKeys.WebdavWindowsSafePaths:
                 case ConfigKeys.UsenetMaxDownloadConnectionsPerStream:
                 case ConfigKeys.UsenetPipeliningEnabled:
                 case ConfigKeys.UsenetCascadeEnabled:
@@ -475,6 +482,13 @@ public class ConfigManager
         var defaultValue = true;
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavEnforceReadonly));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
+    }
+
+    public bool IsWindowsSafePathsEnabled()
+    {
+        var defaultValue = true;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WebdavWindowsSafePaths));
+        return configValue != null ? bool.Parse(configValue) : defaultValue;
     }
 
     public HashSet<string> GetEnsureArticleExistenceCategories()

--- a/backend/Queue/FileAggregators/BaseAggregator.cs
+++ b/backend/Queue/FileAggregators/BaseAggregator.cs
@@ -1,6 +1,7 @@
 ﻿using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Queue.FileAggregators;
 
@@ -25,6 +26,7 @@ public abstract class BaseAggregator
     {
         var pathSegments = relativePath
             .Split(DirectorySeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Select(segment => PathSanitizer.SanitizeComponent(segment))
             .ToArray();
         var parentDirectory = MountDirectory;
         var pathKey = "";
@@ -46,7 +48,7 @@ public abstract class BaseAggregator
         var directory = DavItem.New(
             id: Guid.NewGuid(),
             parent: parentDirectory,
-            name: directoryName,
+            name: PathSanitizer.SanitizeComponent(directoryName),
             fileSize: null,
             type: DavItem.ItemType.Directory,
             subType: DavItem.ItemSubType.Directory,
@@ -59,4 +61,7 @@ public abstract class BaseAggregator
         DBClient.Ctx.Items.Add(directory);
         return directory;
     }
+
+    protected static string SanitizeDavName(string name) =>
+        PathSanitizer.SanitizeComponent(name);
 }

--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -17,7 +17,7 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
             if (processorResult is not FileProcessor.Result result) continue;
             if (result.FileName == "") continue; // skip files whose name we can't determine
             var parentDirectory = EnsureParentDirectory(result.FileName);
-            var name = Path.GetFileName(result.FileName);
+            var name = SanitizeDavName(Path.GetFileName(result.FileName));
 
             var davNzbFile = new DavNzbFile()
             {

--- a/backend/Queue/FileAggregators/MultipartMkvAggregator.cs
+++ b/backend/Queue/FileAggregators/MultipartMkvAggregator.cs
@@ -28,7 +28,7 @@ public class MultipartMkvAggregator(
         {
             var fileParts = multipartMkvFile.Parts;
             var parentDirectory = MountDirectory;
-            var name = multipartMkvFile.Filename;
+            var name = SanitizeDavName(multipartMkvFile.Filename);
 
             var davMultipartFile = new DavMultipartFile()
             {

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -30,12 +30,12 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
     {
         var pathInArchive = result.PathInArchive;
         var parentDirectory = EnsureParentDirectory(pathInArchive);
-        var name = Path.GetFileName(pathInArchive);
+        var name = SanitizeDavName(Path.GetFileName(pathInArchive));
 
         // Mirror the eager path's obfuscation rename: when the archive
         // contains a single obfuscated file, name it after the mount folder.
         if (ObfuscationUtil.IsProbablyObfuscated(name))
-            name = mountDirectory.Name + Path.GetExtension(name);
+            name = SanitizeDavName(mountDirectory.Name + Path.GetExtension(name));
 
         var davMultipartFile = new DavMultipartFile
         {
@@ -93,12 +93,12 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             var aesParams = fileParts.Select(x => x.AesParams).FirstOrDefault(x => x != null);
             var fileSize = aesParams?.DecodedSize ?? fileParts.Sum(x => x.ByteRangeWithinPart.Count);
             var parentDirectory = EnsureParentDirectory(pathWithinArchive);
-            var name = Path.GetFileName(pathWithinArchive);
+            var name = SanitizeDavName(Path.GetFileName(pathWithinArchive));
 
             // If there is only one file in the archive and the file-name is obfuscated,
             // then rename the file to the same name as the containing mount directory.
             if (archiveFiles.Count == 1 && ObfuscationUtil.IsProbablyObfuscated(name))
-                name = mountDirectory.Name + Path.GetExtension(name);
+                name = SanitizeDavName(mountDirectory.Name + Path.GetExtension(name));
 
             var davMultipartFile = new DavMultipartFile()
             {

--- a/backend/Queue/FileAggregators/SevenZipAggregator.cs
+++ b/backend/Queue/FileAggregators/SevenZipAggregator.cs
@@ -31,7 +31,7 @@ public class SevenZipAggregator(
             var pathWithinArchive = sevenZipFile.PathWithinArchive;
             var davMultipartFileMeta = sevenZipFile.DavMultipartFileMeta;
             var parentDirectory = EnsureParentDirectory(pathWithinArchive);
-            var name = Path.GetFileName(pathWithinArchive);
+            var name = SanitizeDavName(Path.GetFileName(pathWithinArchive));
 
             // If there is only one file in the archive and the file-name is obfuscated,
             // then rename the file to the same name as the containing mount directory.

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -54,11 +54,12 @@ public partial class FilenameUtil
     public static string GetJobName(string filename)
     {
         var passMatch = PasswordRegex.Match(filename);
-        return Path.GetFileNameWithoutExtension(
+        var jobName = Path.GetFileNameWithoutExtension(
             passMatch.Success ?
             filename.Replace(passMatch.Groups["rm"].Value, "") :
             filename
         );
+        return PathSanitizer.SanitizeComponentWithLog(jobName);
     }
 
     public static string? GetNzbPassword(string filename)

--- a/backend/Utils/PathSanitizer.cs
+++ b/backend/Utils/PathSanitizer.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using Serilog;
+
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Sanitizes Dav path components for Windows-invalid names. Uses an explicit
+/// Windows character list — never <see cref="Path.GetInvalidFileNameChars()"/>
+/// (host-OS dependent; Linux returns only '/' and NUL).
+/// </summary>
+public static class PathSanitizer
+{
+    private static readonly char[] WindowsInvalidChars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+    private static readonly HashSet<string> WindowsReservedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    };
+
+    private static volatile bool _windowsSafePathsEnabled = true;
+
+    public static void SetWindowsSafePathsEnabled(bool enabled) =>
+        _windowsSafePathsEnabled = enabled;
+
+    public static bool IsWindowsSafePathsEnabled => _windowsSafePathsEnabled;
+
+    public static string SanitizeComponent(string name, bool? windowsSafe = null)
+    {
+        var enabled = windowsSafe ?? _windowsSafePathsEnabled;
+        if (string.IsNullOrEmpty(name))
+            return "untitled";
+
+        if (!enabled)
+            return SanitizeMinimal(name);
+
+        var sb = new StringBuilder(name.Length);
+        foreach (var ch in name)
+        {
+            if (ch < 0x20 || WindowsInvalidChars.Contains(ch))
+                sb.Append('_');
+            else
+                sb.Append(ch);
+        }
+
+        var sanitized = sb.ToString();
+
+        // Windows silently strips trailing dots/spaces — trim all of them.
+        sanitized = sanitized.TrimEnd('.', ' ');
+
+        if (string.IsNullOrEmpty(sanitized))
+            return "untitled";
+
+        var extension = Path.GetExtension(sanitized);
+        var stem = Path.GetFileNameWithoutExtension(sanitized);
+        if (WindowsReservedNames.Contains(stem))
+            sanitized = "_" + sanitized;
+
+        if (sanitized.Length > 240)
+        {
+            if (extension.Length > 0 && extension.Length < 240)
+            {
+                var maxStem = 240 - extension.Length;
+                sanitized = sanitized[..maxStem].TrimEnd('.', ' ') + extension;
+            }
+            else
+            {
+                sanitized = sanitized[..240].TrimEnd('.', ' ');
+            }
+
+            if (string.IsNullOrEmpty(sanitized))
+                return "untitled";
+        }
+
+        return sanitized;
+    }
+
+    /// <summary>
+    /// Minimal sanitization when Windows-safe paths are disabled: only '/' and NUL.
+    /// </summary>
+    private static string SanitizeMinimal(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var ch in name)
+        {
+            if (ch is '/' or '\0')
+                sb.Append('_');
+            else
+                sb.Append(ch);
+        }
+
+        var sanitized = sb.ToString();
+        return string.IsNullOrEmpty(sanitized) ? "untitled" : sanitized;
+    }
+
+    public static string SanitizeComponentWithLog(string original)
+    {
+        var sanitized = SanitizeComponent(original);
+        if (!string.Equals(original, sanitized, StringComparison.Ordinal))
+        {
+            Log.Information("Sanitized path component {Original} -> {Sanitized}", original, sanitized);
+        }
+
+        return sanitized;
+    }
+}

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -57,6 +57,7 @@ const defaultConfig = {
     "webdav.show-hidden-files": "false",
     "webdav.enforce-readonly": "true",
     "webdav.preview-par2-files": "false",
+    "webdav.windows-safe-paths": "true",
     "rclone.rc-enabled": "false",
     "rclone.host": "",
     "rclone.user": "",

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -241,6 +241,22 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     When enabled, par2 files will be rendered as text files on the Dav Explorer page, displaying all File-Descriptor entries.
                 </p>
             </div>
+            <hr />
+            <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <Checkbox
+                        id="windows-safe-paths-checkbox"
+                        aria-describedby="windows-safe-paths-help"
+                        checked={config["webdav.windows-safe-paths"] !== "false"}
+                        onChange={e => setNewConfig({ ...config, "webdav.windows-safe-paths": String(e.target.checked) })} />
+                    <span>Sanitize paths for Windows</span>
+                </label>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="windows-safe-paths-help">
+                    Replace characters that are invalid on Windows (<code>{`<>:"/\\|?*`}</code>), trim trailing
+                    dots/spaces, and prefix reserved device names. Recommended when using Windows WebDAV
+                    clients or rclone on Windows. Applies to newly mounted content only.
+                </p>
+            </div>
         </SettingsPage>
     );
 }
@@ -258,6 +274,7 @@ export function isWebdavSettingsUpdated(config: Record<string, string>, newConfi
         || config["webdav.show-hidden-files"] !== newConfig["webdav.show-hidden-files"]
         || config["webdav.enforce-readonly"] !== newConfig["webdav.enforce-readonly"]
         || config["webdav.preview-par2-files"] !== newConfig["webdav.preview-par2-files"]
+        || config["webdav.windows-safe-paths"] !== newConfig["webdav.windows-safe-paths"]
         || config["usenet.segment-cache.enabled"] !== newConfig["usenet.segment-cache.enabled"]
         || config["usenet.segment-cache.path"] !== newConfig["usenet.segment-cache.path"]
         || config["usenet.segment-cache.max-gb"] !== newConfig["usenet.segment-cache.max-gb"]

--- a/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
@@ -1,0 +1,87 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class PathSanitizerTests
+{
+    public PathSanitizerTests()
+    {
+        PathSanitizer.SetWindowsSafePathsEnabled(true);
+    }
+
+    [Theory]
+    [InlineData("Show: Title?", "Show_ Title_")]
+    [InlineData("a<b>c", "a_b_c")]
+    [InlineData("file|name", "file_name")]
+    [InlineData("q*uery", "q_uery")]
+    public void SanitizeComponent_ReplacesInvalidChars(string input, string expected)
+    {
+        Assert.Equal(expected, PathSanitizer.SanitizeComponent(input));
+    }
+
+    [Fact]
+    public void SanitizeComponent_ReplacesControlChars()
+    {
+        Assert.Equal("a_b", PathSanitizer.SanitizeComponent("a\u0001b"));
+    }
+
+    [Theory]
+    [InlineData("Season 01.", "Season 01")]
+    [InlineData("name.  ", "name")]
+    [InlineData("name.. ", "name")]
+    [InlineData("Subs.", "Subs")]
+    public void SanitizeComponent_TrimsTrailingDotsAndSpaces(string input, string expected)
+    {
+        Assert.Equal(expected, PathSanitizer.SanitizeComponent(input));
+    }
+
+    [Theory]
+    [InlineData("CON", "_CON")]
+    [InlineData("con.mkv", "_con.mkv")]
+    [InlineData("LPT7.txt", "_LPT7.txt")]
+    [InlineData("nul", "_nul")]
+    public void SanitizeComponent_PrefixesReservedDeviceNames(string input, string expected)
+    {
+        Assert.Equal(expected, PathSanitizer.SanitizeComponent(input));
+    }
+
+    [Theory]
+    [InlineData("", "untitled")]
+    [InlineData("...", "untitled")]
+    [InlineData("   ", "untitled")]
+    public void SanitizeComponent_EmptyBecomesUntitled(string input, string expected)
+    {
+        Assert.Equal(expected, PathSanitizer.SanitizeComponent(input));
+    }
+
+    [Fact]
+    public void SanitizeComponent_TruncatesLongNamesPreservingExtension()
+    {
+        var stem = new string('a', 300);
+        var result = PathSanitizer.SanitizeComponent(stem + ".mkv");
+        Assert.True(result.Length <= 240);
+        Assert.EndsWith(".mkv", result);
+    }
+
+    [Fact]
+    public void SanitizeComponent_WhenDisabled_OnlyReplacesSlashAndNul()
+    {
+        PathSanitizer.SetWindowsSafePathsEnabled(false);
+        try
+        {
+            Assert.Equal("Show: Title?", PathSanitizer.SanitizeComponent("Show: Title?"));
+            Assert.Equal("a_b", PathSanitizer.SanitizeComponent("a/b"));
+            Assert.Equal("a_b", PathSanitizer.SanitizeComponent("a\0b"));
+        }
+        finally
+        {
+            PathSanitizer.SetWindowsSafePathsEnabled(true);
+        }
+    }
+
+    [Fact]
+    public void GetJobName_SanitizesWindowsInvalidCharacters()
+    {
+        Assert.Equal("Show_ Title_", FilenameUtil.GetJobName("Show: Title?.nzb"));
+    }
+}


### PR DESCRIPTION
## Summary
- New `PathSanitizer` replaces Windows-invalid chars, trims trailing `.`/spaces, prefixes reserved device names, caps component length.
- Applied at `FilenameUtil.GetJobName`, aggregator directory/file creation (`BaseAggregator` + RAR/7z/file/multipart).
- Config `webdav.windows-safe-paths` (default true) + WebDAV settings toggle; when false only `/` and NUL are replaced.
- Existing DB rows are not migrated (follow-up if needed).

Closes #131
Closes #73

## Test plan
- [x] Unit tests for invalid chars, trailing dots, reserved names, truncation, flag-off minimal mode
- [x] `GetJobName` sanitizes Windows-invalid characters
- [ ] Manual: queue NZB with `:`/`?`/trailing dot — Windows WebDAV client can list and play