### PR TITLE
fix(queue): create STRM files for all video items of a job

### DIFF
--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -8,38 +8,81 @@ using NzbWebDAV.WebDav;
 
 namespace NzbWebDAV.Queue.PostProcessors;
 
-public class CreateStrmFilesPostProcessor(ConfigManager configManager, DavDatabaseClient dbClient)
+public class CreateStrmFilesPostProcessor(
+    ConfigManager configManager,
+    DavDatabaseClient dbClient,
+    Guid historyItemId)
 {
+    private static readonly string ContentRootPrefix =
+        DavItem.ContentFolder.Path.TrimEnd('/') + "/";
+
     public async Task CreateStrmFilesAsync()
     {
-        // Add strm files to the download dir
-        var videoItems = dbClient.Ctx.ChangeTracker.Entries<DavItem>()
-            .Where(x => x.State == EntityState.Added)
-            .Select(x => x.Entity)
-            .Where(x => x.Type != DavItem.ItemType.Directory)
-            .Where(x => FilenameUtil.IsVideoFile(x.Name));
-        foreach (var videoItem in videoItems)
+        var candidates = CollectVideoItems();
+        foreach (var videoItem in candidates)
             await CreateStrmFileAsync(videoItem).ConfigureAwait(false);
     }
 
+    internal List<DavItem> CollectVideoItems()
+    {
+        var byId = new Dictionary<Guid, DavItem>();
+
+        foreach (var item in dbClient.Ctx.ChangeTracker.Entries<DavItem>()
+                     .Where(x => x.State == EntityState.Added)
+                     .Select(x => x.Entity)
+                     .Where(IsStrmCandidate))
+        {
+            byId[item.Id] = item;
+        }
+
+        foreach (var item in dbClient.Ctx.Items
+                     .Where(x => x.HistoryItemId == historyItemId
+                                 && x.Type != DavItem.ItemType.Directory)
+                     .AsEnumerable()
+                     .Where(IsStrmCandidate))
+        {
+            byId.TryAdd(item.Id, item);
+        }
+
+        return byId.Values.ToList();
+    }
+
+    private static bool IsStrmCandidate(DavItem item) =>
+        FilenameUtil.IsVideoFile(item.Name)
+        && !item.Name.EndsWith(".strm", StringComparison.OrdinalIgnoreCase);
+
     private async Task CreateStrmFileAsync(DavItem davItem)
     {
-        // create necessary directories if they don't already exist
         var strmFilePath = GetStrmFilePath(davItem);
         var directoryName = Path.GetDirectoryName(strmFilePath);
         if (directoryName != null)
             await Task.Run(() => Directory.CreateDirectory(directoryName)).ConfigureAwait(false);
 
-        // create the strm file
         var targetUrl = GetStrmTargetUrl(davItem);
+        if (File.Exists(strmFilePath))
+        {
+            var existing = await File.ReadAllTextAsync(strmFilePath).ConfigureAwait(false);
+            if (existing == targetUrl)
+                return;
+        }
+
         await File.WriteAllTextAsync(strmFilePath, targetUrl).ConfigureAwait(false);
     }
 
-    private string GetStrmFilePath(DavItem davItem)
+    internal string GetStrmFilePath(DavItem davItem)
     {
-        var path = davItem.Path + ".strm";
-        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return Path.Join(configManager.GetStrmCompletedDownloadDir(), Path.Join(parts[2..]));
+        var relativePath = GetPathRelativeToContentRoot(davItem.Path) + ".strm";
+        return Path.Join(configManager.GetStrmCompletedDownloadDir(), relativePath);
+    }
+
+    internal static string GetPathRelativeToContentRoot(string davPath)
+    {
+        if (davPath.StartsWith(ContentRootPrefix, StringComparison.Ordinal))
+            return davPath[ContentRootPrefix.Length..];
+
+        // Fallback: preserve previous parts[2..] behavior for unexpected layouts.
+        var parts = davPath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Length > 2 ? Path.Join(parts[2..]) : Path.GetFileName(davPath);
     }
 
     private string GetStrmTargetUrl(DavItem davItem)

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -317,7 +317,8 @@ public class QueueItemProcessor(
 
             // create strm files, if necessary
             if (configManager.GetImportStrategy() == "strm")
-                await new CreateStrmFilesPostProcessor(configManager, dbClient).CreateStrmFilesAsync()
+                await new CreateStrmFilesPostProcessor(configManager, dbClient, queueItem.Id)
+                    .CreateStrmFilesAsync()
                     .ConfigureAwait(false);
 
             return mountFolder;

--- a/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue.PostProcessors;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class CreateStrmFilesPostProcessorTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _strmDir;
+    private readonly DavDatabaseContext _context;
+    private readonly DavDatabaseClient _dbClient;
+    private readonly ConfigManager _config;
+    private readonly Guid _historyItemId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    public CreateStrmFilesPostProcessorTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"strm-test-{Guid.NewGuid():N}.sqlite");
+        _strmDir = Path.Combine(Path.GetTempPath(), $"strm-out-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_strmDir);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        _context = new DavDatabaseContext(options);
+        _context.Database.EnsureCreated();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _config = new ConfigManager();
+        _config.UpdateValues(
+        [
+            new() { ConfigName = ConfigKeys.ApiCompletedDownloadsDir, ConfigValue = _strmDir },
+            new() { ConfigName = ConfigKeys.ApiImportStrategy, ConfigValue = "strm" },
+            new() { ConfigName = "general.base-url", ConfigValue = "http://localhost:3000" },
+            new() { ConfigName = ConfigKeys.ApiStrmKey, ConfigValue = "test-strm-key" },
+        ]);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        try { File.Delete(_dbPath); } catch { /* ignore */ }
+        try { Directory.Delete(_strmDir, recursive: true); } catch { /* ignore */ }
+    }
+
+    [Fact]
+    public void GetPathRelativeToContentRoot_PreservesNestedSeasonFolders()
+    {
+        var relative = CreateStrmFilesPostProcessor.GetPathRelativeToContentRoot(
+            "/content/tv/Show/Season 01/ep.mkv");
+        Assert.Equal(Path.Join("tv", "Show", "Season 01", "ep.mkv"), relative);
+    }
+
+    [Fact]
+    public async Task CreateStrmFilesAsync_CreatesForPersistedVideosNotInAddedState()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "tv");
+        var job = SeedDirectory(category, "Show", _historyItemId);
+        var season = SeedDirectory(job, "Season 01", _historyItemId);
+        for (var i = 1; i <= 8; i++)
+            SeedVideo(season, $"S01E{i:00}.mkv", _historyItemId);
+
+        await _context.SaveChangesAsync();
+        // Clear tracker so items are Unchanged, not Added.
+        _context.ChangeTracker.Clear();
+
+        var processor = new CreateStrmFilesPostProcessor(_config, _dbClient, _historyItemId);
+        await processor.CreateStrmFilesAsync();
+
+        var strmFiles = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories);
+        Assert.Equal(8, strmFiles.Length);
+    }
+
+    [Fact]
+    public async Task CreateStrmFilesAsync_SkipsExistingStrmNamedItems()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "tv");
+        var job = SeedDirectory(category, "Show", _historyItemId);
+        SeedVideo(job, "episode.mkv", _historyItemId);
+        SeedVideo(job, "already.strm", _historyItemId);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var processor = new CreateStrmFilesPostProcessor(_config, _dbClient, _historyItemId);
+        await processor.CreateStrmFilesAsync();
+
+        var strmFiles = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories);
+        Assert.Single(strmFiles);
+        Assert.DoesNotContain(strmFiles, f => f.EndsWith("already.strm.strm", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task CreateStrmFilesAsync_IsIdempotentWhenContentUnchanged()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "movies");
+        var job = SeedDirectory(category, "Movie", _historyItemId);
+        SeedVideo(job, "movie.mkv", _historyItemId);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var processor = new CreateStrmFilesPostProcessor(_config, _dbClient, _historyItemId);
+        await processor.CreateStrmFilesAsync();
+        var path = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories).Single();
+        var mtime1 = File.GetLastWriteTimeUtc(path);
+        await Task.Delay(50);
+        await processor.CreateStrmFilesAsync();
+        var mtime2 = File.GetLastWriteTimeUtc(path);
+
+        Assert.Equal(mtime1, mtime2);
+    }
+
+    private DavItem SeedDirectory(DavItem parent, string name, Guid? historyItemId = null)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(), parent, name, null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, historyItemId, null);
+        _context.Items.Add(item);
+        return item;
+    }
+
+    private DavItem SeedVideo(DavItem parent, string name, Guid historyItemId)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(), parent, name, 100,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            null, null, historyItemId, Guid.NewGuid());
+        _context.Items.Add(item);
+        return item;
+    }
+}


### PR DESCRIPTION
## Summary
- STRM creation no longer depends solely on `EntityState.Added` in the current change tracker — also includes persisted video `DavItem`s for the completing job's history id.
- Exclude names ending in `.strm` (avoids `foo.strm.strm`).
- Path relative to `/content/` instead of magic `parts[2..]`.
- Idempotent writes when target content is unchanged.

**Follow-up:** recreate-STRM maintenance task (phase 2).

Closes #145

## Test plan
- [x] 8 persisted season-pack videos (not Added) → 8 STRMs
- [x] `.strm` item does not produce `.strm.strm`
- [x] Idempotent rewrite leaves mtime unchanged
- [x] Nested path relative to `/content/`