### PR TITLE
feat(ui): modernize the health schedule table

### DIFF
--- a/frontend/app/routes/health/components/health-stats/health-stats.tsx
+++ b/frontend/app/routes/health/components/health-stats/health-stats.tsx
@@ -37,45 +37,72 @@ export function HealthStats({ stats }: HealthStatsProps) {
     return (
         <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
             <div className="card-body gap-4 p-4 md:p-6">
-                <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
                     <h2 className="card-title text-xl">Overview</h2>
-                    <Badge className="badge-ghost">Last 30 Days</Badge>
+                    <Badge className="badge-ghost badge-sm">Last 30 days</Badge>
                 </div>
 
-                <div className="stats stats-vertical w-full shadow sm:stats-horizontal">
-                    <div className="stat place-items-center">
-                        <div className="stat-figure text-base-content/50">
-                            <Icon name="fact_check" className="!text-[22px]" />
-                        </div>
-                        <div className="stat-title">Total Checked</div>
-                        <div className="stat-value font-mono text-3xl md:text-4xl">{totalChecked}</div>
-                    </div>
-
-                    <div className="stat place-items-center">
-                        <div className="stat-figure text-success">
-                            <Icon name="check_circle" filled className="!text-[22px]" />
-                        </div>
-                        <div className="stat-title">Healthy ({getPercentage(healthy)}%)</div>
-                        <div className="stat-value font-mono text-3xl text-success md:text-4xl">{healthy}</div>
-                    </div>
-
-                    <div className="stat place-items-center">
-                        <div className="stat-figure text-info">
-                            <Icon name="build_circle" filled className="!text-[22px]" />
-                        </div>
-                        <div className="stat-title">Repaired ({getPercentage(repaired)}%)</div>
-                        <div className="stat-value font-mono text-3xl text-info md:text-4xl">{repaired}</div>
-                    </div>
-
-                    <div className="stat place-items-center">
-                        <div className="stat-figure text-error">
-                            <Icon name="delete" filled className="!text-[22px]" />
-                        </div>
-                        <div className="stat-title">Deleted ({getPercentage(deleted)}%)</div>
-                        <div className="stat-value font-mono text-3xl text-error md:text-4xl">{deleted}</div>
-                    </div>
+                <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
+                    <Stat
+                        icon="fact_check"
+                        iconClassName="text-base-content/50"
+                        title="Total checked"
+                        value={totalChecked}
+                    />
+                    <Stat
+                        icon="check_circle"
+                        iconClassName="text-success"
+                        iconFilled
+                        title={`Healthy (${getPercentage(healthy)}%)`}
+                        value={healthy}
+                        valueClassName="text-success"
+                    />
+                    <Stat
+                        icon="build_circle"
+                        iconClassName="text-info"
+                        iconFilled
+                        title={`Repaired (${getPercentage(repaired)}%)`}
+                        value={repaired}
+                        valueClassName="text-info"
+                    />
+                    <Stat
+                        icon="delete"
+                        iconClassName="text-error"
+                        iconFilled
+                        title={`Deleted (${getPercentage(deleted)}%)`}
+                        value={deleted}
+                        valueClassName="text-error"
+                    />
                 </div>
             </div>
         </section>
+    );
+}
+
+function Stat({
+    icon,
+    iconClassName,
+    iconFilled,
+    title,
+    value,
+    valueClassName = "",
+}: {
+    icon: string;
+    iconClassName: string;
+    iconFilled?: boolean;
+    title: string;
+    value: number;
+    valueClassName?: string;
+}) {
+    return (
+        <div className="stat place-items-center py-4">
+            <div className={`stat-figure ${iconClassName}`}>
+                <Icon name={icon} filled={iconFilled} className="!text-[22px]" />
+            </div>
+            <div className="stat-title text-xs">{title}</div>
+            <div className={`stat-value font-mono text-3xl tabular-nums md:text-4xl ${valueClassName}`}>
+                {value}
+            </div>
+        </div>
     );
 }

--- a/frontend/app/routes/health/components/health-table/health-table.tsx
+++ b/frontend/app/routes/health/components/health-table/health-table.tsx
@@ -7,103 +7,127 @@ export type HealthTableProps = {
     healthCheckItems: HealthCheckQueueItem[],
 }
 
