### PR TITLE
fix(auth): use fixed-time comparison for websocket API key auth

### DIFF
--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -101,7 +101,7 @@ public class WebsocketManager
     private static async Task<bool> Authenticate(WebSocket socket)
     {
         var apiKey = await ReceiveAuthToken(socket).ConfigureAwait(false);
-        return apiKey == EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY");
+        return apiKey.FixedTimeEquals(EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Replace ordinal `==` with `FixedTimeEquals` in `WebsocketManager.Authenticate`

Closes #358

## Test plan
- [x] Build succeeds (one-line semantic-preserving change)