### PR TITLE
fix(queue): harden Remove Orphaned Files empty-dir sweep

### DIFF
--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -88,7 +88,21 @@ public class DatabaseBackupSchedulerService : BackgroundService
                     _websocketManager,
                     _store,
                     DatabaseBackupKinds.Scheduled);
-                await task.Execute().ConfigureAwait(false);
+                var executed = await task.Execute().ConfigureAwait(false);
+                if (!executed)
+                {
+                    // BaseTask's single-flight slot is shared across all maintenance tasks.
+                    // Do not mark the slot as completed — retry shortly so a concurrent
+                    // orphaned-files/strm task does not silently skip the day's run.
+                    Log.Warning(
+                        "DatabaseBackupScheduler: another maintenance task is running; " +
+                        "will retry in 5 minutes");
+                    using var retryLinked = CancellationTokenSource
+                        .CreateLinkedTokenSource(stoppingToken, reschedule.Token);
+                    await Task.Delay(TimeSpan.FromMinutes(5), retryLinked.Token).ConfigureAwait(false);
+                    continue;
+                }
+
                 _lastRun = nextRun;
             }
             catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -89,7 +89,21 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
 
                 Log.Information("RemoveOrphanedFilesScheduler: running scheduled Remove Orphaned Files task");
                 var task = new RemoveUnlinkedFilesTask(_configManager, _websocketManager, isDryRun: false);
