### PR TITLE
feat(api): opt-in playback stream tracing for debugging seek and zero-fill issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,36 @@ cd frontend && npm install && npm run dev
 
 `npm run dev` silently runs `scripts/sync-dev-env.sh` via the `predev` hook; if the API key drifts, restart the backend with `scripts/run-backend.sh`. The manual `dotnet publish` / env-var flow below remains supported.
 
+`scripts/run-backend.sh` defaults `LOG_LEVEL=Debug` (and `LOG_BUFFER_SIZE=2000`, `STREAM_TRACE_EVENTS=20000`) when unset so local playback debugging is verbose. Docker/production leave these unset and keep Information-level logging.
+
+Stream tracing is **opt-in**: it only runs when `STREAM_TRACE_EVENTS` is set to a positive value (the run script does this for local dev). When unset or `0` — the Docker/production default — no trace events are recorded and the trace APIs report `enabled: false`.
+
 yEnc-decoding tests are skipped on platforms where the rapidyenc native library is unavailable (currently macOS arm64); they run in Linux CI.
+
+## Real-provider playback testing
+
+Use the two-process workflow above with a real Usenet provider (credentials stay in SQLite under `CONFIG_PATH`; never commit them).
+
+1. Start backend + frontend (`./scripts/run-backend.sh`, then `cd frontend && npm run dev`).
+2. Open `http://localhost:5173` → create the admin account if needed.
+3. **Settings → Usenet** — add your provider (host, port, SSL, credentials, connections). Use Test connection / Benchmark if desired.
+4. **Settings → WebDAV** — set a WebDAV username/password (required for rclone and most players).
+5. Drop an `.nzb` on the Queue page and wait for it to mount.
+6. Play via Explore / `/view/...`, or point rclone/VLC at the **frontend** proxy (`http://localhost:5173`), not the backend port directly.
+
+Ports: UI `5173` → proxies WebDAV + `/api` → backend `5000`.
+
+### Dumping a stream trace
+
+While a file is playing, Overview → **Right now** shows a truncated session id (click to copy). After seeking/scrubbing:
+
+```bash
+# Latest active/recent session (or pass an explicit session id)
+./scripts/dump-stream-trace.sh
+./scripts/dump-stream-trace.sh <session-id>
+```
+
+Writes JSON under `swap/` (gitignored), including the correlated range/seek/segment/zero-fill timeline and a recent logs snapshot. Drop that file into chat for analysis. Traces are in-memory only — dump before restarting the backend.
 
 ## Build / run backend
 

--- a/backend/Api/Controllers/GetStreamTrace/GetStreamTraceController.cs
+++ b/backend/Api/Controllers/GetStreamTrace/GetStreamTraceController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services.StreamTrace;
+
+namespace NzbWebDAV.Api.Controllers.GetStreamTrace;
+
+[ApiController]
+[Route("api/get-stream-trace")]
+public class GetStreamTraceController(StreamTraceBuffer buffer) : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        var raw = HttpContext.Request.Query["sessionId"].ToString();
+        if (string.IsNullOrWhiteSpace(raw) || !Guid.TryParse(raw, out var sessionId))
+            throw new BadHttpRequestException("sessionId query parameter is required (GUID).");
+
+        var events = buffer.GetSessionEvents(sessionId);
+        var summary = buffer.ListSessions(500).FirstOrDefault(s => s.SessionId == sessionId);
+
+        return Task.FromResult<IActionResult>(Ok(new GetStreamTraceResponse
+        {
+            Status = true,
+            SessionId = sessionId,
+            Path = summary?.Path,
+            FirstAt = summary?.FirstAt,
+            LastAt = summary?.LastAt,
+            EventCount = events.Count,
+            Events = events,
+        }));
+    }
+}

--- a/backend/Api/Controllers/GetStreamTrace/GetStreamTraceResponse.cs
+++ b/backend/Api/Controllers/GetStreamTrace/GetStreamTraceResponse.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using NzbWebDAV.Services.StreamTrace;
+
+namespace NzbWebDAV.Api.Controllers.GetStreamTrace;
+
+public class GetStreamTraceResponse : BaseApiResponse
+{
+    [JsonPropertyName("sessionId")] public required Guid SessionId { get; init; }
+    [JsonPropertyName("path")] public string? Path { get; init; }
+    [JsonPropertyName("firstAt")] public long? FirstAt { get; init; }
+    [JsonPropertyName("lastAt")] public long? LastAt { get; init; }
+    [JsonPropertyName("eventCount")] public required int EventCount { get; init; }
+    [JsonPropertyName("events")] public required IReadOnlyList<StreamTraceEvent> Events { get; init; }
+}

--- a/backend/Api/Controllers/GetStreamTraces/GetStreamTracesController.cs
+++ b/backend/Api/Controllers/GetStreamTraces/GetStreamTracesController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services.StreamTrace;
+
+namespace NzbWebDAV.Api.Controllers.GetStreamTraces;
+
+[ApiController]
+[Route("api/get-stream-traces")]
+public class GetStreamTracesController(StreamTraceBuffer buffer) : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        var limit = int.TryParse(HttpContext.Request.Query["limit"].ToString(), out var n)
+            ? Math.Clamp(n, 1, 500)
+            : 50;
+
+        var sessions = buffer.ListSessions(limit);
+        return Task.FromResult<IActionResult>(Ok(new GetStreamTracesResponse
+        {
+            Status = true,
+            Enabled = buffer.Enabled,
+            Capacity = buffer.Capacity,
+            Sessions = sessions.Select(s => new StreamTraceSessionDto
+            {
+                SessionId = s.SessionId,
+                Path = s.Path,
+                FirstAt = s.FirstAt,
+                LastAt = s.LastAt,
+                EventCount = s.EventCount,
+                LastKind = s.LastKind,
+            }).ToList(),
+        }));
+    }
+}

--- a/backend/Api/Controllers/GetStreamTraces/GetStreamTracesResponse.cs
+++ b/backend/Api/Controllers/GetStreamTraces/GetStreamTracesResponse.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.Controllers.GetStreamTraces;
+
+public class GetStreamTracesResponse : BaseApiResponse
+{
+    [JsonPropertyName("enabled")] public required bool Enabled { get; init; }
+    [JsonPropertyName("capacity")] public required int Capacity { get; init; }
+    [JsonPropertyName("sessions")] public required IReadOnlyList<StreamTraceSessionDto> Sessions { get; init; }
+}
+
+public class StreamTraceSessionDto
+{
+    [JsonPropertyName("sessionId")] public required Guid SessionId { get; init; }
+    [JsonPropertyName("path")] public string? Path { get; init; }
+    [JsonPropertyName("firstAt")] public required long FirstAt { get; init; }
+    [JsonPropertyName("lastAt")] public required long LastAt { get; init; }
+    [JsonPropertyName("eventCount")] public required int EventCount { get; init; }
+    [JsonPropertyName("lastKind")] public string? LastKind { get; init; }
+}

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -7,9 +7,11 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Par2Recovery;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
 using NzbWebDAV.WebDav.Requests;
