### PR TITLE
feat(ui): show retry trends per provider on the overview scoreboard

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -694,6 +694,7 @@ public class GetOverviewStatsController(
             {
                 acc.Spark[idx] += m.Articles;
                 acc.ErrorSpark[idx] += m.Errors;
+                acc.RetrySpark[idx] += m.Retries;
             }
             byProvider[m.Provider] = acc;
         }
@@ -712,6 +713,7 @@ public class GetOverviewStatsController(
                 ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
                 Spark = kv.Value.Spark.ToList(),
                 ErrorSpark = kv.Value.ErrorSpark.ToList(),
+                RetrySpark = kv.Value.RetrySpark.ToList(),
             })
             .OrderByDescending(r => r.Articles)
             .ToList();
@@ -745,6 +747,7 @@ public class GetOverviewStatsController(
             {
                 acc.Spark[idx] += (long)h.Articles;
                 acc.ErrorSpark[idx] += (long)h.Errors;
+                acc.RetrySpark[idx] += (long)h.Retries;
             }
             byProvider[host] = acc;
         }
@@ -763,6 +766,7 @@ public class GetOverviewStatsController(
                 ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
                 Spark = kv.Value.Spark.ToList(),
                 ErrorSpark = kv.Value.ErrorSpark.ToList(),
+                RetrySpark = kv.Value.RetrySpark.ToList(),
             })
             .OrderByDescending(r => r.Articles)
             .ToList();
@@ -773,10 +777,12 @@ public class GetOverviewStatsController(
         public long Articles, Errors, Retries, SumDurationMs, Bytes;
         public readonly long[] Spark;
         public readonly long[] ErrorSpark;
+        public readonly long[] RetrySpark;
         public ProviderAccumulator(int n)
         {
             Spark = new long[n];
             ErrorSpark = new long[n];
+            RetrySpark = new long[n];
         }
     }
 

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -70,6 +70,8 @@ public class GetOverviewStatsResponse
         public List<long> Spark { get; init; } = new();
         /// <summary>Hard fetch failures per spark bucket (same sizing as <see cref="Spark"/>).</summary>
         public List<long> ErrorSpark { get; init; } = new();
+        /// <summary>Segment-fetch retry counts per spark bucket (same sizing as <see cref="Spark"/>).</summary>
+        public List<long> RetrySpark { get; init; } = new();
         public string CircuitState { get; init; } = "closed";
         public int? CooldownRemainingSeconds { get; init; }
         public string? LastFailureReason { get; init; }

--- a/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
+++ b/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
@@ -30,6 +30,7 @@ internal static class ProviderCircuitOverviewEnricher
                     ErrorRate = existing.ErrorRate,
                     Spark = existing.Spark,
                     ErrorSpark = existing.ErrorSpark,
+                    RetrySpark = existing.RetrySpark,
                     CircuitState = fields.CircuitState,
                     CooldownRemainingSeconds = fields.CooldownRemainingSeconds,
                     LastFailureReason = fields.LastFailureReason,

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -664,6 +664,7 @@ export type ProviderRow = {
     errorRate: number,
     spark: number[],
     errorSpark?: number[],
+    retrySpark?: number[],
     circuitState?: ProviderCircuitState,
     cooldownRemainingSeconds?: number | null,
     lastFailureReason?: string | null,

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -32,7 +32,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                     <th>Read</th>
                                     <th>Share</th>
                                     <th className="w-[120px]">Errors</th>
-                                    <th>Retries</th>
+                                    <th className="w-[120px]">Retries</th>
                                     <th>Avg ms</th>
                                 </tr>
                             </thead>
@@ -78,7 +78,14 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                                     </div>
                                                 </div>
                                             </td>
-                                            <td className="font-mono tabular-nums">{formatNumber(p.retries)}</td>
+                                            <td>
+                                                <div className="flex flex-col gap-0.5">
+                                                    <Sparkline values={p.retrySpark ?? []} tone="warning" />
+                                                    <div className={`font-mono text-[11px] tabular-nums ${p.retries > 0 ? "text-warning" : "text-base-content/60"}`}>
+                                                        {formatNumber(p.retries)}
+                                                    </div>
+                                                </div>
+                                            </td>
                                             <td className="font-mono tabular-nums">{p.avgDurationMs.toFixed(0)}</td>
                                         </tr>
                                     );
@@ -147,7 +154,7 @@ function ShareBar({ share }: { share: number }) {
     );
 }
 
