### PR TITLE
fix(ui): detect updates for main-<sha> builds via version-embedded SHA

### DIFF
--- a/frontend/app/utils/update-check.server.test.ts
+++ b/frontend/app/utils/update-check.server.test.ts
@@ -247,6 +247,47 @@ describe("checkForUpdate", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/releases/latest");
   });
+
+  it("does not compare release builds using version-embedded SHAs", async () => {
+    getBuildCommitMock.mockResolvedValue({
+      sha: "e0eef520",
+      branch: "main",
+      source: "version",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        tag_name: "v0.7.5",
+        html_url: "https://github.com/nzbdav/nzbdav/releases/tag/v0.7.5",
+      }),
+    );
+
+    await expect(checkForUpdate("0.7.5")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/releases/latest");
+  });
+
+  it("notifies main-<sha> builds when main is ahead", async () => {
+    getBuildCommitMock.mockResolvedValue({
+      sha: "e0eef520",
+      branch: "main",
+      source: "version",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: "ahead",
+        ahead_by: 2,
+        html_url: "https://github.com/nzbdav/nzbdav/compare/e0eef520...main",
+      }),
+    );
+
+    await expect(checkForUpdate("main-e0eef520")).resolves.toEqual({
+      kind: "dev",
+      commitsBehind: 2,
+      compareUrl: "https://github.com/nzbdav/nzbdav/compare/e0eef520...main",
+    });
+    expect(getBuildCommitMock).toHaveBeenCalledWith({ version: "main-e0eef520" });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/compare/e0eef520...main");
+  });
 });
 
 describe("checkForUpdate (dev builds)", () => {

--- a/frontend/app/utils/update-check.server.ts
+++ b/frontend/app/utils/update-check.server.ts
@@ -217,8 +217,11 @@ async function checkForReleaseUpdate(
   };
 }
 
-async function checkForDevUpdate(localGitOnly = false): Promise<DevUpdateAvailable | null> {
-  const build = await getBuildCommit();
+async function checkForDevUpdate(
+  localGitOnly = false,
+  currentVersion?: string | null,
+): Promise<DevUpdateAvailable | null> {
+  const build = await getBuildCommit({ version: currentVersion });
   if (!build) return null;
   if (localGitOnly && build.source !== "git") return null;
 
@@ -251,5 +254,7 @@ export async function checkForUpdate(
     return checkForDevUpdate(true);
   }
 
-  return checkForDevUpdate();
+  // Non-comparable versions (e.g. `main-<sha>`) may embed the build commit in
+  // the version label itself, so pass it along as a fallback SHA source.
+  return checkForDevUpdate(false, currentVersion);
 }

--- a/frontend/app/utils/version.server.test.ts
+++ b/frontend/app/utils/version.server.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getBuildCommit } from "./version.server";
+import { getBuildCommit, parseBuildCommitFromVersion } from "./version.server";
 
 describe("getBuildCommit", () => {
   const originalEnv = process.env.NZBDAV_COMMIT_SHA;
@@ -32,7 +32,7 @@ describe("getBuildCommit", () => {
       "1111111111111111111111111111111111111111\n",
     );
 
-    await expect(getBuildCommit(tempGitDir)).resolves.toEqual({
+    await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toEqual({
       sha: "abcdef0123456789abcdef0123456789abcdef01",
       branch: "main",
       source: "env",
@@ -41,7 +41,7 @@ describe("getBuildCommit", () => {
 
   it("rejects invalid NZBDAV_COMMIT_SHA values", async () => {
     process.env.NZBDAV_COMMIT_SHA = "not-a-sha";
-    await expect(getBuildCommit(tempGitDir)).resolves.toBeUndefined();
+    await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toBeUndefined();
   });
 
   it("resolves SHA from refs/heads/main", async () => {
@@ -52,7 +52,7 @@ describe("getBuildCommit", () => {
       "abcdef0123456789abcdef0123456789abcdef01\n",
     );
 
-    await expect(getBuildCommit(tempGitDir)).resolves.toEqual({
+    await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toEqual({
       sha: "abcdef0123456789abcdef0123456789abcdef01",
       branch: "main",
       source: "git",
@@ -71,7 +71,7 @@ describe("getBuildCommit", () => {
       ].join("\n"),
     );
 
-    await expect(getBuildCommit(tempGitDir)).resolves.toEqual({
+    await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toEqual({
       sha: "abcdef0123456789abcdef0123456789abcdef01",
       branch: "main",
       source: "git",
@@ -84,7 +84,7 @@ describe("getBuildCommit", () => {
       "abcdef0123456789abcdef0123456789abcdef01\n",
     );
 
-    await expect(getBuildCommit(tempGitDir)).resolves.toBeUndefined();
+    await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toBeUndefined();
   });
 
   it("returns undefined for non-main branches", async () => {
@@ -95,10 +95,87 @@ describe("getBuildCommit", () => {
       "abcdef0123456789abcdef0123456789abcdef01\n",
     );
 
-    await expect(getBuildCommit(tempGitDir)).resolves.toBeUndefined();
+    await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toBeUndefined();
   });
 
   it("returns undefined when .git is missing", async () => {
-    await expect(getBuildCommit(join(tempGitDir, "missing"))).resolves.toBeUndefined();
+    await expect(
+      getBuildCommit({ gitDir: join(tempGitDir, "missing") }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("falls back to a SHA embedded in a main-<sha> version label", async () => {
+    await expect(
+      getBuildCommit({ gitDir: join(tempGitDir, "missing"), version: "main-E0EEF520" }),
+    ).resolves.toEqual({
+      sha: "e0eef520",
+      branch: "main",
+      source: "version",
+    });
+  });
+
+  it("prefers NZBDAV_COMMIT_SHA over the version-embedded SHA", async () => {
+    process.env.NZBDAV_COMMIT_SHA = "abcdef0123456789abcdef0123456789abcdef01";
+
+    await expect(
+      getBuildCommit({ gitDir: join(tempGitDir, "missing"), version: "main-e0eef520" }),
+    ).resolves.toEqual({
+      sha: "abcdef0123456789abcdef0123456789abcdef01",
+      branch: "main",
+      source: "env",
+    });
+  });
+
+  it("prefers local git over the version-embedded SHA", async () => {
+    await writeFile(join(tempGitDir, "HEAD"), "ref: refs/heads/main\n");
+    await mkdir(join(tempGitDir, "refs", "heads"), { recursive: true });
+    await writeFile(
+      join(tempGitDir, "refs", "heads", "main"),
+      "abcdef0123456789abcdef0123456789abcdef01\n",
+    );
+
+    await expect(
+      getBuildCommit({ gitDir: tempGitDir, version: "main-e0eef520" }),
+    ).resolves.toEqual({
+      sha: "abcdef0123456789abcdef0123456789abcdef01",
+      branch: "main",
+      source: "git",
+    });
+  });
+
+  it("ignores version labels that do not embed a commit SHA", async () => {
+    for (const version of ["pre-42", "0.7.20", "main-", "main-xyz", "dev-abc1234"]) {
+      await expect(
+        getBuildCommit({ gitDir: join(tempGitDir, "missing"), version }),
+      ).resolves.toBeUndefined();
+    }
+  });
+});
+
+describe("parseBuildCommitFromVersion", () => {
+  it.each([
+    ["main-e0eef520", "e0eef520"],
+    ["Main-E0EEF520", "e0eef520"],
+    ["  main-abcdef0123456789abcdef0123456789abcdef01  ", "abcdef0123456789abcdef0123456789abcdef01"],
+  ])("parses %s", (version, expectedSha) => {
+    expect(parseBuildCommitFromVersion(version)).toEqual({
+      sha: expectedSha,
+      branch: "main",
+      source: "version",
+    });
+  });
+
+  it.each([
+    [undefined],
+    [null],
+    [""],
+    ["0.7.20"],
+    ["pre-42"],
+    ["main-"],
+    ["main-xyz123"],
+    ["main-abc123"], // 6 hex chars — too short
+    ["feature-e0eef520"],
+  ])("returns undefined for %s", (version) => {
+    expect(parseBuildCommitFromVersion(version)).toBeUndefined();
   });
 });

--- a/frontend/app/utils/version.server.ts
+++ b/frontend/app/utils/version.server.ts
@@ -7,7 +7,13 @@ const gitDirPath = resolve(process.cwd(), "..", ".git");
 export type BuildCommit = {
   sha: string;
   branch: string;
-  source: "env" | "git";
+  source: "env" | "git" | "version";
+};
+
+type BuildCommitOptions = {
+  gitDir?: string;
+  /** Version label that may embed a commit SHA (e.g. `main-e0eef520`). */
+  version?: string | null;
 };
 
 export async function getAppVersion(): Promise<string | undefined> {
@@ -28,19 +34,35 @@ export async function getAppVersion(): Promise<string | undefined> {
  * Preference order:
  * 1. `NZBDAV_COMMIT_SHA` env (baked into Docker images)
  * 2. Local `.git` checkout when HEAD is on `main`
+ * 3. Commit SHA embedded in the version label (`main-<sha>` builds)
  *
  * Non-main branches and detached HEAD return undefined so feature-branch /
  * fork checkouts do not produce false update notifications.
  */
 export async function getBuildCommit(
-  gitDir: string = gitDirPath,
+  options: BuildCommitOptions = {},
 ): Promise<BuildCommit | undefined> {
+  const { gitDir = gitDirPath, version } = options;
+
   const envSha = process.env.NZBDAV_COMMIT_SHA?.trim();
   if (envSha && isValidSha(envSha)) {
     return { sha: envSha.toLowerCase(), branch: "main", source: "env" };
   }
 
-  return readLocalMainCommit(gitDir);
+  const local = await readLocalMainCommit(gitDir);
+  if (local) return local;
+
+  return parseBuildCommitFromVersion(version);
+}
+
+/** Parse a commit SHA embedded in a `main-<sha>` version label. */
+export function parseBuildCommitFromVersion(
+  version: string | undefined | null,
+): BuildCommit | undefined {
+  if (!version) return undefined;
+  const match = /^main-([0-9a-f]{7,40})$/i.exec(version.trim());
+  if (!match) return undefined;
+  return { sha: match[1].toLowerCase(), branch: "main", source: "version" };
 }
 
 async function readLocalMainCommit(gitDir: string): Promise<BuildCommit | undefined> {


### PR DESCRIPTION
## Summary
- Builds labeled `main-<sha>` (non-semver) take the dev update path, but `getBuildCommit()` only looked at `NZBDAV_COMMIT_SHA` or a local `.git` checkout — the SHA embedded in the version label itself was ignored, so Docker images without either source never notified about new commits on `main`.
- Add `parseBuildCommitFromVersion()` matching `main-<7-40 hex chars>` and use it as a final fallback (after env SHA and local git) with a distinct `source: "version"`.
- Wire `currentVersion` into `checkForDevUpdate` for the non-comparable path. Release images stay release-only: the `localGitOnly` guard still filters out non-`git` sources, so semver builds with env or version-derived SHAs are unchanged.

## Test plan
- [x] `npm run typecheck && npm run build && npm test` (192 tests pass)
- [x] New tests: `main-<sha>` parse (case/whitespace/too-short/non-hex), env > git > version precedence, `checkForUpdate("main-e0eef520")` notifies when GitHub compare reports `main` ahead, release builds never compare via version-embedded SHAs