### PR TITLE
fix(usenet): container no longer boot-loops after upgrading with a large metrics database

### DIFF
--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -22,18 +22,27 @@ public static class UsenetProviderIdentity
     }
 
     /// <summary>
-    /// Assigns missing ProviderIds, persists them to the main config DB, and remaps
-    /// legacy host-keyed metrics rows. Must run after config load and metrics DB
-    /// migration, before UsenetStreamingClient is constructed.
+    /// Assigns missing ProviderIds and persists them to the main config DB. Must run
+    /// after config load, before UsenetStreamingClient is constructed. Never throws:
+    /// startup must not fail over metrics keying, and the connection pool self-heals
+    /// missing ids at construction time.
     /// </summary>
     public static async Task EnsureAsync(ConfigManager configManager, CancellationToken ct = default)
     {
         var providerConfig = configManager.GetUsenetProviderConfig();
         var assigned = EnsureProviderIds(providerConfig);
-        if (assigned)
-            await PersistProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);
+        if (!assigned) return;
 
-        await RemapHostKeyedMetricsAsync(providerConfig, ct).ConfigureAwait(false);
+        try
+        {
+            await PersistProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex,
+                "Failed to persist assigned usenet ProviderIds; continuing with in-memory ids. " +
+                "Metrics keys may not be stable across restarts until a save succeeds.");
+        }
     }
 
     /// <summary>
@@ -126,6 +135,12 @@ public static class UsenetProviderIdentity
     /// <summary>
     /// Remaps legacy host-keyed metrics onto ProviderId keys. When multiple config
     /// entries share a host, only the first inherits the historical rows.
+    ///
+    /// Designed to run in the background after startup: it never throws, and each
+    /// merge commits in its own short transaction so an interrupted run (shutdown,
+    /// container kill) resumes where it left off instead of restarting from zero.
+    /// Raw SegmentFetches rows are intentionally not remapped — they expire within
+    /// 24 hours and rewriting them is what made large databases stall at startup.
     /// </summary>
     public static async Task RemapHostKeyedMetricsAsync(
         UsenetProviderConfig config,
@@ -135,7 +150,6 @@ public static class UsenetProviderIdentity
         if (config.Providers.Count == 0) return;
 
         var seenHosts = new HashSet<string>(StringComparer.Ordinal);
-        await using var tx = await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
         try
         {
             var remapped = 0;
@@ -148,13 +162,9 @@ public static class UsenetProviderIdentity
                     continue;
 
                 var metricsKey = MetricsKey(provider);
-                var hasHostHourly = await db.ProviderHourly
-                    .AnyAsync(x => x.Provider == host, ct)
-                    .ConfigureAwait(false);
-                var hasAnyHostKeyed = hasHostHourly
-                    || await db.ProviderMinutes
+                var hasAnyHostKeyed = await db.ProviderHourly
                         .AnyAsync(x => x.Provider == host, ct).ConfigureAwait(false)
-                    || await db.SegmentFetches
+                    || await db.ProviderMinutes
                         .AnyAsync(x => x.Provider == host, ct).ConfigureAwait(false)
                     || await db.FailoverMisses
                         .AnyAsync(x => x.FromProvider == host || x.ToProvider == host, ct)
@@ -166,81 +176,93 @@ public static class UsenetProviderIdentity
 
                 await MergeProviderMinutesAsync(db, host, metricsKey, ct).ConfigureAwait(false);
                 await MergeProviderHourlyAsync(db, host, metricsKey, ct).ConfigureAwait(false);
-                await RemapSegmentFetchesAsync(db, host, metricsKey, ct).ConfigureAwait(false);
                 await RemapFailoverMissesAsync(db, host, metricsKey, ct).ConfigureAwait(false);
                 await MergeFailoverHourlyAsync(db, host, metricsKey, ct).ConfigureAwait(false);
                 remapped++;
             }
 
-            await db.SaveChangesAsync(ct).ConfigureAwait(false);
-            await tx.CommitAsync(ct).ConfigureAwait(false);
             if (remapped > 0)
                 Log.Information("Remapped host-keyed metrics rows onto ProviderId for {Count} provider(s).", remapped);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            Log.Information("Host-keyed metrics remap interrupted by shutdown; it will resume on next startup.");
+        }
         catch (Exception ex)
         {
-            await tx.RollbackAsync(ct).ConfigureAwait(false);
             Log.Warning(ex, "Failed to remap host-keyed provider metrics; continuing with ProviderId keys going forward.");
         }
     }
 
