### PR TITLE
feat(nntp): windowed breaker tripping with half-open probe

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -3,34 +3,47 @@ using Serilog;
 namespace NzbWebDAV.Clients.Usenet.Connections;
 
 /// <summary>
-/// Tracks consecutive connection failures for an NNTP provider and temporarily
+/// Tracks recent BODY/ARTICLE outcomes for an NNTP provider and temporarily
 /// disables it when a failure threshold is reached, preventing a single
 /// misbehaving provider from blocking the entire download pipeline.
 /// <para>
-/// After tripping, the provider enters a cooldown period during which it is
-/// skipped and additional failures are ignored (latched). When the cooldown
-/// expires, traffic flows again. If failures continue and again reach the
-/// threshold, the breaker re-trips with a doubled cooldown (up to a cap).
-/// A success fully resets the failure counter and cooldown ladder.
+/// Failures accumulate in a short sliding window between successes. A success
+/// clears the window and fully resets the cooldown ladder (same recovery
+/// semantics as the former consecutive-failure breaker). After tripping, the
+/// provider enters a cooldown during which it is skipped and additional
+/// failures are ignored (latched). When the cooldown expires, exactly one
+/// half-open probe is admitted; other callers keep seeing the provider as
+/// tripped until that probe records success or failure. A failed probe
+/// re-trips with the doubled cooldown. An abandoned probe (no outcome within
+/// <see cref="ProbeAbandonTimeout"/>) can be retaken.
 /// </para>
 /// </summary>
 public class ProviderCircuitBreaker
 {
-    private const int FailureThreshold = 3;
+    private const int WindowSeconds = 30;
+    private const int MinFailuresToTrip = 3;
+    private const double TripFailureRate = 0.5;
+
     private static readonly TimeSpan InitialCooldown = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan MaxCooldown = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan DefaultProbeAbandonTimeout = TimeSpan.FromSeconds(60);
 
     private readonly string _providerName;
     private readonly object _lock = new();
+    private readonly Queue<(long AtMs, bool Failed)> _window = new();
 
-    private int _consecutiveFailures;
     private long _trippedUntilMs;
     private TimeSpan _currentCooldown = InitialCooldown;
+    private int _halfOpenProbeInFlight; // 0/1
+    private long _probeStartedMs;
 
     public ProviderCircuitBreaker(string providerName)
     {
         _providerName = providerName;
     }
+
+    /// <summary>How long an unanswered half-open probe may hold the slot. For tests.</summary>
+    internal TimeSpan ProbeAbandonTimeout { get; set; } = DefaultProbeAbandonTimeout;
 
     public bool IsTripped
     {
@@ -38,7 +51,17 @@ public class ProviderCircuitBreaker
         {
             var trippedUntil = Volatile.Read(ref _trippedUntilMs);
             if (trippedUntil == 0) return false;
-            return Environment.TickCount64 < trippedUntil;
+            if (Environment.TickCount64 < trippedUntil) return true;
+
+            // Cooldown expired → half-open: exactly one caller wins the probe slot.
+            TryReclaimAbandonedProbe();
+            if (Interlocked.CompareExchange(ref _halfOpenProbeInFlight, 1, 0) == 0)
+            {
+                Volatile.Write(ref _probeStartedMs, Environment.TickCount64);
+                return false; // this caller is the probe
+            }
+
+            return true; // another probe is already in flight
         }
     }
 
@@ -54,16 +77,28 @@ public class ProviderCircuitBreaker
         }
     }
 
