### PR TITLE
feat(webdav): per-segment streaming timeout with fast failover

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Extensions;
@@ -26,6 +27,22 @@ public class GetWebdavItemController(
 {
     private async Task<Stream> GetWebdavItem(GetWebdavItemRequest request)
     {
+        // /view streams outside NWebDav; attach the same streaming timeout context
+        // BaseStoreStreamFile sets for WebDAV so segment fetches fail fast.
+        // BaseStoreStreamFile may overwrite this on the same token — both scopes
+        // dispose safely (second Remove is a no-op).
+        var streamingTimeoutContext = new StreamingTimeoutContext
+        {
+            PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
+            MaxRetries = configManager.GetStreamingSegmentRetries(),
+        };
+        var scopedStreamingTimeoutContext = HttpContext.RequestAborted.SetContext(streamingTimeoutContext);
+        HttpContext.Response.OnCompleted(() =>
+        {
+            scopedStreamingTimeoutContext.Dispose();
+            return Task.CompletedTask;
+        });
+
         var item = await store.GetItemAsync(request.Item, HttpContext.RequestAborted).ConfigureAwait(false);
         if (item is null) throw new BadHttpRequestException("The file does not exist.");
         if (item is IStoreCollection) throw new BadHttpRequestException("The file does not exist.");

--- a/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
+++ b/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
@@ -21,6 +21,7 @@ public class ContextualCancellationTokenSource : IDisposable
         var cts = CancellationTokenSource.CreateLinkedTokenSource(linkedToken);
         var contextualCts = new ContextualCancellationTokenSource(cts);
         contextualCts.SetContext(linkedToken.GetContext<DownloadPriorityContext>());
+        contextualCts.SetContext(linkedToken.GetContext<StreamingTimeoutContext>());
         return contextualCts;
     }
 
@@ -34,6 +35,8 @@ public class ContextualCancellationTokenSource : IDisposable
         var contextualCts = new ContextualCancellationTokenSource(cts);
         contextualCts.SetContext(linkedToken1.GetContext<DownloadPriorityContext>());
         contextualCts.SetContext(linkedToken2.GetContext<DownloadPriorityContext>());
+        contextualCts.SetContext(linkedToken1.GetContext<StreamingTimeoutContext>());
+        contextualCts.SetContext(linkedToken2.GetContext<StreamingTimeoutContext>());
         return contextualCts;
     }
 

--- a/backend/Clients/Usenet/Contexts/StreamingTimeoutContext.cs
+++ b/backend/Clients/Usenet/Contexts/StreamingTimeoutContext.cs
@@ -1,0 +1,12 @@
+namespace NzbWebDAV.Clients.Usenet.Contexts;
+
+/// <summary>
+/// Attached to WebDAV /view streaming cancellation tokens so segment fetches
+/// fail fast and retry on a fresh connection instead of waiting for UsenetSharp's
+/// ~40s internal read timeout. Not set for queue or health-check traffic.
+/// </summary>
+public record StreamingTimeoutContext
+{
+    public required TimeSpan PerSegmentTimeout { get; init; }
+    public required int MaxRetries { get; init; }
+}

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -110,7 +110,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "STAT",
             SemaphorePriority.Low,
-            (connection, _) => connection.StatAsync(segmentId, ct),
+            (connection, _, commandCt) => connection.StatAsync(segmentId, commandCt),
             onConnectionReadyAgain: null,
             ct
         );
@@ -121,7 +121,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "HEAD",
             SemaphorePriority.Low,
-            (connection, _) => connection.HeadAsync(segmentId, ct),
+            (connection, _, commandCt) => connection.HeadAsync(segmentId, commandCt),
             onConnectionReadyAgain: null,
             ct
         );
@@ -132,7 +132,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "BODY",
             GetDownloadPriority(ct),
-            (connection, onDone) => connection.DecodedBodyAsync(segmentId, onDone, ct),
+            (connection, onDone, commandCt) => connection.DecodedBodyAsync(segmentId, onDone, commandCt),
             onConnectionReadyAgain: null,
             ct
         );
@@ -147,7 +147,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "ARTICLE",
             GetDownloadPriority(ct),
-            (connection, onDone) => connection.DecodedArticleAsync(segmentId, onDone, ct),
+            (connection, onDone, commandCt) => connection.DecodedArticleAsync(segmentId, onDone, commandCt),
             onConnectionReadyAgain: null,
             ct
         );
@@ -158,7 +158,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "DATE",
             SemaphorePriority.Low,
-            (connection, _) => connection.DateAsync(ct),
+            (connection, _, commandCt) => connection.DateAsync(commandCt),
             onConnectionReadyAgain: null,
             ct
         );
