### PR TITLE
feat(queue): prefer PAR2 UniFileN unicode filenames when present

### DIFF
--- a/backend/Par2Recovery/Packets/FileDesc.cs
+++ b/backend/Par2Recovery/Packets/FileDesc.cs
@@ -14,7 +14,7 @@ namespace NzbWebDAV.Par2Recovery.Packets
         public byte[] FileHash { get; protected set; } = null!;
         public byte[] File16kHash { get; protected set; } = null!;
         public ulong FileLength { get; protected set; }
-        public string FileName { get; protected set; } = null!;
+        public string FileName { get; internal set; } = null!;
 
         public FileDesc(Par2PacketHeader header) : base(header)
         {

--- a/backend/Par2Recovery/Packets/UniFileN.cs
+++ b/backend/Par2Recovery/Packets/UniFileN.cs
@@ -1,0 +1,38 @@
+using System.Text;
+
+namespace NzbWebDAV.Par2Recovery.Packets
+{
+    /// <summary>
+    /// Optional PAR 2.0 Unicode Filename packet ("PAR 2.0\0UniFileN").
+    /// Body: 16-byte File ID + UTF-16LE filename (padded to a multiple of 4 bytes).
+    /// </summary>
+    public class UniFileN : Par2Packet
+    {
+        public const string PacketType = "PAR 2.0\0UniFileN";
+
+        public byte[] FileID { get; protected set; } = null!;
+        public string FileName { get; protected set; } = null!;
+
+        public UniFileN(Par2PacketHeader header) : base(header)
+        {
+        }
+
+        protected override void ParseBody(byte[] body)
+        {
+            // 16	MD5 Hash	The File ID of the file.
+            FileID = new byte[16];
+            Buffer.BlockCopy(body, 0, FileID, 0, 16);
+
+            // ?*4	Unicode char array (UTF-16LE)	Name of the file. Not null-terminated.
+            var nameBuffer = new byte[body.Length - 16];
+            Buffer.BlockCopy(body, 16, nameBuffer, 0, nameBuffer.Length);
+
+            FileName = Encoding.Unicode.GetString(nameBuffer).Normalize().TrimEnd('\0');
+        }
+
+        public override string ToString()
+        {
+            return FileName ?? "UniFileN";
+        }
+    }
+}

--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -21,9 +21,14 @@ namespace NzbWebDAV.Par2Recovery
             CancellationToken ct = default
         )
         {
-            Par2Packet? packet = null;
+            // Buffer descriptors and optional UniFileN names so Unicode can win
+            // regardless of packet order (UniFileN may appear before or after FileDesc).
+            var fileDescs = new List<FileDesc>();
+            var unicodeNamesByFileId = new Dictionary<string, string>(StringComparer.Ordinal);
+
             while (stream.Position < stream.Length && !ct.IsCancellationRequested)
             {
+                Par2Packet packet;
                 try
                 {
                     packet = await ReadPacketAsync(stream).ConfigureAwait(false);
@@ -31,13 +36,29 @@ namespace NzbWebDAV.Par2Recovery
                 catch (Exception e)
                 {
                     Log.Warning(e, "Failed to read PAR2 packet");
-                    yield break;
+                    break;
                 }
 
-                if (packet is FileDesc newFile)
+                switch (packet)
                 {
-                    yield return newFile;
+                    case FileDesc fileDesc:
+                        fileDescs.Add(fileDesc);
+                        break;
+                    case UniFileN uniFileN:
+                        unicodeNamesByFileId[Convert.ToHexString(uniFileN.FileID)] = uniFileN.FileName;
+                        break;
                 }
+            }
+
+            foreach (var fileDesc in fileDescs)
+            {
+                if (unicodeNamesByFileId.TryGetValue(Convert.ToHexString(fileDesc.FileID), out var unicodeName)
+                    && !string.IsNullOrEmpty(unicodeName))
+                {
+                    fileDesc.FileName = unicodeName;
+                }
+
+                yield return fileDesc;
             }
         }
 
@@ -58,6 +79,9 @@ namespace NzbWebDAV.Par2Recovery
             {
                 case FileDesc.PacketType:
                     result = new FileDesc(header);
+                    break;
+                case UniFileN.PacketType:
+                    result = new UniFileN(header);
                     break;
                 default:
                     result = new Par2Packet(header);

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2Tests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2Tests.cs
@@ -1,5 +1,7 @@
+using System.Runtime.InteropServices;
 using System.Text;
 using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Par2Recovery.Packets;
 
 namespace NzbWebDAV.Tests.Par2Recovery;
 
@@ -32,5 +34,110 @@ public class Par2Tests
             descriptions.Add(description);
 
         Assert.Empty(descriptions);
+    }
+
+    [Fact]
+    public async Task ReadFileDescriptions_PrefersUniFileNOverFileDescWhenFileIdsMatch()
+    {
+        var fileId = Enumerable.Range(10, 16).Select(i => (byte)i).ToArray();
+        var asciiName = "obfuscated.mkv";
+        var unicodeName = "한국어_예능.mkv";
+
+        await using var stream = new MemoryStream();
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(fileId, asciiName));
+        WritePacket(stream, UniFileN.PacketType, BuildUniFileNBody(fileId, unicodeName));
+        stream.Position = 0;
+
+        var descriptions = new List<FileDesc>();
+        await foreach (var description in Par2.ReadFileDescriptions(stream))
+            descriptions.Add(description);
+
+        var desc = Assert.Single(descriptions);
+        Assert.Equal(unicodeName, desc.FileName);
+        Assert.Equal(fileId, desc.FileID);
+    }
+
+    [Fact]
+    public async Task ReadFileDescriptions_PrefersUniFileNWhenItAppearsBeforeFileDesc()
+    {
+        var fileId = Enumerable.Repeat((byte)0x42, 16).ToArray();
+        var asciiName = "ascii.mkv";
+        var unicodeName = "日本語テスト.mkv";
+
+        await using var stream = new MemoryStream();
+        WritePacket(stream, UniFileN.PacketType, BuildUniFileNBody(fileId, unicodeName));
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(fileId, asciiName));
+        stream.Position = 0;
+
+        var descriptions = new List<FileDesc>();
+        await foreach (var description in Par2.ReadFileDescriptions(stream))
+            descriptions.Add(description);
+
+        Assert.Equal(unicodeName, Assert.Single(descriptions).FileName);
+    }
+
+    [Fact]
+    public async Task ReadFileDescriptions_KeepsFileDescNameWhenNoMatchingUniFileN()
+    {
+        var fileId = Enumerable.Repeat((byte)0x11, 16).ToArray();
+        var otherFileId = Enumerable.Repeat((byte)0x22, 16).ToArray();
+
+        await using var stream = new MemoryStream();
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(fileId, "keep-me.mkv"));
+        WritePacket(stream, UniFileN.PacketType, BuildUniFileNBody(otherFileId, "다른이름.mkv"));
+        stream.Position = 0;
+
+        var descriptions = new List<FileDesc>();
+        await foreach (var description in Par2.ReadFileDescriptions(stream))
+            descriptions.Add(description);
+
+        Assert.Equal("keep-me.mkv", Assert.Single(descriptions).FileName);
+    }
+
+    private static byte[] BuildFileDescBody(byte[] fileId, string fileName)
+    {
+        var nameBytes = Encoding.UTF8.GetBytes(fileName);
+        var paddedLen = ((nameBytes.Length + 3) / 4) * 4;
+        var body = new byte[56 + paddedLen];
+        fileId.CopyTo(body, 0);
+        nameBytes.CopyTo(body, 56);
+        return body;
+    }
+
+    private static byte[] BuildUniFileNBody(byte[] fileId, string fileName)
+    {
+        var nameBytes = Encoding.Unicode.GetBytes(fileName);
+        var paddedLen = ((nameBytes.Length + 3) / 4) * 4;
+        var body = new byte[16 + paddedLen];
+        fileId.CopyTo(body, 0);
+        nameBytes.CopyTo(body, 16);
+        return body;
+    }
+
+    private static void WritePacket(Stream stream, string packetType, byte[] body)
+    {
+        var headerSize = Marshal.SizeOf<Par2PacketHeader>();
+        var header = new Par2PacketHeader
+        {
+            Magic = "PAR2\0PKT"u8.ToArray(),
+            PacketLength = (ulong)(headerSize + body.Length),
+            PacketHash = new byte[16],
+            RecoverySetID = new byte[16],
+            PacketType = Encoding.ASCII.GetBytes(packetType.PadRight(16, '\0')[..16]),
+        };
+
+        var headerBytes = new byte[headerSize];
+        var handle = GCHandle.Alloc(headerBytes, GCHandleType.Pinned);
+        try
+        {
+            Marshal.StructureToPtr(header, handle.AddrOfPinnedObject(), false);
+        }
+        finally
+        {
+            handle.Free();
+        }
+
+        stream.Write(headerBytes);
+        stream.Write(body);
     }
 }

