### PR TITLE
chore(ui): standardize product name to NzbDAV

### DIFF
--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -314,7 +314,7 @@ export function MigrationShell({
         >
           <div className="card-body gap-4">
             <div className="flex items-center gap-3">
-              <img className="h-9 w-9" src="/logo.svg" alt="NzbDav" />
+              <img className="h-9 w-9" src="/logo.svg" alt="NzbDAV" />
               <div className="space-y-1">
                 <h1 className="text-xl font-bold tracking-tight">{title}</h1>
                 {subtitle ? <p className="text-sm leading-relaxed text-base-content/70">{subtitle}</p> : null}

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -43,7 +43,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
           onClick={() => navigate("/")}
         >
           <img className="h-8 w-7" src="/logo.svg" alt="" />
-          <span className="text-xl font-bold tracking-tight">Nzb DAV</span>
+          <span className="text-xl font-bold tracking-tight">NzbDAV</span>
         </button>
       </div>
 
@@ -99,7 +99,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
           >
             <li className="menu-title">
               <span className="flex items-center justify-between gap-2">
-                <span>NzbDav {channelLabel}</span>
+                <span>NzbDAV {channelLabel}</span>
                 <span className="font-mono font-normal normal-case tracking-normal">
                   {displayVersion}
                 </span>

--- a/frontend/app/routes/login/route.tsx
+++ b/frontend/app/routes/login/route.tsx
@@ -34,9 +34,9 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                 >
                     <div className="card-body gap-5">
                         <div className="flex flex-col items-center gap-3 text-center">
-                            <img className="h-16 w-16" src="/logo.svg" alt="NzbDav" />
+                            <img className="h-16 w-16" src="/logo.svg" alt="NzbDAV" />
                             <div>
-                                <h1 className="text-2xl font-bold tracking-tight">NzbDav</h1>
+                                <h1 className="text-2xl font-bold tracking-tight">NzbDAV</h1>
                                 <p className="mt-1 text-sm text-base-content/60">Sign in to manage your server</p>
                             </div>
                         </div>

--- a/frontend/app/routes/onboarding/route.tsx
+++ b/frontend/app/routes/onboarding/route.tsx
@@ -52,9 +52,9 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                 >
                     <div className="card-body gap-5">
                         <div className="flex flex-col items-center gap-3 text-center">
-                            <img className="h-16 w-16" src="/logo.svg" alt="NzbDav" />
+                            <img className="h-16 w-16" src="/logo.svg" alt="NzbDAV" />
                             <div>
-                                <h1 className="text-2xl font-bold tracking-tight">NzbDav</h1>
+                                <h1 className="text-2xl font-bold tracking-tight">NzbDAV</h1>
                                 <p className="mt-1 text-sm text-base-content/60">Set up your administrator account</p>
                             </div>
                         </div>
@@ -67,7 +67,7 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                         {!pageData.error &&
                             <Alert variant="warning">
                                 <p className="mb-1 font-semibold">Welcome!</p>
-                                Create credentials for managing your NzbDav server.
+                                Create credentials for managing your NzbDAV server.
                             </Alert>
                         }
 

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -25,7 +25,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                     <span>Perform Database Vacuum on Start</span>
                 </label>
                     <p className="text-[11px] leading-relaxed text-base-content/45" id="db-startup-vacuum-enabled-help">
-                        When enabled, nzbdav will run a SQLite VACUUM on the database at every startup. This reclaims unused disk space and can improve query performance over time, but may increase startup time for large databases.
+                        When enabled, NzbDAV will run a SQLite VACUUM on the database at every startup. This reclaims unused disk space and can improve query performance over time, but may increase startup time for large databases.
                     </p>
                 </div>
                 <hr />

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -61,7 +61,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                     <span>{`Enable Rclone RC Server Notifications`}</span>
                 </label>
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="rclone-rc-enabled-help">
-                    When enabled, nzbdav will automatically notify your rclone mount via the RC API whenever files are added or removed on the webdav. This allows setting a high dir-cache-time setting on Rclone.
+                    When enabled, NzbDAV will automatically notify your rclone mount via the RC API whenever files are added or removed on the webdav. This allows setting a high dir-cache-time setting on Rclone.
                 </p>
             </div>
             <hr />


### PR DESCRIPTION
## Summary
- Standardize user-facing product name to `NzbDAV` in top nav, login, onboarding, migration shell, and settings help copy
- Remove inconsistent `Nzb DAV` / `NzbDav` / lowercase `nzbdav` display variants in the UI

## Test plan
- [ ] Confirm top nav brand label shows `NzbDAV`
- [ ] Confirm app menu title shows `NzbDAV Stable` / `NzbDAV Dev`
- [ ] Confirm login and onboarding pages show `NzbDAV`
- [ ] Spot-check Rclone and Maintenance settings help text