### PR TITLE
fix(queue): decode UTF-8 PAR2 filenames for CJK releases

### DIFF
--- a/backend/Par2Recovery/Packets/FileDesc.cs
+++ b/backend/Par2Recovery/Packets/FileDesc.cs
@@ -6,6 +6,10 @@ namespace NzbWebDAV.Par2Recovery.Packets
     {
         public const string PacketType = "PAR 2.0\0FileDesc";
 
+        private static readonly Encoding StrictUtf8 = new UTF8Encoding(
+            encoderShouldEmitUTF8Identifier: false,
+            throwOnInvalidBytes: true);
+
         public byte[] FileID { get; protected set; } = null!;
         public byte[] FileHash { get; protected set; } = null!;
         public byte[] File16kHash { get; protected set; } = null!;
@@ -33,72 +37,31 @@ namespace NzbWebDAV.Par2Recovery.Packets
             // 8	8-byte uint	Length of the file.
             FileLength = BitConverter.ToUInt64(body, 48);
 
-            // ?*4	ASCII char array	Name of the file. This array is not guaranteed to be null terminated! Subdirectories are indicated by an HTML-style '/' (a.k.a. the UNIX slash). The filename must be unique.
+            // ?*4	ASCII/UTF-8 char array	Name of the file. Not guaranteed null-terminated.
             var nameBuffer = new byte[body.Length - 56];
             Buffer.BlockCopy(body, 56, nameBuffer, 0, nameBuffer.Length);
 
-            // Use UTF8 encoding if it is either ASCII or has valid byte sequences. Otherwise, go with Windows-1252.
-            var encoding = IsUTF8(nameBuffer) ? Encoding.UTF8 : Encoding.GetEncoding(1252);
-            FileName = encoding.GetString(nameBuffer).Normalize().TrimEnd('\0');
-        }
-
-        private static bool IsUTF8(byte[] input)
-        {
-            if (input == null)
-                return false;
-            if (input.Length == 0)
-                return false;
-
-            // TODO: Check for a BOM.
-
-            for (int i = 0; i < input.Length; i++)
+            // Strip UTF-8 BOM if present.
+            var offset = 0;
+            if (nameBuffer.Length >= 3
+                && nameBuffer[0] == 0xEF
+                && nameBuffer[1] == 0xBB
+                && nameBuffer[2] == 0xBF)
             {
-                // Skip low bytes.
-                if (input[i] < 0x80)
-                    continue;
-
-                // Start of 4-byte sequence
-                if ((input[i] & 0xF8) == 0xF0)
-                {
-                    if (i + 3 >= input.Length)
-                        return false; // Invalid sequence length.
-                    if ((input[i + 1] & 0xC0) != 0x80)
-                        return false; // Invalid sequence.
-                    if ((input[i + 2] & 0xC0) != 0x80)
-                        return false; // Invalid sequence.
-                    if ((input[i + 3] & 0xC0) != 0x80)
-                        return false; // Invalid sequence.
-                    i += 3; // Valid sequence. Skip to the next character.
-                    continue;
-                }
-
-                // Start of 3-byte sequence
-                if ((input[i] & 0xF0) == 0xE0)
-                {
-                    if (i + 2 >= input.Length)
-                        return false; // Invalid sequence length.
-                    if ((input[i + 1] & 0xC0) != 0x80)
-                        return false; // Invalid sequence.
-                    if ((input[i + 2] & 0xC0) != 0x80)
-                        return false; // Invalid sequence.
-                    i += 2; // Valid sequence. Skip to the next character.
-                    continue;
-                }
-
-                // Start of 2-byte sequence
-                if ((input[i] & 0xE0) == 0xC0)
-                {
-                    if (i + 1 >= input.Length)
-                        return false; // Invalid sequence length.
-                    if ((input[i + 1] & 0xC0) != 0x80)
-                        return false; // Invalid sequence.
-                    i += 1; // Valid sequence. Skip to the next character.
-                    continue;
-                }
+                offset = 3;
             }
 
-            // Either all high bytes are valid sequences, or there are no high bytes, and US-ASCII is valid UTF-8.
-            return true;
+            string decoded;
+            try
+            {
+                decoded = StrictUtf8.GetString(nameBuffer, offset, nameBuffer.Length - offset);
+            }
+            catch (DecoderFallbackException)
+            {
+                decoded = Encoding.GetEncoding(1252).GetString(nameBuffer, offset, nameBuffer.Length - offset);
+            }
+
+            FileName = decoded.Normalize().TrimEnd('\0');
         }
 
         public override string ToString()

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -34,7 +34,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);        var (minThreads, maxThreads) = ThreadPoolUtil.ResolveLimits(
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance); var (minThreads, maxThreads) = ThreadPoolUtil.ResolveLimits(
             Environment.ProcessorCount,
             EnvironmentUtil.GetLongVariable("THREADPOOL_MIN_THREADS"),
             EnvironmentUtil.GetLongVariable("THREADPOOL_MAX_THREADS"));

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -33,7 +34,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        var (minThreads, maxThreads) = ThreadPoolUtil.ResolveLimits(
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);        var (minThreads, maxThreads) = ThreadPoolUtil.ResolveLimits(
             Environment.ProcessorCount,
             EnvironmentUtil.GetLongVariable("THREADPOOL_MIN_THREADS"),
             EnvironmentUtil.GetLongVariable("THREADPOOL_MAX_THREADS"));

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -589,3 +589,7 @@ docker compose logs --tail=200 -f nzbdav_rclone
 ```
 
 If the Rclone mount fails, first verify that `/dev/fuse` exists on the host, the sidecar has started after NzbDav became healthy, and the WebDAV username/password in `rclone.conf` match `Settings` → `WebDAV`. If Rclone specifically rejects `--allow-other`, enable `user_allow_other` in the FUSE configuration available inside the sidecar. If **Test Conn** on `Settings` → `Rclone Server` fails, confirm the sidecar has the `--rc*` flags, the host is `http://nzbdav_rclone:5572`, and the RC user/password match.
