### PR TITLE
fix(nntp): fail DMCA'd NZBs faster when NNTP pipelining is enabled

### DIFF
--- a/backend/Clients/Usenet/Models/PipelinedResults.cs
+++ b/backend/Clients/Usenet/Models/PipelinedResults.cs
@@ -8,6 +8,13 @@ public sealed record PipelinedBodyResult
     public required string SegmentId { get; init; }
     public required bool Found { get; init; }
     public YencStream? Stream { get; init; }
+
+    /// <summary>
+    /// True when every provider was tried and returned a definitive miss (430/451).
+    /// False for single-provider verdicts and segment-id mismatches, which must
+    /// remain eligible for rescue/failover.
+    /// </summary>
+    public bool DefinitivelyMissing { get; init; }
 }
 
 public sealed record PipelinedArticleResult
@@ -16,6 +23,13 @@ public sealed record PipelinedArticleResult
     public required bool Found { get; init; }
     public YencStream? Stream { get; init; }
     public UsenetArticleHeader? ArticleHeaders { get; init; }
+
+    /// <summary>
+    /// True when every provider was tried and returned a definitive miss (430/451).
+    /// False for single-provider verdicts and segment-id mismatches, which must
+    /// remain eligible for rescue/failover.
+    /// </summary>
+    public bool DefinitivelyMissing { get; init; }
 }
 
 public sealed record PipelinedStatResult

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -286,6 +286,7 @@ public abstract class NntpClient : INntpClient
                 Found = body.Found,
                 Stream = body.Stream,
                 ArticleHeaders = null,
+                DefinitivelyMissing = body.DefinitivelyMissing,
             };
         }
     }
@@ -349,6 +350,7 @@ public abstract class NntpClient : INntpClient
                 SegmentId = segmentId,
                 Found = false,
                 Stream = null,
+                DefinitivelyMissing = true,
             };
         }
     }

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -82,6 +82,15 @@ public static class FetchFirstSegmentsStep
                         .ConfigureAwait(false);
                     progress?.Report(++completed);
                 }
+                else if (article.DefinitivelyMissing)
+                {
+                    // The batch failover already tried every provider; a rescue pass would
+                    // just repeat the same misses. Record and move on.
+                    Log.Warning("First segment for `{FileName}` missing across all providers",
+                        files[i].GetSubjectFileName());
+                    results[i] = BuildMissingFirstSegment(files[i]);
+                    progress?.Report(++completed);
+                }
                 else if (article.Stream != null)
                 {
                     try { await article.Stream.DisposeAsync().ConfigureAwait(false); }

--- a/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
@@ -14,6 +15,44 @@ namespace NzbWebDAV.Tests.Queue;
 
 public class FetchFirstSegmentsStepTests
 {
+    [Fact]
+    public async Task FetchFirstSegments_PipelinedDefinitivelyMissing_SkipsRescue()
+    {
+        var config = CreatePipeliningConfig(enabled: true, depth: 4);
+        using var client = new MissingPipelinedNntpClient(definitivelyMissing: true);
+        var files = new List<NzbFile>
+        {
+            CreateFile("a@example.com", "\"a.rar\" yEnc"),
+            CreateFile("b@example.com", "\"b.rar\" yEnc"),
+        };
+
+        var results = await FetchFirstSegmentsStep.FetchFirstSegments(
+            files, client, config, CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.True(r.MissingFirstSegment));
+        Assert.Equal(0, client.ArticleFetches);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_PipelinedNonDefinitiveMiss_StillRescues()
+    {
+        var config = CreatePipeliningConfig(enabled: true, depth: 4);
+        using var client = new MissingPipelinedNntpClient(definitivelyMissing: false);
+        var files = new List<NzbFile>
+        {
+            CreateFile("a@example.com", "\"a.rar\" yEnc"),
+            CreateFile("b@example.com", "\"b.rar\" yEnc"),
+        };
+
+        var results = await FetchFirstSegmentsStep.FetchFirstSegments(
+            files, client, config, CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.True(r.MissingFirstSegment));
+        Assert.True(client.ArticleFetches > 0);
+    }
+
     [Fact]
     public async Task FetchFirstSegments_PipelinedMismatch_RescuesViaPerArticlePath()
     {
@@ -103,6 +142,82 @@ public class FetchFirstSegmentsStepTests
             PartSize = payload.Length,
         };
         return new CachedYencStream(headers, new MemoryStream(payload, writable: false));
+    }
+
+    private sealed class MissingPipelinedNntpClient(bool definitivelyMissing) : NntpClient
+    {
+        public int ArticleFetches { get; private set; }
+
+        public override async IAsyncEnumerable<PipelinedArticleResult> DecodedArticlesPipelinedAsync(
+            IReadOnlyList<string> segmentIds,
+            int depth,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var id in segmentIds)
+            {
+                yield return new PipelinedArticleResult
+                {
+                    SegmentId = id,
+                    Found = false,
+                    Stream = null,
+                    ArticleHeaders = null,
+                    DefinitivelyMissing = definitivelyMissing,
+                };
+            }
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            ArticleFetches++;
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotFound);
+            throw new UsenetArticleNotFoundException(segmentId.ToString());
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
     }
 
     private sealed class MismatchThenRescueNntpClient : NntpClient


### PR DESCRIPTION
## Summary
- Mark pipelined BODY/ARTICLE results as `DefinitivelyMissing` only after all providers are exhausted (`UsenetArticleNotFoundException`).
- Skip the queue first-segment rescue pass for those definitive misses so DMCA'd/expired NZBs are not re-verified across every provider a second time.
- Segment-id mismatches and single-provider verdicts still go through rescue unchanged.

## Test plan
- [x] `dotnet test` focused: `FetchFirstSegmentsStepTests` (including skip-rescue + still-rescues regression)
- [ ] CI green on Linux
- [ ] Optional: with `usenet.pipelining-enabled=true`, add a known-missing NZB and confirm fail time is much closer to one full provider sweep (not ~2×)