### PR TITLE
fix(nntp): harden STAT classification, auth, and provider validation from protocol audit

### DIFF
--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -16,7 +16,17 @@ namespace NzbWebDAV.Clients.Usenet;
 /// </summary>
 public class BaseNntpClient : NntpClient
 {
-    private readonly UsenetClient _client = new();
+    private readonly IUsenetClient _client;
+
+    public BaseNntpClient() : this(new UsenetClient())
+    {
+    }
+
+    /// <summary>Test seam for injecting a scripted underlying client.</summary>
+    internal BaseNntpClient(IUsenetClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
 
     public override async Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken)
     {
@@ -55,9 +65,22 @@ public class BaseNntpClient : NntpClient
         }
     }
 
-    public override Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
+    public override async Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
-        return _client.StatAsync(PrepareSegmentId(segmentId), cancellationToken);
+        segmentId = PrepareSegmentId(segmentId);
+        var response = await _client.StatAsync(segmentId, cancellationToken).ConfigureAwait(false);
+
+        // 223 (exists) and definitive-missing (430 / provider 451) are valid STAT
+        // outcomes and are conveyed via the response object — callers check
+        // ResponseType / IsDefinitiveMissing. Connection/session-level codes
+        // (buffered 400 goodbye, 480 auth, 5xx) must not be treated as article verdicts.
+        if (response.ResponseType == UsenetResponseType.ArticleExists ||
+            UsenetArticleAvailability.IsDefinitiveMissing(response))
+        {
+            return response;
+        }
+
+        throw new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage);
     }
 
     public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
@@ -179,7 +202,8 @@ public class BaseNntpClient : NntpClient
 
     public override void Dispose()
     {
-        _client.Dispose();
+        if (_client is IDisposable disposable)
+            disposable.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -80,7 +80,7 @@ public class BaseNntpClient : NntpClient
             return response;
         }
 
-        throw new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage);
+        throw CreateConnectionLevelException(segmentId, response);
     }
 
     public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
@@ -197,7 +197,19 @@ public class BaseNntpClient : NntpClient
     {
         return UsenetArticleAvailability.IsDefinitiveMissing(response)
             ? new UsenetArticleNotFoundException(segmentId, response.ResponseMessage)
-            : new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage);
+            : CreateConnectionLevelException(segmentId, response);
+    }
+
+    private static Exception CreateConnectionLevelException(SegmentId segmentId, UsenetResponse response)
+    {
+        if (response.ResponseCode == 480)
+        {
+            return new UsenetUnexpectedResponseException(
+                segmentId,
+                "Provider requires authentication but no credentials are configured");
+        }
+
+        return new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage);
     }
 
     public override void Dispose()

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -406,7 +406,7 @@ public abstract class NntpClient : INntpClient
     internal static bool IsValidSegmentId(string? id)
     {
         var value = NormalizeSegmentId(id);
-        if (value.Length is < 3 or > 497) return false;
+        if (value.Length is < 3 or > 495) return false;
         if (value[0] == '@' || value[^1] == '@' || !value.Contains('@')) return false;
         if (value.Contains('<') || value.Contains('>')) return false;
         foreach (var character in value)

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -113,7 +113,8 @@ public abstract class NntpClient : INntpClient
         var decodedBodyResponse = await DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
         await using var stream = decodedBodyResponse.Stream!;
         var headers = await stream.GetYencHeadersAsync(ct).ConfigureAwait(false);
-        return headers!;
+        return headers ?? throw new NonRetryableDownloadException(
+            $"Article <{segmentId}> is not yEnc-encoded; only yEnc binaries are supported.");
     }
 
     public virtual async Task<long> GetFileSizeAsync(NzbFile file, CancellationToken ct)
@@ -121,7 +122,7 @@ public abstract class NntpClient : INntpClient
         if (file.Segments.Count == 0) return 0;
         var headers = await GetYencHeadersAsync(file.Segments[^1].MessageId, ct).ConfigureAwait(false);
         file.Segments[^1].ByteRange = LongRange.FromStartAndSize(headers.PartOffset, headers.PartSize);
-        return headers!.PartOffset + headers!.PartSize;
+        return headers.PartOffset + headers.PartSize;
     }
 
     public virtual async Task<NzbFileStream> GetFileStream(

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -147,6 +147,16 @@ public class UsenetStreamingClient : WrappingNntpClient
             maxConnections = 1;
         }
 
