### PR TITLE
feat(queue): try duplicate nzb segment message-ids as ordered fallbacks

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -94,7 +94,8 @@ public interface INntpClient : IDisposable
         int articleBufferSize,
         LongRange[]? segmentByteRanges = null,
         bool usePipelinedBodyRequests = true,
-        string? fileName = null);
+        string? fileName = null,
+        string[][]? segmentFallbacks = null);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -140,7 +140,8 @@ public abstract class NntpClient : INntpClient
             articleBufferSize,
             nzbFile.GetSegmentByteRanges(),
             usePipelinedBodyRequests,
-            ResolveFileName(fileName, nzbFile));
+            ResolveFileName(fileName, nzbFile),
+            nzbFile.GetSegmentFallbackIds());
     }
 
     public virtual NzbFileStream GetFileStream(
@@ -157,7 +158,8 @@ public abstract class NntpClient : INntpClient
             articleBufferSize,
             nzbFile.GetSegmentByteRanges(),
             usePipelinedBodyRequests,
-            ResolveFileName(fileName, nzbFile)
+            ResolveFileName(fileName, nzbFile),
+            nzbFile.GetSegmentFallbackIds()
         );
     }
 
@@ -167,7 +169,8 @@ public abstract class NntpClient : INntpClient
         int articleBufferSize,
         LongRange[]? segmentByteRanges = null,
         bool usePipelinedBodyRequests = true,
-        string? fileName = null)
+        string? fileName = null,
+        string[][]? segmentFallbacks = null)
     {
         return new NzbFileStream(
             segmentIds,
@@ -176,7 +179,8 @@ public abstract class NntpClient : INntpClient
             articleBufferSize,
             segmentByteRanges,
             usePipelinedBodyRequests,
-            fileName);
+            fileName,
+            segmentFallbacks);
     }
 
     private static string? ResolveFileName(string? fileName, NzbFile nzbFile)

--- a/backend/Database/Models/DavMultipartFile.cs
+++ b/backend/Database/Models/DavMultipartFile.cs
@@ -60,6 +60,9 @@ public partial class DavMultipartFile
 
         [MemoryPackOrder(3)]
         public LongRange[]? SegmentByteRanges { get; set; }
+
+        [MemoryPackOrder(4)]
+        public string[][]? SegmentFallbackIds { get; set; }
     }
 
     // A RAR part whose internal byte range hasn't been parsed yet.
@@ -79,5 +82,8 @@ public partial class DavMultipartFile
 
         [MemoryPackOrder(2)]
         public long EstimatedDataSize { get; set; }
+
+        [MemoryPackOrder(3)]
+        public string[][]? SegmentFallbackIds { get; set; }
     }
 }

--- a/backend/Database/Models/DavNzbFile.cs
+++ b/backend/Database/Models/DavNzbFile.cs
@@ -20,7 +20,9 @@ public partial class DavNzbFile
     /// <summary>
     /// Per-segment alternate MessageIds aligned with <see cref="SegmentIds"/>.
     /// Null on blobs written before this field existed.
+    /// Blob/MemoryPack only — not an EF column (nested string[][] is unsupported).
     /// </summary>
+    [NotMapped]
     [MemoryPackOrder(3)]
     public string[][]? SegmentFallbackIds { get; set; }
 

--- a/backend/Database/Models/DavNzbFile.cs
+++ b/backend/Database/Models/DavNzbFile.cs
@@ -17,6 +17,13 @@ public partial class DavNzbFile
     [MemoryPackOrder(2)]
     public LongRange[]? SegmentByteRanges { get; set; }
 
+    /// <summary>
+    /// Per-segment alternate MessageIds aligned with <see cref="SegmentIds"/>.
+    /// Null on blobs written before this field existed.
+    /// </summary>
+    [MemoryPackOrder(3)]
+    public string[][]? SegmentFallbackIds { get; set; }
+
     // navigation helpers
     [MemoryPackIgnore]
     public DavItem? DavItem { get; set; }

