### PR TITLE
fix(usenet): produce stable speed test recommendations

### DIFF
--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
@@ -17,8 +17,19 @@ public class BenchmarkUsenetConnectionController(
     ConfigManager configManager
 ) : BaseApiController
 {
+    // One benchmark at a time, process-wide: overlapping tests contend for the same
+    // provider budget and poison each other's numbers.
+    private static readonly SemaphoreSlim SingleFlight = new(1, 1);
+
     private async Task<BenchmarkUsenetConnectionResponse> BenchmarkAsync(BenchmarkUsenetConnectionRequest request)
     {
+        if (!await SingleFlight.WaitAsync(TimeSpan.Zero).ConfigureAwait(false))
+            return new BenchmarkUsenetConnectionResponse
+            {
+                Status = false,
+                Error = "A speed test is already running. Wait for it to finish (or cancel it) and try again."
+            };
+
         try
         {
             // Pause the download queue + background verifiers for the duration so
@@ -28,26 +39,27 @@ public class BenchmarkUsenetConnectionController(
 
             // Activity we can't pause — a download already mid-flight or live
             // streams — still uses connections; capture it so we can flag it.
-            var streamsActive = activeReads.Count;
-            var (inProgressItem, _) = queueManager.GetInProgressQueueItem();
+            var streamsBefore = activeReads.Count;
+            var (inProgressBefore, _) = queueManager.GetInProgressQueueItem();
 
             var result = await benchmarkService.RunAsync(
                 request.ToConnectionDetails(),
                 request.MaxConnections,
                 request.Intensity,
                 request.PipeliningOnly,
+                request.DataBudgetBytes,
+                request.VerifyConnections,
                 HttpContext.RequestAborted
             ).ConfigureAwait(false);
 
-            if (inProgressItem != null || streamsActive > 0)
-            {
-                var bits = new List<string>();
-                if (inProgressItem != null) bits.Add("a download was still finishing");
-                if (streamsActive > 0) bits.Add($"{streamsActive} active stream{(streamsActive == 1 ? "" : "s")}");
-                result.Warnings.Insert(0,
-                    $"Heads up: {string.Join(" and ", bits)} during the test — those connections couldn't be paused, " +
-                    "so the numbers may read a little low. Re-run when fully idle for the cleanest result.");
-            }
+            var streamsAfter = activeReads.Count;
+            var (inProgressAfter, _) = queueManager.GetInProgressQueueItem();
+            AddContentionWarnings(
+                result,
+                streamsBefore,
+                streamsAfter,
+                inProgressBefore != null,
+                inProgressAfter != null);
 
             return new BenchmarkUsenetConnectionResponse { Status = true, Result = result };
         }
@@ -67,6 +79,34 @@ public class BenchmarkUsenetConnectionController(
                 Error = "Couldn't log in to the provider. Check the username and password."
             };
         }
+        finally
+        {
+            SingleFlight.Release();
+        }
+    }
+
+    private static void AddContentionWarnings(
+        BenchmarkResult result,
+        int streamsBefore,
+        int streamsAfter,
+        bool downloadBefore,
+        bool downloadAfter)
+    {
+        var bits = new List<string>();
+        if (downloadBefore) bits.Add("a download was still finishing");
+        else if (downloadAfter) bits.Add("a download started mid-test");
+        var streams = Math.Max(streamsBefore, streamsAfter);
+        if (streams > 0) bits.Add($"{streams} active stream{(streams == 1 ? "" : "s")}");
+        if (bits.Count == 0) return;
+
+        result.ContentionWarnings.Add(
+            $"{string.Join(" and ", bits)} during the test — those connections can't be paused, " +
+            "so speeds may read low. Re-run when fully idle for the cleanest result.");
+
+        // Concurrent traffic caps how much the numbers can be trusted.
+        result.Confidence = downloadBefore || downloadAfter
+            ? "low"
+            : (result.Confidence == "high" ? "medium" : result.Confidence);
     }
 
     protected override async Task<IActionResult> HandleRequest()

--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
@@ -21,6 +21,12 @@ public class BenchmarkUsenetConnectionRequest
     /// <summary>When true, skip the connection sweep and only tune pipelining depth.</summary>
     public bool PipeliningOnly { get; init; }
 
+    /// <summary>Optional user override for the run's total data budget.</summary>
+    public long? DataBudgetBytes { get; init; }
+
+    /// <summary>When set, skip the sweep and just measure this single connection count.</summary>
+    public int? VerifyConnections { get; init; }
+
     public BenchmarkUsenetConnectionRequest(HttpContext context, ConfigManager configManager)
     {
         Host = context.Request.Form["host"].FirstOrDefault()
@@ -58,6 +64,14 @@ public class BenchmarkUsenetConnectionRequest
 
         var pipeliningOnly = context.Request.Form["pipelining-only"].FirstOrDefault();
         PipeliningOnly = bool.TryParse(pipeliningOnly, out var po) && po;
+
+        var budgetMb = context.Request.Form["data-budget-mb"].FirstOrDefault();
+        DataBudgetBytes = long.TryParse(budgetMb, out var mb) && mb is >= 50 and <= 100_000
+            ? mb * 1_000_000L
+            : null;
+
+        var verify = context.Request.Form["verify-connections"].FirstOrDefault();
+        VerifyConnections = int.TryParse(verify, out var vc) && vc > 0 ? vc : null;
     }
 
     public UsenetProviderConfig.ConnectionDetails ToConnectionDetails()

--- a/backend/Services/Benchmark/BenchmarkConnectionLadder.cs
+++ b/backend/Services/Benchmark/BenchmarkConnectionLadder.cs
@@ -1,0 +1,106 @@
+using System.Runtime.ExceptionServices;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using Serilog;
+
+namespace NzbWebDAV.Services.Benchmark;
+
+/// <summary>
+/// A pool of ad-hoc NNTP connections held open for the duration of a benchmark
+/// run. Reusing sockets across sweep levels avoids provider-side lingering-slot
+/// refusals (no QUIT is sent on close) and keeps TCP windows warm, which is a
+/// large part of making back-to-back runs repeatable.
+/// </summary>
+internal sealed class BenchmarkConnectionLadder(UsenetProviderConfig.ConnectionDetails provider) : IDisposable
+{
+    private readonly List<INntpClient> _connections = [];
+
+    public int Count => _connections.Count;
+    public IReadOnlyList<INntpClient> Connections => _connections;
+
+    /// <summary>Grows the ladder to <paramref name="target"/> connections; returns the achieved count.</summary>
+    public async Task<int> EnsureAsync(int target, CancellationToken ct)
+    {
+        while (_connections.Count < target)
+        {
+            ct.ThrowIfCancellationRequested();
+            Exception? failure = null;
+            INntpClient? conn = null;
+            for (var attempt = 0; attempt < 2 && conn == null; attempt++)
+            {
+                try
+                {
+                    conn = await UsenetStreamingClient.CreateNewConnection(provider, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    failure = e;
+                    // Give the provider a beat to free a lingering slot before retrying.
+                    if (attempt == 0)
+                        await SafeDelay(TimeSpan.FromMilliseconds(500), ct).ConfigureAwait(false);
+                }
+            }
+
+            if (conn == null)
+            {
+                // First connection failing = config/credentials problem — surface it.
+                if (_connections.Count == 0 && failure != null)
+                    ExceptionDispatchInfo.Capture(failure).Throw();
+                Log.Debug(failure, "Benchmark could not open an additional connection (treating as provider ceiling).");
+                break;
+            }
+
+            _connections.Add(conn);
+        }
+
+        return _connections.Count;
+    }
+
+    /// <summary>Disposes and forgets connections that failed mid-measurement.</summary>
+    public void Prune(IReadOnlyCollection<INntpClient> dead)
+    {
+        foreach (var conn in dead)
+        {
+            if (_connections.Remove(conn)) SafeDispose(conn);
+        }
+    }
+
+    public void ShrinkTo(int target)
+    {
+        while (_connections.Count > Math.Max(0, target))
+        {
+            var conn = _connections[^1];
+            _connections.RemoveAt(_connections.Count - 1);
+            SafeDispose(conn);
+        }
+    }
+
+    public void Dispose() => ShrinkTo(0);
+
+    private static void SafeDispose(INntpClient conn)
+    {
+        try
+        {
+            conn.Dispose();
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e, "Failed to dispose benchmark connection.");
+        }
+    }
+
+    private static async Task SafeDelay(TimeSpan delay, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(delay, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}

--- a/backend/Services/Benchmark/BenchmarkModels.cs
+++ b/backend/Services/Benchmark/BenchmarkModels.cs
@@ -21,22 +21,23 @@ public sealed class BenchmarkProfile
     public required int LatencySamples { get; init; }
     public required int MaxCorpusSegments { get; init; }
 
-    /// <summary>Target bytes to transfer at each connection level before moving on.</summary>
+    /// <summary>Floor for the adaptive per-level byte target (bootstrap before we have a speed estimate).</summary>
     public required long PerLevelBytes { get; init; }
 
     /// <summary>Hard wall-clock cap per level so a slow/stalled line can't hang the run.</summary>
     public required TimeSpan PerLevelMaxDuration { get; init; }
 
-    /// <summary>Absolute backstop on total data moved across the whole run.</summary>
+    /// <summary>Ramp time excluded from measurement (TCP slow-start, first-command RTT).</summary>
+    public required TimeSpan WarmupDuration { get; init; }
+
+    /// <summary>Steady-state window we aim to measure after warm-up.</summary>
+    public required TimeSpan MeasureWindow { get; init; }
+
+    /// <summary>Default backstop on total data moved; the request can override it.</summary>
     public required long HardTotalBytes { get; init; }
 
-    /// <summary>Connection counts to sweep (ascending), before clamping to the ceiling/cap.</summary>
     public required int[] SweepLevels { get; init; }
-
-    /// <summary>Connection count used while comparing pipelining on vs. off.</summary>
     public required int PipelineTestConnections { get; init; }
-
-    /// <summary>Pipeline depths to compare against the non-pipelined baseline.</summary>
     public required int[] PipelineDepths { get; init; }
 
     public static BenchmarkProfile For(BenchmarkIntensity intensity) => intensity switch
@@ -46,8 +47,10 @@ public sealed class BenchmarkProfile
             LatencySamples = 8,
             MaxCorpusSegments = 8000,
             PerLevelBytes = 20_000_000,
-            PerLevelMaxDuration = TimeSpan.FromSeconds(10),
-            HardTotalBytes = 650_000_000,
+            PerLevelMaxDuration = TimeSpan.FromSeconds(15),
+            WarmupDuration = TimeSpan.FromSeconds(1.5),
+            MeasureWindow = TimeSpan.FromSeconds(6),
+            HardTotalBytes = 2_000_000_000,
             SweepLevels = [1, 2, 4, 6, 8, 12, 16, 20, 24, 32, 40, 50],
             PipelineTestConnections = 6,
             PipelineDepths = [4, 8, 16],
@@ -57,8 +60,10 @@ public sealed class BenchmarkProfile
             LatencySamples = 5,
             MaxCorpusSegments = 2500,
             PerLevelBytes = 8_000_000,
-            PerLevelMaxDuration = TimeSpan.FromSeconds(8),
-            HardTotalBytes = 160_000_000,
+            PerLevelMaxDuration = TimeSpan.FromSeconds(10),
+            WarmupDuration = TimeSpan.FromSeconds(1),
+            MeasureWindow = TimeSpan.FromSeconds(3),
+            HardTotalBytes = 500_000_000,
             SweepLevels = [1, 2, 4, 8, 16, 24],
             PipelineTestConnections = 4,
             PipelineDepths = [8, 16],
@@ -77,6 +82,9 @@ public sealed class BenchmarkSweepPoint
 {
     public int Connections { get; set; }
     public double MbPerSec { get; set; }
+
+    /// <summary>Coefficient of variation of throughput across sampling buckets (0 = perfectly steady).</summary>
+    public double Cv { get; set; }
 }
 
 public sealed class BenchmarkPipeliningPoint
@@ -113,6 +121,25 @@ public sealed class BenchmarkResult
 
     public BenchmarkPipelining? Pipelining { get; set; }
     public long DataUsedBytes { get; set; }
+
+    /// <summary>Effective data budget for this run (profile default or user override).</summary>
+    public long DataBudgetBytes { get; set; }
+
+    /// <summary>True when the budget stopped the run before all planned levels.</summary>
+    public bool BudgetLimited { get; set; }
+
+    /// <summary>True when the run cycled through the article pool more than once (provider caching may inflate speeds).</summary>
+    public bool WrappedPool { get; set; }
+
+    /// <summary>True when this run only verified a single connection count.</summary>
+    public bool VerificationRun { get; set; }
+
+    /// <summary>"high" | "medium" | "low" — measurement quality signal for the UI.</summary>
+    public string Confidence { get; set; } = "low";
+
+    /// <summary>Warnings about concurrent activity (downloads/streams) that may depress the numbers. Rendered prominently.</summary>
+    public List<string> ContentionWarnings { get; set; } = [];
+
     public List<string> Warnings { get; set; } = [];
 }
 
@@ -124,5 +151,6 @@ public sealed class BenchmarkProgressUpdate
     public int Percent { get; init; }
     public int? CurrentConnections { get; init; }
     public long DataUsedBytes { get; init; }
+    public long DataBudgetBytes { get; init; }
     public List<BenchmarkSweepPoint> Sweep { get; init; } = [];
 }

--- a/backend/Services/Benchmark/BenchmarkSegmentPool.cs
+++ b/backend/Services/Benchmark/BenchmarkSegmentPool.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+
+namespace NzbWebDAV.Services.Benchmark;
+
+/// <summary>
+/// Thread-safe round-robin view over the benchmark corpus for one run. Skips
+/// message-ids observed to be dead (430) so wall-clock isn't wasted re-asking
+/// for them, and tracks whether the run wrapped around the pool (repeat
+/// fetches hit provider caches and inflate speeds).
+/// </summary>
+internal sealed class BenchmarkSegmentPool(IReadOnlyList<string> ids)
+{
+    private readonly ConcurrentDictionary<string, byte> _dead = new();
+    private long _cursor = -1;
+    private long _taken;
+
+    public int Count => ids.Count;
+    public int DeadCount => _dead.Count;
+    public bool WrappedAround => Interlocked.Read(ref _taken) > ids.Count;
+
+    public void MarkDead(string id) => _dead.TryAdd(id, 0);
+
+    public string Next()
+    {
+        Interlocked.Increment(ref _taken);
+        var probes = Math.Min(ids.Count, 64);
+        for (var attempt = 0; attempt < probes; attempt++)
+        {
+            var i = Interlocked.Increment(ref _cursor);
+            var id = ids[(int)((i % ids.Count + ids.Count) % ids.Count)];
+            if (!_dead.ContainsKey(id)) return id;
+        }
+
+        // Everything nearby looks dead — hand one back anyway; the worker just
+        // records another miss and the result carries a corpus warning.
+        var j = Interlocked.Increment(ref _cursor);
+        return ids[(int)((j % ids.Count + ids.Count) % ids.Count)];
+    }
+
+    public List<string> NextBatch(int count)
+    {
+        var batch = new List<string>(count);
+        for (var i = 0; i < count; i++) batch.Add(Next());
+        return batch;
+    }
+}

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -27,10 +27,6 @@ namespace NzbWebDAV.Services.Benchmark;
 /// </summary>
 public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, BenchmarkCorpusProvider corpus)
 {
-    // Rough average decoded article size; used to scale how much data each level
-    // transfers so even high connection counts move enough bytes to measure.
-    private const long ArticleBytesEstimate = 750_000;
-
     // Never open more than this many sockets at once, regardless of provider/config.
     private const int HardConnectionCeiling = 50;
 
@@ -44,20 +40,27 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         int configuredMaxConnections,
         BenchmarkIntensity intensity,
         bool pipeliningOnly,
+        long? dataBudgetBytes,
+        int? verifyConnections,
         CancellationToken ct)
     {
         var profile = BenchmarkProfile.For(intensity);
-        var result = new BenchmarkResult { PipeliningOnly = pipeliningOnly };
-        var cursor = new int[1]; // shared round-robin index into the segment pool
+        var budget = Math.Max(50_000_000, dataBudgetBytes ?? profile.HardTotalBytes);
+        var result = new BenchmarkResult { PipeliningOnly = pipeliningOnly, DataBudgetBytes = budget };
+        long Remaining() => Math.Max(0, budget - result.DataUsedBytes);
+
+        using var ladder = new BenchmarkConnectionLadder(provider);
 
         // 1) Latency — also doubles as a connectivity/credentials check.
         Report("latency", "Measuring latency…", 5, result, null);
-        result.Latency = await MeasureLatencyAsync(provider, profile.LatencySamples, ct).ConfigureAwait(false);
+        await ladder.EnsureAsync(1, ct).ConfigureAwait(false);
+        result.Latency = await MeasureLatencyAsync(
+            ladder.Connections[0], profile.LatencySamples, ct).ConfigureAwait(false);
 
         // 2) Corpus — real message-ids to download.
         Report("corpus", "Gathering test articles…", 12, result, null);
-        var pool = await corpus.GetSegmentPoolAsync(profile.MaxCorpusSegments, ct).ConfigureAwait(false);
-        if (pool.Count == 0)
+        var ids = await corpus.GetSegmentPoolAsync(profile.MaxCorpusSegments, ct).ConfigureAwait(false);
+        if (ids.Count == 0)
         {
             result.ThroughputTested = false;
             result.Warnings.Add(
@@ -67,8 +70,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             return result;
         }
 
+        var pool = new BenchmarkSegmentPool(ids);
         result.ThroughputTested = true;
-        if (pool.Count < 200)
+        if (ids.Count < 200)
             result.Warnings.Add("Only a small pool of test articles was available, so speed numbers may be a little noisy.");
 
         // Pipelining-only mode: leave the connection count alone and just find
@@ -77,132 +81,199 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         {
             var conns = Math.Clamp(configuredMaxConnections, 1, HardConnectionCeiling);
             Report("pipelining", $"Testing pipelining at {conns} connection{(conns == 1 ? "" : "s")}…", 30, result, conns);
+            await ladder.EnsureAsync(conns, ct).ConfigureAwait(false);
             result.Pipelining = await MeasurePipeliningAsync(
-                provider, conns, pool, cursor, profile, FocusedPipelineDepths(intensity),
-                bytes => result.DataUsedBytes += bytes, ct).ConfigureAwait(false);
+                ladder, pool, profile, FocusedPipelineDepths(intensity), Remaining,
+                bytes => result.DataUsedBytes += bytes, result.Warnings, ct).ConfigureAwait(false);
 
             if (conns >= 24)
                 result.Warnings.Add(
                     "At high connection counts, pipelining usually adds little — running many connections in " +
                     "parallel already hides most of the per-request latency it would otherwise save.");
-
-            Report("done", "Done.", 100, result, null);
-            return result;
         }
-
-        // 3) Throughput sweep — climb connection counts until the knee or the cap.
-        var levels = BuildLevels(configuredMaxConnections, profile);
-        int? providerCap = null;
-        for (var i = 0; i < levels.Count; i++)
+        else if (verifyConnections is int vc0)
         {
-            ct.ThrowIfCancellationRequested();
-            var level = levels[i];
+            var vc = Math.Clamp(vc0, 1, HardConnectionCeiling);
+            Report("sweep", $"Verifying {vc} connection{(vc == 1 ? "" : "s")}…", 40, result, vc);
+            var have = await ladder.EnsureAsync(vc, ct).ConfigureAwait(false);
 
-            if (result.DataUsedBytes >= profile.HardTotalBytes)
-            {
-                result.Warnings.Add("Reached the data budget before testing every connection level.");
-                break;
-            }
+            var bootstrap = await MeasureThroughputAsync(
+                ladder, pool, Math.Min(profile.PerLevelBytes, Remaining()),
+                profile.WarmupDuration, TimeSpan.FromSeconds(1.5), profile.PerLevelMaxDuration,
+                pipeliningDepth: 0, ct).ConfigureAwait(false);
+            result.DataUsedBytes += bootstrap.Bytes;
 
-            Report("sweep", $"Testing {level} connection{(level == 1 ? "" : "s")}…",
-                ProgressPercent(15, 75, i, levels.Count), result, level);
-
+            Report("sweep", $"Measuring {have} connection{(have == 1 ? "" : "s")}…", 65, result, have);
             var sample = await MeasureThroughputAsync(
-                provider, level, pool, cursor, TargetBytes(level, profile),
-                profile.PerLevelMaxDuration, pipeliningDepth: 0, ct).ConfigureAwait(false);
+                ladder, pool, AdaptiveTargetBytes(bootstrap.MbPerSec, profile, Remaining()),
+                profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
+                pipeliningDepth: 0, ct).ConfigureAwait(false);
             result.DataUsedBytes += sample.Bytes;
-
-            if (sample.OpenedConnections == 0)
-            {
-                // Couldn't open a single socket at this level — treat the prior
-                // level as the ceiling and stop climbing.
-                providerCap ??= Math.Max(1, level - 1);
-                break;
-            }
 
             result.Sweep.Add(new BenchmarkSweepPoint
             {
-                Connections = sample.OpenedConnections,
+                Connections = have,
                 MbPerSec = Math.Round(sample.MbPerSec, 2),
+                Cv = Math.Round(sample.Cv, 3),
             });
-            Report("sweep", $"{sample.OpenedConnections} conn → {sample.MbPerSec:0.0} MB/s",
-                ProgressPercent(15, 75, i + 1, levels.Count), result, sample.OpenedConnections);
-
-            if (sample.OpenedConnections < level)
+            result.RecommendedConnections = have;
+            result.VerificationRun = true;
+            if (have < vc)
+                result.Warnings.Add($"Only {have} of {vc} connections could be opened for the verification run.");
+        }
+        else
+        {
+            // 3) Throughput sweep — climb connection counts until the knee or the cap.
+            var levels = BuildLevels(configuredMaxConnections, profile);
+            int? providerCap = null;
+            double lastMbPerSec = 0;
+            for (var i = 0; i < levels.Count; i++)
             {
-                // Provider refused the full count — that's the real limit.
-                providerCap = sample.OpenedConnections;
-                result.Warnings.Add(
-                    $"Your provider wouldn't allow more than {sample.OpenedConnections} connections at once, " +
-                    "so the test stopped there.");
-                break;
+                ct.ThrowIfCancellationRequested();
+                var level = levels[i];
+
+                if (Remaining() < MinUsefulBytes(lastMbPerSec, profile))
+                {
+                    result.BudgetLimited = true;
+                    result.Warnings.Add(
+                        "Reached the data budget before testing every connection level. Raise the budget for a fuller picture.");
+                    break;
+                }
+
+                Report("sweep", $"Testing {level} connection{(level == 1 ? "" : "s")}…",
+                    ProgressPercent(15, 75, i, levels.Count), result, level);
+
+                var have = await ladder.EnsureAsync(level, ct).ConfigureAwait(false);
+                if (have == 0)
+                {
+                    providerCap ??= Math.Max(1, i > 0 ? levels[i - 1] : 1);
+                    break;
+                }
+
+                var sample = await MeasureThroughputAsync(
+                    ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, Remaining()),
+                    profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
+                    pipeliningDepth: 0, ct).ConfigureAwait(false);
+                result.DataUsedBytes += sample.Bytes;
+                lastMbPerSec = Math.Max(lastMbPerSec, sample.MbPerSec);
+
+                result.Sweep.Add(new BenchmarkSweepPoint
+                {
+                    Connections = have,
+                    MbPerSec = Math.Round(sample.MbPerSec, 2),
+                    Cv = Math.Round(sample.Cv, 3),
+                });
+                Report("sweep", $"{have} conn → {sample.MbPerSec:0.0} MB/s",
+                    ProgressPercent(15, 75, i + 1, levels.Count), result, have);
+
+                if (have < level)
+                {
+                    providerCap = have;
+                    result.Warnings.Add(
+                        $"Your provider wouldn't allow more than {have} connections at once, so the test stopped there.");
+                    break;
+                }
+            }
+
+            result.ProviderConnectionCap = providerCap;
+            result.RecommendedConnections = DetectKnee(result.Sweep, providerCap, result.Warnings);
+
+            // Thorough only: confirm the pick with a second independent window and blend.
+            if (intensity == BenchmarkIntensity.Thorough
+                && result.RecommendedConnections is int knee
+                && Remaining() > MinUsefulBytes(lastMbPerSec, profile))
+            {
+                Report("sweep", $"Confirming {knee} connection{(knee == 1 ? "" : "s")}…", 80, result, knee);
+                ladder.ShrinkTo(knee);
+                if (ladder.Count > 0)
+                {
+                    var confirm = await MeasureThroughputAsync(
+                        ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, Remaining()),
+                        profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
+                        pipeliningDepth: 0, ct).ConfigureAwait(false);
+                    result.DataUsedBytes += confirm.Bytes;
+                    var point = result.Sweep.FirstOrDefault(p => p.Connections == knee);
+                    if (point != null && confirm.MbPerSec > 0)
+                    {
+                        point.MbPerSec = Math.Round((point.MbPerSec + confirm.MbPerSec) / 2, 2);
+                        point.Cv = Math.Round(Math.Max(point.Cv, confirm.Cv), 3);
+                        result.RecommendedConnections = DetectKnee(result.Sweep, providerCap, []);
+                    }
+                }
+            }
+
+            // 4) Pipelining — compare off vs. a few depths at a moderate concurrency.
+            if (result.Sweep.Count > 0 && Remaining() > MinUsefulBytes(lastMbPerSec, profile))
+            {
+                var pipeConns = Math.Min(result.RecommendedConnections ?? 1, profile.PipelineTestConnections);
+                if (providerCap.HasValue) pipeConns = Math.Min(pipeConns, providerCap.Value);
+                pipeConns = Math.Max(1, pipeConns);
+
+                Report("pipelining", "Testing NNTP pipelining…", 88, result, pipeConns);
+                ladder.ShrinkTo(pipeConns);
+                await ladder.EnsureAsync(pipeConns, ct).ConfigureAwait(false);
+                result.Pipelining = await MeasurePipeliningAsync(
+                    ladder, pool, profile, profile.PipelineDepths, Remaining,
+                    bytes => result.DataUsedBytes += bytes, result.Warnings, ct).ConfigureAwait(false);
             }
         }
 
