### PR TITLE
fix(api): backup download no longer fails with a browser network error

### DIFF
--- a/backend/Api/Controllers/BaseApiController.cs
+++ b/backend/Api/Controllers/BaseApiController.cs
@@ -46,6 +46,11 @@ public abstract class BaseApiController : ControllerBase
                                   !HttpContext.RequestAborted.IsCancellationRequested)
         {
             Log.Error(e, "Unhandled admin API request failure");
+            // Once headers/body have started (e.g. a streamed zip), writing a JSON
+            // 500 would corrupt the response and surface as a browser network error.
+            if (HttpContext.Response.HasStarted)
+                return new EmptyResult();
+
             return StatusCode(500, new BaseApiResponse()
             {
                 Status = false,

--- a/backend/Api/Controllers/DbBackupDownload/DbBackupDownloadController.cs
+++ b/backend/Api/Controllers/DbBackupDownload/DbBackupDownloadController.cs
@@ -23,7 +23,22 @@ public class DbBackupDownloadController(DatabaseBackupStore store) : BaseApiCont
         Response.ContentType = "application/zip";
         Response.Headers.ContentDisposition = $"attachment; filename=\"nzbdav-backup-{id}.zip\"";
 
-        await using var archive = new ZipArchive(Response.Body, ZipArchiveMode.Create, leaveOpen: true);
+        // ZipArchive still performs sync writes (even with async APIs on .NET 10).
+        // BodyWriter.AsStream() tolerates those sync writes; Response.Body does not.
+        await WriteBackupZipAsync(backupDir, Response.BodyWriter.AsStream(), HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        return new EmptyResult();
+    }
+
+    /// <summary>
+    /// Writes the backup directory contents as a zip to <paramref name="output"/>,
+    /// excluding the rollback folder. Extracted for unit testing against async-only streams.
+    /// </summary>
+    internal static async Task WriteBackupZipAsync(
+        string backupDir, Stream output, CancellationToken cancellationToken = default)
+    {
+        await using var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true);
         foreach (var file in Directory.EnumerateFiles(backupDir, "*", SearchOption.AllDirectories))
         {
             var relative = Path.GetRelativePath(backupDir, file).Replace('\\', '/');
@@ -33,9 +48,7 @@ public class DbBackupDownloadController(DatabaseBackupStore store) : BaseApiCont
             var entry = archive.CreateEntry(relative, CompressionLevel.Fastest);
             await using var entryStream = entry.Open();
             await using var fileStream = System.IO.File.OpenRead(file);
-            await fileStream.CopyToAsync(entryStream, HttpContext.RequestAborted).ConfigureAwait(false);
+            await fileStream.CopyToAsync(entryStream, cancellationToken).ConfigureAwait(false);
         }
-
-        return new EmptyResult();
     }
 }

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -212,13 +212,30 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         }
     }, [refreshList]);
 
