### PR TITLE
feat(nntp): idle timeout and range prefetch cap (#59)

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -11,6 +11,7 @@ using NzbWebDAV.Par2Recovery;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
+using NzbWebDAV.WebDav.Requests;
 
 namespace NzbWebDAV.Api.Controllers.GetWebdavItem;
 
@@ -36,6 +37,10 @@ public class GetWebdavItemController(
         // handle par2 preview
         if (Path.GetExtension(item.Name).ToLower() == ".par2" && configManager.IsPreviewPar2FilesEnabled())
             return await GetPar2PreviewStream(item).ConfigureAwait(false);
+
+        // Provisional budget for fully-specified ranges before stream creation.
+        if (request.RangeStart is { } provisionalStart && request.RangeEnd is { } provisionalEnd)
+            RangeContext.SetReadBudget(provisionalEnd - provisionalStart + 1);
 
         // get the file stream and set the file-size in header
         var stream = await item.GetReadableStreamAsync(HttpContext.RequestAborted).ConfigureAwait(false);
@@ -92,6 +97,9 @@ public class GetWebdavItemController(
 
             var chunkSize = 1 + end - rangeStart.Value;
 
+            // Cap prefetch at the range end before Seek recreates segment streams.
+            RangeContext.SetReadBudget(chunkSize);
+
             // seek
             stream.Seek(rangeStart.Value, SeekOrigin.Begin);
             if (rangeEnd is not null) stream = stream.LimitLength(chunkSize);
@@ -103,6 +111,7 @@ public class GetWebdavItemController(
         }
         else
         {
+            RangeContext.SetReadBudget(null);
             Response.Headers["Content-Length"] = fileSize.ToString();
         }
 

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -83,10 +83,12 @@ public class UsenetStreamingClient : WrappingNntpClient
         _ = ProviderUsageHelper.SeedTrackerAsync(bytesTracker, providerConfig);
 
         var connectionPoolStats = new ConnectionPoolStats(providerConfig, websocketManager);
+        var idleTimeoutSeconds = configManager.GetIdleConnectionTimeoutSeconds();
         var providerClients = providerConfig.Providers
             .Select((provider, index) => CreateProviderClient(
                 provider,
-                connectionPoolStats.GetOnConnectionPoolChanged(index)
+                connectionPoolStats.GetOnConnectionPoolChanged(index),
+                idleTimeoutSeconds
             ))
             .ToList();
         return new MultiProviderNntpClient(providerClients, usageTracker, metricsWriter, bytesTracker,
@@ -96,13 +98,15 @@ public class UsenetStreamingClient : WrappingNntpClient
     private static MultiConnectionNntpClient CreateProviderClient
     (
         UsenetProviderConfig.ConnectionDetails connectionDetails,
-        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged
+        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
+        int idleTimeoutSeconds
     )
     {
         var connectionPool = CreateNewConnectionPool(
             maxConnections: connectionDetails.MaxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
-            onConnectionPoolChanged
+            onConnectionPoolChanged,
+            idleTimeoutSeconds
         );
         var circuitBreaker = new ProviderCircuitBreaker(connectionDetails.Host);
         // Ensure a metrics key even if startup backfill was skipped somehow.
@@ -126,10 +130,16 @@ public class UsenetStreamingClient : WrappingNntpClient
     (
         int maxConnections,
         Func<CancellationToken, ValueTask<INntpClient>> connectionFactory,
-        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged
+        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
+        int idleTimeoutSeconds
     )
     {
-        var connectionPool = new ConnectionPool<INntpClient>(maxConnections, connectionFactory);
+        var idleTimeout = TimeSpan.FromSeconds(idleTimeoutSeconds);
+        Log.Information(
+            "Creating NNTP connection pool max={Max} idleTimeout={IdleTimeoutSeconds}s",
+            maxConnections, idleTimeoutSeconds);
+        var connectionPool = new ConnectionPool<INntpClient>(
+            maxConnections, connectionFactory, idleTimeout);
         connectionPool.OnConnectionPoolChanged += onConnectionPoolChanged;
         var args = new ConnectionPoolStats.ConnectionPoolChangedEventArgs(0, 0, maxConnections);
         onConnectionPoolChanged(connectionPool, args);

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -31,6 +31,7 @@ public static class ConfigKeys
     // usenet
     public const string UsenetArticleBufferSize = "usenet.article-buffer-size";
     public const string UsenetCascadeEnabled = "usenet.cascade.enabled";
+    public const string UsenetIdleConnectionTimeoutSeconds = "usenet.idle-connection-timeout-seconds";
     public const string UsenetMaxDownloadConnections = "usenet.max-download-connections";
     public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -151,6 +151,7 @@ public class ConfigManager
                 case ConfigKeys.UsenetMaxQueueConnections:
                 case ConfigKeys.UsenetPipeliningDepth:
                 case ConfigKeys.UsenetArticleBufferSize:
+                case ConfigKeys.UsenetIdleConnectionTimeoutSeconds:
                 case ConfigKeys.UsenetSegmentCacheMaxGb:
                 case ConfigKeys.UsenetStreamingPriority:
                 case ConfigKeys.WardenQuorum:
@@ -426,6 +427,18 @@ public class ConfigManager
             StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetArticleBufferSize))
             ?? "40"
         );
+    }
+
+    /// <summary>
+    /// Idle timeout for pooled NNTP connections. Default 60s; clamped to [15, 300].
+    /// Takes effect on the next connection-pool rebuild (provider config change or restart).
+    /// </summary>
+    public int GetIdleConnectionTimeoutSeconds()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetIdleConnectionTimeoutSeconds));
+        if (configured is null || !int.TryParse(configured, out var value))
+            return 60;
+        return Math.Clamp(value, 15, 300);
     }
 
     public bool IsPipelinedBodyRequestsEnabled()

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -23,6 +23,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly Channel<Task<Stream>> _streamTasks;
     private readonly int _bodyPipelineBatchSize;
     private readonly ContextualCancellationTokenSource _cts;
