### PR TITLE
fix(sab): avoid per-slot provider snapshots for queued items

### DIFF
--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -50,7 +50,8 @@ public class GetQueueController(
                 var isInProgress = queueItem == inProgressQueueItem;
                 var percentage = (isInProgress ? progressPercentage : 0)!.Value;
                 var status = isInProgress ? "Downloading" : "Queued";
-                var providerUsage = providerUsageTracker.Snapshot(queueItem!.Id);
+                IReadOnlyDictionary<string, long> providerUsage =
+                    GetProviderUsageForSlot(isInProgress, queueItem!.Id, providerUsageTracker);
                 if (isInProgress && configuredKeys.Count > 0)
                 {
                     var merged = new Dictionary<string, long>();
@@ -72,6 +73,20 @@ public class GetQueueController(
                 TotalCount = totalCount,
             }
         };
+    }
+
+    /// <summary>
+    /// Queued slots do not display live provider metrics; only snapshot the
+    /// in-progress item to keep large queues responsive.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, long> GetProviderUsageForSlot(
+        bool isInProgress,
+        Guid queueItemId,
+        ProviderUsageTracker providerUsageTracker)
+    {
+        return isInProgress
+            ? providerUsageTracker.Snapshot(queueItemId)
+            : new Dictionary<string, long>();
     }
 
     protected override async Task<IActionResult> Handle()

--- a/tests/NzbWebDAV.Tests/Api/GetQueueProviderUsageTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueProviderUsageTests.cs
@@ -1,0 +1,37 @@
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetQueueProviderUsageTests
+{
+    [Fact]
+    public void GetProviderUsageForSlot_ReturnsEmptyWhenNotInProgress()
+    {
+        var tracker = new ProviderUsageTracker();
+        var id = Guid.NewGuid();
+        using (tracker.BeginScope(id))
+            tracker.RecordSuccess("news.example");
+
+        var usage = GetQueueController.GetProviderUsageForSlot(
+            isInProgress: false, id, tracker);
+
+        Assert.Empty(usage);
+        // Tracker still holds the recorded data — we simply did not snapshot it.
+        Assert.Equal(1, tracker.Snapshot(id)["news.example"]);
+    }
+
+    [Fact]
+    public void GetProviderUsageForSlot_ReturnsSnapshotWhenInProgress()
+    {
+        var tracker = new ProviderUsageTracker();
+        var id = Guid.NewGuid();
+        using (tracker.BeginScope(id))
+            tracker.RecordSuccess("news.example");
+
+        var usage = GetQueueController.GetProviderUsageForSlot(
+            isInProgress: true, id, tracker);
+
+        Assert.Equal(1, usage["news.example"]);
+    }
+}


### PR DESCRIPTION
## Summary
- `mode=queue` only calls `ProviderUsageTracker.Snapshot` for the in-progress slot; queued slots get an empty dictionary (they already render `Providers: null`).
- SAB response shape for the in-progress slot is unchanged.

Closes #102

## Test plan
- [x] Unit: non-in-progress returns empty without needing snapshot data
- [x] Unit: in-progress returns snapshot counts
- [ ] Manual: Sonarr with 500+ queued items — queue refresh stays responsive