@@ -23,7 +25,8 @@ public class GetWebdavItemController(
     ConfigManager configManager,
     ProviderUsageTracker providerUsageTracker,
     ActiveReadRegistry activeReadRegistry,
-    CandidateNegativeCache negativeCache
+    CandidateNegativeCache negativeCache,
+    StreamTraceBuffer streamTrace
 ) : ControllerBase
 {
     private async Task<Stream> GetWebdavItem(GetWebdavItemRequest request)
@@ -125,11 +128,13 @@ public class GetWebdavItemController(
             Response.Headers["Content-Range"] = $"bytes {rangeStart}-{end}/{fileSize}";
             Response.Headers["Content-Length"] = chunkSize.ToString();
             Response.StatusCode = 206;
+            HttpContext.Items["effectiveRangeEnd"] = end;
         }
         else
         {
             RangeContext.SetReadBudget(null);
             Response.Headers["Content-Length"] = fileSize.ToString();
+            HttpContext.Items["effectiveRangeEnd"] = (long?)null;
         }
 
         return stream;
@@ -147,13 +152,45 @@ public class GetWebdavItemController(
             using var scope = providerUsageTracker.BeginScope(sessionId);
             using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
             await using var response = await GetWebdavItem(request);
+            if (response == Stream.Null)
+                return;
             var effectiveStart = (long)(HttpContext.Items["effectiveRangeStart"] ?? 0L);
-            await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, HttpContext.RequestAborted);
+            var rangeEnd = HttpContext.Items["effectiveRangeEnd"] as long?;
+            streamTrace.RangeOpen(
+                sessionId,
+                request.Item,
+                "GET",
+                effectiveStart,
+                rangeEnd,
+                response.CanSeek ? response.Length : null,
+                Request.Headers.UserAgent.ToString(),
+                HttpContext.Connection.RemoteIpAddress?.ToString());
+            try
+            {
+                await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, HttpContext.RequestAborted);
+                FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+            }
+            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                FinishRange(sessionId, ReadSession.EndReasonCode.Aborted);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                FinishRange(sessionId, ReadSession.EndReasonCode.Error, ex.Message);
+                throw;
+            }
         }
         catch (UnauthorizedAccessException)
         {
             Response.StatusCode = 401;
         }
+    }
+
+    private void FinishRange(Guid sessionId, ReadSession.EndReasonCode reason, string? message = null)
+    {
+        activeReadRegistry.SetEndReason(sessionId, reason);
+        streamTrace.RangeEnd(sessionId, reason, activeReadRegistry.GetBytesRead(sessionId), message);
     }
 
     private async Task CopyAndReportAsync(Stream src, Stream dest, Guid sessionId, long startOffset, CancellationToken ct)
@@ -219,8 +256,10 @@ public class GetWebdavItemController(
         // Provisional name from the URL path. GetWebdavItem replaces it with
         // item.Name (the real human-readable filename) once the store lookup runs.
         var fileName = Path.GetFileName(itemPath);
-        var clientKey = $"{HttpContext.Connection.RemoteIpAddress}|{Request.Headers.UserAgent}";
-        return activeReadRegistry.GetOrCreate(itemPath, clientKey, fileName, fileSize: null);
+        var userAgent = Request.Headers.UserAgent.ToString();
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var clientKey = $"{clientIp}|{userAgent}";
+        return activeReadRegistry.GetOrCreate(itemPath, clientKey, fileName, fileSize: null, userAgent, clientIp);
     }
 
     [HttpHead]

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -8,8 +8,10 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
 using Serilog;
