### PR TITLE
fix(webdav): stop broken files from flooding logs and Usenet traffic

### DIFF
--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Channels;
+﻿using System.Runtime.ExceptionServices;
+using System.Threading.Channels;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
@@ -15,6 +16,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 {
     private const int BodyPipelineBatchSize = 4;
     private const int MaxBodyRetries = 2;
+    private const int MaxConsecutiveZeroFills = 3;
 
     private readonly Memory<string> _segmentIds;
     private readonly string[][]? _segmentFallbacks;
@@ -22,11 +24,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly long _expectedSegmentSize;
     private readonly bool _failFastOnFirstSegment;
     private readonly string _fileName;
-    private readonly Channel<Task<Stream>> _streamTasks;
+    private readonly Channel<Task<SegmentDownloadResult>> _streamTasks;
     private readonly int _bodyPipelineBatchSize;
     private readonly ContextualCancellationTokenSource _cts;
     private readonly long? _readBudget;
     private Stream? _stream;
+    private int _consecutiveZeroFills;
     private bool _disposed;
 
     public static Stream Create(
@@ -104,7 +107,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _readBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         _bodyPipelineBatchSize = Math.Min(BodyPipelineBatchSize, articleBufferSize);
-        _streamTasks = Channel.CreateBounded<Task<Stream>>(articleBufferSize);
+        _streamTasks = Channel.CreateBounded<Task<SegmentDownloadResult>>(articleBufferSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _ = DownloadSegments(usePipelinedBodyRequests, _cts.Token);
     }
@@ -226,7 +229,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return segmentsEnqueued * _expectedSegmentSize >= _readBudget.Value + _expectedSegmentSize;
     }
 
-    private async Task<Stream> DownloadSegment(
+    private async Task<SegmentDownloadResult> DownloadSegment(
         string segmentId,
         int segmentIndex,
         UsenetExclusiveConnection exclusiveConnection,
@@ -246,14 +249,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         .DecodedBodyAsync(segmentId, cancellationToken)
                         .ConfigureAwait(false);
 
-                return await DrainSegmentAsync(bodyResponse.Stream!, cancellationToken).ConfigureAwait(false);
+                var stream = await DrainSegmentAsync(bodyResponse.Stream!, cancellationToken).ConfigureAwait(false);
+                return SegmentDownloadResult.Success(stream);
             }
             catch (UsenetArticleNotFoundException e)
             {
                 var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
                     .ConfigureAwait(false);
                 if (fallback is not null)
-                    return fallback;
+                    return SegmentDownloadResult.Success(fallback);
 
                 if (_failFastOnFirstSegment && isFirstSegment)
                 {
@@ -266,7 +270,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
                 return ZeroFillSegment(
                     "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
-                    e.SegmentId);
+                    e.SegmentId,
+                    e);
             }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested)
             {
@@ -297,7 +302,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
     }
 
-    private async Task<Stream> DownloadBatchSegment(
+    private async Task<SegmentDownloadResult> DownloadBatchSegment(
         Task<UsenetDecodedBodyResponse> responseTask,
         string segmentId,
         int segmentIndex,
@@ -307,19 +312,21 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         try
         {
             var response = await responseTask.ConfigureAwait(false);
-            return await DrainSegmentAsync(response.Stream!, cancellationToken).ConfigureAwait(false);
+            var stream = await DrainSegmentAsync(response.Stream!, cancellationToken).ConfigureAwait(false);
+            return SegmentDownloadResult.Success(stream);
         }
         catch (UsenetArticleNotFoundException e)
         {
             var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
                 .ConfigureAwait(false);
             if (fallback is not null)
-                return fallback;
+                return SegmentDownloadResult.Success(fallback);
 
             if (_failFastOnFirstSegment && isFirstSegment) throw;
             return ZeroFillSegment(
                 "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
-                e.SegmentId);
+                e.SegmentId,
+                e);
         }
         catch (Exception e) when (!cancellationToken.IsCancellationRequested)
         {
@@ -373,11 +380,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return _segmentFallbacks[segmentIndex] ?? [];
     }
 
-    private static async Task DisposeStreamAsync(Task<Stream> streamTask)
+    private static async Task DisposeStreamAsync(Task<SegmentDownloadResult> streamTask)
     {
         try
         {
-            await using var stream = await streamTask.ConfigureAwait(false);
+            var result = await streamTask.ConfigureAwait(false);
+            await using var stream = result.Stream;
         }
         catch
         {
@@ -385,16 +393,18 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
     }
 
-    private Stream ZeroFillSegment(string messageTemplate, string segmentId, Exception? exception = null)
+    private SegmentDownloadResult ZeroFillSegment(
+        string messageTemplate,
+        string segmentId,
+        Exception exception)
     {
         var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
-        if (exception == null)
-            Log.Warning(messageTemplate, segmentId, _fileName, fill);
-        else
-            exception.LogWarningKnownOrStack(messageTemplate, segmentId, _fileName, fill);
-        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
-            StreamTrace.TryZeroFill(sessionId, segmentId, fill);
-        return new MemoryStream(new byte[fill], writable: false);
+        return SegmentDownloadResult.ZeroFill(
+            new MemoryStream(new byte[fill], writable: false),
+            messageTemplate,
+            segmentId,
+            fill,
+            exception);
     }
 
     private async Task<Stream> DrainSegmentAsync(Stream source, CancellationToken cancellationToken)
@@ -426,7 +436,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 if (!await _streamTasks.Reader.WaitToReadAsync(cancellationToken)) return 0;
                 if (!_streamTasks.Reader.TryRead(out var streamTask)) return 0;
-                _stream = await streamTask;
+                var result = await streamTask;
+                _stream = AcceptSegment(result);
             }
 
             // read from the stream
@@ -437,6 +448,33 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             await _stream.DisposeAsync();
             _stream = null;
         }
+    }
+
+    private Stream AcceptSegment(SegmentDownloadResult result)
+    {
+        if (!result.IsZeroFill)
+        {
+            _consecutiveZeroFills = 0;
+            return result.Stream;
+        }
+
+        _consecutiveZeroFills++;
+        ZeroFillLogLimiter.Write(
+            result.MessageTemplate!,
+            result.SegmentId!,
+            _fileName,
+            result.Bytes,
+            result.Failure);
+        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+            StreamTrace.TryZeroFill(sessionId, result.SegmentId!, result.Bytes);
+
+        if (_consecutiveZeroFills < MaxConsecutiveZeroFills)
+            return result.Stream;
+
+        result.Stream.Dispose();
+        _cts.Cancel();
+        ExceptionDispatchInfo.Capture(result.Failure!).Throw();
+        throw new InvalidOperationException("Unreachable after rethrowing a zero-fill failure.");
     }
 
     private void ThrowIfDisposed()
