### PR TITLE
fix(db): database upgrade no longer stalls on the Metrics database step

### DIFF
--- a/backend/Database/MetricsMigrations/20260713202318_AddMissesCounters.cs
+++ b/backend/Database/MetricsMigrations/20260713202318_AddMissesCounters.cs
@@ -31,73 +31,16 @@ namespace NzbWebDAV.Database.MetricsMigrations
                 nullable: false,
                 defaultValue: 0L);
 
-            // Prior Errors counted Missing as failures. Split going forward:
-            // Misses = Status Missing (1); Errors = hard failures (Status NOT IN Ok/Missing).
-            var cutoff = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - 24L * 60 * 60 * 1000;
-
-            // Older than raw SegmentFetches retention: treat prior Errors as Misses.
+            // Prior Errors counted Missing as failures. Existing rollups cannot split
+            // those values accurately without scanning the large raw SegmentFetches
+            // table, which can make startup migrations effectively unbounded. Treat
+            // historical Errors as Misses; new rollups track the two counters exactly.
             migrationBuilder.Sql(
-                $"UPDATE ThroughputMinutes SET Misses = Errors, Errors = 0 WHERE Minute < {cutoff};");
+                "UPDATE ThroughputMinutes SET Misses = Errors, Errors = 0;");
             migrationBuilder.Sql(
-                $"UPDATE ProviderMinutes SET Misses = Errors, Errors = 0 WHERE Minute < {cutoff};");
+                "UPDATE ProviderMinutes SET Misses = Errors, Errors = 0;");
             migrationBuilder.Sql(
-                $"UPDATE ProviderHourly SET Misses = Errors, Errors = 0 WHERE Hour < {cutoff};");
-
-            // Last 24h: recompute accurately from raw SegmentFetches.
-            migrationBuilder.Sql(
-                $"""
-                UPDATE ThroughputMinutes
-                SET
-                  Misses = COALESCE((
-                    SELECT COUNT(*) FROM SegmentFetches sf
-                    WHERE sf.At >= ThroughputMinutes.Minute
-                      AND sf.At < ThroughputMinutes.Minute + 60000
-                      AND sf.Status = 1), 0),
-                  Errors = COALESCE((
-                    SELECT COUNT(*) FROM SegmentFetches sf
-                    WHERE sf.At >= ThroughputMinutes.Minute
-                      AND sf.At < ThroughputMinutes.Minute + 60000
-                      AND sf.Status NOT IN (0, 1)), 0)
-                WHERE Minute >= {cutoff};
-                """);
-
-            migrationBuilder.Sql(
-                $"""
-                UPDATE ProviderMinutes
-                SET
-                  Misses = COALESCE((
-                    SELECT COUNT(*) FROM SegmentFetches sf
-                    WHERE sf.At >= ProviderMinutes.Minute
-                      AND sf.At < ProviderMinutes.Minute + 60000
-                      AND sf.Provider = ProviderMinutes.Provider
-                      AND sf.Status = 1), 0),
-                  Errors = COALESCE((
-                    SELECT COUNT(*) FROM SegmentFetches sf
-                    WHERE sf.At >= ProviderMinutes.Minute
-                      AND sf.At < ProviderMinutes.Minute + 60000
-                      AND sf.Provider = ProviderMinutes.Provider
-                      AND sf.Status NOT IN (0, 1)), 0)
-                WHERE Minute >= {cutoff};
-                """);
-
-            migrationBuilder.Sql(
-                $"""
-                UPDATE ProviderHourly
-                SET
-                  Misses = COALESCE((
-                    SELECT COUNT(*) FROM SegmentFetches sf
-                    WHERE sf.At >= ProviderHourly.Hour
-                      AND sf.At < ProviderHourly.Hour + 3600000
-                      AND sf.Provider = ProviderHourly.Provider
-                      AND sf.Status = 1), 0),
-                  Errors = COALESCE((
-                    SELECT COUNT(*) FROM SegmentFetches sf
-                    WHERE sf.At >= ProviderHourly.Hour
-                      AND sf.At < ProviderHourly.Hour + 3600000
-                      AND sf.Provider = ProviderHourly.Provider
-                      AND sf.Status NOT IN (0, 1)), 0)
-                WHERE Hour >= {cutoff};
-                """);
+                "UPDATE ProviderHourly SET Misses = Errors, Errors = 0;");
         }
 
         /// <inheritdoc />

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -365,11 +365,19 @@ class Program
                 .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
                 .ConfigureAwait(false);
             var pendingProbe = (await probeContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
+            await using var metricsProbeContext = new MetricsDbContext();
+            var pendingMetricsProbe = (await metricsProbeContext.Database
+                .GetPendingMigrationsAsync(ct)
+                .ConfigureAwait(false))
+                .ToList();
             var vacuumEnabledProbe = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);
 
             // Routine restarts with nothing to do: skip the status server and its
             // grace delay so Docker does not bind/unbind :8080 just to say "idle".