+using Serilog.Context;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
@@ -19,7 +21,9 @@ public class MultiProviderNntpClient(
     ProviderUsageTracker? usageTracker = null,
     MetricsWriter? metricsWriter = null,
     ProviderBytesTracker? bytesTracker = null,
-    Func<bool>? cascadeEnabled = null
+    Func<bool>? cascadeEnabled = null,
+    StreamTraceBuffer? streamTrace = null,
+    ActiveReadRegistry? activeReadRegistry = null
 ) : NntpClient, INntpConnectionStats
 {
     public int InFlightConnections => providers.Sum(p => p.InFlightConnections);
@@ -41,13 +45,19 @@ public class MultiProviderNntpClient(
     /// <summary>
     /// Tag the current async flow with a read-session id so SegmentFetch rows
     /// emitted while fulfilling this read can be correlated back to the session.
-    /// Disposing the returned scope restores the previous value.
+    /// Also pushes ReadSessionId into the Serilog LogContext for Debug logs.
+    /// Disposing the returned scope restores the previous values.
     /// </summary>
     public static IDisposable BeginReadSessionScope(Guid readSessionId)
     {
         var previous = ReadSessionScope.Value;
         ReadSessionScope.Value = readSessionId;
-        return new ScopeReleaser(() => ReadSessionScope.Value = previous);
+        var logProp = LogContext.PushProperty("ReadSessionId", readSessionId);
+        return new ScopeReleaser(() =>
+        {
+            logProp.Dispose();
+            ReadSessionScope.Value = previous;
+        });
     }
 
     private sealed class ScopeReleaser(Action onDispose) : IDisposable
@@ -661,6 +671,11 @@ public class MultiProviderNntpClient(
 
     private void RecordFetch(string metricsKey, SegmentFetch.FetchStatus status, long durationMs, int retries)
     {
+        if (ReadSessionScope.Value is { } sessionId)
+        {
+            streamTrace?.Segment(sessionId, metricsKey, status, (int)Math.Min(int.MaxValue, durationMs), retries);
+        }
+
         if (metricsWriter == null) return;
         metricsWriter.RecordFetch(new SegmentFetch
         {
@@ -678,6 +693,12 @@ public class MultiProviderNntpClient(
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses,
         string rescuer)
     {
+        if (priorMisses != null && ReadSessionScope.Value is { } sessionId)
+        {
+            foreach (var (from, reason) in priorMisses)
+                streamTrace?.Failover(sessionId, from, rescuer, reason.ToString());
+        }
+
         if (metricsWriter == null || priorMisses == null) return;
         var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         foreach (var (from, reason) in priorMisses)
@@ -698,9 +719,9 @@ public class MultiProviderNntpClient(
         return result switch
         {
             UsenetDecodedBodyResponse b
-                => (T)(object)(b with { Stream = new CountingYencStream(b.Stream!, bytesTracker, metricsKey) }),
+                => (T)(object)(b with { Stream = new CountingYencStream(b.Stream!, bytesTracker, metricsKey, activeReadRegistry) }),
             UsenetDecodedArticleResponse a
-                => (T)(object)(a with { Stream = new CountingYencStream(a.Stream!, bytesTracker, metricsKey) }),
+                => (T)(object)(a with { Stream = new CountingYencStream(a.Stream!, bytesTracker, metricsKey, activeReadRegistry) }),
             _ => result,
         };
     }

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Websocket;
 using Serilog;
 
@@ -15,8 +16,12 @@ public class UsenetStreamingClient : WrappingNntpClient
         WebsocketManager websocketManager,
         ProviderUsageTracker usageTracker,
         MetricsWriter metricsWriter,
-        ProviderBytesTracker bytesTracker)
-        : base(CreateDownloadingNntpClient(configManager, websocketManager, usageTracker, metricsWriter, bytesTracker))
+        ProviderBytesTracker bytesTracker,
+        StreamTraceBuffer streamTrace,
+        ActiveReadRegistry activeReadRegistry)
+        : base(CreateDownloadingNntpClient(
+            configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
+            streamTrace, activeReadRegistry))
     {
         // when config changes, create a new MultiProviderClient to use instead.
         configManager.OnConfigChanged += (_, configEventArgs) =>
@@ -28,7 +33,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             {
                 // update the connection-pool according to the new config
                 var newUsenetClient = CreateDownloadingNntpClient(
-                    configManager, websocketManager, usageTracker, metricsWriter, bytesTracker);
+                    configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
+                    streamTrace, activeReadRegistry);
                 ReplaceUnderlyingClient(newUsenetClient);
             }
             catch (Exception e)
@@ -46,10 +52,14 @@ public class UsenetStreamingClient : WrappingNntpClient
         WebsocketManager websocketManager,
         ProviderUsageTracker usageTracker,
         MetricsWriter metricsWriter,
-        ProviderBytesTracker bytesTracker
+        ProviderBytesTracker bytesTracker,
+        StreamTraceBuffer streamTrace,
+        ActiveReadRegistry activeReadRegistry
     )
     {
-        var multiProviderClient = CreateMultiProviderClient(configManager, websocketManager, usageTracker, metricsWriter, bytesTracker);
+        var multiProviderClient = CreateMultiProviderClient(
+            configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
+            streamTrace, activeReadRegistry);
         var downloadingClient = new DownloadingNntpClient(multiProviderClient, configManager);
         INntpClient inner = downloadingClient;
         if (configManager.IsSegmentCacheEnabled())
@@ -89,7 +99,9 @@ public class UsenetStreamingClient : WrappingNntpClient
         WebsocketManager websocketManager,
         ProviderUsageTracker usageTracker,
         MetricsWriter metricsWriter,
-        ProviderBytesTracker bytesTracker
+        ProviderBytesTracker bytesTracker,
+        StreamTraceBuffer streamTrace,
+        ActiveReadRegistry activeReadRegistry
     )
     {
         var providerConfig = configManager.GetUsenetProviderConfig();
@@ -109,8 +121,11 @@ public class UsenetStreamingClient : WrappingNntpClient
                 idleTimeoutSeconds
             ))
             .ToList();
-        return new MultiProviderNntpClient(providerClients, usageTracker, metricsWriter, bytesTracker,
-            cascadeEnabled: configManager.IsCascadeEnabled);
+        return new MultiProviderNntpClient(
+            providerClients, usageTracker, metricsWriter, bytesTracker,
+            cascadeEnabled: configManager.IsCascadeEnabled,
+            streamTrace: streamTrace,
+            activeReadRegistry: activeReadRegistry);
     }
 
     private static MultiConnectionNntpClient CreateProviderClient

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -19,6 +19,7 @@ using NzbWebDAV.Middlewares;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
 using NzbWebDAV.WebDav.Base;
@@ -47,6 +48,13 @@ class Program
         var level = Enum.TryParse<LogEventLevel>(envLevel, true, out var parsed) ? parsed : defaultLevel;
         var bufferSize = (int)Math.Clamp(EnvironmentUtil.GetLongVariable("LOG_BUFFER_SIZE") ?? 2000, 100, 50000);
         var logBufferSink = new LogBufferSink(bufferSize);
+        // Stream tracing is opt-in: unset or 0 disables it. scripts/run-backend.sh
+        // enables it for local dev; Docker/production leave it off by default.
+        var streamTraceEvents = EnvironmentUtil.GetLongVariable("STREAM_TRACE_EVENTS") ?? 0;
+        var streamTraceBuffer = new StreamTraceBuffer(
+            (int)Math.Clamp(streamTraceEvents, 100, 200000),
+            enabled: streamTraceEvents > 0);
+        StreamTrace.Configure(streamTraceBuffer);
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Is(level)
             .MinimumLevel.Override("NWebDAV", AtLeast(level, LogEventLevel.Warning))
@@ -76,6 +84,10 @@ class Program
                 "ThreadPool configured with minimum {MinThreads} and maximum {MaxThreads} worker and IOCP threads",
                 minThreads,
                 maxThreads);
+            if (streamTraceBuffer.Enabled)
+                Log.Information(
+                    "Stream tracing enabled with a capacity of {Capacity} events (STREAM_TRACE_EVENTS)",
+                    streamTraceBuffer.Capacity);
 
             // run database migration / restore, if necessary.
             // Restore must run before opening the live DavDatabaseContext so pending
@@ -145,6 +157,7 @@ class Program
                 .AddSingleton(configManager)
                 .AddSingleton(websocketManager)
                 .AddSingleton(logBufferSink)
+                .AddSingleton(streamTraceBuffer)
                 .AddSingleton<BenchmarkGate>()
                 .AddHostedService<LogBroadcaster>()
                 .AddSingleton<ActiveReadRegistry>()

--- a/backend/Services/ActiveReadRegistry.cs
+++ b/backend/Services/ActiveReadRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using NzbWebDAV.Database.Models.Metrics;
 
 namespace NzbWebDAV.Services;
 
@@ -27,7 +28,13 @@ public class ActiveReadRegistry
     private long _totalBytesServed;
     public long TotalBytesServed => Interlocked.Read(ref _totalBytesServed);
 
-    public Guid GetOrCreate(string path, string clientKey, string fileName, long? fileSize)
+    public Guid GetOrCreate(
+        string path,
+        string clientKey,
+        string fileName,
+        long? fileSize,
+        string? clientUserAgent = null,
+        string? clientIp = null)
     {
         var key = BuildKey(path, clientKey);
         var now = DateTimeOffset.UtcNow;
@@ -39,6 +46,8 @@ public class ActiveReadRegistry
             {
                 existing.LastActivityAt = now;
                 if (fileSize is { } size) existing.FileSize = size;
+                if (!string.IsNullOrEmpty(clientUserAgent)) existing.ClientUserAgent = clientUserAgent;
+                if (!string.IsNullOrEmpty(clientIp)) existing.ClientIp = clientIp;
                 return existingId;
             }
 
@@ -50,6 +59,8 @@ public class ActiveReadRegistry
                 FileName = fileName,
                 FileSize = fileSize,
                 ClientKey = clientKey,
+                ClientUserAgent = clientUserAgent,
+                ClientIp = clientIp,
                 StartedAt = now,
                 LastActivityAt = now,
             };
@@ -78,6 +89,22 @@ public class ActiveReadRegistry
                 Interlocked.Exchange(ref entry.CurrentOffset, currentOffset.Value);
         }
     }
