### PR TITLE
feat(queue): recreate-strm-files maintenance task

### DIFF
--- a/backend/Api/Controllers/RecreateStrmFiles/RecreateStrmFilesController.cs
+++ b/backend/Api/Controllers/RecreateStrmFiles/RecreateStrmFilesController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.RecreateStrmFiles;
+
+[ApiController]
+[Route("api/recreate-strm-files")]
+public class RecreateStrmFilesController(
+    ConfigManager configManager,
+    DavDatabaseClient dbClient,
+    WebsocketManager websocketManager
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var rewriteAll = string.Equals(
+            HttpContext.Request.Query["rewriteAll"].FirstOrDefault(),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        var task = new RecreateStrmFilesTask(configManager, dbClient, websocketManager, rewriteAll);
+        var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed)
+            return Conflict(new { error = "Recreate STRM Files task is already running." });
+        return Ok(executed);
+    }
+}

--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -51,29 +51,46 @@ public class CreateStrmFilesPostProcessor(
         FilenameUtil.IsVideoFile(item.Name)
         && !item.Name.EndsWith(".strm", StringComparison.OrdinalIgnoreCase);
 
-    private async Task CreateStrmFileAsync(DavItem davItem)
+    /// <summary>
+    /// Writes (or updates) the STRM sidecar for a DavItem. Shared by queue post-processing
+    /// and the Recreate STRM maintenance task.
+    /// </summary>
+    internal static async Task WriteStrmFileAsync(
+        ConfigManager configManager,
+        DavItem davItem,
+        bool forceRewrite,
+        CancellationToken cancellationToken = default)
     {
-        var strmFilePath = GetStrmFilePath(davItem);
+        if (!IsStrmCandidate(davItem))
+            return;
+
+        var strmFilePath = GetStrmFilePath(configManager, davItem);
         var directoryName = Path.GetDirectoryName(strmFilePath);
         if (directoryName != null)
-            await Task.Run(() => Directory.CreateDirectory(directoryName)).ConfigureAwait(false);
+            await Task.Run(() => Directory.CreateDirectory(directoryName), cancellationToken).ConfigureAwait(false);
 
-        var targetUrl = GetStrmTargetUrl(davItem);
-        if (File.Exists(strmFilePath))
+        var targetUrl = GetStrmTargetUrl(configManager, davItem);
+        if (!forceRewrite && File.Exists(strmFilePath))
         {
-            var existing = await File.ReadAllTextAsync(strmFilePath).ConfigureAwait(false);
+            var existing = await File.ReadAllTextAsync(strmFilePath, cancellationToken).ConfigureAwait(false);
             if (existing == targetUrl)
                 return;
         }
 
-        await File.WriteAllTextAsync(strmFilePath, targetUrl).ConfigureAwait(false);
+        await File.WriteAllTextAsync(strmFilePath, targetUrl, cancellationToken).ConfigureAwait(false);
     }
 
-    internal string GetStrmFilePath(DavItem davItem)
+    private async Task CreateStrmFileAsync(DavItem davItem) =>
+        await WriteStrmFileAsync(configManager, davItem, forceRewrite: false).ConfigureAwait(false);
+
+    internal static string GetStrmFilePath(ConfigManager configManager, DavItem davItem)
     {
         var relativePath = GetPathRelativeToContentRoot(davItem.Path) + ".strm";
         return Path.Join(configManager.GetStrmCompletedDownloadDir(), relativePath);
     }
+
+    internal string GetStrmFilePath(DavItem davItem) =>
+        GetStrmFilePath(configManager, davItem);
 
     internal static string GetPathRelativeToContentRoot(string davPath)
     {
@@ -85,7 +102,7 @@ public class CreateStrmFilesPostProcessor(
         return parts.Length > 2 ? Path.Join(parts[2..]) : Path.GetFileName(davPath);
     }
 
-    private string GetStrmTargetUrl(DavItem davItem)
+    internal static string GetStrmTargetUrl(ConfigManager configManager, DavItem davItem)
     {
         var baseUrl = configManager.GetBaseUrl();
         if (baseUrl.EndsWith('/')) baseUrl = baseUrl.TrimEnd('/');
@@ -96,4 +113,7 @@ public class CreateStrmFilesPostProcessor(
         var extension = Path.GetExtension(davItem.Name).ToLower().TrimStart('.');
         return $"{baseUrl}/view/{pathUrl}?downloadKey={downloadKey}&extension={extension}";
     }
+
+    private string GetStrmTargetUrl(DavItem davItem) =>
+        GetStrmTargetUrl(configManager, davItem);
 }

--- a/backend/Tasks/RecreateStrmFilesTask.cs
+++ b/backend/Tasks/RecreateStrmFilesTask.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Utils;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+/// <summary>
+/// Writes missing STRM sidecars for mounted video DavItems, or rewrites all when
+/// <paramref name="rewriteAll"/> is true (e.g. after a base-url change).
+/// </summary>
+public class RecreateStrmFilesTask(
+    ConfigManager configManager,
+    DavDatabaseClient dbClient,
+    WebsocketManager websocketManager,
+    bool rewriteAll = false
+) : BaseTask
+{
+    private const int BatchSize = 100;
+
+    protected override async Task ExecuteInternal()
+    {
+        try
+        {
+            var ct = SigtermUtil.GetCancellationToken();
+            await RecreateAllAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Report($"Failed: {e.Message}");
+            Log.Error(e, "Failed to recreate STRM files.");
+        }
+    }
+
+    private async Task RecreateAllAsync(CancellationToken ct)
+    {
+        var written = 0;
+        var skipped = 0;
+        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
+        ReportProgress("Scanning mounted videos...", written, skipped);
+
+        var offset = 0;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var batch = await dbClient.Ctx.Items
+                .AsNoTracking()
+                .Where(x => x.Type == DavItem.ItemType.UsenetFile)
+                .OrderBy(x => x.Path)
+                .Skip(offset)
+                .Take(BatchSize)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            if (batch.Count == 0)
+                break;
+
+            foreach (var item in batch)
+            {
+                if (!FilenameUtil.IsVideoFile(item.Name)
+                    || item.Name.EndsWith(".strm", StringComparison.OrdinalIgnoreCase))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var path = CreateStrmFilesPostProcessor.GetStrmFilePath(configManager, item);
+                var target = CreateStrmFilesPostProcessor.GetStrmTargetUrl(configManager, item);
+                if (!rewriteAll && File.Exists(path))
+                {
+                    var existing = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);
+                    if (existing == target)
+                    {
+                        skipped++;
+                        debounce(() => ReportProgress("Writing STRM files...", written, skipped));
+                        continue;
+                    }
+                }
+
+                await CreateStrmFilesPostProcessor
+                    .WriteStrmFileAsync(configManager, item, rewriteAll, ct)
+                    .ConfigureAwait(false);
+                written++;
+                debounce(() => ReportProgress("Writing STRM files...", written, skipped));
+            }
+
+            offset += batch.Count;
+            if (batch.Count < BatchSize)
+                break;
+        }
+
+        ReportProgress("Done!", written, skipped);
+    }
+
+    private void Report(string message)
+    {
+        _ = websocketManager.SendMessage(WebsocketTopic.RecreateStrmTaskProgress, message);
+    }
+
+    private void ReportProgress(string message, int written, int skipped)
+    {
+        var mode = rewriteAll ? "rewrite-all" : "missing-or-changed";
+        Report($"{message}\nMode: {mode}\nWritten: {written}\nSkipped: {skipped}");
+    }
+}

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -8,6 +8,7 @@ public class WebsocketTopic
     public static readonly WebsocketTopic SymlinkTaskProgress = new("stp", TopicType.State);
     public static readonly WebsocketTopic CleanupTaskProgress = new("ctp", TopicType.State);
     public static readonly WebsocketTopic StrmToSymlinksTaskProgress = new("st2sy", TopicType.State);