-            if (MigrationProgress.IsIdleMaintenance(pendingProbe.Count, vacuumEnabledProbe))
+            if (MigrationProgress.IsIdleMaintenance(
+                    pendingProbe.Count,
+                    pendingMetricsProbe.Count,
+                    vacuumEnabledProbe))
             {
                 Log.Information("No pending database migrations");
                 await using var metricsContext = new MetricsDbContext();

--- a/backend/Services/MigrationProgress.cs
+++ b/backend/Services/MigrationProgress.cs
@@ -24,6 +24,7 @@ public sealed class MigrationProgress
         "20260129182923_Update-DavItems-Type-And-SubType",
         "20260203071130_Add-DavCleanupItems-Table",
         "20260712000000_Fix-Empty-Categories",
+        "20260713120000_Add-Path-Index-To-DavItems",
     };
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -122,11 +123,17 @@ public sealed class MigrationProgress
     public static bool IsSlow(string migrationId) => SlowMigrations.Contains(migrationId);
 
     /// <summary>
-    /// True when there is nothing user-visible to report: no pending EF migrations
-    /// and vacuum is disabled. The migration runner skips the status server in this case.
+    /// True when there is nothing user-visible to report: no pending main or
+    /// metrics EF migrations and vacuum is disabled. The migration runner skips
+    /// the status server in this case.
     /// </summary>