-    private static async Task MergeProviderMinutesAsync(
-        MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
+    /// <summary>
+    /// Runs a merge-and-delete pair atomically so a mid-run interruption can never
+    /// double-count rows when the remap is retried on the next startup.
+    /// </summary>
+    private static async Task ExecuteAtomicallyAsync(
+        MetricsDbContext db, CancellationToken ct, Func<Task> work)
     {
-        await db.Database.ExecuteSqlRawAsync(
-            """
-            INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
-            SELECT Minute, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
-            FROM ProviderMinutes WHERE Provider = {1}
-            ON CONFLICT(Minute, Provider) DO UPDATE SET
-                Articles = ProviderMinutes.Articles + excluded.Articles,
-                BytesFetched = ProviderMinutes.BytesFetched + excluded.BytesFetched,
-                Misses = ProviderMinutes.Misses + excluded.Misses,
-                Errors = ProviderMinutes.Errors + excluded.Errors,
-                Retries = ProviderMinutes.Retries + excluded.Retries,
-                FailoverSaves = ProviderMinutes.FailoverSaves + excluded.FailoverSaves,
-                SumDurationMs = ProviderMinutes.SumDurationMs + excluded.SumDurationMs;
-            """,
-            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
-        await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM ProviderMinutes WHERE Provider = {0}",
-            new object[] { host }, ct).ConfigureAwait(false);
+        await using var tx = await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
+        await work().ConfigureAwait(false);
+        await tx.CommitAsync(ct).ConfigureAwait(false);
     }
 
-    private static async Task MergeProviderHourlyAsync(
+    private static Task MergeProviderMinutesAsync(
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
-        await db.Database.ExecuteSqlRawAsync(
-            """
-            INSERT INTO ProviderHourly (Hour, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
-            SELECT Hour, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs
-            FROM ProviderHourly WHERE Provider = {1}
-            ON CONFLICT(Hour, Provider) DO UPDATE SET
-                Articles = ProviderHourly.Articles + excluded.Articles,
-                BytesFetched = ProviderHourly.BytesFetched + excluded.BytesFetched,
-                Misses = ProviderHourly.Misses + excluded.Misses,
-                Errors = ProviderHourly.Errors + excluded.Errors,
-                Retries = ProviderHourly.Retries + excluded.Retries,
-                FailoverSaves = ProviderHourly.FailoverSaves + excluded.FailoverSaves,
-                SumDurationMs = ProviderHourly.SumDurationMs + excluded.SumDurationMs;
-            """,
-            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
-        await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM ProviderHourly WHERE Provider = {0}",
-            new object[] { host }, ct).ConfigureAwait(false);
+        return ExecuteAtomicallyAsync(db, ct, async () =>
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+                SELECT Minute, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
+                FROM ProviderMinutes WHERE Provider = {1}
+                ON CONFLICT(Minute, Provider) DO UPDATE SET
+                    Articles = ProviderMinutes.Articles + excluded.Articles,
+                    BytesFetched = ProviderMinutes.BytesFetched + excluded.BytesFetched,
+                    Misses = ProviderMinutes.Misses + excluded.Misses,
+                    Errors = ProviderMinutes.Errors + excluded.Errors,
+                    Retries = ProviderMinutes.Retries + excluded.Retries,
+                    FailoverSaves = ProviderMinutes.FailoverSaves + excluded.FailoverSaves,
+                    SumDurationMs = ProviderMinutes.SumDurationMs + excluded.SumDurationMs;
+                """,
+                new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM ProviderMinutes WHERE Provider = {0}",
+                new object[] { host }, ct).ConfigureAwait(false);
+        });
     }
 
-    private static async Task RemapSegmentFetchesAsync(
+    private static Task MergeProviderHourlyAsync(
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
-        await db.Database.ExecuteSqlRawAsync(
-            "UPDATE SegmentFetches SET Provider = {0} WHERE Provider = {1}",
-            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+        return ExecuteAtomicallyAsync(db, ct, async () =>
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO ProviderHourly (Hour, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
+                SELECT Hour, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs
+                FROM ProviderHourly WHERE Provider = {1}
+                ON CONFLICT(Hour, Provider) DO UPDATE SET
+                    Articles = ProviderHourly.Articles + excluded.Articles,
+                    BytesFetched = ProviderHourly.BytesFetched + excluded.BytesFetched,
+                    Misses = ProviderHourly.Misses + excluded.Misses,
+                    Errors = ProviderHourly.Errors + excluded.Errors,
+                    Retries = ProviderHourly.Retries + excluded.Retries,
+                    FailoverSaves = ProviderHourly.FailoverSaves + excluded.FailoverSaves,
+                    SumDurationMs = ProviderHourly.SumDurationMs + excluded.SumDurationMs;
+                """,
+                new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM ProviderHourly WHERE Provider = {0}",
+                new object[] { host }, ct).ConfigureAwait(false);
+        });
     }
 
     private static async Task RemapFailoverMissesAsync(
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
+        // Single UPDATEs are naturally resumable: rerunning after an interruption
+        // simply matches fewer (or zero) rows.
         await db.Database.ExecuteSqlRawAsync(
             "UPDATE FailoverMisses SET FromProvider = {0} WHERE FromProvider = {1}",
             new object[] { metricsKey, host }, ct).ConfigureAwait(false);
@@ -253,30 +275,36 @@ public static class UsenetProviderIdentity
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
         // Remap FromProvider first, then ToProvider, merging on conflict.
-        await db.Database.ExecuteSqlRawAsync(
-            """
-            INSERT INTO FailoverHourly (Hour, FromProvider, ToProvider, Reason, Count)
-            SELECT Hour, {0}, ToProvider, Reason, Count
-            FROM FailoverHourly WHERE FromProvider = {1}
-            ON CONFLICT(Hour, FromProvider, ToProvider, Reason) DO UPDATE SET
-                Count = FailoverHourly.Count + excluded.Count;
-            """,
-            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
-        await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM FailoverHourly WHERE FromProvider = {0}",
-            new object[] { host }, ct).ConfigureAwait(false);
+        await ExecuteAtomicallyAsync(db, ct, async () =>
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO FailoverHourly (Hour, FromProvider, ToProvider, Reason, Count)
+                SELECT Hour, {0}, ToProvider, Reason, Count
+                FROM FailoverHourly WHERE FromProvider = {1}
+                ON CONFLICT(Hour, FromProvider, ToProvider, Reason) DO UPDATE SET
+                    Count = FailoverHourly.Count + excluded.Count;
+                """,
+                new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM FailoverHourly WHERE FromProvider = {0}",
+                new object[] { host }, ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
 
-        await db.Database.ExecuteSqlRawAsync(
-            """
-            INSERT INTO FailoverHourly (Hour, FromProvider, ToProvider, Reason, Count)
-            SELECT Hour, FromProvider, {0}, Reason, Count
-            FROM FailoverHourly WHERE ToProvider = {1}
-            ON CONFLICT(Hour, FromProvider, ToProvider, Reason) DO UPDATE SET
-                Count = FailoverHourly.Count + excluded.Count;
-            """,
-            new object[] { metricsKey, host }, ct).ConfigureAwait(false);
-        await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM FailoverHourly WHERE ToProvider = {0}",
-            new object[] { host }, ct).ConfigureAwait(false);
+        await ExecuteAtomicallyAsync(db, ct, async () =>
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO FailoverHourly (Hour, FromProvider, ToProvider, Reason, Count)
+                SELECT Hour, FromProvider, {0}, Reason, Count
+                FROM FailoverHourly WHERE ToProvider = {1}
+                ON CONFLICT(Hour, FromProvider, ToProvider, Reason) DO UPDATE SET
+                    Count = FailoverHourly.Count + excluded.Count;
+                """,
+                new object[] { metricsKey, host }, ct).ConfigureAwait(false);
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM FailoverHourly WHERE ToProvider = {0}",
+                new object[] { host }, ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -107,8 +107,9 @@ class Program
             var configManager = new ConfigManager();
             await configManager.LoadConfig().ConfigureAwait(false);
 
-            // Assign stable ProviderIds (persisting if needed) and remap legacy
-            // host-keyed metrics rows before the streaming client is built.
+            // Assign stable ProviderIds (persisting if needed) before the streaming
+            // client is built. Cheap and non-fatal; the heavy legacy-metrics remap
+            // runs in the background after the app starts (see below).
             await UsenetProviderIdentity
                 .EnsureAsync(configManager, SigtermUtil.GetCancellationToken())
                 .ConfigureAwait(false);
@@ -243,6 +244,15 @@ class Program
             app.UseWebdavBasicAuthentication();
             app.UseNWebDav();
             app.Lifetime.ApplicationStopping.Register(SigtermUtil.Cancel);
+            // Remap legacy host-keyed metrics rows onto ProviderIds after the app is
+            // serving. This can rewrite a lot of rows on old databases and must never
+            // delay the /health endpoint: blocking startup on it caused a container
+            // boot-loop (entrypoint kills the backend after its 30s health window).
+            // The remap is chunked, resumable, and never throws.
+            app.Lifetime.ApplicationStarted.Register(() => _ = Task.Run(() =>
+                UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
+                    configManager.GetUsenetProviderConfig(),
+                    SigtermUtil.GetCancellationToken())));
             await app.RunAsync().ConfigureAwait(false);
         }
         catch (Exception exception)

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
@@ -154,6 +154,120 @@ public class ProviderMetricsKeyTests
         Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == secondKey));
     }
 
