### PR TITLE
fix(config): clamp streaming-priority and harden numeric getters

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -447,10 +447,8 @@ public class ConfigManager
 
     public int GetArticleBufferSize()
     {
-        return int.Parse(
-            StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetArticleBufferSize))
-            ?? "40"
-        );
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetArticleBufferSize));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 1000) : 40;
     }
 
     /// <summary>
@@ -486,7 +484,8 @@ public class ConfigManager
 
     public long GetSegmentCacheMaxBytes()
     {
-        var gb = long.Parse(StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheMaxGb)) ?? "10");
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheMaxGb));
+        var gb = long.TryParse(v, out var n) ? n : 10;
         return Math.Max(1, gb) * 1024L * 1024L * 1024L;
     }
 
@@ -503,8 +502,8 @@ public class ConfigManager
     public SemaphorePriorityOdds GetStreamingPriority()
     {
         var stringValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingPriority));
-        var numericalValue = int.Parse(stringValue ?? "80");
-        return new SemaphorePriorityOdds() { HighPriorityOdds = numericalValue };
+        var numericalValue = int.TryParse(stringValue, out var n) ? Math.Clamp(n, 0, 100) : 80;
+        return new SemaphorePriorityOdds { HighPriorityOdds = numericalValue };
     }
 
     public TimeSpan GetStreamingSegmentTimeout()

--- a/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
@@ -1,0 +1,65 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class StreamingPriorityConfigTests
+{
+    [Theory]
+    [InlineData("150", 100)]
+    [InlineData("-5", 0)]
+    [InlineData("abc", 80)]
+    [InlineData("", 80)]
+    [InlineData(null, 80)]
+    [InlineData("80", 80)]
+    public void GetStreamingPriority_ClampsAndFallsBack(string? value, int expected)
+    {
+        var config = new ConfigManager();
+        if (value is not null)
+        {
+            config.UpdateValues(
+            [
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.UsenetStreamingPriority,
+                    ConfigValue = value,
+                },
+            ]);
+        }
+
+        Assert.Equal(expected, config.GetStreamingPriority().HighPriorityOdds);
+    }
+
+    [Theory]
+    [InlineData("abc", 10L * 1024 * 1024 * 1024)]
+    [InlineData("0", 1L * 1024 * 1024 * 1024)]
+    [InlineData("2", 2L * 1024 * 1024 * 1024)]
+    public void GetSegmentCacheMaxBytes_SafeParse(string value, long expected)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetSegmentCacheMaxGb,
+                ConfigValue = value,
+            },
+        ]);
+        Assert.Equal(expected, config.GetSegmentCacheMaxBytes());
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsNonNumericStreamingPriority()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems(
+            [
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.UsenetStreamingPriority,
+                    ConfigValue = "nope",
+                },
+            ]));
+        Assert.Contains("whole number", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- Clamp `usenet.streaming-priority` to 0–100 with fallback 80
- Harden `GetArticleBufferSize` / `GetSegmentCacheMaxBytes` against non-numeric values

Closes #357

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~StreamingPriorityConfigTests`