### PR TITLE
fix(db): NZB blob name cleanup and backup retention (#83)

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -24,6 +24,7 @@ public static class ConfigKeys
     public const string ApiManualCategory = "api.manual-category";
     public const string ApiNzbBackupEnabled = "api.nzb-backup-enabled";
     public const string ApiNzbBackupLocation = "api.nzb-backup-location";
+    public const string ApiNzbBackupRetentionDays = "api.nzb-backup-retention-days";
     public const string ApiSearchUserAgent = "api.search-user-agent";
     public const string ApiStrmKey = "api.strm-key";
     public const string ApiUserAgent = "api.user-agent";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -194,6 +194,7 @@ public class ConfigManager
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleTime:
                 case ConfigKeys.BackupScheduleTime:
                 case ConfigKeys.BackupRetentionCount:
+                case ConfigKeys.ApiNzbBackupRetentionDays:
                     RequireLong(item.ConfigName, value);
                     break;
 
@@ -1119,10 +1120,10 @@ public class ConfigManager
             defaultValue: 30);
     }
 
-    private int GetRetentionDaysSetting(string configKey, string environmentVariable, int defaultValue)
+    private int GetRetentionDaysSetting(string configKey, string? environmentVariable, int defaultValue)
     {
         var rawValue = StringUtil.EmptyToNull(GetConfigValue(configKey))
-                       ?? EnvironmentUtil.GetEnvironmentVariable(environmentVariable);
+                       ?? (environmentVariable != null ? EnvironmentUtil.GetEnvironmentVariable(environmentVariable) : null);
         return int.TryParse(rawValue, out var parsed) && parsed >= 0 ? parsed : defaultValue;
     }
 
@@ -1136,6 +1137,18 @@ public class ConfigManager
     public string? GetNzbBackupLocation()
     {
         return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiNzbBackupLocation));
+    }
+
+    /// <summary>
+    /// Days to keep on-disk NZB backup files (written by <c>AddFileController</c> when
+    /// <see cref="IsNzbBackupEnabled"/> is on). 0 disables age-based pruning. Default is 30.
+    /// </summary>
+    public int GetNzbBackupRetentionDays()
+    {
+        return GetRetentionDaysSetting(
+            ConfigKeys.ApiNzbBackupRetentionDays,
+            environmentVariable: null,
+            defaultValue: 30);
     }
 
     public bool IsRemoveOrphanedFilesScheduleEnabled()

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -8,7 +8,7 @@ namespace NzbWebDAV.Database;
 public class BlobStore
 {
     private static readonly int CompressionLevel = 1;
-    private static readonly string ConfigPath = DavDatabaseContext.ConfigPath;
+    private static string ConfigPath => DavDatabaseContext.ConfigPath;
     private static readonly Lock LockObj = new();
     private static readonly MemoryCache MetadataCache = new(new MemoryCacheOptions
     {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -202,6 +202,7 @@ class Program
                 .AddHostedService<ArrMonitoringService>()
                 .AddHostedService<BlobCleanupService>()
                 .AddHostedService<NzbBlobCleanupService>()
+                .AddHostedService<NzbBackupRetentionService>()
                 .AddHostedService<HistoryCleanupService>()
                 .AddHostedService<HistoryRetentionService>()
                 .AddHostedService<WatchdogPurgeService>()

--- a/backend/Services/NzbBackupRetentionService.cs
+++ b/backend/Services/NzbBackupRetentionService.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Prunes aged on-disk NZB backup copies written when
+/// <c>api.nzb-backup-enabled</c> is on. Only deletes <c>*.nzb</c> files under
+/// the configured backup directory; never touches <c>/</c> or empty paths.
+/// </summary>
+public class NzbBackupRetentionService(ConfigManager configManager) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromHours(1), stoppingToken).ConfigureAwait(false);
+                await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+            {
+                return;
+            }
+        }
+    }
+
+    internal static int SweepDirectory(string backupLocation, int retentionDays, DateTime utcNow)
+    {
+        if (retentionDays <= 0)
+            return 0;
+
+        if (string.IsNullOrWhiteSpace(backupLocation))
+            return 0;
+
+        var trimmed = backupLocation.Trim();
+        if (trimmed is "/" or "\\" )
+            return 0;
+
+        string backupRoot;
+        try
+        {
+            backupRoot = Path.GetFullPath(trimmed);
+        }
+        catch
+        {
+            return 0;
+        }
+
+        if (backupRoot is "/" or "\\" || !Directory.Exists(backupRoot))
+            return 0;
+
+        var cutoff = utcNow.AddDays(-retentionDays);
+        var deleted = 0;
+
+        foreach (var path in Directory.EnumerateFiles(backupRoot, "*.nzb", SearchOption.AllDirectories))
+        {
+            try
+            {
+                var lastWrite = File.GetLastWriteTimeUtc(path);
+                if (lastWrite > cutoff)
+                    continue;
+
+                File.Delete(path);
+                deleted++;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Failed to prune NZB backup file {Path}", path);
+            }
+        }
+
+        return deleted;
+    }
+
+    private async Task SafeSweepAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            if (!configManager.IsNzbBackupEnabled())
+                return;
+
+            var retentionDays = configManager.GetNzbBackupRetentionDays();
+            if (retentionDays <= 0)
+                return;
+
+            var location = configManager.GetNzbBackupLocation();
+            if (location is null)
+                return;
+
+            var deleted = SweepDirectory(location, retentionDays, DateTime.UtcNow);
+            if (deleted > 0)
+                Log.Information("Pruned {Count} NZB backup file(s) older than {Days} day(s)", deleted, retentionDays);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error pruning NZB backup directory: {Message}", ex.Message);
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+}