+    [Fact]
+    public async Task Remap_LeavesRawSegmentFetchRowsUntouched()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "user");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var hour = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        hour -= hour % 3_600_000;
+
+        // Host-keyed rollup row (must merge) and raw fetch row (must be skipped —
+        // rewriting SegmentFetches at startup is what caused the 0.7.17 boot loop).
+        harness.Context.ProviderHourly.Add(new ProviderHourly
+        {
+            Hour = hour,
+            Provider = "news.example.com",
+            BytesFetched = 1234,
+        });
+        harness.Context.SegmentFetches.Add(new SegmentFetch
+        {
+            At = hour,
+            Provider = "news.example.com",
+            Bytes = 42,
+            Status = SegmentFetch.FetchStatus.Ok,
+        });
+        await harness.Context.SaveChangesAsync();
+
+        await UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
+            new UsenetProviderConfig { Providers = [provider] },
+            harness.Context);
+
+        await using var verify = harness.CreateContext();
+        Assert.True(await verify.SegmentFetches.AnyAsync(x => x.Provider == "news.example.com"));
+        Assert.False(await verify.SegmentFetches.AnyAsync(x => x.Provider == key));
+        var hourly = await verify.ProviderHourly.SingleAsync(x => x.Provider == key);
+        Assert.Equal(1234, hourly.BytesFetched);
+        Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == "news.example.com"));
+    }
+
+    [Fact]
+    public async Task Remap_DoesNotThrowWhenMetricsDatabaseIsUnusable()
+    {
+        // Un-migrated database: every table query throws "no such table". The remap
+        // must contain the failure — throwing here used to crash backend startup.
+        var dir = Path.Combine(Path.GetTempPath(), $"nzbdav-metrics-broken-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={Path.Combine(dir, "metrics.sqlite")}")
+                .Options;
+            await using var context = new MetricsDbContext(options);
+
+            await UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
+                new UsenetProviderConfig { Providers = [MakeProvider("news.example.com", "user")] },
+                context);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task Remap_ResumesAfterPartialRunWithoutDoubleCounting()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "user");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var hour = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        hour -= hour % 3_600_000;
+        var minute = hour;
+
+        // Simulate a run that committed the ProviderMinutes merge and was then
+        // killed: minute rows are already id-keyed, hourly rows are still host-keyed.
+        harness.Context.ProviderMinutes.Add(new ProviderMinute
+        {
+            Minute = minute,
+            Provider = key,
+            BytesFetched = 700,
+            Articles = 7,
+        });
+        harness.Context.ProviderHourly.Add(new ProviderHourly
+        {
+            Hour = hour,
+            Provider = "news.example.com",
+            BytesFetched = 700,
+            Articles = 7,
+        });
+        await harness.Context.SaveChangesAsync();
+
+        await UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
+            new UsenetProviderConfig { Providers = [provider] },
+            harness.Context);
+
+        await using var verify = harness.CreateContext();
+        var minuteRow = await verify.ProviderMinutes.SingleAsync(x => x.Provider == key);
+        Assert.Equal(700, minuteRow.BytesFetched);
+        Assert.Equal(7, minuteRow.Articles);
+        var hourly = await verify.ProviderHourly.SingleAsync(x => x.Provider == key);
+        Assert.Equal(700, hourly.BytesFetched);
+        Assert.Equal(7, hourly.Articles);
+        Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == "news.example.com"));
+
+        // A second full run is a no-op (nothing left to remap).
+        await using (var rerun = harness.CreateContext())
+        {
+            await UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
+                new UsenetProviderConfig { Providers = [provider] }, rerun);
+        }
+        await using var verifyAgain = harness.CreateContext();
+        Assert.Equal(700, (await verifyAgain.ProviderHourly.SingleAsync(x => x.Provider == key)).BytesFetched);
+    }
+
     private static UsenetProviderConfig.ConnectionDetails MakeProvider(
         string host,
         string user,


### PR DESCRIPTION
## Summary

Fixes the 0.7.17+ startup boot loop reported by users upgrading from 0.7.16 ("Backend failed health check after 30 retries. Exiting." looping forever; frontend shows `/login` 500 and `/api/migration-status` 502).

**Root cause:** the ProviderId metrics remap introduced in 0.7.17 (`UsenetProviderIdentity.EnsureAsync`) ran synchronously in normal backend startup, before Kestrel binds :8080, inside one large transaction that rewrote up to 24h of `SegmentFetches` rows (potentially millions). On large metrics databases / slow storage this exceeded the entrypoint's 30x1s health window; the container was killed mid-transaction, SQLite rolled everything back, and the next boot restarted the remap from zero - an infinite loop. `BeginTransactionAsync` and the ConfigItems persist were also outside the try/catch, so a locked metrics DB crashed the process outright.

**Changes:**
- Startup now only assigns missing ProviderIds and persists them, fully guarded - it can no longer throw or block (the connection pool already self-heals missing ids).
- The legacy host-keyed metrics remap runs as a background task after `ApplicationStarted`, so `/health` responds immediately.
- The remap no longer rewrites raw `SegmentFetches` rows (24h TTL - they age out on their own); only the long-lived rollup tables (`ProviderMinutes`, `ProviderHourly`, `FailoverMisses`, `FailoverHourly`) are merged.
- Each merge-and-delete pair commits in its own short transaction, so an interrupted run resumes with forward progress instead of restarting, and cannot double-count on retry.
- All remap failures (including cancellation at shutdown) are contained and logged; the remap can never take down the backend.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` - 515 passed, 11 skipped (rapidyenc)
- [x] New regression tests: remap leaves raw SegmentFetches untouched, does not throw on an unusable metrics DB, and resumes a partially-completed remap without double-counting
- [ ] Manual: seed a metrics.sqlite with host-keyed rows, confirm :8080 binds immediately and the remap completes in the background