+
+    public void AddBytesFetched(Guid id, long bytes)
+    {
+        if (bytes <= 0) return;
+        if (_entries.TryGetValue(id, out var entry))
+            Interlocked.Add(ref entry.BytesFetched, bytes);
+    }
+
+    public void SetEndReason(Guid id, ReadSession.EndReasonCode reason)
+    {
+        if (_entries.TryGetValue(id, out var entry))
+            entry.EndReason = reason;
+    }
+
+    public long GetBytesRead(Guid id)
+        => _entries.TryGetValue(id, out var entry) ? Interlocked.Read(ref entry.BytesRead) : 0;
 
     /// <summary>
     /// Update the user-facing metadata on an existing session. Used once the
@@ -137,9 +164,13 @@ public class ActiveReadRegistry
         public string FileName { get; set; } = "";
         public long? FileSize { get; set; }
         public string ClientKey { get; init; } = "";
+        public string? ClientUserAgent { get; set; }
+        public string? ClientIp { get; set; }
         public DateTimeOffset StartedAt { get; init; }
         public DateTimeOffset LastActivityAt { get; set; }
         public long BytesRead;
+        public long BytesFetched;
+        public ReadSession.EndReasonCode EndReason { get; set; } = ReadSession.EndReasonCode.Completed;
         /// <summary>
         /// Most recent absolute file offset the player has been served (i.e. the
         /// "where the read head is" position). Updated after every chunk so the

--- a/backend/Services/ActiveReadsBroadcaster.cs
+++ b/backend/Services/ActiveReadsBroadcaster.cs
@@ -68,11 +68,11 @@ public class ActiveReadsBroadcaster(
                 Path = entry.Path,
                 FileSize = entry.FileSize,
                 BytesServed = Interlocked.Read(ref entry.BytesRead),
-                BytesFetched = 0, // not measured per-session yet (bytes stream after fetch attribution)
+                BytesFetched = Interlocked.Read(ref entry.BytesFetched),
                 FailoverSaves = (int)Math.Min(int.MaxValue, failoverSaves),
-                ClientUserAgent = null,
-                ClientIp = null,
-                EndReason = ReadSession.EndReasonCode.Completed,
+                ClientUserAgent = entry.ClientUserAgent,
+                ClientIp = entry.ClientIp,
+                EndReason = entry.EndReason,
             });
         }
 

--- a/backend/Services/StreamTrace/StreamTrace.cs
+++ b/backend/Services/StreamTrace/StreamTrace.cs
@@ -1,0 +1,24 @@
+namespace NzbWebDAV.Services.StreamTrace;
+
+/// <summary>
+/// Process-wide accessor for <see cref="StreamTraceBuffer"/> so deep stream
+/// code (MultiSegmentStream, NzbFileStream) can emit without DI plumbing.
+/// Configured once at startup from Program.cs.
+/// </summary>
+public static class StreamTrace
+{
+    private static StreamTraceBuffer? _buffer;
+
+    public static void Configure(StreamTraceBuffer buffer) => _buffer = buffer;
+
+    public static StreamTraceBuffer? Buffer => _buffer;
+
+    public static void TrySeek(Guid sessionId, long offset)
+        => _buffer?.Seek(sessionId, offset);
+
+    public static void TryZeroFill(Guid sessionId, string segmentId, long bytes)
+        => _buffer?.ZeroFill(sessionId, segmentId, bytes);
+
+    public static void TryRetry(Guid sessionId, string segmentId, int attempt, string? message = null)
+        => _buffer?.Retry(sessionId, segmentId, attempt, message);
+}