-function Sparkline({ values, tone = "success" }: { values: number[], tone?: "success" | "error" }) {
+function Sparkline({ values, tone = "success" }: { values: number[], tone?: "success" | "error" | "warning" }) {
     if (values.length === 0) return <div className="h-[22px] w-[110px] rounded-sm bg-base-content/[0.04]" />;
     const w = 110;
     const h = 22;
@@ -158,14 +165,16 @@ function Sparkline({ values, tone = "success" }: { values: number[], tone?: "suc
         .map((v, i) => `${i === 0 ? "M" : "L"}${(i * step).toFixed(1)},${y(v).toFixed(1)}`)
         .join(" ");
     const area = `${path} L${((values.length - 1) * step).toFixed(1)},${h} L0,${h} Z`;
-    const stroke = tone === "error" ? "var(--color-error)" : "var(--color-success)";
-    const fill = tone === "error"
-        ? "color-mix(in srgb, var(--color-error) 16%, transparent)"
-        : "color-mix(in srgb, var(--color-success) 16%, transparent)";
+    const colorVar = tone === "error"
+        ? "var(--color-error)"
+        : tone === "warning"
+            ? "var(--color-warning)"
+            : "var(--color-success)";
+    const fill = `color-mix(in srgb, ${colorVar} 16%, transparent)`;
     return (
         <svg viewBox={`0 0 ${w} ${h}`} className="block h-[22px] w-[110px]" preserveAspectRatio="none">
             <path d={area} fill={fill} />
-            <path d={path} fill="none" stroke={stroke} strokeWidth="1.2" vectorEffect="non-scaling-stroke" />
+            <path d={path} fill="none" stroke={colorVar} strokeWidth="1.2" vectorEffect="non-scaling-stroke" />
         </svg>
     );
 }

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -74,6 +74,7 @@ describe("mergeOverviewStats", () => {
                 errorRate: 0.08,
                 spark: [1, 2],
                 errorSpark: [0, 1],
+                retrySpark: [2, 0],
             }],
             [{
                 provider: "11111111-1111-1111-1111-111111111111",
@@ -89,6 +90,7 @@ describe("mergeOverviewStats", () => {
 
         expect(providers[0]?.articles).toBe(12);
         expect(providers[0]?.errorSpark).toEqual([0, 1]);
+        expect(providers[0]?.retrySpark).toEqual([2, 0]);
         expect(providers[0]?.circuitState).toBe("open");
         expect(providers[0]?.cooldownRemainingSeconds).toBe(30);
     });

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -141,6 +141,7 @@ export function mergeProviderCircuitBreakers(
                 errorRate: 0,
                 spark: [],
                 errorSpark: [],
+                retrySpark: [],
             }),
             circuitState: breaker.circuitState,
             cooldownRemainingSeconds: breaker.cooldownRemainingSeconds,

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
@@ -45,15 +45,15 @@ public class GetOverviewStatsProviderFilterTests
     }
 
     [Fact]
-    public void BuildProvidersFromMinutes_BucketsErrorSparkAlongsideActivitySpark()
+    public void BuildProvidersFromMinutes_BucketsErrorAndRetrySparksAlongsideActivitySpark()
     {
         var windowStart = 1_700_000_000_000L; // aligned to minute
         var minute0 = windowStart;
         var minute1 = windowStart + 60_000;
         var minutes = new[]
         {
-            (minute0, ConfiguredKey, 10L, 1000L, 2L, 0L, 100L),
-            (minute1, ConfiguredKey, 5L, 500L, 1L, 0L, 50L),
+            (minute0, ConfiguredKey, 10L, 1000L, 2L, 4L, 100L),
+            (minute1, ConfiguredKey, 5L, 500L, 1L, 3L, 50L),
         };
 
         var rows = GetOverviewStatsController.BuildProvidersFromMinutes(
@@ -64,13 +64,18 @@ public class GetOverviewStatsProviderFilterTests
 
         Assert.Single(rows);
         Assert.Equal(3, rows[0].Errors);
+        Assert.Equal(7, rows[0].Retries);
         Assert.Equal(60, rows[0].Spark.Count);
         Assert.Equal(60, rows[0].ErrorSpark.Count);
+        Assert.Equal(60, rows[0].RetrySpark.Count);
         Assert.Equal(10, rows[0].Spark[0]);
         Assert.Equal(2, rows[0].ErrorSpark[0]);
+        Assert.Equal(4, rows[0].RetrySpark[0]);
         Assert.Equal(5, rows[0].Spark[1]);
         Assert.Equal(1, rows[0].ErrorSpark[1]);
+        Assert.Equal(3, rows[0].RetrySpark[1]);
         Assert.Equal(0, rows[0].ErrorSpark[2]);
+        Assert.Equal(0, rows[0].RetrySpark[2]);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
@@ -22,6 +22,7 @@ public class ProviderCircuitOverviewEnricherTests
                 Articles = 10,
                 Spark = [1, 2],
                 ErrorSpark = [0, 1],
+                RetrySpark = [2, 0],
             },
         };
         var snapshots = new List<ProviderCircuitRuntimeSnapshot>
@@ -45,6 +46,7 @@ public class ProviderCircuitOverviewEnricherTests
         Assert.Equal(42, primary.CooldownRemainingSeconds);
         Assert.Equal(10, primary.Articles);
         Assert.Equal([0L, 1L], primary.ErrorSpark);
+        Assert.Equal([2L, 0L], primary.RetrySpark);
 
         var backup = enriched.Single(p => p.Provider == KeyB);
         Assert.Equal("closed", backup.CircuitState);


### PR DESCRIPTION
## Summary
- Overview Providers **Retries** column now includes a warning-toned sparkline (same buckets as Activity/Errors).
- Backend exposes `retrySpark` from existing `ProviderMinutes` / `ProviderHourly` retry rollups.
- Total retry count remains under the graph.

Color choice: **warning** (`--color-warning`) — retries are recoverable degradation, distinct from activity (success) and hard failures (error).

## Test plan
- [x] Focused backend overview/enricher tests
- [x] Frontend merge-overview-stats tests + typecheck
- [ ] Overview → Providers: Retries shows amber sparkline + count
- [ ] Window changes update retry spark with Activity/Errors