+    /// <summary>Force the open cooldown into the past so half-open tests can proceed.</summary>
+    internal void ExpireCooldownForTests()
+    {
+        lock (_lock)
+        {
+            if (_trippedUntilMs > 0)
+                _trippedUntilMs = Environment.TickCount64 - 1;
+        }
+    }
+
     public void RecordSuccess()
     {
         lock (_lock)
         {
-            if (_consecutiveFailures > 0 || _trippedUntilMs > 0)
+            if (_window.Count > 0 || _trippedUntilMs > 0 || _halfOpenProbeInFlight != 0)
                 Log.Information("Provider {Provider} recovered — circuit breaker reset.", _providerName);
 
-            _consecutiveFailures = 0;
+            _window.Clear();
             _trippedUntilMs = 0;
             _currentCooldown = InitialCooldown;
+            Volatile.Write(ref _halfOpenProbeInFlight, 0);
+            Volatile.Write(ref _probeStartedMs, 0);
         }
     }
 
@@ -71,29 +106,72 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
+            var now = Environment.TickCount64;
+
             // Already latched open: ignore in-flight failures from the same burst
             // so they cannot extend the window, double the cooldown, or spam logs.
-            if (_trippedUntilMs > 0 && Environment.TickCount64 < _trippedUntilMs)
+            if (_trippedUntilMs > 0 && now < _trippedUntilMs)
                 return;
+
+            // Half-open probe failed → re-trip immediately with the current
+            // (already doubled from the previous trip) cooldown, then advance ladder.
+            if (Volatile.Read(ref _halfOpenProbeInFlight) == 1)
+            {
+                Volatile.Write(ref _halfOpenProbeInFlight, 0);
+                Volatile.Write(ref _probeStartedMs, 0);
+                Trip(now, "half-open probe failure");
+                return;
+            }
 
             // Cooldown expired (or never tripped); clear a stale trip marker so
             // success recovery logging stays accurate.
             if (_trippedUntilMs > 0)
                 _trippedUntilMs = 0;
 
-            _consecutiveFailures++;
-            if (_consecutiveFailures < FailureThreshold) return;
+            EvictOldEntries(now);
+            _window.Enqueue((now, true));
 
-            var failuresAtTrip = _consecutiveFailures;
-            _trippedUntilMs = Environment.TickCount64 + (long)_currentCooldown.TotalMilliseconds;
-            Log.Warning(
-                "Provider {Provider} tripped after {Failures} consecutive failures. " +
-                "Skipping for {Cooldown}s.",
-                _providerName, failuresAtTrip, _currentCooldown.TotalSeconds);
+            var failures = 0;
+            foreach (var entry in _window)
+                if (entry.Failed) failures++;
 
-            _consecutiveFailures = 0;
-            _currentCooldown = TimeSpan.FromMilliseconds(
-                Math.Min(_currentCooldown.TotalMilliseconds * 2, MaxCooldown.TotalMilliseconds));
+            if (failures >= MinFailuresToTrip
+                && failures / (double)_window.Count >= TripFailureRate)
+            {
+                Trip(now, $"{failures} failures in {_window.Count}-sample window");
+            }
         }
+    }
+
+    private void Trip(long nowMs, string reason)
+    {
+        _trippedUntilMs = nowMs + (long)_currentCooldown.TotalMilliseconds;
+        Log.Warning(
+            "Provider {Provider} tripped ({Reason}). Skipping for {Cooldown}s.",
+            _providerName, reason, _currentCooldown.TotalSeconds);
+
+        _window.Clear();
+        _currentCooldown = TimeSpan.FromMilliseconds(
+            Math.Min(_currentCooldown.TotalMilliseconds * 2, MaxCooldown.TotalMilliseconds));
+    }
+
+    private void EvictOldEntries(long nowMs)
+    {
+        var cutoff = nowMs - WindowSeconds * 1000L;
+        while (_window.Count > 0 && _window.Peek().AtMs < cutoff)
+            _window.Dequeue();
+    }
+
+    private void TryReclaimAbandonedProbe()
+    {
+        if (Volatile.Read(ref _halfOpenProbeInFlight) != 1) return;
+        var started = Volatile.Read(ref _probeStartedMs);
+        if (started == 0) return;
+        if (Environment.TickCount64 - started < (long)ProbeAbandonTimeout.TotalMilliseconds) return;
+
+        // Abandoned probe (cancelled request, etc.): free the slot so another
+        // caller can retry. CompareExchange so we don't clear a just-resolved probe.
+        if (Interlocked.CompareExchange(ref _halfOpenProbeInFlight, 0, 1) == 1)
+            Volatile.Write(ref _probeStartedMs, 0);
     }
 }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -445,10 +445,11 @@ public class MultiConnectionNntpClient(
                 attemptCts?.Dispose();
             }
 