--- a/backend/Services/StreamTrace/StreamTraceBuffer.cs
+++ b/backend/Services/StreamTrace/StreamTraceBuffer.cs
@@ -1,0 +1,254 @@
+using System.Collections.Concurrent;
+using NzbWebDAV.Database.Models.Metrics;
+
+namespace NzbWebDAV.Services.StreamTrace;
+
+/// <summary>
+/// In-memory ring buffer of playback stream events keyed by ReadSessionId.
+/// Same lifetime model as LogBufferSink: process-local, dump before restart.
+/// </summary>
+public sealed class StreamTraceBuffer
+{
+    private readonly int _capacity;
+    private readonly int _maxSessions;
+    private readonly StreamTraceEvent?[] _buffer;
+    private readonly object _gate = new();
+    private long _nextSequence;
+
+    // Newest session first for summary listing.
+    private readonly ConcurrentDictionary<Guid, SessionMeta> _sessions = new();
+
+    public StreamTraceBuffer(int capacity, int maxSessions = 200, bool enabled = true)
+    {
+        Enabled = enabled;
+        _capacity = Math.Max(100, capacity);
+        _maxSessions = Math.Max(10, maxSessions);
+        _buffer = new StreamTraceEvent?[enabled ? _capacity : 0];
+    }
+
+    public int Capacity => _capacity;
+
+    /// <summary>
+    /// Tracing is opt-in (STREAM_TRACE_EVENTS &gt; 0). When disabled, Record is
+    /// a no-op so production deployments pay no memory or hot-path cost.
+    /// </summary>
+    public bool Enabled { get; }
+
+    public void Record(StreamTraceEvent entry)
+    {
+        if (!Enabled) return;
+        var sequence = Interlocked.Increment(ref _nextSequence);
+        var withSeq = entry with { Sequence = sequence };
+        lock (_gate)
+        {
+            _buffer[(sequence - 1) % _capacity] = withSeq;
+        }
+
+        _sessions.AddOrUpdate(
+            entry.SessionId,
+            _ => new SessionMeta
+            {
+                SessionId = entry.SessionId,
+                FirstAt = entry.AtUnixMs,
+                LastAt = entry.AtUnixMs,
+                Path = entry.Path,
+                EventCount = 1,
+                LastKind = entry.Kind,
+            },
+            (_, existing) =>
+            {
+                existing.LastAt = entry.AtUnixMs;
+                existing.EventCount++;
+                existing.LastKind = entry.Kind;
+                if (!string.IsNullOrEmpty(entry.Path)) existing.Path = entry.Path;
+                return existing;
+            });
+
+        TrimSessionsIfNeeded();
+    }
+
+    public void RangeOpen(
+        Guid sessionId,
+        string path,
+        string method,
+        long rangeStart,
+        long? rangeEnd,
+        long? fileSize,
+        string? userAgent,
+        string? clientIp)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.RangeOpen.ToString(),
+            Path = path,
+            Method = method,
+            RangeStart = rangeStart,
+            RangeEnd = rangeEnd,
+            FileSize = fileSize,
+            UserAgent = userAgent,
+            ClientIp = clientIp,
+        });
+    }
+
+    public void Seek(Guid sessionId, long offset)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.Seek.ToString(),
+            Offset = offset,
+        });
+    }
+
+    public void Segment(
+        Guid sessionId,
+        string provider,
+        SegmentFetch.FetchStatus status,
+        int durationMs,
+        int retries,
+        string? segmentId = null)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.Segment.ToString(),
+            Provider = provider,
+            Status = StreamTraceEvent.StatusName(status),
+            DurationMs = durationMs,
+            Retries = retries,
+            SegmentId = StreamTraceEvent.TruncateSegmentId(segmentId),
+        });
+    }
+
+    public void ZeroFill(Guid sessionId, string segmentId, long bytes, string? message = null)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.ZeroFill.ToString(),
+            SegmentId = StreamTraceEvent.TruncateSegmentId(segmentId),
+            Bytes = bytes,
+            Message = message,
+        });
+    }
+
+    public void Failover(Guid sessionId, string fromProvider, string toProvider, string? reason = null)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.Failover.ToString(),
+            FromProvider = fromProvider,
+            ToProvider = toProvider,
+            Status = reason,
+        });
+    }
+
+    public void Retry(Guid sessionId, string segmentId, int attempt, string? message = null)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.Retry.ToString(),
+            SegmentId = StreamTraceEvent.TruncateSegmentId(segmentId),
+            Attempt = attempt,
+            Message = message,
+        });
+    }
+
+    public void RangeEnd(
+        Guid sessionId,
+        ReadSession.EndReasonCode endReason,
+        long bytesServed,
+        string? message = null)
+    {
+        Record(new StreamTraceEvent
+        {
+            Sequence = 0,
+            AtUnixMs = Now(),
+            SessionId = sessionId,
+            Kind = StreamTraceKind.RangeEnd.ToString(),
+            EndReason = StreamTraceEvent.EndReasonName(endReason),
+            BytesServed = bytesServed,
+            Message = message,
+        });
+    }
+
+    public IReadOnlyList<StreamTraceSessionSummary> ListSessions(int limit = 50)
+    {
+        return _sessions.Values
+            .OrderByDescending(s => s.LastAt)
+            .Take(Math.Clamp(limit, 1, 500))
+            .Select(s => new StreamTraceSessionSummary(
+                s.SessionId,
+                s.Path,
+                s.FirstAt,
+                s.LastAt,
+                s.EventCount,
+                s.LastKind))
+            .ToList();
+    }
+
+    public IReadOnlyList<StreamTraceEvent> GetSessionEvents(Guid sessionId)
+    {
+        if (!Enabled) return [];
+
+        StreamTraceEvent[] copy;
+        lock (_gate)
+        {
+            copy = new StreamTraceEvent[_capacity];
+            _buffer.CopyTo(copy, 0);
+        }
+
+        return copy
+            .Where(e => e is not null && e.SessionId == sessionId)
+            .OrderBy(e => e!.Sequence)
+            .Select(e => e!)
+            .ToList();
+    }
+
+    private void TrimSessionsIfNeeded()
+    {
+        if (_sessions.Count <= _maxSessions) return;
+        var excess = _sessions.Values
+            .OrderBy(s => s.LastAt)
+            .Take(_sessions.Count - _maxSessions)
+            .Select(s => s.SessionId)
+            .ToList();
+        foreach (var id in excess)
+            _sessions.TryRemove(id, out _);
+    }
+
+    private static long Now() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    private sealed class SessionMeta
+    {
+        public Guid SessionId { get; init; }
+        public long FirstAt { get; set; }
+        public long LastAt { get; set; }
+        public string? Path { get; set; }
+        public int EventCount { get; set; }
+        public string? LastKind { get; set; }
+    }
+}
+
+public sealed record StreamTraceSessionSummary(
+    Guid SessionId,
+    string? Path,
+    long FirstAt,
+    long LastAt,
+    int EventCount,
+    string? LastKind);

--- a/backend/Services/StreamTrace/StreamTraceEvent.cs
+++ b/backend/Services/StreamTrace/StreamTraceEvent.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+using NzbWebDAV.Database.Models.Metrics;
+
+namespace NzbWebDAV.Services.StreamTrace;
+
+public sealed record StreamTraceEvent
+{
+    [JsonPropertyName("seq")] public required long Sequence { get; init; }
+    [JsonPropertyName("at")] public required long AtUnixMs { get; init; }
+    [JsonPropertyName("sessionId")] public required Guid SessionId { get; init; }
+    [JsonPropertyName("kind")] public required string Kind { get; init; }
+
+    [JsonPropertyName("path")] public string? Path { get; init; }
+    [JsonPropertyName("method")] public string? Method { get; init; }
+    [JsonPropertyName("rangeStart")] public long? RangeStart { get; init; }
+    [JsonPropertyName("rangeEnd")] public long? RangeEnd { get; init; }
+    [JsonPropertyName("fileSize")] public long? FileSize { get; init; }
+    [JsonPropertyName("userAgent")] public string? UserAgent { get; init; }
+    [JsonPropertyName("clientIp")] public string? ClientIp { get; init; }
+
+    [JsonPropertyName("offset")] public long? Offset { get; init; }
+
+    [JsonPropertyName("provider")] public string? Provider { get; init; }
+    [JsonPropertyName("status")] public string? Status { get; init; }
+    [JsonPropertyName("durationMs")] public int? DurationMs { get; init; }
+    [JsonPropertyName("retries")] public int? Retries { get; init; }
+    [JsonPropertyName("segmentId")] public string? SegmentId { get; init; }
+
+    [JsonPropertyName("bytes")] public long? Bytes { get; init; }
+    [JsonPropertyName("endReason")] public string? EndReason { get; init; }
+    [JsonPropertyName("bytesServed")] public long? BytesServed { get; init; }
+    [JsonPropertyName("fromProvider")] public string? FromProvider { get; init; }
+    [JsonPropertyName("toProvider")] public string? ToProvider { get; init; }
+    [JsonPropertyName("attempt")] public int? Attempt { get; init; }
+    [JsonPropertyName("message")] public string? Message { get; init; }
+
+    public static string StatusName(SegmentFetch.FetchStatus status) => status.ToString();
+
+    public static string EndReasonName(ReadSession.EndReasonCode reason) => reason.ToString();
+
+    /// <summary>
+    /// Truncate a Message-ID for traces (enough to correlate, not full payload noise).
+    /// </summary>
+    public static string? TruncateSegmentId(string? segmentId, int maxLen = 48)
+    {
+        if (string.IsNullOrEmpty(segmentId)) return null;
+        return segmentId.Length <= maxLen ? segmentId : segmentId[..maxLen] + "…";
+    }
+}

