### PR TITLE
chore(tests): skip rapidyenc-dependent tests when native lib missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,8 @@ cd frontend && npm install && npm run dev
 
 `npm run dev` silently runs `scripts/sync-dev-env.sh` via the `predev` hook; if the API key drifts, restart the backend with `scripts/run-backend.sh`. The manual `dotnet publish` / env-var flow below remains supported.
 
+yEnc-decoding tests are skipped on platforms where the rapidyenc native library is unavailable (currently macOS arm64); they run in Linux CI.
+
 ## Build / run backend
 
 The `NzbDav.UsenetSharp` dependency is published on NuGet.org and restores without

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
@@ -1,14 +1,16 @@
 using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
 public class ArticleCachingNntpClientTests
 {
-    [Fact]
+    [SkippableFact]
     public async Task DecodedBodyAsync_CachesDecodedBytesAfterFirstRead()
     {
+        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
         var inner = new FakeNntpClient(new Dictionary<string, byte[]>
         {
             ["segment"] = Encoding.ASCII.GetBytes("cached payload")
@@ -25,9 +27,10 @@ public class ArticleCachingNntpClientTests
         Assert.Equal(1, inner.BodyRequestCount);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task DecodedBodiesAsync_PreservesOrderAcrossCachedAndMissingSegments()
     {
+        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
         var inner = new FakeNntpClient(new Dictionary<string, byte[]>
         {
             ["one"] = Encoding.ASCII.GetBytes("one"),

--- a/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
+++ b/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -25,13 +26,14 @@ public class NzbFileStreamTests
         new(10, 15)
     ];
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(0, "abcdefghijklmno")]
     [InlineData(1, "abcdefghijklmno")]
     [InlineData(4, "abcdefghijklmno")]
     public async Task ReadAsync_ConcatenatesSegmentsWithConfiguredPipeline(
         int articleBufferSize, string expected)
     {
+        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
         var client = CreateClient();
         await using var stream = new NzbFileStream(
             SegmentIds, 15, client, articleBufferSize, SegmentRanges);
@@ -71,7 +73,7 @@ public class NzbFileStreamTests
             Assert.Equal(SegmentIds.Length, client.BodyRequestCount);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(0, "abc")]
     [InlineData(4, "efg")]
     [InlineData(5, "fgh")]
@@ -79,6 +81,7 @@ public class NzbFileStreamTests
     [InlineData(14, "o")]
     public async Task Seek_ReadsAcrossSegmentBoundaries(long offset, string expected)
     {
+        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
         var client = CreateClient();
         await using var stream = new NzbFileStream(
             SegmentIds, 15, client, 2, SegmentRanges);
@@ -103,9 +106,10 @@ public class NzbFileStreamTests
             () => stream.Seek(16, SeekOrigin.Begin));
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task SmallForwardSeek_DrainsExistingPipeline()
     {
+        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
         var client = CreateClient();
         await using var stream = new NzbFileStream(
             SegmentIds, 15, client, 2, SegmentRanges);

--- a/tests/NzbWebDAV.Tests/TestUtils/RapidYenc.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/RapidYenc.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+public static class RapidYenc
+{
+    public static readonly bool IsAvailable = Probe();
+
+    private static bool Probe()
+    {
+        try
+        {
+            return NativeLibrary.TryLoad("rapidyenc", typeof(RapidYenc).Assembly, null, out _);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RapidYenc.IsAvailable` probe and `Xunit.SkippableFact`
- Skip the 11 yEnc-decoding tests when the native library is unavailable
- Document the skip behavior in `CONTRIBUTING.md`

Closes #360

## Test plan
- [x] macOS arm64: 0 failed, 11 skipped for the affected suites
- [ ] Linux CI: same tests still execute (probe returns true)