### PR TITLE
feat(ui): show error trends per provider on the overview scoreboard

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -690,7 +690,11 @@ public class GetOverviewStatsController(
             acc.SumDurationMs += m.SumDurationMs;
             acc.Bytes += m.BytesFetched;
             var idx = (int)((m.Minute - sparkStart) / sparkSize);
-            if (idx >= 0 && idx < sparkBuckets) acc.Spark[idx] += m.Articles;
+            if (idx >= 0 && idx < sparkBuckets)
+            {
+                acc.Spark[idx] += m.Articles;
+                acc.ErrorSpark[idx] += m.Errors;
+            }
             byProvider[m.Provider] = acc;
         }
 
@@ -707,6 +711,7 @@ public class GetOverviewStatsController(
                 AvgDurationMs = kv.Value.Articles > 0 ? (double)kv.Value.SumDurationMs / kv.Value.Articles : 0,
                 ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
                 Spark = kv.Value.Spark.ToList(),
+                ErrorSpark = kv.Value.ErrorSpark.ToList(),
             })
             .OrderByDescending(r => r.Articles)
             .ToList();
@@ -736,7 +741,11 @@ public class GetOverviewStatsController(
             acc.SumDurationMs += (long)h.SumDurationMs;
             acc.Bytes += (long)h.BytesFetched;
             var idx = (int)(((long)h.Hour - sparkStart) / sparkSize);
-            if (idx >= 0 && idx < sparkBuckets) acc.Spark[idx] += (long)h.Articles;
+            if (idx >= 0 && idx < sparkBuckets)
+            {
+                acc.Spark[idx] += (long)h.Articles;
+                acc.ErrorSpark[idx] += (long)h.Errors;
+            }
             byProvider[host] = acc;
         }
 
@@ -753,6 +762,7 @@ public class GetOverviewStatsController(
                 AvgDurationMs = kv.Value.Articles > 0 ? (double)kv.Value.SumDurationMs / kv.Value.Articles : 0,
                 ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
                 Spark = kv.Value.Spark.ToList(),
+                ErrorSpark = kv.Value.ErrorSpark.ToList(),
             })
             .OrderByDescending(r => r.Articles)
             .ToList();
