### PR TITLE
fix(queue): back off on persistent loop errors and honor shutdown idle

### DIFF
--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -30,6 +30,14 @@ public class QueueManager : IDisposable
     private CancellationTokenSource _sleepingQueueToken = new();
     private readonly Lock _sleepingQueueLock = new();
 
+    // Overridable in tests so persistent-failure / idle-sleep behaviour can be
+    // exercised without a real database.
+    internal TimeSpan ErrorBackoffDelay { get; set; } = TimeSpan.FromSeconds(5);
+    internal TimeSpan IdleDelay { get; set; } = TimeSpan.FromMinutes(1);
+    internal Func<CancellationToken, Task<(QueueItem? queueItem, Stream? queueNzbStream)>>?
+        GetTopQueueItemOverride
+    { get; set; }
+
     public QueueManager(
         UsenetStreamingClient usenetClient,
         ConfigManager configManager,
@@ -38,6 +46,21 @@ public class QueueManager : IDisposable
         WatchdogLog watchdogLog,
         QueueItemSourceTracker sourceTracker,
         BenchmarkGate benchmarkGate
+    ) : this(
+        usenetClient, configManager, websocketManager, providerUsageTracker,
+        watchdogLog, sourceTracker, benchmarkGate, startLoop: true)
+    {
+    }
+
+    internal QueueManager(
+        UsenetStreamingClient usenetClient,
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        ProviderUsageTracker providerUsageTracker,
+        WatchdogLog watchdogLog,
+        QueueItemSourceTracker sourceTracker,
+        BenchmarkGate benchmarkGate,
+        bool startLoop
     )
     {
         _usenetClient = usenetClient;
@@ -49,7 +72,8 @@ public class QueueManager : IDisposable
         _benchmarkGate = benchmarkGate;
         _cancellationTokenSource = CancellationTokenSource
             .CreateLinkedTokenSource(SigtermUtil.GetCancellationToken());
-        _ = ProcessQueueAsync(_cancellationTokenSource.Token);
+        if (startLoop)
+            _ = ProcessQueueAsync(_cancellationTokenSource.Token);
     }
 
     public (QueueItem? queueItem, int? progress) GetInProgressQueueItem()
@@ -92,7 +116,7 @@ public class QueueManager : IDisposable
         }).ConfigureAwait(false);
     }
 
