### PR TITLE
fix(webdav): keep encrypted archive playback running when parts end early

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -200,6 +201,12 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                 }
             });
 
+            if (IsTruncatedCiphertextException(e) &&
+                context.Items["DavItem"] is DavItem truncatedItem)
+            {
+                ScheduleRepair(truncatedItem.Id);
+            }
+
             AbortStartedResponse(context);
         }
     }
@@ -338,6 +345,15 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         // match queue-side helpers — including bare InvalidFormatException.
         for (var current = e; current != null; current = current.InnerException)
         {
+            if (current is EndOfStreamException &&
+                current.Message.StartsWith(
+                    AesDecoderStream.TruncatedCiphertextMessagePrefix,
+                    StringComparison.Ordinal))
+            {
+                message = $"Encrypted file data ended prematurely. {current.Message}";
+                return true;
+            }
+
             if (current.IsRetryableDownloadException() || current.IsNonRetryableDownloadException())
             {
                 message = current.Message;
@@ -346,6 +362,22 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         }
 
         message = string.Empty;
+        return false;
+    }
+
+    private static bool IsTruncatedCiphertextException(Exception e)
+    {
+        for (var current = e; current != null; current = current.InnerException)
+        {
+            if (current is EndOfStreamException &&
+                current.Message.StartsWith(
+                    AesDecoderStream.TruncatedCiphertextMessagePrefix,
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/backend/Streams/AesDecoderStream.cs
+++ b/backend/Streams/AesDecoderStream.cs
@@ -25,6 +25,8 @@ namespace NzbWebDAV.Streams
 
         private const int BlockSize = 16;
         private const int BufferSize = 256 * 1024;
+        internal const string TruncatedCiphertextMessagePrefix =
+            "Unexpected end of ciphertext stream";
 
         public AesDecoderStream(Stream input, AesParams aesParams)
         {
@@ -208,7 +210,9 @@ namespace NzbWebDAV.Streams
                 if (read == 0)
                 {
                     throw new EndOfStreamException(
-                        "Unexpected end of ciphertext stream (not a multiple of block size).");
+                        $"{TruncatedCiphertextMessagePrefix} after decoding {_mWritten} of {_mLimit} bytes: " +
+                        $"read {cipherRead} ciphertext bytes in the current batch, leaving a partial block of " +
+                        $"{cipherRead & (BlockSize - 1)} bytes.");
                 }
 
                 cipherRead += read;

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -245,7 +245,10 @@ public class DavMultipartFileStream : Stream
             _fileName,
             part.SegmentFallbackIds);
         stream.Seek(part.FilePartByteRange.StartInclusive + extraOffset, SeekOrigin.Begin);
-        return stream.LimitLength(part.FilePartByteRange.Count - extraOffset);
+        var expectedLength = part.FilePartByteRange.Count - extraOffset;
+        var partId = part.SegmentIds.FirstOrDefault()
+                     ?? $"range:{part.FilePartByteRange.StartInclusive}-{part.FilePartByteRange.EndExclusive}";
+        return new PaddedLengthStream(stream, expectedLength, partId, _fileName);
     }
 
     private async Task<Stream> ResolveAndOpenAsync(int targetIndex, CancellationToken ct)

--- a/backend/Streams/PaddedLengthStream.cs
+++ b/backend/Streams/PaddedLengthStream.cs
@@ -1,0 +1,90 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Services.StreamTrace;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Caps a stream at a declared length and fills a premature shortfall with
+/// zeros so subsequent multipart data retains its expected byte offsets.
+/// </summary>
+public sealed class PaddedLengthStream(
+    Stream stream,
+    long length,
+    string partId,
+    string? fileName = null) : FastReadOnlyNonSeekableStream
+{
+    private readonly string _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
+    private long _position;
+    private bool _underlyingEnded;
+    private bool _shortfallReported;
+    private bool _disposed;
+
+    public override long Length => length;
+    public override long Position => _position;
+
+    public override void Flush() => stream.Flush();
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (buffer.IsEmpty || _position >= length)
+            return 0;
+
+        var bytesToRead = (int)Math.Min(length - _position, buffer.Length);
+        if (!_underlyingEnded)
+        {
+            var bytesRead = await stream.ReadAsync(buffer[..bytesToRead], cancellationToken)
+                .ConfigureAwait(false);
+            if (bytesRead > 0)
+            {
+                _position += bytesRead;
+                return bytesRead;
+            }
+
+            _underlyingEnded = true;
+            ReportShortfall(length - _position);
+        }
+
+        buffer.Span[..bytesToRead].Clear();
+        _position += bytesToRead;
+        return bytesToRead;
+    }
+
+    private void ReportShortfall(long bytes)
+    {
+        if (_shortfallReported)
+            return;
+
+        _shortfallReported = true;
+        ZeroFillLogLimiter.Write(
+            "Packed part {SegmentId} ended early while reading {FileName}. Zero-filling {Bytes} bytes to preserve multipart offsets.",
+            partId,
+            _fileName,
+            bytes);
+
+        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+            StreamTrace.TryZeroFill(sessionId, partId, bytes);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed || !disposing)
+            return;
+
+        stream.Dispose();
+        _disposed = true;
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        await stream.DisposeAsync().ConfigureAwait(false);
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/AesDecoderStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/AesDecoderStreamTests.cs
@@ -56,6 +56,26 @@ public class AesDecoderStreamTests
             () => new AesDecoderStream(new MemoryStream(new byte[15]), parameters));
     }
 
