### PR TITLE
fix(ui): Overview live-stat row is visible against the page background

### DIFF
--- a/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
+++ b/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
@@ -13,7 +13,7 @@ export function LiveTiles({ tiles }: LiveTilesProps) {
     const bytesPerSec = tiles.bytesServedPerMinute / 60;
     const articlesPerSec = tiles.articlesPerMinute / 60;
     return (
-        <div className="stats stats-vertical w-full shadow lg:stats-horizontal">
+        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow lg:stats-horizontal">
             <Tile
                 label="Active reads"
                 value={tiles.activeReads.toString()}


### PR DESCRIPTION
## Summary
- Add a subtle border and elevated `bg-base-200` fill to the Overview live-stat row so it no longer blends into the page background.

## Test plan
- [ ] Open Overview and confirm the top stats row (Active reads / Articles / throughput / Fetch errors) has a visible outline and elevated surface
- [ ] Confirm it still matches the look of other daisyUI stats rows (e.g. Watchdog) at desktop and narrow widths