-    const downloadBackup = useCallback((id: string) => {
-        const a = document.createElement("a");
-        a.href = `/api/db-backup-download?id=${encodeURIComponent(id)}`;
-        a.download = `nzbdav-backup-${id}.zip`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
+    const downloadBackup = useCallback(async (id: string) => {
+        setBusy(`download-${id}`);
+        setMessage(null);
+        try {
+            const res = await fetch(`/api/db-backup-download?id=${encodeURIComponent(id)}`);
+            if (!res.ok) {
+                const data = await res.json().catch(() => null);
+                setMessage({ text: data?.error || `Download failed (${res.status})`, variant: "danger" });
+                return;
+            }
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `nzbdav-backup-${id}.zip`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch {
+            setMessage({ text: "Download failed.", variant: "danger" });
+        } finally {
+            setBusy(null);
+        }
     }, []);
 
     const uploadBackup = useCallback(async (file: File) => {
@@ -544,9 +561,12 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                                         <Button
                                             variant="outline"
                                             size="small"
-                                            onClick={() => downloadBackup(backup.id)}
+                                            disabled={busy === `download-${backup.id}`}
+                                            onClick={() => void downloadBackup(backup.id)}
                                         >
-                                            <Icon name="download" className="!text-[16px]" />
+                                            {busy === `download-${backup.id}`
+                                                ? <Spinner className="h-4 w-4" />
+                                                : <Icon name="download" className="!text-[16px]" />}
                                             Download
                                         </Button>
                                         <Button

--- a/tests/NzbWebDAV.Tests/Api/DbBackupDownloadZipTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DbBackupDownloadZipTests.cs
@@ -1,0 +1,155 @@
+using System.IO.Compression;
+using System.IO.Pipelines;
+using System.Text;
+using NzbWebDAV.Api.Controllers.DbBackupDownload;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class DbBackupDownloadZipTests
+{
+    [Fact]
+    public async Task WriteBackupZipAsync_ThroughBodyWriterStyleStream_ProducesReadableZipExcludingRollback()
+    {
+        var backupDir = CreateStagingBackup();
+        try
+        {
+            // Mirror the controller: ZipArchive sync-writes into BodyWriter.AsStream(),
+            // which tolerates sync I/O (unlike Kestrel's Response.Body).
+            var pipe = new Pipe(new PipeOptions(
+                pauseWriterThreshold: long.MaxValue,
+                resumeWriterThreshold: long.MaxValue / 2));
+
+            await using (var writerStream = pipe.Writer.AsStream(leaveOpen: true))
+            {
+                await DbBackupDownloadController.WriteBackupZipAsync(backupDir, writerStream);
+            }
+
+            await pipe.Writer.CompleteAsync();
+
+            await using var zipStream = new MemoryStream();
+            await pipe.Reader.CopyToAsync(zipStream);
+            await pipe.Reader.CompleteAsync();
+            zipStream.Position = 0;
+
+            using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+            var names = archive.Entries.Select(e => e.FullName).OrderBy(x => x, StringComparer.Ordinal).ToList();
+
+            Assert.Equal(
+                ["db.sql", "manifest.json"],
+                names);
+            Assert.DoesNotContain(names, n => n.StartsWith("rollback/", StringComparison.OrdinalIgnoreCase));
+
+            var dbEntry = archive.GetEntry("db.sql");
+            Assert.NotNull(dbEntry);
+            await using var entryStream = dbEntry!.Open();
+            using var reader = new StreamReader(entryStream, Encoding.UTF8);
+            Assert.Equal("SELECT 1;", await reader.ReadToEndAsync());
+        }
+        finally
+        {
+            Directory.Delete(backupDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBackupZipAsync_AgainstAsyncOnlyStream_ThrowsLikeKestrelResponseBody()
+    {
+        // Documents why the controller must use BodyWriter.AsStream() instead of Response.Body:
+        // ZipArchive still performs synchronous writes on .NET 10.
+        var backupDir = CreateStagingBackup();
+        try
+        {
+            await using var inner = new MemoryStream();
+            await using var asyncOnly = new AsyncOnlyStream(inner);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => DbBackupDownloadController.WriteBackupZipAsync(backupDir, asyncOnly));
+
+            Assert.Contains("Synchronous operations are disallowed", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(backupDir, recursive: true);
+        }
+    }
+
+    private static string CreateStagingBackup()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "nzbdav-backup-zip-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        Directory.CreateDirectory(Path.Combine(dir, DatabaseBackupStore.RollbackFolderName));
+
+        File.WriteAllText(Path.Combine(dir, "db.sql"), "SELECT 1;");
+        File.WriteAllText(Path.Combine(dir, "manifest.json"), """{"id":"test"}""");
+        File.WriteAllText(
+            Path.Combine(dir, DatabaseBackupStore.RollbackFolderName, "db.sql"),
+            "SHOULD_NOT_BE_IN_ZIP");
+
+        return dir;
+    }
+
+    /// <summary>
+    /// Mimics Kestrel's Response.Body: async I/O only; sync Write/Flush throw.
+    /// </summary>
+    private sealed class AsyncOnlyStream(Stream inner) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() =>
+            throw new InvalidOperationException(
+                "Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
+
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            inner.FlushAsync(cancellationToken);
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new InvalidOperationException(
+                "Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new InvalidOperationException(
+                "Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
+
+        public override void Write(ReadOnlySpan<byte> buffer) =>
+            throw new InvalidOperationException(
+                "Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.WriteAsync(buffer, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Stream backup zips via `Response.BodyWriter.AsStream()` so `ZipArchive`'s sync writes no longer abort under Kestrel (Chrome "Failed – Network error").
- Guard `BaseApiController` so mid-stream exceptions do not try to write a JSON 500 onto an already-started response.
- Switch the Backup Download button to `fetch` + blob with in-page error messages.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~DbBackupDownloadZipTests`
- [ ] Create a backup in Settings → Backup, click Download, confirm a valid `.zip` saves
- [ ] Confirm a missing/invalid backup id shows an error Alert instead of a silent browser failure