+
+### Korean / Japanese (CJK) filenames
+
+NzbDav stores and serves WebDAV paths as UTF-8. If CJK release names appear as mojibake or are inaccessible from a Windows WebDAV mapping or rclone, check the **client** encoding settings (for example rclone `--local-encoding` / Windows system locale / UTF-8 code page). Filenames recovered from PAR2 packets are decoded as UTF-8 when valid, with a Windows-1252 fallback for legacy packers.

--- a/tests/NzbWebDAV.Tests/Par2Recovery/FileDescEncodingTests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/FileDescEncodingTests.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using NzbWebDAV.Par2Recovery.Packets;
+
+namespace NzbWebDAV.Tests.Par2Recovery;
+
+public class FileDescEncodingTests
+{
+    static FileDescEncodingTests()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    [Theory]
+    [InlineData("한국어_예능.mkv")]
+    [InlineData("日本語テスト.mkv")]
+    [InlineData("Show_한국어_mix.mkv")]
+    [InlineData("ascii-only.mkv")]
+    public void ParseBody_DecodesUtf8Names(string fileName)
+    {
+        var desc = Parse(BuildBody(fileName, Encoding.UTF8));
+        Assert.Equal(fileName, desc.FileName);
+    }
+
+    [Fact]
+    public void ParseBody_FallsBackToWindows1252ForLegacyNames()
+    {
+        var fileName = "Café.mkv";
+        var encoding1252 = Encoding.GetEncoding(1252);
+        var desc = Parse(BuildBody(fileName, encoding1252));
+        Assert.Equal(fileName, desc.FileName);
+    }
+
+    [Fact]
+    public void ParseBody_StripsUtf8Bom()
+    {
+        var fileName = "bom-test.mkv";
+        var nameBytes = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes(fileName)).ToArray();
+        var body = BuildBodyFromNameBytes(nameBytes);
+        var desc = Parse(body);
+        Assert.Equal(fileName, desc.FileName);
+    }
+
+    private static TestFileDesc Parse(byte[] body)
+    {
+        var header = new Par2PacketHeader
+        {
+            Magic = "PAR2\0PKT"u8.ToArray(),
+            PacketLength = (ulong)(64 + body.Length),
+            PacketHash = new byte[16],
+            RecoverySetID = new byte[16],
+            PacketType = Encoding.ASCII.GetBytes(FileDesc.PacketType.PadRight(16, '\0')[..16]),
+        };
+        var desc = new TestFileDesc(header);
+        desc.Parse(body);
+        return desc;
+    }
+
+    private static byte[] BuildBody(string fileName, Encoding encoding) =>
+        BuildBodyFromNameBytes(encoding.GetBytes(fileName));
+
+    private static byte[] BuildBodyFromNameBytes(byte[] nameBytes)
+    {
+        var paddedLen = ((nameBytes.Length + 3) / 4) * 4;
+        var body = new byte[56 + paddedLen];
+        nameBytes.CopyTo(body, 56);
+        return body;
+    }
+
+    private sealed class TestFileDesc(Par2PacketHeader header) : FileDesc(header)
+    {
+        public void Parse(byte[] body) => ParseBody(body);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hand-rolled \`IsUTF8\` with BCL strict UTF-8 try/catch and Windows-1252 fallback.
- Strip UTF-8 BOM when present.
- Register code-pages provider at startup; docs note for client-side UTF-8 caveats.

**Follow-up:** PAR2 UniFileN Unicode packet parser (phase 2).

Closes #96

## Test plan
- [x] UTF-8 Korean/Japanese/mixed/ASCII names round-trip
- [x] Windows-1252 \`Café.mkv\` falls back correctly
- [x] UTF-8 BOM stripped