### PR TITLE
fix: drain WithConcurrencyAsync running tasks on early exit

### DIFF
--- a/backend/Extensions/IEnumerableTaskExtensions.cs
+++ b/backend/Extensions/IEnumerableTaskExtensions.cs
@@ -73,22 +73,36 @@ public static class IEnumerableTaskExtensions
             throw new ArgumentException("concurrency must be greater than zero.");
 
         var runningTasks = new HashSet<Task<T>>();
-        foreach (var task in tasks)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            runningTasks.Add(task);
-            if (runningTasks.Count < concurrency) continue;
-            var completedTask = await Task.WhenAny(runningTasks).ConfigureAwait(false);
-            runningTasks.Remove(completedTask);
-            yield return await completedTask.ConfigureAwait(false);
-        }
+            foreach (var task in tasks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                runningTasks.Add(task);
+                if (runningTasks.Count < concurrency) continue;
+                var completedTask = await Task.WhenAny(runningTasks).ConfigureAwait(false);
+                runningTasks.Remove(completedTask);
+                yield return await completedTask.ConfigureAwait(false);
+            }
 
-        while (runningTasks.Count > 0)
+            while (runningTasks.Count > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var completedTask = await Task.WhenAny(runningTasks).ConfigureAwait(false);
+                runningTasks.Remove(completedTask);
+                yield return await completedTask.ConfigureAwait(false);
+            }
+        }
+        finally
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var completedTask = await Task.WhenAny(runningTasks).ConfigureAwait(false);
-            runningTasks.Remove(completedTask);
-            yield return await completedTask.ConfigureAwait(false);
+            // Early exit (fault, cancellation, abandoned enumeration): wait for in-flight
+            // tasks so they cannot race post-enumeration cleanup, and observe their
+            // exceptions so they don't become unobserved-task noise.
+            if (runningTasks.Count > 0)
+            {
+                try { await Task.WhenAll(runningTasks).ConfigureAwait(false); }
+                catch { /* original exception stays authoritative */ }
+            }
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Extensions/WithConcurrencyAsyncCancellationTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/WithConcurrencyAsyncCancellationTests.cs
@@ -31,4 +31,126 @@ public class WithConcurrencyAsyncCancellationTests
 
         Assert.Equal([0, 1, 2, 3, 4], results.OrderBy(x => x).ToList());
     }
+
+    [Fact]
+    public async Task WithConcurrencyAsync_DrainsInFlightTasksOnConsumerBreak()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var tasks = new[]
+        {
+            Task.FromResult(1),
+            HoldUntilReleased(gate, drained),
+        };
+
+        var enumerator = tasks.WithConcurrencyAsync(2).GetAsyncEnumerator();
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(1, enumerator.Current);
+
+        // Break without consuming the in-flight task. DisposeAsync drains via finally,
+        // so kick disposal off, then release the held task so drain can finish.
+        var dispose = enumerator.DisposeAsync().AsTask();
+        gate.TrySetResult();
+        await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(drained.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task WithConcurrencyAsync_DrainsInFlightTasksOnFault()
+    {
+        var siblingCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSibling = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var tasks = new[]
+        {
+            Task.FromException<int>(new InvalidOperationException("boom")),
+            CompleteAfterRelease(releaseSibling, siblingCompleted),
+            Task.FromResult(3),
+        };
+
+        // Kick off enumeration; WhenAny will surface the faulted task first once
+        // concurrency is reached. Release the sibling so drain can finish.
+        var enumerate = EnumerateAll(tasks.WithConcurrencyAsync(2));
+        releaseSibling.TrySetResult();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => enumerate);
+        Assert.Equal("boom", ex.Message);
+        Assert.True(siblingCompleted.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task WithConcurrencyAsync_DrainsInFlightTasksOnCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var drainStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDrain = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var tasks = new[]
+        {
+            Task.FromResult(1),
+            HoldUntilReleased(releaseDrain, drained, drainStarted),
+            Task.FromResult(3),
+            Task.FromResult(4),
+        };
+
+        var enumerate = Task.Run(async () =>
+        {
+            await foreach (var value in tasks.WithConcurrencyAsync(2, cts.Token).ConfigureAwait(false))
+            {
+                if (value == 1)
+                    await cts.CancelAsync().ConfigureAwait(false);
+            }
+        });
+
+        // Wait until the in-flight hold task is actually running, then release it
+        // so the finally drain can complete and surface the cancellation.
+        await drainStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releaseDrain.TrySetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => enumerate);
+        Assert.True(drained.Task.IsCompleted);
+    }
+
+    private static async Task<List<int>> EnumerateAll(IAsyncEnumerable<int> source)
+    {
+        var results = new List<int>();
+        await foreach (var value in source.ConfigureAwait(false))
+            results.Add(value);
+        return results;
+    }
+
+    private static async Task<int> HoldUntilReleased(
+        TaskCompletionSource release,
+        TaskCompletionSource drained,
+        TaskCompletionSource? started = null)
+    {
+        started?.TrySetResult();
+        try
+        {
+            await release.Task.ConfigureAwait(false);
+            return 2;
+        }
+        finally
+        {
+            drained.TrySetResult();
+        }
+    }
+
+    private static async Task<int> CompleteAfterRelease(
+        TaskCompletionSource release,
+        TaskCompletionSource completed)
+    {
+        try
+        {
+            await release.Task.ConfigureAwait(false);
+            return 2;
+        }
+        finally
+        {
+            completed.TrySetResult();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Drain in-flight tasks in `WithConcurrencyAsync` via `try`/`finally` before the iterator exits (mirrors the sync `WithConcurrency` drain)
- On early exit (fault, cancellation, abandoned enumeration), `Task.WhenAll` observes remaining tasks so their exceptions stay swallowed and the original exception stays authoritative
- Add drain-on-break, drain-on-fault, and drain-on-cancellation tests

Refs #163 (first of the re-scoped checklist; does not close — watchdog item remains)

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~WithConcurrencyAsync` (5/5)
- [x] Full backend suite: Passed 508, Skipped 11, Failed 0