@@ -762,7 +772,12 @@ public class GetOverviewStatsController(
     {
         public long Articles, Errors, Retries, SumDurationMs, Bytes;
         public readonly long[] Spark;
-        public ProviderAccumulator(int n) { Spark = new long[n]; }
+        public readonly long[] ErrorSpark;
+        public ProviderAccumulator(int n)
+        {
+            Spark = new long[n];
+            ErrorSpark = new long[n];
+        }
     }
 
     private static async Task<GetOverviewStatsResponse.HeatmapBlock> BuildHeatmapAsync(

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -68,6 +68,8 @@ public class GetOverviewStatsResponse
         public double AvgDurationMs { get; init; }
         public double ErrorRate { get; init; }
         public List<long> Spark { get; init; } = new();
+        /// <summary>Hard fetch failures per spark bucket (same sizing as <see cref="Spark"/>).</summary>
+        public List<long> ErrorSpark { get; init; } = new();
         public string CircuitState { get; init; } = "closed";
         public int? CooldownRemainingSeconds { get; init; }
         public string? LastFailureReason { get; init; }

--- a/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
+++ b/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
@@ -29,6 +29,7 @@ internal static class ProviderCircuitOverviewEnricher
                     AvgDurationMs = existing.AvgDurationMs,
                     ErrorRate = existing.ErrorRate,
                     Spark = existing.Spark,
+                    ErrorSpark = existing.ErrorSpark,
                     CircuitState = fields.CircuitState,
                     CooldownRemainingSeconds = fields.CooldownRemainingSeconds,
                     LastFailureReason = fields.LastFailureReason,

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -663,6 +663,7 @@ export type ProviderRow = {
     avgDurationMs: number,
     errorRate: number,
     spark: number[],
+    errorSpark?: number[],
     circuitState?: ProviderCircuitState,
     cooldownRemainingSeconds?: number | null,
     lastFailureReason?: string | null,

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -31,7 +31,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                     <th>Articles</th>
                                     <th>Read</th>
                                     <th>Share</th>
-                                    <th>Errors</th>
+                                    <th className="w-[120px]">Errors</th>
                                     <th>Retries</th>
                                     <th>Avg ms</th>
                                 </tr>
@@ -58,20 +58,25 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                                 </div>
                                             </td>
                                             <td>
-                                                <Sparkline values={p.spark} />
+                                                <Sparkline values={p.spark} tone="success" />
                                             </td>
                                             <td className="font-mono tabular-nums">{formatNumber(p.articles)}</td>
                                             <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>
                                             <td>
                                                 <ShareBar share={share} />
                                             </td>
-                                            <td className={`font-mono tabular-nums ${p.errorRate > 0.05 ? "text-error" : ""}`}>
-                                                {formatNumber(p.errors)}
-                                                {p.errorRate > 0 && (
-                                                    <span className="text-xs text-base-content/50">
-                                                        {" "}({formatPercent(p.errorRate * 100, 1)})
-                                                    </span>
-                                                )}
+                                            <td>
+                                                <div className="flex flex-col gap-0.5">
+                                                    <Sparkline values={p.errorSpark ?? []} tone="error" />
+                                                    <div className={`font-mono text-[11px] tabular-nums ${p.errorRate > 0.05 ? "text-error" : "text-base-content/60"}`}>
+                                                        {formatNumber(p.errors)}
+                                                        {p.errorRate > 0 && (
+                                                            <span className="text-base-content/50">
+                                                                {" "}({formatPercent(p.errorRate * 100, 1)})
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                </div>
                                             </td>
                                             <td className="font-mono tabular-nums">{formatNumber(p.retries)}</td>
                                             <td className="font-mono tabular-nums">{p.avgDurationMs.toFixed(0)}</td>
@@ -142,7 +147,7 @@ function ShareBar({ share }: { share: number }) {
     );
 }
 
-function Sparkline({ values }: { values: number[] }) {
+function Sparkline({ values, tone = "success" }: { values: number[], tone?: "success" | "error" }) {
     if (values.length === 0) return <div className="h-[22px] w-[110px] rounded-sm bg-base-content/[0.04]" />;
     const w = 110;
     const h = 22;
@@ -153,10 +158,14 @@ function Sparkline({ values }: { values: number[] }) {
         .map((v, i) => `${i === 0 ? "M" : "L"}${(i * step).toFixed(1)},${y(v).toFixed(1)}`)
         .join(" ");
     const area = `${path} L${((values.length - 1) * step).toFixed(1)},${h} L0,${h} Z`;
+    const stroke = tone === "error" ? "var(--color-error)" : "var(--color-success)";
+    const fill = tone === "error"
+        ? "color-mix(in srgb, var(--color-error) 16%, transparent)"
+        : "color-mix(in srgb, var(--color-success) 16%, transparent)";
     return (
         <svg viewBox={`0 0 ${w} ${h}`} className="block h-[22px] w-[110px]" preserveAspectRatio="none">
-            <path d={area} fill="color-mix(in srgb, var(--color-success) 16%, transparent)" />
-            <path d={path} fill="none" stroke="var(--color-success)" strokeWidth="1.2" vectorEffect="non-scaling-stroke" />
+            <path d={area} fill={fill} />
+            <path d={path} fill="none" stroke={stroke} strokeWidth="1.2" vectorEffect="non-scaling-stroke" />
         </svg>
     );
 }

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -73,6 +73,7 @@ describe("mergeOverviewStats", () => {
                 avgDurationMs: 40,
                 errorRate: 0.08,
                 spark: [1, 2],
+                errorSpark: [0, 1],
             }],
             [{
                 provider: "11111111-1111-1111-1111-111111111111",
@@ -87,6 +88,7 @@ describe("mergeOverviewStats", () => {
         );
 
         expect(providers[0]?.articles).toBe(12);
+        expect(providers[0]?.errorSpark).toEqual([0, 1]);
         expect(providers[0]?.circuitState).toBe("open");
         expect(providers[0]?.cooldownRemainingSeconds).toBe(30);
     });

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -140,6 +140,7 @@ export function mergeProviderCircuitBreakers(
                 avgDurationMs: 0,
                 errorRate: 0,
                 spark: [],
+                errorSpark: [],
             }),
             circuitState: breaker.circuitState,
             cooldownRemainingSeconds: breaker.cooldownRemainingSeconds,

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
@@ -45,6 +45,35 @@ public class GetOverviewStatsProviderFilterTests
     }
 
     [Fact]
+    public void BuildProvidersFromMinutes_BucketsErrorSparkAlongsideActivitySpark()
+    {
+        var windowStart = 1_700_000_000_000L; // aligned to minute
+        var minute0 = windowStart;
+        var minute1 = windowStart + 60_000;
+        var minutes = new[]
+        {
+            (minute0, ConfiguredKey, 10L, 1000L, 2L, 0L, 100L),
+            (minute1, ConfiguredKey, 5L, 500L, 1L, 0L, 50L),
+        };
+
+        var rows = GetOverviewStatsController.BuildProvidersFromMinutes(
+            minutes,
+            windowStart,
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour,
+            Labels);
+
+        Assert.Single(rows);
+        Assert.Equal(3, rows[0].Errors);
+        Assert.Equal(60, rows[0].Spark.Count);
+        Assert.Equal(60, rows[0].ErrorSpark.Count);
+        Assert.Equal(10, rows[0].Spark[0]);
+        Assert.Equal(2, rows[0].ErrorSpark[0]);
+        Assert.Equal(5, rows[0].Spark[1]);
+        Assert.Equal(1, rows[0].ErrorSpark[1]);
+        Assert.Equal(0, rows[0].ErrorSpark[2]);
+    }
+
+    [Fact]
     public void BuildFailover_OmitsDeletedProvidersFromListsButKeepsAggregateTotals()
     {
         var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
@@ -21,6 +21,7 @@ public class ProviderCircuitOverviewEnricherTests
                 Nickname = "Primary",
                 Articles = 10,
                 Spark = [1, 2],
+                ErrorSpark = [0, 1],
             },
         };
         var snapshots = new List<ProviderCircuitRuntimeSnapshot>
@@ -43,6 +44,7 @@ public class ProviderCircuitOverviewEnricherTests
         Assert.Equal("open", primary.CircuitState);
         Assert.Equal(42, primary.CooldownRemainingSeconds);
         Assert.Equal(10, primary.Articles);
+        Assert.Equal([0L, 1L], primary.ErrorSpark);
 
         var backup = enriched.Single(p => p.Provider == KeyB);
         Assert.Equal("closed", backup.CircuitState);


### PR DESCRIPTION
## Summary
- Overview Providers card Errors column now includes a sparkline of hard fetch failures over the selected window (same buckets as Activity).
- Backend exposes `errorSpark` from existing `ProviderMinutes` / `ProviderHourly` rollups — no new persistence.
- Total error count and error rate remain under the graph.

## Test plan
- [x] `dotnet test` filter: `GetOverviewStatsProviderFilterTests` + `ProviderCircuitOverviewEnricherTests`
- [x] Frontend `merge-overview-stats.test.ts`
- [x] Frontend `npm run typecheck`
- [ ] Open Overview → Providers; confirm Errors shows a red-toned sparkline + count/rate
- [ ] Change window (1h / 24h / 7d) and confirm error spark buckets update with Activity