### PR TITLE
fix(auth): raise password verification cache size for Basic Auth retry bursts

### DIFF
--- a/backend/Utils/PasswordUtil.cs
+++ b/backend/Utils/PasswordUtil.cs
@@ -7,7 +7,10 @@ namespace NzbWebDAV.Utils;
 
 public static class PasswordUtil
 {
-    private static readonly MemoryCache Cache = new(new MemoryCacheOptions() { SizeLimit = 5 });
+    // 1024 entries (~a few hundred KB worst case, each expiring after 5 idle minutes) so
+    // Basic Auth retry storms with many distinct credentials — e.g. WebDAV clients hammering
+    // during a provider outage — cannot thrash the cache back into per-request PBKDF2 work.
+    private static readonly MemoryCache Cache = new(new MemoryCacheOptions() { SizeLimit = 1024 });
     private static readonly PasswordHasher<object> Hasher = new();
     private static readonly byte[] CacheKeySecret = RandomNumberGenerator.GetBytes(32);
 


### PR DESCRIPTION
## Summary

- Raise `PasswordUtil` MemoryCache `SizeLimit` from 5 to 1024 so Basic Auth retry bursts with several distinct credentials cannot thrash the cache back into per-request PBKDF2 hashing (the exact CPU-pegging failure mode ElfHosted hit during provider outages).
- Entries are HMAC-keyed hashes with a 5-minute sliding expiration, so worst-case memory stays a few hundred KB.

This is the "PasswordUtil MemoryCache SizeLimit 5 → 1024" checklist item from #162, shipped standalone per that issue's own guidance to peel off the small low-risk pieces.

Refs #162

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 505 passed, 0 failed (11 skipped: rapidyenc-native tests)
- [x] Existing `PasswordVerify_CacheHitsPreserveCorrectness` covers cache-hit correctness; no size-dependent behavior beyond capacity