+    public static readonly WebsocketTopic RecreateStrmTaskProgress = new("rstm", TopicType.State);
     public static readonly WebsocketTopic QueueItemStatus = new("qs", TopicType.State);
     public static readonly WebsocketTopic QueueItemProgress = new("qp", TopicType.State);
     public static readonly WebsocketTopic QueueItemProviders = new("qpv", TopicType.State);

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -2,6 +2,7 @@ import { SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
+import { RecreateStrmFiles } from "./recreate-strm-files/recreate-strm-files";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
 import { ResetHealthCheckStats } from "./reset-health-check-stats/reset-health-check-stats";
 import type { Dispatch, SetStateAction } from "react";
@@ -155,6 +156,14 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                         </summary>
                         <div className={'border-t border-slate-700/70 p-4'}>
                             <ConvertStrmToSymlinks savedConfig={savedConfig} />
+                        </div>
+                    </details>
+                    <details className={'overflow-hidden rounded border border-slate-700/70'}>
+                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-white hover:bg-white/5">
+                            Recreate STRM Files
+                        </summary>
+                        <div className={'border-t border-slate-700/70 p-4'}>
+                            <RecreateStrmFiles savedConfig={savedConfig} />
                         </div>
                     </details>
                     <details className={'overflow-hidden rounded border border-slate-700/70'}>

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -1,0 +1,145 @@
+import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/feedback";
+import { Checkbox } from "~/components/ui/form";
+import { Icon } from "~/components/ui/icon";
+import { useCallback, useState } from "react";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
+
+type RecreateStrmFilesProps = {
+    savedConfig: Record<string, string>
+};
+
+export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
+    const [connected, setConnected] = useState<boolean>(false);
+    const [progress, setProgress] = useState<string | null>(null);
+    const [isFetching, setIsFetching] = useState<boolean>(false);
+    const [runStarted, setRunStarted] = useState<boolean>(false);
+    const [rewriteAll, setRewriteAll] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const completedDir = savedConfig["api.completed-downloads-dir"]?.trim();
+    const importStrategy = savedConfig["api.import-strategy"] ?? "symlinks";
+    const baseUrl = savedConfig["general.base-url"]?.trim();
+    const isStrmStrategy = importStrategy === "strm";
+    const canRun = !!completedDir && !!baseUrl && isStrmStrategy;
+
+    const isFinished = !!progress && (
+        progress.startsWith("Done") || progress.startsWith("Failed") || progress.startsWith("Aborted")
+    );
+    const isRunning = runStarted && !isFinished && (isFetching || progress !== null);
+    const isRunButtonEnabled = canRun && connected && !isRunning;
+    const runButtonVariant = isRunButtonEnabled ? "success" : "secondary";
+    const runButtonLabel = isRunning ? "Running..." : "Run Task";
+
+    useWebsocketTopic("rstm", "state", (msg) => {
+        if (runStarted) setProgress(msg);
+    }, {
+        onOpen: () => setConnected(true),
+        onClose: () => {
+            setConnected(false);
+            if (!runStarted) setProgress(null);
+        },
+    });
+
+    const onRun = useCallback(async () => {
+        setError(null);
+        setRunStarted(true);
+        setIsFetching(true);
+        setProgress(null);
+        try {
+            const qs = rewriteAll ? "?rewriteAll=true" : "";
+            const response = await fetch(`/api/recreate-strm-files${qs}`);
+            if (response.status === 409) {
+                setError("Another maintenance task is already running.");
+                setRunStarted(false);
+                return;
+            }
+            if (!response.ok) {
+                setError(`Request failed (${response.status}).`);
+                setRunStarted(false);
+            }
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Request failed.");
+            setRunStarted(false);
+        } finally {
+            setIsFetching(false);
+        }
+    }, [rewriteAll]);
+
+    return (
+        <>
+            {!canRun &&
+                <Alert className={"mb-3"} variant="warning">
+                    Warning
+                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
+                        {!isStrmStrategy &&
+                            <li className={"text-xs"}>
+                                Import strategy must be set to STRM Files under the SABnzbd tab.
+                            </li>
+                        }
+                        {!completedDir &&
+                            <li className={"text-xs"}>
+                                Configure Completed Downloads Directory under the SABnzbd tab.
+                            </li>
+                        }
+                        {!baseUrl &&
+                            <li className={"text-xs"}>
+                                Configure Base URL under the SABnzbd tab (used inside STRM URLs).
+                            </li>
+                        }
+                    </ul>
+                </Alert>
+            }
+            {canRun &&
+                <Alert className={"mb-3"} variant="warning">
+                    <span className="font-semibold">Note</span>
+                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
+                        <li className={"text-xs"}>
+                            Writes STRM sidecars under `{completedDir}` mirroring `/content`.
+                        </li>
+                        <li className={"text-xs"}>
+                            Default mode only creates missing files or updates ones whose URL content changed
+                            (e.g. after a base-url change). Rewrite-all forces every file to be rewritten and
+                            will update mtimes, which may trigger a media-server library rescan.
+                        </li>
+                    </ul>
+                </Alert>
+            }
+            {error &&
+                <Alert className={"mb-3"} variant="danger">{error}</Alert>
+            }
+            <div className={"space-y-3"}>
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <Checkbox
+                        id="recreate-strm-rewrite-all"
+                        checked={rewriteAll}
+                        onChange={e => setRewriteAll(e.target.checked)}
+                        disabled={isRunning}
+                    />
+                    <span>Rewrite all STRM files (update mtimes)</span>
+                </label>
+                <div className={"flex flex-col gap-3 sm:flex-row sm:items-center"}>
+                    <Button
+                        className={"shrink-0"}
+                        variant={runButtonVariant}
+                        onClick={onRun}
+                        disabled={!isRunButtonEnabled}
+                    >
+                        <Icon
+                            name={isRunning ? "progress_activity" : "play_arrow"}
+                            className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`}
+                        />
+                        {runButtonLabel}
+                    </Button>
+                    <div className={"whitespace-pre-wrap font-mono text-xs text-slate-300"}>
+                        {progress}
+                    </div>
+                </div>
+                <p className="text-[11px] leading-relaxed text-base-content/45">
+                    Use this to repair libraries that missed STRM creation (e.g. season packs processed
+                    before the create-for-all-videos fix), or to refresh URLs after changing Base URL.
+                </p>
+            </div>
+        </>
+    );
+}

--- a/tests/NzbWebDAV.Tests/Tasks/RecreateStrmFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RecreateStrmFilesTaskTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Tasks;
+
+[Collection(nameof(BaseTaskCollection))]
+public class RecreateStrmFilesTaskTests : IAsyncLifetime
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"recreate-strm-{Guid.NewGuid():N}.sqlite");
+    private readonly string _strmDir = Path.Combine(Path.GetTempPath(), $"recreate-strm-out-{Guid.NewGuid():N}");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private ConfigManager _config = null!;
+
+    public async Task InitializeAsync()
+    {
+        Directory.CreateDirectory(_strmDir);
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.EnsureCreatedAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _config = new ConfigManager();
+        _config.UpdateValues(
+        [
+            new() { ConfigName = ConfigKeys.ApiCompletedDownloadsDir, ConfigValue = _strmDir },
+            new() { ConfigName = ConfigKeys.ApiImportStrategy, ConfigValue = "strm" },
+            new() { ConfigName = "general.base-url", ConfigValue = "http://localhost:3000" },
+            new() { ConfigName = ConfigKeys.ApiStrmKey, ConfigValue = "test-strm-key" },
+        ]);
+
+        await BaseTask.ResetRunningTaskForTestsAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await _context.DisposeAsync();
+        try { File.Delete(_dbPath); } catch { /* ignore */ }
+        try { Directory.Delete(_strmDir, recursive: true); } catch { /* ignore */ }
+    }
+
+    [Fact]
+    public async Task CreatesMissingStrmForMountedVideos()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "tv");
+        var job = SeedDirectory(category, "Show");
+        SeedVideo(job, "ep01.mkv");
+        SeedVideo(job, "ep02.mkv");
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var executed = await new RecreateStrmFilesTask(
+            _config, _dbClient, new WebsocketManager(), rewriteAll: false).Execute();
+
+        Assert.True(executed);
+        var strmFiles = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories);
+        Assert.Equal(2, strmFiles.Length);
+    }
+
+    [Fact]
+    public async Task SkipsIdenticalExistingContent()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "movies");
+        var job = SeedDirectory(category, "Movie");
+        var video = SeedVideo(job, "movie.mkv");
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, video, forceRewrite: false);
+        var path = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories).Single();
+        var mtime1 = File.GetLastWriteTimeUtc(path);
+
+        await Task.Delay(50);
+        await new RecreateStrmFilesTask(_config, _dbClient, new WebsocketManager()).Execute();
+        var mtime2 = File.GetLastWriteTimeUtc(path);
+
+        Assert.Equal(mtime1, mtime2);
+    }
+
+    [Fact]
+    public async Task RewriteAllForcesRewrite()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "movies");
+        var job = SeedDirectory(category, "Movie");
+        var video = SeedVideo(job, "movie.mkv");
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, video, forceRewrite: false);
+        var path = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories).Single();
+        var mtime1 = File.GetLastWriteTimeUtc(path);
+
+        await Task.Delay(50);
+        await new RecreateStrmFilesTask(_config, _dbClient, new WebsocketManager(), rewriteAll: true).Execute();
+        var mtime2 = File.GetLastWriteTimeUtc(path);
+
+        Assert.True(mtime2 > mtime1);
+    }
+
+    [Fact]
+    public async Task DoesNotDoubleWrapExistingStrmNamedItems()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "tv");
+        var job = SeedDirectory(category, "Show");
+        SeedVideo(job, "ep.mkv");
+        SeedVideo(job, "sidecar.strm");
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await new RecreateStrmFilesTask(_config, _dbClient, new WebsocketManager()).Execute();
+
+        var strmFiles = Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories);
+        Assert.Single(strmFiles);
+        Assert.DoesNotContain(strmFiles, f => f.EndsWith("sidecar.strm.strm", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private DavItem SeedDirectory(DavItem parent, string name)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(), parent, name, null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        _context.Items.Add(item);
+        return item;
+    }
+
+    private DavItem SeedVideo(DavItem parent, string name)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(), parent, name, 100,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            null, null, null, Guid.NewGuid());
+        _context.Items.Add(item);
+        return item;
+    }
+}


### PR DESCRIPTION
## Summary
- Maintenance task + `/api/recreate-strm-files` (+ optional `rewriteAll=true`) to create/update STRM sidecars for mounted videos
- Settings → Maintenance → Recreate STRM Files card with websocket progress
- Shared STRM write helpers extracted from `CreateStrmFilesPostProcessor`

Closes #49

Follow-up to the season-pack STRM fix (#145 / #332).

## Test plan
- [x] `RecreateStrmFilesTaskTests` + `CreateStrmFilesPostProcessorTests`
- [x] Frontend typecheck
- [ ] Manual: import-strategy=strm, run task, confirm missing sidecars appear under completed-downloads-dir