### PR TITLE
feat(ui): show provider circuit breaker status on overview

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -17,7 +18,8 @@ public class GetOverviewStatsController(
     LiveStatsBroadcaster liveStats,
     MetricsWriter metricsWriter,
     ConfigManager configManager,
-    IndexerHitTracker hitTracker
+    IndexerHitTracker hitTracker,
+    UsenetStreamingClient usenetStreamingClient
 ) : BaseApiController
 {
     private const long OneMinute = 60_000;
@@ -324,6 +326,10 @@ public class GetOverviewStatsController(
 
         var tiles = BuildLiveTiles(liveCounts?.Articles ?? 0, liveCounts?.Errors ?? 0);
         var sessionsBlock = BuildSessionsBlock(sessionsRows.Select(s => (s.DurationMs, s.BytesServed)));
+        providers = ProviderCircuitOverviewEnricher.EnrichProviders(
+            providers,
+            usenetStreamingClient.GetProviderCircuitSnapshots(),
+            labelsByMetricsKey);
 
         return new WindowSectionResult(
             tiles, throughput, providers, sessionsBlock, heatmap, failover,

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -64,6 +64,12 @@ public class GetOverviewStatsResponse
         public double AvgDurationMs { get; init; }
         public double ErrorRate { get; init; }
         public List<long> Spark { get; init; } = new();
+        public string CircuitState { get; init; } = "closed";
+        public int? CooldownRemainingSeconds { get; init; }
+        public string? LastFailureReason { get; init; }
+        public long TripCount { get; init; }
+        public long FailureCount { get; init; }
+        public long ArticleMissCount { get; init; }
     }
 
     public class CatalogueBlock

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -1,3 +1,4 @@
+using NzbWebDAV.Clients.Usenet.Models;
 using Serilog;
 
 namespace NzbWebDAV.Clients.Usenet.Connections;
@@ -36,6 +37,10 @@ public class ProviderCircuitBreaker
     private TimeSpan _currentCooldown = InitialCooldown;
     private int _halfOpenProbeInFlight; // 0/1
     private long _probeStartedMs;
+    private string? _lastFailureReason;
+    private long _tripCount;
+    private long _failureCount;
+    private long _articleMissCount;
 
     public ProviderCircuitBreaker(string providerName)
     {
@@ -97,8 +102,54 @@ public class ProviderCircuitBreaker
             _window.Clear();
             _trippedUntilMs = 0;
             _currentCooldown = InitialCooldown;
+            _lastFailureReason = null;
             Volatile.Write(ref _halfOpenProbeInFlight, 0);
             Volatile.Write(ref _probeStartedMs, 0);
+        }
+    }
+
+    /// <summary>
+    /// Article permanently missing from retention. Counts as a miss for diagnostics
+    /// but does not contribute to provider-failure tripping.
+    /// </summary>
+    public void RecordArticleNotFound()
+    {
+        Interlocked.Increment(ref _articleMissCount);
+        RecordSuccess();
+    }
+
+    /// <summary>Read-only snapshot for dashboards. Does not claim a half-open probe.</summary>
+    public ProviderCircuitBreakerSnapshot GetSnapshot()
+    {
+        lock (_lock)
+        {
+            var now = Environment.TickCount64;
+            var trippedUntil = _trippedUntilMs;
+            var probeInFlight = Volatile.Read(ref _halfOpenProbeInFlight) == 1;
+
+            ProviderCircuitState state;
+            int? cooldownRemainingSeconds = null;
+            if (trippedUntil > 0 && now < trippedUntil)
+            {
+                state = ProviderCircuitState.Open;
+                cooldownRemainingSeconds = Math.Max(0, (int)Math.Ceiling((trippedUntil - now) / 1000.0));
+            }
+            else if (trippedUntil > 0 || probeInFlight)
+            {
+                state = ProviderCircuitState.HalfOpen;
+            }
+            else
+            {
+                state = ProviderCircuitState.Closed;
+            }
+
+            return new ProviderCircuitBreakerSnapshot(
+                state,
+                cooldownRemainingSeconds,
+                _lastFailureReason,
+                Volatile.Read(ref _tripCount),
+                Volatile.Read(ref _failureCount),
+                Volatile.Read(ref _articleMissCount));
         }
     }
 
@@ -130,6 +181,7 @@ public class ProviderCircuitBreaker
 
             EvictOldEntries(now);
             _window.Enqueue((now, true));
+            Interlocked.Increment(ref _failureCount);
 
             var failures = 0;
             foreach (var entry in _window)
@@ -145,6 +197,8 @@ public class ProviderCircuitBreaker
 
     private void Trip(long nowMs, string reason)
     {
+        _lastFailureReason = reason;
+        Interlocked.Increment(ref _tripCount);
         _trippedUntilMs = nowMs + (long)_currentCooldown.TotalMilliseconds;
         Log.Warning(
             "Provider {Provider} tripped ({Reason}). Skipping for {Cooldown}s.",

--- a/backend/Clients/Usenet/Models/ProviderCircuitSnapshot.cs
+++ b/backend/Clients/Usenet/Models/ProviderCircuitSnapshot.cs
@@ -1,0 +1,26 @@
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Clients.Usenet.Models;
+
+public enum ProviderCircuitState
+{
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+/// <summary>Read-only circuit breaker view for APIs and live dashboards.</summary>
+public sealed record ProviderCircuitBreakerSnapshot(
+    ProviderCircuitState State,
+    int? CooldownRemainingSeconds,
+    string? LastFailureReason,
+    long TripCount,
+    long FailureCount,
+    long ArticleMissCount);
+
+/// <summary>Per configured provider account, keyed by metrics ProviderId.</summary>
+public sealed record ProviderCircuitRuntimeSnapshot(
+    string MetricsKey,
+    string Host,
+    ProviderType ProviderType,
+    ProviderCircuitBreakerSnapshot Breaker);

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -81,6 +81,7 @@ public class MultiConnectionNntpClient(
     public long? ByteLimit { get; } = byteLimit;
     public long BytesUsedOffset { get; } = bytesUsedOffset;
     public bool IsTripped => circuitBreaker.IsTripped;
+    public ProviderCircuitBreakerSnapshot GetCircuitBreakerSnapshot() => circuitBreaker.GetSnapshot();
     public int LiveConnections => connectionPool.LiveConnections;
     public int IdleConnections => connectionPool.IdleConnections;
     public int ActiveConnections => connectionPool.ActiveConnections;
@@ -210,8 +211,10 @@ public class MultiConnectionNntpClient(
                     switch (result)
                     {
                         case ArticleBodyResult.Retrieved:
-                        case ArticleBodyResult.NotFound:
                             circuitBreaker.RecordSuccess();
+                            break;
+                        case ArticleBodyResult.NotFound:
+                            circuitBreaker.RecordArticleNotFound();
                             break;
                         case ArticleBodyResult.Cancelled:
                             break;
@@ -461,7 +464,7 @@ public class MultiConnectionNntpClient(
             // body and article
             else if ((result?.Success ?? false) == false)
             {
-                circuitBreaker.RecordSuccess();
+                circuitBreaker.RecordArticleNotFound();
                 deferredCallback.Discard();
                 LogException(() => connectionLock?.Dispose());
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
@@ -481,6 +484,10 @@ public class MultiConnectionNntpClient(
                     else if (articleBodyResult == ArticleBodyResult.Retrieved)
                     {
                         circuitBreaker.RecordSuccess();
+                    }
+                    else if (articleBodyResult == ArticleBodyResult.NotFound)
+                    {
+                        circuitBreaker.RecordArticleNotFound();
                     }
 
                     LogException(() => connectionLock?.Dispose());

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -23,6 +23,17 @@ public class MultiProviderNntpClient(
 ) : NntpClient, INntpConnectionStats
 {
     public int InFlightConnections => providers.Sum(p => p.InFlightConnections);
+
+    public IReadOnlyList<ProviderCircuitRuntimeSnapshot> GetProviderCircuitSnapshots()
+    {
+        return providers
+            .Select(p => new ProviderCircuitRuntimeSnapshot(
+                p.MetricsKey,
+                p.Host,
+                p.ProviderType,
+                p.GetCircuitBreakerSnapshot()))
+            .ToList();
+    }
     private readonly ProviderUsageTracker _usageTracker = usageTracker ?? new ProviderUsageTracker();
     private static readonly AsyncLocal<Guid?> ReadSessionScope = new();
     internal static Guid? CurrentReadSessionId => ReadSessionScope.Value;

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -1,4 +1,5 @@
 ﻿using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
@@ -73,6 +74,13 @@ public class UsenetStreamingClient : WrappingNntpClient
         // Always wrap with header caching so seek probes reuse immutable yEnc headers
         // even when the optional on-disk segment body cache is disabled.
         return new HeaderCachingNntpClient(inner);
+    }
+
+    public IReadOnlyList<ProviderCircuitRuntimeSnapshot> GetProviderCircuitSnapshots()
+    {
+        return WrappingNntpClient.Unwrap(InnerClient) is MultiProviderNntpClient multi
+            ? multi.GetProviderCircuitSnapshots()
+            : Array.Empty<ProviderCircuitRuntimeSnapshot>();
     }
 
     private static MultiProviderNntpClient CreateMultiProviderClient

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -13,6 +13,14 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
     private static readonly TimeSpan DrainPollInterval = TimeSpan.FromMilliseconds(250);
 
     private INntpClient _usenetClient = usenetClient;
+    protected INntpClient InnerClient => _usenetClient;
+
+    internal static INntpClient Unwrap(INntpClient client)
+    {
+        while (client is WrappingNntpClient wrap)
+            client = wrap.InnerClient;
+        return client;
+    }
     private readonly ConcurrentQueue<(INntpClient Client, DateTimeOffset Deadline)> _retiringClients = new();
     private int _retiringCount;
     private int _drainLoopRunning;

--- a/backend/Services/Metrics/LiveStatsBroadcaster.cs
+++ b/backend/Services/Metrics/LiveStatsBroadcaster.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Utils;
@@ -22,7 +24,9 @@ namespace NzbWebDAV.Services.Metrics;
 /// </summary>
 public class LiveStatsBroadcaster(
     ActiveReadRegistry registry,
-    WebsocketManager websocketManager
+    WebsocketManager websocketManager,
+    UsenetStreamingClient usenetStreamingClient,
+    ConfigManager configManager
 ) : BackgroundService
 {
     private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(5);
@@ -80,6 +84,12 @@ public class LiveStatsBroadcaster(
         var bytesPerMinute = _byteSamples.Count > 0 ? totalBytes - _byteSamples.Peek().Total : 0;
         Interlocked.Exchange(ref _bytesServedLastMinute, bytesPerMinute);
 
+        var labelsByMetricsKey = ProviderUsageHelper.BuildLabelsByMetricsKey(
+            configManager.GetUsenetProviderConfig().Providers);
+        var providerBreakers = ProviderCircuitOverviewEnricher.ToLivePayload(
+            usenetStreamingClient.GetProviderCircuitSnapshots(),
+            labelsByMetricsKey);
+
         var snapshot = new
         {
             activeReads = registry.Count,
@@ -87,6 +97,7 @@ public class LiveStatsBroadcaster(
             errorsPerMinute = errors,
             bytesServedPerMinute = bytesPerMinute,
             ts = nowMs,
+            providerBreakers,
         };
 
         var payload = JsonSerializer.Serialize(snapshot, JsonOptions);

--- a/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
+++ b/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
@@ -1,0 +1,108 @@
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Services.Metrics;
+
+internal static class ProviderCircuitOverviewEnricher
+{
+    internal static List<GetOverviewStatsResponse.ProviderRow> EnrichProviders(
+        IReadOnlyList<GetOverviewStatsResponse.ProviderRow> providers,
+        IReadOnlyList<ProviderCircuitRuntimeSnapshot> runtimeSnapshots,
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
+    {
+        var byKey = providers.ToDictionary(p => p.Provider, StringComparer.Ordinal);
+        foreach (var runtime in runtimeSnapshots)
+        {
+            var fields = ToRowFields(runtime.Breaker);
+            if (byKey.TryGetValue(runtime.MetricsKey, out var existing))
+            {
+                byKey[runtime.MetricsKey] = new GetOverviewStatsResponse.ProviderRow
+                {
+                    Provider = existing.Provider,
+                    Nickname = existing.Nickname,
+                    Articles = existing.Articles,
+                    BytesFetched = existing.BytesFetched,
+                    Errors = existing.Errors,
+                    Retries = existing.Retries,
+                    AvgDurationMs = existing.AvgDurationMs,
+                    ErrorRate = existing.ErrorRate,
+                    Spark = existing.Spark,
+                    CircuitState = fields.CircuitState,
+                    CooldownRemainingSeconds = fields.CooldownRemainingSeconds,
+                    LastFailureReason = fields.LastFailureReason,
+                    TripCount = fields.TripCount,
+                    FailureCount = fields.FailureCount,
+                    ArticleMissCount = fields.ArticleMissCount,
+                };
+                continue;
+            }
+
+            byKey[runtime.MetricsKey] = new GetOverviewStatsResponse.ProviderRow
+            {
+                Provider = runtime.MetricsKey,
+                Nickname = labelsByMetricsKey.GetValueOrDefault(runtime.MetricsKey),
+                CircuitState = fields.CircuitState,
+                CooldownRemainingSeconds = fields.CooldownRemainingSeconds,
+                LastFailureReason = fields.LastFailureReason,
+                TripCount = fields.TripCount,
+                FailureCount = fields.FailureCount,
+                ArticleMissCount = fields.ArticleMissCount,
+            };
+        }
+
+        return byKey.Values
+            .OrderByDescending(r => r.Articles)
+            .ThenBy(r => r.Nickname ?? r.Provider, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    internal static List<object> ToLivePayload(
+        IReadOnlyList<ProviderCircuitRuntimeSnapshot> runtimeSnapshots,
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
+    {
+        return runtimeSnapshots
+            .Select(runtime =>
+            {
+                var fields = ToRowFields(runtime.Breaker);
+                return (object)new
+                {
+                    provider = runtime.MetricsKey,
+                    nickname = labelsByMetricsKey.GetValueOrDefault(runtime.MetricsKey),
+                    providerType = runtime.ProviderType.ToString(),
+                    circuitState = fields.CircuitState,
+                    cooldownRemainingSeconds = fields.CooldownRemainingSeconds,
+                    lastFailureReason = fields.LastFailureReason,
+                    tripCount = fields.TripCount,
+                    failureCount = fields.FailureCount,
+                    articleMissCount = fields.ArticleMissCount,
+                };
+            })
+            .ToList();
+    }
+
+    private static (
+        string CircuitState,
+        int? CooldownRemainingSeconds,
+        string? LastFailureReason,
+        long TripCount,
+        long FailureCount,
+        long ArticleMissCount) ToRowFields(ProviderCircuitBreakerSnapshot breaker)
+    {
+        return (
+            ToWireState(breaker.State),
+            breaker.CooldownRemainingSeconds,
+            breaker.LastFailureReason,
+            breaker.TripCount,
+            breaker.FailureCount,
+            breaker.ArticleMissCount);
+    }
+
+    private static string ToWireState(ProviderCircuitState state) => state switch
+    {
+        ProviderCircuitState.Open => "open",
+        ProviderCircuitState.HalfOpen => "halfOpen",
+        _ => "closed",
+    };
+}

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -649,6 +649,8 @@ export type ThroughputPoint = {
     bytesServed: number,
 }
 
+export type ProviderCircuitState = "closed" | "open" | "halfOpen";
+
 export type ProviderRow = {
     provider: string,
     nickname?: string | null,
@@ -659,6 +661,24 @@ export type ProviderRow = {
     avgDurationMs: number,
     errorRate: number,
     spark: number[],
+    circuitState?: ProviderCircuitState,
+    cooldownRemainingSeconds?: number | null,
+    lastFailureReason?: string | null,
+    tripCount?: number,
+    failureCount?: number,
+    articleMissCount?: number,
+}
+
+export type ProviderCircuitBreakerRow = {
+    provider: string,
+    nickname?: string | null,
+    providerType?: string,
+    circuitState: ProviderCircuitState,
+    cooldownRemainingSeconds?: number | null,
+    lastFailureReason?: string | null,
+    tripCount?: number,
+    failureCount?: number,
+    articleMissCount?: number,
 }
 
 export type HeatmapMode = "day" | "week" | "month" | "year";
@@ -720,6 +740,7 @@ export type LiveStatsMessage = {
     errorsPerMinute: number,
     bytesServedPerMinute: number,
     ts: number,
+    providerBreakers?: ProviderCircuitBreakerRow[],
 }
 
 export type LogLevel = "Verbose" | "Debug" | "Information" | "Warning" | "Error" | "Fatal";

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.module.css
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.module.css
@@ -95,8 +95,44 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--success);
     flex-shrink: 0;
+}
+
+.dotClosed {
+    background: var(--success);
+}
+
+.dotOpen {
+    background: var(--danger-muted);
+}
+
+.dotHalfOpen {
+    background: var(--warning);
+}
+
+.circuitBadge {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    text-transform: uppercase;
+}
+
+.badgeClosed {
+    color: var(--success);
+    background: rgba(52, 211, 153, 0.12);
+}
+
+.badgeOpen {
+    color: var(--danger-muted);
+    background: rgba(248, 113, 113, 0.12);
+}
+
+.badgeHalfOpen {
+    color: var(--warning);
+    background: rgba(251, 191, 36, 0.12);
 }
 
 .warn {

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.module.css.d.ts
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.module.css.d.ts
@@ -10,6 +10,13 @@ declare const styles: {
   readonly providerCell: string;
   readonly providerName: string;
   readonly dot: string;
+  readonly dotClosed: string;
+  readonly dotOpen: string;
+  readonly dotHalfOpen: string;
+  readonly circuitBadge: string;
+  readonly badgeClosed: string;
+  readonly badgeOpen: string;
+  readonly badgeHalfOpen: string;
   readonly warn: string;
   readonly errorRate: string;
   readonly sparkCol: string;

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -1,5 +1,5 @@
 import styles from "./provider-scoreboard.module.css";
-import type { OverviewWindow, ProviderRow } from "~/clients/backend-client.server";
+import type { OverviewWindow, ProviderCircuitState, ProviderRow } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber, formatPercent } from "../../utils/format";
 
 export type ProviderScoreboardProps = {
@@ -18,7 +18,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
             </div>
 
             {providers.length === 0 ? (
-                <div className={styles.empty}>No fetches yet.</div>
+                <div className={styles.empty}>No providers configured.</div>
             ) : (
                 <div className={styles.tableWrap}>
                 <table className={styles.table}>
@@ -37,12 +37,20 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                     <tbody>
                         {providers.map(p => {
                             const share = total > 0 ? (p.articles / total) * 100 : 0;
+                            const circuitState = p.circuitState ?? "closed";
                             return (
                                 <tr key={p.provider}>
                                     <td>
-                                        <div className={styles.providerCell} title={p.nickname?.trim() || p.provider}>
-                                            <span className={styles.dot} />
+                                        <div
+                                            className={styles.providerCell}
+                                            title={buildProviderTooltip(p, circuitState)}>
+                                            <span className={`${styles.dot} ${dotClass(circuitState)}`} />
                                             <span className={styles.providerName}>{p.nickname?.trim() || p.provider}</span>
+                                            {circuitState !== "closed" && (
+                                                <span className={`${styles.circuitBadge} ${badgeClass(circuitState)}`}>
+                                                    {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                                                </span>
+                                            )}
                                         </div>
                                     </td>
                                     <td className={styles.sparkCol}>
@@ -71,6 +79,50 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
             )}
         </div>
     );
+}
+
+function dotClass(state: ProviderCircuitState) {
+    switch (state) {
+        case "open": return styles.dotOpen;
+        case "halfOpen": return styles.dotHalfOpen;
+        default: return styles.dotClosed;
+    }
+}
+
+function badgeClass(state: ProviderCircuitState) {
+    switch (state) {
+        case "open": return styles.badgeOpen;
+        case "halfOpen": return styles.badgeHalfOpen;
+        default: return styles.badgeClosed;
+    }
+}
+
+function circuitLabel(state: ProviderCircuitState, cooldownRemainingSeconds?: number | null) {
+    if (state === "open") {
+        return cooldownRemainingSeconds != null && cooldownRemainingSeconds > 0
+            ? `Tripped · ${cooldownRemainingSeconds}s`
+            : "Tripped";
+    }
+    if (state === "halfOpen") return "Probing";
+    return "Healthy";
+}
+
+function buildProviderTooltip(p: ProviderRow, state: ProviderCircuitState) {
+    const lines = [p.nickname?.trim() || p.provider];
+    if (state === "open") {
+        lines.push("Circuit open — provider temporarily skipped after repeated failures.");
+        if (p.cooldownRemainingSeconds != null && p.cooldownRemainingSeconds > 0)
+            lines.push(`Retry in about ${p.cooldownRemainingSeconds}s.`);
+    } else if (state === "halfOpen") {
+        lines.push("Circuit half-open — one probe request may test recovery.");
+    } else {
+        lines.push("Circuit closed — provider is healthy.");
+    }
+    if (p.lastFailureReason) lines.push(`Last trip: ${p.lastFailureReason}`);
+    if ((p.tripCount ?? 0) > 0) lines.push(`Trips (lifetime): ${p.tripCount}`);
+    if ((p.failureCount ?? 0) > 0) lines.push(`Recorded failures: ${p.failureCount}`);
+    if ((p.articleMissCount ?? 0) > 0) lines.push(`Article misses: ${p.articleMissCount}`);
+    return lines.join("\n");
 }
 
 function Sparkline({ values }: { values: number[] }) {

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -23,6 +23,7 @@ import { useRowOrder } from "./utils/use-row-order";
 import {
     EMPTY_OVERVIEW_STATS,
     mergeOverviewStats,
+    mergeProviderCircuitBreakers,
     type LiveStatsMessage,
     type OverviewStatsResponse,
     type OverviewWindow,
@@ -47,10 +48,10 @@ const DEFAULT_ROW_ORDER = [
     "liveTiles",
     "liveReads",
     "throughput",
+    "providers",
     "activity",
     "latency",
     "errorsSessions",
-    "providers",
     "failover",
     "indexers",
     "indexerApiUsage",
@@ -167,7 +168,8 @@ export default function Overview(_props: Route.ComponentProps) {
                     articlesPerMinute: live.articlesPerMinute,
                     errorsPerMinute: live.errorsPerMinute,
                     bytesServedPerMinute: live.bytesServedPerMinute,
-                }
+                },
+                providers: mergeProviderCircuitBreakers(s.providers, live.providerBreakers),
             }));
             setLastLiveStatsAt(Date.now());
             setTransportFailed(false);

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EMPTY_OVERVIEW_STATS, mergeOverviewStats } from "./merge-overview-stats";
+import { EMPTY_OVERVIEW_STATS, mergeOverviewStats, mergeProviderCircuitBreakers } from "./merge-overview-stats";
 import type { OverviewStatsResponse } from "~/clients/backend-client.server";
 
 function partial(overrides: Partial<OverviewStatsResponse> & { includedSections: string[] }): OverviewStatsResponse {
@@ -59,5 +59,35 @@ describe("mergeOverviewStats", () => {
         expect(withDetail.throughput).toHaveLength(1);
         expect(withDetail.latency.p50Ms).toBe(12);
         expect(withDetail.errors).toEqual([{ status: "Missing", count: 3 }]);
+    });
+
+    it("merges live breaker updates without wiping historical provider columns", () => {
+        const providers = mergeProviderCircuitBreakers(
+            [{
+                provider: "11111111-1111-1111-1111-111111111111",
+                nickname: "Primary",
+                articles: 12,
+                bytesFetched: 1000,
+                errors: 1,
+                retries: 0,
+                avgDurationMs: 40,
+                errorRate: 0.08,
+                spark: [1, 2],
+            }],
+            [{
+                provider: "11111111-1111-1111-1111-111111111111",
+                nickname: "Primary",
+                circuitState: "open",
+                cooldownRemainingSeconds: 30,
+                lastFailureReason: "3 failures in 3-sample window",
+                tripCount: 1,
+                failureCount: 3,
+                articleMissCount: 0,
+            }],
+        );
+
+        expect(providers[0]?.articles).toBe(12);
+        expect(providers[0]?.circuitState).toBe("open");
+        expect(providers[0]?.cooldownRemainingSeconds).toBe(30);
     });
 });

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -2,6 +2,8 @@ import type {
     LiveStatsMessage,
     OverviewStatsResponse,
     OverviewWindow,
+    ProviderCircuitBreakerRow,
+    ProviderRow,
 } from "~/clients/backend-client.server";
 
 export type { LiveStatsMessage, OverviewStatsResponse, OverviewWindow };
@@ -114,4 +116,44 @@ export function mergeOverviewStats(
         ...new Set([...(prev.includedSections ?? []), ...(partial.includedSections ?? [])]),
     ];
     return next;
+}
+
+export function mergeProviderCircuitBreakers(
+    providers: ProviderRow[],
+    breakers: ProviderCircuitBreakerRow[] | undefined,
+): ProviderRow[] {
+    if (!breakers?.length) return providers;
+
+    const byKey = new Map(providers.map(p => [p.provider, { ...p }]));
+    for (const breaker of breakers) {
+        const existing = byKey.get(breaker.provider);
+        const merged: ProviderRow = {
+            ...(existing ?? {
+                provider: breaker.provider,
+                nickname: breaker.nickname,
+                articles: 0,
+                bytesFetched: 0,
+                errors: 0,
+                retries: 0,
+                avgDurationMs: 0,
+                errorRate: 0,
+                spark: [],
+            }),
+            circuitState: breaker.circuitState,
+            cooldownRemainingSeconds: breaker.cooldownRemainingSeconds,
+            lastFailureReason: breaker.lastFailureReason,
+            tripCount: breaker.tripCount,
+            failureCount: breaker.failureCount,
+            articleMissCount: breaker.articleMissCount,
+        };
+        if (!existing?.nickname && breaker.nickname) merged.nickname = breaker.nickname;
+        byKey.set(breaker.provider, merged);
+    }
+
+    return Array.from(byKey.values()).sort((a, b) => {
+        if (b.articles !== a.articles) return b.articles - a.articles;
+        const aName = (a.nickname ?? a.provider).toLowerCase();
+        const bName = (b.nickname ?? b.provider).toLowerCase();
+        return aName.localeCompare(bName);
+    });
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
@@ -1,5 +1,6 @@
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
 using UsenetSharp.Concurrency;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -135,6 +136,56 @@ public class ConcurrencyTests
         // Further callers are fully open again (not stuck behind a half-open slot).
         Assert.False(breaker.IsTripped);
         Assert.False(breaker.IsTripped);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_GetSnapshotReportsOpenWithCountdown()
+    {
+        var breaker = new ProviderCircuitBreaker("snapshot-open");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+
+        var snapshot = breaker.GetSnapshot();
+
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.NotNull(snapshot.CooldownRemainingSeconds);
+        Assert.True(snapshot.CooldownRemainingSeconds > 0);
+        Assert.Equal(1, snapshot.TripCount);
+        Assert.Equal(3, snapshot.FailureCount);
+        Assert.NotNull(snapshot.LastFailureReason);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_GetSnapshotDoesNotClaimHalfOpenProbe()
+    {
+        var breaker = new ProviderCircuitBreaker("snapshot-half-open");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.ExpireCooldownForTests();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.HalfOpen, snapshot.State);
+
+        // Snapshot reads must not consume the probe slot.
+        Assert.Equal(ProviderCircuitState.HalfOpen, breaker.GetSnapshot().State);
+        Assert.False(breaker.IsTripped);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_RecordArticleNotFoundCountsMissWithoutTripping()
+    {
+        var breaker = new ProviderCircuitBreaker("article-miss");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordArticleNotFound();
+        breaker.RecordArticleNotFound();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Closed, snapshot.State);
+        Assert.Equal(2, snapshot.ArticleMissCount);
+        Assert.Equal(2, snapshot.FailureCount);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
@@ -1,0 +1,53 @@
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+public class ProviderCircuitOverviewEnricherTests
+{
+    private const string KeyA = "11111111-1111-1111-1111-111111111111";
+    private const string KeyB = "22222222-2222-2222-2222-222222222222";
+
+    [Fact]
+    public void EnrichProviders_MergesBreakerFieldsAndAddsConfiguredProvidersWithoutMetrics()
+    {
+        var providers = new List<GetOverviewStatsResponse.ProviderRow>
+        {
+            new()
+            {
+                Provider = KeyA,
+                Nickname = "Primary",
+                Articles = 10,
+                Spark = [1, 2],
+            },
+        };
+        var snapshots = new List<ProviderCircuitRuntimeSnapshot>
+        {
+            new(KeyA, "news.example", ProviderType.Pooled, new ProviderCircuitBreakerSnapshot(
+                ProviderCircuitState.Open, 42, "3 failures in 3-sample window", 1, 3, 0)),
+            new(KeyB, "backup.example", ProviderType.BackupOnly, new ProviderCircuitBreakerSnapshot(
+                ProviderCircuitState.Closed, null, null, 0, 0, 2)),
+        };
+        var labels = new Dictionary<string, string?>
+        {
+            [KeyA] = "Primary",
+            [KeyB] = "Backup",
+        };
+
+        var enriched = ProviderCircuitOverviewEnricher.EnrichProviders(providers, snapshots, labels);
+
+        Assert.Equal(2, enriched.Count);
+        var primary = enriched.Single(p => p.Provider == KeyA);
+        Assert.Equal("open", primary.CircuitState);
+        Assert.Equal(42, primary.CooldownRemainingSeconds);
+        Assert.Equal(10, primary.Articles);
+
+        var backup = enriched.Single(p => p.Provider == KeyB);
+        Assert.Equal("closed", backup.CircuitState);
+        Assert.Equal(0, backup.Articles);
+        Assert.Equal("Backup", backup.Nickname);
+        Assert.Equal(2, backup.ArticleMissCount);
+    }
+}


### PR DESCRIPTION
## Summary
- Expose live provider circuit breaker state (closed / open / half-open, cooldown remaining, last trip reason, lifetime trip/failure/article-miss counters) from `ProviderCircuitBreaker` through `UsenetStreamingClient`.
- Enrich overview `GET /api/get-overview-stats?sections=window` provider rows and the `ls` websocket payload so the Providers card can show status in real time.
- Render status on the Overview Providers card (dot + badge + tooltip) and move that card under the throughput chart / above the activity heatmap.

Refs #162 (remaining scope item 1: breaker observability)

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ProviderCircuit|FullyQualifiedName~ConcurrencyTests.ProviderCircuit"` — 12 passed
- [x] Frontend `npm run typecheck` and `npm test -- merge-overview-stats.test.ts`
- [ ] Open Overview with providers configured: Providers card appears under throughput chart
- [ ] Healthy providers show a green status dot
- [ ] After forcing a trip (or during a real provider outage): red "Tripped · Ns" badge and tooltip with last failure reason
- [ ] After cooldown: amber "Probing" while half-open, then green again on recovery
- [ ] Live updates arrive via `ls` websocket without waiting for the 30s REST poll
- [ ] Configured providers with zero historical fetches still appear with circuit state