### PR TITLE
feat(health): auto-remove files after repeated streaming failures

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -55,6 +55,8 @@ public static class ConfigKeys
     public const string MediaLibraryDir = "media.library-dir";
     public const string RepairEnable = "repair.enable";
     public const string RepairHealthcheckConcurrency = "repair.healthcheck-concurrency";
+    public const string RepairAutoRemoveAfterFailures = "repair.auto-remove-after-failures";
+    public const string RepairAutoRemoveUnlinkedOnly = "repair.auto-remove-unlinked-only";
     public const string ArrInstances = "arr.instances";
 
     // rclone

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1013,7 +1013,7 @@ public class ConfigManager
     /// items still go through *Arr remove-and-search. When false, linked items are force-deleted
     /// after the failure threshold as well.
     /// </summary>
-    public bool GetAutoRemoveUnlinkedOnly()
+    public bool IsAutoRemoveUnlinkedOnly()
     {
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairAutoRemoveUnlinkedOnly));
         return configValue == null || bool.Parse(configValue);

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -189,6 +189,7 @@ public class ConfigManager
                 case ConfigKeys.WatchtowerSeasonBundleFallbackRecentCount:
                 case ConfigKeys.WatchtowerSeasonBundleFallbackMaxEpisodes:
                 case ConfigKeys.RepairHealthcheckConcurrency:
+                case ConfigKeys.RepairAutoRemoveAfterFailures:
                 case ConfigKeys.DatabaseHistoryRetentionDays:
                 case ConfigKeys.DatabaseHealthcheckRetentionDays:
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleTime:
@@ -221,6 +222,7 @@ public class ConfigManager
                 case ConfigKeys.WardenHideDead:
                 case ConfigKeys.WardenBackboneScope:
                 case ConfigKeys.RepairEnable:
+                case ConfigKeys.RepairAutoRemoveUnlinkedOnly:
                 case ConfigKeys.RcloneRcEnabled:
                 case ConfigKeys.DbIsStartupVacuumEnabled:
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled:
@@ -993,6 +995,28 @@ public class ConfigManager
             ?? "50"
         );
         return Math.Clamp(configured, 1, Math.Max(1, poolSize));
+    }
+
+    /// <summary>
+    /// Number of streaming failures before auto-removing a broken file during urgent repair.
+    /// 0 (default) disables auto-remove and preserves today's immediate-repair behavior.
+    /// </summary>
+    public int GetAutoRemoveAfterFailures()
+    {
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairAutoRemoveAfterFailures));
+        if (configValue == null) return 0;
+        return int.TryParse(configValue, out var n) ? Math.Max(0, n) : 0;
+    }
+
+    /// <summary>
+    /// When true (default), auto-remove only deletes unlinked/orphaned files; library-linked
+    /// items still go through *Arr remove-and-search. When false, linked items are force-deleted
+    /// after the failure threshold as well.
+    /// </summary>
+    public bool GetAutoRemoveUnlinkedOnly()
+    {
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairAutoRemoveUnlinkedOnly));
+        return configValue == null || bool.Parse(configValue);
     }
 
     public ArrConfig GetArrConfig()

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -6,12 +6,13 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 using Serilog;
 
 namespace NzbWebDAV.Middlewares;
 