--- a/tests/NzbWebDAV.Tests/Par2Recovery/UniFileNTests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/UniFileNTests.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using NzbWebDAV.Par2Recovery.Packets;
+
+namespace NzbWebDAV.Tests.Par2Recovery;
+
+public class UniFileNTests
+{
+    // UTF-16LE code units for "한국어.mkv" per PAR2 Unicode Filename packet:
+    // 한 U+D55C, 국 U+AD6D, 어 U+C5B4, . U+002E, m U+006D, k U+006B, v U+0076
+    private static readonly byte[] KoreanUtf16Le =
+    [
+        0x5C, 0xD5, 0x6D, 0xAD, 0xB4, 0xC5, 0x2E, 0x00,
+        0x6D, 0x00, 0x6B, 0x00, 0x76, 0x00,
+    ];
+
+    // UTF-16LE for "日本語.mkv":
+    // 日 U+65E5, 本 U+672C, 語 U+8A9E, . U+002E, m U+006D, k U+006B, v U+0076
+    private static readonly byte[] JapaneseUtf16Le =
+    [
+        0xE5, 0x65, 0x2C, 0x67, 0x9E, 0x8A, 0x2E, 0x00,
+        0x6D, 0x00, 0x6B, 0x00, 0x76, 0x00,
+    ];
+
+    [Fact]
+    public void PacketType_IsExactlySixteenBytes()
+    {
+        Assert.Equal(16, Encoding.ASCII.GetByteCount(UniFileN.PacketType));
+        Assert.Equal("PAR 2.0\0UniFileN", UniFileN.PacketType);
+    }
+
+    [Fact]
+    public void ParseBody_DecodesKoreanUtf16LeName()
+    {
+        // Hardcoded fixture bytes must be UTF-16LE per PAR2 2.0 UniFileN.
+        Assert.True(
+            KoreanUtf16Le.AsSpan().SequenceEqual(Encoding.Unicode.GetBytes("한국어.mkv")),
+            "Fixture must match UTF-16LE encoding of the Korean filename");
+
+        var fileId = Enumerable.Range(1, 16).Select(i => (byte)i).ToArray();
+        var uni = Parse(BuildBody(fileId, KoreanUtf16Le));
+
+        Assert.Equal(fileId, uni.FileID);
+        Assert.Equal("한국어.mkv", uni.FileName);
+    }
+
+    [Fact]
+    public void ParseBody_DecodesJapaneseUtf16LeName()
+    {
+        Assert.True(
+            JapaneseUtf16Le.AsSpan().SequenceEqual(Encoding.Unicode.GetBytes("日本語.mkv")),
+            "Fixture must match UTF-16LE encoding of the Japanese filename");
+
+        var fileId = Enumerable.Repeat((byte)0xAB, 16).ToArray();
+        var uni = Parse(BuildBody(fileId, JapaneseUtf16Le));
+
+        Assert.Equal(fileId, uni.FileID);
+        Assert.Equal("日本語.mkv", uni.FileName);
+    }
+
+    [Fact]
+    public void ParseBody_TrimsNullPadding()
+    {
+        // Name padded with UTF-16LE nulls to 4-byte alignment (PAR2 packet body rule).
+        var nameBytes = Encoding.Unicode.GetBytes("가.mkv");
+        var padded = new byte[((nameBytes.Length + 3) / 4) * 4];
+        nameBytes.CopyTo(padded, 0);
+
+        var uni = Parse(BuildBody(new byte[16], padded));
+        Assert.Equal("가.mkv", uni.FileName);
+    }
+
+    private static TestUniFileN Parse(byte[] body)
+    {
+        var header = new Par2PacketHeader
+        {
+            Magic = "PAR2\0PKT"u8.ToArray(),
+            PacketLength = (ulong)(64 + body.Length),
+            PacketHash = new byte[16],
+            RecoverySetID = new byte[16],
+            PacketType = Encoding.ASCII.GetBytes(UniFileN.PacketType),
+        };
+        var packet = new TestUniFileN(header);
+        packet.Parse(body);
+        return packet;
+    }
+
+    private static byte[] BuildBody(byte[] fileId, byte[] utf16LeName)
+    {
+        var paddedLen = ((utf16LeName.Length + 3) / 4) * 4;
+        var body = new byte[16 + paddedLen];
+        fileId.CopyTo(body, 0);
+        utf16LeName.CopyTo(body, 16);
+        return body;
+    }
+
+    private sealed class TestUniFileN(Par2PacketHeader header) : UniFileN(header)
+    {
+        public void Parse(byte[] body) => ParseBody(body);
+    }
+}


### PR DESCRIPTION
## Summary
- Add PAR 2.0 `UniFileN` packet parser (`PAR 2.0\0UniFileN`: 16-byte FileID + UTF-16LE name per the PAR2 2.0 spec).
- Prefer UniFileN Unicode names over `FileDesc.FileName` when both are present and FileIDs match (order-independent).
- Leave existing FileDesc UTF-8 / Windows-1252 decoding unchanged.

Follow-up to closed #96 (phase-2 UniFileN support after FileDesc encoding fixes).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~Par2Recovery`
- [x] Hardcoded CJK UTF-16LE fixtures verified against `Encoding.Unicode` (UTF-16LE)
- [x] Preference tests: UniFileN after FileDesc, UniFileN before FileDesc, unmatched FileID keeps FileDesc name