-        result.ProviderConnectionCap = providerCap;
-        result.RecommendedConnections = DetectKnee(result.Sweep, providerCap, result.Warnings);
-
-        // 4) Pipelining — compare off vs. a few depths at a moderate concurrency.
-        if (result.Sweep.Count > 0 && result.DataUsedBytes < profile.HardTotalBytes)
+        if (pool.WrappedAround)
         {
-            var pipeConns = Math.Min(result.RecommendedConnections ?? 1, profile.PipelineTestConnections);
-            if (providerCap.HasValue) pipeConns = Math.Min(pipeConns, providerCap.Value);
-            pipeConns = Math.Max(1, pipeConns);
-
-            Report("pipelining", "Testing NNTP pipelining…", 88, result, pipeConns);
-            result.Pipelining = await MeasurePipeliningAsync(
-                provider, pipeConns, pool, cursor, profile, profile.PipelineDepths,
-                bytes => result.DataUsedBytes += bytes, ct).ConfigureAwait(false);
+            result.WrappedPool = true;
+            result.Warnings.Add(
+                "The test re-downloaded some articles more than once, so provider caching may make speeds read high. " +
+                "A larger library of completed downloads gives the test more unique data.");
         }
+        if (pool.DeadCount > 0 && pool.DeadCount * 10 > pool.Count)
+            result.Warnings.Add(
+                $"{pool.DeadCount} test articles were no longer available on the provider, which can bias speeds low. " +
+                "Downloading something recent refreshes the test pool.");
 
