### PR TITLE
fix(webdav): remove spurious Content-Length mismatch errors when playback hits missing articles

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -67,6 +67,8 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             if (context.Items["DavItem"] is DavItem davItem)
                 ScheduleRepair(davItem.Id);
+
+            AbortStartedResponse(context);
         }
         catch (SeekPositionNotFoundException)
         {
@@ -93,6 +95,8 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                         filePath,
                         seekPosition);
             });
+
+            AbortStartedResponse(context);
         }
         catch (CouldNotLoginToUsenetException e)
         {
@@ -121,6 +125,8 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             {
                 Log.Error("File {FilePath} provider authentication failed: {ErrorMessage}", filePath, errorDetail);
             }
+
+            AbortStartedResponse(context);
         }
         catch (CouldNotConnectToUsenetException e)
         {
@@ -132,6 +138,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             var filePath = GetRequestFilePath(context);
             Log.Error("File {FilePath} could not connect to usenet provider: {ErrorMessage}", filePath, e.Message);
+            AbortStartedResponse(context);
         }
         catch (Exception e) when (IsDavItemRequest(context))
         {
@@ -192,7 +199,15 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                         userAgent);
                 }
             });
+
+            AbortStartedResponse(context);
         }
+    }
+
+    private static void AbortStartedResponse(HttpContext context)
+    {
+        if (context.Response.HasStarted)
+            context.Abort();
     }
 
     private void ScheduleRepair(Guid davItemId)

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Middlewares;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Middlewares;
+
+public class ExceptionMiddlewareTests
+{
+    [Fact]
+    public async Task MissingArticleAfterResponseStarted_AbortsConnection()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetArticleNotFoundException("missing-segment"));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task MissingArticleBeforeResponseStarted_ReturnsNotFoundWithoutAborting()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetArticleNotFoundException("missing-segment"));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(lifetimeFeature.Aborted);
+    }
+
+    private static ExceptionMiddleware CreateMiddleware(RequestDelegate next)
+    {
+        return new ExceptionMiddleware(
+            next,
+            new ConfigManager(),
+            new StreamingFailureTracker());
+    }
+
+    private static DefaultHttpContext CreateContext(
+        bool hasStarted,
+        TestHttpRequestLifetimeFeature lifetimeFeature)
+    {
+        var context = new DefaultHttpContext();
+        context.Features.Set<IHttpResponseFeature>(new TestHttpResponseFeature(hasStarted));
+        context.Features.Set<IHttpRequestLifetimeFeature>(lifetimeFeature);
+        return context;
+    }
+
+    private sealed class TestHttpResponseFeature(bool hasStarted) : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted { get; } = hasStarted;
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+        }
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+        }
+    }
+
+    private sealed class TestHttpRequestLifetimeFeature : IHttpRequestLifetimeFeature
+    {
+        public bool Aborted { get; private set; }
+        public CancellationToken RequestAborted { get; set; }
+
+        public void Abort()
+        {
+            Aborted = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- abort started WebDAV responses after handled streaming failures so Kestrel does not finalize truncated bodies against their declared Content-Length
- preserve existing status responses for failures caught before headers are sent
- cover missing-article failures before and after response start with middleware regression tests

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~ExceptionMiddlewareTests` (2 passed)
- [x] backend suite excluding `MultiSegmentStreamPrefetchBudgetTests.ReadBudget_CapsPrefetchBelowArticleBufferSize` (560 passed, 11 skipped)
- [ ] full Linux CI suite (the excluded test requires rapidyenc, which is unavailable on local macOS arm64)