### PR TITLE
chore(db): remove UPGRADE=0.6.0 gate and auto-apply breaking migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ Docker image builds are shared via the reusable workflow. Branch and dependabot 
 - **Proxy paths:** new WebDAV mount points must be added to the proxy allowlists in `frontend/server/app.ts` and compression skip list in `frontend/server.ts`.
 - **Editing CHANGELOG.md:** it is generated — commit messages are the source of truth.
 - **Package release ordering:** do not bump UsenetSharp merely because a release/tag exists; confirm the package publish job completed.
-- **Breaking upgrades:** major incompatible releases may gate startup in `Program.cs` (see `UPGRADE` env var pattern).
+- **Breaking upgrades:** irreversible schema changes ship as ordinary EF migrations that auto-apply on startup and surface through the migration-progress splash; there is no `UPGRADE` env-var interlock. Advise a `/config` backup before upgrading across such a migration.
 - **Test fixtures:** prefer deterministic generated data and `FakeNntpClient`; do not require live Usenet providers in the automated suite.
 - **Streaming changes:** run the focused backend tests and retain manual range, rclone scrubbing, and encrypted-archive playback checks for behavior not covered by automation.
 

--- a/backend/Database/DatabaseStartupGuards.cs
+++ b/backend/Database/DatabaseStartupGuards.cs
@@ -7,8 +7,6 @@ namespace NzbWebDAV.Database;
 /// </summary>
 internal static class DatabaseStartupGuards
 {
-    public const string V06BreakingMigration = "20260226053712_Add-NzbBlobId-And-NzbNames";
-
     /// <summary>
     /// True when the operational database has a <c>ConfigItems</c> table.
     /// Fresh / WAL-created empty files do not, so callers must not query config yet.
@@ -27,27 +25,5 @@ internal static class DatabaseStartupGuards
             .FirstAsync(cancellationToken)
             .ConfigureAwait(false);
         return count > 0;
-    }
-
-    /// <summary>
-    /// Whether startup should refuse to continue until the operator sets <c>UPGRADE=0.6.0</c>.
-    /// A WAL-created empty <c>db.sqlite</c> (no applied migrations) is a fresh install, not an upgrade.
-    /// </summary>
-    public static bool ShouldBlockUpgradeToV06X(
-        bool databaseFileExists,
-        IEnumerable<string> appliedMigrations,
-        IEnumerable<string> pendingMigrations,
-        string? upgradeEnv)
-    {
-        if (!databaseFileExists)
-            return false;
-
-        if (!appliedMigrations.Any())
-            return false;
-
-        if (!pendingMigrations.Contains(V06BreakingMigration))
-            return false;
-
-        return upgradeEnv != "0.6.0";
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -77,9 +77,6 @@ class Program
                 minThreads,
                 maxThreads);
 
-            // Block upgrades to version 0.6.x
-            BlockUpgradesToV06X();
-
             // run database migration / restore, if necessary.
             // Restore must run before opening the live DavDatabaseContext so pending
             // migrations are computed against the restored schema.
@@ -284,41 +281,6 @@ class Program
                 Log.Warning("Ignoring invalid TRUSTED_PROXY_CIDRS entry: {Entry}", part);
             }
         }