--- a/backend/Services/NzbBackupRetentionService.cs
+++ b/backend/Services/NzbBackupRetentionService.cs
@@ -39,7 +39,7 @@ public class NzbBackupRetentionService(ConfigManager configManager) : Background
             return 0;
 
         var trimmed = backupLocation.Trim();
-        if (trimmed is "/" or "\\" )
+        if (trimmed is "/" or "\\")
             return 0;
 
         string backupRoot;

--- a/backend/Services/NzbBlobCleanupService.cs
+++ b/backend/Services/NzbBlobCleanupService.cs
@@ -22,65 +22,15 @@ public class NzbBlobCleanupService : BackgroundService
             {
                 await using var dbContext = new DavDatabaseContext();
 
-                // Get the first item from the queue
-                var cleanupItem = await dbContext.NzbBlobCleanupItems
-                    .FirstOrDefaultAsync(stoppingToken)
-                    .ConfigureAwait(false);
+                var processed = await ProcessNextCleanupItemAsync(dbContext, stoppingToken).ConfigureAwait(false);
 
                 // If no items in queue, wait 10 seconds before checking again
-                if (cleanupItem == null)
+                if (!processed)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
-                    continue;
                 }
 
-                var blobId = cleanupItem.Id;
-
-                // Use a serializable (BEGIN IMMEDIATE) transaction so that the three
-                // reference checks and the removal of the cleanup item are atomic.
-                // Without this, a concurrent HistoryItem/DavItem deletion could:
-                //   1. occur between our reference checks (making one check stale), and
-                //   2. have its trigger INSERT OR IGNORE suppressed because our cleanup
-                //      item is still in the table, permanently orphaning the blob.
-                // With BEGIN IMMEDIATE, concurrent writers are blocked until we commit.
-                // After commit, the cleanup item is gone, so any trigger that fires
-                // will successfully insert a new item for the next service pass.
-                await using var tx = await dbContext.Database
-                    .BeginTransactionAsync(IsolationLevel.Serializable, stoppingToken)
-                    .ConfigureAwait(false);
-
-                // Only delete the blob if it is no longer referenced anywhere.
-                // QueueItem.Id IS the NZB blob ID (the blob is stored at that GUID).
-                var isReferencedByQueue = await dbContext.QueueItems
-                    .AnyAsync(x => x.Id == blobId, stoppingToken)
-                    .ConfigureAwait(false);
-
-                var isReferencedByHistory = await dbContext.HistoryItems
-                    .AnyAsync(x => x.NzbBlobId == blobId, stoppingToken)
-                    .ConfigureAwait(false);
-
-                var isReferencedByDavItems = await dbContext.Items
-                    .AnyAsync(x => x.NzbBlobId == blobId, stoppingToken)
-                    .ConfigureAwait(false);
-
-                if (!isReferencedByQueue && !isReferencedByHistory && !isReferencedByDavItems)
-                {
-                    // Delete the blob before SaveChangesAsync so that if SaveChangesAsync
-                    // fails, the cleanup item remains in the DB and the service retries.
-                    // On retry, BlobStore.Delete succeeds even if the file is already gone.
-                    BlobStore.Delete(blobId);
-
-                    var nzbName = await dbContext.NzbNames.FindAsync([blobId], stoppingToken).ConfigureAwait(false);
-                    if (nzbName != null)
-                        dbContext.NzbNames.Remove(nzbName);
-                }
-
-                // Remove the cleanup queue item and commit.
-                dbContext.NzbBlobCleanupItems.Remove(cleanupItem);
-                await dbContext.SaveChangesAsync(stoppingToken).ConfigureAwait(false);
-                await tx.CommitAsync(stoppingToken).ConfigureAwait(false);
-
-                // Continue immediately to next iteration to process more items
+                // Otherwise continue immediately to process more items
             }
             catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
             {
@@ -95,5 +45,84 @@ public class NzbBlobCleanupService : BackgroundService
                 await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    /// Processes the next item from the NZB blob cleanup queue, if any.
+    /// Returns <c>false</c> when the queue is empty (nothing to do).
+    /// Extracted as an internal static method so lifecycle behavior is unit-testable
+    /// against a SQLite-backed <see cref="DavDatabaseContext"/> without running the
+    /// background service loop.
+    /// </summary>
+    internal static async Task<bool> ProcessNextCleanupItemAsync(DavDatabaseContext dbContext, CancellationToken ct)
+    {
+        // Get the first item from the queue
+        var cleanupItem = await dbContext.NzbBlobCleanupItems
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (cleanupItem == null) return false;
+
+        var blobId = cleanupItem.Id;
+
+        // Use a serializable (BEGIN IMMEDIATE) transaction so that the three
+        // reference checks and the removal of the cleanup item are atomic.
+        // Without this, a concurrent HistoryItem/DavItem deletion could:
+        //   1. occur between our reference checks (making one check stale), and
+        //   2. have its trigger INSERT OR IGNORE suppressed because our cleanup
+        //      item is still in the table, permanently orphaning the blob.
+        // With BEGIN IMMEDIATE, concurrent writers are blocked until we commit.
+        // After commit, the cleanup item is gone, so any trigger that fires
+        // will successfully insert a new item for the next service pass.
+        await using var tx = await dbContext.Database
+            .BeginTransactionAsync(IsolationLevel.Serializable, ct)
+            .ConfigureAwait(false);
+
+        // Only delete the blob if it is no longer referenced anywhere.
+        // QueueItem.Id IS the NZB blob ID (the blob is stored at that GUID).
+        var isReferencedByQueue = await dbContext.QueueItems
+            .AnyAsync(x => x.Id == blobId, ct)
+            .ConfigureAwait(false);
+
+        var isReferencedByHistory = await dbContext.HistoryItems
+            .AnyAsync(x => x.NzbBlobId == blobId, ct)
+            .ConfigureAwait(false);
+
+        // Fetch (rather than just check) so a skip can be logged with the
+        // referencing item's path — this turns future "leaked blob" reports
+        // into a one-grep diagnosis.
+        var referencingDavItemPath = await dbContext.Items
+            .Where(x => x.NzbBlobId == blobId)
+            .Select(x => x.Path)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (!isReferencedByQueue && !isReferencedByHistory && referencingDavItemPath == null)
+        {
+            // Delete the blob before SaveChangesAsync so that if SaveChangesAsync
+            // fails, the cleanup item remains in the DB and the service retries.
+            // On retry, BlobStore.Delete succeeds even if the file is already gone.
+            BlobStore.Delete(blobId);
+
+            // The NzbName row (original filename, used to serve the NZB at
+            // download time) must not outlive its blob — otherwise it becomes
+            // an orphaned row that nothing ever prunes.
+            var nzbName = await dbContext.NzbNames.FindAsync([blobId], ct).ConfigureAwait(false);
+            if (nzbName != null)
+                dbContext.NzbNames.Remove(nzbName);
+        }
+        else if (referencingDavItemPath != null)
+        {
+            Log.Debug(
+                "Skipping nzb blob cleanup for {BlobId}: still referenced by dav item at {Path}",
+                blobId, referencingDavItemPath);
+        }
+
+        // Remove the cleanup queue item and commit.
+        dbContext.NzbBlobCleanupItems.Remove(cleanupItem);
+        await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        await tx.CommitAsync(ct).ConfigureAwait(false);
+
+        return true;
     }
 }

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -538,6 +538,12 @@ NzbDav can prune aged SAB history and health-check rows so `db.sqlite` does not 
 
 These can also be set under **Settings → Maintenance** (`database.history-retention-days`, `database.healthcheck-retention-days`). Use **Reset Health-Check Statistics** on that page to clear all health-check counters immediately.
 