+        result.Confidence = ComputeConfidence(result);
         Report("done", "Done.", 100, result, null);
         return result;
     }
 
     // ---- Phases ----------------------------------------------------------
 
-    private async Task<BenchmarkLatency> MeasureLatencyAsync(
-        UsenetProviderConfig.ConnectionDetails provider, int samples, CancellationToken ct)
+    private static async Task<BenchmarkLatency> MeasureLatencyAsync(
+        INntpClient conn, int samples, CancellationToken ct)
     {
-        var conn = await UsenetStreamingClient.CreateNewConnection(provider, ct).ConfigureAwait(false);
-        try
+        await conn.DateAsync(ct).ConfigureAwait(false); // warm-up; excludes TLS/first-command setup
+        var measured = new List<double>(samples);
+        for (var i = 0; i < samples; i++)
         {
-            await conn.DateAsync(ct).ConfigureAwait(false); // warm-up; excludes TLS/first-command setup
-            var measured = new List<double>(samples);
-            for (var i = 0; i < samples; i++)
-            {
-                ct.ThrowIfCancellationRequested();
-                var sw = Stopwatch.StartNew();
-                await conn.DateAsync(ct).ConfigureAwait(false);
-                sw.Stop();
-                measured.Add(sw.Elapsed.TotalMilliseconds);
-            }
+            ct.ThrowIfCancellationRequested();
+            var sw = Stopwatch.StartNew();
+            await conn.DateAsync(ct).ConfigureAwait(false);
+            sw.Stop();
+            measured.Add(sw.Elapsed.TotalMilliseconds);
+        }
 
-            return new BenchmarkLatency
-            {
-                MinMs = Math.Round(measured.Min(), 1),
-                AvgMs = Math.Round(measured.Average(), 1),
-                Samples = measured.Count,
-            };
-        }
-        finally
+        return new BenchmarkLatency
         {
-            SafeDispose(conn);
-        }
+            MinMs = Math.Round(measured.Min(), 1),
+            AvgMs = Math.Round(measured.Average(), 1),
+            Samples = measured.Count,
+        };
     }
 
     private async Task<BenchmarkPipelining> MeasurePipeliningAsync(
-        UsenetProviderConfig.ConnectionDetails provider, int connections, IReadOnlyList<string> pool,
-        int[] cursor, BenchmarkProfile profile, int[] depths, Action<long> addData, CancellationToken ct)
+        BenchmarkConnectionLadder ladder, BenchmarkSegmentPool pool, BenchmarkProfile profile,
+        int[] depths, Func<long> remainingBudget, Action<long> addData, List<string> warnings,
+        CancellationToken ct)
     {
-        var result = new BenchmarkPipelining { TestedAtConnections = connections };
-        var target = TargetBytes(connections, profile);
+        var result = new BenchmarkPipelining { TestedAtConnections = ladder.Count };
+        double last = 0;
 
         // Baseline: pipelining off.
         var baseline = await MeasureThroughputAsync(
-            provider, connections, pool, cursor, target, profile.PerLevelMaxDuration, pipeliningDepth: 0, ct)
-            .ConfigureAwait(false);
+            ladder, pool, AdaptiveTargetBytes(last, profile, remainingBudget()),
+            profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
+            pipeliningDepth: 0, ct).ConfigureAwait(false);
         addData(baseline.Bytes);
