### PR TITLE
feat(queue): setting to fail jobs when non-video files have missing articles

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -25,6 +25,7 @@ public static class ConfigKeys
     public const string ApiNzbBackupEnabled = "api.nzb-backup-enabled";
     public const string ApiNzbBackupLocation = "api.nzb-backup-location";
     public const string ApiSearchUserAgent = "api.search-user-agent";
+    public const string ApiSkipNonVideoOnMissingArticles = "api.skip-non-video-on-missing-articles";
     public const string ApiStrmKey = "api.strm-key";
     public const string ApiUserAgent = "api.user-agent";
 

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -201,6 +201,7 @@ public class ConfigManager
                 case ConfigKeys.ApiIgnoreHistoryLimit:
                 case ConfigKeys.ApiLazyRarParsing:
                 case ConfigKeys.ApiNzbBackupEnabled:
+                case ConfigKeys.ApiSkipNonVideoOnMissingArticles:
                 case ConfigKeys.WebdavShowHiddenFiles:
                 case ConfigKeys.WebdavEnforceReadonly:
                 case ConfigKeys.WebdavPreviewPar2Files:
@@ -334,6 +335,17 @@ public class ConfigManager
         var defaultValue = true;
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiEnsureImportableVideo));
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
+    }
+
+    /// <summary>
+    /// When true (default), non-video files with missing articles are skipped
+    /// instead of failing the job.
+    /// </summary>
+    public bool IsSkipNonVideoOnMissingArticlesEnabled()
+    {
+        var defaultValue = true;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiSkipNonVideoOnMissingArticles));
+        return configValue != null ? bool.Parse(configValue) : defaultValue;
     }
 
     public bool ShowHiddenWebdavFiles()

--- a/backend/Queue/FileProcessors/FileProcessor.cs
+++ b/backend/Queue/FileProcessors/FileProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
@@ -10,6 +11,7 @@ namespace NzbWebDAV.Queue.FileProcessors;
 public class FileProcessor(
     GetFileInfosStep.FileInfo fileInfo,
     INntpClient usenetClient,
+    ConfigManager configManager,
     CancellationToken ct
 ) : BaseProcessor
 {
@@ -28,9 +30,11 @@ public class FileProcessor(
             };
         }
 
-        // Ignore missing articles if it's not a video file.
+        // Ignore missing articles if it's not a video file (default).
         // In that case, simply skip the file altogether.
-        catch (UsenetArticleNotFoundException) when (!FilenameUtil.IsVideoFile(fileInfo.FileName))
+        catch (UsenetArticleNotFoundException) when (
+            !FilenameUtil.IsVideoFile(fileInfo.FileName)
+            && configManager.IsSkipNonVideoOnMissingArticlesEnabled())
         {
             Log.Warning(
                 "File {FileName} has missing articles; skipping it because it is not a video",

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -351,7 +351,7 @@ public class QueueItemProcessor(
 
             else if (group.Key == "other")
                 foreach (var fileInfo in group)
-                    yield return new FileProcessor(fileInfo, usenetClient, ct);
+                    yield return new FileProcessor(fileInfo, usenetClient, configManager, ct);
         }
     }
 

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -30,6 +30,7 @@ const defaultConfig = {
     "api.categories": "",
     "api.manual-category": "uncategorized",
     "api.ensure-importable-video": "true",
+    "api.skip-non-video-on-missing-articles": "true",
     "api.ensure-article-existence-categories": "",
     "api.ignore-history-limit": "true",
     "api.download-file-blocklist": "*.nfo, *.par2, *.sfv, *sample.mkv",

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -197,6 +197,24 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-slate-300">
                     <Checkbox
+                    id="fail-missing-non-video-checkbox"
+                    aria-describedby="fail-missing-non-video-help"
+                    checked={config["api.skip-non-video-on-missing-articles"] === "false"}
+                    onChange={e => setNewConfig({
+                        ...config,
+                        "api.skip-non-video-on-missing-articles": String(!e.target.checked)
+                    })} />
+                    <span>Fail downloads when non-video files have missing articles</span>
+                </label>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="fail-missing-non-video-help">
+                    By default, missing articles in PAR2/NFO/subtitle files are skipped and the job still completes.
+                    Enable this to fail the download instead so *Arr can grab an alternate release.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <Checkbox
                     id="ensure-article-existence-checkbox"
                     aria-describedby="ensure-article-existence-help"
                     ref={ensureArticleExistanceSetting.masterCheckboxRef}
@@ -319,6 +337,7 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
         || config["api.manual-category"] !== newConfig["api.manual-category"]
         || config["rclone.mount-dir"] !== newConfig["rclone.mount-dir"]
         || config["api.ensure-importable-video"] !== newConfig["api.ensure-importable-video"]
+        || config["api.skip-non-video-on-missing-articles"] !== newConfig["api.skip-non-video-on-missing-articles"]
         || config["api.ensure-article-existence-categories"] !== newConfig["api.ensure-article-existence-categories"]
         || config["api.ignore-history-limit"] !== newConfig["api.ignore-history-limit"]
         || config["api.duplicate-nzb-behavior"] !== newConfig["api.duplicate-nzb-behavior"]

--- a/tests/NzbWebDAV.Tests/Queue/FileProcessorMissingArticlesTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FileProcessorMissingArticlesTests.cs
@@ -1,0 +1,76 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class FileProcessorMissingArticlesTests
+{
+    [Fact]
+    public void IsSkipNonVideoOnMissingArticlesEnabled_DefaultsTrue()
+    {
+        var config = new ConfigManager();
+        Assert.True(config.IsSkipNonVideoOnMissingArticlesEnabled());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SkipsNonVideoWhenFlagEnabled()
+    {
+        var config = Config(skip: true);
+        var processor = CreateProcessor("file.par2", config, missing: true);
+
+        var result = await processor.ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ThrowsForNonVideoWhenFlagDisabled()
+    {
+        var config = Config(skip: false);
+        var processor = CreateProcessor("file.par2", config, missing: true);
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() => processor.ProcessAsync());
+    }
+
+    private static ConfigManager Config(bool skip)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiSkipNonVideoOnMissingArticles,
+                ConfigValue = skip ? "true" : "false"
+            }
+        ]);
+        return config;
+    }
+
+    private static FileProcessor CreateProcessor(string fileName, ConfigManager config, bool missing)
+    {
+        var segments = missing
+            ? new Dictionary<string, byte[]>()
+            : new Dictionary<string, byte[]> { ["seg"] = [1, 2, 3] };
+        var client = new FakeNntpClient(segments);
+        var nzbFile = new NzbFile { Subject = fileName };
+        if (!missing)
+            nzbFile.Segments.Add(new NzbSegment { Bytes = 3, MessageId = "seg" });
+        else
+            nzbFile.Segments.Add(new NzbSegment { Bytes = 3, MessageId = "missing" });
+
+        var fileInfo = new GetFileInfosStep.FileInfo
+        {
+            NzbFile = nzbFile,
+            FileName = fileName,
+            FileSize = null,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+        };
+        return new FileProcessor(fileInfo, client, config, CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary
- Config `api.skip-non-video-on-missing-articles` defaults to true (current skip behavior).
- When set false, missing articles in non-video files fail the job.
- SABnzbd settings toggle: \"Fail downloads when non-video files have missing articles\".

Closes #122

## Test plan
- [x] Default config ⇒ skip enabled
- [x] Flag on + missing `.par2` ⇒ ProcessAsync returns null
- [x] Flag off + missing `.par2` ⇒ throws UsenetArticleNotFoundException