@@ -459,5 +497,25 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             _ = DisposeStreamAsync(streamTask);
 
         base.Dispose();
+    }
+
+    private sealed record SegmentDownloadResult(
+        Stream Stream,
+        string? MessageTemplate = null,
+        string? SegmentId = null,
+        long Bytes = 0,
+        Exception? Failure = null)
+    {
+        public bool IsZeroFill => Failure is not null;
+
+        public static SegmentDownloadResult Success(Stream stream) => new(stream);
+
+        public static SegmentDownloadResult ZeroFill(
+            Stream stream,
+            string messageTemplate,
+            string segmentId,
+            long bytes,
+            Exception failure) =>
+            new(stream, messageTemplate, segmentId, bytes, failure);
     }
 }

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -1,12 +1,14 @@
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Exceptions;
-using Serilog;
+using NzbWebDAV.Services.StreamTrace;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
 
 public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 {
+    private const int MaxConsecutiveZeroFills = 3;
+
     private readonly Memory<string> _segmentIds;
     private readonly string[][]? _segmentFallbacks;
     private readonly INntpClient _usenetClient;
@@ -14,6 +16,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly string _fileName;
     private Stream? _stream;
     private int _currentIndex;
+    private int _consecutiveZeroFills;
     private bool _disposed;
 
 
@@ -49,6 +52,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 {
                     var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken);
                     _stream = body.Stream!;
+                    _consecutiveZeroFills = 0;
                 }
                 catch (UsenetArticleNotFoundException e)
                 {
@@ -57,13 +61,23 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                     if (fallback is not null)
                     {
                         _stream = fallback;
+                        _consecutiveZeroFills = 0;
                     }
                     else
                     {
                         var fill = _expectedSegmentSize > 0 ? _expectedSegmentSize : 1;
-                        Log.Warning(
+                        _consecutiveZeroFills++;
+                        ZeroFillLogLimiter.Write(
                             "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
-                            e.SegmentId, _fileName, fill);
+                            e.SegmentId,
+                            _fileName,
+                            fill,
+                            e);
+                        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+                            StreamTrace.TryZeroFill(sessionId, e.SegmentId, fill);
+                        if (_consecutiveZeroFills >= MaxConsecutiveZeroFills)
+                            throw;
+
                         _stream = new MemoryStream(new byte[fill], writable: false);
                     }
                 }