+        last = baseline.MbPerSec;
         result.BaselineMbPerSec = Math.Round(baseline.MbPerSec, 2);
         if (baseline.OpenedConnections == 0) return result;
 
@@ -211,10 +282,18 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         foreach (var depth in depths)
         {
             ct.ThrowIfCancellationRequested();
+            if (remainingBudget() < MinUsefulBytes(last, profile))
+            {
+                warnings.Add("Reached the data budget before testing every pipelining depth.");
+                break;
+            }
+
             var sample = await MeasureThroughputAsync(
-                provider, connections, pool, cursor, target, profile.PerLevelMaxDuration, depth, ct)
-                .ConfigureAwait(false);
+                ladder, pool, AdaptiveTargetBytes(last, profile, remainingBudget()),
+                profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
+                depth, ct).ConfigureAwait(false);
             addData(sample.Bytes);
+            last = Math.Max(last, sample.MbPerSec);
             result.Tested.Add(new BenchmarkPipeliningPoint { Depth = depth, MbPerSec = Math.Round(sample.MbPerSec, 2) });
             if (sample.MbPerSec > bestMbps) { bestMbps = sample.MbPerSec; bestDepth = depth; }
         }
@@ -236,58 +315,70 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
 
     // ---- Throughput core -------------------------------------------------
 
-    private readonly record struct ThroughputSample(double MbPerSec, long Bytes, int OpenedConnections);
+    private readonly record struct ThroughputSample(
+        double MbPerSec, double Cv, long Bytes, int OpenedConnections, double WindowSeconds);
 