+        if (ShouldWarnCleartextCredentials(connectionDetails.UseSsl, connectionDetails.User))
+        {
+            var label = string.IsNullOrWhiteSpace(connectionDetails.Nickname)
+                ? connectionDetails.Host
+                : connectionDetails.Nickname;
+            Log.Warning(
+                "Provider '{Provider}' uses a cleartext connection (no TLS) with credentials; the password is sent unencrypted. Prefer port 563 with SSL.",
+                label);
+        }
+
         var connectionPool = CreateNewConnectionPool(
             maxConnections: maxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
@@ -195,6 +205,9 @@ public class UsenetStreamingClient : WrappingNntpClient
     // short enough that three stuck handshakes cannot pin the pool forever.
     // Settable for tests so timeout coverage does not wait a full 15s.
     internal static TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(15);
+
+    internal static bool ShouldWarnCleartextCredentials(bool useSsl, string? user) =>
+        !useSsl && !string.IsNullOrEmpty(user);
 
     public static ValueTask<INntpClient> CreateNewConnection
     (

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -217,9 +217,13 @@ public class UsenetStreamingClient : WrappingNntpClient
             await connection.ConnectAsync(
                 connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
                 timeoutCts.Token).ConfigureAwait(false);
-            await connection.AuthenticateAsync(
-                connectionDetails.User, connectionDetails.Pass,
-                timeoutCts.Token).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(connectionDetails.User) ||
+                !string.IsNullOrEmpty(connectionDetails.Pass))
+            {
+                await connection.AuthenticateAsync(
+                    connectionDetails.User, connectionDetails.Pass,
+                    timeoutCts.Token).ConfigureAwait(false);
+            }
             return connection;
         }
         catch

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -209,6 +209,15 @@ public class UsenetStreamingClient : WrappingNntpClient
         CancellationToken ct
     )
     {
+        if (ContainsControlChars(connectionDetails.Host) ||
+            ContainsControlChars(connectionDetails.User) ||
+            ContainsControlChars(connectionDetails.Pass) ||
+            connectionDetails.Host.Contains(' '))
+        {
+            throw new ArgumentException(
+                "Provider host/username/password must not contain whitespace or control characters.");
+        }
+
         var connection = connectionFactory();
         try
         {
@@ -231,5 +240,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             connection.Dispose();
             throw;
         }
+
+        static bool ContainsControlChars(string? s) =>
+            !string.IsNullOrEmpty(s) && s.Any(c => c < 0x20 || c == 0x7F);
     }
 }

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -305,6 +305,14 @@ public class ConfigManager
                 var label = string.IsNullOrWhiteSpace(p.Nickname) ? p.Host : p.Nickname;
                 if (string.IsNullOrWhiteSpace(p.Host))
                     throw new ArgumentException($"Provider #{i + 1}: host must not be empty.");
+                if (ContainsControlChars(p.Host) || p.Host.Contains(' '))
+                    throw new ArgumentException($"Provider '{label}': host contains whitespace or control characters.");
+                if (ContainsControlChars(p.User))
+                    throw new ArgumentException($"Provider '{label}': username contains control characters.");
+                if (ContainsControlChars(p.Pass))
+                    throw new ArgumentException($"Provider '{label}': password contains control characters.");
+                if ((p.User?.Length ?? 0) > 400 || (p.Pass?.Length ?? 0) > 400)
+                    throw new ArgumentException($"Provider '{label}': username/password exceeds 400 characters.");
                 if (p.Port is < 1 or > 65535)
                     throw new ArgumentException($"Provider '{label}': port must be between 1 and 65535, but was {p.Port}.");
                 if (p.MaxConnections < 1)
@@ -312,6 +320,9 @@ public class ConfigManager
                 if (p.ByteLimit is < 0)
                     throw new ArgumentException($"Provider '{label}': byte limit must not be negative.");
             }
+
+            static bool ContainsControlChars(string? s) =>
+                !string.IsNullOrEmpty(s) && s.Any(c => c < 0x20 || c == 0x7F);
         }
     }
 

--- a/frontend/app/routes/settings/usenet/cleartext-credentials.test.ts
+++ b/frontend/app/routes/settings/usenet/cleartext-credentials.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { shouldWarnCleartextCredentials } from "./cleartext-credentials";
+
+describe("shouldWarnCleartextCredentials", () => {
+  it("warns when SSL is off and a username is set", () => {
+    expect(shouldWarnCleartextCredentials(false, "user")).toBe(true);
+  });
+
+  it("does not warn when SSL is on", () => {
+    expect(shouldWarnCleartextCredentials(true, "user")).toBe(false);
+  });
+
+  it("does not warn when username is empty or whitespace", () => {
+    expect(shouldWarnCleartextCredentials(false, "")).toBe(false);
+    expect(shouldWarnCleartextCredentials(false, "   ")).toBe(false);
+  });
+});