-    }
-
-    private static void BlockUpgradesToV06X()
-    {
-        var databaseFileExists = File.Exists(DavDatabaseContext.DatabaseFilePath);
-        IEnumerable<string> appliedMigrations = [];
-        IEnumerable<string> pendingMigrations = [];
-        if (databaseFileExists)
-        {
-            using var databaseContext = new DavDatabaseContext();
-            appliedMigrations = databaseContext.Database.GetAppliedMigrations().ToList();
-            pendingMigrations = databaseContext.Database.GetPendingMigrations().ToList();
-        }
-
-        if (!DatabaseStartupGuards.ShouldBlockUpgradeToV06X(
-                databaseFileExists,
-                appliedMigrations,
-                pendingMigrations,
-                EnvironmentUtil.GetEnvironmentVariable("UPGRADE")))
-        {
-            return;
-        }
-
-        // Otherwise, display the upgrade message, and exit.
-        Log.Fatal(
-            """
-            Version 0.6.0 of nzbdav is NOT backwards compatible.
-            You can upgrade, but you won't be able to downgrade.
-            Make a backup of your entire /config directory prior to upgrading.
-            The only way to downgrade back to a previous version is by restoring this backup.
-            To acknowledge this message and continue upgrading, set the env variable UPGRADE=0.6.0
-            """
-        );
-        Log.CloseAndFlush();
-        Environment.Exit(1);
     }
 
     private static async Task RunDatabaseMigrationsAsync(string[] args)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -586,7 +586,7 @@ docker compose up -d nzbdav_rclone
 The `latest` tag follows stable releases. For reproducible deployments, replace `latest` with a specific release tag from the [GitHub releases page](https://github.com/nzbdav/nzbdav/releases).
 
 > [!IMPORTANT]
-> When upgrading an installation older than `0.6.0`, NzbDav deliberately stops before the irreversible database migration. After making a complete `/config` backup, add `UPGRADE: "0.6.0"` to the NzbDav service's `environment`, run the update again, and remove the variable after the upgrade succeeds.
+> Upgrading an installation older than `0.6.0` applies an irreversible database migration — once it runs you cannot downgrade to a pre-`0.6.0` version. Make a complete `/config` backup before updating; restoring that backup is the only way to roll back. The migration applies automatically on startup (no environment variable required) and its progress is shown on the maintenance splash page.
 
 ### View logs
 

--- a/tests/NzbWebDAV.Tests/Database/DatabaseStartupGuardsTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseStartupGuardsTests.cs
@@ -8,35 +8,6 @@ namespace NzbWebDAV.Tests.Database;
 
 public class DatabaseStartupGuardsTests
 {
-    [Theory]
-    [InlineData(false, false, false, null, false)]
-    [InlineData(true, false, true, null, false)] // empty WAL file: applied=none, pending=yes → fresh install
-    [InlineData(true, true, true, null, true)] // real pre-0.6 DB without acknowledgement
-    [InlineData(true, true, true, "0.6.0", false)] // acknowledged
-    [InlineData(true, true, false, null, false)] // already past the breaking migration
-    public void ShouldBlockUpgradeToV06X_MatchesFreshVsUpgradeSemantics(
-        bool databaseFileExists,
-        bool hasAppliedMigrations,
-        bool hasPendingBreakingMigration,
-        string? upgradeEnv,
-        bool expectedBlock)
-    {
-        var applied = hasAppliedMigrations
-            ? new[] { "20250529081501_InitializeDatabase" }
-            : Array.Empty<string>();
-        var pending = hasPendingBreakingMigration
-            ? new[] { DatabaseStartupGuards.V06BreakingMigration }
-            : Array.Empty<string>();
-
-        Assert.Equal(
-            expectedBlock,
-            DatabaseStartupGuards.ShouldBlockUpgradeToV06X(
-                databaseFileExists,
-                applied,
-                pending,
-                upgradeEnv));
-    }
-
     [Fact]
     public async Task ConfigItemsTableExistsAsync_ReturnsFalse_OnEmptySqliteFile()
     {


### PR DESCRIPTION
## Summary

Closes #373.

Removes the `UPGRADE=0.6.0` acknowledgement gate so upgrades from pre-0.6.0 databases apply all pending EF migrations automatically, without requiring an environment variable. EF migrations already stack in order and the migration-progress splash already covers the irreversible `20260226053712_Add-NzbBlobId-And-NzbNames` step, so the hard env interlock was pure friction.

- Removed `BlockUpgradesToV06X()` call and method from `backend/Program.cs`.
- Removed `ShouldBlockUpgradeToV06X` and the now-unused `V06BreakingMigration` const from `backend/Database/DatabaseStartupGuards.cs` (kept `ConfigItemsTableExistsAsync`).
- Removed the `ShouldBlockUpgradeToV06X` theory from `DatabaseStartupGuardsTests.cs`; retained the `ConfigItemsTableExistsAsync` tests.
- Rewrote the `UPGRADE: "0.6.0"` note in `docs/setup-guide.md` to advisory `/config`-backup guidance (no env var), and updated the AGENTS.md breaking-upgrades pitfall.
- Kept the migration itself.

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj` succeeds.
- [x] `DatabaseStartupGuardsTests` pass (2/2).
- [x] No remaining references to `UPGRADE=0.6.0` / `ShouldBlockUpgradeToV06X` / `V06BreakingMigration` (excluding CHANGELOG.md).
- [ ] Manual: start from a pre-0.6 (or simulated pending `20260226053712_...`) DB without `UPGRADE` set; confirm migrations run and splash UI appears.
- [ ] Manual: already-migrated DB still starts with idle maintenance (no unnecessary splash).