-    private async Task<ThroughputSample> MeasureThroughputAsync(
-        UsenetProviderConfig.ConnectionDetails provider, int requestedConnections, IReadOnlyList<string> pool,
-        int[] cursor, long targetBytes, TimeSpan maxDuration, int pipeliningDepth, CancellationToken ct)
+    private static async Task<ThroughputSample> MeasureThroughputAsync(
+        BenchmarkConnectionLadder ladder, BenchmarkSegmentPool pool, long targetBytes,
+        TimeSpan warmup, TimeSpan window, TimeSpan maxDuration, int pipeliningDepth,
+        CancellationToken ct)
     {
-        var connections = new List<INntpClient>(requestedConnections);
+        var opened = ladder.Count;
+        if (opened == 0) return new ThroughputSample(0, 0, 0, 0, 0);
+
+        var counter = new StrongBox<long>(0);
+        var dead = new System.Collections.Concurrent.ConcurrentBag<INntpClient>();
+        using var levelCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        levelCts.CancelAfter(maxDuration);
+        var token = levelCts.Token;
+
+        var workers = ladder.Connections
+            .Select(conn => Task.Run(async () =>
+            {
+                var healthy = await DownloadWorkerAsync(
+                    conn, pool, targetBytes, counter, pipeliningDepth, token).ConfigureAwait(false);
+                if (!healthy) dead.Add(conn);
+            }, token))
+            .ToList();
+
+        // Warm-up: let TCP windows open and the first-article latency pass, unmeasured.
+        await SafeDelay(warmup, token).ConfigureAwait(false);
+        var startBytes = Interlocked.Read(ref counter.Value);
+        var sw = Stopwatch.StartNew();
+
+        // Steady window: snapshot the counter into ~500ms buckets with real timestamps.
+        var buckets = new List<(long Bytes, double Seconds)>();
+        var prevBytes = startBytes;
+        var prevTime = 0.0;
+        while (sw.Elapsed < window && !token.IsCancellationRequested && !workers.All(w => w.IsCompleted))
+        {
+            await SafeDelay(TimeSpan.FromMilliseconds(500), token).ConfigureAwait(false);
+            var nowBytes = Interlocked.Read(ref counter.Value);
+            var nowTime = sw.Elapsed.TotalSeconds;
+            buckets.Add((nowBytes - prevBytes, nowTime - prevTime));
+            (prevBytes, prevTime) = (nowBytes, nowTime);
+        }
+
+        var endBytes = Interlocked.Read(ref counter.Value);
+        var elapsed = Math.Max(sw.Elapsed.TotalSeconds, 0.001);
+        levelCts.Cancel();
         try
         {
-            for (var i = 0; i < requestedConnections; i++)
-            {
-                ct.ThrowIfCancellationRequested();
-                var conn = await TryOpenConnectionAsync(provider, ct).ConfigureAwait(false);
-                if (conn == null) break; // hit the provider's ceiling
-                connections.Add(conn);
-            }
-
-            if (connections.Count == 0)
-                return new ThroughputSample(0, 0, 0);
-
-            var counter = new StrongBox<long>(0);
-            using var levelCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            levelCts.CancelAfter(maxDuration);
-            var token = levelCts.Token;
-
-            var sw = Stopwatch.StartNew();
-            var workers = connections
-                .Select(conn => Task.Run(() =>
-                    DownloadWorkerAsync(conn, pool, cursor, targetBytes, counter, pipeliningDepth, token), token))
-                .ToList();
-            try
-            {
-                await Task.WhenAll(workers).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected: the measurement window elapsed.
-            }
-            sw.Stop();
-
-            var seconds = Math.Max(sw.Elapsed.TotalSeconds, 0.001);
-            var megabytes = counter.Value / 1_000_000.0;
-            return new ThroughputSample(megabytes / seconds, counter.Value, connections.Count);
+            await Task.WhenAll(workers).ConfigureAwait(false);
         }
-        finally
+        catch (OperationCanceledException)
         {
-            foreach (var conn in connections) SafeDispose(conn);
         }
+
+        ladder.Prune(dead.ToArray());
+
+        var totalBytes = Interlocked.Read(ref counter.Value);
+        var (steady, cv) = ComputeSteadyRate(buckets, endBytes - startBytes, elapsed);
+        return new ThroughputSample(steady, cv, totalBytes, opened, elapsed);
     }
 
-    private static async Task DownloadWorkerAsync(
-        INntpClient conn, IReadOnlyList<string> pool, int[] cursor, long targetBytes,
+    private static async Task<bool> DownloadWorkerAsync(
+        INntpClient conn, BenchmarkSegmentPool pool, long targetBytes,
         StrongBox<long> counter, int depth, CancellationToken ct)
     {
         var buffer = new byte[64 * 1024];
@@ -297,7 +388,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             {
                 while (!ct.IsCancellationRequested && Interlocked.Read(ref counter.Value) < targetBytes)
                 {
-                    var id = NextId(pool, cursor);
+                    var id = pool.Next();
                     try
                     {
                         var response = await conn.DecodedBodyAsync(id, ct).ConfigureAwait(false);
@@ -305,7 +396,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                     }
                     catch (UsenetArticleNotFoundException)
                     {
-                        // Expired/removed article — just move on to the next id.
+                        pool.MarkDead(id);
                     }
                 }
             }
@@ -313,7 +404,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             {
                 while (!ct.IsCancellationRequested && Interlocked.Read(ref counter.Value) < targetBytes)
                 {
-                    var batch = NextBatch(pool, cursor, depth * 4);
+                    var batch = pool.NextBatch(depth * 4);
                     await foreach (var r in conn.DecodedBodiesPipelinedAsync(batch, depth, ct)
                                        .WithCancellation(ct).ConfigureAwait(false))
                     {
@@ -324,16 +415,17 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                     }
                 }
             }
+
+            return true;
         }
         catch (OperationCanceledException)
         {
-            // Window elapsed mid-fetch — fine.
+            return true;
         }
         catch (Exception e) when (!e.IsCancellationException())
         {
-            // A dead/poisoned connection just drops out for the rest of this
-            // window; the remaining workers carry the measurement.
             Log.Debug(e, "Benchmark download worker stopped early.");
+            return false;
         }
     }
 
@@ -349,30 +441,67 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
 
     // ---- Helpers ---------------------------------------------------------
 
-    private static async Task<INntpClient?> TryOpenConnectionAsync(
-        UsenetProviderConfig.ConnectionDetails provider, CancellationToken ct)
+    // Bytes needed to keep the pipe busy through warm-up plus a minimally-useful (~1.5s) window.
+    internal static long MinUsefulBytes(double lastMbPerSec, BenchmarkProfile profile)
     {
-        for (var attempt = 0; attempt < 2; attempt++)
+        var seconds = profile.WarmupDuration.TotalSeconds + 1.5;
+        var bytesPerSec = lastMbPerSec > 0 ? lastMbPerSec * 1_000_000 : 2_000_000;
+        return Math.Max(4_000_000, (long)(bytesPerSec * seconds));
+    }
+
+    // Target enough bytes that workers never run dry before the wall clock stops the
+    // window, even if this level doubles the previous level's throughput.
+    internal static long AdaptiveTargetBytes(
+        double lastMbPerSec, BenchmarkProfile profile, long remainingBudget)
+    {
+        var seconds = (profile.WarmupDuration + profile.MeasureWindow).TotalSeconds;
+        var est = lastMbPerSec > 0
+            ? (long)(lastMbPerSec * 1_000_000 * 2.0 * seconds)
+            : profile.PerLevelBytes;
+        var max = Math.Max(1_000_000, remainingBudget);
+        var min = Math.Min(profile.PerLevelBytes, max);
+        return Math.Clamp(est, min, max);
+    }
+
+    // Median-of-buckets rate + coefficient of variation. Falls back to the whole-window
+    // mean (with a pessimistic CV) when the window produced too few buckets to judge.
+    internal static (double MbPerSec, double Cv) ComputeSteadyRate(
+        IReadOnlyList<(long Bytes, double Seconds)> buckets,
+        long fallbackBytes,
+        double fallbackSeconds)
+    {
+        var rates = buckets
+            .Where(b => b.Seconds > 0.05)
+            .Select(b => b.Bytes / b.Seconds / 1_000_000.0)
+            .ToList();
+
+        if (rates.Count < 3)
         {
-            ct.ThrowIfCancellationRequested();
-            try
-            {
-                return await UsenetStreamingClient.CreateNewConnection(provider, ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception e)
-            {
-                // CouldNotConnect / CouldNotLogin here almost always means we've
-                // hit the provider's simultaneous-connection limit (502). Retry
-                // once to rule out a transient blip, then give up gracefully.
-                if (attempt == 1) Log.Debug(e, "Benchmark could not open an additional connection.");
-            }
+            var mean = fallbackSeconds > 0.05
+                ? fallbackBytes / fallbackSeconds / 1_000_000.0
+                : 0;
+            return (mean, rates.Count == 0 ? 1.0 : 0.5);
         }
 
-        return null;
+        var sorted = rates.OrderBy(r => r).ToList();
+        var median = sorted.Count % 2 == 1
+            ? sorted[sorted.Count / 2]
+            : (sorted[sorted.Count / 2 - 1] + sorted[sorted.Count / 2]) / 2.0;
+
+        var avg = rates.Average();
+        var cv = avg > 0
+            ? Math.Sqrt(rates.Sum(r => (r - avg) * (r - avg)) / rates.Count) / avg
+            : 0;
+        return (median, cv);
+    }
+
+    internal static string ComputeConfidence(BenchmarkResult result)
+    {
+        if (!result.ThroughputTested) return "low";
+        var maxCv = result.Sweep.Count > 0 ? result.Sweep.Max(p => p.Cv) : 0;
+        if (result.BudgetLimited || maxCv > 0.30) return "low";
+        if (result.WrappedPool || maxCv > 0.15) return "medium";
+        return "high";
     }
 
     private static List<int> BuildLevels(int configuredMaxConnections, BenchmarkProfile profile)
@@ -390,19 +519,21 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             .ToList();
     }
 