-public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManager)
+public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManager, StreamingFailureTracker failureTracker)
 {
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentMissingArticles = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentConnectionLimitErrors = new();
@@ -196,6 +197,8 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
     private void ScheduleRepair(Guid davItemId)
     {
+        failureTracker.RecordFailure(davItemId);
+
         if (!configManager.IsRepairJobEnabled())
             return;
 

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -197,10 +197,13 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
     private void ScheduleRepair(Guid davItemId)
     {
-        failureTracker.RecordFailure(davItemId);
-
         if (!configManager.IsRepairJobEnabled())
             return;
+
+        // Track every distinct streaming failure (not deduped by RepairDedupeWindow below) so the
+        // optional repair.auto-remove-after-failures policy in HealthCheckService can see how many
+        // times playback has actually failed against this item.
+        failureTracker.RecordFailure(davItemId);
 
         var now = DateTime.UtcNow;
         var isDuplicate = false;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -176,6 +176,7 @@ class Program
                 .AddSingleton<SearchExcludeSyncService>()
                 .AddHostedService(sp => sp.GetRequiredService<SearchExcludeSyncService>())
                 .AddSingleton<PlaybackFastVerifier>()
+                .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<WatchdogLog>()
                 .AddSingleton<PreflightCache>()
                 .AddSingleton<PreflightSessionRegistry>()

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -152,6 +152,7 @@ class Program
                 .AddSingleton<ProviderUsageTracker>(sp =>
                     new ProviderUsageTracker(sp.GetRequiredService<ActiveReadRegistry>()))
                 .AddSingleton<QueueItemSourceTracker>()
+                .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<UsenetStreamingClient>()
                 // LazyRarResolver takes INntpClient (for testability) but must
                 // use the shared streaming client; wire it explicitly instead
@@ -176,7 +177,6 @@ class Program
                 .AddSingleton<SearchExcludeSyncService>()
                 .AddHostedService(sp => sp.GetRequiredService<SearchExcludeSyncService>())
                 .AddSingleton<PlaybackFastVerifier>()
-                .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<WatchdogLog>()
                 .AddSingleton<PreflightCache>()
                 .AddSingleton<PreflightSessionRegistry>()

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -180,7 +180,7 @@ public class HealthCheckService : BackgroundService
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
-            _failureTracker.Clear(davItem.Id);
+            _failureTracker.ClearFailure(davItem.Id);
             var healthyMessage = sampled.Count < totalSegments
                 ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
                 : "File is healthy.";
@@ -344,8 +344,8 @@ public class HealthCheckService : BackgroundService
     private async Task HandleUrgentRepair(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
     {
         var threshold = _configManager.GetAutoRemoveAfterFailures();
-        var failureCount = _failureTracker.GetCount(davItem.Id);
-        var unlinkedOnly = _configManager.GetAutoRemoveUnlinkedOnly();
+        var failureCount = _failureTracker.GetFailureCount(davItem.Id);
+        var unlinkedOnly = _configManager.IsAutoRemoveUnlinkedOnly();
         var hasLibraryLink = OrganizedLinksUtil.GetLink(davItem, _configManager) != null;
         var disposition = GetUrgentRepairDisposition(threshold, failureCount, hasLibraryLink, unlinkedOnly);
 
@@ -389,7 +389,7 @@ public class HealthCheckService : BackgroundService
             if (BlocklistedFilePostProcessor.MatchesAnyPattern(davItem.Name, blocklistedFiles))
             {
                 dbClient.Ctx.Items.Remove(davItem);
-                _failureTracker.Clear(davItem.Id);
+                _failureTracker.ClearFailure(davItem.Id);
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,
@@ -411,7 +411,7 @@ public class HealthCheckService : BackgroundService
                     await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
 
                 dbClient.Ctx.Items.Remove(davItem);
-                _failureTracker.Clear(davItem.Id);
+                _failureTracker.ClearFailure(davItem.Id);
 
                 var failureNote = streamingFailureCount is > 0
                     ? $" Streaming failure count: {streamingFailureCount}."
@@ -503,7 +503,7 @@ public class HealthCheckService : BackgroundService
                 if (removedAndSearched)
                 {
                     dbClient.Ctx.Items.Remove(davItem);
-                    _failureTracker.Clear(davItem.Id);
+                    _failureTracker.ClearFailure(davItem.Id);
                     await RecordHealthResult(
                         dbClient, davItem,
                         HealthCheckResult.HealthResult.Unhealthy,
@@ -548,7 +548,7 @@ public class HealthCheckService : BackgroundService
             // then we can delete both the item and the link-file.
             await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
             dbClient.Ctx.Items.Remove(davItem);
-            _failureTracker.Clear(davItem.Id);
+            _failureTracker.ClearFailure(davItem.Id);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Unhealthy,

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -24,6 +24,7 @@ public class HealthCheckService : BackgroundService
     private readonly INntpClient _usenetClient;
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
+    private readonly StreamingFailureTracker _failureTracker;
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
@@ -33,13 +34,15 @@ public class HealthCheckService : BackgroundService
         ConfigManager configManager,
         UsenetStreamingClient usenetClient,
         WebsocketManager websocketManager,
-        BenchmarkGate benchmarkGate
+        BenchmarkGate benchmarkGate,
+        StreamingFailureTracker failureTracker
     )
     {
         _configManager = configManager;
         _usenetClient = usenetClient;
         _websocketManager = websocketManager;
         _benchmarkGate = benchmarkGate;
+        _failureTracker = failureTracker;
 
         _configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -141,7 +144,7 @@ public class HealthCheckService : BackgroundService
         if (isUrgentRepair)
         {
             Log.Information("Performing urgent dynamic repair for {FilePath}", davItem.Path);
-            await Repair(davItem, dbClient, ct).ConfigureAwait(false);
+            await HandleUrgentRepair(davItem, dbClient, ct).ConfigureAwait(false);
             return;
         }
 
@@ -177,6 +180,7 @@ public class HealthCheckService : BackgroundService
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
+            _failureTracker.Clear(davItem.Id);
             var healthyMessage = sampled.Count < totalSegments
                 ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
                 : "File is healthy.";
@@ -296,7 +300,86 @@ public class HealthCheckService : BackgroundService
         return [];
     }
 
-    private async Task Repair(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
+    /// <summary>
+    /// How an urgent (streaming-triggered) repair should proceed given auto-remove settings.
+    /// </summary>
+    public enum UrgentRepairDisposition
+    {
+        /// <summary>Call Repair() with today's behavior (Arr search or orphan delete).</summary>
+        RepairNormally,
+        /// <summary>Clear the urgent flag and wait for more streaming failures.</summary>
+        Defer,
+        /// <summary>Force the repair-delete path even for library-linked items.</summary>
+        ForceDelete,
+    }
+
+    /// <summary>
+    /// Decides urgent-repair disposition from failure count and auto-remove config.
+    /// Threshold 0 disables the feature (identical to today's immediate Repair).
+    /// </summary>
+    public static UrgentRepairDisposition GetUrgentRepairDisposition(
+        int threshold,
+        int failureCount,
+        bool hasLibraryLink,
+        bool autoRemoveUnlinkedOnly)
+    {
+        if (threshold <= 0)
+            return UrgentRepairDisposition.RepairNormally;
+
+        if (failureCount < threshold)
+        {
+            // Library-linked + unlinked-only: prefer Arr remove-and-search immediately.
+            // Unlinked (and aggressive linked) wait until the threshold before deleting.
+            if (hasLibraryLink && autoRemoveUnlinkedOnly)
+                return UrgentRepairDisposition.RepairNormally;
+            return UrgentRepairDisposition.Defer;
+        }
+
+        if (hasLibraryLink && autoRemoveUnlinkedOnly)
+            return UrgentRepairDisposition.RepairNormally;
+
+        return UrgentRepairDisposition.ForceDelete;
+    }
+
+    private async Task HandleUrgentRepair(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
+    {
+        var threshold = _configManager.GetAutoRemoveAfterFailures();
+        var failureCount = _failureTracker.GetCount(davItem.Id);
+        var unlinkedOnly = _configManager.GetAutoRemoveUnlinkedOnly();
+        var hasLibraryLink = OrganizedLinksUtil.GetLink(davItem, _configManager) != null;
+        var disposition = GetUrgentRepairDisposition(threshold, failureCount, hasLibraryLink, unlinkedOnly);
+
+        if (disposition == UrgentRepairDisposition.Defer)
+        {
+            var utcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = utcNow + TimeSpan.FromHours(1);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                string.Join(" ", [
+                    "File had missing articles during streaming.",
+                    $"Streaming failure count: {failureCount}/{threshold}.",
+                    "Auto-remove deferred until the failure threshold is reached."
+                ]), ct).ConfigureAwait(false);
+            return;
+        }
+
+        await Repair(
+            davItem,
+            dbClient,
+            ct,
+            forceDelete: disposition == UrgentRepairDisposition.ForceDelete,
+            streamingFailureCount: failureCount).ConfigureAwait(false);
+    }
+
+    private async Task Repair(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        CancellationToken ct,
+        bool forceDelete = false,
+        int? streamingFailureCount = null)
     {
         try
         {
@@ -306,6 +389,7 @@ public class HealthCheckService : BackgroundService
             if (BlocklistedFilePostProcessor.MatchesAnyPattern(davItem.Name, blocklistedFiles))
             {
                 dbClient.Ctx.Items.Remove(davItem);
+                _failureTracker.Clear(davItem.Id);
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,
@@ -318,21 +402,52 @@ public class HealthCheckService : BackgroundService
                 return;
             }
 
-            // if the unhealthy item is unlinked/orphaned,
-            // then we can simply delete it.
+            // if the unhealthy item is unlinked/orphaned, or auto-remove force-delete is requested,
+            // then we can simply delete it (and the library link when present).
             var symlinkOrStrmPath = OrganizedLinksUtil.GetLink(davItem, _configManager);
-            if (symlinkOrStrmPath == null)
+            if (symlinkOrStrmPath == null || forceDelete)
             {
+                if (forceDelete && symlinkOrStrmPath != null)
+                    await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
+
                 dbClient.Ctx.Items.Remove(davItem);
+                _failureTracker.Clear(davItem.Id);
+
+                var failureNote = streamingFailureCount is > 0
+                    ? $" Streaming failure count: {streamingFailureCount}."
+                    : "";
+                string deleteMessage;
+                if (forceDelete && symlinkOrStrmPath != null)
+                {
+                    var forceDeleteLinkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+                    deleteMessage = string.Join(" ", [
+                        "File had missing articles.",
+                        $"Auto-removed after repeated streaming failures.{failureNote}",
+                        $"Deleted the webdav-file and {forceDeleteLinkType}."
+                    ]);
+                }
+                else if (forceDelete)
+                {
+                    deleteMessage = string.Join(" ", [
+                        "File had missing articles.",
+                        $"Auto-removed after repeated streaming failures.{failureNote}",
+                        "Deleted file."
+                    ]);
+                }
+                else
+                {
+                    deleteMessage = string.Join(" ", [
+                        "File had missing articles.",
+                        "Could not find corresponding symlink or strm-file within Library Dir.",
+                        "Deleted file."
+                    ]);
+                }
+
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,
                     HealthCheckResult.RepairAction.Deleted,
-                    string.Join(" ", [
-                        "File had missing articles.",
-                        "Could not find corresponding symlink or strm-file within Library Dir.",
-                        "Deleted file."
-                    ]), ct).ConfigureAwait(false);
+                    deleteMessage, ct).ConfigureAwait(false);
                 return;
             }
 
@@ -388,6 +503,7 @@ public class HealthCheckService : BackgroundService
                 if (removedAndSearched)
                 {
                     dbClient.Ctx.Items.Remove(davItem);
+                    _failureTracker.Clear(davItem.Id);
                     await RecordHealthResult(
                         dbClient, davItem,
                         HealthCheckResult.HealthResult.Unhealthy,
@@ -432,6 +548,7 @@ public class HealthCheckService : BackgroundService
             // then we can delete both the item and the link-file.
             await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
             dbClient.Ctx.Items.Remove(davItem);
+            _failureTracker.Clear(davItem.Id);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Unhealthy,

--- a/backend/Services/StreamingFailureTracker.cs
+++ b/backend/Services/StreamingFailureTracker.cs
@@ -3,28 +3,34 @@ using System.Collections.Concurrent;
 namespace NzbWebDAV.Services;
 
 /// <summary>
-/// In-memory per-DavItem count of streaming failures (missing articles).
-/// Used by health repair to auto-remove files after repeated failures.
+/// In-memory counter of consecutive streaming failures (missing usenet articles) per
+/// <c>DavItem</c>. Incremented by <c>ExceptionMiddleware</c> whenever it schedules an urgent
+/// repair for an item; consulted (and cleared) by <c>HealthCheckService</c> to power the
+/// opt-in "auto-remove after N failures" repair policy (see <c>repair.auto-remove-after-failures</c>).
+///
+/// Deliberately in-memory rather than persisted: failures recur naturally on replay, so a
+/// process restart simply resets the count, which is an acceptable trade-off for avoiding a
+/// schema migration for a niche opt-in feature.
 /// </summary>
 public class StreamingFailureTracker
 {
-    private readonly ConcurrentDictionary<Guid, (int Count, DateTimeOffset First)> _failures = new();
+    private readonly ConcurrentDictionary<Guid, int> _failureCounts = new();
 
+    /// <summary>Increments and returns the new failure count for the item.</summary>
     public int RecordFailure(Guid davItemId)
     {
-        var now = DateTimeOffset.UtcNow;
-        return _failures.AddOrUpdate(
-            davItemId,
-            _ => (1, now),
-            (_, existing) => (existing.Count + 1, existing.First)).Count;
+        return _failureCounts.AddOrUpdate(davItemId, 1, (_, count) => count + 1);
     }
 
+    /// <summary>Returns the current failure count for the item (0 if never recorded).</summary>
     public int GetCount(Guid davItemId)
-        => _failures.TryGetValue(davItemId, out var entry) ? entry.Count : 0;
+    {
+        return _failureCounts.GetValueOrDefault(davItemId);
+    }
 
-    public DateTimeOffset? GetFirstFailure(Guid davItemId)
-        => _failures.TryGetValue(davItemId, out var entry) ? entry.First : null;
-
+    /// <summary>Clears the counter, e.g. after a successful health check or once the item is repaired/removed.</summary>
     public void Clear(Guid davItemId)
-        => _failures.TryRemove(davItemId, out _);
+    {
+        _failureCounts.TryRemove(davItemId, out _);
+    }
 }

--- a/backend/Services/StreamingFailureTracker.cs
+++ b/backend/Services/StreamingFailureTracker.cs
@@ -23,13 +23,13 @@ public class StreamingFailureTracker
     }
 
     /// <summary>Returns the current failure count for the item (0 if never recorded).</summary>
-    public int GetCount(Guid davItemId)
+    public int GetFailureCount(Guid davItemId)
     {
         return _failureCounts.GetValueOrDefault(davItemId);
     }
 
     /// <summary>Clears the counter, e.g. after a successful health check or once the item is repaired/removed.</summary>
-    public void Clear(Guid davItemId)
+    public void ClearFailure(Guid davItemId)
     {
         _failureCounts.TryRemove(davItemId, out _);
     }

--- a/backend/Services/StreamingFailureTracker.cs
+++ b/backend/Services/StreamingFailureTracker.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// In-memory per-DavItem count of streaming failures (missing articles).
+/// Used by health repair to auto-remove files after repeated failures.
+/// </summary>
+public class StreamingFailureTracker
+{
+    private readonly ConcurrentDictionary<Guid, (int Count, DateTimeOffset First)> _failures = new();
+
+    public int RecordFailure(Guid davItemId)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return _failures.AddOrUpdate(
+            davItemId,
+            _ => (1, now),
+            (_, existing) => (existing.Count + 1, existing.First)).Count;
+    }
+
+    public int GetCount(Guid davItemId)
+        => _failures.TryGetValue(davItemId, out var entry) ? entry.Count : 0;
+
+    public DateTimeOffset? GetFirstFailure(Guid davItemId)
+        => _failures.TryGetValue(davItemId, out var entry) ? entry.First : null;
+
+    public void Clear(Guid davItemId)
+        => _failures.TryRemove(davItemId, out _);
+}

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -8,6 +8,11 @@ type RepairsSettingsProps = {
     setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
 };
 
+function isNonNegativeInteger(value: string) {
+    const num = Number(value);
+    return Number.isInteger(num) && num >= 0 && value.trim() === num.toString();
+}
+
 export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) {
     const libraryDirConfig = config["media.library-dir"];
     const arrConfig = JSON.parse(config["arr.instances"]);
@@ -18,6 +23,8 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
     const helpText = canEnableRepairs
         ? "When enabled, usenet items will be continuously monitored for health. Unhealthy items will be removed. If an unhealthy item is part of your Radarr/Sonarr library, a new search will be triggered to find a replacement."
         : "When enabled, usenet items will be continuously monitored for health. Unhealthy items will be removed and replaced. This setting can only be enabled once your Library-Directory and Radarr/Sonarr instances are configured.";
+    const autoRemoveAfter = config["repair.auto-remove-after-failures"] ?? "0";
+    const autoRemoveEnabled = isNonNegativeInteger(autoRemoveAfter) && Number(autoRemoveAfter) > 0;
 
     return (
         <SettingsPage>
@@ -54,6 +61,39 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             <hr />
             <div className="space-y-2">
+                <label className="block text-sm font-medium text-slate-200" htmlFor="auto-remove-after-failures-input">Auto-Remove After Streaming Failures</label>
+                <Input
+                    className={`w-full ${!isNonNegativeInteger(autoRemoveAfter || "0") ? "border-red-500" : ""}`}
+                    type="text"
+                    id="auto-remove-after-failures-input"
+                    aria-describedby="auto-remove-after-failures-help"
+                    placeholder="0"
+                    value={autoRemoveAfter}
+                    onChange={e => setNewConfig({ ...config, "repair.auto-remove-after-failures": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-after-failures-help">
+                    After this many streaming playback failures (missing articles), urgent repair will
+                    auto-remove the broken file. Set to 0 to disable (default). Example: 3 removes an
+                    unlinked file on the third failure.
+                </p>
+            </div>
+            <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <Checkbox
+                    id="auto-remove-unlinked-only-checkbox"
+                    aria-describedby="auto-remove-unlinked-only-help"
+                    checked={(config["repair.auto-remove-unlinked-only"] ?? "true") === "true"}
+                    disabled={!autoRemoveEnabled}
+                    onChange={e => setNewConfig({ ...config, "repair.auto-remove-unlinked-only": "" + e.target.checked })}  />
+                    <span>Auto-remove unlinked files only</span>
+                </label>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-unlinked-only-help">
+                    When enabled (default), library-linked files still go through Radarr/Sonarr
+                    remove-and-search instead of silent delete. Disable for aggressive mode that
+                    force-deletes linked files after the failure threshold.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
                 <label className="block text-sm font-medium text-slate-200" htmlFor="library-dir-input">Library Directory</label>
                 <Input
                     className={'w-full'}
@@ -74,10 +114,15 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
 export function isRepairsSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["repair.enable"] !== newConfig["repair.enable"]
         || config["repair.healthcheck-concurrency"] !== newConfig["repair.healthcheck-concurrency"]
+        || config["repair.auto-remove-after-failures"] !== newConfig["repair.auto-remove-after-failures"]
+        || config["repair.auto-remove-unlinked-only"] !== newConfig["repair.auto-remove-unlinked-only"]
         || config["media.library-dir"] !== newConfig["media.library-dir"];
 }
 
 export function isRepairsSettingsValid(newConfig: Record<string, string>) {
-    const value = newConfig["repair.healthcheck-concurrency"];
-    return value === undefined || value === "" || isPositiveInteger(value);
+    const concurrency = newConfig["repair.healthcheck-concurrency"];
+    const autoRemove = newConfig["repair.auto-remove-after-failures"];
+    const concurrencyOk = concurrency === undefined || concurrency === "" || isPositiveInteger(concurrency);
+    const autoRemoveOk = autoRemove === undefined || autoRemove === "" || isNonNegativeInteger(autoRemove);
+    return concurrencyOk && autoRemoveOk;
 }

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -93,6 +93,8 @@ const defaultConfig = {
     "preflight.indexer-max-wait-seconds": "5",
     "repair.enable": "false",
     "repair.healthcheck-concurrency": "50",
+    "repair.auto-remove-after-failures": "0",
+    "repair.auto-remove-unlinked-only": "true",
     "db.is-startup-vacuum-enabled": "false",
     "database.history-retention-days": "90",
     "database.healthcheck-retention-days": "30",

--- a/tests/NzbWebDAV.Tests/Services/StreamingFailureTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamingFailureTrackerTests.cs
@@ -5,41 +5,35 @@ namespace NzbWebDAV.Tests.Services;
 public class StreamingFailureTrackerTests
 {
     [Fact]
-    public void RecordFailure_IncrementsCountAndTracksFirst()
+    public void RecordFailure_IncrementsCount()
     {
         var tracker = new StreamingFailureTracker();
         var id = Guid.NewGuid();
 
         Assert.Equal(1, tracker.RecordFailure(id));
-        var first = tracker.GetFirstFailure(id);
-        Assert.NotNull(first);
-
         Assert.Equal(2, tracker.RecordFailure(id));
         Assert.Equal(3, tracker.RecordFailure(id));
-        Assert.Equal(3, tracker.GetCount(id));
-        Assert.Equal(first, tracker.GetFirstFailure(id));
+        Assert.Equal(3, tracker.GetFailureCount(id));
     }
 
     [Fact]
-    public void GetCount_ReturnsZeroForUnknownItem()
+    public void GetFailureCount_ReturnsZeroForUnknownItem()
     {
         var tracker = new StreamingFailureTracker();
-        Assert.Equal(0, tracker.GetCount(Guid.NewGuid()));
-        Assert.Null(tracker.GetFirstFailure(Guid.NewGuid()));
+        Assert.Equal(0, tracker.GetFailureCount(Guid.NewGuid()));
     }
 
     [Fact]
-    public void Clear_ResetsCount()
+    public void ClearFailure_ResetsCount()
     {
         var tracker = new StreamingFailureTracker();
         var id = Guid.NewGuid();
         tracker.RecordFailure(id);
         tracker.RecordFailure(id);
 
-        tracker.Clear(id);
+        tracker.ClearFailure(id);
 
-        Assert.Equal(0, tracker.GetCount(id));
-        Assert.Null(tracker.GetFirstFailure(id));
+        Assert.Equal(0, tracker.GetFailureCount(id));
     }
 
     [Fact]
@@ -53,7 +47,7 @@ public class StreamingFailureTrackerTests
         tracker.RecordFailure(a);
         tracker.RecordFailure(b);
 
-        Assert.Equal(2, tracker.GetCount(a));
-        Assert.Equal(1, tracker.GetCount(b));
+        Assert.Equal(2, tracker.GetFailureCount(a));
+        Assert.Equal(1, tracker.GetFailureCount(b));
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/StreamingFailureTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamingFailureTrackerTests.cs
@@ -1,0 +1,59 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class StreamingFailureTrackerTests
+{
+    [Fact]
+    public void RecordFailure_IncrementsCountAndTracksFirst()
+    {
+        var tracker = new StreamingFailureTracker();
+        var id = Guid.NewGuid();
+
+        Assert.Equal(1, tracker.RecordFailure(id));
+        var first = tracker.GetFirstFailure(id);
+        Assert.NotNull(first);
+
+        Assert.Equal(2, tracker.RecordFailure(id));
+        Assert.Equal(3, tracker.RecordFailure(id));
+        Assert.Equal(3, tracker.GetCount(id));
+        Assert.Equal(first, tracker.GetFirstFailure(id));
+    }
+
+    [Fact]
+    public void GetCount_ReturnsZeroForUnknownItem()
+    {
+        var tracker = new StreamingFailureTracker();
+        Assert.Equal(0, tracker.GetCount(Guid.NewGuid()));
+        Assert.Null(tracker.GetFirstFailure(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Clear_ResetsCount()
+    {
+        var tracker = new StreamingFailureTracker();
+        var id = Guid.NewGuid();
+        tracker.RecordFailure(id);
+        tracker.RecordFailure(id);
+
+        tracker.Clear(id);
+
+        Assert.Equal(0, tracker.GetCount(id));
+        Assert.Null(tracker.GetFirstFailure(id));
+    }
+
+    [Fact]
+    public void RecordFailure_TracksItemsIndependently()
+    {
+        var tracker = new StreamingFailureTracker();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+
+        tracker.RecordFailure(a);
+        tracker.RecordFailure(a);
+        tracker.RecordFailure(b);
+
+        Assert.Equal(2, tracker.GetCount(a));
+        Assert.Equal(1, tracker.GetCount(b));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
@@ -1,0 +1,60 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class UrgentRepairDispositionTests
+{
+    [Theory]
+    [InlineData(0, 0, false, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
+    [InlineData(0, 5, false, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
+    [InlineData(0, 5, true, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
+    public void ThresholdZero_AlwaysRepairNormally(
+        int threshold,
+        int failureCount,
+        bool hasLibraryLink,
+        bool unlinkedOnly,
+        HealthCheckService.UrgentRepairDisposition expected)
+    {
+        Assert.Equal(
+            expected,
+            HealthCheckService.GetUrgentRepairDisposition(threshold, failureCount, hasLibraryLink, unlinkedOnly));
+    }
+
+    [Fact]
+    public void Unlinked_BelowThreshold_Defers()
+    {
+        Assert.Equal(
+            HealthCheckService.UrgentRepairDisposition.Defer,
+            HealthCheckService.GetUrgentRepairDisposition(3, 2, hasLibraryLink: false, autoRemoveUnlinkedOnly: true));
+    }
+
+    [Fact]
+    public void Unlinked_AtThreshold_ForceDeletes()
+    {
+        Assert.Equal(
+            HealthCheckService.UrgentRepairDisposition.ForceDelete,
+            HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: false, autoRemoveUnlinkedOnly: true));
+    }
+
+    [Fact]
+    public void Linked_UnlinkedOnly_UsesArrPathEvenAtThreshold()
+    {
+        Assert.Equal(
+            HealthCheckService.UrgentRepairDisposition.RepairNormally,
+            HealthCheckService.GetUrgentRepairDisposition(3, 1, hasLibraryLink: true, autoRemoveUnlinkedOnly: true));
+        Assert.Equal(
+            HealthCheckService.UrgentRepairDisposition.RepairNormally,
+            HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: true, autoRemoveUnlinkedOnly: true));
+    }
+
+    [Fact]
+    public void Linked_Aggressive_BelowThreshold_Defers_AtThreshold_ForceDeletes()
+    {
+        Assert.Equal(
+            HealthCheckService.UrgentRepairDisposition.Defer,
+            HealthCheckService.GetUrgentRepairDisposition(3, 2, hasLibraryLink: true, autoRemoveUnlinkedOnly: false));
+        Assert.Equal(
+            HealthCheckService.UrgentRepairDisposition.ForceDelete,
+            HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: true, autoRemoveUnlinkedOnly: false));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an in-memory `StreamingFailureTracker` (incremented from `ExceptionMiddleware` when streaming hits missing articles) and config knobs `repair.auto-remove-after-failures` (default 0 = off) and `repair.auto-remove-unlinked-only` (default true), including repairs settings UI.
- On urgent repair, when the failure count reaches the threshold: unlinked (or aggressive) files are deleted via the existing `Repair` delete path with a `Deleted` health result; library-linked files with unlinked-only keep *Arr remove-and-search. Threshold 0 preserves today’s behavior.
- Surfaces streaming failure count in deferred/auto-remove health result messages; clears the tracker on healthy checks and successful deletes/repairs. Leaves `PlaybackFastVerifier` alone.

Closes #68

## Test plan
- [x] `dotnet test` focused: `StreamingFailureTracker` + `UrgentRepairDisposition` + existing HealthCheck tests (22 passed)
- [x] Full backend suite: new tests pass; 11 pre-existing rapidyenc native-lib failures unrelated to this change
- [ ] Manual: enable repairs, set auto-remove threshold to 3, stream an unlinked broken file 3 times → Health shows `Deleted` with failure count in the message
- [ ] Manual: library-linked file with unlinked-only=true → still *Arr remove-and-search, not silent delete
- [ ] Manual: threshold 0 → urgent repair behaves as before