### PR TITLE
fix(queue): stop PAR2 scans when enumeration is cancelled

### DIFF
--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using NzbWebDAV.Par2Recovery.Packets;
@@ -18,7 +19,7 @@ namespace NzbWebDAV.Par2Recovery
         public static async IAsyncEnumerable<FileDesc> ReadFileDescriptions
         (
             Stream stream,
-            CancellationToken ct = default
+            [EnumeratorCancellation] CancellationToken ct = default
         )
         {
             // Buffer descriptors and optional UniFileN names so Unicode can win


### PR DESCRIPTION
## Summary
- wire async-enumerator cancellation into PAR2 file-description scans
- preserve cancellation passed directly by existing callers while supporting `WithCancellation`

## Test plan
- [x] Run focused `Par2Tests` suite
- [x] Confirm the CS8425 compiler warning is removed