-    private static int? DetectKnee(List<BenchmarkSweepPoint> sweep, int? providerCap, List<string> warnings)
+    internal static int? DetectKnee(
+        List<BenchmarkSweepPoint> sweep, int? providerCap, List<string> warnings)
     {
         if (sweep.Count == 0) return null;
-
         var ordered = sweep.OrderBy(p => p.Connections).ToList();
-        var best = ordered.Max(p => p.MbPerSec);
-        if (best <= 0) return ordered[0].Connections;
 
-        // Smallest connection count that reaches ~92% of peak throughput.
-        var knee = ordered.First(p => p.MbPerSec >= 0.92 * best).Connections;
+        // Reference peak = mean of the two best points so a single lucky spike can't
+        // drag the recommendation around between runs.
+        var peakRef = ordered.OrderByDescending(p => p.MbPerSec).Take(2).Average(p => p.MbPerSec);
+        if (peakRef <= 0) return ordered[0].Connections;
+
+        var knee = ordered.First(p => p.MbPerSec >= 0.92 * peakRef).Connections;
         if (providerCap.HasValue) knee = Math.Min(knee, providerCap.Value);
 
-        // If we were still climbing at the top of the sweep, say so.
+        var best = ordered.Max(p => p.MbPerSec);
         var peak = ordered[^1];
         if (peak.MbPerSec >= best - 1e-9 && ordered.Count >= 2)
         {
@@ -411,30 +542,27 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 warnings.Add("Speed was still climbing at the highest level tested — a faster line or even more connections may help.");
         }
 
+        if (ordered.Any(p => p.Cv > 0.25))
+            warnings.Add(
+                "Some measurements were noisy (throughput fluctuated during the window), " +
+                "so the recommendation may shift slightly between runs.");
+
         return Math.Max(1, knee);
     }
-
-    // Scale how much data a level transfers with its connection count so even
-    // high counts move enough bytes per connection to measure meaningfully,
-    // clamped between the profile's base and 3× that base.
-    private static long TargetBytes(int connections, BenchmarkProfile profile) =>
-        Math.Clamp((long)connections * ArticleBytesEstimate * 2, profile.PerLevelBytes, profile.PerLevelBytes * 3);
 
     // A wider depth spread for pipelining-only runs, where the depth is the whole point.
     private static int[] FocusedPipelineDepths(BenchmarkIntensity intensity) =>
         intensity == BenchmarkIntensity.Thorough ? [4, 8, 16, 32] : [4, 8, 16];
 
-    private static string NextId(IReadOnlyList<string> pool, int[] cursor)
+    private static async Task SafeDelay(TimeSpan delay, CancellationToken ct)
     {
-        var i = Interlocked.Increment(ref cursor[0]) - 1;
-        return pool[((i % pool.Count) + pool.Count) % pool.Count];
-    }
-
-    private static List<string> NextBatch(IReadOnlyList<string> pool, int[] cursor, int count)
-    {
-        var batch = new List<string>(count);
-        for (var i = 0; i < count; i++) batch.Add(NextId(pool, cursor));
-        return batch;
+        try
+        {
+            await Task.Delay(delay, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     private static int ProgressPercent(int start, int end, int step, int totalSteps) =>
@@ -449,15 +577,15 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             Percent = percent,
             CurrentConnections = currentConnections,
             DataUsedBytes = result.DataUsedBytes,
-            Sweep = result.Sweep.Select(p => new BenchmarkSweepPoint { Connections = p.Connections, MbPerSec = p.MbPerSec }).ToList(),
+            DataBudgetBytes = result.DataBudgetBytes,
+            Sweep = result.Sweep.Select(p => new BenchmarkSweepPoint
+            {
+                Connections = p.Connections,
+                MbPerSec = p.MbPerSec,
+                Cv = p.Cv,
+            }).ToList(),
         };
         // Fire-and-forget: progress is best-effort and must not block the run.
         _ = websocketManager.SendMessage(WebsocketTopic.BenchmarkProgress, JsonSerializer.Serialize(update, JsonOptions));
-    }
-
-    private static void SafeDispose(INntpClient conn)
-    {
-        try { conn.Dispose(); }
-        catch (Exception e) { Log.Debug(e, "Failed to dispose benchmark connection."); }
     }
 }

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -27,7 +27,7 @@ const USAGE_POLL_INTERVAL_MS = 10_000;
 
 // Mirrors the camelCase JSON the backend benchmark endpoint + websocket emit.
 type BenchmarkLatency = { minMs: number; avgMs: number; samples: number };
-type BenchmarkSweepPoint = { connections: number; mbPerSec: number };
+type BenchmarkSweepPoint = { connections: number; mbPerSec: number; cv?: number };
 type BenchmarkPipeliningPoint = { depth: number; mbPerSec: number };
 type BenchmarkPipelining = {
     testedAtConnections: number;
@@ -45,6 +45,12 @@ type BenchmarkResult = {
     providerConnectionCap?: number | null;
     pipelining?: BenchmarkPipelining | null;
     dataUsedBytes: number;
+    dataBudgetBytes?: number;
+    confidence?: "high" | "medium" | "low";
+    contentionWarnings?: string[];
+    verificationRun?: boolean;
+    budgetLimited?: boolean;
+    wrappedPool?: boolean;
     warnings: string[];
 };
 type BenchmarkProgress = {
@@ -53,6 +59,7 @@ type BenchmarkProgress = {
     percent: number;
     currentConnections?: number | null;
     dataUsedBytes: number;
+    dataBudgetBytes?: number;
     sweep: BenchmarkSweepPoint[];
 };
 type BenchmarkIntensity = "quick" | "thorough";
@@ -759,6 +766,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
     const [connectionTested, setConnectionTested] = useState(false);
     const [testError, setTestError] = useState<string | null>(null);
     const [intensity, setIntensity] = useState<BenchmarkIntensity>("quick");
+    const [dataBudget, setDataBudget] = useState<string>("");
     const [isBenchmarking, setIsBenchmarking] = useState(false);
     const [benchmarkProgress, setBenchmarkProgress] = useState<BenchmarkProgress | null>(null);
     const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkResult | null>(null);
@@ -789,6 +797,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             setConnectionTested(false);
             setTestError(null);
             setIntensity("quick");
+            setDataBudget("");
             setIsBenchmarking(false);
             setBenchmarkProgress(null);
             setBenchmarkResult(null);
@@ -840,7 +849,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
         }
     }, [host, port, useSsl, user, pass]);
 
