### PR TITLE
feat(webdav): maintenance task to rename windows-invalid dav paths

### DIFF
--- a/backend/Api/Controllers/RenameWindowsInvalidDavPaths/RenameWindowsInvalidDavPathsAuditController.cs
+++ b/backend/Api/Controllers/RenameWindowsInvalidDavPaths/RenameWindowsInvalidDavPathsAuditController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Tasks;
+
+namespace NzbWebDAV.Api.Controllers.RenameWindowsInvalidDavPaths;
+
+[ApiController]
+[Route("api/rename-windows-invalid-dav-paths/audit")]
+public class RenameWindowsInvalidDavPathsAuditController : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        var report = RenameWindowsInvalidDavPathsTask.GetAuditReport();
+        return Task.FromResult<IActionResult>(Ok(report));
+    }
+}

--- a/backend/Api/Controllers/RenameWindowsInvalidDavPaths/RenameWindowsInvalidDavPathsController.cs
+++ b/backend/Api/Controllers/RenameWindowsInvalidDavPaths/RenameWindowsInvalidDavPathsController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.RenameWindowsInvalidDavPaths;
+
+[ApiController]
+[Route("api/rename-windows-invalid-dav-paths")]
+public class RenameWindowsInvalidDavPathsController(
+    ConfigManager configManager,
+    WebsocketManager websocketManager
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var task = new RenameWindowsInvalidDavPathsTask(configManager, websocketManager, isDryRun: false);
+        var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed)
+            return Conflict(new { error = "Rename Windows-Invalid Dav Paths task is already running." });
+        return Ok(executed);
+    }
+}

--- a/backend/Api/Controllers/RenameWindowsInvalidDavPaths/RenameWindowsInvalidDavPathsDryRunController.cs
+++ b/backend/Api/Controllers/RenameWindowsInvalidDavPaths/RenameWindowsInvalidDavPathsDryRunController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.RenameWindowsInvalidDavPaths;
+
+[ApiController]
+[Route("api/rename-windows-invalid-dav-paths/dry-run")]
+public class RenameWindowsInvalidDavPathsDryRunController(
+    ConfigManager configManager,
+    WebsocketManager websocketManager
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var task = new RenameWindowsInvalidDavPathsTask(configManager, websocketManager, isDryRun: true);
+        var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed)
+            return Conflict(new { error = "Rename Windows-Invalid Dav Paths task is already running." });
+        return Ok(executed);
+    }
+}

