### PR TITLE
fix(metrics): do not record STAT/HEAD/DATE successes as Missing

### DIFF
--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -611,10 +611,13 @@ public class MultiProviderNntpClient(
                     }
                     result = WrapStreamForByteCounting(result, provider.MetricsKey);
                 }
-                else
+                else if (result is UsenetDecodedBodyResponse or UsenetDecodedArticleResponse)
                 {
+                    // BODY/ARTICLE response with an unexpected (non-success, non-430) response type.
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
                 }
+                // STAT/HEAD/DATE successes: intentionally no SegmentFetch row (not a segment transfer;
+                // matches StatsPipelinedAsync which records nothing).
 
                 return result;
             }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -138,6 +138,58 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task StatAsync_Success_DoesNotRecordSegmentFetch()
+    {
+        var writer = new MetricsWriter();
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+            [CreateProvider(connection)], metricsWriter: writer);
+
+        var response = await client.StatAsync("segment", CancellationToken.None);
+        Assert.True(response.ArticleExists);
+        Assert.Equal(0, writer.Stats.QueuedFetches);
+    }
+
+    [Fact]
+    public async Task StatAsync_DefinitiveMissing_RecordsMissingFetch()
+    {
+        var writer = new MetricsWriter();
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = (int)UsenetResponseType.NoArticleWithThatMessageId,
+        };
+        using var client = new MultiProviderNntpClient(
+            [CreateProvider(connection)], metricsWriter: writer);
+
+        var response = await client.StatAsync("segment", CancellationToken.None);
+        Assert.False(response.ArticleExists);
+        Assert.Equal(1, writer.Stats.QueuedFetches);
+    }
+
+    [Fact]
+    public async Task DecodedBodyAsync_UnexpectedResponseType_RecordsMissingFetch()
+    {
+        var writer = new MetricsWriter();
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 400,
+            SingularResponseCode = 400,
+        };
+        using var client = new MultiProviderNntpClient(
+            [CreateProvider(connection)], metricsWriter: writer);
+
+        var response = await client.DecodedBodyAsync(
+            "segment", onConnectionReadyAgain: null, CancellationToken.None);
+        Assert.False(response.Success);
+        Assert.Equal(1, writer.Stats.QueuedFetches);
+    }
+
+    [Fact]
     public async Task PipelinedBody_PrimaryMiss_FailsOverToBackup()
     {
         var primary = new ScriptedNntpClient


### PR DESCRIPTION
## Summary
- Stop writing `SegmentFetch.Missing` for successful STAT/HEAD/DATE responses in `RunFromPoolWithBackup`
- Keep Missing recording for definitive 430 misses and unexpected BODY/ARTICLE response types

Closes #355

## Test plan
- [x] Stat success → 0 fetches; Stat 430 → Missing; unexpected BODY → Missing