-            // stat, head, and date
+            // stat, head, and date — do not feed the circuit breaker.
+            // STAT/HEAD/DATE successes were resetting BODY failure streaks and
+            // preventing trips under mixed traffic (STAT-ok/BODY-fail providers).
             if (name is "STAT" or "HEAD" or "DATE")
             {
-                circuitBreaker.RecordSuccess();
                 deferredCallback.Discard();
                 LogException(() => connectionLock?.Dispose());
             }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
@@ -81,6 +81,83 @@ public class ConcurrencyTests
     }
 
     [Fact]
+    public void ProviderCircuitBreaker_HalfOpenAdmitsExactlyOneProbe()
+    {
+        var breaker = new ProviderCircuitBreaker("half-open");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.True(breaker.IsTripped);
+
+        breaker.ExpireCooldownForTests();
+
+        Assert.False(breaker.IsTripped); // first caller wins the probe
+        Assert.True(breaker.IsTripped);  // everyone else stays blocked
+        Assert.True(breaker.IsTripped);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_ProbeFailureReTripsWithDoubledCooldown()
+    {
+        var breaker = new ProviderCircuitBreaker("probe-fail");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped); // take probe
+
+        breaker.RecordFailure();
+        Assert.True(breaker.IsTripped);
+        Assert.True(breaker.TrippedUntilMs > Environment.TickCount64);
+        // Re-trip used the 120s cooldown, then ladder advanced to 240s.
+        Assert.Equal(TimeSpan.FromSeconds(240), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_ProbeSuccessFullyCloses()
+    {
+        var breaker = new ProviderCircuitBreaker("probe-ok");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped); // take probe
+
+        breaker.RecordSuccess();
+        Assert.False(breaker.IsTripped);
+        Assert.Equal(0, breaker.TrippedUntilMs);
+        Assert.Equal(TimeSpan.FromSeconds(60), breaker.CurrentCooldown);
+
+        // Further callers are fully open again (not stuck behind a half-open slot).
+        Assert.False(breaker.IsTripped);
+        Assert.False(breaker.IsTripped);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_AbandonedProbeCanBeRetaken()
+    {
+        var breaker = new ProviderCircuitBreaker("probe-abandon")
+        {
+            ProbeAbandonTimeout = TimeSpan.FromMilliseconds(50),
+        };
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.ExpireCooldownForTests();
+
+        Assert.False(breaker.IsTripped); // first probe, then abandoned
+        Assert.True(breaker.IsTripped);
+
+        Thread.Sleep(80);
+        Assert.False(breaker.IsTripped); // reclaimed
+        Assert.True(breaker.IsTripped);
+    }
+
+    [Fact]
     public async Task PrioritizedSemaphore_BlocksUntilPermitIsReleased()
     {
         using var semaphore = new PrioritizedSemaphore(initialAllowed: 1, maxAllowed: 1);


### PR DESCRIPTION
## Summary
- Rewrite `ProviderCircuitBreaker` with a short failure window (clear-on-success) and single-slot half-open probing after cooldown
- Stop calling `RecordSuccess` for STAT/HEAD/DATE so mixed STAT-ok/BODY-fail traffic can still trip
- Cover half-open admit/fail/success/abandon plus existing trip/latch/ladder cases

Closes #353
Refs #162

## Test plan
- [x] `dotnet test … --filter "FullyQualifiedName~ProviderCircuitBreaker_|FullyQualifiedName~StreamingTimeoutTests|FullyQualifiedName~MultiProviderNntpClientTests"`