-    public static bool IsIdleMaintenance(int pendingMigrationCount, bool vacuumEnabled) =>
-        pendingMigrationCount == 0 && !vacuumEnabled;
+    public static bool IsIdleMaintenance(
+        int pendingMigrationCount,
+        int pendingMetricsMigrationCount,
+        bool vacuumEnabled) =>
+        pendingMigrationCount == 0
+        && pendingMetricsMigrationCount == 0
+        && !vacuumEnabled;
 
     private sealed class StepState(string id, string name, bool slow)
     {

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -93,11 +93,11 @@ services:
     container_name: nzbdav
     restart: unless-stopped
     healthcheck:
-      # Follow the onboarding/login redirect and verify that the UI can reach the backend
-      test: ["CMD-SHELL", "curl -fsSL http://localhost:3000/login > /dev/null || exit 1"]
+      # Keep the container healthy while one-time backend maintenance is running
+      test: ["CMD-SHELL", "curl -fsSL http://localhost:3000/healthz > /dev/null || exit 1"]
       interval: 30s
       retries: 3         # mark unhealthy after 3 consecutive failures
-      start_period: 30s  # allow migrations and both processes to start
+      start_period: 60s  # allow the frontend process to start
       timeout: 5s
     ports:
       - "3000:3000"
@@ -118,7 +118,7 @@ Run the container:
 docker compose up -d
 ```
 
-The image runs two processes: the frontend and public proxy on port `3000`, and the backend on internal port `8080`. Clients should use port `3000`; the compose healthcheck follows the login/onboarding flow so it verifies that the frontend can also reach the backend.
+The image runs two processes: the frontend and public proxy on port `3000`, and the backend on internal port `8080`. Clients should use port `3000`; the compose healthcheck targets the frontend-local `/healthz` endpoint so long one-time database maintenance does not mark the container unhealthy. The entrypoint separately waits for the backend health endpoint and exits the container if the backend cannot start.
 
 !!! warning "Important"
 

--- a/tests/NzbWebDAV.Tests/Database/MetricsMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/MetricsMigrationTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class MetricsMigrationTests
+{
+    private const string PriorMigration = "20260601104313_AddFailoverEdges";
+
+    [Fact]
+    public async Task AddMissesCounters_MovesExistingErrorsWithoutScanningRawFetches()
+    {
+        var databasePath = Path.Combine(
+            Path.GetTempPath(),
+            $"nzbdav-metrics-migration-{Guid.NewGuid():N}.sqlite");
+        var options = new DbContextOptionsBuilder<MetricsDbContext>()
+            .UseSqlite($"Data Source={databasePath};Pooling=False")
+            .AddInterceptors(new SqliteMetricsPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+
+        try
+        {
+            await using var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO ThroughputMinutes
+                    (Minute, BytesServed, BytesFetched, Articles, Errors, ActiveReadsMax)
+                VALUES (60000, 10, 20, 3, 7, 1);
+
+                INSERT INTO ProviderMinutes
+                    (Minute, Provider, Articles, BytesFetched, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+                VALUES (60000, 'provider-a', 3, 20, 5, 1, 1, 30, NULL);
+
+                INSERT INTO ProviderHourly
+                    (Hour, Provider, Articles, BytesFetched, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
+                VALUES (0, 'provider-a', 3, 20, 9, 1, 1, 30, 10);
+
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Bytes, DurationMs, Status, Retries)
+                VALUES
+                    (60001, 'provider-a', NULL, NULL, 10, 1, 1, 0),
+                    (60002, 'provider-a', NULL, NULL, 10, 1, 2, 0);
+                """);
+
+            await context.Database.MigrateAsync();
+            context.ChangeTracker.Clear();
+
+            var throughput = await context.ThroughputMinutes.AsNoTracking().SingleAsync();
+            Assert.Equal(7, throughput.Misses);
+            Assert.Equal(0, throughput.Errors);
+
+            var providerMinute = await context.ProviderMinutes.AsNoTracking().SingleAsync();
+            Assert.Equal(5, providerMinute.Misses);
+            Assert.Equal(0, providerMinute.Errors);
+
+            var providerHour = await context.ProviderHourly.AsNoTracking().SingleAsync();
+            Assert.Equal(9, providerHour.Misses);
+            Assert.Equal(0, providerHour.Errors);
+
+            Assert.Empty(await context.Database.GetPendingMigrationsAsync());
+        }
+        finally
+        {
+            File.Delete(databasePath);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/MigrationProgressTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/MigrationProgressTests.cs
@@ -5,15 +5,28 @@ namespace NzbWebDAV.Tests.Services;
 public class MigrationProgressTests
 {
     [Theory]
-    [InlineData(0, false, true)]
-    [InlineData(0, true, false)]
-    [InlineData(1, false, false)]
-    [InlineData(2, true, false)]
+    [InlineData(0, 0, false, true)]
+    [InlineData(0, 0, true, false)]
+    [InlineData(1, 0, false, false)]
+    [InlineData(0, 1, false, false)]
+    [InlineData(2, 3, true, false)]
     public void IsIdleMaintenance_MatchesPendingAndVacuum(
         int pendingCount,
+        int pendingMetricsCount,
         bool vacuumEnabled,
         bool expected)
     {
-        Assert.Equal(expected, MigrationProgress.IsIdleMaintenance(pendingCount, vacuumEnabled));
+        Assert.Equal(
+            expected,
+            MigrationProgress.IsIdleMaintenance(
+                pendingCount,
+                pendingMetricsCount,
+                vacuumEnabled));
+    }
+
+    [Fact]
+    public void IsSlow_FlagsPathIndexMigration()
+    {
+        Assert.True(MigrationProgress.IsSlow("20260713120000_Add-Path-Index-To-DavItems"));
     }
 }


### PR DESCRIPTION
## Summary
- replace the expensive raw `SegmentFetches` backfill with a bounded rollup-counter conversion
- include pending metrics migrations in maintenance detection so retries remain visible
- keep long maintenance from failing the documented frontend healthcheck
- add regression coverage for migration semantics and maintenance status

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~MigrationProgressTests|FullyQualifiedName~MetricsMigrationTests'`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `git diff --check`