+    private readonly long? _readBudget;
     private Stream? _stream;
     private bool _disposed;
 
@@ -32,7 +33,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         int articleBufferSize,
         bool usePipelinedBodyRequests,
         CancellationToken cancellationToken,
-        string? fileName = null)
+        string? fileName = null,
+        long? readBudget = null)
     {
         return Create(
             segmentIds,
@@ -42,7 +44,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             failFastOnFirstSegment: false,
             usePipelinedBodyRequests,
             cancellationToken,
-            fileName);
+            fileName,
+            readBudget);
     }
 
     public static Stream Create
@@ -54,7 +57,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool failFastOnFirstSegment,
         bool usePipelinedBodyRequests,
         CancellationToken cancellationToken,
-        string? fileName = null
+        string? fileName = null,
+        long? readBudget = null
     )
     {
         return articleBufferSize == 0
@@ -67,7 +71,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 failFastOnFirstSegment,
                 usePipelinedBodyRequests,
                 cancellationToken,
-                fileName);
+                fileName,
+                readBudget);
     }
 
     private MultiSegmentStream
@@ -79,7 +84,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool failFastOnFirstSegment,
         bool usePipelinedBodyRequests,
         CancellationToken cancellationToken,
-        string? fileName
+        string? fileName,
+        long? readBudget
     )
     {
         _segmentIds = segmentIds;
@@ -87,6 +93,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _expectedSegmentSize = expectedSegmentSize;
         _failFastOnFirstSegment = failFastOnFirstSegment;
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
+        _readBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         _bodyPipelineBatchSize = Math.Min(BodyPipelineBatchSize, articleBufferSize);
         _streamTasks = Channel.CreateBounded<Task<Stream>>(articleBufferSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -122,8 +129,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
     private async Task DownloadPipelinedSegments(CancellationToken cancellationToken)
     {
+        var segmentsEnqueued = 0;
         for (var batchStart = 0; batchStart < _segmentIds.Length;)
         {
+            if (ShouldStopPrefetch(segmentsEnqueued))
+                break;
+
             var batchCount = Math.Min(
                 _bodyPipelineBatchSize, _segmentIds.Length - batchStart);
             var segmentIds = new SegmentId[batchCount];
@@ -152,6 +163,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 {
                     await _streamTasks.Writer.WriteAsync(
                         streamTasks[responseIndex], cancellationToken);
+                    segmentsEnqueued++;
                 }
             }
             catch
@@ -172,6 +184,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         for (var index = 0; index < _segmentIds.Length; index++)
         {
+            if (ShouldStopPrefetch(index))
+                break;
+
             var segmentId = _segmentIds.Span[index];
             await _streamTasks.Writer.WaitToWriteAsync(cancellationToken);
             var connection = await _usenetClient.AcquireExclusiveConnectionAsync(
@@ -188,6 +203,17 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 throw;
             }
         }
+    }
+
+    /// <summary>
+    /// Stop enqueueing once estimated fetched bytes cover the read budget plus
+    /// one segment of slack for yEnc size variance. Null budget = unbounded.
+    /// </summary>
+    private bool ShouldStopPrefetch(int segmentsEnqueued)
+    {
+        if (_readBudget is null || _expectedSegmentSize <= 0)
+            return false;
+        return segmentsEnqueued * _expectedSegmentSize >= _readBudget.Value + _expectedSegmentSize;
     }
 
     private async Task<Stream> DownloadSegment(

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -7,6 +7,7 @@ using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Services;
+using NzbWebDAV.WebDav.Requests;
 
 namespace NzbWebDAV.WebDav.Base;
 
@@ -59,6 +60,11 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         var range = request.GetRange();
         var copyStart = 0L;
         long? copyEnd = null;
+
+        // Provisional budget from a fully-specified Range before the stream is
+        // constructed so MultiSegmentStream can cap prefetch from the start.
+        if (range is { Start: not null, End: not null })
+            RangeContext.SetReadBudget(range.End.Value - range.Start.Value + 1);
 
         // Obtain the WebDAV collection
         var entry = await _store.GetItemAsync(request.GetUri(), httpContext.RequestAborted).ConfigureAwait(false);
@@ -173,6 +179,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                 // HEAD method doesn't require the actual item data
                 if (!isHeadRequest)
                 {
+                    // Cap segment prefetch at the range end (open-ended ranges leave budget null).
+                    if (copyEnd.HasValue)
+                        RangeContext.SetReadBudget(copyEnd.Value - copyStart + 1);
+                    else
+                        RangeContext.SetReadBudget(null);
+
                     var path = request.GetUri().AbsolutePath;
                     var clientKey = $"{httpContext.Connection.RemoteIpAddress}|{request.Headers.UserAgent}";
                     // DatabaseStoreIdFile.Name returns the GUID (it backs rclone symlink

--- a/backend/WebDav/Requests/RangeContext.cs
+++ b/backend/WebDav/Requests/RangeContext.cs
@@ -1,0 +1,15 @@
+namespace NzbWebDAV.WebDav.Requests;
+
+/// <summary>
+/// Carries an optional byte budget for the current ranged read on the async
+/// call context so stream constructors can cap segment prefetch.
+/// </summary>
+public static class RangeContext
+{
+    private static readonly AsyncLocal<long?> CurrentReadBudget = new();
+
+    public static void SetReadBudget(long? readBudgetBytes) =>
+        CurrentReadBudget.Value = readBudgetBytes;
+
+    public static long? GetReadBudget() => CurrentReadBudget.Value;
+}

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -45,6 +45,7 @@ const defaultConfig = {
     "usenet.max-queue-connections": "",
     "usenet.streaming-priority": "80",
     "usenet.article-buffer-size": "40",
+    "usenet.idle-connection-timeout-seconds": "60",
     "usenet.pipelined-body-requests": "true",
     "usenet.segment-cache.enabled": "false",
     "usenet.segment-cache.path": "/config/segment-cache",

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -185,6 +185,24 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
             </div>
             <hr />
             <div className="space-y-2">
+                <label className="block text-sm font-medium text-slate-200" htmlFor="idle-connection-timeout-input">Idle connection timeout (seconds)</label>
+                <Input
+                    {...className(['w-full', !isValidIdleConnectionTimeout(config["usenet.idle-connection-timeout-seconds"]) && 'border-red-500 focus:border-red-500'])}
+                    type="text"
+                    id="idle-connection-timeout-input"
+                    aria-describedby="idle-connection-timeout-help"
+                    placeholder="60"
+                    value={config["usenet.idle-connection-timeout-seconds"] ?? "60"}
+                    onChange={e => setNewConfig({ ...config, "usenet.idle-connection-timeout-seconds": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="idle-connection-timeout-help">
+                    How long unused NNTP connections stay in the pool before being closed (15–300, default 60).
+                    Raising this can reduce reconnect stalls during playback gaps, but values above your
+                    provider&apos;s server-side idle timeout are counterproductive. Takes effect on the next
+                    connection-pool rebuild (provider config change or restart).
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-slate-300">
                     <Checkbox
                     id="pipelined-body-requests-checkbox"
@@ -254,6 +272,7 @@ export function isWebdavSettingsUpdated(config: Record<string, string>, newConfi
         || config["usenet.max-queue-connections"] !== newConfig["usenet.max-queue-connections"]
         || config["usenet.streaming-priority"] !== newConfig["usenet.streaming-priority"]
         || config["usenet.article-buffer-size"] !== newConfig["usenet.article-buffer-size"]
+        || config["usenet.idle-connection-timeout-seconds"] !== newConfig["usenet.idle-connection-timeout-seconds"]
         || config["usenet.pipelined-body-requests"] !== newConfig["usenet.pipelined-body-requests"]
         || config["webdav.show-hidden-files"] !== newConfig["webdav.show-hidden-files"]
         || config["webdav.enforce-readonly"] !== newConfig["webdav.enforce-readonly"]
@@ -272,6 +291,7 @@ export function isWebdavSettingsValid(newConfig: Record<string, string>) {
         && isValidMaxQueueConnections(newConfig["usenet.max-queue-connections"])
         && isValidStreamingPriority(newConfig["usenet.streaming-priority"])
         && isValidArticleBufferSize(newConfig["usenet.article-buffer-size"])
+        && isValidIdleConnectionTimeout(newConfig["usenet.idle-connection-timeout-seconds"])
         && segmentCacheValid;
 }
 
@@ -304,4 +324,10 @@ function isValidStreamingPriority(value: string): boolean {
 
 function isValidArticleBufferSize(value: string): boolean {
     return isPositiveInteger(value);
+}
+
+function isValidIdleConnectionTimeout(value: string | undefined): boolean {
+    if (value == null || value.trim() === "") return true;
+    const num = Number(value);
+    return Number.isInteger(num) && num >= 15 && num <= 300;
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolIdleTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolIdleTimeoutTests.cs
@@ -1,0 +1,27 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ConnectionPoolIdleTimeoutTests
+{
+    [Fact]
+    public void Constructor_UsesConfiguredIdleTimeout()
+    {
+        using var pool = new ConnectionPool<object>(
+            maxConnections: 1,
+            connectionFactory: _ => ValueTask.FromResult(new object()),
+            idleTimeout: TimeSpan.FromSeconds(120));
+
+        Assert.Equal(TimeSpan.FromSeconds(120), pool.IdleTimeout);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsIdleTimeoutTo60Seconds()
+    {
+        using var pool = new ConnectionPool<object>(
+            maxConnections: 1,
+            connectionFactory: _ => ValueTask.FromResult(new object()));
+
+        Assert.Equal(TimeSpan.FromSeconds(60), pool.IdleTimeout);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -12,6 +12,7 @@ internal sealed class FakeNntpClient(
 {
     public int BatchRequestCount { get; private set; }
     public int BodyRequestCount { get; private set; }
+    public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
 
     public override Task ConnectAsync(
         string host, int port, bool useSsl, CancellationToken cancellationToken) =>
@@ -54,6 +55,7 @@ internal sealed class FakeNntpClient(
     {
         cancellationToken.ThrowIfCancellationRequested();
         BodyRequestCount++;
+        RequestedSegmentIds.Add(segmentId.ToString());
         try
         {
             var response = CreateBodyResponse(segmentId);

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -1,0 +1,81 @@
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class MultiSegmentStreamPrefetchBudgetTests
+{
+    [Fact]
+    public async Task ReadBudget_CapsPrefetchBelowArticleBufferSize()
+    {
+        const int segmentCount = 20;
+        const int segmentSize = 1000;
+        const int articleBufferSize = 10;
+        // 2.5 segments of budget → stop once enqueued*size >= budget + size → 4 segments max
+        const long readBudget = 2500;
+
+        var segments = Enumerable.Range(0, segmentCount)
+            .ToDictionary(
+                i => $"seg-{i}",
+                i => Enumerable.Repeat((byte)(i % 256), segmentSize).ToArray());
+        var client = new FakeNntpClient(segments);
+        var segmentIds = segments.Keys.ToArray().AsMemory();
+
+        await using var stream = MultiSegmentStream.Create(
+            segmentIds,
+            client,
+            articleBufferSize,
+            expectedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "budget.bin",
+            readBudget: readBudget);
+
+        var buffer = new byte[readBudget];
+        var totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            var n = await stream.ReadAsync(buffer.AsMemory(totalRead));
+            if (n == 0) break;
+            totalRead += n;
+        }
+
+        Assert.True(client.RequestedSegmentIds.Count <= 4,
+            $"Expected ≤4 unique segments with budget, got {client.RequestedSegmentIds.Count} (BODY={client.BodyRequestCount})");
+        Assert.True(client.RequestedSegmentIds.Count < articleBufferSize);
+    }
+
+    [Fact]
+    public async Task NullBudget_PrefetchesUpToArticleBufferSize()
+    {
+        const int segmentCount = 20;
+        const int segmentSize = 100;
+        const int articleBufferSize = 10;
+
+        var segments = Enumerable.Range(0, segmentCount)
+            .ToDictionary(
+                i => $"seg-{i}",
+                _ => Enumerable.Repeat((byte)1, segmentSize).ToArray());
+        var client = new FakeNntpClient(segments);
+
+        await using var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            client,
+            articleBufferSize,
+            expectedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "full.bin",
+            readBudget: null);
+
+        // Drain one segment so the producer can fill the channel.
+        var buffer = new byte[segmentSize];
+        _ = await stream.ReadAsync(buffer);
+        await Task.Delay(200);
+
+        Assert.True(client.RequestedSegmentIds.Count >= articleBufferSize - 1,
+            $"Expected prefetch near buffer size without budget, got {client.RequestedSegmentIds.Count}");
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable `usenet.idle-connection-timeout-seconds` (default 60, clamp 15–300) wired into `ConnectionPool`
- Cap `MultiSegmentStream` segment prefetch using an HTTP Range byte budget from WebDAV and `/view` handlers

Closes #59

## Test plan
- [x] `ConnectionPoolIdleTimeoutTests` + `MultiSegmentStreamPrefetchBudgetTests`
- [ ] Raise idle timeout in settings, restart, confirm pool log shows configured value
- [ ] Ranged GET with small Range should fetch far fewer segments than `article-buffer-size`