### PR TITLE
test(health): assert unreachable Arr defers repair delete

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -20,7 +20,7 @@ public class ArrClient(string host, string apiKey)
     public virtual Task<bool> RemoveAndSearch(string symlinkOrStrmPath) =>
         throw new InvalidOperationException();
 
-    public Task<List<ArrRootFolder>> GetRootFolders() =>
+    public virtual Task<List<ArrRootFolder>> GetRootFolders() =>
         Get<List<ArrRootFolder>>($"/rootfolder");
 
     public Task<List<ArrDownloadClient>> GetDownloadClientsAsync() =>

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
@@ -341,6 +342,95 @@ public class HealthCheckService : BackgroundService
         return UrgentRepairDisposition.ForceDelete;
     }
 
+    /// <summary>
+    /// Outcome of consulting Arr instances for a library-linked unhealthy item.
+    /// </summary>
+    public enum ArrLinkedRepairDecision
+    {
+        /// <summary>An Arr instance owned the file and remove-and-search succeeded.</summary>
+        RemoveAndSearchSucceeded,
+        /// <summary>
+        /// At least one Arr instance was unreachable/unusable and no instance confirmed the link
+        /// as an orphan — leave the DavItem in place.
+        /// </summary>
+        DeferUnreachable,
+        /// <summary>Ownership was fully determined: no Arr media-item; safe to delete.</summary>
+        DeleteConfirmedOrphan,
+    }
+
+    /// <summary>
+    /// Consults Arr clients to decide whether a library-linked unhealthy item should trigger
+    /// remove-and-search, be deferred while an instance is down, or be deleted as a confirmed orphan.
+    /// Extracted so the unreachable-instance fail-safe can be unit-tested without a full Repair harness.
+    /// </summary>
+    internal static async Task<ArrLinkedRepairDecision> DecideArrLinkedRepairAsync(
+        IEnumerable<ArrClient> arrClients,
+        string symlinkOrStrmPath,
+        CancellationToken ct)
+    {
+        // Track whether we could fully determine ownership. If any instance was unreachable,
+        // errored, or returned an unusable root folder, a later "no owner found" is unreliable
+        // and we must not delete a link one of those instances may own. This is independent of
+        // ownerConfirmedOrphan below, which is a definite answer and deletes regardless.
+        var anInstanceFailed = false;
+        var ownerConfirmedOrphan = false;
+
+        foreach (var arrClient in arrClients)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            List<ArrRootFolder> rootFolders;
+            try
+            {
+                rootFolders = await arrClient.GetRootFolders().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                anInstanceFailed = true;
+                Log.Warning(e, "Health-check repair: could not query root folders from {Host}",
+                            arrClient.Host);
+                continue;
+            }
+
+            // Skip null/empty paths: StartsWith(null) throws, and StartsWith("") matches everything.
+            // A null/empty path is a malformed response we can't rule this instance in or out
+            // with, so if nothing else matches, treat it like an unreachable instance rather
+            // than falling through to a delete this instance may not have sanctioned.
+            if (!rootFolders.Any(x => !string.IsNullOrEmpty(x.Path) && symlinkOrStrmPath.StartsWith(x.Path)))
+            {
+                if (rootFolders.Any(x => string.IsNullOrEmpty(x.Path))) anInstanceFailed = true;
+                continue;
+            }
+
+            bool removedAndSearched;
+            try
+            {
+                removedAndSearched = await arrClient.RemoveAndSearch(symlinkOrStrmPath).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                anInstanceFailed = true;
+                Log.Warning(e, "Health-check repair: remove-and-search failed on {Host}",
+                            arrClient.Host);
+                continue;
+            }
+
+            if (removedAndSearched)
+                return ArrLinkedRepairDecision.RemoveAndSearchSucceeded;
+
+            // The owning instance was reached and reports no corresponding media-item, so this
+            // link is a confirmed orphan. Record that ownership was determined and break; the
+            // delete below then proceeds even if some other instance was unreachable.
+            ownerConfirmedOrphan = true;
+            break;
+        }
+
+        if (anInstanceFailed && !ownerConfirmedOrphan)
+            return ArrLinkedRepairDecision.DeferUnreachable;
+
+        return ArrLinkedRepairDecision.DeleteConfirmedOrphan;
+    }
+
     private async Task HandleUrgentRepair(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
     {
         var threshold = _configManager.GetAutoRemoveAfterFailures();
@@ -465,83 +555,35 @@ public class HealthCheckService : BackgroundService
             // if the unhealthy item is linked within the organized media-library
             // then we must find the corresponding arr instance and trigger a new search.
             var linkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+            var arrDecision = await DecideArrLinkedRepairAsync(
+                _configManager.GetArrConfig().GetArrClients(),
+                symlinkOrStrmPath,
+                ct).ConfigureAwait(false);
 
-            // Track whether we could fully determine ownership. If any instance was unreachable,
-            // errored, or returned an unusable root folder, a later "no owner found" is unreliable
-            // and we must not delete a link one of those instances may own. This is independent of
-            // ownerConfirmedOrphan below, which is a definite answer and deletes regardless.
-            var anInstanceFailed = false;
-            var ownerConfirmedOrphan = false;
-
-            foreach (var arrClient in _configManager.GetArrConfig().GetArrClients())
+            if (arrDecision == ArrLinkedRepairDecision.RemoveAndSearchSucceeded)
             {
-                List<ArrRootFolder> rootFolders;
-                try
-                {
-                    rootFolders = await arrClient.GetRootFolders().ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    anInstanceFailed = true;
-                    Log.Warning(e, "Health-check repair: could not query root folders from {Host}",
-                                arrClient.Host);
-                    continue;
-                }
-
-                // Skip null/empty paths: StartsWith(null) throws, and StartsWith("") matches everything.
-                // A null/empty path is a malformed response we can't rule this instance in or out
-                // with, so if nothing else matches, treat it like an unreachable instance rather
-                // than falling through to a delete this instance may not have sanctioned.
-                if (!rootFolders.Any(x => !string.IsNullOrEmpty(x.Path) && symlinkOrStrmPath.StartsWith(x.Path)))
-                {
-                    if (rootFolders.Any(x => string.IsNullOrEmpty(x.Path))) anInstanceFailed = true;
-                    continue;
-                }
-
-                bool removedAndSearched;
-                try
-                {
-                    removedAndSearched = await arrClient.RemoveAndSearch(symlinkOrStrmPath).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    anInstanceFailed = true;
-                    Log.Warning(e, "Health-check repair: remove-and-search failed on {Host}",
-                                arrClient.Host);
-                    continue;
-                }
-
-                if (removedAndSearched)
-                {
-                    DeletionAuditLog.Record(
-                        "health-repair",
-                        davItem,
-                        "missing articles; Arr remove-and-search triggered");
-                    dbClient.Ctx.Items.Remove(davItem);
-                    _failureTracker.ClearFailure(davItem.Id);
-                    await RecordHealthResult(
-                        dbClient, davItem,
-                        HealthCheckResult.HealthResult.Unhealthy,
-                        HealthCheckResult.RepairAction.Repaired,
-                        string.Join(" ", [
-                            "File had missing articles.",
-                            $"Corresponding {linkType} found within Library Dir.",
-                            "Triggered new Arr search."
-                        ]), ct).ConfigureAwait(false);
-                    return;
-                }
-
-                // The owning instance was reached and reports no corresponding media-item, so this
-                // link is a confirmed orphan. Record that ownership was determined and break; the
-                // delete below then proceeds even if some other instance was unreachable.
-                ownerConfirmedOrphan = true;
-                break;
+                DeletionAuditLog.Record(
+                    "health-repair",
+                    davItem,
+                    "missing articles; Arr remove-and-search triggered");
+                dbClient.Ctx.Items.Remove(davItem);
+                _failureTracker.ClearFailure(davItem.Id);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.Repaired,
+                    string.Join(" ", [
+                        "File had missing articles.",
+                        $"Corresponding {linkType} found within Library Dir.",
+                        "Triggered new Arr search."
+                    ]), ct).ConfigureAwait(false);
+                return;
             }
 
             // Ownership indeterminate (an instance could not be reached or fully queried, and no
             // instance confirmed the file as an orphan): don't delete a link it may own. Defer like
             // the catch below so the item isn't re-selected every scan cycle while the instance is down.
-            if (anInstanceFailed && !ownerConfirmedOrphan)
+            if (arrDecision == ArrLinkedRepairDecision.DeferUnreachable)
             {
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -1,0 +1,142 @@
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class ArrLinkedRepairDecisionTests
+{
+    private const string LibraryPath = "/media/movies/Some Movie (2020)/Some Movie (2020).mkv";
+
+    [Fact]
+    public async Task UnreachableRootFolders_DefersWithoutDelete()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://unreachable",
+                rootFolders: () => throw new HttpRequestException("connection refused"),
+                removeAndSearch: _ => Task.FromResult(false)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+    }
+
+    [Fact]
+    public async Task RemoveAndSearchThrows_DefersWithoutDelete()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndSearch: _ => throw new HttpRequestException("timeout")),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+    }
+
+    [Fact]
+    public async Task EmptyRootFolderPath_DefersWithoutDelete()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "" },
+                }),
+                removeAndSearch: _ => Task.FromResult(false)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+    }
+
+    [Fact]
+    public async Task ConfirmedOrphan_DeletesEvenIfAnotherInstanceUnreachable()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://unreachable",
+                rootFolders: () => throw new HttpRequestException("down"),
+                removeAndSearch: _ => Task.FromResult(false)),
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndSearch: _ => Task.FromResult(false)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeleteConfirmedOrphan, decision);
+    }
+
+    [Fact]
+    public async Task RemoveAndSearchSucceeded_ReturnsRemoveAndSearch()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndSearch: _ => Task.FromResult(true)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndSearchSucceeded, decision);
+    }
+
+    [Fact]
+    public async Task NoMatchingRoot_DeletesAsOrphan()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://sonarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/tv" },
+                }),
+                removeAndSearch: _ => Task.FromResult(false)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeleteConfirmedOrphan, decision);
+    }
+
+    private sealed class ScriptedArrClient(
+        string host,
+        Func<Task<List<ArrRootFolder>>> rootFolders,
+        Func<string, Task<bool>> removeAndSearch) : ArrClient(host, "test-key")
+    {
+        public override Task<List<ArrRootFolder>> GetRootFolders() => rootFolders();
+
+        public override Task<bool> RemoveAndSearch(string symlinkOrStrmPath) =>
+            removeAndSearch(symlinkOrStrmPath);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `DecideArrLinkedRepairAsync` from `HealthCheckService.Repair` so the Arr ownership fail-safe is unit-testable
- Add tests proving unreachable/unusable Arr instances defer deletion instead of removing library-linked DavItems

Completes bugs.md #117 phase-2 item 6 (unreachable Arr ⇒ ActionNeeded, no delete).

## Test plan
- [x] `ArrLinkedRepairDecisionTests` + `UrgentRepairDispositionTests`