--- a/backend/Database/Models/DavRarFile.cs
+++ b/backend/Database/Models/DavRarFile.cs
@@ -33,6 +33,9 @@ public partial class DavRarFile
 
         [MemoryPackOrder(4)]
         public LongRange[]? SegmentByteRanges { get; set; }
+
+        [MemoryPackOrder(5)]
+        public string[][]? SegmentFallbackIds { get; set; }
     }
 
     public DavMultipartFile.Meta ToDavMultipartFileMeta()
@@ -45,6 +48,7 @@ public partial class DavRarFile
                 SegmentIdByteRange = LongRange.FromStartAndSize(0, x.PartSize),
                 FilePartByteRange = LongRange.FromStartAndSize(x.Offset, x.ByteCount),
                 SegmentByteRanges = x.SegmentByteRanges,
+                SegmentFallbackIds = x.SegmentFallbackIds,
             }).ToArray()
         };
     }

--- a/backend/Models/Nzb/NzbFile.cs
+++ b/backend/Models/Nzb/NzbFile.cs
@@ -11,6 +11,7 @@ public class NzbFile
     /// <summary>
     /// Sort by segment number (when all present) and drop duplicates so every
     /// consumer sees one logical segment per ordinal / message-id.
+    /// Duplicate numbers keep alternate MessageIds on the primary as ordered fallbacks.
     /// </summary>
     public void CanonicalizeSegments()
     {
@@ -19,23 +20,43 @@ public class NzbFile
         var allNumbered = Segments.All(s => s.Number is not null);
         if (allNumbered)
         {
+            // Stable OrderBy preserves document order within the same number.
             var ordered = Segments
                 .OrderBy(s => s.Number!.Value)
                 .ToList();
 
             var deduped = new List<NzbSegment>(ordered.Count);
             var duplicateCount = 0;
-            int? lastNumber = null;
+            NzbSegment? primary = null;
+            List<string>? fallbacks = null;
             foreach (var segment in ordered)
             {
-                if (lastNumber == segment.Number)
+                if (primary is not null && primary.Number == segment.Number)
                 {
                     duplicateCount++;
+                    if (!string.Equals(segment.MessageId, primary.MessageId, StringComparison.Ordinal))
+                    {
+                        fallbacks ??= [];
+                        fallbacks.Add(segment.MessageId);
+                    }
+
                     continue;
                 }
 
-                deduped.Add(segment);
-                lastNumber = segment.Number;
+                if (primary is not null)
+                {
+                    primary.FallbackMessageIds = fallbacks is { Count: > 0 } ? fallbacks.ToArray() : [];
+                    deduped.Add(primary);
+                    fallbacks = null;
+                }
+
+                primary = segment;
+            }
+
+            if (primary is not null)
+            {
+                primary.FallbackMessageIds = fallbacks is { Count: > 0 } ? fallbacks.ToArray() : [];
+                deduped.Add(primary);
             }
 
             if (duplicateCount > 0)
@@ -51,6 +72,7 @@ public class NzbFile
         }
 
         // Numbers missing/partial: drop exact duplicate MessageIds only.
+        // Same MessageId has nothing to fall back to — keep current drop behavior.
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         var kept = new List<NzbSegment>(Segments.Count);
         var droppedIds = 0;
@@ -81,6 +103,9 @@ public class NzbFile
             .Select(x => x.MessageId)
             .ToArray();
     }
+
+    public string[][] GetSegmentFallbackIds() =>
+        Segments.Select(s => s.FallbackMessageIds).ToArray();
 
     public LongRange[]? GetSegmentByteRanges()
     {

--- a/backend/Models/Nzb/NzbSegment.cs
+++ b/backend/Models/Nzb/NzbSegment.cs
@@ -10,5 +10,10 @@ public class NzbSegment
     /// NZB segment ordinal from the <c>number</c> attribute, when present.
     /// </summary>
     public int? Number { get; init; }
+    /// <summary>
+    /// Alternate MessageIds for the same segment number, in document order.
+    /// Populated by <see cref="NzbFile.CanonicalizeSegments"/> when duplicates collapse.
+    /// </summary>
+    public string[] FallbackMessageIds { get; set; } = [];
     public LongRange? ByteRange { get; set; }
 }