+const desktopHeaderClass =
+    "hidden min-[900px]:table-cell text-center text-xs font-semibold uppercase tracking-wide";
+const desktopCellClass =
+    "hidden min-[900px]:table-cell max-w-[160px] whitespace-nowrap px-1 py-3 text-center align-middle font-mono text-xs tabular-nums text-base-content/70";
+
 export function HealthTable({ isEnabled, healthCheckItems }: HealthTableProps) {
-
     return (
-        <section className="w-full overflow-hidden rounded-lg border border-base-content/10 bg-base-100 shadow-md">
-            <div className="flex flex-wrap items-center justify-between gap-4 p-4 md:p-6">
-                <h2 className="text-xl font-semibold text-base-content">Schedule</h2>
-                <Badge className="px-3 py-1 text-xs text-base-content/60">
-                    Only {healthCheckItems.length} shown
-                </Badge>
-            </div>
+        <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
+            <div className="card-body gap-0 p-0">
+                <div className="flex flex-wrap items-center justify-between gap-3 border-b border-base-content/10 px-4 py-4 md:px-6">
+                    <h2 className="card-title text-xl">Schedule</h2>
+                    {isEnabled && healthCheckItems.length > 0 && (
+                        <Badge className="badge-ghost badge-sm font-mono tabular-nums">
+                            Showing {healthCheckItems.length}
+                        </Badge>
+                    )}
+                </div>
 
-            {!isEnabled ? (
-                <div className="px-5 py-14 text-center text-base-content/60">
-                    <Icon name="health_and_safety" className="mb-4 !text-[48px] text-primary/70" />
-                    <div className="mb-2 text-base font-semibold text-base-content">Enable Repairs In Settings</div>
-                    <div className="mx-auto max-w-md text-sm leading-relaxed">
-                        Once you enable repairs, all mounted usenet files will be queued for continuous health monitoring
-                    </div>
-                </div>
-            ) : healthCheckItems.length === 0 ? (
-                <div className="px-5 py-14 text-center text-base-content/60">
-                    <Icon name="health_and_safety" className="mb-4 !text-[48px] text-primary/70" />
-                    <div className="mb-2 text-base font-semibold text-base-content">No Items To Health-Check</div>
-                    <div className="mx-auto max-w-md text-sm leading-relaxed">
-                        Once you begin processing nzbs, the mounted usenet files will be queued for continuous health monitoring
-                    </div>
-                </div>
-            ) : (
-                <div className="min-h-[200px] overflow-x-auto">
-                    <table className="m-0 w-full border-collapse text-base-content/80">
-                        <thead className="max-[899px]:hidden">
-                            <tr>
-                                <th className="w-1/2 bg-base-300/70 px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-base-content/80">Name</th>
-                                <th className="w-[100px] whitespace-nowrap bg-base-300/70 px-3 py-4 text-center text-xs font-semibold uppercase tracking-wide text-base-content/80">Created</th>
-                                <th className="w-[100px] whitespace-nowrap bg-base-300/70 px-3 py-4 text-center text-xs font-semibold uppercase tracking-wide text-base-content/80">Last Check</th>
-                                <th className="w-[100px] whitespace-nowrap bg-base-300/70 px-3 py-4 text-center text-xs font-semibold uppercase tracking-wide text-base-content/80">Next Check</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {healthCheckItems.map(item => (
-                                <tr key={item.id} className="border-b border-base-content/10 last:border-b-0">
-                                    <td className="max-w-[200px] px-6 py-4 align-middle max-[899px]:max-w-none max-[899px]:p-6">
-                                        <div className="flex min-w-0 flex-col gap-1">
-                                            <div className="break-all text-sm font-medium leading-snug text-base-content"><Truncate>{item.name}</Truncate></div>
-                                            <div className="break-all text-xs italic leading-snug text-base-content/50"><Truncate>{item.path}</Truncate></div>
-                                            <div className="hidden max-[899px]:block">
-                                                <DateDetailsTable item={item} />
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td className="max-w-[200px] px-3 py-4 text-center text-xs tabular-nums text-base-content/60 max-[899px]:hidden">
-                                        {formatAge(item.releaseDate, 'Unknown')}
-                                    </td>
-                                    <td className="max-w-[200px] px-3 py-4 text-center text-xs tabular-nums text-base-content/60 max-[899px]:hidden">
-                                        {formatAge(item.lastHealthCheck, 'Never')}
-                                    </td>
-                                    <td className="max-w-[200px] px-3 py-4 text-center text-xs tabular-nums text-base-content/60 max-[899px]:hidden">
-                                        {item.progress > 0
-                                            ? <HealthProgressBadge percentage={item.progress} />
-                                            : formatWhen(item.nextHealthCheck, 'ASAP')
-                                        }
-                                    </td>
+                {!isEnabled ? (
+                    <EmptyState
+                        title="Enable repairs in settings"
+                        body="Once you enable repairs, mounted usenet files are queued for continuous health monitoring."
+                    />
+                ) : healthCheckItems.length === 0 ? (
+                    <EmptyState
+                        title="No items to health-check"
+                        body="Once you begin processing NZBs, mounted usenet files are queued for continuous health monitoring."
+                    />
+                ) : (
+                    <div className="overflow-x-auto">
+                        <table className="table table-zebra table-sm mb-0 w-full min-w-0 text-base-content min-[900px]:min-w-[720px]">
+                            <thead>
+                                <tr className="border-base-content/10 [&_th]:bg-base-200 [&_th]:text-base-content/70">
+                                    <th className="py-3 pl-4 text-left text-xs font-semibold uppercase tracking-wide md:pl-6">
+                                        Name
+                                    </th>
+                                    <th className={desktopHeaderClass}>Created</th>
+                                    <th className={desktopHeaderClass}>Last check</th>
+                                    <th className={`${desktopHeaderClass} pr-4 md:pr-6`}>Next check</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            )}
+                            </thead>
+                            <tbody>
+                                {healthCheckItems.map(item => (
+                                    <tr key={item.id} className="border-base-content/10">
+                                        <td className="max-w-[280px] py-3 pl-4 align-middle md:pl-6 max-[899px]:max-w-none">
+                                            <div className="flex min-w-0 flex-col gap-1">
+                                                <div className="break-all text-sm font-medium leading-snug text-base-content">
+                                                    <Truncate>{item.name}</Truncate>
+                                                </div>
+                                                <div className="break-all text-xs leading-snug text-base-content/45">
+                                                    <Truncate>{item.path}</Truncate>
+                                                </div>
+                                                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 min-[900px]:hidden">
+                                                    <MetaChip label="Created" value={formatAge(item.releaseDate, "Unknown")} />
+                                                    <MetaChip label="Last" value={formatAge(item.lastHealthCheck, "Never")} />
+                                                    <MetaChip
+                                                        label="Next"
+                                                        value={
+                                                            item.progress > 0
+                                                                ? null
+                                                                : formatWhen(item.nextHealthCheck, "ASAP")
+                                                        }
+                                                        progress={item.progress > 0 ? item.progress : undefined}
+                                                    />
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td className={desktopCellClass}>
+                                            {formatAge(item.releaseDate, "Unknown")}
+                                        </td>
+                                        <td className={desktopCellClass}>
+                                            {formatAge(item.lastHealthCheck, "Never")}
+                                        </td>
+                                        <td className={`${desktopCellClass} pr-4 md:pr-6`}>
+                                            {item.progress > 0
+                                                ? <HealthProgressBadge percentage={item.progress} />
+                                                : formatWhen(item.nextHealthCheck, "ASAP")}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
         </section>
     );
 }
 
-function DateDetailsTable({ item }: { item: HealthCheckQueueItem }) {
+function EmptyState({ title, body }: { title: string; body: string }) {
     return (
-        <div className="mt-3 rounded-md border border-base-content/10 bg-base-300/50 p-3">
-            <div className="flex items-center justify-between border-b border-base-content/10 py-2 first:pt-0">
-                <div className="min-w-20 text-[11px] font-medium uppercase tracking-wide text-base-content/60">Created</div>
-                <div className="ml-3 flex-1 text-right text-xs tabular-nums text-base-content">
-                    {formatAge(item.releaseDate, 'Unknown')}
-                </div>
-            </div>
-            <div className="flex items-center justify-between border-b border-base-content/10 py-2">
-                <div className="min-w-20 text-[11px] font-medium uppercase tracking-wide text-base-content/60">Last Health Check</div>
-                <div className="ml-3 flex-1 text-right text-xs tabular-nums text-base-content">
-                    {formatAge(item.lastHealthCheck, 'Never')}
-                </div>
-            </div>
-            <div className="flex items-center justify-between pt-2">
-                <div className="min-w-20 text-[11px] font-medium uppercase tracking-wide text-base-content/60">Next Health Check</div>
-                <div className="ml-3 flex-1 text-right text-xs tabular-nums text-base-content">
-                    {item.progress > 0
-                        ? <HealthProgressBadge percentage={item.progress} />
-                        : formatWhen(item.nextHealthCheck, 'ASAP')
-                    }
+        <div className="hero min-h-[220px] py-8">
+            <div className="hero-content">
+                <div className="flex max-w-md flex-col items-center text-center">
+                    <Icon name="health_and_safety" className="mb-3 !text-[48px] text-base-content/40" />
+                    <h3 className="text-base font-semibold text-base-content">{title}</h3>
+                    <p className="mt-1 text-xs leading-relaxed text-base-content/60">{body}</p>
                 </div>
             </div>
         </div>
+    );
+}
+
+function MetaChip({
+    label,
+    value,
+    progress,
+}: {
+    label: string;
+    value: string | null;
+    progress?: number;
+}) {
+    return (
+        <span className="inline-flex items-center gap-1.5 text-[11px] text-base-content/55">
+            <span className="uppercase tracking-wide text-base-content/40">{label}</span>
+            {progress != null ? (
+                <HealthProgressBadge percentage={progress} compact />
+            ) : (
+                <span className="font-mono tabular-nums text-base-content/70">{value}</span>
+            )}
+        </span>
     );
 }
 
@@ -111,7 +135,7 @@ function formatAge(dateString: string | null, fallback: string) {
     if (!dateString) return fallback;
     const age = Math.max(0, Math.floor((Date.now() - new Date(dateString).getTime()) / 1000));
     if (Number.isNaN(age)) return fallback;
-    if (age < 5) return 'just now';
+    if (age < 5) return "just now";
     if (age < 60) return `${age}s ago`;
     if (age < 3600) return `${Math.floor(age / 60)}m ago`;
     if (age < 86400) return `${Math.floor(age / 3600)}h ago`;
@@ -122,19 +146,25 @@ function formatWhen(dateString: string | null, fallback: string) {
     if (!dateString) return fallback;
     const delta = Math.floor((new Date(dateString).getTime() - Date.now()) / 1000);
     if (Number.isNaN(delta)) return fallback;
-    if (delta <= 0) return 'soon';
+    if (delta <= 0) return "soon";
     if (delta < 60) return `in ${delta}s`;
     if (delta < 3600) return `in ${Math.floor(delta / 60)}m`;
     if (delta < 86400) return `in ${Math.floor(delta / 3600)}h`;
     return `in ${Math.floor(delta / 86400)}d`;
 }
 
-function HealthProgressBadge({ percentage }: { percentage: number }) {
+function HealthProgressBadge({ percentage, compact = false }: { percentage: number; compact?: boolean }) {
     const progress = Math.max(0, Math.min(percentage, 100));
     return (
-        <span className="relative inline-block w-[85px] overflow-hidden rounded-full border border-primary/40 bg-base-300/70 px-1.5 py-0.5 font-mono text-xs text-base-content">
-            <span className="absolute inset-y-0 left-0 bg-primary/40" style={{ width: `${progress}%` }} />
-            <span className="relative">{percentage}%</span>
-        </span>
+        <div className={`inline-flex flex-col gap-0.5 ${compact ? "w-[72px]" : "w-[85px]"}`}>
+            <Badge className="badge-sm w-full justify-center font-semibold tabular-nums">
+                {percentage}%
+            </Badge>
+            <progress
+                className="progress progress-success h-1 w-full"
+                value={progress}
+                max={100}
+            />
+        </div>
     );
 }

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -120,24 +120,17 @@ export default function Health({ loaderData }: Route.ComponentProps) {
     useWebsocketTopics(topicSubscriptions, onWebsocketMessage);
 
     return (
-        <div className="flex min-h-full min-w-full flex-col gap-8 px-4 py-4 text-sm text-base-content/80 md:px-8">
+        <div className="flex min-h-full min-w-full flex-col gap-8 px-4 py-4 text-sm text-base-content md:px-8">
             <HealthStats stats={historyStats} />
             {isEnabled && uncheckedCount > 20 &&
-                <Alert className="flex gap-3 p-3" variant="warning">
-                    <Icon name="warning" filled className="mt-0.5 shrink-0 !text-[20px]" />
+                <Alert className="alert-soft" variant="warning">
+                    <Icon name="warning" filled className="shrink-0 !text-[20px]" />
                     <div>
-                        <div className="font-semibold">Attention</div>
-                        <ul className="mb-0 mt-1 list-disc space-y-1 pl-4">
-                            <li>
-                                You have ~{uncheckedCount} files whose health has never been determined.
-                            </li>
-                            <li>
-                                The queue will run an initial health check of these files.
-                            </li>
-                            <li>
-                                Under normal operation, health checks will occur much less frequently.
-                            </li>
-                        </ul>
+                        <div className="font-semibold">Initial health scan pending</div>
+                        <p className="mt-1 text-xs leading-relaxed text-base-content/70">
+                            About {uncheckedCount} files have never been health-checked. The queue will
+                            run an initial scan; later checks are much less frequent.
+                        </p>
                     </div>
                 </Alert>
             }


### PR DESCRIPTION
## Summary
- Refreshes the health schedule to match queue/daisyUI patterns (`table table-zebra table-sm`, card shell, denser rows).
- Replaces the custom progress pill with badge + daisyUI progress, and uses inline mobile meta chips instead of a nested detail panel.
- Tidies overview stats typography and softens the initial-scan warning alert.

## Test plan
- [ ] Open `/health` with repairs enabled and queued items — confirm table layout at desktop and narrow widths
- [ ] Confirm in-progress items show % badge + progress bar
- [ ] Confirm empty and repairs-disabled empty states
- [ ] Confirm overview stats and warning alert when unchecked count is high
- [ ] `cd frontend && npm run typecheck`