### PR TITLE
fix(queue): Remove Orphaned Files no longer scans the linked-id table per row

### DIFF
--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -117,11 +117,12 @@ public class RemoveUnlinkedFilesTask(
         }
 
         // Remove duplicates and add primary key index.
-        // Create a new table with unique constraint, copy distinct values, then swap.
+        // COLLATE NOCASE on the column (not predicates) so the PK remains seekable while
+        // matching uppercase TMP_LINKED_FILES ids to lowercase migration-seeded DavItems.Id.
         Report($"Indexing {scannedCount} linked files...");
         await dbContext.Database.ExecuteSqlRawAsync(
             """
-            CREATE TABLE TMP_LINKED_FILES_UNIQUE (Id TEXT NOT NULL PRIMARY KEY);
+            CREATE TABLE TMP_LINKED_FILES_UNIQUE (Id TEXT NOT NULL COLLATE NOCASE PRIMARY KEY);
             INSERT OR IGNORE INTO TMP_LINKED_FILES_UNIQUE (Id) SELECT Id FROM TMP_LINKED_FILES;
             DROP TABLE TMP_LINKED_FILES;
             ALTER TABLE TMP_LINKED_FILES_UNIQUE RENAME TO TMP_LINKED_FILES;
@@ -270,16 +271,16 @@ public class RemoveUnlinkedFilesTask(
         await using var dbContext = CreateContext();
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
 
-        // LEFT JOIN is equivalent to the NOT IN subquery used by RemoveUnlinkedItems /
+        // LEFT JOIN is equivalent to the NOT EXISTS used by RemoveUnlinkedItems /
         // DryRunIdentifyUnlinkedFiles; CountDeletableItems mirrors these predicates without
         // the link join so the safety ratio compares the same population.
-        // COLLATE NOCASE: TMP_LINKED_FILES stores uppercase Guids while some DavItems.Id
-        // rows are lowercase (migration-seeded); a case-sensitive miss would delete linked files.
+        // Join as t.Id = i.Id so SQLite inherits NOCASE from TMP_LINKED_FILES (left operand)
+        // and can seek the PK; i.Id = t.Id would use BINARY and miss both index and casing.
         var count = await dbContext.Database
             .SqlQuery<int>(
                 $"""
                  SELECT COUNT(i.Id) AS Value FROM DavItems i
-                 LEFT JOIN TMP_LINKED_FILES t ON i.Id = t.Id COLLATE NOCASE
+                 LEFT JOIN TMP_LINKED_FILES t ON t.Id = i.Id
                  WHERE i.Type = {usenetFileType}
                    AND i.HistoryItemId IS NULL
                    AND i.CreatedAt < {createdBefore}
@@ -301,8 +302,8 @@ public class RemoveUnlinkedFilesTask(
 
         while (true)
         {
-            // Select items to delete (batch of 100). NOT EXISTS + COLLATE NOCASE so a
-            // lowercase DavItems.Id still matches an uppercase TMP_LINKED_FILES row.
+            // Select items to delete (batch of 100). t.Id on the left inherits NOCASE from
+            // the TMP_LINKED_FILES PK so lowercase DavItems.Id still match uppercase links.
             var itemsToDelete = await dbContext.Database
                 .SqlQuery<UnlinkedItemInfo>(
                     $"""
@@ -312,7 +313,7 @@ public class RemoveUnlinkedFilesTask(
                        AND CreatedAt < {createdBefore}
                        AND NOT EXISTS (
                            SELECT 1 FROM TMP_LINKED_FILES t
-                           WHERE t.Id = DavItems.Id COLLATE NOCASE
+                           WHERE t.Id = DavItems.Id
                        )
                      LIMIT 100
                      """)
@@ -492,7 +493,7 @@ public class RemoveUnlinkedFilesTask(
                        AND Id > {lastId}
                        AND NOT EXISTS (
                            SELECT 1 FROM TMP_LINKED_FILES t
-                           WHERE t.Id = DavItems.Id COLLATE NOCASE
+                           WHERE t.Id = DavItems.Id
                        )
                      ORDER BY Id
                      LIMIT 100

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -367,6 +367,48 @@ public class RemoveUnlinkedFilesTaskTests
         Assert.Equal(3, count);
     }
 
+    [Fact]
+    public async Task LinkedFilesLookup_UsesPrimaryKeySeek_NotFullScan()
+    {
+        // Regression for #408: predicate COLLATE NOCASE made the BINARY PK ineligible,
+        // turning each NOT EXISTS into SCAN t. Column NOCASE + t.Id = DavItems.Id must SEEK.
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+
+        await ctx.Database.ExecuteSqlRawAsync(
+            """
+            DROP TABLE IF EXISTS TMP_LINKED_FILES;
+            CREATE TABLE TMP_LINKED_FILES (Id TEXT NOT NULL COLLATE NOCASE PRIMARY KEY);
+            INSERT INTO TMP_LINKED_FILES (Id) VALUES ('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE');
+            """);
+
+        var connection = ctx.Database.GetDbConnection();
+        await using var command = connection.CreateCommand();
+        if (command.Connection!.State != System.Data.ConnectionState.Open)
+            await command.Connection.OpenAsync();
+        command.CommandText =
+            """
+            EXPLAIN QUERY PLAN
+            SELECT Id FROM DavItems
+            WHERE NOT EXISTS (
+                SELECT 1 FROM TMP_LINKED_FILES t
+                WHERE t.Id = DavItems.Id
+            )
+            """;
+
+        var details = new List<string>();
+        await using (var reader = await command.ExecuteReaderAsync())
+        {
+            var detailOrdinal = reader.GetOrdinal("detail");
+            while (await reader.ReadAsync())
+                details.Add(reader.GetString(detailOrdinal));
+        }
+
+        var plan = string.Join('\n', details);
+        Assert.Contains("SEARCH t", plan, StringComparison.Ordinal);
+        Assert.DoesNotContain("SCAN t", plan, StringComparison.Ordinal);
+    }
+
     private static DavItem NewDir(Guid id, DavItem parent, string name) =>
         DavItem.New(id, parent, name, null, DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
             null, null, null, null);


### PR DESCRIPTION
## Summary
- Fixes [#408](https://github.com/nzbdav/nzbdav/issues/408): Remove Orphaned Files was O(N×M) since v0.7.20 because predicate `COLLATE NOCASE` made the BINARY PK on `TMP_LINKED_FILES` ineligible for seeks.
- Declares `COLLATE NOCASE` on the temp table PK, drops the three predicate `COLLATE`s, and joins as `t.Id = i.Id` so case-insensitive matching and index seeks both work.
- Adds an `EXPLAIN QUERY PLAN` regression test asserting `SEARCH t` rather than `SCAN t`.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter RemoveUnlinkedFilesTask` (10 passed)
- [ ] Dry-run Remove Orphaned Files on a large library and confirm wall time is back near pre-0.7.20 levels
- [ ] Confirm linked files with lowercase `DavItems.Id` are still treated as linked (not deleted)