--- a/frontend/app/routes/settings/usenet/cleartext-credentials.ts
+++ b/frontend/app/routes/settings/usenet/cleartext-credentials.ts
@@ -1,0 +1,4 @@
+/** Whether to warn that AUTHINFO credentials will be sent without TLS. */
+export function shouldWarnCleartextCredentials(useSsl: boolean, user: string): boolean {
+  return !useSsl && user.trim().length > 0;
+}

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -4,6 +4,7 @@ import { Button } from "~/components/ui/button";
 import { Icon, SettingsPage } from "~/components/ui";
 import { subscribeWebsocketTopics, useWebsocketTopic } from "~/utils/shared-websocket";
 import { isMaskedSecret } from "~/utils/config-mask";
+import { shouldWarnCleartextCredentials } from "./cleartext-credentials";
 import {
     DndContext,
     type DragEndEvent,
@@ -1193,6 +1194,14 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                                     Use SSL
                                 </label>
                             </div>
+                            {shouldWarnCleartextCredentials(useSsl, user) && (
+                                <div
+                                    role="alert"
+                                    className="mt-2 rounded border border-amber-600/50 bg-amber-500/10 px-3 py-2 text-xs text-amber-200"
+                                >
+                                    Credentials are sent unencrypted without SSL. Prefer port 563 with SSL enabled.
+                                </div>
+                            )}
                         </div>
 
                         <div className={`${styles["form-group"]} ${styles["full-width"]}`}>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
@@ -1,0 +1,115 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
+using UsenetSharp.Clients;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class BaseNntpClientStatTests
+{
+    [Fact]
+    public async Task StatAsync_With223_ReturnsExistsResponse()
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient(223));
+
+        var response = await client.StatAsync("seg@example", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleExists, response.ResponseType);
+        Assert.True(response.ArticleExists);
+    }
+
+    [Fact]
+    public async Task StatAsync_With430_ReturnsDefinitiveMissing()
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient(430));
+
+        var response = await client.StatAsync("seg@example", CancellationToken.None);
+
+        Assert.True(UsenetArticleAvailability.IsDefinitiveMissing(response));
+        Assert.False(response.ArticleExists);
+    }
+
+    [Fact]
+    public async Task StatAsync_With451_ReturnsDefinitiveMissing()
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient(451));
+
+        var response = await client.StatAsync("seg@example", CancellationToken.None);
+
+        Assert.True(UsenetArticleAvailability.IsDefinitiveMissing(response));
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(480)]
+    [InlineData(503)]
+    public async Task StatAsync_WithConnectionLevelCode_ThrowsUnexpectedResponse(int responseCode)
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient(responseCode));
+
+        var exception = await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(() =>
+            client.StatAsync("seg@example", CancellationToken.None));
+
+        Assert.IsAssignableFrom<RetryableDownloadException>(exception);
+        Assert.Equal("seg@example", exception.SegmentId);
+    }
+
+    private sealed class ScriptedUsenetClient(int responseCode) : IUsenetClient
+    {
+        public bool IsConnected => true;
+        public bool IsHealthy => true;
+
+        public Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = responseCode,
+                ResponseMessage = $"{responseCode} <{segmentId}>",
+                ArticleExists = responseCode == (int)UsenetResponseType.ArticleExists,
+            });
+
+        public Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetBodyResponse> BodyAsync(SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetBodyResponse> BodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetArticleResponse> ArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetArticleResponse> ArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task WaitForReadyAsync(CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
@@ -54,6 +54,17 @@ public class BaseNntpClientStatTests
         Assert.Equal("seg@example", exception.SegmentId);
     }
 
+    [Fact]
+    public async Task StatAsync_With480_UsesClearAuthRequiredMessage()
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient(480));
+
+        var exception = await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(() =>
+            client.StatAsync("seg@example", CancellationToken.None));
+
+        Assert.Contains("requires authentication", exception.Message);
+    }
+
     private sealed class ScriptedUsenetClient(int responseCode) : IUsenetClient
     {
         public bool IsConnected => true;

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CleartextCredentialsWarningTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CleartextCredentialsWarningTests.cs
@@ -1,0 +1,18 @@
+using NzbWebDAV.Clients.Usenet;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class CleartextCredentialsWarningTests
+{
+    [Theory]
+    [InlineData(false, "user", true)]
+    [InlineData(false, "", false)]
+    [InlineData(false, null, false)]
+    [InlineData(true, "user", false)]
+    [InlineData(true, "", false)]
+    public void ShouldWarnCleartextCredentials_OnlyWhenCleartextWithUser(
+        bool useSsl, string? user, bool expected)
+    {
+        Assert.Equal(expected, UsenetStreamingClient.ShouldWarnCleartextCredentials(useSsl, user));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
@@ -99,6 +99,20 @@ public class CreateNewConnectionTests
         Assert.Equal("secret", fake.LastAuthPass);
     }
 
+    [Fact]
+    public async Task CreateNewConnection_RejectsControlCharactersInCredentials()
+    {
+        var fake = new HandshakeNntpClient();
+        var details = MakeDetails();
+        details.User = "user\r\nQUIT";
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None));
+
+        Assert.False(fake.Connected);
+        Assert.Equal(0, fake.DisposeCount);
+    }
+
     private static UsenetProviderConfig.ConnectionDetails MakeDetails() =>
         new()
         {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
@@ -61,7 +61,42 @@ public class CreateNewConnectionTests
 
         Assert.Same(fake, connection);
         Assert.Equal(0, fake.DisposeCount);
+        Assert.Equal(1, fake.AuthenticateCount);
+        Assert.Equal("u", fake.LastAuthUser);
+        Assert.Equal("p", fake.LastAuthPass);
         connection.Dispose();
+    }
+
+    [Fact]
+    public async Task CreateNewConnection_SkipsAuthenticateWhenCredentialsEmpty()
+    {
+        var fake = new HandshakeNntpClient();
+        var details = MakeDetails();
+        details.User = "";
+        details.Pass = "";
+
+        var connection = await UsenetStreamingClient.CreateNewConnection(
+            details, () => fake, CancellationToken.None);
+
+        Assert.Same(fake, connection);
+        Assert.True(fake.Connected);
+        Assert.Equal(0, fake.AuthenticateCount);
+        connection.Dispose();
+    }
+
+    [Fact]
+    public async Task CreateNewConnection_AuthenticatesWhenOnlyPasswordSet()
+    {
+        var fake = new HandshakeNntpClient();
+        var details = MakeDetails();
+        details.User = "";
+        details.Pass = "secret";
+
+        await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None);
+
+        Assert.Equal(1, fake.AuthenticateCount);
+        Assert.Equal("", fake.LastAuthUser);
+        Assert.Equal("secret", fake.LastAuthPass);
     }
 
     private static UsenetProviderConfig.ConnectionDetails MakeDetails() =>