--- a/backend/Services/StreamTrace/StreamTraceKind.cs
+++ b/backend/Services/StreamTrace/StreamTraceKind.cs
@@ -1,0 +1,12 @@
+namespace NzbWebDAV.Services.StreamTrace;
+
+public enum StreamTraceKind
+{
+    RangeOpen = 0,
+    Seek = 1,
+    Segment = 2,
+    ZeroFill = 3,
+    Failover = 4,
+    RangeEnd = 5,
+    Retry = 6,
+}

--- a/backend/Streams/CountingYencStream.cs
+++ b/backend/Streams/CountingYencStream.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -16,14 +18,20 @@ public sealed class CountingYencStream : YencStream
     private readonly YencStream _inner;
     private readonly ProviderBytesTracker _tracker;
     private readonly string _providerKey;
+    private readonly ActiveReadRegistry? _activeReadRegistry;
     private long _bytes;
     private long _activeReadTicks;
 
-    public CountingYencStream(YencStream inner, ProviderBytesTracker tracker, string providerKey) : base(Null)
+    public CountingYencStream(
+        YencStream inner,
+        ProviderBytesTracker tracker,
+        string providerKey,
+        ActiveReadRegistry? activeReadRegistry = null) : base(Null)
     {
         _inner = inner;
         _tracker = tracker;
         _providerKey = providerKey;
+        _activeReadRegistry = activeReadRegistry;
     }
 
     public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(CancellationToken cancellationToken = default)
@@ -38,6 +46,8 @@ public sealed class CountingYencStream : YencStream
         {
             _tracker.Add(_providerKey, n);
             _bytes += n;
+            if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+                _activeReadRegistry?.AddBytesFetched(sessionId, n);
         }
         return n;
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Services.StreamTrace;
 using Serilog;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -273,6 +274,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 {
                     Log.Debug(e, "Transient failure fetching segment {SegmentId} (attempt {Attempt}). Retrying.",
                         segmentId, attempt + 1);
+                    if (MultiProviderNntpClient.CurrentReadSessionId is { } retrySession)
+                        StreamTrace.TryRetry(retrySession, segmentId, attempt + 1, e.Message);
                     await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), cancellationToken)
                         .ConfigureAwait(false);
                     continue;
@@ -389,6 +392,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             Log.Warning(messageTemplate, segmentId, _fileName, fill);
         else
             exception.LogWarningKnownOrStack(messageTemplate, segmentId, _fileName, fill);
+        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+            StreamTrace.TryZeroFill(sessionId, segmentId, fill);
         return new MemoryStream(new byte[fill], writable: false);
     }
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
 using Serilog;
 using UsenetSharp.Models;
@@ -109,6 +110,8 @@ public class NzbFileStream(
         {
             _pendingForwardDrain += absoluteOffset - _position;
             _position = absoluteOffset;
+            if (MultiProviderNntpClient.CurrentReadSessionId is { } drainSession)
+                StreamTrace.TrySeek(drainSession, _position);
             return _position;
         }
 
@@ -116,6 +119,8 @@ public class NzbFileStream(
         _innerStream?.Dispose();
         _innerStream = null;
         _pendingForwardDrain = 0;
+        if (MultiProviderNntpClient.CurrentReadSessionId is { } seekSession)
+            StreamTrace.TrySeek(seekSession, _position);
         return _position;
     }
 

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -6,7 +6,9 @@ using NWebDav.Server.Helpers;
 using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.WebDav.Requests;
 
 namespace NzbWebDAV.WebDav.Base;
@@ -26,15 +28,18 @@ public class GetAndHeadHandlerPatch : IRequestHandler
     private readonly IStore _store;
     private readonly ProviderUsageTracker _providerUsageTracker;
     private readonly ActiveReadRegistry _activeReadRegistry;
+    private readonly StreamTraceBuffer _streamTrace;
 
     public GetAndHeadHandlerPatch(
         IStore store,
         ProviderUsageTracker providerUsageTracker,
-        ActiveReadRegistry activeReadRegistry)
+        ActiveReadRegistry activeReadRegistry,
+        StreamTraceBuffer streamTrace)
     {
         _store = store;
         _providerUsageTracker = providerUsageTracker;
         _activeReadRegistry = activeReadRegistry;
+        _streamTrace = streamTrace;
     }
 
     /// <summary>
@@ -186,7 +191,9 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         RangeContext.SetReadBudget(null);
 
                     var path = request.GetUri().AbsolutePath;
-                    var clientKey = $"{httpContext.Connection.RemoteIpAddress}|{request.Headers.UserAgent}";
+                    var userAgent = request.Headers.UserAgent.ToString();
+                    var clientIp = httpContext.Connection.RemoteIpAddress?.ToString();
+                    var clientKey = $"{clientIp}|{userAgent}";
                     // DatabaseStoreIdFile.Name returns the GUID (it backs rclone symlink
                     // targets), so prefer FriendlyName when that's what we got.
                     var fileName = entry switch
@@ -195,12 +202,30 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         _ => !string.IsNullOrEmpty(entry.Name) ? entry.Name : System.IO.Path.GetFileName(path)
                     };
                     var sessionId = _activeReadRegistry.GetOrCreate(
-                        path, clientKey, fileName, stream.CanSeek ? stream.Length : null);
+                        path, clientKey, fileName, stream.CanSeek ? stream.Length : null,
+                        userAgent, clientIp);
+                    _streamTrace.RangeOpen(
+                        sessionId, path, request.Method, copyStart, copyEnd,
+                        stream.CanSeek ? stream.Length : null, userAgent, clientIp);
                     using var scope = _providerUsageTracker.BeginScope(sessionId);
                     using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
-                    await CopyToAsync(stream, response.Body, copyStart, copyEnd,
-                        (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                        httpContext.RequestAborted).ConfigureAwait(false);
+                    try
+                    {
+                        await CopyToAsync(stream, response.Body, copyStart, copyEnd,
+                            (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
+                            httpContext.RequestAborted).ConfigureAwait(false);
+                        FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+                    }
+                    catch (OperationCanceledException) when (httpContext.RequestAborted.IsCancellationRequested)
+                    {
+                        FinishRange(sessionId, ReadSession.EndReasonCode.Aborted);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        FinishRange(sessionId, ReadSession.EndReasonCode.Error, ex.Message);
+                        throw;
+                    }
                 }
             }
             else
@@ -210,6 +235,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
             }
         }
         return true;