-    private async Task ProcessQueueAsync(CancellationToken ct)
+    internal async Task ProcessQueueAsync(CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
@@ -109,58 +133,90 @@ public class QueueManager : IDisposable
 
             try
             {
-                // get the next queue-item from the database
-                await using var dbContext = new DavDatabaseContext();
-                var dbClient = new DavDatabaseClient(dbContext);
-                var topItem = await LockAsync(() => dbClient.GetTopQueueItem(ct)).ConfigureAwait(false);
-                if (topItem.queueItem is null)
-                {
-                    try
-                    {
-                        // if we're done with the queue, wait a minute before checking again.
-                        // or wait until awoken by cancellation of _sleepingQueueToken
-                        await Task.Delay(TimeSpan.FromMinutes(1), _sleepingQueueToken.Token).ConfigureAwait(false);
-                    }
-                    catch when (_sleepingQueueToken.IsCancellationRequested)
-                    {
-                        lock (_sleepingQueueLock)
-                        {
-                            if (!_sleepingQueueToken.TryReset())
-                            {
-                                _sleepingQueueToken.Dispose();
-                                _sleepingQueueToken = new CancellationTokenSource();
-                            }
-                        }
-                    }
-
-                    continue;
-                }
-
-                // create an article-caching nntp-client.
-                // the cache will be scoped only to this single queue-item.
-                using var cachingUsenetClient = new ArticleCachingNntpClient(_usenetClient);
-
-                // process the queue-item
+                // get the next queue-item from the database (or test override)
+                (QueueItem? queueItem, Stream? queueNzbStream) topItem;
+                DavDatabaseClient? dbClient = null;
+                DavDatabaseContext? dbContext = null;
                 try
                 {
-                    using var queueItemCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                    await LockAsync(() =>
+                    if (GetTopQueueItemOverride is not null)
                     {
-                        // ReSharper disable twice AccessToDisposedClosure
-                        _inProgressQueueItem = BeginProcessingQueueItem(dbClient, cachingUsenetClient,
-                            topItem.queueItem, topItem.queueNzbStream, queueItemCancellationTokenSource);
-                    }).ConfigureAwait(false);
-                    await (_inProgressQueueItem?.ProcessingTask ?? Task.CompletedTask).ConfigureAwait(false);
+                        topItem = await GetTopQueueItemOverride(ct).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        dbContext = new DavDatabaseContext();
+                        dbClient = new DavDatabaseClient(dbContext);
+                        topItem = await LockAsync(() => dbClient.GetTopQueueItem(ct)).ConfigureAwait(false);
+                    }
+
+                    if (topItem.queueItem is null)
+                    {
+                        try
+                        {
+                            // if we're done with the queue, wait a minute before checking again.
+                            // or wait until awoken by cancellation of _sleepingQueueToken /
+                            // process shutdown (ct).
+                            using var idleWait = CancellationTokenSource.CreateLinkedTokenSource(
+                                ct, _sleepingQueueToken.Token);
+                            await Task.Delay(IdleDelay, idleWait.Token).ConfigureAwait(false);
+                        }
+                        catch when (_sleepingQueueToken.IsCancellationRequested)
+                        {
+                            lock (_sleepingQueueLock)
+                            {
+                                if (!_sleepingQueueToken.TryReset())
+                                {
+                                    _sleepingQueueToken.Dispose();
+                                    _sleepingQueueToken = new CancellationTokenSource();
+                                }
+                            }
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // ct fired: fall through; the while condition exits the loop
+                        }
+
+                        continue;
+                    }
+
+                    // create an article-caching nntp-client.
+                    // the cache will be scoped only to this single queue-item.
+                    using var cachingUsenetClient = new ArticleCachingNntpClient(_usenetClient);
+
+                    // process the queue-item
+                    try
+                    {
+                        using var queueItemCancellationTokenSource =
+                            CancellationTokenSource.CreateLinkedTokenSource(ct);
+                        await LockAsync(() =>
+                        {
+                            // ReSharper disable twice AccessToDisposedClosure
+                            _inProgressQueueItem = BeginProcessingQueueItem(
+                                dbClient!, cachingUsenetClient,
+                                topItem.queueItem, topItem.queueNzbStream,
+                                queueItemCancellationTokenSource);
+                        }).ConfigureAwait(false);
+                        await (_inProgressQueueItem?.ProcessingTask ?? Task.CompletedTask)
+                            .ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        if (topItem.queueNzbStream is not null)
+                            await topItem.queueNzbStream!.DisposeAsync();
+                    }
                 }
                 finally
                 {
-                    if (topItem.queueNzbStream is not null)
-                        await topItem.queueNzbStream!.DisposeAsync();
+                    if (dbContext is not null)
+                        await dbContext.DisposeAsync().ConfigureAwait(false);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(e, "An unexpected error occurred while processing the queue");
+                try { await Task.Delay(ErrorBackoffDelay, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { /* shutting down */ }
             }
             finally
             {

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class QueueManagerLoopTests
+{
+    [Fact]
+    public async Task ProcessQueueAsync_BacksOffOnPersistentFetchErrors()
+    {
+        using var manager = CreateManager();
+        var iterations = 0;
+        manager.ErrorBackoffDelay = TimeSpan.FromSeconds(5);
+        manager.GetTopQueueItemOverride = _ =>
+        {
+            Interlocked.Increment(ref iterations);
+            throw new InvalidOperationException("persistent db failure");
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        await manager.ProcessQueueAsync(cts.Token);
+
+        // Without backoff this would spin dozens of times; with 5s backoff, ≤2 in 8s.
+        Assert.InRange(iterations, 1, 2);
+    }
+
+    [Fact]
+    public async Task ProcessQueueAsync_ExitsIdleSleepPromptlyOnShutdown()
+    {
+        using var manager = CreateManager();
+        manager.IdleDelay = TimeSpan.FromMinutes(1);
+        manager.GetTopQueueItemOverride = _ =>
+            Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+
+        using var cts = new CancellationTokenSource();
+        var loop = manager.ProcessQueueAsync(cts.Token);
+        await Task.Delay(50);
+        await cts.CancelAsync();
+
+        var completed = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.Same(loop, completed);
+        await loop; // observe completion / no fault
+    }
+
+    private static QueueManager CreateManager()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        var usenet = new UsenetStreamingClient(
+            config,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker());
+
+        return new QueueManager(
+            usenet,
+            config,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+}


### PR DESCRIPTION
## Summary
- Back off 5s after unexpected errors in `QueueManager.ProcessQueueAsync` so persistent DB failures cannot spin at 100% CPU
- Link empty-queue idle sleep to the loop cancellation token so shutdown does not wait up to 60s
- Add internal test hooks and unit coverage for backoff + idle exit

Closes #350

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~QueueManagerLoopTests`