### PR TITLE
fix(queue): cap ArticleCachingNntpClient cache-dir delete retries

### DIFF
--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -6,6 +6,7 @@ using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
+using Serilog;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -521,20 +522,37 @@ public class ArticleCachingNntpClient(
         GC.SuppressFinalize(this);
     }
 
-    private static async Task DeleteCacheDir(string cacheDir)
+    // Initial retry delay; shortened in tests so capped-failure coverage does not wait seconds.
+    internal static int DeleteCacheDirInitialDelayMs { get; set; } = 1000;
+
+    internal static async Task DeleteCacheDir(string cacheDir)
     {
         var ct = SigtermUtil.GetCancellationToken();
-        var delay = 1000;
-        while (!ct.IsCancellationRequested)
+        var delay = DeleteCacheDirInitialDelayMs;
+        const int maxAttempts = 10; // ~1m40s worst case with the existing backoff ladder
+        for (var attempt = 1; attempt <= maxAttempts && !ct.IsCancellationRequested; attempt++)
         {
             try
             {
                 Directory.Delete(cacheDir, recursive: true);
                 return;
             }
-            catch (Exception)
+            catch (DirectoryNotFoundException)
             {
-                await Task.Delay(delay, ct).ConfigureAwait(false);
+                return; // already gone — success
+            }
+            catch (Exception e)
+            {
+                if (attempt == maxAttempts)
+                {
+                    Log.Warning(e,
+                        "Giving up deleting article cache dir {CacheDir} after {Attempts} attempts",
+                        cacheDir, attempt);
+                    return;
+                }
+
+                try { await Task.Delay(delay, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { return; }
                 delay = Math.Min(delay * 2, 10000);
             }
         }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DeleteCacheDirTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DeleteCacheDirTests.cs
@@ -1,0 +1,40 @@
+using NzbWebDAV.Clients.Usenet;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class DeleteCacheDirTests
+{
+    [Fact]
+    public async Task DeleteCacheDir_NonexistentPath_ReturnsPromptly()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "nzbdav-missing-" + Guid.NewGuid().ToString("N"));
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await ArticleCachingNntpClient.DeleteCacheDir(path);
+        sw.Stop();
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task DeleteCacheDir_UndeletablePath_StopsAfterMaxAttempts()
+    {
+        var previous = ArticleCachingNntpClient.DeleteCacheDirInitialDelayMs;
+        ArticleCachingNntpClient.DeleteCacheDirInitialDelayMs = 1;
+        var blocker = Path.Combine(Path.GetTempPath(), "nzbdav-block-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // A file at the target path makes Directory.Delete throw IOException.
+            await File.WriteAllTextAsync(blocker, "not-a-directory");
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            await ArticleCachingNntpClient.DeleteCacheDir(blocker);
+            sw.Stop();
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+                $"Expected capped retries; elapsed={sw.Elapsed}");
+            Assert.True(File.Exists(blocker));
+        }
+        finally
+        {
+            ArticleCachingNntpClient.DeleteCacheDirInitialDelayMs = previous;
+            try { File.Delete(blocker); } catch { /* ignore */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Cap `DeleteCacheDir` at 10 attempts with existing backoff
- Treat already-deleted dirs as success
- Log and give up on persistently undeletable paths

Closes #356

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~DeleteCacheDirTests`