@@ -174,7 +174,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "BODY",
             GetDownloadPriority(ct),
-            (connection, onDone) => connection.DecodedBodyAsync(segmentId, onDone, ct),
+            (connection, onDone, commandCt) => connection.DecodedBodyAsync(segmentId, onDone, commandCt),
             onConnectionReadyAgain,
             ct
         );
@@ -287,7 +287,7 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "ARTICLE",
             GetDownloadPriority(ct),
-            (connection, onDone) => connection.DecodedArticleAsync(segmentId, onDone, ct),
+            (connection, onDone, commandCt) => connection.DecodedArticleAsync(segmentId, onDone, commandCt),
             onConnectionReadyAgain,
             ct
         );
@@ -297,12 +297,16 @@ public class MultiConnectionNntpClient(
     (
         string name,
         SemaphorePriority priority,
-        Func<INntpClient, Action<ArticleBodyResult>, Task<T>> command,
+        Func<INntpClient, Action<ArticleBodyResult>, CancellationToken, Task<T>> command,
         Action<ArticleBodyResult>? onConnectionReadyAgain,
         CancellationToken ct,
         int retryCount = 1
     ) where T : UsenetResponse
     {
+        var streamingTimeout = ct.GetContext<StreamingTimeoutContext>();
+        if (streamingTimeout != null)
+            retryCount = streamingTimeout.MaxRetries;
+
         while (true)
         {
             ConnectionLock<INntpClient>? connectionLock = null;
@@ -335,10 +339,47 @@ public class MultiConnectionNntpClient(
 
             T? result;
             var deferredCallback = new DeferredArticleBodyCallback();
+            CancellationTokenSource? attemptCts = null;
             try
             {
-                result = await command(connectionLock.Connection, deferredCallback.Invoke)
+                var commandCt = ct;
+                if (streamingTimeout != null)
+                {
+                    attemptCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    attemptCts.CancelAfter(streamingTimeout.PerSegmentTimeout);
+                    commandCt = attemptCts.Token;
+                }
+
+                result = await command(connectionLock.Connection, deferredCallback.Invoke, commandCt)
                     .ConfigureAwait(false);
+            }
+            catch (Exception e) when (
+                streamingTimeout != null
+                && e.IsCancellationException()
+                && !ct.IsCancellationRequested)
+            {
+                // Per-segment CancelAfter fired while the caller is still alive.
+                // The connection has an in-flight command → NotRetrieved (replace).
+                // Do not invoke onConnectionReadyAgain on retry: the outer download
+                // permit stays held across attempts (same pattern as other retries).
+                deferredCallback.Discard();
+                LogException(() => connectionLock?.Replace());
+                LogException(() => connectionLock?.Dispose());
+                if (retryCount > 0)
+                {
+                    Log.Debug(
+                        "Streaming timeout executing nntp {Command} command after {Timeout}s. Retrying with a new connection ({Retries} left).",
+                        name, streamingTimeout.PerSegmentTimeout.TotalSeconds, retryCount);
+                    retryCount--;
+                    continue;
+                }
+
+                Log.Warning(
+                    "Streaming timeout executing nntp {Command} command after {Timeout}s. No retries left.",
+                    name, streamingTimeout.PerSegmentTimeout.TotalSeconds);
+                LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
+                throw new TimeoutException(
+                    $"Timeout executing nntp {name} command after {streamingTimeout.MaxRetries + 1} attempts.");
             }
             catch (Exception e) when (e.IsCancellationException(ct))
             {
@@ -398,6 +439,10 @@ public class MultiConnectionNntpClient(
                     "Error executing nntp {Command} command for provider {Provider}.", name, providerName);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
+            }
+            finally
+            {
+                attemptCts?.Dispose();
             }
 
             // stat, head, and date

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -43,6 +43,8 @@ public static class ConfigKeys
     public const string UsenetSegmentCacheMaxGb = "usenet.segment-cache.max-gb";
     public const string UsenetSegmentCachePath = "usenet.segment-cache.path";
     public const string UsenetStreamingPriority = "usenet.streaming-priority";
+    public const string UsenetStreamingSegmentTimeoutSeconds = "usenet.streaming-segment-timeout-seconds";
+    public const string UsenetStreamingSegmentRetries = "usenet.streaming-segment-retries";
 
     // webdav
     public const string WebdavEnforceReadonly = "webdav.enforce-readonly";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -153,6 +153,8 @@ public class ConfigManager
                 case ConfigKeys.UsenetArticleBufferSize:
                 case ConfigKeys.UsenetSegmentCacheMaxGb:
                 case ConfigKeys.UsenetStreamingPriority:
+                case ConfigKeys.UsenetStreamingSegmentTimeoutSeconds:
+                case ConfigKeys.UsenetStreamingSegmentRetries:
                 case ConfigKeys.WardenQuorum:
                 case ConfigKeys.WardenMaxSourceEntries:
                 case ConfigKeys.PlayTotalBudgetSeconds:
@@ -468,6 +470,19 @@ public class ConfigManager
         var stringValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingPriority));
         var numericalValue = int.Parse(stringValue ?? "80");
         return new SemaphorePriorityOdds() { HighPriorityOdds = numericalValue };
+    }
+
+    public TimeSpan GetStreamingSegmentTimeout()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingSegmentTimeoutSeconds));
+        var seconds = int.TryParse(v, out var n) ? Math.Clamp(n, 2, 40) : 8;
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    public int GetStreamingSegmentRetries()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingSegmentRetries));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 5) : 3;
     }
 
     public bool IsEnforceReadonlyWebdavEnabled()