+    [Fact]
+    public async Task ReadAsync_ReportsPositionWhenCiphertextEndsMidBlock()
+    {
+        var parameters = new AesParams
+        {
+            Key = new byte[32],
+            Iv = new byte[16],
+            DecodedSize = 16
+        };
+        await using var stream = new AesDecoderStream(
+            new DeclaredLengthStream(new byte[15], 16), parameters);
+
+        var exception = await Assert.ThrowsAsync<EndOfStreamException>(
+            async () => await stream.ReadExactlyAsync(new byte[16]));
+
+        Assert.Contains("after decoding 0 of 16 bytes", exception.Message);
+        Assert.Contains("read 15 ciphertext bytes", exception.Message);
+        Assert.Contains("partial block of 15 bytes", exception.Message);
+    }
+
     private static (byte[] Ciphertext, AesParams Parameters) Encrypt(byte[] plaintext)
     {
         var key = Enumerable.Range(0, 32).Select(index => (byte)index).ToArray();
@@ -75,5 +95,48 @@ public class AesDecoderStreamTests
             Iv = iv,
             DecodedSize = plaintext.Length
         });
+    }
+
+    private sealed class DeclaredLengthStream(byte[] content, long declaredLength) : Stream
+    {
+        private readonly MemoryStream _inner = new(content, writable: false);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => declaredLength;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            _inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
@@ -19,6 +19,60 @@ public class BasicStreamTests
     }
 
     [Fact]
+    public async Task PaddedLengthStream_FillsPrematureEofToConfiguredLength()
+    {
+        await using var stream = new PaddedLengthStream(
+            new MemoryStream(Encoding.ASCII.GetBytes("ab")), 5, "part-1", "test.bin");
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal(new byte[] { (byte)'a', (byte)'b', 0, 0, 0 }, destination.ToArray());
+        Assert.Equal(5, stream.Position);
+        Assert.Equal(0, await stream.ReadAsync(new byte[1]));
+    }
+
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("", 3)]
+    [InlineData("abc", 3)]
+    public async Task PaddedLengthStream_HandlesEmptyAndExactLengthInputs(
+        string content, int declaredLength)
+    {
+        await using var stream = new PaddedLengthStream(
+            new MemoryStream(Encoding.ASCII.GetBytes(content)),
+            declaredLength,
+            "part-1",
+            "test.bin");
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        var expected = new byte[declaredLength];
+        Encoding.ASCII.GetBytes(content).CopyTo(expected, 0);
+        Assert.Equal(expected, destination.ToArray());
+    }
+
+    [Fact]
+    public async Task CombinedStream_PaddedShortPartPreservesFollowingPartOffset()
+    {
+        var streams = new[]
+        {
+            Task.FromResult<Stream>(new PaddedLengthStream(
+                new MemoryStream(Encoding.ASCII.GetBytes("ab")), 4, "part-1", "test.bin")),
+            Task.FromResult<Stream>(new MemoryStream(Encoding.ASCII.GetBytes("cd")))
+        };
+        await using var stream = new CombinedStream(streams);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal(new byte[] { (byte)'a', (byte)'b', 0, 0, (byte)'c', (byte)'d' },
+            destination.ToArray());
+        Assert.Equal(6, stream.Position);
+    }
+
+    [Fact]
     public async Task CombinedStream_ConcatenatesEmptyAndNonEmptyStreams()
     {
         var streams = new[]


### PR DESCRIPTION
## Summary
- zero-pad short multipart ciphertext ranges so subsequent encrypted archive data keeps its expected offsets
- report residual AES truncation clearly and schedule affected WebDAV items for repair
- add regression coverage for padding, multipart boundaries, and mid-block ciphertext EOFs

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~AesDecoderStream|FullyQualifiedName~PaddedLength|FullyQualifiedName~CombinedStream|FullyQualifiedName~BasicStream\"` (20 passed)
- [x] backend suite excluding the native-only prefetch-budget tests (571 passed, 11 skipped)
- [ ] full local suite (blocked on this macOS checkout because the test host cannot load `rapidyenc`; CI supplies the native runtime)
- [ ] manually stream and seek a password-protected multipart archive with a missing article