-                await task.Execute().ConfigureAwait(false);
+                var executed = await task.Execute().ConfigureAwait(false);
+                if (!executed)
+                {
+                    // BaseTask's single-flight slot is shared across all maintenance tasks.
+                    // Do not mark the slot as completed — retry shortly so a concurrent
+                    // backup/strm task does not silently skip the day's run.
+                    Log.Warning(
+                        "RemoveOrphanedFilesScheduler: another maintenance task is running; " +
+                        "will retry in 5 minutes");
+                    using var retryLinked = CancellationTokenSource
+                        .CreateLinkedTokenSource(stoppingToken, reschedule.Token);
+                    await Task.Delay(TimeSpan.FromMinutes(5), retryLinked.Token).ConfigureAwait(false);
+                    continue;
+                }
+
                 _lastRun = nextRun;
             }
             catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -20,7 +20,7 @@ public class RemoveUnlinkedFilesTask(
 {
     private static List<string> _allRemovedPaths = [];
 
-    private record UnlinkedItemInfo(string Id, int Type, string Path);
+    internal record UnlinkedItemInfo(string Id, int Type, string Path);
 
     private DavDatabaseContext CreateContext() => createContext?.Invoke() ?? new DavDatabaseContext();
 
@@ -45,6 +45,7 @@ public class RemoveUnlinkedFilesTask(
         var linkedIdCount = await WriteLinkedIdsToTable().ConfigureAwait(false);
         if (linkedIdCount < 5)
         {
+            _allRemovedPaths.Clear();
             Report($"Aborted: " +
                    $"There are less than five linked files found in your library. " +
                    $"Cancelling operation to prevent accidental bulk deletion.");
@@ -73,6 +74,7 @@ public class RemoveUnlinkedFilesTask(
 
             if (!isDryRun)
             {
+                _allRemovedPaths.Clear();
                 Report($"Aborted: {detail} Cancelling to prevent accidental bulk deletion. " +
                        $"Run a dry-run to inspect if this is genuinely expected.");
                 return;
@@ -106,17 +108,17 @@ public class RemoveUnlinkedFilesTask(
             CREATE TABLE TMP_LINKED_FILES (Id TEXT NOT NULL);
             """).ConfigureAwait(false);
 
-        var count = 0;
+        var scannedCount = 0;
         var batches = GetLinkedIds().ToBatches(100);
         foreach (var batch in batches)
         {
             await InsertLinkedIdBatchAsync(dbContext, batch).ConfigureAwait(false);
-            count += batch.Count;
+            scannedCount += batch.Count;
         }
 
         // Remove duplicates and add primary key index.
         // Create a new table with unique constraint, copy distinct values, then swap.
-        Report($"Indexing {count} linked files...");
+        Report($"Indexing {scannedCount} linked files...");
         await dbContext.Database.ExecuteSqlRawAsync(
             """
             CREATE TABLE TMP_LINKED_FILES_UNIQUE (Id TEXT NOT NULL PRIMARY KEY);
@@ -125,7 +127,12 @@ public class RemoveUnlinkedFilesTask(
             ALTER TABLE TMP_LINKED_FILES_UNIQUE RENAME TO TMP_LINKED_FILES;
             """).ConfigureAwait(false);
 
-        return count;
+        // Guard uses distinct dav-item ids, not raw symlink/strm count (many links can
+        // point at the same item and otherwise sail past the < 5 safety check).
+        return await dbContext.Database
+            .SqlQueryRaw<int>("SELECT COUNT(*) AS Value FROM TMP_LINKED_FILES")
+            .FirstAsync()
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -185,6 +192,39 @@ public class RemoveUnlinkedFilesTask(
 #pragma warning restore EF1002
     }
 
+    /// <summary>
+    /// Deletes empty directories by Id, re-checking emptiness in the same statement so a
+    /// concurrent insert under a selected folder cannot race into a cascade delete.
+    /// </summary>
+    internal static async Task<int> DeleteEmptyDirectoriesByIdTextAsync(
+        DavDatabaseContext dbContext,
+        IReadOnlyList<UnlinkedItemInfo> items,
+        CancellationToken cancellationToken = default)
+    {
+        var parameters = new SqliteParameter[items.Count];
+        var placeholders = new string[items.Count];
+        for (var i = 0; i < items.Count; i++)
+        {
+            var name = $"@p{i}";
+            placeholders[i] = name;
+            parameters[i] = new SqliteParameter(name, items[i].Id);
+        }
+
+        // Placeholder names are generated locally (@p0..@pN); values are bound via SqliteParameter.
+#pragma warning disable EF1002
+        return await dbContext.Database.ExecuteSqlRawAsync(
+            $"""
+             DELETE FROM DavItems
+             WHERE Id IN ({string.Join(",", placeholders)})
+               AND NOT EXISTS (
+                   SELECT 1 FROM DavItems c WHERE c.ParentId = DavItems.Id
+               )
+             """,
+            parameters.AsEnumerable(),
+            cancellationToken).ConfigureAwait(false);
+#pragma warning restore EF1002
+    }
+
     private IEnumerable<Guid> GetLinkedIds()
     {
         var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(500));
@@ -233,11 +273,13 @@ public class RemoveUnlinkedFilesTask(
         // LEFT JOIN is equivalent to the NOT IN subquery used by RemoveUnlinkedItems /
         // DryRunIdentifyUnlinkedFiles; CountDeletableItems mirrors these predicates without
         // the link join so the safety ratio compares the same population.
+        // COLLATE NOCASE: TMP_LINKED_FILES stores uppercase Guids while some DavItems.Id
+        // rows are lowercase (migration-seeded); a case-sensitive miss would delete linked files.
         var count = await dbContext.Database
             .SqlQuery<int>(
                 $"""
                  SELECT COUNT(i.Id) AS Value FROM DavItems i
-                 LEFT JOIN TMP_LINKED_FILES t ON i.Id = t.Id
+                 LEFT JOIN TMP_LINKED_FILES t ON i.Id = t.Id COLLATE NOCASE
                  WHERE i.Type = {usenetFileType}
                    AND i.HistoryItemId IS NULL
                    AND i.CreatedAt < {createdBefore}
@@ -259,7 +301,8 @@ public class RemoveUnlinkedFilesTask(
 
         while (true)
         {
-            // Select items to delete (batch of 100)
+            // Select items to delete (batch of 100). NOT EXISTS + COLLATE NOCASE so a
+            // lowercase DavItems.Id still matches an uppercase TMP_LINKED_FILES row.
             var itemsToDelete = await dbContext.Database
                 .SqlQuery<UnlinkedItemInfo>(
                     $"""
@@ -267,7 +310,10 @@ public class RemoveUnlinkedFilesTask(
                      WHERE Type = {usenetFileType}
                        AND HistoryItemId IS NULL
                        AND CreatedAt < {createdBefore}
-                       AND Id NOT IN (SELECT Id FROM TMP_LINKED_FILES)
+                       AND NOT EXISTS (
+                           SELECT 1 FROM TMP_LINKED_FILES t
+                           WHERE t.Id = DavItems.Id COLLATE NOCASE
+                       )
                      LIMIT 100
                      """)
                 .ToListAsync()
@@ -329,8 +375,11 @@ public class RemoveUnlinkedFilesTask(
     }
 
     /// <summary>
-    /// Deletes empty regular directories in batches and returns the number removed. Throws if a
-    /// selected batch deletes 0 rows, which would otherwise loop forever with a climbing counter.
+    /// Deletes empty regular directories in batches and returns the number removed.
+    /// Category folders under /content and /nzbs are excluded (WebDAV synthesizes them;
+    /// deleting them races with in-flight queue processing via DavCleanupService cascade).
+    /// Mount folders still linked to SAB history are also excluded. The DELETE re-checks
+    /// emptiness so a concurrent child insert cannot race into a cascade delete.
     /// </summary>
     internal static async Task<int> RemoveEmptyDirectoriesAsync(
         DavDatabaseContext dbContext,
@@ -341,6 +390,11 @@ public class RemoveUnlinkedFilesTask(
     {
         var removed = 0;
         var directorySubType = (int)DavItem.ItemSubType.Directory;
+        var contentFolderId = DavItem.ContentFolder.Id.ToString();
+        var nzbFolderId = DavItem.NzbFolder.Id.ToString();
+        // When a selected batch deletes fewer rows than selected (child appeared mid-flight),
+        // retry. Only abort if the same batch ids keep making no progress.
+        string? lastStuckBatchKey = null;
 
         while (true)
         {
@@ -351,7 +405,9 @@ public class RemoveUnlinkedFilesTask(
                     $"""
                      SELECT d.Id AS Id, d.Type AS Type, d.Path AS Path FROM DavItems d
                      WHERE d.SubType = {directorySubType}
+                       AND d.HistoryItemId IS NULL
                        AND d.CreatedAt < {createdBefore}
+                       AND d.ParentId NOT IN ({contentFolderId}, {nzbFolderId})
                        AND NOT EXISTS (
                            SELECT 1 FROM DavItems c WHERE c.ParentId = d.Id
                        )
@@ -364,23 +420,38 @@ public class RemoveUnlinkedFilesTask(
                 break;
 
             // Delete by the exact Id text from the select so stored casing never matters
-            // (the Fix-Empty-Categories migration seeds a lowercase-Id folder).
+            // (the Fix-Empty-Categories migration seeds a lowercase-Id folder). Re-check
+            // emptiness in the DELETE so a concurrent insert under a selected folder
+            // cannot race into TR_DavItems_DeleteDirectory + DavCleanupService cascade.
+            var deleted = await DeleteEmptyDirectoriesByIdTextAsync(
+                    dbContext, emptyDirs, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (deleted == 0)
+            {
+                var batchKey = string.Join(",", emptyDirs.Select(x => x.Id));
+                if (batchKey == lastStuckBatchKey)
+                {
+                    throw new InvalidOperationException(
+                        $"selected {emptyDirs.Count} empty directories but deleted 0 twice; " +
+                        $"aborting to avoid an infinite loop.");
+                }
+
+                lastStuckBatchKey = batchKey;
+                continue;
+            }
+
+            lastStuckBatchKey = null;
+
+            // Prefer auditing the full selected batch when every row deleted. On a partial
+            // delete the survivors remain for the next iteration; over-auditing the rare
+            // race case is preferable to missing deleted paths.
             foreach (var dir in emptyDirs)
             {
                 DeletionAuditLog.Record(
                     "remove-orphaned",
                     new DavItem { Id = Guid.Parse(dir.Id), Path = dir.Path },
                     "empty directory after orphaned-file cleanup");
-            }
-
-            var deleted = await DeleteItemsByIdTextAsync(dbContext, emptyDirs, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (deleted == 0)
-            {
-                throw new InvalidOperationException(
-                    $"selected {emptyDirs.Count} empty directories but deleted 0; " +
-                    $"aborting to avoid an infinite loop.");
             }
 
             if (onDeleted is not null)
@@ -419,7 +490,10 @@ public class RemoveUnlinkedFilesTask(
                        AND HistoryItemId IS NULL
                        AND CreatedAt < {createdBefore}
                        AND Id > {lastId}
-                       AND Id NOT IN (SELECT Id FROM TMP_LINKED_FILES)
+                       AND NOT EXISTS (
+                           SELECT 1 FROM TMP_LINKED_FILES t
+                           WHERE t.Id = DavItems.Id COLLATE NOCASE
+                       )
                      ORDER BY Id
                      LIMIT 100
                      """)

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -20,13 +20,14 @@ public class RemoveUnlinkedFilesTaskTests
         var ctx = harness.Context;
         var createdBefore = DateTime.Now.AddMinutes(1);
 
-        var parent = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "show");
+        // Category folder under /content is protected; nested empties beneath it are removed.
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "movies");
+        var parent = NewDir(Guid.NewGuid(), category, "show");
         var child = NewDir(Guid.NewGuid(), parent, "season");
         var grandchild = NewDir(Guid.NewGuid(), child, "empty");
-        // keptFile under ContentFolder keeps that root non-empty; empty show/season tree is removed.
         var keptFile = DavItem.New(
             Guid.NewGuid(),
-            DavItem.ContentFolder,
+            category,
             "keep.mkv",
             10,
             DavItem.ItemType.UsenetFile,
@@ -36,7 +37,7 @@ public class RemoveUnlinkedFilesTaskTests
             null,
             null);
         await SeedRootsAsync(ctx);
-        ctx.Items.AddRange(parent, child, grandchild, keptFile);
+        ctx.Items.AddRange(category, parent, child, grandchild, keptFile);
         await ctx.SaveChangesAsync();
 
         var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
@@ -47,7 +48,97 @@ public class RemoveUnlinkedFilesTaskTests
         Assert.False(await ctx.Items.AnyAsync(x => x.Id == grandchild.Id));
         Assert.False(await ctx.Items.AnyAsync(x => x.Id == child.Id));
         Assert.False(await ctx.Items.AnyAsync(x => x.Id == parent.Id));
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == category.Id));
         Assert.True(await ctx.Items.AnyAsync(x => x.Id == keptFile.Id));
+    }
+
+    [Fact]
+    public async Task RemoveEmptyDirectoriesAsync_PreservesEmptyCategoryFolderUnderContent()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        await SeedRootsAsync(ctx);
+
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "tv");
+        ctx.Items.Add(category);
+        await ctx.SaveChangesAsync();
+
+        var createdBefore = DateTime.Now.AddMinutes(1);
+        await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(ctx, createdBefore);
+
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == category.Id));
+    }
+
+    [Fact]
+    public async Task RemoveEmptyDirectoriesAsync_PreservesEmptyDirWithHistoryItemId()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        await SeedRootsAsync(ctx);
+
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "movies");
+        var mountFolder = DavItem.New(
+            Guid.NewGuid(),
+            category,
+            "Some.Release",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            historyItemId: Guid.NewGuid(),
+            fileBlobId: null);
+        ctx.Items.AddRange(category, mountFolder);
+        await ctx.SaveChangesAsync();
+
+        var createdBefore = DateTime.Now.AddMinutes(1);
+        var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(ctx, createdBefore);
+
+        Assert.Equal(0, removed);
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == mountFolder.Id));
+    }
+
+    [Fact]
+    public async Task DeleteEmptyDirectoriesByIdTextAsync_SkipsDirThatGainedChild()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        await SeedRootsAsync(ctx);
+
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "movies");
+        var emptyDir = NewDir(Guid.NewGuid(), category, "release");
+        ctx.Items.AddRange(category, emptyDir);
+        await ctx.SaveChangesAsync();
+
+        var candidates = new[]
+        {
+            new RemoveUnlinkedFilesTask.UnlinkedItemInfo(
+                emptyDir.Id.ToString().ToUpperInvariant(),
+                (int)emptyDir.Type,
+                emptyDir.Path),
+        };
+
+        // Simulate a concurrent queue insert between SELECT and DELETE.
+        var child = DavItem.New(
+            Guid.NewGuid(),
+            emptyDir,
+            "video.mkv",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        ctx.Items.Add(child);
+        await ctx.SaveChangesAsync();
+
+        var deleted = await RemoveUnlinkedFilesTask.DeleteEmptyDirectoriesByIdTextAsync(
+            ctx, candidates);
+
+        Assert.Equal(0, deleted);
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == emptyDir.Id));
+        Assert.True(await ctx.Items.AnyAsync(x => x.Id == child.Id));
     }
 
     [Fact]
