### PR TITLE
fix(config): validate usenet providers to prevent MaxConnections boot-loop

### DIFF
--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -23,9 +23,19 @@ public class UsenetStreamingClient : WrappingNntpClient
             // if unrelated config changed, do nothing
             if (!configEventArgs.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders)) return;
 
-            // update the connection-pool according to the new config
-            var newUsenetClient = CreateDownloadingNntpClient(configManager, websocketManager, usageTracker, metricsWriter, bytesTracker);
-            ReplaceUnderlyingClient(newUsenetClient);
+            try
+            {
+                // update the connection-pool according to the new config
+                var newUsenetClient = CreateDownloadingNntpClient(
+                    configManager, websocketManager, usageTracker, metricsWriter, bytesTracker);
+                ReplaceUnderlyingClient(newUsenetClient);
+            }
+            catch (Exception e)
+            {
+                // Keep the previous (working) client and let remaining OnConfigChanged
+                // subscribers run — a throw from a multicast handler aborts the rest.
+                Log.Error(e, "Failed to rebuild usenet client after provider config change; keeping previous client");
+            }
         };
     }
 
@@ -102,8 +112,20 @@ public class UsenetStreamingClient : WrappingNntpClient
         int idleTimeoutSeconds
     )
     {
+        var maxConnections = connectionDetails.MaxConnections;
+        if (maxConnections < 1)
+        {
+            Log.Warning(
+                "Provider '{Provider}' has MaxConnections={MaxConnections}; clamping to 1 so the connection pool can start",
+                string.IsNullOrWhiteSpace(connectionDetails.Nickname)
+                    ? connectionDetails.Host
+                    : connectionDetails.Nickname,
+                maxConnections);
+            maxConnections = 1;
+        }
+
         var connectionPool = CreateNewConnectionPool(
-            maxConnections: connectionDetails.MaxConnections,
+            maxConnections: maxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
             onConnectionPoolChanged,
             idleTimeoutSeconds

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -243,7 +243,7 @@ public class ConfigManager
                     break;
 
                 case ConfigKeys.UsenetProviders:
-                    RequireJson<UsenetProviderConfig>(item.ConfigName, value);
+                    RequireValidUsenetProviders(item.ConfigName, value);
                     break;
 
                 case ConfigKeys.ArrInstances:
@@ -283,6 +283,34 @@ public class ConfigManager
             catch (JsonException e)
             {
                 throw new ArgumentException($"Config value for '{key}' is not valid JSON: {e.Message}");
+            }
+        }
+
+        static void RequireValidUsenetProviders(string key, string value)
+        {
+            UsenetProviderConfig? config;
+            try
+            {
+                config = JsonSerializer.Deserialize<UsenetProviderConfig>(value);
+            }
+            catch (JsonException e)
+            {
+                throw new ArgumentException($"Config value for '{key}' is not valid JSON: {e.Message}");
+            }
+
+            if (config?.Providers is null) return;
+            for (var i = 0; i < config.Providers.Count; i++)
+            {
+                var p = config.Providers[i];
+                var label = string.IsNullOrWhiteSpace(p.Nickname) ? p.Host : p.Nickname;
+                if (string.IsNullOrWhiteSpace(p.Host))
+                    throw new ArgumentException($"Provider #{i + 1}: host must not be empty.");
+                if (p.Port is < 1 or > 65535)
+                    throw new ArgumentException($"Provider '{label}': port must be between 1 and 65535, but was {p.Port}.");
+                if (p.MaxConnections < 1)
+                    throw new ArgumentException($"Provider '{label}': max connections must be at least 1, but was {p.MaxConnections}.");
+                if (p.ByteLimit is < 0)
+                    throw new ArgumentException($"Provider '{label}': byte limit must not be negative.");
             }
         }
     }

--- a/tests/NzbWebDAV.Tests/Config/UsenetProvidersValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/UsenetProvidersValidationTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class UsenetProvidersValidationTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ValidateConfigItems_RejectsNonPositiveMaxConnections(int maxConnections)
+    {
+        var items = ProvidersConfigItems(MakeProvider(maxConnections: maxConnections, nickname: "bad-pool"));
+        var ex = Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(items));
+        Assert.Contains("max connections must be at least 1", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("bad-pool", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(70000)]
+    public void ValidateConfigItems_RejectsInvalidPort(int port)
+    {
+        var items = ProvidersConfigItems(MakeProvider(port: port, nickname: "port-bad"));
+        var ex = Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(items));
+        Assert.Contains("port must be between 1 and 65535", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("port-bad", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsEmptyHost()
+    {
+        var items = ProvidersConfigItems(MakeProvider(host: "   "));
+        var ex = Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(items));
+        Assert.Contains("host must not be empty", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Provider #1", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsNegativeByteLimit()
+    {
+        var items = ProvidersConfigItems(MakeProvider(byteLimit: -1, nickname: "block"));
+        var ex = Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(items));
+        Assert.Contains("byte limit must not be negative", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("block", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsDisabledProviderWithZeroMaxConnections()
+    {
+        var items = ProvidersConfigItems(MakeProvider(
+            type: ProviderType.Disabled,
+            maxConnections: 0,
+            nickname: "disabled-zero"));
+        var ex = Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(items));
+        Assert.Contains("max connections must be at least 1", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("disabled-zero", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_AcceptsValidMultiProviderPayload()
+    {
+        var items = ProvidersConfigItems(
+            MakeProvider(host: "pool.example", maxConnections: 20, nickname: "pool"),
+            MakeProvider(host: "backup.example", type: ProviderType.BackupOnly, maxConnections: 5, nickname: "backup"),
+            MakeProvider(host: "off.example", type: ProviderType.Disabled, maxConnections: 1, nickname: "off"));
+
+        ConfigManager.ValidateConfigItems(items);
+    }
+
+    [Fact]
+    public void UsenetStreamingClient_ClampsLegacyZeroMaxConnectionsWithoutThrowing()
+    {
+        // Bypass ValidateConfigItems to simulate a pre-existing bad DB row.
+        var config = new ConfigManager();
+        config.UpdateValues(ProvidersConfigItems(MakeProvider(maxConnections: 0, nickname: "legacy-zero")));
+
+        var client = new UsenetStreamingClient(
+            config,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker());
+
+        Assert.NotNull(client);
+        client.Dispose();
+    }
+
+    private static List<ConfigItem> ProvidersConfigItems(
+        params UsenetProviderConfig.ConnectionDetails[] providers)
+    {
+        return
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers = [.. providers],
+                }),
+            },
+        ];
+    }
+
+    private static UsenetProviderConfig.ConnectionDetails MakeProvider(
+        string host = "nntp.example",
+        int port = 563,
+        int maxConnections = 10,
+        ProviderType type = ProviderType.Pooled,
+        string? nickname = null,
+        long? byteLimit = null)
+    {
+        return new UsenetProviderConfig.ConnectionDetails
+        {
+            Type = type,
+            Host = host,
+            Port = port,
+            UseSsl = true,
+            User = "u",
+            Pass = "p",
+            MaxConnections = maxConnections,
+            Nickname = nickname,
+            ByteLimit = byteLimit,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Validate `usenet.providers` JSON for host, port, max connections, and byte limit before persist
- Clamp `MaxConnections < 1` to 1 when building connection pools so legacy bad DB rows cannot boot-loop Docker
- Catch failures in the `UsenetStreamingClient` `OnConfigChanged` rebuild so the previous client stays live and other subscribers still run

Closes #349

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~UsenetProvidersValidationTests`
- [ ] Manual: `curl` `/api/update-config` with `MaxConnections: 0` → 400, DB unchanged, restart boots