--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -24,6 +24,7 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
                 Id = Guid.NewGuid(),
                 SegmentIds = result.NzbFile.GetSegmentIds(),
                 SegmentByteRanges = result.NzbFile.GetSegmentByteRanges(),
+                SegmentFallbackIds = result.NzbFile.GetSegmentFallbackIds(),
             };
 
             var davItem = DavItem.New(

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -113,6 +113,7 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
                         SegmentIdByteRange = LongRange.FromStartAndSize(0, x.PartSize),
                         FilePartByteRange = x.ByteRangeWithinPart,
                         SegmentByteRanges = x.NzbFile.GetSegmentByteRanges(),
+                        SegmentFallbackIds = x.NzbFile.GetSegmentFallbackIds(),
                     }).ToArray(),
                 }
             };

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -131,6 +131,7 @@ public class LazyRarProcessor(
             SegmentIds = firstInfo.NzbFile.GetSegmentIds(),
             SegmentIdByteRange = LongRange.FromStartAndSize(0, firstFileSize),
             FilePartByteRange = firstPartByteRange,
+            SegmentFallbackIds = firstInfo.NzbFile.GetSegmentFallbackIds(),
         };
 
         var trailingInfos = sorted.Skip(1).ToList();
@@ -153,6 +154,7 @@ public class LazyRarProcessor(
                 SegmentIds = partInfo.NzbFile.GetSegmentIds(),
                 SegmentIdByteRange = LongRange.FromStartAndSize(0, streamLength),
                 EstimatedDataSize = estimate,
+                SegmentFallbackIds = partInfo.NzbFile.GetSegmentFallbackIds(),
             });
             pendingSum += estimate;
         }

--- a/backend/Queue/FileProcessors/MultipartMkvProcessor.cs
+++ b/backend/Queue/FileProcessors/MultipartMkvProcessor.cs
@@ -41,6 +41,7 @@ public class MultipartMkvProcessor : BaseProcessor
                 SegmentIdByteRange = LongRange.FromStartAndSize(0, partSize),
                 FilePartByteRange = LongRange.FromStartAndSize(0, partSize),
                 SegmentByteRanges = fileInfo.NzbFile.GetSegmentByteRanges(),
+                SegmentFallbackIds = fileInfo.NzbFile.GetSegmentFallbackIds(),
             });
         }
 

--- a/backend/Queue/FileProcessors/SevenZipProcessor.cs
+++ b/backend/Queue/FileProcessors/SevenZipProcessor.cs
@@ -189,6 +189,7 @@ public class SevenZipProcessor : BaseProcessor
                     SegmentIdByteRange = LongRange.FromStartAndSize(0, multipartFile.FileParts[index].PartSize),
                     FilePartByteRange = LongRange.FromStartAndSize(partStartInclusive, partByteCount),
                     SegmentByteRanges = multipartFile.FileParts[index].NzbFile.GetSegmentByteRanges(),
+                    SegmentFallbackIds = multipartFile.FileParts[index].NzbFile.GetSegmentFallbackIds(),
                 };
             })
             .ToArray();

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -181,7 +181,8 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         long fileSize,
         CancellationToken ct)
     {
-        await using var stream = OpenVolumeStream(pending.SegmentIds, fileSize);
+        await using var stream = OpenVolumeStream(
+            pending.SegmentIds, fileSize, pending.SegmentFallbackIds);
 
         // Find-and-stop so SharpCompress never seeks past the matched header.
         // The seek would force NzbFileStream to fire InterpolationSearch
@@ -205,12 +206,14 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
             SegmentIds = pending.SegmentIds,
             SegmentIdByteRange = LongRange.FromStartAndSize(0, dataStart + dataSize),
             FilePartByteRange = LongRange.FromStartAndSize(dataStart, dataSize),
+            SegmentFallbackIds = pending.SegmentFallbackIds,
         };
     }
 
