### PR TITLE
fix(nntp): add connect/auth timeout and dispose failed handshakes

### DIFF
--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -146,20 +146,41 @@ public class UsenetStreamingClient : WrappingNntpClient
         return connectionPool;
     }
 
-    public static async ValueTask<INntpClient> CreateNewConnection
+    // Hard ceiling for TCP/TLS connect + AUTHINFO. Long enough for slow providers,
+    // short enough that three stuck handshakes cannot pin the pool forever.
+    // Settable for tests so timeout coverage does not wait a full 15s.
+    internal static TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(15);
+
+    public static ValueTask<INntpClient> CreateNewConnection
     (
         UsenetProviderConfig.ConnectionDetails connectionDetails,
         CancellationToken ct
+    ) => CreateNewConnection(connectionDetails, static () => new BaseNntpClient(), ct);
+
+    internal static async ValueTask<INntpClient> CreateNewConnection
+    (
+        UsenetProviderConfig.ConnectionDetails connectionDetails,
+        Func<INntpClient> connectionFactory,
+        CancellationToken ct
     )
     {
-        var connection = new BaseNntpClient();
-        var host = connectionDetails.Host;
-        var port = connectionDetails.Port;
-        var useSsl = connectionDetails.UseSsl;
-        var user = connectionDetails.User;
-        var pass = connectionDetails.Pass;
-        await connection.ConnectAsync(host, port, useSsl, ct).ConfigureAwait(false);
-        await connection.AuthenticateAsync(user, pass, ct).ConfigureAwait(false);
-        return connection;
+        var connection = connectionFactory();
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(ConnectTimeout);
+            await connection.ConnectAsync(
+                connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
+                timeoutCts.Token).ConfigureAwait(false);
+            await connection.AuthenticateAsync(
+                connectionDetails.User, connectionDetails.Pass,
+                timeoutCts.Token).ConfigureAwait(false);
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
@@ -1,0 +1,151 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class CreateNewConnectionTests
+{
+    [Fact]
+    public async Task CreateNewConnection_DisposesConnectionWhenAuthFails()
+    {
+        var fake = new HandshakeNntpClient
+        {
+            AuthenticateException = new CouldNotLoginToUsenetException("bad credentials"),
+        };
+        var details = MakeDetails();
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(async () =>
+            await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None));
+
+        Assert.Equal(1, fake.DisposeCount);
+        Assert.True(fake.Connected);
+    }
+
+    [Fact]
+    public async Task CreateNewConnection_TimesOutHungConnect()
+    {
+        var previous = UsenetStreamingClient.ConnectTimeout;
+        UsenetStreamingClient.ConnectTimeout = TimeSpan.FromMilliseconds(100);
+        try
+        {
+            var fake = new HandshakeNntpClient { HangConnect = true };
+            var details = MakeDetails();
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None));
+
+            sw.Stop();
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+                $"Expected timeout well under OS connect default; elapsed={sw.Elapsed}");
+            Assert.Equal(1, fake.DisposeCount);
+        }
+        finally
+        {
+            UsenetStreamingClient.ConnectTimeout = previous;
+        }
+    }
+
+    [Fact]
+    public async Task CreateNewConnection_ReturnsLiveConnectionOnSuccess()
+    {
+        var fake = new HandshakeNntpClient();
+        var details = MakeDetails();
+
+        var connection = await UsenetStreamingClient.CreateNewConnection(
+            details, () => fake, CancellationToken.None);
+
+        Assert.Same(fake, connection);
+        Assert.Equal(0, fake.DisposeCount);
+        connection.Dispose();
+    }
+
+    private static UsenetProviderConfig.ConnectionDetails MakeDetails() =>
+        new()
+        {
+            Type = ProviderType.Pooled,
+            Host = "nntp.example",
+            Port = 563,
+            UseSsl = true,
+            User = "u",
+            Pass = "p",
+            MaxConnections = 1,
+        };
+
+    private sealed class HandshakeNntpClient : NntpClient
+    {
+        public bool HangConnect { get; init; }
+        public Exception? AuthenticateException { get; init; }
+        public bool Connected { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public override async Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken)
+        {
+            if (HangConnect)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            Connected = true;
+        }
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (AuthenticateException is not null)
+                throw AuthenticateException;
+            return Task.FromResult(new UsenetResponse
+            {
+                ResponseCode = (int)UsenetResponseType.AuthenticationAccepted,
+                ResponseMessage = "281 Ok",
+            });
+        }
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose() => DisposeCount++;
+    }
+}


### PR DESCRIPTION
## Summary
- Apply a 15s connect/auth timeout in `UsenetStreamingClient.CreateNewConnection`
- Dispose the NNTP client on any handshake failure (auth reject, timeout, connect error)
- Add injectable factory + timeout test hooks with unit coverage

Closes #351
Refs #162

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~CreateNewConnectionTests`