+### NZB blob and backup lifetime
+
+Incoming NZB documents are stored as blobs under `{CONFIG_PATH}/blobs/`. A blob is kept while it is still referenced by a queue item, a history row, or mounted WebDAV content under `/content`. When the last reference is removed, a background cleanup deletes the blob and its `NzbNames` mapping. History retention prunes aged SAB history without deleting mounted content, so blobs for still-mounted releases are retained on purpose.
+
+When **Settings → SABnzbd → Save backup copies of incoming NZBs** is enabled, copies are written under the configured backup directory (by category). Those on-disk `*.nzb` files are pruned by age according to `api.nzb-backup-retention-days` (default 30; `0` keeps them forever).
+
 ### Back up NzbDav
 
 NzbDav includes an in-app **Settings → Backup & Restore** flow that dumps all SQLite databases (`db.sqlite`, `metrics.sqlite`, and `warden.db`) to portable `.sql` files under `{CONFIG_PATH}/backups/`. You can:

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -103,6 +103,7 @@ const defaultConfig = {
     "backup.retention-count": "5",
     "api.nzb-backup-enabled": "false",
     "api.nzb-backup-location": "",
+    "api.nzb-backup-retention-days": "30",
     "watchtower.enabled": "false",
     "watchtower.profile-token": "",
     "watchtower.ranking": "watchdog",

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -252,6 +252,21 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     When enabled, a copy of each incoming NZB will be saved to this directory, organized by category.
                     The directory will be created if it doesn't already exist.
                 </p>
+                <label className="mt-4 flex items-center gap-2 text-sm text-slate-300" htmlFor="nzb-backup-retention-days-input">
+                    <span>Keep NZB backups for (days)</span>
+                </label>
+                <Input
+                    className="mt-2 w-full"
+                    type="number"
+                    min={0}
+                    id="nzb-backup-retention-days-input"
+                    aria-describedby="nzb-backup-retention-days-help"
+                    value={config["api.nzb-backup-retention-days"] ?? "30"}
+                    disabled={config["api.nzb-backup-enabled"] !== "true"}
+                    onChange={e => setNewConfig({ ...config, "api.nzb-backup-retention-days": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="nzb-backup-retention-days-help">
+                    Aged <code>*.nzb</code> files under the backup directory are pruned hourly. Use <code>0</code> to keep backups forever. Default is 30 days.
+                </p>
             </div>
         </SettingsPage>
     );
@@ -329,6 +344,7 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
         || config["api.user-agent"] !== newConfig["api.user-agent"]
         || config["api.nzb-backup-enabled"] !== newConfig["api.nzb-backup-enabled"]
         || config["api.nzb-backup-location"] !== newConfig["api.nzb-backup-location"]
+        || config["api.nzb-backup-retention-days"] !== newConfig["api.nzb-backup-retention-days"]
 }
 
 export function isSabnzbdSettingsValid(newConfig: Record<string, string>) {

--- a/tests/NzbWebDAV.Tests/Services/NzbBackupRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbBackupRetentionServiceTests.cs
@@ -1,0 +1,60 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class NzbBackupRetentionServiceTests : IDisposable
+{
+    private readonly string _backupRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-nzb-backup-retention-{Guid.NewGuid():N}");
+
+    public NzbBackupRetentionServiceTests()
+    {
+        Directory.CreateDirectory(Path.Combine(_backupRoot, "tv"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_backupRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void SweepDirectory_DeletesAgedNzbFiles_KeepsRecent()
+    {
+        var oldPath = Path.Combine(_backupRoot, "tv", "old.nzb");
+        var recentPath = Path.Combine(_backupRoot, "tv", "recent.nzb");
+        var otherPath = Path.Combine(_backupRoot, "tv", "notes.txt");
+        File.WriteAllText(oldPath, "old");
+        File.WriteAllText(recentPath, "recent");
+        File.WriteAllText(otherPath, "keep");
+        File.SetLastWriteTimeUtc(oldPath, DateTime.UtcNow.AddDays(-40));
+        File.SetLastWriteTimeUtc(recentPath, DateTime.UtcNow.AddDays(-5));
+
+        var deleted = NzbBackupRetentionService.SweepDirectory(_backupRoot, retentionDays: 30, DateTime.UtcNow);
+
+        Assert.Equal(1, deleted);
+        Assert.False(File.Exists(oldPath));
+        Assert.True(File.Exists(recentPath));
+        Assert.True(File.Exists(otherPath));
+    }
+
+    [Fact]
+    public void SweepDirectory_WithZeroRetention_DeletesNothing()
+    {
+        var path = Path.Combine(_backupRoot, "tv", "old.nzb");
+        File.WriteAllText(path, "old");
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-400));
+
+        var deleted = NzbBackupRetentionService.SweepDirectory(_backupRoot, retentionDays: 0, DateTime.UtcNow);
+
+        Assert.Equal(0, deleted);
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void SweepDirectory_RefusesRootOrEmpty()
+    {
+        Assert.Equal(0, NzbBackupRetentionService.SweepDirectory("/", 30, DateTime.UtcNow));
+        Assert.Equal(0, NzbBackupRetentionService.SweepDirectory("", 30, DateTime.UtcNow));
+        Assert.Equal(0, NzbBackupRetentionService.SweepDirectory("   ", 30, DateTime.UtcNow));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/NzbBlobCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbBlobCleanupServiceTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class NzbBlobCleanupServiceTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-nzb-blob-cleanup-cfg-{Guid.NewGuid():N}");
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-nzb-blob-cleanup-{Guid.NewGuid():N}.sqlite");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { File.Delete(_databasePath); } catch { /* best effort */ }
+        try { Directory.Delete(_configRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task QueueItemDelete_EnqueuesCleanup_AndRemovesBlobAndNzbName()
+    {
+        var blobId = Guid.NewGuid();
+        await using (Stream stream = new MemoryStream("nzb-content"u8.ToArray()))
+            await BlobStore.WriteBlob(blobId, stream);
+
+        _context.QueueItems.Add(new QueueItem
+        {
+            Id = blobId,
+            CreatedAt = DateTime.UtcNow,
+            FileName = "show.nzb",
+            JobName = "show",
+            NzbFileSize = 10,
+            TotalSegmentBytes = 10,
+            Category = "tv",
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        });
+        _context.NzbNames.Add(new NzbName { Id = blobId, FileName = "show.nzb" });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var queueItem = await _context.QueueItems.SingleAsync(x => x.Id == blobId);
+        _context.QueueItems.Remove(queueItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        Assert.NotNull(await _context.NzbBlobCleanupItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == blobId));
+
+        var processed = await NzbBlobCleanupService.ProcessNextCleanupItemAsync(_context, CancellationToken.None);
+        Assert.True(processed);
+
+        Assert.Null(BlobStore.ReadBlob(blobId));
+        Assert.Null(await _context.NzbNames.AsNoTracking().SingleOrDefaultAsync(x => x.Id == blobId));
+        Assert.Empty(await _context.NzbBlobCleanupItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Cleanup_SkipsBlobStillReferencedByDavItem()
+    {
+        var blobId = Guid.NewGuid();
+        await using (Stream stream = new MemoryStream("nzb-content"u8.ToArray()))
+            await BlobStore.WriteBlob(blobId, stream);
+
+        _context.NzbNames.Add(new NzbName { Id = blobId, FileName = "mounted.nzb" });
+        var davItem = DavItem.New(
+            Guid.NewGuid(), DavItem.Root, "mounted.mkv", 100,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            null, null, null, null, blobId);
+        _context.Items.Add(davItem);
+        _context.NzbBlobCleanupItems.Add(new NzbBlobCleanupItem { Id = blobId });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var processed = await NzbBlobCleanupService.ProcessNextCleanupItemAsync(_context, CancellationToken.None);
+        Assert.True(processed);
+
+        Assert.NotNull(BlobStore.ReadBlob(blobId));
+        Assert.NotNull(await _context.NzbNames.AsNoTracking().SingleOrDefaultAsync(x => x.Id == blobId));
+        Assert.Empty(await _context.NzbBlobCleanupItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Cleanup_RemovesOrphanNzbNameWithBlob()
+    {
+        var blobId = Guid.NewGuid();
+        await using (Stream stream = new MemoryStream("nzb-content"u8.ToArray()))
+            await BlobStore.WriteBlob(blobId, stream);
+
+        _context.NzbNames.Add(new NzbName { Id = blobId, FileName = "orphan.nzb" });
+        _context.NzbBlobCleanupItems.Add(new NzbBlobCleanupItem { Id = blobId });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await NzbBlobCleanupService.ProcessNextCleanupItemAsync(_context, CancellationToken.None);
+
+        Assert.Null(BlobStore.ReadBlob(blobId));
+        Assert.Null(await _context.NzbNames.AsNoTracking().SingleOrDefaultAsync(x => x.Id == blobId));
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure `NzbNames` rows are removed with NZB blobs during cleanup, with Debug skip logs when a DavItem still references the blob
- Add `api.nzb-backup-retention-days` (default 30; `0` keeps forever) and hourly pruning of on-disk `*.nzb` backups
- Document NZB blob/backup lifetime in the setup guide

Closes #83

## Test plan
- [x] `dotnet test` — `NzbBlobCleanupServiceTests` + `NzbBackupRetentionServiceTests`
- [ ] Enable NZB backups, drop aged `*.nzb` files under the backup dir, confirm hourly prune
- [ ] Delete a queue-only NZB and confirm blob + NzbNames are cleaned; mounted DavItem retains blob