-    private Stream OpenVolumeStream(string[] segmentIds, long fileSize) =>
+    private Stream OpenVolumeStream(string[] segmentIds, long fileSize, string[][]? segmentFallbacks = null) =>
         VolumeStreamFactory?.Invoke(segmentIds, fileSize)
-        ?? usenetClient.GetFileStream(segmentIds, fileSize, articleBufferSize: 0);
+        ?? usenetClient.GetFileStream(segmentIds, fileSize, articleBufferSize: 0,
+            segmentFallbacks: segmentFallbacks);
 
     private async Task<long> MeasureVolumeSizeAsync(string[] segmentIds, CancellationToken ct)
     {

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -242,7 +242,8 @@ public class DavMultipartFileStream : Stream
             _articleBufferSize,
             part.SegmentByteRanges,
             _usePipelinedBodyRequests,
-            _fileName);
+            _fileName,
+            part.SegmentFallbackIds);
         stream.Seek(part.FilePartByteRange.StartInclusive + extraOffset, SeekOrigin.Begin);
         return stream.LimitLength(part.FilePartByteRange.Count - extraOffset);
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -16,6 +16,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private const int MaxBodyRetries = 2;
 
     private readonly Memory<string> _segmentIds;
+    private readonly string[][]? _segmentFallbacks;
     private readonly INntpClient _usenetClient;
     private readonly long _expectedSegmentSize;
     private readonly bool _failFastOnFirstSegment;
@@ -34,7 +35,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool usePipelinedBodyRequests,
         CancellationToken cancellationToken,
         string? fileName = null,
-        long? readBudget = null)
+        long? readBudget = null,
+        string[][]? segmentFallbacks = null)
     {
         return Create(
             segmentIds,
@@ -45,7 +47,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             usePipelinedBodyRequests,
             cancellationToken,
             fileName,
-            readBudget);
+            readBudget,
+            segmentFallbacks);
     }
 
     public static Stream Create
@@ -58,11 +61,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool usePipelinedBodyRequests,
         CancellationToken cancellationToken,
         string? fileName = null,
-        long? readBudget = null
+        long? readBudget = null,
+        string[][]? segmentFallbacks = null
     )
     {
         return articleBufferSize == 0
-            ? new UnbufferedMultiSegmentStream(segmentIds, usenetClient, expectedSegmentSize, fileName)
+            ? new UnbufferedMultiSegmentStream(
+                segmentIds, usenetClient, expectedSegmentSize, fileName, segmentFallbacks)
             : new MultiSegmentStream(
                 segmentIds,
                 usenetClient,
@@ -72,7 +77,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 usePipelinedBodyRequests,
                 cancellationToken,
                 fileName,
-                readBudget);
+                readBudget,
+                segmentFallbacks);
     }
 
     private MultiSegmentStream
@@ -85,10 +91,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool usePipelinedBodyRequests,
         CancellationToken cancellationToken,
         string? fileName,