@@ -70,10 +161,8 @@ public class RemoveUnlinkedFilesTaskTests
         ctx.Items.Add(file);
         await ctx.SaveChangesAsync();
 
-        // Drain migration-seeded empty category folders (e.g. /content/uncategorized
-        // from Fix-Empty-Categories). Filling them via EF fails: ParentId is stored
-        // uppercase while the seeded folder Id is lowercase, so raw SQL still sees
-        // the folder as empty.
+        // Category folders under /content are protected; migration-seeded empties
+        // (e.g. /content/uncategorized) remain and must not block a clean second pass.
         var createdBefore = DateTime.Now.AddMinutes(1);
         await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(ctx, createdBefore);
 
@@ -83,6 +172,89 @@ public class RemoveUnlinkedFilesTaskTests
 
         Assert.Equal(0, removed);
         Assert.True(await ctx.Items.AnyAsync(x => x.Id == file.Id));
+    }
+
+    [Fact]
+    public async Task DryRun_DoesNotTreatLowercaseLinkedIdAsUnlinked()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Combine(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+
+            var linkedIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToList();
+            foreach (var id in linkedIds)
+            {
+                ctx.Items.Add(DavItem.New(
+                    id,
+                    DavItem.ContentFolder,
+                    $"{id:N}.mkv",
+                    10,
+                    DavItem.ItemType.UsenetFile,
+                    DavItem.ItemSubType.NzbFile,
+                    null,
+                    null,
+                    null,
+                    null));
+            }
+
+            await ctx.SaveChangesAsync();
+
+            // Seed a lowercase-Id UsenetFile the way Fix-Empty-Categories seeds folders.
+            var lowercaseId = Guid.NewGuid();
+            var lowercaseIdText = lowercaseId.ToString().ToLowerInvariant();
+            await ctx.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO DavItems (Id, IdPrefix, CreatedAt, ParentId, Name, FileSize, Type, SubType, Path)
+                VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})
+                """,
+                lowercaseIdText,
+                lowercaseIdText[..5],
+                DateTime.Now.AddMinutes(-1),
+                DavItem.ContentFolder.Id.ToString(),
+                $"{lowercaseId:N}.mkv",
+                10L,
+                (int)DavItem.ItemType.UsenetFile,
+                (int)DavItem.ItemSubType.NzbFile,
+                $"/content/{lowercaseId:N}.mkv");
+
+            foreach (var id in linkedIds.Append(lowercaseId))
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(libraryDir, $"{id:N}.strm"),
+                    $"http://localhost/view/.ids/{id}.mkv");
+            }
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var task = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.StartsWith("Dry Run - Done.", progress);
+            Assert.Contains("Identified 0 unlinked files", progress);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch { /* best effort */ }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Protect `/content` and `/nzbs` category folders and history-linked mount dirs from the empty-directory sweep; re-check emptiness atomically on DELETE to avoid racing in-flight queue inserts (DavCleanupService cascade).
- Match `TMP_LINKED_FILES` ids with `COLLATE NOCASE`; count distinct linked ids for the `< 5` guard; clear the audit list on abort paths.
- Retry scheduled orphaned-files / database-backup runs when `BaseTask.Execute()` returns false instead of silently skipping the day.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (506 passed)
- [x] New regressions: empty category survives; history-linked empty dir survives; dir that gains a child mid-delete is skipped; lowercase linked id is not treated as unlinked