--- a/backend/Tasks/RenameWindowsInvalidDavPathsTask.cs
+++ b/backend/Tasks/RenameWindowsInvalidDavPathsTask.cs
@@ -1,0 +1,323 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+/// <summary>
+/// Renames existing DavItems whose <see cref="DavItem.Name"/> fails Windows path rules
+/// when <c>webdav.windows-safe-paths</c> is enabled. New items are already sanitized on
+/// create; this maintenance task repairs rows created before that gate existed.
+/// </summary>
+public class RenameWindowsInvalidDavPathsTask(
+    ConfigManager configManager,
+    WebsocketManager websocketManager,
+    bool isDryRun,
+    Func<DavDatabaseContext>? createContext = null
+) : BaseTask
+{
+    private static List<string> _auditLines = [];
+
+    private DavDatabaseContext CreateContext() => createContext?.Invoke() ?? new DavDatabaseContext();
+
+    protected override async Task ExecuteInternal()
+    {
+        try
+        {
+            await RenameInvalidPaths().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Report($"Failed: {e.Message}");
+            Log.Error(e, "Failed to rename Windows-invalid Dav paths.");
+        }
+    }
+
+    private async Task RenameInvalidPaths()
+    {
+        PathSanitizer.SetWindowsSafePathsEnabled(configManager.IsWindowsSafePathsEnabled());
+        if (!PathSanitizer.IsWindowsSafePathsEnabled)
+        {
+            Report("Aborted: webdav.windows-safe-paths is disabled. " +
+                   "Enable it in WebDAV settings before running this task.");
+            return;
+        }
+
+        Report("Scanning DavItems for Windows-invalid names...");
+        await using var dbContext = CreateContext();
+        var items = await dbContext.Items.AsNoTracking().ToListAsync(CancellationToken).ConfigureAwait(false);
+
+        var plan = BuildRenamePlan(items);
+        if (plan.Renames.Count == 0)
+        {
+            _auditLines = [];
+            Report("Done. No Windows-invalid DavItem names found.");
+            return;
+        }
+
+        Report($"Found {plan.Renames.Count} item(s) to rename " +
+               $"({plan.PathUpdates.Count} path update(s) including subtree).");
+
+        _auditLines = plan.Renames
+            .Select(r => $"{r.OldPath} -> {r.NewPath}")
+            .ToList();
+
+        if (isDryRun)
+        {
+            Report($"Done. Identified {_auditLines.Count} rename(s).");
+            return;
+        }
+
+        await ApplyPlan(dbContext, plan).ConfigureAwait(false);
+        Report($"Done. Renamed {_auditLines.Count} item(s).");
+    }
+
+    /// <summary>
+    /// Computes renames (Name + Path) and descendant Path-only updates without writing.
+    /// Exposed for unit tests.
+    /// </summary>
+    internal static RenamePlan BuildRenamePlan(IReadOnlyList<DavItem> items)
+    {
+        var namesById = items.ToDictionary(x => x.Id, x => x.Name);
+        var pathsById = items.ToDictionary(x => x.Id, x => x.Path);
+        var parentIdsById = items.ToDictionary(x => x.Id, x => x.ParentId);
+        var typesById = items.ToDictionary(x => x.Id, x => x.Type);
+        var protectedIds = GetProtectedRootIds();
+
+        var invalid = items
+            .Where(x => !protectedIds.Contains(x.Id))
+            .Where(x => NeedsWindowsRename(x.Name))
+            .OrderBy(x => PathDepth(x.Path))
+            .ThenBy(x => x.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Id)
+            .ToList();
+
+        var renames = new List<RenameEntry>();
+        var pathUpdates = new Dictionary<Guid, string>();
+
+        foreach (var item in invalid)
+        {
+            var currentPath = pathsById[item.Id];
+            var parentPath = GetParentPath(currentPath);
+            var desiredName = PathSanitizer.SanitizeComponent(namesById[item.Id]);
+            var uniqueName = ResolveUniqueName(
+                desiredName,
+                item.Id,
+                parentIdsById[item.Id],
+                parentPath,
+                namesById,
+                pathsById,
+                parentIdsById);
+            var newPath = JoinDavPath(parentPath, uniqueName);
+
+            if (string.Equals(namesById[item.Id], uniqueName, StringComparison.Ordinal) &&
+                string.Equals(currentPath, newPath, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            renames.Add(new RenameEntry(
+                item.Id,
+                typesById[item.Id],
+                namesById[item.Id],
+                uniqueName,
+                currentPath,
+                newPath));
+
+            namesById[item.Id] = uniqueName;
+            pathsById[item.Id] = newPath;
+            pathUpdates[item.Id] = newPath;
+
+            UpdateDescendantPaths(item.Id, currentPath, newPath, pathsById, pathUpdates);
+        }
+
+        return new RenamePlan(renames, pathUpdates
+            .Select(kv => new PathUpdate(kv.Key, typesById[kv.Key], kv.Value))
+            .ToList());
+    }
+
+    private async Task ApplyPlan(DavDatabaseContext dbContext, RenamePlan plan)
+    {
+        Report("Applying renames...");
+        var idsToUpdate = plan.PathUpdates.Select(x => x.Id).ToHashSet();
+        var tracked = await dbContext.Items
+            .Where(x => idsToUpdate.Contains(x.Id))
+            .ToListAsync(CancellationToken)
+            .ConfigureAwait(false);
+        var byId = tracked.ToDictionary(x => x.Id);
+
+        var forgetItems = new List<DavItem>();
+        foreach (var rename in plan.Renames)
+        {
+            forgetItems.Add(new DavItem
+            {
+                Id = rename.Id,
+                Type = rename.Type,
+                Path = rename.OldPath,
+            });
+            forgetItems.Add(new DavItem
+            {
+                Id = rename.Id,
+                Type = rename.Type,
+                Path = rename.NewPath,
+            });
+        }
+
+        var renameById = plan.Renames.ToDictionary(x => x.Id);
+        foreach (var update in plan.PathUpdates)
+        {
+            if (!byId.TryGetValue(update.Id, out var entity))
+                continue;
+
+            entity.Path = update.NewPath;
+            if (renameById.TryGetValue(update.Id, out var rename))
+                entity.Name = rename.NewName;
+        }
+
+        await dbContext.SaveChangesAsync(CancellationToken).ConfigureAwait(false);
+        _ = DavDatabaseContext.RcloneVfsForget(forgetItems);
+        Report($"Applying renames...\nRenamed {plan.Renames.Count}...");
+    }
+
+    internal static bool NeedsWindowsRename(string name) =>
+        !string.Equals(name, PathSanitizer.SanitizeComponent(name), StringComparison.Ordinal);
+
+    internal static string ResolveUniqueName(
+        string desiredName,
+        Guid itemId,
+        Guid? parentId,
+        string parentPath,
+        IReadOnlyDictionary<Guid, string> namesById,
+        IReadOnlyDictionary<Guid, string> pathsById,
+        IReadOnlyDictionary<Guid, Guid?> parentIdsById)
+    {
+        var candidate = desiredName;
+        var suffix = 2;
+        while (true)
+        {
+            var candidatePath = JoinDavPath(parentPath, candidate);
+            var nameTaken = false;
+            foreach (var (id, name) in namesById)
+            {
+                if (id == itemId)
+                    continue;
+                if (parentIdsById[id] == parentId &&
+                    string.Equals(name, candidate, StringComparison.Ordinal))
+                {
+                    nameTaken = true;
+                    break;
+                }
+            }
+
+            var pathTaken = false;
+            if (!nameTaken)
+            {
+                foreach (var (id, path) in pathsById)
+                {
+                    if (id == itemId)
+                        continue;
+                    if (string.Equals(path, candidatePath, StringComparison.Ordinal))
+                    {
+                        pathTaken = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!nameTaken && !pathTaken)
+                return candidate;
+
+            var extension = Path.GetExtension(desiredName);
+            var stem = Path.GetFileNameWithoutExtension(desiredName);
+            candidate = $"{stem}_{suffix}{extension}";
+            suffix++;
+        }
+    }
+
+    internal static string JoinDavPath(string parentPath, string name)
+    {
+        if (string.IsNullOrEmpty(parentPath) || parentPath == "/")
+            return "/" + name;
+        return parentPath.TrimEnd('/') + "/" + name;
+    }
+
+    internal static string GetParentPath(string path)
+    {
+        if (string.IsNullOrEmpty(path) || path == "/")
+            return "/";
+        var trimmed = path.TrimEnd('/');
+        var idx = trimmed.LastIndexOf('/');
+        if (idx <= 0)
+            return "/";
+        return trimmed[..idx];
+    }
+
+    private static void UpdateDescendantPaths(
+        Guid renamedId,
+        string oldPath,
+        string newPath,
+        Dictionary<Guid, string> pathsById,
+        Dictionary<Guid, string> pathUpdates)
+    {
+        if (string.Equals(oldPath, newPath, StringComparison.Ordinal))
+            return;
+
+        var oldPrefix = oldPath.TrimEnd('/') + "/";
+        foreach (var (id, path) in pathsById.ToList())
+        {
+            if (id == renamedId)
+                continue;
+            if (!path.StartsWith(oldPrefix, StringComparison.Ordinal))
+                continue;
+
+            var updated = newPath.TrimEnd('/') + path[oldPath.TrimEnd('/').Length..];
+            pathsById[id] = updated;
+            pathUpdates[id] = updated;
+        }
+    }
+
+    private static HashSet<Guid> GetProtectedRootIds() =>
+    [
+        DavItem.Root.Id,
+        DavItem.NzbFolder.Id,
+        DavItem.ContentFolder.Id,
+        DavItem.SymlinkFolder.Id,
+        DavItem.IdsFolder.Id,
+    ];
+
+    private static int PathDepth(string path) =>
+        path.Count(c => c == '/');
+
+    private void Report(string message)
+    {
+        var dryRun = isDryRun ? "Dry Run - " : string.Empty;
+        _ = websocketManager.SendMessage(WebsocketTopic.RenameWindowsInvalidPathsProgress, $"{dryRun}{message}");
+    }
+
+    public static string GetAuditReport()
+    {
+        return _auditLines.Count > 0
+            ? string.Join("\n", _auditLines)
+            : "This list is Empty.\nYou must first run the task.";
+    }
+
+    internal static void ClearAuditForTests() => _auditLines = [];
+
+    internal sealed record RenameEntry(
+        Guid Id,
+        DavItem.ItemType Type,
+        string OldName,
+        string NewName,
+        string OldPath,
+        string NewPath);
+
+    internal sealed record PathUpdate(Guid Id, DavItem.ItemType Type, string NewPath);
+
+    internal sealed record RenamePlan(
+        IReadOnlyList<RenameEntry> Renames,
+        IReadOnlyList<PathUpdate> PathUpdates);
+}

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -7,6 +7,7 @@ public class WebsocketTopic
     public static readonly WebsocketTopic ActiveReads = new("ar", TopicType.State);
     public static readonly WebsocketTopic SymlinkTaskProgress = new("stp", TopicType.State);
     public static readonly WebsocketTopic CleanupTaskProgress = new("ctp", TopicType.State);
+    public static readonly WebsocketTopic RenameWindowsInvalidPathsProgress = new("rwip", TopicType.State);
     public static readonly WebsocketTopic StrmToSymlinksTaskProgress = new("st2sy", TopicType.State);
     public static readonly WebsocketTopic QueueItemStatus = new("qs", TopicType.State);
     public static readonly WebsocketTopic QueueItemProgress = new("qp", TopicType.State);

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,6 +1,7 @@
 import { SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
+import { RenameWindowsInvalidDavPaths } from "./rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
 import { ResetHealthCheckStats } from "./reset-health-check-stats/reset-health-check-stats";
@@ -147,6 +148,14 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                         </summary>
                         <div className={'border-t border-slate-700/70 p-4'}>
                             <RemoveUnlinkedFiles savedConfig={savedConfig} />
+                        </div>
+                    </details>
+                    <details className={'overflow-hidden rounded border border-slate-700/70'}>
+                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-white hover:bg-white/5">
+                            Rename Windows-Invalid Paths
+                        </summary>
+                        <div className={'border-t border-slate-700/70 p-4'}>
+                            <RenameWindowsInvalidDavPaths savedConfig={savedConfig} />
                         </div>
                     </details>
                     <details className={'overflow-hidden rounded border border-slate-700/70'}>

--- a/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
+++ b/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
@@ -1,0 +1,144 @@
+import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/feedback";
+import { Icon } from "~/components/ui/icon";
+import { useCallback, useEffect, useState } from "react";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
+
+type RenameWindowsInvalidDavPathsProps = {
+    savedConfig: Record<string, string>
+};
+
+export function RenameWindowsInvalidDavPaths({ savedConfig }: RenameWindowsInvalidDavPathsProps) {
+    const [connected, setConnected] = useState<boolean>(false);
+    const [progress, setProgress] = useState<string | null>(null);
+    const [isFetching, setIsFetching] = useState<boolean>(false);
+    const [runStarted, setRunStarted] = useState<boolean>(false);
+    const [statusError, setStatusError] = useState<string | null>(null);
+    const progressMessage = progress?.replace("Dry Run - ", "");
+
+    const windowsSafeEnabled = savedConfig["webdav.windows-safe-paths"] !== "false";
+    const isDone = progressMessage?.startsWith("Done");
+    const isFinished = progressMessage?.startsWith("Done")
+        || progressMessage?.startsWith("Failed")
+        || progressMessage?.startsWith("Aborted");
+    const isRunning = !isFinished && (isFetching || runStarted);
+    const isRunButtonEnabled = windowsSafeEnabled && connected && !isRunning;
+    const runButtonVariant = isRunButtonEnabled ? "success" : "secondary";
+    const runButtonLabel = isRunning ? "Running..." : "Apply Renames";
+
+    useWebsocketTopic("rwip", "state", setProgress, {
+        onOpen: () => setConnected(true),
+        onClose: () => setProgress(null),
+    });
+
+    useEffect(() => {
+        if (isFinished)
+            setRunStarted(false);
+    }, [isFinished]);
+
+    const startTask = useCallback(async (url: string) => {
+        setStatusError(null);
+        setProgress(null);
+        setRunStarted(true);
+        setIsFetching(true);
+        try {
+            const response = await fetch(url);
+            if (response.status === 409) {
+                setStatusError("Task already running.");
+                setRunStarted(false);
+                return;
+            }
+            if (!response.ok) {
+                setStatusError(`Request failed (${response.status}).`);
+                setRunStarted(false);
+            }
+        } catch {
+            setStatusError("Request failed.");
+            setRunStarted(false);
+        } finally {
+            setIsFetching(false);
+        }
+    }, []);
+
+    const onApply = useCallback(async () => {
+        await startTask("/api/rename-windows-invalid-dav-paths");
+    }, [startTask]);
+
+    const onDryRun = useCallback(async () => {
+        await startTask("/api/rename-windows-invalid-dav-paths/dry-run");
+    }, [startTask]);
+
+    const dryRunButton =
+        <Button
+            className={"inline-flex"}
+            disabled={!isRunButtonEnabled}
+            onClick={onDryRun}
+            variant="warning"
+            size="small"
+        >
+            <Icon name="science" className="!text-[18px]" />
+            perform a dry-run
+        </Button>;
+
+    return (
+        <>
+            {!windowsSafeEnabled &&
+                <Alert className={"mb-3"} variant="warning">
+                    Warning
+                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
+                        <li className={"text-xs"}>
+                            Enable &quot;Windows-safe paths&quot; under the WebDAV settings tab before running this task.
+                        </li>
+                    </ul>
+                </Alert>
+            }
+            {windowsSafeEnabled &&
+                <Alert className={"mb-3"} variant="warning">
+                    <span className="font-semibold">Note</span>
+                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
+                        <li className={"text-xs"}>
+                            Make a backup of your NzbDAV database prior to applying renames.
+                        </li>
+                        <li className={"text-xs"}>
+                            Prefer a dry-run first to review the report of paths that would change.
+                        </li>
+                    </ul>
+                </Alert>
+            }
+            <div className={"space-y-3"}>
+                <div className="space-y-2">
+                    <div className={"flex flex-col gap-3 sm:flex-row sm:items-center"}>
+                        <Button
+                            className={"shrink-0"}
+                            variant={runButtonVariant}
+                            onClick={onApply}
+                            disabled={!isRunButtonEnabled}
+                        >
+                            <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
+                            {runButtonLabel}
+                        </Button>
+                        <div className={"font-mono text-xs text-slate-300"}>
+                            {statusError ?? progress}
+                            {isDone && <>
+                                &nbsp;<a href="/api/rename-windows-invalid-dav-paths/audit">Report.</a>
+                            </>}
+                        </div>
+                    </div>
+                    <p className="text-[11px] leading-relaxed text-base-content/45" id="rename-windows-invalid-paths-help">
+                        <br />
+                        This task finds WebDAV items whose names contain characters invalid on Windows
+                        (or trailing dots/spaces / reserved device names) and renames those path
+                        components to match the current Windows-safe sanitizer. Child paths are updated
+                        for the whole subtree. Name collisions get a <code>_2</code> / <code>_3</code> suffix.
+                        Start with a {dryRunButton} to generate a report without writing changes.
+                        <br />
+                        <br />
+                        Library STRM files and symlinks target items by DavItem Id under <code>/.ids</code>,
+                        so organized libraries keep working after renames. WebDAV browse paths and any
+                        on-disk STRM file locations that mirror the old path will change.
+                    </p>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/tests/NzbWebDAV.Tests/Tasks/RenameWindowsInvalidDavPathsTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RenameWindowsInvalidDavPathsTaskTests.cs
@@ -1,0 +1,408 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Utils;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Tasks;
+
+[Collection(nameof(BaseTaskCollection))]
+public class RenameWindowsInvalidDavPathsTaskTests
+{
+    public RenameWindowsInvalidDavPathsTaskTests()
+    {
+        PathSanitizer.SetWindowsSafePathsEnabled(true);
+    }
+
+    [Fact]
+    public void BuildRenamePlan_RenamesInvalidComponent()
+    {
+        var parent = DavItem.ContentFolder;
+        var invalid = DavItem.New(
+            Guid.NewGuid(),
+            parent,
+            "Show: Title?",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+
+        var plan = RenameWindowsInvalidDavPathsTask.BuildRenamePlan([parent, invalid]);
+
+        Assert.Single(plan.Renames);
+        Assert.Equal("Show: Title?", plan.Renames[0].OldName);
+        Assert.Equal("Show_ Title_", plan.Renames[0].NewName);
+        Assert.Equal("/content/Show: Title?", plan.Renames[0].OldPath);
+        Assert.Equal("/content/Show_ Title_", plan.Renames[0].NewPath);
+    }
+
+    [Fact]
+    public void BuildRenamePlan_UpdatesSubtreePaths()
+    {
+        var show = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "Show: Title",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+        var season = DavItem.New(
+            Guid.NewGuid(),
+            show,
+            "Season 01.",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+        var episode = DavItem.New(
+            Guid.NewGuid(),
+            season,
+            "ep.mkv",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+
+        var plan = RenameWindowsInvalidDavPathsTask.BuildRenamePlan(
+            [DavItem.ContentFolder, show, season, episode]);
+
+        Assert.Equal(2, plan.Renames.Count);
+        var showRename = plan.Renames.Single(r => r.Id == show.Id);
+        var seasonRename = plan.Renames.Single(r => r.Id == season.Id);
+        Assert.Equal("/content/Show_ Title", showRename.NewPath);
+        Assert.Equal("Season 01", seasonRename.NewName);
+        Assert.Equal("/content/Show_ Title/Season 01", seasonRename.NewPath);
+
+        var episodeUpdate = plan.PathUpdates.Single(u => u.Id == episode.Id);
+        Assert.Equal("/content/Show_ Title/Season 01/ep.mkv", episodeUpdate.NewPath);
+    }
+
+    [Fact]
+    public void BuildRenamePlan_SuffixesCollidingSanitizedNames()
+    {
+        var a = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "A:B",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        var b = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "A?B",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        // Deterministic order: lower path depth same, then Path ordinal, then Id.
+        // Force path order by ensuring A:B sorts before A?B (':' < '?').
+        var plan = RenameWindowsInvalidDavPathsTask.BuildRenamePlan(
+            [DavItem.ContentFolder, a, b]);
+
+        Assert.Equal(2, plan.Renames.Count);
+        var first = plan.Renames.Single(r => r.Id == a.Id);
+        var second = plan.Renames.Single(r => r.Id == b.Id);
+        Assert.Equal("A_B", first.NewName);
+        Assert.Equal("A_B_2", second.NewName);
+        Assert.Equal("/content/A_B", first.NewPath);
+        Assert.Equal("/content/A_B_2", second.NewPath);
+    }
+
+    [Fact]
+    public void BuildRenamePlan_SuffixesWhenSanitizedNameAlreadyExists()
+    {
+        var existing = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "Show_ Title_",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        var invalid = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "Show: Title?",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+
+        var plan = RenameWindowsInvalidDavPathsTask.BuildRenamePlan(
+            [DavItem.ContentFolder, existing, invalid]);
+
+        Assert.Single(plan.Renames);
+        Assert.Equal("Show_ Title__2", plan.Renames[0].NewName);
+        Assert.Equal("/content/Show_ Title__2", plan.Renames[0].NewPath);
+    }
+
+    [Fact]
+    public void ResolveUniqueName_PreservesExtensionWhenSuffixing()
+    {
+        var id = Guid.NewGuid();
+        var otherId = Guid.NewGuid();
+        var names = new Dictionary<Guid, string>
+        {
+            [id] = "file:name.mkv",
+            [otherId] = "file_name.mkv",
+        };
+        var paths = new Dictionary<Guid, string>
+        {
+            [id] = "/content/file:name.mkv",
+            [otherId] = "/content/file_name.mkv",
+        };
+        var parents = new Dictionary<Guid, Guid?>
+        {
+            [id] = DavItem.ContentFolder.Id,
+            [otherId] = DavItem.ContentFolder.Id,
+        };
+
+        var result = RenameWindowsInvalidDavPathsTask.ResolveUniqueName(
+            "file_name.mkv",
+            id,
+            DavItem.ContentFolder.Id,
+            "/content",
+            names,
+            paths,
+            parents);
+
+        Assert.Equal("file_name_2.mkv", result);
+    }
+
+    [Fact]
+    public async Task Execute_DryRun_DoesNotWriteAndReportsDone()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+            var invalid = DavItem.New(
+                Guid.NewGuid(),
+                DavItem.ContentFolder,
+                "Bad:Name?",
+                10,
+                DavItem.ItemType.UsenetFile,
+                DavItem.ItemSubType.NzbFile,
+                null,
+                null,
+                null,
+                null);
+            ctx.Items.Add(invalid);
+            await ctx.SaveChangesAsync();
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.WebdavWindowsSafePaths, ConfigValue = "true" },
+            ]);
+            var websocket = new WebsocketManager();
+            var task = new RenameWindowsInvalidDavPathsTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            await using var verify = harness.CreateContext();
+            var stillBad = await verify.Items.SingleAsync(x => x.Id == invalid.Id);
+            Assert.Equal("Bad:Name?", stillBad.Name);
+
+            var progress = websocket.PeekLastMessage(WebsocketTopic.RenameWindowsInvalidPathsProgress);
+            Assert.NotNull(progress);
+            Assert.StartsWith("Dry Run - Done.", progress);
+            Assert.Contains("Identified 1 rename", progress);
+
+            var audit = RenameWindowsInvalidDavPathsTask.GetAuditReport();
+            Assert.Contains("Bad:Name?", audit);
+            Assert.Contains("Bad_Name_", audit);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RenameWindowsInvalidDavPathsTask.ClearAuditForTests();
+        }
+    }
+
+    [Fact]
+    public async Task Execute_Apply_PersistsRenamesAndSubtreePaths()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+            var show = DavItem.New(
+                Guid.NewGuid(),
+                DavItem.ContentFolder,
+                "Show: Title",
+                null,
+                DavItem.ItemType.Directory,
+                DavItem.ItemSubType.Directory,
+                null,
+                null,
+                null,
+                null);
+            var episode = DavItem.New(
+                Guid.NewGuid(),
+                show,
+                "ep.mkv",
+                10,
+                DavItem.ItemType.UsenetFile,
+                DavItem.ItemSubType.NzbFile,
+                null,
+                null,
+                null,
+                null);
+            ctx.Items.AddRange(show, episode);
+            await ctx.SaveChangesAsync();
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.WebdavWindowsSafePaths, ConfigValue = "true" },
+            ]);
+            var websocket = new WebsocketManager();
+            var task = new RenameWindowsInvalidDavPathsTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            await using var verify = harness.CreateContext();
+            var renamedShow = await verify.Items.SingleAsync(x => x.Id == show.Id);
+            var renamedEpisode = await verify.Items.SingleAsync(x => x.Id == episode.Id);
+            Assert.Equal("Show_ Title", renamedShow.Name);
+            Assert.Equal("/content/Show_ Title", renamedShow.Path);
+            Assert.Equal("ep.mkv", renamedEpisode.Name);
+            Assert.Equal("/content/Show_ Title/ep.mkv", renamedEpisode.Path);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RenameWindowsInvalidDavPathsTask.ClearAuditForTests();
+        }
+    }
+
+    [Fact]
+    public async Task Execute_AbortsWhenWindowsSafePathsDisabled()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.WebdavWindowsSafePaths, ConfigValue = "false" },
+            ]);
+            var websocket = new WebsocketManager();
+            var task = new RenameWindowsInvalidDavPathsTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+            var progress = websocket.PeekLastMessage(WebsocketTopic.RenameWindowsInvalidPathsProgress);
+            Assert.NotNull(progress);
+            Assert.Contains("Aborted:", progress);
+            Assert.Contains("windows-safe-paths", progress);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            PathSanitizer.SetWindowsSafePathsEnabled(true);
+            RenameWindowsInvalidDavPathsTask.ClearAuditForTests();
+        }
+    }
+
+    private static async Task SeedRootsAsync(DavDatabaseContext ctx)
+    {
+        if (!await ctx.Items.AnyAsync(x => x.Id == DavItem.Root.Id))
+            ctx.Items.Add(DavItem.Root);
+        if (!await ctx.Items.AnyAsync(x => x.Id == DavItem.ContentFolder.Id))
+            ctx.Items.Add(DavItem.ContentFolder);
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class TempDb : IAsyncDisposable
+    {
+        private readonly string _path;
+        private TempDb(string path, DavDatabaseContext context)
+        {
+            _path = path;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public DavDatabaseContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={_path}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            return new DavDatabaseContext(options);
+        }
+
+        public static async Task<TempDb> CreateAsync()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"nzbdav-winrename-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMainDbPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync();
+            return new TempDb(path, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try { File.Delete(_path); } catch { /* best effort */ }
+            try { File.Delete(_path + "-wal"); } catch { /* best effort */ }
+            try { File.Delete(_path + "-shm"); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a maintenance task that finds existing `DavItem` names failing Windows rules (when `webdav.windows-safe-paths` is on), renames via `PathSanitizer.SanitizeComponent`, updates subtree `Path` values, and resolves unique-index collisions with `_2` / `_3` suffixes.
- Ships dry-run (report) and apply modes with audit report, `RcloneVfsForget` on apply, admin API endpoints, and a Maintenance UI card. Library STRM/symlinks target by DavItem Id, so organized libraries survive renames.
- Follow-up to closed issues #131 / #73 (sanitize-on-create already shipped; this repairs leftover bad rows).

## Test plan
- [x] `dotnet test` filter `RenameWindowsInvalidDavPathsTaskTests` (8 passed)
- [x] `frontend` `npm run typecheck`
- [ ] Dry-run from Settings → Maintenance → Rename Windows-Invalid Paths and review report
- [ ] Apply on a backup DB and confirm WebDAV paths + rclone vfs refresh; library links still resolve