+    }
+
+    private void FinishRange(Guid sessionId, ReadSession.EndReasonCode reason, string? message = null)
+    {
+        _activeReadRegistry.SetEndReason(sessionId, reason);
+        _streamTrace.RangeEnd(sessionId, reason, _activeReadRegistry.GetBytesRead(sessionId), message);
     }
 
     private async Task CopyToAsync(

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.module.css
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.module.css
@@ -74,6 +74,24 @@
     min-width: 0;
 }
 
+.sessionId {
+    align-self: flex-start;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 11px;
+    color: var(--text-muted);
+    cursor: pointer;
+    letter-spacing: 0.02em;
+}
+
+.sessionId:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+}
+
 .progressWrap {
     position: relative;
     height: 4px;

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.module.css.d.ts
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.module.css.d.ts
@@ -8,6 +8,7 @@ declare const styles: {
   readonly grid: string;
   readonly card: string;
   readonly fileName: string;
+  readonly sessionId: string;
   readonly progressWrap: string;
   readonly progressFill: string;
   readonly progressIndeterminate: string;

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -65,6 +65,14 @@ export function LiveReadsPanel() {
                             <div className={styles.fileName} title={r.path}>
                                 {r.fileName || lastSegment(r.path)}
                             </div>
+                            <button
+                                type="button"
+                                className={styles.sessionId}
+                                title={`Copy session id: ${r.id}`}
+                                onClick={() => void navigator.clipboard.writeText(r.id)}
+                            >
+                                {shortSessionId(r.id)}
+                            </button>
                             <div className={styles.progressWrap}>
                                 <div
                                     className={pct !== null ? styles.progressFill : styles.progressIndeterminate}
@@ -108,4 +116,8 @@ export function LiveReadsPanel() {
 function lastSegment(path: string): string {
     const idx = path.lastIndexOf("/");
     return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+function shortSessionId(id: string): string {
+    return id.length > 8 ? id.slice(0, 8) : id;
 }

--- a/scripts/dump-stream-trace.sh
+++ b/scripts/dump-stream-trace.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_PATH="${CONFIG_PATH:-/tmp/nzbdav-config}"
+BACKEND_URL="${BACKEND_URL:-http://localhost:5000}"
+API_KEY_FILE="$CONFIG_PATH/.frontend-backend-api-key"
+SWAP_DIR="$ROOT_DIR/swap"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+
+usage() {
+  cat <<'EOF'
+Dump a correlated stream playback trace (and recent logs) into swap/.
+
+Usage: scripts/dump-stream-trace.sh [session-id]
+
+If session-id is omitted, uses the most recently active traced session.
+
+Environment:
+  CONFIG_PATH=/tmp/nzbdav-config
+  BACKEND_URL=http://localhost:5000
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ ! -f "$API_KEY_FILE" ]]; then
+  echo "API key file not found at $API_KEY_FILE (start the backend with scripts/run-backend.sh first)" >&2
+  exit 1
+fi
+
+API_KEY="$(tr -d '[:space:]' < "$API_KEY_FILE")"
+mkdir -p "$SWAP_DIR"
+
+auth_hdr=(-H "x-api-key: $API_KEY")
+
+SESSIONS_JSON="$(curl -fsS "${auth_hdr[@]}" "$BACKEND_URL/api/get-stream-traces?limit=1")"
+ENABLED="$(python3 -c 'import json,sys; print(str(json.load(sys.stdin).get("enabled", False)).lower())' <<<"$SESSIONS_JSON")"
+if [[ "$ENABLED" != "true" ]]; then
+  echo "Stream tracing is disabled (STREAM_TRACE_EVENTS unset or 0)." >&2
+  echo "Start the backend via scripts/run-backend.sh, or export STREAM_TRACE_EVENTS=20000 and restart." >&2
+  exit 1
+fi
+
+SESSION_ID="${1:-}"
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$(python3 -c 'import json,sys; s=json.load(sys.stdin).get("sessions") or []; print(s[0]["sessionId"] if s else "")' <<<"$SESSIONS_JSON")"
+  if [[ -z "$SESSION_ID" ]]; then
+    echo "No stream traces in memory yet. Play a file (with seeking) first." >&2
+    exit 1
+  fi
+  echo "Using latest session: $SESSION_ID"
+fi
+
+OUT_TRACE="$SWAP_DIR/stream-trace-${SESSION_ID}-${TS}.json"
+OUT_LOGS="$SWAP_DIR/stream-logs-${SESSION_ID}-${TS}.json"
+
+curl -fsS "${auth_hdr[@]}" "$BACKEND_URL/api/get-stream-trace?sessionId=$SESSION_ID" -o "$OUT_TRACE"
+curl -fsS "${auth_hdr[@]}" "$BACKEND_URL/api/get-logs?limit=1000&levels=Debug,Information,Warning,Error,Fatal&search=$SESSION_ID" -o "$OUT_LOGS" \
+  || curl -fsS "${auth_hdr[@]}" "$BACKEND_URL/api/get-logs?limit=1000&levels=Warning,Error,Fatal" -o "$OUT_LOGS"
+
+echo "Wrote $OUT_TRACE"
+echo "Wrote $OUT_LOGS"

--- a/scripts/run-backend.sh
+++ b/scripts/run-backend.sh
@@ -28,6 +28,9 @@ Environment (defaults shown):
   CONFIG_PATH=/tmp/nzbdav-config
   BACKEND_URL=http://localhost:5000
   FRONTEND_BACKEND_API_KEY=<persisted in $CONFIG_PATH/.frontend-backend-api-key>
+  LOG_LEVEL=Debug
+  LOG_BUFFER_SIZE=2000
+  STREAM_TRACE_EVENTS=20000
 
 frontend/.env is written automatically for npm run dev.
 EOF
@@ -66,6 +69,10 @@ done
 export CONFIG_PATH="${CONFIG_PATH:-/tmp/nzbdav-config}"
 export BACKEND_URL="${BACKEND_URL:-http://localhost:5000}"
 export ASPNETCORE_URLS="${ASPNETCORE_URLS:-$BACKEND_URL}"
+# Local-dev defaults only (Docker/entrypoint leave LOG_LEVEL unset → Information).
+export LOG_LEVEL="${LOG_LEVEL:-Debug}"
+export LOG_BUFFER_SIZE="${LOG_BUFFER_SIZE:-2000}"
+export STREAM_TRACE_EVENTS="${STREAM_TRACE_EVENTS:-20000}"
 
 API_KEY_FILE="$CONFIG_PATH/.frontend-backend-api-key"
 if [[ -z "${FRONTEND_BACKEND_API_KEY:-}" ]]; then

--- a/tests/NzbWebDAV.Tests/Config/UsenetProvidersValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/UsenetProvidersValidationTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Database.Models;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Config;
@@ -86,7 +87,9 @@ public class UsenetProvidersValidationTests
             new WebsocketManager(),
             new ProviderUsageTracker(),
             new MetricsWriter(),
-            new ProviderBytesTracker());
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
 
         Assert.NotNull(client);
         client.Dispose();

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Queue;
@@ -65,7 +66,9 @@ public class QueueManagerLoopTests
             new WebsocketManager(),
             new ProviderUsageTracker(),
             new MetricsWriter(),
-            new ProviderBytesTracker());
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
 
         return new QueueManager(
             usenet,

--- a/tests/NzbWebDAV.Tests/Services/ActiveReadRegistryEnrichmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ActiveReadRegistryEnrichmentTests.cs
@@ -1,0 +1,42 @@
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class ActiveReadRegistryEnrichmentTests
+{
+    [Fact]
+    public void GetOrCreate_StoresClientMetadata()
+    {
+        var registry = new ActiveReadRegistry();
+        var id = registry.GetOrCreate(
+            "/view/movie.mkv",
+            "127.0.0.1|VLC",
+            "movie.mkv",
+            1024,
+            "VLC/3.0",
+            "127.0.0.1");
+
+        var snap = registry.Snapshot().Single(e => e.Id == id);
+        Assert.Equal("VLC/3.0", snap.ClientUserAgent);
+        Assert.Equal("127.0.0.1", snap.ClientIp);
+        Assert.Equal(ReadSession.EndReasonCode.Completed, snap.EndReason);
+    }
+
+    [Fact]
+    public void SetEndReason_And_AddBytesFetched_UpdateEntry()
+    {
+        var registry = new ActiveReadRegistry();
+        var id = registry.GetOrCreate("/p", "k", "f", 100);
+        registry.AddBytesFetched(id, 40);
+        registry.AddBytesFetched(id, 10);
+        registry.Touch(id, 25, 25);
+        registry.SetEndReason(id, ReadSession.EndReasonCode.Aborted);
+
+        var entry = registry.Snapshot().Single(e => e.Id == id);
+        Assert.Equal(50, Interlocked.Read(ref entry.BytesFetched));
+        Assert.Equal(25, Interlocked.Read(ref entry.BytesRead));
+        Assert.Equal(ReadSession.EndReasonCode.Aborted, entry.EndReason);
+        Assert.Equal(25, registry.GetBytesRead(id));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -1,0 +1,64 @@
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+
+namespace NzbWebDAV.Tests.Services.StreamTrace;
+
+public class StreamTraceBufferTests
+{
+    [Fact]
+    public void Record_PreservesPerSessionOrderingAndCapsBuffer()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+        var sessionA = Guid.NewGuid();
+        var sessionB = Guid.NewGuid();
+
+        buffer.RangeOpen(sessionA, "/view/a.mkv", "GET", 0, 99, 1000, "ua", "127.0.0.1");
+        buffer.Seek(sessionA, 50);
+        buffer.Segment(sessionA, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
+        buffer.RangeOpen(sessionB, "/view/b.mkv", "GET", 0, null, 2000, null, null);
+        buffer.ZeroFill(sessionA, "missing@a", 64);
+        buffer.RangeEnd(sessionA, ReadSession.EndReasonCode.Completed, 100);
+        buffer.Failover(sessionB, "p1", "p2", "Missing");
+
+        var eventsA = buffer.GetSessionEvents(sessionA);
+        Assert.Equal(5, eventsA.Count);
+        Assert.True(eventsA.Zip(eventsA.Skip(1)).All(pair => pair.First.Sequence < pair.Second.Sequence));
+        Assert.Equal(StreamTraceKind.RangeOpen.ToString(), eventsA[0].Kind);
+        Assert.Equal(StreamTraceKind.RangeEnd.ToString(), eventsA[^1].Kind);
+
+        var sessions = buffer.ListSessions();
+        Assert.Contains(sessions, s => s.SessionId == sessionA);
+        Assert.Contains(sessions, s => s.SessionId == sessionB);
+        Assert.Equal(100, buffer.Capacity);
+    }
+
+    [Fact]
+    public void DisabledBuffer_RecordsNothing()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        var session = Guid.NewGuid();
+
+        buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 10, null, null);
+        buffer.Seek(session, 5);
+        buffer.RangeEnd(session, ReadSession.EndReasonCode.Completed, 10);
+
+        Assert.False(buffer.Enabled);
+        Assert.Empty(buffer.GetSessionEvents(session));
+        Assert.Empty(buffer.ListSessions());
+    }
+
+    [Fact]
+    public void ListSessions_ReturnsNewestFirst()
+    {
+        var buffer = new StreamTraceBuffer(100);
+        var older = Guid.NewGuid();
+        var newer = Guid.NewGuid();
+        buffer.RangeOpen(older, "/old", "GET", 0, 1, 10, null, null);
+        Thread.Sleep(5);
+        buffer.RangeOpen(newer, "/new", "GET", 0, 1, 10, null, null);
+
+        var sessions = buffer.ListSessions();
+        Assert.Equal(newer, sessions[0].SessionId);
+        Assert.Equal(older, sessions[1].SessionId);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in, in-memory stream trace buffer that records a correlated per-session timeline of playback activity: range open/close (completed vs aborted vs error), seeks, per-segment fetches with provider/status/latency, failover rescues, and zero-fills.
- **Off by default**: tracing only runs when `STREAM_TRACE_EVENTS` is set to a positive value. Docker/production deployments are unaffected (no memory or hot-path cost); `scripts/run-backend.sh` enables it for local dev.
- New admin endpoints `GET /api/get-stream-traces` (session summaries) and `GET /api/get-stream-trace?sessionId=` (full timeline), plus `scripts/dump-stream-trace.sh` which writes the timeline JSON to `swap/` for offline analysis.
- Terminal `ReadSession` metrics rows are now accurate: client user-agent/IP, real end reason (completed/aborted/error), and bytes fetched are persisted instead of nulls/zeroes.
- Overview "Right now" cards show a copyable truncated session id; `BeginReadSessionScope` pushes `ReadSessionId` into the Serilog LogContext so debug logs correlate with traces.
- CONTRIBUTING gains a real-provider playback testing runbook for the two-process local workflow.

## Test plan

- [x] Backend suite: 520 passed, 11 skipped (macOS rapidyenc skips)
- [x] New unit tests: trace buffer ordering/caps/disabled mode, registry enrichment (UA/IP, end reason, bytes fetched)
- [x] Frontend typecheck, build, and tests (174 passed)
- [ ] Manual: real-provider playback with seeking, then `./scripts/dump-stream-trace.sh` produces a correlated timeline
- [ ] Manual: with `STREAM_TRACE_EVENTS` unset, `/api/get-stream-traces` reports `enabled: false` and playback behaves identically