@@ -82,6 +117,9 @@ public class CreateNewConnectionTests
         public Exception? AuthenticateException { get; init; }
         public bool Connected { get; private set; }
         public int DisposeCount { get; private set; }
+        public int AuthenticateCount { get; private set; }
+        public string? LastAuthUser { get; private set; }
+        public string? LastAuthPass { get; private set; }
 
         public override async Task ConnectAsync(
             string host, int port, bool useSsl, CancellationToken cancellationToken)
@@ -100,6 +138,9 @@ public class CreateNewConnectionTests
             string user, string pass, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            AuthenticateCount++;
+            LastAuthUser = user;
+            LastAuthPass = pass;
             if (AuthenticateException is not null)
                 throw AuthenticateException;
             return Task.FromResult(new UsenetResponse

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -138,6 +138,33 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task StatAsync_UnexpectedResponse_FailsOverToBackup()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 400,
+            SingularException = segmentId =>
+                new UsenetUnexpectedResponseException(segmentId, "400 idle timeout"),
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primary, host: "a.example"),
+            CreateProvider(backup, host: "b.example"),
+        ]);
+
+        var response = await client.StatAsync("segment", CancellationToken.None);
+
+        Assert.True(response.ArticleExists);
+        Assert.True(primary.SingularRequests >= 1);
+        Assert.True(backup.SingularRequests >= 1);
+    }
+
+    [Fact]
     public async Task StatAsync_Success_DoesNotRecordSegmentFetch()
     {
         var writer = new MetricsWriter();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientNonYencHeadersTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientNonYencHeadersTests.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class NntpClientNonYencHeadersTests
+{
+    [Fact]
+    public async Task GetYencHeadersAsync_NonYencBody_ThrowsNonRetryable()
+    {
+        var client = new PlainTextBodyClient();
+
+        var exception = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            client.GetYencHeadersAsync("plain@example.com", CancellationToken.None));
+
+        Assert.Contains("plain@example.com", exception.Message);
+        Assert.Contains("not yEnc-encoded", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetFileSizeAsync_NonYencLastSegment_PropagatesNonRetryable()
+    {
+        var client = new PlainTextBodyClient();
+        var file = new NzbFile { Subject = "test" };
+        file.Segments.Add(new NzbSegment
+        {
+            Bytes = 100,
+            MessageId = "plain@example.com",
+            Number = 1,
+        });
+
+        await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            client.GetFileSizeAsync(file, CancellationToken.None));
+    }
+
+    private sealed class PlainTextBodyClient : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var bytes = Encoding.ASCII.GetBytes("this is not a yEnc article\r\n.\r\n");
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body follows",
+                Stream = new NullHeaderYencStream(bytes),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class NullHeaderYencStream(byte[] bytes) : YencStream(new MemoryStream(bytes, writable: false))
+    {
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<UsenetYencHeader?>(null);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -60,6 +60,19 @@ public class NntpClientPipelinedMappingTests
     }
 
     [Fact]
+    public void IsValidSegmentId_RejectsBareIdsLongerThan495Octets()
+    {
+        // With client-added angle brackets the wire argument must stay ≤ 497 octets.
+        var tooLong = new string('a', 492) + "@x.y"; // 496 octets
+        Assert.Equal(496, tooLong.Length);
+        Assert.False(NntpClient.IsValidSegmentId(tooLong));
+
+        var maxOk = new string('a', 491) + "@x.y"; // 495 octets
+        Assert.Equal(495, maxOk.Length);
+        Assert.True(NntpClient.IsValidSegmentId(maxOk));
+    }
+
+    [Fact]
     public void HasSegmentIdMismatch_IgnoresSyntheticMessagesWithoutWireId()
     {
         Assert.False(NntpClient.HasSegmentIdMismatch(

--- a/tests/NzbWebDAV.Tests/Config/UsenetProviderValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/UsenetProviderValidationTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class UsenetProviderValidationTests
+{
+    [Fact]
+    public void ValidateConfigItems_AcceptsCleanProvider()
+    {
+        ConfigManager.ValidateConfigItems([MakeItem(MakeProvider())]);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsUsernameWithCrlf()
+    {
+        var provider = MakeProvider();
+        provider.User = "user\r\nBODY <x@y>";
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([MakeItem(provider)]));
+
+        Assert.Contains("username contains control characters", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsPasswordWithNewline()
+    {
+        var provider = MakeProvider();
+        provider.Pass = "secret\n";
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([MakeItem(provider)]));
+
+        Assert.Contains("password contains control characters", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsHostWithSpace()
+    {
+        var provider = MakeProvider();
+        provider.Host = "bad host.example";
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([MakeItem(provider)]));
+
+        Assert.Contains("host contains whitespace or control characters", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsOversizedUsername()
+    {
+        var provider = MakeProvider();
+        provider.User = new string('a', 401);
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([MakeItem(provider)]));
+
+        Assert.Contains("exceeds 400 characters", ex.Message);
+    }
+
+    private static ConfigItem MakeItem(UsenetProviderConfig.ConnectionDetails provider) =>
+        new()
+        {
+            ConfigName = ConfigKeys.UsenetProviders,
+            ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+            {
+                Providers = [provider],
+            }),
+        };
+
+    private static UsenetProviderConfig.ConnectionDetails MakeProvider() =>
+        new()
+        {
+            Type = ProviderType.Pooled,
+            Host = "nntp.example",
+            Port = 563,
+            UseSsl = true,
+            User = "user",
+            Pass = "pass",
+            MaxConnections = 1,
+        };
+}


### PR DESCRIPTION
## Summary
- Treat connection-level STAT codes (400/480/5xx) as retryable connection failures instead of article verdicts, preventing false Warden “dead” poisoning and dead-connection re-pooling (`Fixes #390`).
- Skip AUTHINFO when provider credentials are empty; map NNTP 480 to a clear missing-credentials message (`Fixes #391`).
- Reject control characters / oversized Host/User/Pass and tighten bare message-id length to 495 octets (`Fixes #392`).
- Fail non-yEnc size probes with `NonRetryableDownloadException` instead of NRE (`Fixes #395`).
- Warn in logs and the provider settings UI when credentials are configured without TLS (`Fixes #394`).

## Deferred (UsenetSharp upgrade)
- #393 — yEnc CRC validation when present
- #396 — best-effort QUIT on idle dispose

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~Clients.Usenet|FullyQualifiedName~UsenetProviderValidation|FullyQualifiedName~Cleartext"` (119 passed, 2 skipped rapidyenc)
- [x] `cd frontend && npm test -- --run cleartext-credentials && npm run typecheck`
- [ ] Manual: configure provider with SSL off + username → warning under Use SSL; empty credentials connect to open NNTP spool without AUTHINFO