--- a/backend/WebDav/Base/BaseStoreStreamFile.cs
+++ b/backend/WebDav/Base/BaseStoreStreamFile.cs
@@ -20,6 +20,13 @@ public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager con
         };
         var scopedDownloadPriorityContext = cancellationToken.SetContext(downloadPriorityContext);
 
+        var streamingTimeoutContext = new StreamingTimeoutContext
+        {
+            PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
+            MaxRetries = configManager.GetStreamingSegmentRetries(),
+        };
+        var scopedStreamingTimeoutContext = cancellationToken.SetContext(streamingTimeoutContext);
+
         // Keep this stream's per-stream budget in sync with live config changes,
         // mirroring how DownloadingNntpClient resizes the shared streaming semaphore.
         // The per-stream count depends on the total connection setting, the preset,
@@ -47,6 +54,7 @@ public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager con
         {
             if (onConfigChanged is not null) configManager.OnConfigChanged -= onConfigChanged;
             scopedDownloadPriorityContext.Dispose();
+            scopedStreamingTimeoutContext.Dispose();
             streamSemaphore?.Dispose();
             return Task.CompletedTask;
         });

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -44,6 +44,8 @@ const defaultConfig = {
     "usenet.max-download-connections-per-stream-preset": "high",
     "usenet.max-queue-connections": "",
     "usenet.streaming-priority": "80",
+    "usenet.streaming-segment-timeout-seconds": "8",
+    "usenet.streaming-segment-retries": "3",
     "usenet.article-buffer-size": "40",
     "usenet.pipelined-body-requests": "true",
     "usenet.segment-cache.enabled": "false",

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -170,6 +170,39 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
             </div>
             <hr />
             <div className="space-y-2">
+                <label className="block text-sm font-medium text-slate-200" htmlFor="streaming-segment-timeout-input">Streaming Segment Timeout</label>
+                <div className="flex w-full">
+                    <Input
+                        className={!isValidStreamingSegmentTimeout(config["usenet.streaming-segment-timeout-seconds"]) ? 'border-red-500 focus:border-red-500' : undefined}
+                        type="text"
+                        id="streaming-segment-timeout-input"
+                        aria-describedby="streaming-segment-timeout-help"
+                        placeholder="8"
+                        value={config["usenet.streaming-segment-timeout-seconds"]}
+                        onChange={e => setNewConfig({ ...config, "usenet.streaming-segment-timeout-seconds": e.target.value })} />
+                    <span className="flex items-center rounded-r border border-l-0 border-slate-600 bg-slate-800 px-2 text-sm text-slate-300">sec</span>
+                </div>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-segment-timeout-help">
+                    Per-segment deadline for WebDAV playback (2–40s). Stalled connections are replaced and retried before waiting for the provider&apos;s ~40s read timeout.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-slate-200" htmlFor="streaming-segment-retries-input">Streaming Segment Retries</label>
+                <Input
+                    className={!isValidStreamingSegmentRetries(config["usenet.streaming-segment-retries"]) ? 'border-red-500 focus:border-red-500' : undefined}
+                    type="text"
+                    id="streaming-segment-retries-input"
+                    aria-describedby="streaming-segment-retries-help"
+                    placeholder="3"
+                    value={config["usenet.streaming-segment-retries"]}
+                    onChange={e => setNewConfig({ ...config, "usenet.streaming-segment-retries": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-segment-retries-help">
+                    Extra attempts on a fresh connection after a streaming segment timeout (0–5). Queue and health checks are unaffected.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
                 <label className="block text-sm font-medium text-slate-200" htmlFor="article-buffer-size-input">Article Buffer Size</label>
                 <Input
                     {...className(['w-full', !isValidArticleBufferSize(config["usenet.article-buffer-size"]) && 'border-red-500 focus:border-red-500'])}
@@ -253,6 +286,8 @@ export function isWebdavSettingsUpdated(config: Record<string, string>, newConfi
         || config["usenet.max-download-connections-per-stream-preset"] !== newConfig["usenet.max-download-connections-per-stream-preset"]
         || config["usenet.max-queue-connections"] !== newConfig["usenet.max-queue-connections"]
         || config["usenet.streaming-priority"] !== newConfig["usenet.streaming-priority"]
+        || config["usenet.streaming-segment-timeout-seconds"] !== newConfig["usenet.streaming-segment-timeout-seconds"]
+        || config["usenet.streaming-segment-retries"] !== newConfig["usenet.streaming-segment-retries"]
         || config["usenet.article-buffer-size"] !== newConfig["usenet.article-buffer-size"]
         || config["usenet.pipelined-body-requests"] !== newConfig["usenet.pipelined-body-requests"]
         || config["webdav.show-hidden-files"] !== newConfig["webdav.show-hidden-files"]
@@ -271,6 +306,8 @@ export function isWebdavSettingsValid(newConfig: Record<string, string>) {
         && isValidMaxDownloadConnections(newConfig["usenet.max-download-connections"])
         && isValidMaxQueueConnections(newConfig["usenet.max-queue-connections"])
         && isValidStreamingPriority(newConfig["usenet.streaming-priority"])
+        && isValidStreamingSegmentTimeout(newConfig["usenet.streaming-segment-timeout-seconds"])
+        && isValidStreamingSegmentRetries(newConfig["usenet.streaming-segment-retries"])
         && isValidArticleBufferSize(newConfig["usenet.article-buffer-size"])
         && segmentCacheValid;
 }
@@ -300,6 +337,18 @@ function isValidStreamingPriority(value: string): boolean {
     if (value.trim() === "") return false;
     const num = Number(value);
     return Number.isInteger(num) && num >= 0 && num <= 100;
+}
+
+function isValidStreamingSegmentTimeout(value: string): boolean {
+    if (value.trim() === "") return false;
+    const num = Number(value);
+    return Number.isInteger(num) && num >= 2 && num <= 40;
+}
+
+function isValidStreamingSegmentRetries(value: string): boolean {
+    if (value.trim() === "") return false;
+    const num = Number(value);
+    return Number.isInteger(num) && num >= 0 && num <= 5;
 }
 
 function isValidArticleBufferSize(value: string): boolean {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -1,0 +1,343 @@
+using System.Diagnostics;
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class StreamingTimeoutTests
+{
+    [Fact]
+    public async Task RunWithConnection_WithStreamingTimeout_FailsFastAndRetriesOnFreshConnection()
+    {
+        HangingNntpClient? hanging = null;
+        var created = 0;
+        using var pool = new ConnectionPool<INntpClient>(maxConnections: 2, _ =>
+        {
+            var n = Interlocked.Increment(ref created);
+            if (n == 1)
+            {
+                hanging = new HangingNntpClient();
+                return ValueTask.FromResult<INntpClient>(hanging);
+            }
+
+            return ValueTask.FromResult<INntpClient>(
+                new HealthyNntpClient(new Dictionary<string, byte[]>
+                {
+                    ["seg"] = [1, 2, 3, 4],
+                }));
+        });
+
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("streaming-timeout"),
+            "streaming-timeout");
+
+        using var cts = new CancellationTokenSource();
+        using var timeoutScope = cts.Token.SetContext(new StreamingTimeoutContext
+        {
+            PerSegmentTimeout = TimeSpan.FromMilliseconds(200),
+            MaxRetries = 1,
+        });
+
+        var outerCallbacks = 0;
+        var sw = Stopwatch.StartNew();
+        var response = await client.DecodedBodyAsync(
+            "seg",
+            _ => Interlocked.Increment(ref outerCallbacks),
+            cts.Token);
+        sw.Stop();
+
+        Assert.True(response.Success);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"Expected fast failover, took {sw.Elapsed}");
+        Assert.NotNull(hanging);
+        Assert.Equal(1, hanging!.BodyRequestCount);
+        Assert.Equal(1, hanging.CallbackCount);
+        Assert.True(hanging.Disposed);
+        Assert.Equal(1, outerCallbacks);
+        Assert.Equal(2, created);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_WithoutStreamingTimeout_DoesNotCancelAfter()
+    {
+        var hanging = new HangingNntpClient();
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1, _ => ValueTask.FromResult<INntpClient>(hanging));
+
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("no-streaming-timeout"),
+            "no-streaming-timeout");
+
+        using var cts = new CancellationTokenSource();
+        var bodyTask = client.DecodedBodyAsync("seg", onConnectionReadyAgain: null, cts.Token);
+
+        // WaitAsync abandons the await without cancelling the caller's token.
+        // If CancelAfter had been applied, the hang would observe cancellation.
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            bodyTask.WaitAsync(TimeSpan.FromMilliseconds(300)));
+
+        Assert.Equal(1, hanging.BodyRequestCount);
+        Assert.False(hanging.SawCancellation);
+        Assert.Equal(0, hanging.CallbackCount);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => bodyTask);
+        Assert.True(hanging.SawCancellation);
+        Assert.Equal(1, hanging.CallbackCount);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_StreamingTimeoutExhausted_ThrowsTimeoutException()
+    {
+        var created = 0;
+        using var pool = new ConnectionPool<INntpClient>(maxConnections: 2, _ =>
+        {
+            Interlocked.Increment(ref created);
+            return ValueTask.FromResult<INntpClient>(new HangingNntpClient());
+        });
+
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("streaming-timeout-exhausted"),
+            "streaming-timeout-exhausted");
+
+        using var cts = new CancellationTokenSource();
+        using var timeoutScope = cts.Token.SetContext(new StreamingTimeoutContext
+        {
+            PerSegmentTimeout = TimeSpan.FromMilliseconds(100),
+            MaxRetries = 1,
+        });
+
+        var outerCallbacks = 0;
+        var sw = Stopwatch.StartNew();
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            client.DecodedBodyAsync("seg", _ => Interlocked.Increment(ref outerCallbacks), cts.Token));
+        sw.Stop();
+
+        Assert.Contains("2 attempts", ex.Message);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5));
+        Assert.Equal(1, outerCallbacks);
+        Assert.Equal(2, created);
+    }
+
+    /// <summary>
+    /// BODY that hangs until cancelled, firing NotRetrieved exactly once
+    /// (in-flight cancel → connection not reusable).
+    /// </summary>
+    private sealed class HangingNntpClient : NntpClient
+    {
+        private int _callbackCount;
+
+        public int BodyRequestCount { get; private set; }
+        public int CallbackCount => Volatile.Read(ref _callbackCount);
+        public bool SawCancellation { get; private set; }
+        public bool Disposed { get; private set; }
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BodyRequestCount++;
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                throw new InvalidOperationException("Hang was expected to be cancelled.");
+            }
+            catch (OperationCanceledException)
+            {
+                SawCancellation = true;
+                // Mid-command cancel leaves the socket unclean → NotRetrieved (replace).
+                Interlocked.Increment(ref _callbackCount);
+                onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+                throw;
+            }
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+
+    private sealed class HealthyNntpClient(IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var key = segmentId.ToString();
+            if (!segments.TryGetValue(key, out var bytes))
+                throw new InvalidOperationException($"Missing segment {key}");
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 ok",
+                Stream = new YencStream(new MemoryStream(EncodeYenc(bytes), writable: false)),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        private static byte[] EncodeYenc(ReadOnlySpan<byte> source)
+        {
+            using var output = new MemoryStream(source.Length + 128);
+            output.Write(Encoding.ASCII.GetBytes(
+                $"=ybegin line=128 size={source.Length} name=fake.bin\r\n"));
+            foreach (var value in source)
+                output.WriteByte(unchecked((byte)(value + 42)));
+            output.Write(Encoding.ASCII.GetBytes("\r\n"));
+            output.Write(Encoding.ASCII.GetBytes($"=yend size={source.Length}\r\n"));
+            return output.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `StreamingTimeoutContext` and apply a per-segment `CancelAfter` in `MultiConnectionNntpClient.RunWithConnection` for WebDAV/`/view` streaming only (queue/health unchanged).
- New settings `usenet.streaming-segment-timeout-seconds` (default 8, clamp 2–40) and `usenet.streaming-segment-retries` (default 3, clamp 0–5) with WebDAV settings UI + defaults.
- On timeout: replace the connection (`NotRetrieved`), retry up to `MaxRetries`, then throw `TimeoutException` so `MultiProviderNntpClient` can fail over. Completion callbacks stay single-fire via `DeferredArticleBodyCallback` discard + one outer release.

Closes #54

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~StreamingTimeoutTests`
- [ ] Manual: throttle one provider and play via rclone/WebDAV; recovery within ~`timeout × (retries+1)` instead of ~40s+