-    const handleAutoTune = useCallback(async () => {
+    const handleAutoTune = useCallback(async (verifyConnections?: number) => {
         // Abort any previous run still in flight before starting a new one.
         benchmarkAbortRef.current?.abort();
         const controller = new AbortController();
@@ -876,6 +885,8 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             formData.append('max-connections', maxConnections || "10");
             formData.append('intensity', intensity);
             formData.append('pipelining-only', pipeliningOnly ? 'true' : 'false');
+            if (dataBudget) formData.append('data-budget-mb', dataBudget);
+            if (verifyConnections) formData.append('verify-connections', String(verifyConnections));
 
             const response = await fetch('/api/benchmark-usenet-connection', {
                 method: 'POST', body: formData, signal: controller.signal,
@@ -903,7 +914,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             if (benchmarkAbortRef.current === controller) benchmarkAbortRef.current = null;
             unsubscribeProgress();
         }
-    }, [host, port, useSsl, user, pass, maxConnections, intensity, pipeliningOnly]);
+    }, [host, port, useSsl, user, pass, maxConnections, intensity, pipeliningOnly, dataBudget]);
 
     const handleApplyRecommendation = useCallback(() => {
         if (!benchmarkResult) return;
@@ -1229,12 +1240,15 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                 isBenchmarking={isBenchmarking}
                 intensity={intensity}
                 setIntensity={setIntensity}
+                dataBudget={dataBudget}
+                setDataBudget={setDataBudget}
                 pipeliningOnly={pipeliningOnly}
                 setPipeliningOnly={setPipeliningOnly}
                 progress={benchmarkProgress}
                 result={benchmarkResult}
                 error={benchmarkError}
-                onRun={handleAutoTune}
+                onRun={() => handleAutoTune()}
+                onVerify={(connections) => handleAutoTune(connections)}
                 onCancel={handleCancelBenchmark}
                 onApply={handleApplyRecommendation}
             />
@@ -1247,12 +1261,15 @@ type BenchmarkPanelProps = {
     isBenchmarking: boolean;
     intensity: BenchmarkIntensity;
     setIntensity: (value: BenchmarkIntensity) => void;
+    dataBudget: string;
+    setDataBudget: (value: string) => void;
     pipeliningOnly: boolean;
     setPipeliningOnly: (value: boolean) => void;
     progress: BenchmarkProgress | null;
     result: BenchmarkResult | null;
     error: string | null;
     onRun: () => void;
+    onVerify: (connections: number) => void;
     onCancel: () => void;
     onApply: () => void;
 };
@@ -1260,7 +1277,8 @@ type BenchmarkPanelProps = {
 function BenchmarkPanel(props: BenchmarkPanelProps) {
     const {
         canBenchmark, isBenchmarking, intensity, setIntensity,
-        pipeliningOnly, setPipeliningOnly, progress, result, error, onRun, onCancel, onApply,
+        dataBudget, setDataBudget, pipeliningOnly, setPipeliningOnly,
+        progress, result, error, onRun, onVerify, onCancel, onApply,
     } = props;
     const [applied, setApplied] = useState(false);
     // A fresh result means the previous "Applied" state no longer holds.
@@ -1306,6 +1324,20 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                             Thorough
                         </Button>
                     </div>
+                    <Select
+                        value={dataBudget}
+                        onChange={(e) => setDataBudget(e.target.value)}
+                        disabled={isBenchmarking}
+                        aria-label="Data budget"
+                    >
+                        <option value="">Auto ({intensity === "quick" ? "up to 500 MB" : "up to 2 GB"})</option>
+                        <option value="100">100 MB</option>
+                        <option value="250">250 MB</option>
+                        <option value="500">500 MB</option>
+                        <option value="1000">1 GB</option>
+                        <option value="2000">2 GB</option>
+                        <option value="5000">5 GB</option>
+                    </Select>
                     <Button variant="primary" onClick={onRun} disabled={!canBenchmark || isBenchmarking}>
                         {isBenchmarking ? "Testing…" : (pipeliningOnly ? "Test pipelining" : "Run speed test")}
                     </Button>
@@ -1329,8 +1361,8 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                 {pipeliningOnly
                     ? "Won't change your connection count — it tests pipelining depth at the Max Connections you've set. Run it idle for the cleanest read."
                     : (intensity === "quick"
-                        ? "Quick downloads roughly 100 MB of real data — light on metered / block accounts."
-                        : "Thorough downloads roughly 400 MB for steadier numbers on fast connections.")}
+                        ? "Quick sizes each step to your line speed, up to the data budget (default 500 MB) — light on metered / block accounts."
+                        : "Thorough runs longer measurement windows for steadier numbers, up to the data budget (default 2 GB).")}
             </HelpText>
 
             {error && (
@@ -1341,7 +1373,10 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                 <div className="mt-3.5">
                     <div className="mb-1.5 flex justify-between gap-2.5 text-xs text-base-content/80">
                         <span>{progress.status}</span>
-                        <span>{formatBytes(progress.dataUsedBytes)} used</span>
+                        <span>
+                            {formatBytes(progress.dataUsedBytes)}
+                            {progress.dataBudgetBytes ? ` / ${formatBytes(progress.dataBudgetBytes)}` : ""} used
+                        </span>
                     </div>
                     <div className="h-1.5 w-full overflow-hidden rounded-full bg-base-300">
                         <div
@@ -1358,6 +1393,33 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
 
             {result && !isBenchmarking && (
                 <>
+                    {result.contentionWarnings?.map((warning) => (
+                        <Alert key={warning} variant="warning" className="mt-3 text-xs">
+                            {warning}
+                        </Alert>
+                    ))}
+
+                    {result.confidence && (
+                        <div className="mt-3">
+                            <span
+                                className={`badge badge-sm badge-outline font-medium ${
+                                    result.confidence === "high"
+                                        ? "border-success/30 text-success"
+                                        : result.confidence === "medium"
+                                            ? "border-warning/30 text-warning"
+                                            : "border-error/30 text-error"
+                                }`}
+                                title="How steady the measurements were (bucket-to-bucket throughput variation, article-pool reuse, and concurrent activity)."
+                            >
+                                {result.confidence === "high"
+                                    ? "High confidence"
+                                    : result.confidence === "medium"
+                                        ? "Medium confidence"
+                                        : "Low confidence"}
+                            </span>
+                        </div>
+                    )}
+
                     {result.pipeliningOnly ? (
                         pipe ? (
                             <>
@@ -1400,6 +1462,15 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                                 Couldn’t measure pipelining{result.latency ? ` (latency ${result.latency.avgMs} ms)` : ""}. Try again when idle.
                             </div>
                         )
+                    ) : result.verificationRun && result.sweep[0] ? (
+                        <div className="mt-4 text-sm leading-relaxed text-base-content/80">
+                            Verified: <strong className="font-semibold text-base-content">
+                                {result.sweep[0].mbPerSec} MB/s
+                            </strong>{" "}
+                            at <strong className="font-semibold text-base-content">
+                                {result.sweep[0].connections} connection{result.sweep[0].connections === 1 ? "" : "s"}
+                            </strong>.
+                        </div>
                     ) : result.throughputTested && recommended ? (
                         <div className="mt-4 grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                             <div className="flex flex-col gap-0.5 rounded-md border border-base-content/10 bg-base-300 px-2.5 py-2">
@@ -1448,11 +1519,20 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                         </ul>
                     )}
 
-                    {canApply && (
-                        <div className="mt-3.5">
+                    {(canApply || (recommended != null && !result.verificationRun)) && (
+                        <div className="mt-3.5 flex flex-wrap gap-2">
                             <Button variant={applied ? "secondary" : "primary"} onClick={() => { onApply(); setApplied(true); }}>
                                 {applied ? "Applied ✓ — review & save" : (result.pipeliningOnly ? "Apply pipelining" : "Apply recommendation")}
                             </Button>
+                            {recommended != null && !result.verificationRun && (
+                                <Button
+                                    variant="secondary"
+                                    onClick={() => onVerify(recommended)}
+                                    disabled={isBenchmarking}
+                                >
+                                    Verify at {recommended} connection{recommended === 1 ? "" : "s"}
+                                </Button>
+                            )}
                         </div>
                     )}
                 </>

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
@@ -1,0 +1,135 @@
+using NzbWebDAV.Services.Benchmark;
+
+namespace NzbWebDAV.Tests.Services.Benchmark;
+
+public class BenchmarkMathTests
+{
+    [Fact]
+    public void ComputeSteadyRate_UsesMedianOfBuckets()
+    {
+        var buckets = new List<(long Bytes, double Seconds)>
+        {
+            (10_000_000, 0.5),
+            (12_000_000, 0.5),
+            (11_000_000, 0.5),
+        };
+
+        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(buckets, 0, 0);
+
+        Assert.Equal(22, mbPerSec, 6);
+        Assert.InRange(cv, 0.07, 0.08);
+    }
+
+    [Fact]
+    public void ComputeSteadyRate_IdenticalBucketsHaveZeroVariation()
+    {
+        var buckets = Enumerable.Repeat((Bytes: 10_000_000L, Seconds: 0.5), 3).ToList();
+
+        var (_, cv) = UsenetBenchmarkService.ComputeSteadyRate(buckets, 0, 0);
+
+        Assert.Equal(0, cv);
+    }
+
+    [Fact]
+    public void ComputeSteadyRate_FallsBackWhenThereAreTooFewBuckets()
+    {
+        var buckets = new List<(long Bytes, double Seconds)>
+        {
+            (10_000_000, 0.5),
+            (12_000_000, 0.5),
+        };
+
+        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
+            buckets, fallbackBytes: 9_000_000, fallbackSeconds: 0.5);
+
+        Assert.Equal(18, mbPerSec, 6);
+        Assert.True(cv >= 0.5);
+    }
+
+    [Fact]
+    public void ComputeSteadyRate_ZeroDurationFallbackReturnsZero()
+    {
+        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
+            [], fallbackBytes: 9_000_000, fallbackSeconds: 0);
+
+        Assert.Equal(0, mbPerSec);
+        Assert.Equal(1, cv);
+    }
+
+    [Fact]
+    public void AdaptiveTargetBytes_UsesProfileFloorWithoutEstimate()
+    {
+        var profile = BenchmarkProfile.For(BenchmarkIntensity.Quick);
+
+        var bytes = UsenetBenchmarkService.AdaptiveTargetBytes(0, profile, 500_000_000);
+
+        Assert.Equal(profile.PerLevelBytes, bytes);
+    }
+
+    [Fact]
+    public void AdaptiveTargetBytes_ScalesFastEstimateAcrossFullWindow()
+    {
+        var profile = BenchmarkProfile.For(BenchmarkIntensity.Quick);
+
+        var bytes = UsenetBenchmarkService.AdaptiveTargetBytes(10, profile, 500_000_000);
+
+        Assert.Equal(80_000_000, bytes);
+    }
+
+    [Fact]
+    public void AdaptiveTargetBytes_HandlesBudgetBelowProfileFloor()
+    {
+        var profile = BenchmarkProfile.For(BenchmarkIntensity.Quick);
+
+        var exception = Record.Exception(
+            () => UsenetBenchmarkService.AdaptiveTargetBytes(10, profile, 5_000_000));
+        var bytes = UsenetBenchmarkService.AdaptiveTargetBytes(10, profile, 5_000_000);
+
+        Assert.Null(exception);
+        Assert.Equal(5_000_000, bytes);
+    }
+
+    [Fact]
+    public void AdaptiveTargetBytes_RespectsRemainingBudget()
+    {
+        var profile = BenchmarkProfile.For(BenchmarkIntensity.Thorough);
+
+        var bytes = UsenetBenchmarkService.AdaptiveTargetBytes(100, profile, 75_000_000);
+
+        Assert.Equal(75_000_000, bytes);
+    }
+
+    [Fact]
+    public void MinUsefulBytes_HasFloorAndScalesWithSpeed()
+    {
+        var profile = BenchmarkProfile.For(BenchmarkIntensity.Quick);
+
+        Assert.Equal(4_000_000, UsenetBenchmarkService.MinUsefulBytes(0.5, profile));
+        Assert.Equal(25_000_000, UsenetBenchmarkService.MinUsefulBytes(10, profile));
+    }
+
+    [Theory]
+    [InlineData(0.1, false, false, true, "high")]
+    [InlineData(0.2, false, false, true, "medium")]
+    [InlineData(0.1, true, false, true, "medium")]
+    [InlineData(0.35, false, false, true, "low")]
+    [InlineData(0.1, false, true, true, "low")]
+    [InlineData(0.1, false, false, false, "low")]
+    public void ComputeConfidence_ReflectsMeasurementQuality(
+        double cv,
+        bool wrappedPool,
+        bool budgetLimited,
+        bool throughputTested,
+        string expected)
+    {
+        var result = new BenchmarkResult
+        {
+            ThroughputTested = throughputTested,
+            WrappedPool = wrappedPool,
+            BudgetLimited = budgetLimited,
+            Sweep = [new BenchmarkSweepPoint { Connections = 1, MbPerSec = 10, Cv = cv }],
+        };
+
+        Assert.Equal(expected, UsenetBenchmarkService.ComputeConfidence(result));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkSegmentPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkSegmentPoolTests.cs
@@ -1,0 +1,54 @@
+using NzbWebDAV.Services.Benchmark;
+
+namespace NzbWebDAV.Tests.Services.Benchmark;
+
+public class BenchmarkSegmentPoolTests
+{
+    [Fact]
+    public void Next_ReturnsIdsInRoundRobinOrder()
+    {
+        var pool = new BenchmarkSegmentPool(["a", "b", "c"]);
+
+        var actual = Enumerable.Range(0, 4).Select(_ => pool.Next()).ToList();
+
+        Assert.Equal(["a", "b", "c", "a"], actual);
+    }
+
+    [Fact]
+    public void MarkDead_SkipsIdOnSubsequentCalls()
+    {
+        var pool = new BenchmarkSegmentPool(["a", "b", "c"]);
+        pool.MarkDead("b");
+
+        var actual = Enumerable.Range(0, 4).Select(_ => pool.Next()).ToList();
+
+        Assert.DoesNotContain("b", actual);
+        Assert.Equal(["a", "c", "a", "c"], actual);
+    }
+
+    [Fact]
+    public void WrappedAround_BecomesTrueAfterCountIsExceeded()
+    {
+        var pool = new BenchmarkSegmentPool(["a", "b", "c"]);
+
+        pool.Next();
+        pool.Next();
+        pool.Next();
+        Assert.False(pool.WrappedAround);
+
+        pool.Next();
+        Assert.True(pool.WrappedAround);
+    }
+
+    [Fact]
+    public void Next_WhenAllIdsAreDead_StillReturnsAValue()
+    {
+        var pool = new BenchmarkSegmentPool(["a", "b"]);
+        pool.MarkDead("a");
+        pool.MarkDead("b");
+
+        var value = pool.Next();
+
+        Assert.Contains(value, new[] { "a", "b" });
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
@@ -1,0 +1,71 @@
+using NzbWebDAV.Services.Benchmark;
+
+namespace NzbWebDAV.Tests.Services.Benchmark;
+
+public class DetectKneeTests
+{
+    [Fact]
+    public void DetectKnee_FindsPlateau()
+    {
+        var sweep = Sweep((1, 10), (2, 20), (4, 35), (8, 40), (16, 41));
+
+        var knee = UsenetBenchmarkService.DetectKnee(sweep, null, []);
+
+        Assert.Equal(8, knee);
+    }
+
+    [Fact]
+    public void DetectKnee_SoftensSinglePeakSpike()
+    {
+        var sweep = Sweep((1, 30), (2, 38), (4, 40), (8, 41), (16, 46));
+
+        var knee = UsenetBenchmarkService.DetectKnee(sweep, null, []);
+
+        Assert.Equal(8, knee);
+    }
+
+    [Fact]
+    public void DetectKnee_ClampsToProviderCap()
+    {
+        var sweep = Sweep((1, 10), (2, 20), (4, 35), (8, 40), (16, 41));
+
+        var knee = UsenetBenchmarkService.DetectKnee(sweep, providerCap: 4, []);
+
+        Assert.Equal(4, knee);
+    }
+
+    [Fact]
+    public void DetectKnee_EmptySweepReturnsNull()
+    {
+        Assert.Null(UsenetBenchmarkService.DetectKnee([], null, []));
+    }
+
+    [Fact]
+    public void DetectKnee_AllZeroSpeedsReturnsFirstConnectionCount()
+    {
+        var sweep = Sweep((2, 0), (4, 0), (8, 0));
+
+        var knee = UsenetBenchmarkService.DetectKnee(sweep, null, []);
+
+        Assert.Equal(2, knee);
+    }
+
+    [Fact]
+    public void DetectKnee_AddsWarningForNoisyMeasurement()
+    {
+        var sweep = Sweep((1, 10), (2, 20), (4, 21));
+        sweep[1].Cv = 0.3;
+        var warnings = new List<string>();
+
+        UsenetBenchmarkService.DetectKnee(sweep, null, warnings);
+
+        Assert.Contains(warnings, warning => warning.Contains("noisy", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static List<BenchmarkSweepPoint> Sweep(params (int Connections, double MbPerSec)[] points) =>
+        points.Select(point => new BenchmarkSweepPoint
+        {
+            Connections = point.Connections,
+            MbPerSec = point.MbPerSec,
+        }).ToList();
+}


### PR DESCRIPTION
## Summary
- measure steady-state throughput with warm-up exclusion, adaptive data targets, and persistent NNTP connections
- improve recommendation stability with bucket medians, noise-aware knee detection, confidence signals, and verification runs
- add data-budget controls, prominent contention warnings, and focused benchmark math/pool coverage

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~NzbWebDAV.Tests.Services.Benchmark` (25 passed)
- [x] Full backend suite (597 passed, 11 skipped; one known Apple Silicon rapidyenc native-library failure)
- [x] `cd frontend && npm run typecheck && npm run build && npm test` (195 passed)