### PR TITLE
fix(api): skip unpack decoy videos in profiles play selection

### DIFF
--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -1169,8 +1169,6 @@ public class ProfilePlayController(
     private async Task<DavItem?> FindLargestVideoAsync(Guid historyItemId, CancellationToken ct)
         => await FindBestVideoAsync(historyItemId, entry: null, ct).ConfigureAwait(false);
 
-    private static readonly char[] TokenSeparators = ['.', '_', '-', ' ', '(', ')', '[', ']', '{', '}', '+'];
-
     private async Task<DavItem?> FindBestVideoAsync(Guid historyItemId, NzbResolutionCache.Entry? entry, CancellationToken ct)
     {
         var files = await dbClient.Ctx.Items.AsNoTracking()
@@ -1183,45 +1181,27 @@ public class ProfilePlayController(
             .ToList();
         if (videos.Count == 0) return null;
 
+        int? season = null;
+        int? episode = null;
         if (entry is not null && TryParseSeasonEpisode(entry.Type, entry.Id, out var reqSeason, out var reqEpisode))
         {
-            var episodeFile = SelectEpisodeFile(videos, reqSeason, reqEpisode);
-            if (episodeFile is not null) return episodeFile;
+            season = reqSeason;
+            episode = reqEpisode;
         }
 
-        if (entry is null)
+        var best = VideoSelection.SelectBest(videos, season, episode, entry?.Primary.Title);
+
+        Log.Debug("play selection for {HistoryItemId}: chose {Name} among {Count} videos",
+            historyItemId, best?.Name ?? "<none>", videos.Count);
+        var skippedDecoys = videos.Where(v => !ReferenceEquals(v, best) && VideoSelection.IsProbablyDecoy(v.Name)).ToList();
+        if (skippedDecoys.Count > 0)
         {
-            return videos.Count == 1
-                ? videos[0]
-                : videos.OrderByDescending(x => x.FileSize ?? 0).First();
+            Log.Information(
+                "play selection for {HistoryItemId}: skipped {Count} probable decoy file(s): {Names}",
+                historyItemId, skippedDecoys.Count, string.Join(", ", skippedDecoys.Select(v => v.Name)));
         }
 
-        var clickTokens = TokenizeName(entry.Primary.Title);
-        if (clickTokens.Count == 0)
-        {
-            return videos.Count == 1
-                ? videos[0]
-                : videos.OrderByDescending(x => x.FileSize ?? 0).First();
-        }
-
-        DavItem? best = null;
-        int bestScore = 0;
-        long bestSize = -1;
-        foreach (var v in videos)
-        {
-            if (v.Name.Contains("sample", StringComparison.OrdinalIgnoreCase)) continue;
-            var fileTokens = TokenizeName(Path.GetFileNameWithoutExtension(v.Name));
-            if (fileTokens.Count == 0) continue;
-            var score = fileTokens.Count(t => clickTokens.Contains(t));
-            var size = v.FileSize ?? 0;
-            if (score > bestScore || (score == bestScore && score > 0 && size > bestSize))
-            {
-                best = v;
-                bestScore = score;
-                bestSize = size;
-            }
-        }
-        return bestScore > 0 ? best : null;
+        return best;
     }
 
     private static bool TryParseSeasonEpisode(string? type, string? id, out int season, out int episode)
@@ -1232,36 +1212,6 @@ public class ProfilePlayController(
         var parts = id.Split(':');
         if (parts.Length < 3) return false;
         return int.TryParse(parts[^2], out season) && int.TryParse(parts[^1], out episode);
-    }
-
-    private static DavItem? SelectEpisodeFile(List<DavItem> videos, int season, int episode)
-    {
-        DavItem? best = null;
-        long bestSize = -1;
-        foreach (var v in videos)
-        {
-            if (v.Name.Contains("sample", StringComparison.OrdinalIgnoreCase)) continue;
-            if (FilenameMatcher.ParseEpisode(v.Name) is not { } tag) continue;
-            if (tag.Season != season) continue;
-            if (tag.Episode is not { } start) continue;
-            var end = tag.EpisodeEnd ?? start;
-            if (episode < start || episode > end) continue;
-            var size = v.FileSize ?? 0;
-            if (size > bestSize)
-            {
-                best = v;
-                bestSize = size;
-            }
-        }
-        return best;
-    }
-
-    private static HashSet<string> TokenizeName(string s)
-    {
-        if (string.IsNullOrWhiteSpace(s)) return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        return s.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(t => t.Length > 1)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static string SanitizeFileName(string name)

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1025,7 +1025,7 @@ public class ConfigManager
 
     public HashSet<string> GetBlocklistedFiles()
     {
-        var defaultValue = "*.nfo, *.par2, *.sfv, *sample.mkv";
+        var defaultValue = "*.nfo, *.par2, *.sfv, *sample.mkv, *unpack.mkv, *.unpack.mp4";
         return (GetConfigValue(ConfigKeys.ApiDownloadFileBlocklist) ?? defaultValue)
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())

--- a/backend/Utils/VideoSelection.cs
+++ b/backend/Utils/VideoSelection.cs
@@ -1,0 +1,116 @@
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Pure, unit-testable selection logic for picking the "best" video candidate among a
+/// release's video files for Profiles/manifest play. Extracted from
+/// <c>ProfilePlayController.FindBestVideoAsync</c> so the episode-tag / token-overlap /
+/// decoy-skip behavior can be exercised without a controller or database.
+/// </summary>
+internal static class VideoSelection
+{
+    private static readonly char[] TokenSeparators = ['.', '_', '-', ' ', '(', ')', '[', ']', '{', '}', '+'];
+
+    /// <summary>
+    /// Flags obviously-fake "decoy" releases (e.g. rar-bomb/rickroll uploads named
+    /// <c>*.unpack.mkv</c>) that indexers occasionally ship alongside — or instead of — the
+    /// real episode. The leading dot on <c>".unpack."</c> is intentional: it guards against
+    /// matching legitimate filenames like <c>Unpacked.2017.mkv</c>.
+    /// </summary>
+    internal static bool IsProbablyDecoy(string name) =>
+        name.Contains(".unpack.", StringComparison.OrdinalIgnoreCase) ||
+        name.Contains("rickroll", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Selects the best video among <paramref name="videos"/> (already filtered to
+    /// video-content-type files).
+    /// </summary>
+    /// <param name="videos">Candidate video files. Must be non-empty for a non-null result.</param>
+    /// <param name="season">Requested season, when the manifest id encodes a season/episode.</param>
+    /// <param name="episode">Requested episode, when the manifest id encodes a season/episode.</param>
+    /// <param name="primaryTitle">The clicked release title, used for token-overlap scoring.</param>
+    internal static DavItem? SelectBest(
+        IReadOnlyList<DavItem> videos,
+        int? season,
+        int? episode,
+        string? primaryTitle)
+    {
+        if (videos.Count == 0) return null;
+
+        if (season is { } s && episode is { } e)
+        {
+            var episodeFile = SelectEpisodeFile(videos, s, e);
+            if (episodeFile is not null) return episodeFile;
+        }
+
+        if (primaryTitle is null) return PickFallback(videos);
+
+        var clickTokens = TokenizeName(primaryTitle);
+        if (clickTokens.Count == 0) return PickFallback(videos);
+
+        DavItem? best = null;
+        var bestScore = 0;
+        long bestSize = -1;
+        foreach (var v in videos)
+        {
+            if (v.Name.Contains("sample", StringComparison.OrdinalIgnoreCase)) continue;
+            if (IsProbablyDecoy(v.Name)) continue;
+            var fileTokens = TokenizeName(Path.GetFileNameWithoutExtension(v.Name));
+            if (fileTokens.Count == 0) continue;
+            var score = fileTokens.Count(t => clickTokens.Contains(t));
+            var size = v.FileSize ?? 0;
+            if (score > bestScore || (score == bestScore && score > 0 && size > bestSize))
+            {
+                best = v;
+                bestScore = score;
+                bestSize = size;
+            }
+        }
+        return bestScore > 0 ? best : null;
+    }
+
+    private static DavItem? SelectEpisodeFile(IReadOnlyList<DavItem> videos, int season, int episode)
+    {
+        DavItem? best = null;
+        long bestSize = -1;
+        foreach (var v in videos)
+        {
+            if (v.Name.Contains("sample", StringComparison.OrdinalIgnoreCase)) continue;
+            if (IsProbablyDecoy(v.Name)) continue;
+            if (FilenameMatcher.ParseEpisode(v.Name) is not { } tag) continue;
+            if (tag.Season != season) continue;
+            if (tag.Episode is not { } start) continue;
+            var end = tag.EpisodeEnd ?? start;
+            if (episode < start || episode > end) continue;
+            var size = v.FileSize ?? 0;
+            if (size > bestSize)
+            {
+                best = v;
+                bestSize = size;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Used when there's no episode-tag match and no (or no useful) title to score against —
+    /// falls back to the largest file. Prefers non-decoy candidates, but a false-positive
+    /// decoy match must never make playback return "nothing playable": if every candidate
+    /// looks like a decoy (e.g. it's the release's only video), fall back to the unfiltered list.
+    /// </summary>
+    private static DavItem PickFallback(IReadOnlyList<DavItem> videos)
+    {
+        var nonDecoy = videos.Where(v => !IsProbablyDecoy(v.Name)).ToList();
+        var pool = nonDecoy.Count > 0 ? nonDecoy : videos;
+        return pool.Count == 1 ? pool[0] : pool.OrderByDescending(x => x.FileSize ?? 0).First();
+    }
+
+    private static HashSet<string> TokenizeName(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return s.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(t => t.Length > 1)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -32,7 +32,7 @@ const defaultConfig = {
     "api.ensure-importable-video": "true",
     "api.ensure-article-existence-categories": "",
     "api.ignore-history-limit": "true",
-    "api.download-file-blocklist": "*.nfo, *.par2, *.sfv, *sample.mkv",
+    "api.download-file-blocklist": "*.nfo, *.par2, *.sfv, *sample.mkv, *unpack.mkv, *.unpack.mp4",
     "api.duplicate-nzb-behavior": "increment",
     "api.import-strategy": "symlinks",
     "api.completed-downloads-dir": "",

--- a/tests/NzbWebDAV.Tests/Utils/VideoSelectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/VideoSelectionTests.cs
@@ -1,0 +1,119 @@
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class VideoSelectionTests
+{
+    private static DavItem Video(string name, long fileSize) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        FileSize = fileSize,
+        Type = DavItem.ItemType.UsenetFile,
+        SubType = DavItem.ItemSubType.NzbFile,
+        Path = "/" + name,
+    };
+
+    [Theory]
+    [InlineData("Show.S01E02.unpack.mkv")]
+    [InlineData("SHOW.S01E02.UNPACK.MKV")]
+    [InlineData("show.rickroll.mkv")]
+    public void IsProbablyDecoy_MatchesKnownDecoyPatterns(string name)
+    {
+        Assert.True(VideoSelection.IsProbablyDecoy(name));
+    }
+
+    [Theory]
+    [InlineData("Unpacked.2017.mkv")] // leading-dot guard: "unpack" without ".unpack." must not match
+    [InlineData("Show.S01E02.1080p.mkv")]
+    [InlineData("Show.S01E02.WEB-DL.mkv")]
+    public void IsProbablyDecoy_DoesNotMatchLegitimateNames(string name)
+    {
+        Assert.False(VideoSelection.IsProbablyDecoy(name));
+    }
+
+    // a. decoy `show.unpack.mkv` (8GB) + real `Show.S01E02.1080p.mkv` (2GB), entry S01E02 → real file.
+    [Fact]
+    public void SelectBest_EpisodeMatch_PrefersRealFileOverLargerDecoy()
+    {
+        var decoy = Video("show.unpack.mkv", 8_000_000_000);
+        var real = Video("Show.S01E02.1080p.mkv", 2_000_000_000);
+        var videos = new List<DavItem> { decoy, real };
+
+        var best = VideoSelection.SelectBest(videos, season: 1, episode: 2, primaryTitle: "Show S01E02");
+
+        Assert.Same(real, best);
+    }
+
+    // b. decoy + obfuscated real file (`abc123.mkv`), no episode tags, zero tokens → non-decoy chosen.
+    [Fact]
+    public void SelectBest_NoEpisodeTagsAndNoTokens_PrefersNonDecoyFallback()
+    {
+        var decoy = Video("release.unpack.mkv", 8_000_000_000);
+        var real = Video("abc123.mkv", 2_000_000_000);
+        var videos = new List<DavItem> { decoy, real };
+
+        // A title that tokenizes to nothing (only single-char tokens are dropped by TokenizeName).
+        var best = VideoSelection.SelectBest(videos, season: null, episode: null, primaryTitle: "a b c");
+
+        Assert.Same(real, best);
+    }
+
+    // c. only file is `whatever.unpack.mkv` → still returned (fallback rule).
+    [Fact]
+    public void SelectBest_OnlyCandidateIsDecoy_StillReturnedRatherThanNull()
+    {
+        var decoy = Video("whatever.unpack.mkv", 1_000_000_000);
+        var videos = new List<DavItem> { decoy };
+
+        var best = VideoSelection.SelectBest(videos, season: null, episode: null, primaryTitle: null);
+
+        Assert.Same(decoy, best);
+    }
+
+    // d. `sample` behavior unchanged.
+    [Fact]
+    public void SelectBest_SkipsSampleFiles_EpisodeMatch()
+    {
+        var sample = Video("Show.S01E02.sample.mkv", 50_000_000);
+        var real = Video("Show.S01E02.1080p.mkv", 2_000_000_000);
+        var videos = new List<DavItem> { sample, real };
+
+        var best = VideoSelection.SelectBest(videos, season: 1, episode: 2, primaryTitle: "Show S01E02");
+
+        Assert.Same(real, best);
+    }
+
+    [Fact]
+    public void SelectBest_SkipsSampleFiles_TokenOverlap()
+    {
+        var sample = Video("MyShow.Title.sample.mkv", 50_000_000);
+        var real = Video("MyShow.Title.mkv", 2_000_000_000);
+        var videos = new List<DavItem> { sample, real };
+
+        var best = VideoSelection.SelectBest(videos, season: null, episode: null, primaryTitle: "MyShow Title");
+
+        Assert.Same(real, best);
+    }
+
+    [Fact]
+    public void SelectBest_TokenOverlap_SkipsDecoyEvenWhenLarger()
+    {
+        var decoy = Video("MyShow.Title.unpack.mkv", 8_000_000_000);
+        var real = Video("MyShow.Title.mkv", 2_000_000_000);
+        var videos = new List<DavItem> { decoy, real };
+
+        var best = VideoSelection.SelectBest(videos, season: null, episode: null, primaryTitle: "MyShow Title");
+
+        Assert.Same(real, best);
+    }
+
+    [Fact]
+    public void SelectBest_EmptyVideoList_ReturnsNull()
+    {
+        var best = VideoSelection.SelectBest(new List<DavItem>(), season: null, episode: null, primaryTitle: "anything");
+
+        Assert.Null(best);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #261 — Profile/manifest play could select a decoy `*.unpack.mkv` (or rickroll) file instead of the real episode when the episode-tag/token-overlap heuristics fell through to a size-based tie-break.

Defense in depth, per the remediation plan:

- Extracted the video-selection body of `ProfilePlayController.FindBestVideoAsync` into a new, unit-testable `internal static VideoSelection.SelectBest(...)` helper (`backend/Utils/VideoSelection.cs`). The controller now only fetches `DavItem`s and delegates.
- Added `VideoSelection.IsProbablyDecoy(name)`, matching `.unpack.` (leading-dot guard so `Unpacked.2017.mkv` isn't a false positive) or `rickroll`.
- Applied the decoy skip everywhere `"sample"` is already skipped: the episode-tag loop and the token-overlap loop.
- In the single-video / largest-file fallback paths, non-decoy candidates are preferred, but if filtering would leave nothing playable (e.g. the release's only video is decoy-named), it falls back to the unfiltered list — a false-positive decoy match must never break playback.
- Added observability: `Log.Debug` on every selection outcome, plus `Log.Information` when one or more probable decoys were skipped.
- Extended the default `api.download-file-blocklist` (fresh installs only) with `*unpack.mkv` and `*.unpack.mp4`, in both the backend default (`ConfigManager.GetBlocklistedFiles`) and the frontend `defaultConfig` (`frontend/app/routes/settings/route.tsx`).

## Unit tests

Added `tests/NzbWebDAV.Tests/Utils/VideoSelectionTests.cs` covering the cases from the bug writeup:

- a. decoy `show.unpack.mkv` (8GB) + real `Show.S01E02.1080p.mkv` (2GB), entry S01E02 → real file wins.
- b. decoy + obfuscated real file (`abc123.mkv`), no episode tags, zero tokens → non-decoy chosen.
- c. only file is `whatever.unpack.mkv` → still returned (fallback rule, never "nothing playable").
- d. `sample` skip behavior unchanged (episode-tag and token-overlap paths).
- Plus: `IsProbablyDecoy` leading-dot guard, and token-overlap should also skip a decoy even when it's larger than the real file.

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj` — succeeds, no new warnings.
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — new `VideoSelectionTests` all pass (13/13); pre-existing unrelated failures on this machine are native `librapidyenc` library load errors in yEnc streaming tests, not touched by this change.
- [x] `cd frontend && npm run typecheck` — passes.

Closes #261