--- a/backend/Streams/ZeroFillLogLimiter.cs
+++ b/backend/Streams/ZeroFillLogLimiter.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+using NzbWebDAV.Extensions;
+using Serilog;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Coalesces zero-fill warnings by file so a release with many unavailable
+/// articles cannot flood the application log.
+/// </summary>
+internal static class ZeroFillLogLimiter
+{
+    private static readonly ConcurrentDictionary<string, WindowState> Windows =
+        new(StringComparer.Ordinal);
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
+    private static int _callCount;
+
+    public static void Write(
+        string messageTemplate,
+        string segmentId,
+        string fileName,
+        long bytes,
+        Exception? exception = null)
+    {
+        var now = DateTime.UtcNow;
+        var state = Windows.GetOrAdd(fileName, static _ => new WindowState());
+        var shouldLog = false;
+        var suppressed = 0;
+
+        lock (state)
+        {
+            if (state.WindowStarted == default || now - state.WindowStarted >= Window)
+            {
+                suppressed = state.Suppressed;
+                state.WindowStarted = now;
+                state.Suppressed = 0;
+                shouldLog = true;
+            }
+            else
+            {
+                state.Suppressed++;
+            }
+        }
+
+        if (shouldLog)
+        {
+            if (suppressed > 0)
+            {
+                Log.Warning(
+                    "Suppressed {SuppressedCount} additional zero-fill warnings for {FileName} in the previous 60 seconds.",
+                    suppressed,
+                    fileName);
+            }
+
+            if (exception is null)
+                Log.Warning(messageTemplate, segmentId, fileName, bytes);
+            else
+                exception.LogWarningKnownOrStack(messageTemplate, segmentId, fileName, bytes);
+        }
+
+        if (Interlocked.Increment(ref _callCount) % 256 == 0)
+            Cleanup(now);
+    }
+
+    private static void Cleanup(DateTime now)
+    {
+        foreach (var entry in Windows)
+        {
+            lock (entry.Value)
+            {
+                if (now - entry.Value.WindowStarted >= CleanupThreshold)
+                    Windows.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+
+    private sealed class WindowState
+    {
+        public DateTime WindowStarted { get; set; }
+        public int Suppressed { get; set; }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -172,6 +172,74 @@ public class NzbFileStreamTests
         }
     }
 
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(4, true)]
+    public async Task MissingArticles_ZeroFillWarningsAreCoalescedByFile(
+        int articleBufferSize,
+        bool usePipelinedBodyRequests)
+    {
+        var fileName = $"/content/show/coalesced-episode-{articleBufferSize}.mkv";
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            var client = new FakeNntpClient(new Dictionary<string, byte[]>());
+            await using var stream = MultiSegmentStream.Create(
+                new[] { "missing-one", "missing-two" }.AsMemory(),
+                client,
+                articleBufferSize: articleBufferSize,
+                expectedSegmentSize: 5,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: usePipelinedBodyRequests,
+                cancellationToken: CancellationToken.None,
+                fileName: fileName);
+
+            var buffer = new byte[5];
+            Assert.Equal(5, await stream.ReadAsync(buffer));
+            Assert.Equal(5, await stream.ReadAsync(buffer));
+
+            var zeroFillWarnings = sink.Events.Count(e =>
+                e.Level == LogEventLevel.Warning &&
+                e.RenderMessage().Contains(fileName, StringComparison.Ordinal) &&
+                e.RenderMessage().Contains("Zero-filling", StringComparison.Ordinal));
+            Assert.Equal(1, zeroFillWarnings);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task MissingArticles_ThirdConsecutiveZeroFillFailsStream()
+    {
+        var client = new FakeNntpClient(new Dictionary<string, byte[]>());
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "missing-one", "missing-two", "missing-three", "missing-four" }.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            expectedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            cancellationToken: CancellationToken.None,
+            fileName: "/content/show/dead-episode.mkv");
+
+        var buffer = new byte[5];
+        Assert.Equal(5, await stream.ReadAsync(buffer));
+        Assert.Equal(5, await stream.ReadAsync(buffer));
+        await Assert.ThrowsAsync<NzbWebDAV.Exceptions.UsenetArticleNotFoundException>(
+            async () => await stream.ReadAtLeastAsync(
+                buffer, buffer.Length, throwOnEndOfStream: false));
+
+        Assert.Equal(3, client.BodyRequestCount);
+    }
+
     // These fast-seek tests use CachedYencStream (pre-parsed headers over decoded
     // bytes), so they run even where the rapidyenc native library is unavailable.
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
@@ -74,6 +74,70 @@ public class SegmentFallbackTests
         Assert.Equal(2, client.BodyRequestCount);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MultiSegmentStream_ConsecutiveMissingArticlesStopPrefetch(
+        bool usePipelinedBodyRequests)
+    {
+        var segmentIds = Enumerable.Range(0, 20)
+            .Select(index => $"missing-{index}")
+            .ToArray();
+        var client = new RawBodyNntpClient(new Dictionary<string, byte[]>());
+
+        await using var stream = MultiSegmentStream.Create(
+            segmentIds.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            expectedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: usePipelinedBodyRequests,
+            cancellationToken: CancellationToken.None,
+            fileName: $"dead-prefetch-{usePipelinedBodyRequests}.bin");
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream.CopyToAsync(new MemoryStream()));
+        await Task.Delay(50);
+
+        Assert.True(
+            client.BodyRequestCount < segmentIds.Length,
+            $"Expected prefetch cancellation before all {segmentIds.Length} articles, got {client.BodyRequestCount} requests.");
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(4, true)]
+    public async Task MultiSegmentStream_SuccessResetsConsecutiveZeroFillCount(
+        int articleBufferSize,
+        bool usePipelinedBodyRequests)
+    {
+        var client = new RawBodyNntpClient(new Dictionary<string, byte[]>
+        {
+            ["good"] = Encoding.ASCII.GetBytes("abcde"),
+        });
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "missing-one", "good", "missing-two", "missing-three", "missing-four" }.AsMemory(),
+            client,
+            articleBufferSize: articleBufferSize,
+            expectedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: usePipelinedBodyRequests,
+            cancellationToken: CancellationToken.None,
+            fileName: $"reset-zero-fill-streak-{articleBufferSize}.bin");
+
+        var buffer = new byte[5];
+        Assert.Equal(5, await stream.ReadAsync(buffer));
+        Assert.Equal(5, await stream.ReadAsync(buffer));
+        Assert.Equal("abcde", Encoding.ASCII.GetString(buffer));
+        Assert.Equal(5, await stream.ReadAsync(buffer));
+        Assert.Equal(5, await stream.ReadAsync(buffer));
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream.ReadAtLeastAsync(
+                buffer, buffer.Length, throwOnEndOfStream: false));
+
+        Assert.Equal(5, client.BodyRequestCount);
+    }
+
     [Fact]
     public void DavNzbFile_MemoryPackRoundTrip_WithAndWithoutFallbacks()
     {


### PR DESCRIPTION
## Summary
- coalesce repeated zero-fill warnings per file over a 60-second window
- stop buffered, pipelined, and unbuffered reads after three consecutive zero-fills so broken releases trigger urgent repair
- preserve playback resilience for sparse misses and reset the failure streak after a successful segment

## Test plan
- [x] Build backend with `dotnet build backend/NzbWebDAV.csproj --no-restore`
- [x] Run 10 focused zero-fill regression cases
- [x] Run stream suite excluding the existing native-dependent prefetch tests: 32 passed, 9 skipped
- [ ] Run native `rapidyenc`-dependent prefetch tests in CI