-        long? readBudget
+        long? readBudget,
+        string[][]? segmentFallbacks
     )
     {
         _segmentIds = segmentIds;
+        _segmentFallbacks = segmentFallbacks;
         _usenetClient = usenetClient;
         _expectedSegmentSize = expectedSegmentSize;
         _failFastOnFirstSegment = failFastOnFirstSegment;
@@ -152,6 +160,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 .Select((response, index) => DownloadBatchSegment(
                     response,
                     segmentIds[index],
+                    segmentIndex: batchStart + index,
                     isFirstSegment: batchStart + index == 0,
                     cancellationToken))
                 .ToArray();
@@ -192,7 +201,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             var connection = await _usenetClient.AcquireExclusiveConnectionAsync(
                 segmentId, cancellationToken);
             var streamTask = DownloadSegment(
-                segmentId, connection, isFirstSegment: index == 0, cancellationToken);
+                segmentId, index, connection, isFirstSegment: index == 0, cancellationToken);
             try
             {
                 await _streamTasks.Writer.WriteAsync(streamTask, cancellationToken);
@@ -218,6 +227,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
     private async Task<Stream> DownloadSegment(
         string segmentId,
+        int segmentIndex,
         UsenetExclusiveConnection exclusiveConnection,
         bool isFirstSegment,
         CancellationToken cancellationToken
@@ -239,6 +249,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch (UsenetArticleNotFoundException e)
             {
+                var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
+                    .ConfigureAwait(false);
+                if (fallback is not null)
+                    return fallback;
+
                 if (_failFastOnFirstSegment && isFirstSegment)
                 {
                     e.LogWarningKnownOrStack(
@@ -282,6 +297,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private async Task<Stream> DownloadBatchSegment(
         Task<UsenetDecodedBodyResponse> responseTask,
         string segmentId,
+        int segmentIndex,
         bool isFirstSegment,
         CancellationToken cancellationToken)
     {
@@ -292,6 +308,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
         catch (UsenetArticleNotFoundException e)
         {
+            var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
+                .ConfigureAwait(false);
+            if (fallback is not null)
+                return fallback;
+
             if (_failFastOnFirstSegment && isFirstSegment) throw;
             return ZeroFillSegment(
                 "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
@@ -304,6 +325,49 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 "Segment {SegmentId} unavailable while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
                 segmentId, e);
         }
+    }
+
+    /// <summary>
+    /// Try alternate MessageIds for a missing primary segment. Each BODY
+    /// attempt completes its callback exactly once via DecodedBodyAsync.
+    /// </summary>
+    private async Task<Stream?> TryFallbackSegmentsAsync(
+        int segmentIndex,
+        CancellationToken cancellationToken)
+    {
+        var fallbacks = GetFallbacks(segmentIndex);
+        if (fallbacks.Length == 0) return null;
+
+        foreach (var fallbackId in fallbacks)
+        {
+            try
+            {
+                var bodyResponse = await _usenetClient
+                    .DecodedBodyAsync(fallbackId, cancellationToken)
+                    .ConfigureAwait(false);
+                Log.Debug(
+                    "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
+                    segmentIndex, fallbackId, _fileName);
+                return await DrainSegmentAsync(bodyResponse.Stream!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (UsenetArticleNotFoundException)
+            {
+                // Try the next alternate MessageId.
+            }
+        }
+
+        return null;
+    }
+
+    private string[] GetFallbacks(int segmentIndex)
+    {
+        if (_segmentFallbacks is null ||
+            segmentIndex < 0 ||
+            segmentIndex >= _segmentFallbacks.Length)
+            return [];
+
+        return _segmentFallbacks[segmentIndex] ?? [];
     }
 
     private static async Task DisposeStreamAsync(Task<Stream> streamTask)

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -17,7 +17,8 @@ public class NzbFileStream(
     int articleBufferSize,
     LongRange[]? segmentByteRanges = null,
     bool usePipelinedBodyRequests = true,
-    string? fileName = null
+    string? fileName = null,
+    string[][]? segmentFallbacks = null
 ) : FastReadOnlyStream
 {
     private const long MaximumForwardDrainBytes = 1024 * 1024;
@@ -278,6 +279,10 @@ public class NzbFileStream(
         CancellationToken cancellationToken)
     {
         var segmentIds = fileSegmentIds.AsMemory()[firstSegmentIndex..];
+        string[][]? fallbacks = null;
+        if (segmentFallbacks is { Length: > 0 } && firstSegmentIndex < segmentFallbacks.Length)
+            fallbacks = segmentFallbacks[firstSegmentIndex..];
+
         return MultiSegmentStream.Create(
             segmentIds,
             usenetClient,
@@ -286,7 +291,8 @@ public class NzbFileStream(
             failFastOnFirstSegment,
             usePipelinedBodyRequests,
             cancellationToken,
-            fileName);
+            fileName,
+            segmentFallbacks: fallbacks);
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -8,6 +8,7 @@ namespace NzbWebDAV.Streams;
 public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 {
     private readonly Memory<string> _segmentIds;
+    private readonly string[][]? _segmentFallbacks;
     private readonly INntpClient _usenetClient;
     private readonly long _expectedSegmentSize;
     private readonly string _fileName;
@@ -20,9 +21,11 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         Memory<string> segmentIds,
         INntpClient usenetClient,
         long expectedSegmentSize,
-        string? fileName = null)
+        string? fileName = null,
+        string[][]? segmentFallbacks = null)
     {
         _segmentIds = segmentIds;
+        _segmentFallbacks = segmentFallbacks;
         _usenetClient = usenetClient;
         _expectedSegmentSize = expectedSegmentSize;
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
@@ -40,6 +43,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             if (_stream == null)
             {
                 if (_currentIndex >= _segmentIds.Length) return 0;
+                var segmentIndex = _currentIndex;
                 var segmentId = _segmentIds.Span[_currentIndex++];
                 try
                 {
@@ -48,11 +52,20 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 }
                 catch (UsenetArticleNotFoundException e)
                 {
-                    var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
-                    Log.Warning(
-                        "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
-                        e.SegmentId, _fileName, fill);
-                    _stream = new MemoryStream(new byte[fill], writable: false);
+                    var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (fallback is not null)
+                    {
+                        _stream = fallback;
+                    }
+                    else
+                    {
+                        var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
+                        Log.Warning(
+                            "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                            e.SegmentId, _fileName, fill);
+                        _stream = new MemoryStream(new byte[fill], writable: false);
+                    }
                 }
             }
 
@@ -64,6 +77,34 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             await _stream.DisposeAsync();
             _stream = null;
         }
+    }
+
+    private async Task<Stream?> TryFallbackSegmentsAsync(
+        int segmentIndex,
+        CancellationToken cancellationToken)
+    {
+        if (_segmentFallbacks is null ||
+            segmentIndex < 0 ||
+            segmentIndex >= _segmentFallbacks.Length)
+            return null;
+
+        var fallbacks = _segmentFallbacks[segmentIndex] ?? [];
+        foreach (var fallbackId in fallbacks)
+        {
+            try
+            {
+                var body = await _usenetClient
+                    .DecodedBodyAsync(fallbackId, cancellationToken)
+                    .ConfigureAwait(false);
+                return body.Stream!;
+            }
+            catch (UsenetArticleNotFoundException)
+            {
+                // Try the next alternate MessageId.
+            }
+        }
+
+        return null;
     }
 
     private void ThrowIfDisposed()

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -42,7 +42,8 @@ public class DatabaseStoreNzbFile(
             configManager.GetArticleBufferSize(),
             nzbFile.SegmentByteRanges,
             configManager.IsPipelinedBodyRequestsEnabled(),
-            davNzbFile.Path
+            davNzbFile.Path,
+            nzbFile.SegmentFallbackIds
         );
     }
 }

--- a/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
+++ b/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
@@ -113,6 +113,7 @@ public class NzbDocumentTests
         Assert.Equal(3, file.Segments.Count);
         Assert.Equal(["a@example", "b-first@example", "c@example"], file.GetSegmentIds());
         Assert.Equal([1, 2, 3], file.Segments.Select(s => s.Number!.Value).ToArray());
+        Assert.Equal([[], ["b-second@example"], []], file.GetSegmentFallbackIds());
     }
 
     [Fact]
@@ -146,10 +147,36 @@ public class NzbDocumentTests
             """;
         await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
-        var document = await NzbDocument.LoadAsync(stream);
+        var file = Assert.Single((await NzbDocument.LoadAsync(stream)).Files);
 
-        Assert.Equal(["a@example", "b@example", "c@example"],
-            Assert.Single(document.Files).GetSegmentIds());
+        Assert.Equal(["a@example", "b@example", "c@example"], file.GetSegmentIds());
+        // Same MessageId has nothing to fall back to — drop only.
+        Assert.All(file.GetSegmentFallbackIds(), fallbacks => Assert.Empty(fallbacks));
+    }
+
+    [Fact]
+    public async Task LoadAsync_DuplicateNumbers_KeepOrderedFallbacksOnPrimary()
+    {
+        const string xml = """
+            <nzb><file subject="fallbacks"><segments>
+              <segment bytes="10" number="1">a@example</segment>
+              <segment bytes="20" number="2">b-primary@example</segment>
+              <segment bytes="21" number="2">b-alt1@example</segment>
+              <segment bytes="22" number="2">b-alt2@example</segment>
+              <segment bytes="30" number="3">c@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        var document = await NzbDocument.LoadAsync(stream);
+        var file = Assert.Single(document.Files);
+
+        Assert.Equal(["a@example", "b-primary@example", "c@example"], file.GetSegmentIds());
+        Assert.Equal(
+            [[], ["b-alt1@example", "b-alt2@example"], []],
+            file.GetSegmentFallbackIds());
+        Assert.Empty(file.Segments[0].FallbackMessageIds);
+        Assert.Equal(["b-alt1@example", "b-alt2@example"], file.Segments[1].FallbackMessageIds);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
@@ -1,0 +1,253 @@
+using System.Text;
+using MemoryPack;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class SegmentFallbackTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MultiSegmentStream_FallsBackWhenPrimaryArticleMissing(
+        bool usePipelinedBodyRequests)
+    {
+        var client = new RawBodyNntpClient(new Dictionary<string, byte[]>
+        {
+            // primary "one" is intentionally absent → 430
+            ["one-fallback"] = Encoding.ASCII.GetBytes("hello"),
+            ["two"] = Encoding.ASCII.GetBytes("world"),
+        });
+
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "one", "two" }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            expectedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: usePipelinedBodyRequests,
+            cancellationToken: CancellationToken.None,
+            fileName: "fallback.bin",
+            segmentFallbacks: [["one-fallback"], []]);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal("helloworld", Encoding.ASCII.GetString(destination.ToArray()));
+        Assert.Contains("one", client.RequestedSegmentIds);
+        Assert.Contains("one-fallback", client.RequestedSegmentIds);
+        Assert.Contains("two", client.RequestedSegmentIds);
+        // Primary 430 + fallback success + second segment.
+        Assert.True(client.BodyRequestCount >= 3,
+            $"Expected BODY for primary, fallback, and second segment; got {client.BodyRequestCount}");
+    }
+
+    [Fact]
+    public async Task MultiSegmentStream_Unbuffered_FallsBackWhenPrimaryMissing()
+    {
+        var client = new RawBodyNntpClient(new Dictionary<string, byte[]>
+        {
+            ["alt"] = Encoding.ASCII.GetBytes("abcde"),
+        });
+
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "missing" }.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            expectedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            cancellationToken: CancellationToken.None,
+            segmentFallbacks: [["alt"]]);
+
+        var buffer = new byte[5];
+        var read = await stream.ReadAsync(buffer);
+
+        Assert.Equal(5, read);
+        Assert.Equal("abcde", Encoding.ASCII.GetString(buffer));
+        Assert.Equal(2, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public void DavNzbFile_MemoryPackRoundTrip_WithAndWithoutFallbacks()
+    {
+        var without = new DavNzbFile
+        {
+            Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            SegmentIds = ["a", "b"],
+        };
+        var with = new DavNzbFile
+        {
+            Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            SegmentIds = ["a", "b"],
+            SegmentFallbackIds = [[], ["b-alt1", "b-alt2"]],
+        };
+
+        var withoutRoundTrip = MemoryPackSerializer.Deserialize<DavNzbFile>(
+            MemoryPackSerializer.Serialize(without))!;
+        var withRoundTrip = MemoryPackSerializer.Deserialize<DavNzbFile>(
+            MemoryPackSerializer.Serialize(with))!;
+
+        Assert.Equal(without.Id, withoutRoundTrip.Id);
+        Assert.Equal(without.SegmentIds, withoutRoundTrip.SegmentIds);
+        Assert.Null(withoutRoundTrip.SegmentFallbackIds);
+
+        Assert.Equal(with.Id, withRoundTrip.Id);
+        Assert.Equal(with.SegmentIds, withRoundTrip.SegmentIds);
+        Assert.Equal(with.SegmentFallbackIds, withRoundTrip.SegmentFallbackIds);
+    }
+
+    [Fact]
+    public void DavNzbFile_LegacyBlobWithoutFallbackField_DeserializesNullFallbacks()
+    {
+        var legacy = new DavNzbFile
+        {
+            Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            SegmentIds = ["seg-1"],
+            SegmentFallbackIds = null,
+        };
+        var bytes = MemoryPackSerializer.Serialize(legacy);
+        var roundTrip = MemoryPackSerializer.Deserialize<DavNzbFile>(bytes)!;
+
+        Assert.Null(roundTrip.SegmentFallbackIds);
+        Assert.Equal(["seg-1"], roundTrip.SegmentIds);
+    }
+
+    /// <summary>
+    /// Returns already-decoded body streams so tests do not require rapidyenc.
+    /// </summary>
+    private sealed class RawBodyNntpClient(
+        IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public int BodyRequestCount { get; private set; }
+        public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            BodyRequestCount++;
+            var key = segmentId.ToString();
+            RequestedSegmentIds.Add(key);
+            if (!segments.TryGetValue(key, out var bytes))
+            {
+                onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotFound);
+                return Task.FromException<UsenetDecodedBodyResponse>(
+                    new UsenetArticleNotFoundException(key, "430 No such article"));
+            }
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 fake body",
+                Stream = new RawYencStream(bytes),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(segmentId => DecodedBodyAsync(segmentId, cancellationToken))
+                .ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodiesAsync(
+                segmentIds, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Already-decoded body stream typed as <see cref="YencStream"/> so tests
+    /// do not require the rapidyenc native library.
+    /// </summary>
+    private sealed class RawYencStream(byte[] bytes) : YencStream(new MemoryStream(bytes, writable: false))
+    {
+        private int _offset;
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_offset >= bytes.Length) return 0;
+            var count = Math.Min(buffer.Length, bytes.Length - _offset);
+            bytes.AsSpan(_offset, count).CopyTo(buffer.Span);
+            _offset += count;
+            return await Task.FromResult(count).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- When NZB parse collapses duplicate segment numbers, retain alternate MessageIds on the primary as ordered `FallbackMessageIds` and persist them as VersionTolerant `SegmentFallbackIds` on DavNzbFile / RarPart / FilePart / PendingPart (new MemoryPack orders only).
- On streaming `UsenetArticleNotFoundException` for a primary segment, try each fallback MessageId (new BODY acquire) before zero-fill/fail in `MultiSegmentStream` and `UnbufferedMultiSegmentStream`.
- Wire fallbacks from NZB parse through queue aggregators/processors and WebDAV store streams.

References nzbdav-dev/nzbdav#310 (local #113 phase-2; already closed).

## Test plan
- [x] `dotnet test` — `NzbDocumentTests` (duplicate numbers keep ordered fallbacks; MessageId-only dedupe has none)
- [x] `dotnet test` — `SegmentFallbackTests` (primary 430 → fallback content; BodyRequestCount covers both; MemoryPack round-trip with/without field)
- [ ] CI backend test suite on PR