### PR TITLE
fix(queue): queue no longer waits a full minute before retrying after provider errors

### DIFF
--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -192,6 +192,17 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         return (queueItem, queueNzbStream);
     }
 
+    public Task<DateTime?> GetNextQueueItemPauseUntil(CancellationToken ct = default)
+    {
+        // Matches GetTopQueueItem's local-time convention (PauseUntil is written
+        // with DateTime.Now). MIN over an empty set yields null.
+        var nowTime = DateTime.Now;
+        return Ctx.QueueItems
+            .AsNoTracking()
+            .Where(q => q.PauseUntil != null && q.PauseUntil > nowTime)
+            .MinAsync(q => q.PauseUntil, ct);
+    }
+
     public Task<QueueItem[]> GetQueueItems
     (
         string? category,

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -227,6 +227,12 @@ public class QueueItemProcessor(
             .ToList();
         if (importantFilesMissing.Count > 0)
         {
+            // Remember the missing first segments so retries of this item and re-grabs
+            // of the same release fail in milliseconds via the step-0 precheck instead
+            // of re-verifying every article across all providers.
+            HealthCheckService.AddMissingSegmentIds(
+                importantFilesMissing.Select(x => x.NzbFile.Segments[0].MessageId));
+
             var fileNames = string.Join(", ", importantFilesMissing
                 .Select(x => string.IsNullOrEmpty(x.FileName) ? x.NzbFile.Subject : x.FileName)
                 .Take(3));

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Utils;
@@ -37,6 +38,7 @@ public class QueueManager : IDisposable
     internal Func<CancellationToken, Task<(QueueItem? queueItem, Stream? queueNzbStream)>>?
         GetTopQueueItemOverride
     { get; set; }
+    internal Func<CancellationToken, Task<DateTime?>>? GetNextPauseUntilOverride { get; set; }
 
     public QueueManager(
         UsenetStreamingClient usenetClient,
@@ -154,12 +156,14 @@ public class QueueManager : IDisposable
                     {
                         try
                         {
-                            // if we're done with the queue, wait a minute before checking again.
-                            // or wait until awoken by cancellation of _sleepingQueueToken /
-                            // process shutdown (ct).
+                            // if we're done with the queue, wait until the next retry pause
+                            // expires (or IdleDelay, whichever is sooner). Also wake early
+                            // on cancellation of _sleepingQueueToken / process shutdown (ct).
+                            var idleDelay = await ComputeIdleDelayAsync(dbClient, ct)
+                                .ConfigureAwait(false);
                             using var idleWait = CancellationTokenSource.CreateLinkedTokenSource(
                                 ct, _sleepingQueueToken.Token);
-                            await Task.Delay(IdleDelay, idleWait.Token).ConfigureAwait(false);
+                            await Task.Delay(idleDelay, idleWait.Token).ConfigureAwait(false);
                         }
                         catch when (_sleepingQueueToken.IsCancellationRequested)
                         {
@@ -331,6 +335,34 @@ public class QueueManager : IDisposable
         finally
         {
             _semaphore.Release();
+        }
+    }
+
+    private async Task<TimeSpan> ComputeIdleDelayAsync(
+        DavDatabaseClient? dbClient, CancellationToken ct)
+    {
+        try
+        {
+            DateTime? nextPause;
+            if (GetNextPauseUntilOverride is not null)
+                nextPause = await GetNextPauseUntilOverride(ct).ConfigureAwait(false);
+            else if (dbClient is not null)
+                nextPause = await dbClient.GetNextQueueItemPauseUntil(ct).ConfigureAwait(false);
+            else
+                return IdleDelay;
+
+            if (nextPause is null) return IdleDelay;
+
+            // Small buffer so we wake just AFTER the pause expires; waking a hair
+            // early would find no eligible item and sleep a full IdleDelay again.
+            var untilNextPause = nextPause.Value - DateTime.Now + TimeSpan.FromMilliseconds(250);
+            if (untilNextPause <= TimeSpan.Zero) return TimeSpan.FromMilliseconds(250);
+            return untilNextPause < IdleDelay ? untilNextPause : IdleDelay;
+        }
+        catch (Exception e) when (!e.IsCancellationException())
+        {
+            Log.Debug(e, "Failed to compute next queue pause; falling back to idle delay");
+            return IdleDelay;
         }
     }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -670,6 +670,20 @@ public class HealthCheckService : BackgroundService
         return result;
     }
 
+    public static void AddMissingSegmentIds(IEnumerable<string> segmentIds)
+    {
+        lock (_missingSegmentIds)
+        {
+            foreach (var segmentId in segmentIds)
+            {
+                if (_missingSegmentIds.Add(segmentId))
+                    _missingSegmentOrder.Enqueue(segmentId);
+                while (_missingSegmentIds.Count > MaximumMissingSegmentIds)
+                    _missingSegmentIds.Remove(_missingSegmentOrder.Dequeue());
+            }
+        }
+    }
+
     public static void CheckCachedMissingSegmentIds(IEnumerable<string> segmentIds)
     {
         lock (_missingSegmentIds)

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -32,6 +32,57 @@ public class QueueManagerLoopTests
     }
 
     [Fact]
+    public async Task ProcessQueueAsync_WakesBeforeIdleDelayWhenPauseExpires()
+    {
+        using var manager = CreateManager();
+        manager.IdleDelay = TimeSpan.FromSeconds(30);
+
+        var pollTimes = new List<DateTime>();
+        var pauseCalls = 0;
+        manager.GetTopQueueItemOverride = _ =>
+        {
+            lock (pollTimes) pollTimes.Add(DateTime.UtcNow);
+            return Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+        };
+        manager.GetNextPauseUntilOverride = _ =>
+        {
+            var call = Interlocked.Increment(ref pauseCalls);
+            return Task.FromResult<DateTime?>(
+                call == 1 ? DateTime.Now.AddSeconds(2) : null);
+        };
+
+        using var cts = new CancellationTokenSource();
+        var loop = manager.ProcessQueueAsync(cts.Token);
+
+        // Wait until we've seen a second top-item poll (pause-aware wake), then stop.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(8);
+        while (DateTime.UtcNow < deadline)
+        {
+            lock (pollTimes)
+            {
+                if (pollTimes.Count >= 2) break;
+            }
+            await Task.Delay(50);
+        }
+
+        await cts.CancelAsync();
+        await loop;
+
+        DateTime first;
+        DateTime second;
+        lock (pollTimes)
+        {
+            Assert.True(pollTimes.Count >= 2, $"Expected ≥2 polls, got {pollTimes.Count}");
+            first = pollTimes[0];
+            second = pollTimes[1];
+        }
+
+        var gap = second - first;
+        Assert.True(gap < TimeSpan.FromSeconds(5),
+            $"Second poll should wake within ~5s of pause expiry, took {gap.TotalSeconds:F1}s");
+    }
+
+    [Fact]
     public async Task ProcessQueueAsync_ExitsIdleSleepPromptlyOnShutdown()
     {
         using var manager = CreateManager();

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckMissingSegmentCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckMissingSegmentCacheTests.cs
@@ -1,0 +1,23 @@
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class HealthCheckMissingSegmentCacheTests
+{
+    [Fact]
+    public void AddMissingSegmentIds_IsVisibleToCheckCachedMissingSegmentIds()
+    {
+        var missingId = $"<{Guid.NewGuid():N}@test>";
+        var otherId = $"<{Guid.NewGuid():N}@test>";
+
+        HealthCheckService.AddMissingSegmentIds([missingId]);
+
+        var ex = Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([missingId]));
+        Assert.Equal(missingId, ex.SegmentId);
+
+        // Unrelated ids must not throw — the cache is a shared static with no reset API.
+        HealthCheckService.CheckCachedMissingSegmentIds([otherId]);
+    }
+}


### PR DESCRIPTION
## Summary
- Wake the download queue when a retry `PauseUntil` expires instead of always sleeping a flat minute, so transient provider errors resume on their backoff schedule.
- Remember missing first-segment IDs from definitive queue failures so retries and *Arr re-grabs of the same release fail in milliseconds via the existing step-0 cache precheck.

## Test plan
- [x] `dotnet test` focused: `QueueManagerLoopTests` + `HealthCheckMissingSegmentCacheTests`
- [ ] CI green on Linux
- [ ] Optional: add an NZB that hits a transient provider error and confirm the queue resumes near the backoff (10s/20s/…) rather than ~60s later
- [ ] Optional: re-add a previously failed DMCA'd NZB and confirm it fails immediately at step 0