### PR TITLE
fix(queue): Remove Orphaned Files no longer looks frozen mid-scan

### DIFF
--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Data.Sqlite;
+﻿using System.Diagnostics;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -11,50 +12,84 @@ using Serilog;
 
 namespace NzbWebDAV.Tasks;
 
-public class RemoveUnlinkedFilesTask(
-    ConfigManager configManager,
-    WebsocketManager websocketManager,
-    bool isDryRun,
-    Func<DavDatabaseContext>? createContext = null
-) : BaseTask
+public class RemoveUnlinkedFilesTask : BaseTask
 {
+    private static readonly TimeSpan DefaultProgressHeartbeatInterval = TimeSpan.FromSeconds(2);
     private static List<string> _allRemovedPaths = [];
+    private readonly ConfigManager _configManager;
+    private readonly WebsocketManager _websocketManager;
+    private readonly bool _isDryRun;
+    private readonly Func<DavDatabaseContext>? _createContext;
+    private readonly TimeSpan _progressHeartbeatInterval;
+    private readonly Action<string>? _progressObserver;
+    private ProgressHeartbeat? _progressHeartbeat;
 
     internal record UnlinkedItemInfo(string Id, int Type, string Path);
 
-    private DavDatabaseContext CreateContext() => createContext?.Invoke() ?? new DavDatabaseContext();
+    public RemoveUnlinkedFilesTask(
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        bool isDryRun)
+        : this(configManager, websocketManager, isDryRun, null)
+    {
+    }
+
+    internal RemoveUnlinkedFilesTask(
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        bool isDryRun,
+        Func<DavDatabaseContext>? createContext,
+        TimeSpan? progressHeartbeatInterval = null,
+        Action<string>? progressObserver = null)
+    {
+        _configManager = configManager;
+        _websocketManager = websocketManager;
+        _isDryRun = isDryRun;
+        _createContext = createContext;
+        _progressHeartbeatInterval = progressHeartbeatInterval ?? DefaultProgressHeartbeatInterval;
+        _progressObserver = progressObserver;
+    }
+
+    private DavDatabaseContext CreateContext() => _createContext?.Invoke() ?? new DavDatabaseContext();
 
     protected override async Task ExecuteInternal()
     {
+        await using var progressHeartbeat = new ProgressHeartbeat(Report, _progressHeartbeatInterval);
+        _progressHeartbeat = progressHeartbeat;
         try
         {
             await RemoveUnlinkedFiles().ConfigureAwait(false);
         }
         catch (Exception e)
         {
-            Report($"Failed: {e.Message}");
+            Complete($"Failed: {e.Message}");
             Log.Error(e, "Failed to remove unlinked files.");
+        }
+        finally
+        {
+            _progressHeartbeat = null;
         }
     }
 
     private async Task RemoveUnlinkedFiles()
     {
         // get linked file paths
-        Report("Scanning all linked files...");
+        StartPhase("Scanning all linked files...");
         var startTime = DateTime.Now;
         var linkedIdCount = await WriteLinkedIdsToTable().ConfigureAwait(false);
         if (linkedIdCount < 5)
         {
             _allRemovedPaths.Clear();
-            Report($"Aborted: " +
-                   $"There are less than five linked files found in your library. " +
-                   $"Cancelling operation to prevent accidental bulk deletion.");
+            Complete(
+                "Aborted: There are less than five linked files found in your library. " +
+                "Cancelling operation to prevent accidental bulk deletion.");
             return;
         }
 
-        Report("Searching for unlinked webdav items...");
+        StartPhase("Searching for unlinked webdav items...");
         var unlinkedItems = await CountUnlinkedItems(startTime).ConfigureAwait(false);
-        Report($"Found {unlinkedItems} webdav items to remove.");
+        UpdatePhase(
+            $"Searching for unlinked webdav items...\nFound {unlinkedItems} webdav items to remove.");
 
         // The `linkedIdCount < 5` check above only catches a COMPLETELY empty scan. A library
         // dir that is partially mounted, or pointed at the wrong path, can still expose a
@@ -72,27 +107,28 @@ public class RemoveUnlinkedFilesTask(
                 $"That usually means the library directory is missing, unmounted, or misconfigured " +
                 $"rather than that the items are orphaned.";
 
-            if (!isDryRun)
+            if (!_isDryRun)
             {
                 _allRemovedPaths.Clear();
-                Report($"Aborted: {detail} Cancelling to prevent accidental bulk deletion. " +
-                       $"Run a dry-run to inspect if this is genuinely expected.");
+                Complete($"Aborted: {detail} Cancelling to prevent accidental bulk deletion. " +
+                         "Run a dry-run to inspect if this is genuinely expected.");
                 return;
             }
 
-            Report($"Warning: {detail} A non-dry-run would abort.");
+            UpdatePhase($"Warning: {detail} A non-dry-run would abort.");
         }
 
-        if (isDryRun)
+        if (_isDryRun)
         {
+            StartPhase("Identifying unlinked files...");
             await DryRunIdentifyUnlinkedFiles(startTime).ConfigureAwait(false);
-            Report($"Done. Identified {_allRemovedPaths.Count} unlinked files.");
+            Complete($"Done. Identified {_allRemovedPaths.Count} unlinked files.");
         }
         else
         {
             await RemoveUnlinkedItems(startTime, unlinkedItems).ConfigureAwait(false);
             await RemoveEmptyDirectories(startTime).ConfigureAwait(false);
-            Report($"Done. Removed {_allRemovedPaths.Count} unlinked files.");
+            Complete($"Done. Removed {_allRemovedPaths.Count} unlinked files.");
         }
     }
 
@@ -119,7 +155,7 @@ public class RemoveUnlinkedFilesTask(
         // Remove duplicates and add primary key index.
         // COLLATE NOCASE on the column (not predicates) so the PK remains seekable while
         // matching uppercase TMP_LINKED_FILES ids to lowercase migration-seeded DavItems.Id.
-        Report($"Indexing {scannedCount} linked files...");
+        StartPhase($"Indexing {scannedCount} linked files...");
         await dbContext.Database.ExecuteSqlRawAsync(
             """
             CREATE TABLE TMP_LINKED_FILES_UNIQUE (Id TEXT NOT NULL COLLATE NOCASE PRIMARY KEY);
@@ -228,20 +264,24 @@ public class RemoveUnlinkedFilesTask(
 
     private IEnumerable<Guid> GetLinkedIds()
     {
-        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(500));
         var linkedIds = OrganizedLinksUtil
-            .GetLibraryDavItemLinks(configManager)
+            .GetLibraryDavItemLinks(_configManager)
             .Select(x => x.DavItemId);
 
         var count = 0;
+        var lastProgressAt = Stopwatch.GetTimestamp();
         foreach (var linkedId in linkedIds)
         {
             count++;
-            debounce(() => Report($"Scanning all linked files...\nFound {count}..."));
+            if (Stopwatch.GetElapsedTime(lastProgressAt) >= TimeSpan.FromMilliseconds(500))
+            {
+                UpdatePhase($"Scanning all linked files...\nFound {count}...");
+                lastProgressAt = Stopwatch.GetTimestamp();
+            }
             yield return linkedId;
         }
 
-        Report($"Scanning all linked files...\nFound {count}...");
+        UpdatePhase($"Scanning all linked files...\nFound {count}...");
     }
 
     /// <summary>
@@ -294,7 +334,7 @@ public class RemoveUnlinkedFilesTask(
 
     private async Task RemoveUnlinkedItems(DateTime createdBefore, int totalCount)
     {
-        Report("Removing unlinked items...");
+        StartPhase("Removing unlinked items...");
         _allRemovedPaths.Clear();
         await using var dbContext = CreateContext();
         var removed = 0;
@@ -357,20 +397,20 @@ public class RemoveUnlinkedFilesTask(
             _allRemovedPaths.AddRange(itemsToDelete.Select(x => x.Path));
             removed += deleted;
 
-            Report($"Removing unlinked items...\nRemoved {removed}/{totalCount}...");
+            UpdatePhase($"Removing unlinked items...\nRemoved {removed}/{totalCount}...");
         }
 
-        Report($"Removing unlinked items...\nRemoved {removed} of {removed}...");
+        UpdatePhase($"Removing unlinked items...\nRemoved {removed} of {removed}...");
     }
 
     private async Task RemoveEmptyDirectories(DateTime createdBefore)
     {
-        Report($"Removing empty directories...");
+        StartPhase("Removing empty directories...");
         await using var dbContext = CreateContext();
         await RemoveEmptyDirectoriesAsync(
             dbContext,
             createdBefore,
-            removedSoFar => Report($"Removing empty directories...\nRemoved {removedSoFar}..."),
+            removedSoFar => UpdatePhase($"Removing empty directories...\nRemoved {removedSoFar}..."),
             dirs => DavDatabaseContext.RcloneVfsForget(dirs),
             CancellationToken).ConfigureAwait(false);
     }
@@ -506,14 +546,114 @@ public class RemoveUnlinkedFilesTask(
 
             _allRemovedPaths.AddRange(batch.Select(x => x.Path));
             lastId = batch[^1].Id;
-            Report($"Identifying unlinked files...\nFound {_allRemovedPaths.Count}...");
+            UpdatePhase($"Identifying unlinked files...\nFound {_allRemovedPaths.Count}...");
         }
+    }
+
+    private void StartPhase(string message) => _progressHeartbeat?.StartPhase(message);
+
+    private void UpdatePhase(string message) => _progressHeartbeat?.UpdatePhase(message);
+
+    private void Complete(string message)
+    {
+        if (_progressHeartbeat is not null)
+            _progressHeartbeat.Complete(message);
+        else
+            Report(message);
     }
 
     private void Report(string message)
     {
-        var dryRun = isDryRun ? "Dry Run - " : string.Empty;
-        _ = websocketManager.SendMessage(WebsocketTopic.CleanupTaskProgress, $"{dryRun}{message}");
+        var dryRun = _isDryRun ? "Dry Run - " : string.Empty;
+        var progress = $"{dryRun}{message}";
+        _progressObserver?.Invoke(progress);
+        _ = _websocketManager.SendMessage(WebsocketTopic.CleanupTaskProgress, progress);
+    }
+
+    internal sealed class ProgressHeartbeat : IAsyncDisposable
+    {
+        private readonly object _sync = new();
+        private readonly Action<string> _report;
+        private readonly TimeSpan _interval;
+        private readonly Timer _timer;
+        private string? _message;
+        private long _phaseStartedAt;
+        private bool _completed;
+        private bool _disposed;
+
+        public ProgressHeartbeat(Action<string> report, TimeSpan interval)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero);
+            _report = report;
+            _interval = interval;
+            _timer = new Timer(
+                static state => ((ProgressHeartbeat)state!).ReportHeartbeat(),
+                this,
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan);
+        }
+
+        public void StartPhase(string message)
+        {
+            lock (_sync)
+            {
+                if (_disposed || _completed) return;
+                _message = message;
+                _phaseStartedAt = Stopwatch.GetTimestamp();
+                _report(message);
+                _timer.Change(_interval, _interval);
+            }
+        }
+
+        public void UpdatePhase(string message)
+        {
+            lock (_sync)
+            {
+                if (_disposed || _completed) return;
+                _message = message;
+                _report(message);
+            }
+        }
+
+        public void Complete(string message)
+        {
+            lock (_sync)
+            {
+                if (_disposed || _completed) return;
+                _completed = true;
+                _message = null;
+                _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                _report(message);
+            }
+        }
+
+        private void ReportHeartbeat()
+        {
+            lock (_sync)
+            {
+                if (_disposed || _message is null) return;
+                var elapsed = Stopwatch.GetElapsedTime(_phaseStartedAt);
+                _report($"{_message}\nElapsed: {FormatElapsed(elapsed)}");
+            }
+        }
+
+        private static string FormatElapsed(TimeSpan elapsed) =>
+            elapsed.TotalMinutes >= 1
+                ? $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds}s"
+                : $"{Math.Max(1, (int)elapsed.TotalSeconds)}s";
+
+        public async ValueTask DisposeAsync()
+        {
+            lock (_sync)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                _message = null;
+                _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            }
+
+            await _timer.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     public static string GetAuditReport()

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -10,7 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Alert, Badge, Spinner } from "~/components/ui/feedback";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
-import { SettingsPage } from "~/components/ui";
+import { SettingsIntro, SettingsPage } from "~/components/ui";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type BackupSettingsProps = {
@@ -325,198 +325,319 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
 
     return (
         <SettingsPage>
+            <SettingsIntro>
+                Create logical SQL dumps of your databases, schedule automatic backups, and restore from a previous
+                snapshot when needed.
+            </SettingsIntro>
+
             {!reportDismissed && lastRestoreReport && lastRestoreReport.missingBlobRefs > 0 && (
-                <Alert variant="warning" className="mb-4 text-sm">
-                    <div className="flex items-start justify-between gap-3">
+                <Alert className="alert-soft items-start py-3 text-sm" variant="warning">
+                    <Icon name="warning" className="!text-[20px]" />
+                    <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
                         <div>
-                            Last restore of <span className="font-mono">{lastRestoreReport.backupId}</span> found{" "}
-                            <strong>{lastRestoreReport.missingBlobRefs}</strong> of{" "}
-                            {lastRestoreReport.checkedRefs} blob references pointing to missing files under{" "}
-                            <code className="font-mono">blobs/</code>. Affected items may fail to stream until
-                            re-downloaded.
+                            <p className="font-semibold">Missing blobs after restore</p>
+                            <p className="mt-0.5 text-xs opacity-80">
+                                Restore of <span className="font-mono">{lastRestoreReport.backupId}</span> found{" "}
+                                <strong>{lastRestoreReport.missingBlobRefs}</strong> of{" "}
+                                {lastRestoreReport.checkedRefs} blob references pointing to missing files under{" "}
+                                <code className="font-mono">blobs/</code>. Affected items may fail to stream until
+                                re-downloaded.
+                            </p>
                         </div>
-                        <Button variant="ghost" size="small" onClick={() => setReportDismissed(true)}>
+                        <Button variant="ghost" size="xsmall" onClick={() => setReportDismissed(true)}>
                             Dismiss
                         </Button>
                     </div>
                 </Alert>
             )}
 
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                        id="backup-schedule-enabled"
-                        checked={scheduleEnabled}
-                        onChange={(e) =>
-                            setNewConfig({
-                                ...config,
-                                "backup.schedule-enabled": "" + e.target.checked,
-                            })
-                        }
-                    />
-                    <span>Schedule database backup daily</span>
-                </label>
-                <div className="mt-4 flex w-full gap-2">
-                    <Select
-                        disabled={!scheduleEnabled}
-                        value={scheduleTime.hour}
-                        onChange={(e) =>
-                            setNewConfig({
-                                ...config,
-                                "backup.schedule-time": buildScheduledTime(
-                                    parseInt(e.target.value),
-                                    scheduleTime.minute,
-                                    scheduleTime.period,
-                                ),
-                            })
-                        }
-                    >
-                        {Array.from({ length: 12 }, (_, i) => i + 1).map((h) => (
-                            <option key={h} value={h}>
-                                {h}
-                            </option>
-                        ))}
-                    </Select>
-                    <Select
-                        disabled={!scheduleEnabled}
-                        value={scheduleTime.minute}
-                        onChange={(e) =>
-                            setNewConfig({
-                                ...config,
-                                "backup.schedule-time": buildScheduledTime(
-                                    scheduleTime.hour,
-                                    parseInt(e.target.value),
-                                    scheduleTime.period,
-                                ),
-                            })
-                        }
-                    >
-                        <option value={0}>00</option>
-                        <option value={15}>15</option>
-                        <option value={30}>30</option>
-                        <option value={45}>45</option>
-                    </Select>
-                    <Select
-                        disabled={!scheduleEnabled}
-                        value={scheduleTime.period}
-                        onChange={(e) =>
-                            setNewConfig({
-                                ...config,
-                                "backup.schedule-time": buildScheduledTime(
-                                    scheduleTime.hour,
-                                    scheduleTime.minute,
-                                    e.target.value as "am" | "pm",
-                                ),
-                            })
-                        }
-                    >
-                        <option value="am">am</option>
-                        <option value="pm">pm</option>
-                    </Select>
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+                    <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                        <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                            <Icon name="event_repeat" className="!text-[20px]" />
+                        </span>
+                        <div>
+                            <h2 className="text-sm font-semibold text-base-content">Scheduled backups</h2>
+                            <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                                Create a database dump automatically once per day.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="space-y-4 p-4">
+                        <label
+                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
+                            htmlFor="backup-schedule-enabled"
+                        >
+                            <Checkbox
+                                className="checkbox-primary mt-0.5 shrink-0"
+                                id="backup-schedule-enabled"
+                                checked={scheduleEnabled}
+                                onChange={(e) =>
+                                    setNewConfig({
+                                        ...config,
+                                        "backup.schedule-enabled": String(e.target.checked),
+                                    })
+                                }
+                            />
+                            <span>
+                                <span className="block text-sm font-medium text-base-content">Enable daily backup</span>
+                                <span className="mt-0.5 block text-xs leading-relaxed text-base-content/50">
+                                    Writes a logical <code className="font-mono">.sql</code> dump of all databases under
+                                    the config volume.
+                                </span>
+                            </span>
+                        </label>
+
+                        <fieldset className="space-y-2" disabled={!scheduleEnabled}>
+                            <legend className="text-xs font-medium uppercase tracking-wide text-base-content/50">
+                                Daily run time
+                            </legend>
+                            <div className="grid grid-cols-3 gap-2">
+                                <label className="space-y-1">
+                                    <span className="block text-[11px] text-base-content/45">Hour</span>
+                                    <Select
+                                        className="w-full"
+                                        aria-label="Backup hour"
+                                        value={scheduleTime.hour}
+                                        onChange={(e) =>
+                                            setNewConfig({
+                                                ...config,
+                                                "backup.schedule-time": buildScheduledTime(
+                                                    parseInt(e.target.value),
+                                                    scheduleTime.minute,
+                                                    scheduleTime.period,
+                                                ),
+                                            })
+                                        }
+                                    >
+                                        {Array.from({ length: 12 }, (_, i) => i + 1).map((h) => (
+                                            <option key={h} value={h}>
+                                                {h}
+                                            </option>
+                                        ))}
+                                    </Select>
+                                </label>
+                                <label className="space-y-1">
+                                    <span className="block text-[11px] text-base-content/45">Minute</span>
+                                    <Select
+                                        className="w-full"
+                                        aria-label="Backup minute"
+                                        value={scheduleTime.minute}
+                                        onChange={(e) =>
+                                            setNewConfig({
+                                                ...config,
+                                                "backup.schedule-time": buildScheduledTime(
+                                                    scheduleTime.hour,
+                                                    parseInt(e.target.value),
+                                                    scheduleTime.period,
+                                                ),
+                                            })
+                                        }
+                                    >
+                                        <option value={0}>00</option>
+                                        <option value={15}>15</option>
+                                        <option value={30}>30</option>
+                                        <option value={45}>45</option>
+                                    </Select>
+                                </label>
+                                <label className="space-y-1">
+                                    <span className="block text-[11px] text-base-content/45">Period</span>
+                                    <Select
+                                        className="w-full"
+                                        aria-label="Backup period"
+                                        value={scheduleTime.period}
+                                        onChange={(e) =>
+                                            setNewConfig({
+                                                ...config,
+                                                "backup.schedule-time": buildScheduledTime(
+                                                    scheduleTime.hour,
+                                                    scheduleTime.minute,
+                                                    e.target.value as "am" | "pm",
+                                                ),
+                                            })
+                                        }
+                                    >
+                                        <option value="am">AM</option>
+                                        <option value="pm">PM</option>
+                                    </Select>
+                                </label>
+                            </div>
+                        </fieldset>
+
+                        <div className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55">
+                            <Icon name="schedule" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                            <p>
+                                Schedule times use the server timezone. Set{" "}
+                                <code className="font-mono text-base-content/70">TZ</code> in the container environment
+                                if the displayed time does not match your location.
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+                    <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                        <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                            <Icon name="inventory_2" className="!text-[20px]" />
+                        </span>
+                        <div>
+                            <h2 className="text-sm font-semibold text-base-content">Retention</h2>
+                            <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                                Control how many non-preserved backups are kept automatically.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="space-y-4 p-4">
+                        <div className="space-y-2">
+                            <label className="block text-sm font-medium text-base-content" htmlFor="backup-retention-count">
+                                Keep newest backups
+                            </label>
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    id="backup-retention-count"
+                                    type="number"
+                                    min={0}
+                                    value={config["backup.retention-count"] ?? "5"}
+                                    onChange={(e) =>
+                                        setNewConfig({
+                                            ...config,
+                                            "backup.retention-count": e.target.value,
+                                        })
+                                    }
+                                    className="w-full max-w-[8rem]"
+                                />
+                                <span className="text-xs text-base-content/45">count</span>
+                            </div>
+                            <p className="text-[11px] leading-relaxed text-base-content/45">
+                                Prunes older non-preserved backups. Set to 0 to disable pruning.
+                            </p>
+                        </div>
+
+                        <div className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55">
+                            <Icon name="lock" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                            <p>
+                                <span className="font-medium text-base-content/70">Preserved backups are never pruned.</span>
+                                {" "}Mark important snapshots as preserved in the list below.
+                            </p>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+                <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                    <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                        <Icon name="backup" className="!text-[20px]" />
+                    </span>
+                    <div>
+                        <h2 className="text-sm font-semibold text-base-content">Create or upload</h2>
+                        <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                            Start a backup now or import a previously downloaded archive.
+                        </p>
+                    </div>
                 </div>
-                <p className="text-[11px] leading-relaxed text-base-content/45">
-                    Creates a logical <code className="font-mono">.sql</code> dump of all databases under the config
-                    volume. Set the <code className="font-mono">TZ</code> env variable for the correct timezone.
-                </p>
-            </div>
 
-            <hr />
-
-            <div className="space-y-2">
-                <label className="block text-sm text-base-content/80" htmlFor="backup-retention-count">
-                    Retention count (non-preserved backups)
-                </label>
-                <Input
-                    id="backup-retention-count"
-                    type="number"
-                    min={0}
-                    value={config["backup.retention-count"] ?? "5"}
-                    onChange={(e) =>
-                        setNewConfig({
-                            ...config,
-                            "backup.retention-count": e.target.value,
-                        })
-                    }
-                    className="max-w-xs"
-                />
-                <p className="text-[11px] leading-relaxed text-base-content/45">
-                    Keep the newest N backups that are not preserved. Set to 0 to disable pruning. Preserved backups
-                    are never deleted by retention.
-                </p>
-            </div>
-
-            <hr />
-
-            <div className="space-y-3">
-                <h2 className="text-sm font-semibold text-base-content">Create backup now</h2>
-                <Input
-                    placeholder="Optional notes"
-                    value={notes}
-                    onChange={(e) => setNotes(e.target.value)}
-                />
-                <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                        variant="success"
-                        disabled={busy === "create" || taskRunning}
-                        onClick={() => void createBackup()}
-                    >
-                        {busy === "create" ? <Spinner className="h-4 w-4" /> : <Icon name="backup" className="!text-[18px]" />}
-                        Create Backup
-                    </Button>
-                    <Button
-                        variant="outline"
-                        disabled={busy === "upload"}
-                        onClick={() => fileInputRef.current?.click()}
-                    >
-                        {busy === "upload" ? <Spinner className="h-4 w-4" /> : <Icon name="upload" className="!text-[18px]" />}
-                        Upload Backup
-                    </Button>
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        accept=".zip,.sql,application/zip,text/plain"
-                        className="hidden"
-                        onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (file) void uploadBackup(file);
-                        }}
+                <div className="space-y-4 p-4">
+                    <Input
+                        placeholder="Optional notes for this backup"
+                        value={notes}
+                        onChange={(e) => setNotes(e.target.value)}
                     />
-                    {!wsConnected && (
-                        <span className="text-[11px] text-base-content/45">Connecting for live progress…</span>
+
+                    <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <Button
+                                    className="shrink-0"
+                                    variant="primary"
+                                    disabled={busy === "create" || taskRunning}
+                                    onClick={() => void createBackup()}
+                                >
+                                    {busy === "create"
+                                        ? <Spinner className="h-4 w-4" />
+                                        : <Icon name="backup" className="!text-[18px]" />}
+                                    Create Backup
+                                </Button>
+                                <Button
+                                    className="shrink-0"
+                                    variant="outline"
+                                    disabled={busy === "upload"}
+                                    onClick={() => fileInputRef.current?.click()}
+                                >
+                                    {busy === "upload"
+                                        ? <Spinner className="h-4 w-4" />
+                                        : <Icon name="upload" className="!text-[18px]" />}
+                                    Upload Backup
+                                </Button>
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept=".zip,.sql,application/zip,text/plain"
+                                    className="hidden"
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) void uploadBackup(file);
+                                    }}
+                                />
+                            </div>
+                            <div
+                                aria-live="polite"
+                                className="min-w-0 whitespace-pre-line break-words font-mono text-xs text-base-content/70"
+                            >
+                                {backupProgress
+                                    || (restoreProgress && restorePhase === "staging" ? restoreProgress : null)
+                                    || (!wsConnected ? "Connecting for live progress…" : "Ready to create a backup.")}
+                            </div>
+                        </div>
+                    </div>
+
+                    {(message || listError) && (
+                        <Alert
+                            className="alert-soft text-sm"
+                            variant={
+                                listError || message?.variant === "danger"
+                                    ? "danger"
+                                    : message?.variant === "warning"
+                                        ? "warning"
+                                        : "success"
+                            }
+                        >
+                            {listError ?? message?.text}
+                        </Alert>
                     )}
                 </div>
-                {backupProgress && (
-                    <p className="font-mono text-xs text-base-content/70">{backupProgress}</p>
-                )}
-                {restoreProgress && restorePhase === "staging" && (
-                    <p className="font-mono text-xs text-base-content/70">{restoreProgress}</p>
-                )}
-            </div>
+            </section>
 
-            {message && (
-                <Alert variant={message.variant === "danger" ? "danger" : message.variant === "warning" ? "warning" : "success"} className="text-sm">
-                    {message.text}
-                </Alert>
-            )}
-            {listError && (
-                <Alert variant="danger" className="text-sm">
-                    {listError}
-                </Alert>
-            )}
-
-            <hr />
-
-            <div className="space-y-3">
-                <div className="flex items-center justify-between gap-2">
-                    <h2 className="text-sm font-semibold text-base-content">Backups</h2>
-                    <Button variant="ghost" size="small" onClick={() => void refreshList()}>
-                        <Icon name="refresh" className="!text-[16px]" />
-                        Refresh
-                    </Button>
+            <section className="space-y-3">
+                <div className="flex items-end justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-semibold text-base-content">Backup library</h2>
+                        <p className="mt-1 text-xs leading-relaxed text-base-content/50">
+                            Download, preserve, restore, or delete existing snapshots.
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="badge badge-ghost badge-sm shrink-0">
+                            {backups.length} {backups.length === 1 ? "backup" : "backups"}
+                        </span>
+                        <Button variant="ghost" size="small" onClick={() => void refreshList()}>
+                            <Icon name="refresh" className="!text-[16px]" />
+                            Refresh
+                        </Button>
+                    </div>
                 </div>
 
                 {backups.length === 0 ? (
-                    <p className="text-sm text-base-content/50">No backups yet.</p>
+                    <div className="rounded-lg border border-dashed border-base-content/15 bg-base-200/20 px-4 py-8 text-center">
+                        <Icon name="folder_off" className="!text-[28px] text-base-content/35" />
+                        <p className="mt-2 text-sm text-base-content/55">No backups yet.</p>
+                        <p className="mt-1 text-xs text-base-content/40">
+                            Create one above or upload an archive to get started.
+                        </p>
+                    </div>
                 ) : (
                     <ul className="space-y-3">
                         {backups.map((backup) => {
@@ -524,22 +645,25 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                             return (
                                 <li
                                     key={backup.id}
-                                    className="rounded border border-base-content/10 bg-base-200/40 p-3 space-y-3"
+                                    className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100"
                                 >
-                                    <div className="flex flex-wrap items-start justify-between gap-2">
-                                        <div className="space-y-1">
+                                    <div className="flex flex-wrap items-start justify-between gap-3 border-b border-base-content/10 p-4">
+                                        <div className="min-w-0 space-y-1">
                                             <div className="flex flex-wrap items-center gap-2">
                                                 <span className="font-mono text-sm text-base-content">{backup.id}</span>
-                                                <Badge className="badge-sm">{backup.kind}</Badge>
-                                                {backup.preserved && <Badge className="badge-sm badge-warning">preserved</Badge>}
+                                                <Badge className="badge-sm badge-ghost">{backup.kind}</Badge>
+                                                {backup.preserved && (
+                                                    <Badge className="badge-sm badge-warning badge-soft">preserved</Badge>
+                                                )}
                                             </div>
                                             <p className="text-[11px] text-base-content/50">
                                                 {formatDate(backup.createdAt)} · {formatBytes(totalBytes)}
                                                 {backup.appVersion ? ` · v${backup.appVersion}` : ""}
                                             </p>
                                         </div>
-                                        <label className="flex items-center gap-2 text-xs text-base-content/80">
+                                        <label className="flex cursor-pointer items-center gap-2 rounded-lg bg-base-200/40 px-3 py-1.5 text-xs text-base-content/80">
                                             <Checkbox
+                                                className="checkbox-primary checkbox-sm"
                                                 checked={backup.preserved}
                                                 onChange={(e) =>
                                                     void updateBackup(backup.id, { preserved: e.target.checked })
@@ -548,59 +672,66 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                                             Preserve
                                         </label>
                                     </div>
-                                    <Input
-                                        defaultValue={backup.notes ?? ""}
-                                        placeholder="Notes"
-                                        onBlur={(e) => {
-                                            if (e.target.value !== (backup.notes ?? "")) {
-                                                void updateBackup(backup.id, { notes: e.target.value });
-                                            }
-                                        }}
-                                    />
-                                    <div className="flex flex-wrap gap-2">
-                                        <Button
-                                            variant="outline"
-                                            size="small"
-                                            disabled={busy === `download-${backup.id}`}
-                                            onClick={() => void downloadBackup(backup.id)}
-                                        >
-                                            {busy === `download-${backup.id}`
-                                                ? <Spinner className="h-4 w-4" />
-                                                : <Icon name="download" className="!text-[16px]" />}
-                                            Download
-                                        </Button>
-                                        <Button
-                                            variant="warning"
-                                            size="small"
-                                            disabled={!!busy || taskRunning}
-                                            onClick={() => setConfirmRestoreId(backup.id)}
-                                        >
-                                            <Icon name="restore" className="!text-[16px]" />
-                                            Restore
-                                        </Button>
-                                        <Button
-                                            variant="danger"
-                                            size="small"
-                                            disabled={busy === `delete-${backup.id}`}
-                                            onClick={() => setConfirmDeleteId(backup.id)}
-                                        >
-                                            <Icon name="delete" className="!text-[16px]" />
-                                            Delete
-                                        </Button>
+
+                                    <div className="space-y-3 p-4">
+                                        <Input
+                                            defaultValue={backup.notes ?? ""}
+                                            placeholder="Notes"
+                                            onBlur={(e) => {
+                                                if (e.target.value !== (backup.notes ?? "")) {
+                                                    void updateBackup(backup.id, { notes: e.target.value });
+                                                }
+                                            }}
+                                        />
+                                        <div className="flex flex-wrap gap-2">
+                                            <Button
+                                                variant="outline"
+                                                size="small"
+                                                disabled={busy === `download-${backup.id}`}
+                                                onClick={() => void downloadBackup(backup.id)}
+                                            >
+                                                {busy === `download-${backup.id}`
+                                                    ? <Spinner className="h-4 w-4" />
+                                                    : <Icon name="download" className="!text-[16px]" />}
+                                                Download
+                                            </Button>
+                                            <Button
+                                                variant="warning"
+                                                size="small"
+                                                disabled={!!busy || taskRunning}
+                                                onClick={() => setConfirmRestoreId(backup.id)}
+                                            >
+                                                <Icon name="restore" className="!text-[16px]" />
+                                                Restore
+                                            </Button>
+                                            <Button
+                                                variant="danger"
+                                                size="small"
+                                                disabled={busy === `delete-${backup.id}`}
+                                                onClick={() => setConfirmDeleteId(backup.id)}
+                                            >
+                                                <Icon name="delete" className="!text-[16px]" />
+                                                Delete
+                                            </Button>
+                                        </div>
                                     </div>
                                 </li>
                             );
                         })}
                     </ul>
                 )}
-            </div>
 
-            <p className="text-[11px] leading-relaxed text-base-content/45">
-                Backups include <code className="font-mono">db.sqlite</code>,{" "}
-                <code className="font-mono">metrics.sqlite</code>, and <code className="font-mono">warden.db</code> as
-                logical SQL dumps. The <code className="font-mono">blobs/</code> folder is not included — restoring an
-                older dump may leave some items with missing blob files.
-            </p>
+                <div className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55">
+                    <Icon name="info" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                    <p>
+                        Backups include <code className="font-mono text-base-content/70">db.sqlite</code>,{" "}
+                        <code className="font-mono text-base-content/70">metrics.sqlite</code>, and{" "}
+                        <code className="font-mono text-base-content/70">warden.db</code> as logical SQL dumps. The{" "}
+                        <code className="font-mono text-base-content/70">blobs/</code> folder is not included — restoring
+                        an older dump may leave some items with missing blob files.
+                    </p>
+                </div>
+            </section>
 
             <ConfirmModal
                 show={confirmDeleteId !== null}

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,12 +1,13 @@
-import { SettingsPage } from "~/components/ui";
+import { SettingsIntro, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
+import { Icon } from "~/components/ui/icon";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
 import { RenameWindowsInvalidDavPaths } from "./rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
 import { RecreateStrmFiles } from "./recreate-strm-files/recreate-strm-files";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
 import { ResetHealthCheckStats } from "./reset-health-check-stats/reset-health-check-stats";
-import type { Dispatch, SetStateAction } from "react";
 
 type MaintenanceProps = {
     savedConfig: Record<string, string>,
@@ -15,185 +16,271 @@ type MaintenanceProps = {
 };
 
 export function Maintenance({ savedConfig, config, setNewConfig }: MaintenanceProps) {
+    const orphanScheduleEnabled = isScheduledOrphanTaskEnabled(config);
+    const scheduledTime = getScheduledTime(config);
+
     return (
         <SettingsPage>
-                <div className="space-y-2">
-                    <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                        id="db-startup-vacuum-enabled-checkbox"
-                        aria-describedby="db-startup-vacuum-enabled-help"
-                        checked={config["db.is-startup-vacuum-enabled"] === "true"}
-                        onChange={e => setNewConfig({ ...config, "db.is-startup-vacuum-enabled": "" + e.target.checked })}  />
-                    <span>Perform Database Vacuum on Start</span>
-                </label>
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="db-startup-vacuum-enabled-help">
-                        When enabled, NzbDAV will run a SQLite VACUUM on the database at every startup. This reclaims unused disk space and can improve query performance over time, but may increase startup time for large databases.
-                    </p>
-                </div>
-                <hr />
-                <div className="space-y-2">
-                    <label className="block text-sm text-base-content/80" htmlFor="history-retention-days">
-                        SAB History Retention (days)
-                    </label>
-                    <Input
-                        id="history-retention-days"
-                        type="number"
-                        min={0}
-                        aria-describedby="history-retention-days-help"
-                        value={config["database.history-retention-days"] ?? "90"}
-                        onChange={e => setNewConfig({
-                            ...config,
-                            "database.history-retention-days": e.target.value,
-                        })}
-                        className="max-w-xs"
-                    />
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="history-retention-days-help">
-                        Automatically prune SAB history rows older than this many days.
-                        Pruning unlinks mounts from SAB history but does not delete WebDAV files —
-                        they remain under /content until you delete them (or Remove Orphaned Files
-                        removes items with no library symlink/STRM). History pruning alone does not
-                        make items eligible for orphan removal. Set to 0 to keep everything.
-                        Can also be set with DATABASE_HISTORY_RETENTION_DAYS.
-                    </p>
-                </div>
-                <hr />
-                <div className="space-y-2">
-                    <label className="block text-sm text-base-content/80" htmlFor="healthcheck-retention-days">
-                        Health-Check History Retention (days)
-                    </label>
-                    <Input
-                        id="healthcheck-retention-days"
-                        type="number"
-                        min={0}
-                        aria-describedby="healthcheck-retention-days-help"
-                        value={config["database.healthcheck-retention-days"] ?? "30"}
-                        onChange={e => setNewConfig({
-                            ...config,
-                            "database.healthcheck-retention-days": e.target.value,
-                        })}
-                        className="max-w-xs"
-                    />
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-retention-days-help">
-                        Automatically prune health-check result rows older than this many days. Set to 0 to keep everything.
-                        Can also be set with the DATABASE_HEALTHCHECK_RETENTION_DAYS environment variable.
-                    </p>
-                </div>
-                <hr />
-                <div className="space-y-2">
-                    <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                        id="remove-orphaned-schedule-enabled-checkbox"
-                        aria-describedby="remove-orphaned-schedule-help"
-                        checked={isScheduledOrphanTaskEnabled(config)}
-                        onChange={e => setNewConfig({ ...config, "maintenance.remove-orphaned-schedule-enabled": "" + e.target.checked })}  />
-                    <span>{'Schedule "Remove Orphaned Files" Task Daily'}</span>
-                </label>
-                    <div className="mt-4 flex w-full gap-2">
-                        <Select
-                            disabled={!isScheduledOrphanTaskEnabled(config)}
-                            value={getScheduledTime(config).hour}
-                            onChange={e => setNewConfig({
-                                ...config,
-                                "maintenance.remove-orphaned-schedule-time": buildScheduledTime(
-                                    parseInt(e.target.value),
-                                    getScheduledTime(config).minute,
-                                    getScheduledTime(config).period
-                                )
-                            })}>
-                            {Array.from({ length: 12 }, (_, i) => i + 1).map(h => (
-                                <option key={h} value={h}>{h}</option>
-                            ))}
-                        </Select>
-                        <Select
-                            disabled={!isScheduledOrphanTaskEnabled(config)}
-                            value={getScheduledTime(config).minute}
-                            onChange={e => setNewConfig({
-                                ...config,
-                                "maintenance.remove-orphaned-schedule-time": buildScheduledTime(
-                                    getScheduledTime(config).hour,
-                                    parseInt(e.target.value),
-                                    getScheduledTime(config).period
-                                )
-                            })}>
-                            <option value={0}>00</option>
-                            <option value={15}>15</option>
-                            <option value={30}>30</option>
-                            <option value={45}>45</option>
-                        </Select>
-                        <Select
-                            disabled={!isScheduledOrphanTaskEnabled(config)}
-                            value={getScheduledTime(config).period}
-                            onChange={e => setNewConfig({
-                                ...config,
-                                "maintenance.remove-orphaned-schedule-time": buildScheduledTime(
-                                    getScheduledTime(config).hour,
-                                    getScheduledTime(config).minute,
-                                    e.target.value as "am" | "pm"
-                                )
-                            })}>
-                            <option value="am">am</option>
-                            <option value="pm">pm</option>
-                        </Select>
+            <SettingsIntro>
+                Configure routine database housekeeping and schedule automatic orphan cleanup.
+                Run one-off repair and migration tools from the maintenance task panels below.
+            </SettingsIntro>
+
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+                    <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                        <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                            <Icon name="database" className="!text-[20px]" />
+                        </span>
+                        <div>
+                            <h2 className="text-sm font-semibold text-base-content">Database upkeep</h2>
+                            <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                                Control startup optimization and automatic history pruning.
+                            </p>
+                        </div>
                     </div>
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="remove-orphaned-schedule-help">
-                        When enabled, the "Remove Orphaned Files" task will run every day at the specified time.
-                        You may need to set the TZ env variable to ensure the correct timezone.
-                    </p>
-                </div>
-            <div className={'mt-6 space-y-3'}>
-                <hr />
-                <div className="space-y-3">
-                    <details className={'overflow-hidden rounded border border-base-content/10'}>
-                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-base-content hover:bg-base-content/5">
-                            Remove Orphaned Files
-                        </summary>
-                        <div className={'border-t border-base-content/10 p-4'}>
-                            <RemoveUnlinkedFiles savedConfig={savedConfig} />
+
+                    <div className="space-y-4 p-4">
+                        <label
+                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
+                            htmlFor="db-startup-vacuum-enabled-checkbox"
+                        >
+                            <Checkbox
+                                className="checkbox-primary mt-0.5 shrink-0"
+                                id="db-startup-vacuum-enabled-checkbox"
+                                aria-describedby="db-startup-vacuum-enabled-help"
+                                checked={config["db.is-startup-vacuum-enabled"] === "true"}
+                                onChange={e => setNewConfig({
+                                    ...config,
+                                    "db.is-startup-vacuum-enabled": String(e.target.checked),
+                                })}
+                            />
+                            <span>
+                                <span className="block text-sm font-medium text-base-content">Vacuum on startup</span>
+                                <span
+                                    className="mt-0.5 block text-xs leading-relaxed text-base-content/50"
+                                    id="db-startup-vacuum-enabled-help"
+                                >
+                                    Reclaim unused SQLite space. Large databases may take longer to start.
+                                </span>
+                            </span>
+                        </label>
+
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <label className="block text-sm font-medium text-base-content" htmlFor="history-retention-days">
+                                    SAB history retention
+                                </label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        className="w-full"
+                                        id="history-retention-days"
+                                        type="number"
+                                        min={0}
+                                        aria-describedby="history-retention-days-help"
+                                        value={config["database.history-retention-days"] ?? "90"}
+                                        onChange={e => setNewConfig({
+                                            ...config,
+                                            "database.history-retention-days": e.target.value,
+                                        })}
+                                    />
+                                    <span className="text-xs text-base-content/45">days</span>
+                                </div>
+                                <p className="text-[11px] leading-relaxed text-base-content/45" id="history-retention-days-help">
+                                    Prunes SAB history without deleting WebDAV files or making them eligible for orphan cleanup.
+                                    Set to 0 to keep everything.
+                                    Environment: <code className="break-all font-mono">DATABASE_HISTORY_RETENTION_DAYS</code>.
+                                </p>
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="block text-sm font-medium text-base-content" htmlFor="healthcheck-retention-days">
+                                    Health-check retention
+                                </label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        className="w-full"
+                                        id="healthcheck-retention-days"
+                                        type="number"
+                                        min={0}
+                                        aria-describedby="healthcheck-retention-days-help"
+                                        value={config["database.healthcheck-retention-days"] ?? "30"}
+                                        onChange={e => setNewConfig({
+                                            ...config,
+                                            "database.healthcheck-retention-days": e.target.value,
+                                        })}
+                                    />
+                                    <span className="text-xs text-base-content/45">days</span>
+                                </div>
+                                <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-retention-days-help">
+                                    Prunes old health-check results. Set to 0 to keep everything.
+                                    Environment: <code className="break-all font-mono">DATABASE_HEALTHCHECK_RETENTION_DAYS</code>.
+                                </p>
+                            </div>
                         </div>
-                    </details>
-                    <details className={'overflow-hidden rounded border border-base-content/10'}>
-                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-base-content hover:bg-base-content/5">
-                            Rename Windows-Invalid Paths
-                        </summary>
-                        <div className={'border-t border-base-content/10 p-4'}>
-                            <RenameWindowsInvalidDavPaths savedConfig={savedConfig} />
+                    </div>
+                </section>
+
+                <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+                    <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                        <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                            <Icon name="event_repeat" className="!text-[20px]" />
+                        </span>
+                        <div>
+                            <h2 className="text-sm font-semibold text-base-content">Scheduled cleanup</h2>
+                            <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                                Run Remove Orphaned Files automatically once per day.
+                            </p>
                         </div>
-                    </details>
-                    <details className={'overflow-hidden rounded border border-base-content/10'}>
-                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-base-content hover:bg-base-content/5">
-                            Convert Strm Files to Symlnks
-                        </summary>
-                        <div className={'border-t border-base-content/10 p-4'}>
-                            <ConvertStrmToSymlinks savedConfig={savedConfig} />
+                    </div>
+
+                    <div className="space-y-4 p-4">
+                        <label
+                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
+                            htmlFor="remove-orphaned-schedule-enabled-checkbox"
+                        >
+                            <Checkbox
+                                className="checkbox-primary mt-0.5 shrink-0"
+                                id="remove-orphaned-schedule-enabled-checkbox"
+                                aria-describedby="remove-orphaned-schedule-help"
+                                checked={orphanScheduleEnabled}
+                                onChange={e => setNewConfig({
+                                    ...config,
+                                    "maintenance.remove-orphaned-schedule-enabled": String(e.target.checked),
+                                })}
+                            />
+                            <span>
+                                <span className="block text-sm font-medium text-base-content">Enable daily cleanup</span>
+                                <span
+                                    className="mt-0.5 block text-xs leading-relaxed text-base-content/50"
+                                    id="remove-orphaned-schedule-help"
+                                >
+                                    Runs the same protected cleanup available in the task panel below.
+                                </span>
+                            </span>
+                        </label>
+
+                        <fieldset className="space-y-2" disabled={!orphanScheduleEnabled}>
+                            <legend className="text-xs font-medium uppercase tracking-wide text-base-content/50">
+                                Daily run time
+                            </legend>
+                            <div className="grid grid-cols-3 gap-2">
+                                <label className="space-y-1">
+                                    <span className="block text-[11px] text-base-content/45">Hour</span>
+                                    <Select
+                                        className="w-full"
+                                        aria-label="Cleanup hour"
+                                        value={scheduledTime.hour}
+                                        onChange={e => setNewConfig({
+                                            ...config,
+                                            "maintenance.remove-orphaned-schedule-time": buildScheduledTime(
+                                                parseInt(e.target.value),
+                                                scheduledTime.minute,
+                                                scheduledTime.period
+                                            )
+                                        })}>
+                                        {Array.from({ length: 12 }, (_, i) => i + 1).map(h => (
+                                            <option key={h} value={h}>{h}</option>
+                                        ))}
+                                    </Select>
+                                </label>
+                                <label className="space-y-1">
+                                    <span className="block text-[11px] text-base-content/45">Minute</span>
+                                    <Select
+                                        className="w-full"
+                                        aria-label="Cleanup minute"
+                                        value={scheduledTime.minute}
+                                        onChange={e => setNewConfig({
+                                            ...config,
+                                            "maintenance.remove-orphaned-schedule-time": buildScheduledTime(
+                                                scheduledTime.hour,
+                                                parseInt(e.target.value),
+                                                scheduledTime.period
+                                            )
+                                        })}>
+                                        <option value={0}>00</option>
+                                        <option value={15}>15</option>
+                                        <option value={30}>30</option>
+                                        <option value={45}>45</option>
+                                    </Select>
+                                </label>
+                                <label className="space-y-1">
+                                    <span className="block text-[11px] text-base-content/45">Period</span>
+                                    <Select
+                                        className="w-full"
+                                        aria-label="Cleanup period"
+                                        value={scheduledTime.period}
+                                        onChange={e => setNewConfig({
+                                            ...config,
+                                            "maintenance.remove-orphaned-schedule-time": buildScheduledTime(
+                                                scheduledTime.hour,
+                                                scheduledTime.minute,
+                                                e.target.value as "am" | "pm"
+                                            )
+                                        })}>
+                                        <option value="am">AM</option>
+                                        <option value="pm">PM</option>
+                                    </Select>
+                                </label>
+                            </div>
+                        </fieldset>
+
+                        <div className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55">
+                            <Icon name="schedule" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                            <p>
+                                Schedule times use the server timezone. Set <code className="font-mono text-base-content/70">TZ</code>
+                                {" "}in the container environment if the displayed time does not match your location.
+                            </p>
                         </div>
-                    </details>
-                    <details className={'overflow-hidden rounded border border-base-content/10'}>
-                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-base-content hover:bg-base-content/5">
-                            Recreate STRM Files
-                        </summary>
-                        <div className={'border-t border-base-content/10 p-4'}>
-                            <RecreateStrmFiles savedConfig={savedConfig} />
-                        </div>
-                    </details>
-                    <details className={'overflow-hidden rounded border border-base-content/10'}>
-                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-base-content hover:bg-base-content/5">
-                            Migrate Large Database Blobs to Blobstore
-                        </summary>
-                        <div className={'border-t border-base-content/10 p-4'}>
-                            <MigrateDatabaseFilesToBlobstore savedConfig={savedConfig} />
-                        </div>
-                    </details>
-                    <details className={'overflow-hidden rounded border border-base-content/10'}>
-                        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-base-content hover:bg-base-content/5">
-                            Reset Health-Check Statistics
-                        </summary>
-                        <div className={'border-t border-base-content/10 p-4'}>
-                            <ResetHealthCheckStats />
-                        </div>
-                    </details>
-                </div>
+                    </div>
+                </section>
             </div>
+
+            <section className="space-y-3">
+                <div className="flex items-end justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-semibold text-base-content">Maintenance tasks</h2>
+                        <p className="mt-1 text-xs leading-relaxed text-base-content/50">
+                            Run repair, migration, and destructive cleanup tools on demand.
+                        </p>
+                    </div>
+                    <span className="badge badge-ghost badge-sm shrink-0">6 tools</span>
+                </div>
+                <div className="space-y-3">
+                    <MaintenanceTaskDetails title="Remove Orphaned Files">
+                        <RemoveUnlinkedFiles savedConfig={savedConfig} />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Rename Windows-Invalid Paths">
+                        <RenameWindowsInvalidDavPaths savedConfig={savedConfig} />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Convert STRM Files to Symlinks">
+                        <ConvertStrmToSymlinks savedConfig={savedConfig} />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Recreate STRM Files">
+                        <RecreateStrmFiles savedConfig={savedConfig} />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Migrate Large Database Blobs to Blobstore">
+                        <MigrateDatabaseFilesToBlobstore savedConfig={savedConfig} />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Reset Health-Check Statistics">
+                        <ResetHealthCheckStats />
+                    </MaintenanceTaskDetails>
+                </div>
+            </section>
         </SettingsPage>
+    );
+}
+
+function MaintenanceTaskDetails({ title, children }: { title: string, children: ReactNode }) {
+    return (
+        <details className="collapse collapse-arrow overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+            <summary className="collapse-title min-h-0 cursor-pointer px-4 py-3 text-sm font-semibold text-base-content transition-colors hover:bg-base-content/5">
+                {title}
+            </summary>
+            <div className="collapse-content border-t border-base-content/10 px-4 pb-4 pt-4">
+                {children}
+            </div>
+        </details>
     );
 }
 

--- a/frontend/app/routes/settings/maintenance/migrate-database-files-to-blobstore/migrate-database-files-to-blobstore.tsx
+++ b/frontend/app/routes/settings/maintenance/migrate-database-files-to-blobstore/migrate-database-files-to-blobstore.tsx
@@ -1,34 +1,57 @@
 import { useState } from "react";
+import { Icon } from "~/components/ui/icon";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
-type ConvertStrmToSymlinksProps = {
+type MigrateDatabaseFilesToBlobstoreProps = {
     savedConfig: Record<string, string>
 };
 
-export function MigrateDatabaseFilesToBlobstore({ savedConfig }: ConvertStrmToSymlinksProps) {
-    // stateful variables
-    const [connected, setConnected] = useState<boolean>(false);
+export function MigrateDatabaseFilesToBlobstore(_props: MigrateDatabaseFilesToBlobstoreProps) {
     const [progress, setProgress] = useState<string | null>(null);
 
     useWebsocketTopic("uftbmp", "state", setProgress, {
-        onOpen: () => setConnected(true),
         onClose: () => setProgress(null),
     });
 
     return (
-        <div className={'space-y-3'}>
-            <div className="space-y-2">
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="blob-task-progress-help">
-                    <br />
-                    This task runs automatically in the background to optimize the database. No action is required on your part.
-                    You can simply track the progress here. For context, the sqlite database used by the backend is slow at reading and writing large data blobs.
-                    It is better to store those externally in the filesystem directly, as documented <a href="https://sqlite.org/intern-v-extern-blob.html">here</a>.
-                    However, as of now, all blobs have been stored in the database directly. This task migrates those blobs to the filesystem, for better performance.
-                    <br />
-                    <br />
-                    <code>
-                        {progress || "The task has not started."}
-                    </code>
+        <div className="space-y-4">
+            <p className="text-sm leading-relaxed text-base-content/70">
+                Move large blobs out of SQLite and into the filesystem to improve database read and write performance.
+            </p>
+
+            <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                <div className="flex items-start gap-3">
+                    <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                        <Icon name="database" className="!text-[20px]" />
+                    </span>
+                    <div className="min-w-0">
+                        <p className="text-sm font-medium text-base-content">Automatic background migration</p>
+                        <p
+                            aria-live="polite"
+                            className="mt-1 whitespace-pre-line break-words font-mono text-xs text-base-content/65"
+                        >
+                            {progress || "Waiting for the migration to start."}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div
+                className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55"
+                id="blob-task-progress-help"
+            >
+                <Icon name="info" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                <p>
+                    <span className="font-medium text-base-content/70">No action is required.</span>
+                    {" "}The backend runs this optimization automatically. Read more about
+                    {" "}<a
+                        className="link link-primary"
+                        href="https://sqlite.org/intern-v-extern-blob.html"
+                        rel="noreferrer"
+                        target="_blank"
+                    >
+                        SQLite blob storage
+                    </a>.
                 </p>
             </div>
         </div>

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -28,7 +28,7 @@ export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
     );
     const isRunning = runStarted && !isFinished && (isFetching || progress !== null);
     const isRunButtonEnabled = canRun && connected && !isRunning;
-    const runButtonVariant = isRunButtonEnabled ? "success" : "secondary";
+    const runButtonVariant = isRunButtonEnabled ? "primary" : "secondary";
     const runButtonLabel = isRunning ? "Running..." : "Run Task";
 
     useWebsocketTopic("rstm", "state", (msg) => {
@@ -69,76 +69,77 @@ export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
     return (
         <>
             {!canRun &&
-                <Alert className={"mb-3"} variant="warning">
-                    Warning
-                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
+                <Alert className="alert-soft mb-4 items-start text-sm" variant="warning">
+                    <Icon name="settings_alert" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Configuration required</p>
+                        <ul className="mt-1 list-disc space-y-1 pl-4 text-xs opacity-80">
                         {!isStrmStrategy &&
-                            <li className={"text-xs"}>
+                            <li>
                                 Import strategy must be set to STRM Files under the SABnzbd tab.
                             </li>
                         }
                         {!completedDir &&
-                            <li className={"text-xs"}>
+                            <li>
                                 Configure Completed Downloads Directory under the SABnzbd tab.
                             </li>
                         }
                         {!baseUrl &&
-                            <li className={"text-xs"}>
+                            <li>
                                 Configure Base URL under the SABnzbd tab (used inside STRM URLs).
                             </li>
                         }
-                    </ul>
-                </Alert>
-            }
-            {canRun &&
-                <Alert className={"mb-3"} variant="warning">
-                    <span className="font-semibold">Note</span>
-                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
-                        <li className={"text-xs"}>
-                            Writes STRM sidecars under `{completedDir}` mirroring `/content`.
-                        </li>
-                        <li className={"text-xs"}>
-                            Default mode only creates missing files or updates ones whose URL content changed
-                            (e.g. after a base-url change). Rewrite-all forces every file to be rewritten and
-                            will update mtimes, which may trigger a media-server library rescan.
-                        </li>
-                    </ul>
+                        </ul>
+                    </div>
                 </Alert>
             }
             {error &&
-                <Alert className={"mb-3"} variant="danger">{error}</Alert>
+                <Alert className="alert-soft mb-4 text-sm" variant="danger">{error}</Alert>
             }
-            <div className={"space-y-3"}>
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                        id="recreate-strm-rewrite-all"
-                        checked={rewriteAll}
-                        onChange={e => setRewriteAll(e.target.checked)}
-                        disabled={isRunning}
-                    />
-                    <span>Rewrite all STRM files (update mtimes)</span>
-                </label>
-                <div className={"flex flex-col gap-3 sm:flex-row sm:items-center"}>
-                    <Button
-                        className={"shrink-0"}
-                        variant={runButtonVariant}
-                        onClick={onRun}
-                        disabled={!isRunButtonEnabled}
-                    >
-                        <Icon
-                            name={isRunning ? "progress_activity" : "play_arrow"}
-                            className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`}
+            <div className="space-y-4">
+                <p className="text-sm leading-relaxed text-base-content/70">
+                    Create missing STRM sidecars for mounted videos or refresh sidecars whose target URL has changed.
+                </p>
+
+                <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                    <label className="flex items-center gap-2 text-sm text-base-content/75">
+                        <Checkbox
+                            id="recreate-strm-rewrite-all"
+                            checked={rewriteAll}
+                            onChange={e => setRewriteAll(e.target.checked)}
+                            disabled={isRunning}
                         />
-                        {runButtonLabel}
-                    </Button>
-                    <div className={"whitespace-pre-wrap font-mono text-xs text-base-content/80"}>
-                        {progress}
+                        <span>Rewrite every STRM file and update modification times</span>
+                    </label>
+                    <div className="mt-3 flex flex-col gap-3 border-t border-base-content/10 pt-3 sm:flex-row sm:items-center sm:justify-between">
+                        <Button
+                            className="shrink-0"
+                            variant={runButtonVariant}
+                            onClick={onRun}
+                            disabled={!isRunButtonEnabled}
+                        >
+                            <Icon
+                                name={isRunning ? "progress_activity" : "refresh"}
+                                className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`}
+                            />
+                            {runButtonLabel}
+                        </Button>
+                        <div
+                            aria-live="polite"
+                            className="min-w-0 whitespace-pre-line break-words font-mono text-xs text-base-content/70"
+                        >
+                            {progress ?? "Ready to recreate sidecars."}
+                        </div>
                     </div>
                 </div>
-                <p className="text-[11px] leading-relaxed text-base-content/45">
-                    Use this to repair libraries that missed STRM creation (e.g. season packs processed
-                    before the create-for-all-videos fix), or to refresh URLs after changing Base URL.
-                </p>
+
+                <div className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55">
+                    <Icon name="info" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                    <p>
+                        STRM files are written under <span className="font-mono text-base-content/70">{completedDir || "the completed downloads directory"}</span>.
+                        {" "}Rewrite-all can trigger a media-server rescan because it updates every file&apos;s modification time.
+                    </p>
+                </div>
             </div>
         </>
     );

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -24,7 +24,7 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
     const isFinished = progressMessage?.startsWith("Done") || progressMessage?.startsWith("Failed") || progressMessage?.startsWith("Aborted");
     const isRunning = !isFinished && (isFetching || runStarted);
     const isRunButtonEnabled = !!libraryDir && connected && !isRunning;
-    const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
+    const runButtonVariant = isRunButtonEnabled ? 'danger' : 'secondary';
     const runButtonLabel = isRunning ? "Running..." : "Run Task";
 
     useWebsocketTopic("ctp", "state", setProgress, {
@@ -72,77 +72,82 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
         await startTask("/api/remove-unlinked-files/dry-run");
     }, [startTask]);
 
-    // view
-    const dryRunButton =
-        <Button
-            className={'inline-flex'}
-            disabled={!isRunButtonEnabled}
-            onClick={onDryRun}
-            variant="warning"
-            size="small"
-        >
-            <Icon name="science" className="!text-[18px]" />
-            perform a dry-run
-        </Button>;
-
     return (
         <>
             {!libraryDir &&
-                <Alert className={'mb-3'} variant="warning">
-                    Warning
-                    <ul className={'mt-2 list-disc space-y-1 pl-5'}>
-                        <li className={'text-xs'}>
-                            You must first configure the Library Directory setting before running this task.
-                            Head over to the Repairs tab.
-                        </li>
-                    </ul>
+                <Alert className="alert-soft mb-4 items-start text-sm" variant="warning">
+                    <Icon name="folder_off" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Library directory required</p>
+                        <p className="mt-0.5 text-xs opacity-80">
+                            Configure the Library Directory under Repairs before running this task.
+                        </p>
+                    </div>
                 </Alert>
             }
             {libraryDir &&
-                <Alert className={'mb-3'} variant="danger">
-                    <span className="font-semibold">Danger</span>
-                    <ul className={'mt-2 list-disc space-y-1 pl-5'}>
-                        <li className={'text-xs'}>
-                            Make a backup of your NzbDAV database prior to running this task
-                        </li>
-                        <li className={'text-xs'}>
-                            Files will be removed from the webdav and will not be recoverable without a backup
-                        </li>
-                    </ul>
+                <Alert className="alert-soft mb-4 items-start py-3 text-sm" variant="warning">
+                    <Icon name="backup" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Back up before cleanup</p>
+                        <p className="mt-0.5 text-xs opacity-80">
+                            Unlinked WebDAV files are permanently removed and can only be recovered from a database backup.
+                        </p>
+                    </div>
                 </Alert>
             }
-            <div className={'space-y-3'}>
-                <div className="space-y-2">
-                    <div className={'flex flex-col gap-3 sm:flex-row sm:items-center'}>
-                        <Button
-                            className={'shrink-0'}
-                            variant={runButtonVariant}
-                            onClick={onRun}
-                            disabled={!isRunButtonEnabled}
+            <div className="space-y-4">
+                <p className="text-sm leading-relaxed text-base-content/70">
+                    Scan the organized media library for symlink and STRM references, then remove WebDAV files
+                    that are no longer linked from the library.
+                </p>
+
+                <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Button
+                                className={'shrink-0'}
+                                variant={runButtonVariant}
+                                onClick={onRun}
+                                disabled={!isRunButtonEnabled}
+                            >
+                                <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
+                                {runButtonLabel}
+                            </Button>
+                            <Button
+                                className="shrink-0"
+                                disabled={!isRunButtonEnabled}
+                                onClick={onDryRun}
+                                variant="outline"
+                                size="small"
+                            >
+                                <Icon name="science" className="!text-[18px]" />
+                                Dry Run
+                            </Button>
+                        </div>
+                        <div
+                            aria-live="polite"
+                            className="min-w-0 whitespace-pre-line break-words font-mono text-xs text-base-content/70"
                         >
-                            <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
-                            {runButtonLabel}
-                        </Button>
-                        <div className={'font-mono text-xs text-base-content/80'}>
-                            {statusError ?? progress}
+                            {statusError ?? progress ?? "Ready to scan."}
                             {isDone && <>
-                                &nbsp;<a href="/api/remove-unlinked-files/audit">Audit.</a>
+                                {" "}<a className="link link-primary" href="/api/remove-unlinked-files/audit">View audit</a>
                             </>}
                         </div>
                     </div>
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="cleanup-task-progress-help">
-                        <br />
-                        This task will scan your organized media library for all symlinked or *.strm linked files.
-                        Any file on the webdav that is not pointed to by your library will be deleted.
-                        If you would like to see what would be deleted without running the task, you can {dryRunButton}.
-                        The dry-run will not delete anything.
-                        <br />
-                        <br />
-                        Note: Files still present in the History table will not be removed when running this task.
-                        It is assumed that files still present in the History table have not yet been imported by Arrs
-                        and they are expected to not yet have a corresponding symlink/strm in the Library folder.
-                        These files will remain intact until Arrs have a chance to process them and remove them from the
-                        History table.
+                    <p className="mt-3 border-t border-base-content/10 pt-2.5 text-xs text-base-content/50">
+                        Dry Run previews the files that would be removed without changing anything.
+                    </p>
+                </div>
+
+                <div
+                    className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55"
+                    id="cleanup-task-progress-help"
+                >
+                    <Icon name="history" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                    <p>
+                        <span className="font-medium text-base-content/70">History items are protected.</span>
+                        {" "}Files still in SAB history are left intact so Arrs can finish importing them before cleanup.
                     </p>
                 </div>
             </div>

--- a/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
+++ b/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
@@ -23,7 +23,7 @@ export function RenameWindowsInvalidDavPaths({ savedConfig }: RenameWindowsInval
         || progressMessage?.startsWith("Aborted");
     const isRunning = !isFinished && (isFetching || runStarted);
     const isRunButtonEnabled = windowsSafeEnabled && connected && !isRunning;
-    const runButtonVariant = isRunButtonEnabled ? "success" : "secondary";
+    const runButtonVariant = isRunButtonEnabled ? "warning" : "secondary";
     const runButtonLabel = isRunning ? "Running..." : "Apply Renames";
 
     useWebsocketTopic("rwip", "state", setProgress, {
@@ -68,74 +68,84 @@ export function RenameWindowsInvalidDavPaths({ savedConfig }: RenameWindowsInval
         await startTask("/api/rename-windows-invalid-dav-paths/dry-run");
     }, [startTask]);
 
-    const dryRunButton =
-        <Button
-            className={"inline-flex"}
-            disabled={!isRunButtonEnabled}
-            onClick={onDryRun}
-            variant="warning"
-            size="small"
-        >
-            <Icon name="science" className="!text-[18px]" />
-            perform a dry-run
-        </Button>;
-
     return (
         <>
             {!windowsSafeEnabled &&
-                <Alert className={"mb-3"} variant="warning">
-                    Warning
-                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
-                        <li className={"text-xs"}>
-                            Enable &quot;Windows-safe paths&quot; under the WebDAV settings tab before running this task.
-                        </li>
-                    </ul>
+                <Alert className="alert-soft mb-4 items-start text-sm" variant="warning">
+                    <Icon name="settings_alert" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Windows-safe paths required</p>
+                        <p className="mt-0.5 text-xs opacity-80">
+                            Enable Windows-safe paths under WebDAV settings before running this task.
+                        </p>
+                    </div>
                 </Alert>
             }
             {windowsSafeEnabled &&
-                <Alert className={"mb-3"} variant="warning">
-                    <span className="font-semibold">Note</span>
-                    <ul className={"mt-2 list-disc space-y-1 pl-5"}>
-                        <li className={"text-xs"}>
-                            Make a backup of your NzbDAV database prior to applying renames.
-                        </li>
-                        <li className={"text-xs"}>
-                            Prefer a dry-run first to review the report of paths that would change.
-                        </li>
-                    </ul>
+                <Alert className="alert-soft mb-4 items-start py-3 text-sm" variant="warning">
+                    <Icon name="backup" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Back up before renaming</p>
+                        <p className="mt-0.5 text-xs opacity-80">
+                            Review a dry run first, then back up the database before applying path changes.
+                        </p>
+                    </div>
                 </Alert>
             }
-            <div className={"space-y-3"}>
-                <div className="space-y-2">
-                    <div className={"flex flex-col gap-3 sm:flex-row sm:items-center"}>
-                        <Button
-                            className={"shrink-0"}
-                            variant={runButtonVariant}
-                            onClick={onApply}
-                            disabled={!isRunButtonEnabled}
+            <div className="space-y-4">
+                <p className="text-sm leading-relaxed text-base-content/70">
+                    Find WebDAV names that Windows cannot use and rename those path components with the
+                    configured Windows-safe sanitizer.
+                </p>
+
+                <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Button
+                                className="shrink-0"
+                                variant={runButtonVariant}
+                                onClick={onApply}
+                                disabled={!isRunButtonEnabled}
+                            >
+                                <Icon name={isRunning ? "progress_activity" : "drive_file_rename_outline"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
+                                {runButtonLabel}
+                            </Button>
+                            <Button
+                                className="shrink-0"
+                                disabled={!isRunButtonEnabled}
+                                onClick={onDryRun}
+                                variant="outline"
+                                size="small"
+                            >
+                                <Icon name="science" className="!text-[18px]" />
+                                Dry Run
+                            </Button>
+                        </div>
+                        <div
+                            aria-live="polite"
+                            className="min-w-0 whitespace-pre-line break-words font-mono text-xs text-base-content/70"
                         >
-                            <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
-                            {runButtonLabel}
-                        </Button>
-                        <div className={"font-mono text-xs text-base-content/80"}>
-                            {statusError ?? progress}
+                            {statusError ?? progress ?? "Ready to scan."}
                             {isDone && <>
-                                &nbsp;<a href="/api/rename-windows-invalid-dav-paths/audit">Report.</a>
+                                {" "}<a className="link link-primary" href="/api/rename-windows-invalid-dav-paths/audit">View report</a>
                             </>}
                         </div>
                     </div>
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="rename-windows-invalid-paths-help">
-                        <br />
-                        This task finds WebDAV items whose names contain characters invalid on Windows
-                        (or trailing dots/spaces / reserved device names) and renames those path
-                        components to match the current Windows-safe sanitizer. Child paths are updated
-                        for the whole subtree. Name collisions get a <code>_2</code> / <code>_3</code> suffix.
-                        Start with a {dryRunButton} to generate a report without writing changes.
-                        <br />
-                        <br />
-                        Library STRM files and symlinks target items by DavItem Id under <code>/.ids</code>,
-                        so organized libraries keep working after renames. WebDAV browse paths and any
-                        on-disk STRM file locations that mirror the old path will change.
+                    <p className="mt-3 border-t border-base-content/10 pt-2.5 text-xs text-base-content/50">
+                        Dry Run generates a report without changing paths. Name collisions receive a
+                        {" "}<code className="font-mono">_2</code>, <code className="font-mono">_3</code>, or later suffix.
+                    </p>
+                </div>
+
+                <div
+                    className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55"
+                    id="rename-windows-invalid-paths-help"
+                >
+                    <Icon name="link" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                    <p>
+                        <span className="font-medium text-base-content/70">Organized links remain valid.</span>
+                        {" "}STRM files and symlinks target stable DavItem IDs, although browse paths and
+                        mirrored on-disk STRM locations will change.
                     </p>
                 </div>
             </div>

--- a/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
+import { Icon } from "~/components/ui/icon";
 
 export function ResetHealthCheckStats() {
     const [isRunning, setIsRunning] = useState(false);
@@ -35,21 +36,50 @@ export function ResetHealthCheckStats() {
     }, []);
 
     return (
-        <div className="space-y-3">
-            <p className="text-[11px] leading-relaxed text-base-content/45">
-                Clears all accumulated health-check history and counters (repairs, deletions, healthy/unhealthy totals).
+        <div className="space-y-4">
+            <Alert className="alert-soft items-start py-3 text-sm" variant="warning">
+                <Icon name="warning" className="!text-[20px]" />
+                <div>
+                    <p className="font-semibold">This cannot be undone</p>
+                    <p className="mt-0.5 text-xs opacity-80">
+                        All accumulated health-check results and counters will be permanently removed.
+                    </p>
+                </div>
+            </Alert>
+
+            <p className="text-sm leading-relaxed text-base-content/70">
+                Clear health-check history and reset repair, deletion, healthy, and unhealthy counters.
             </p>
-            <Button
-                type="button"
-                variant={isRunning ? "secondary" : "danger"}
-                disabled={isRunning}
-                className="inline-flex"
-                onClick={onReset}
-            >
-                {isRunning ? "Resetting..." : "Reset Health-Check Statistics"}
-            </Button>
-            {message && <Alert variant="success">{message}</Alert>}
-            {error && <Alert variant="danger">{error}</Alert>}
+
+            <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <Button
+                        type="button"
+                        variant={isRunning ? "secondary" : "danger"}
+                        disabled={isRunning}
+                        className="shrink-0"
+                        onClick={onReset}
+                    >
+                        <Icon
+                            name={isRunning ? "progress_activity" : "delete_sweep"}
+                            className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`}
+                        />
+                        {isRunning ? "Resetting..." : "Reset Statistics"}
+                    </Button>
+                    <div
+                        aria-live="polite"
+                        className={`min-w-0 break-words font-mono text-xs ${
+                            error
+                                ? "text-error"
+                                : message
+                                    ? "text-success"
+                                    : "text-base-content/70"
+                        }`}
+                    >
+                        {error ?? message ?? "Ready to reset."}
+                    </div>
+                </div>
+            </div>
         </div>
     );
 }

--- a/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
+++ b/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
@@ -16,11 +16,10 @@ export function ConvertStrmToSymlinks({ savedConfig }: ConvertStrmToSymlinksProp
 
     // derived variables
     const libraryDir = savedConfig["media.library-dir"];
-    const isDone = progress?.startsWith("Done");
     const isFinished = progress?.startsWith("Done") || progress?.startsWith("Failed");
     const isRunning = !isFinished && (isFetching || progress !== null);
     const isRunButtonEnabled = !!libraryDir && connected && !isRunning;
-    const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
+    const runButtonVariant = isRunButtonEnabled ? 'danger' : 'secondary';
     const runButtonLabel = isRunning ? "Running..." : "Run Task";
 
     useWebsocketTopic("st2sy", "state", setProgress, {
@@ -38,34 +37,38 @@ export function ConvertStrmToSymlinks({ savedConfig }: ConvertStrmToSymlinksProp
     return (
         <>
             {!libraryDir &&
-                <Alert className={'mb-3'} variant="warning">
-                    Warning
-                    <ul className={'mt-2 list-disc space-y-1 pl-5'}>
-                        <li className={'text-xs'}>
-                            You must first configure the Library Directory setting before running this task.
-                            Head over to the Repairs tab.
-                        </li>
-                    </ul>
+                <Alert className="alert-soft mb-4 items-start text-sm" variant="warning">
+                    <Icon name="folder_off" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Library directory required</p>
+                        <p className="mt-0.5 text-xs opacity-80">
+                            Configure the Library Directory under Repairs before running this task.
+                        </p>
+                    </div>
                 </Alert>
             }
             {libraryDir &&
-                <Alert className={'mb-3'} variant="danger">
-                    <span className="font-semibold">Danger</span>
-                    <ul className={'mt-2 list-disc space-y-1 pl-5'}>
-                        <li className={'text-xs'}>
-                            Make a backup of your entire Library Dir prior to running this task
-                        </li>
-                        <li className={'text-xs'}>
-                            Strm files will be deleted from `{libraryDir}` and will not be recoverable without a backup.
-                        </li>
-                    </ul>
+                <Alert className="alert-soft mb-4 items-start py-3 text-sm" variant="warning">
+                    <Icon name="backup" className="!text-[20px]" />
+                    <div>
+                        <p className="font-semibold">Back up the library first</p>
+                        <p className="mt-0.5 text-xs opacity-80">
+                            STRM files under <span className="font-mono">{libraryDir}</span> are replaced and
+                            cannot be recovered without a backup.
+                        </p>
+                    </div>
                 </Alert>
             }
-            <div className={'space-y-3'}>
-                <div className="space-y-2">
-                    <div className={'flex flex-col gap-3 sm:flex-row sm:items-center'}>
+            <div className="space-y-4">
+                <p className="text-sm leading-relaxed text-base-content/70">
+                    Replace NzbDav STRM files in the organized media library with filesystem symlinks to
+                    the corresponding files in the rclone mount.
+                </p>
+
+                <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <Button
-                            className={'shrink-0'}
+                            className="shrink-0"
                             variant={runButtonVariant}
                             onClick={onRun}
                             disabled={!isRunButtonEnabled}
@@ -73,15 +76,26 @@ export function ConvertStrmToSymlinks({ savedConfig }: ConvertStrmToSymlinksProp
                             <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
                             {runButtonLabel}
                         </Button>
-                        <div className={'font-mono text-xs text-base-content/80'}>
-                            {progress}
+                        <div
+                            aria-live="polite"
+                            className="min-w-0 whitespace-pre-line break-words font-mono text-xs text-base-content/70"
+                        >
+                            {progress ?? "Ready to convert."}
                         </div>
                     </div>
-                    <p className="text-[11px] leading-relaxed text-base-content/45" id="cleanup-task-progress-help">
-                        <br />
-                        This task will scan your organized media library for all *.strm files.
-                        Every *.strm file that links to nzbdav media will be deleted and be replaced by a symlink.
-                        The newly created symlinks will all point to the corresponding file within your rclone mount.
+                    <p className="mt-3 border-t border-base-content/10 pt-2.5 text-xs text-base-content/50">
+                        Only STRM files that link to NzbDav media are converted.
+                    </p>
+                </div>
+
+                <div
+                    className="flex items-start gap-2 rounded-lg bg-base-200/30 px-3 py-2.5 text-xs leading-relaxed text-base-content/55"
+                    id="convert-strm-to-symlinks-help"
+                >
+                    <Icon name="link" className="mt-0.5 !text-[17px] shrink-0 text-base-content/45" />
+                    <p>
+                        <span className="font-medium text-base-content/70">The rclone mount must remain available.</span>
+                        {" "}Created symlinks point directly to their matching mounted files.
                     </p>
                 </div>
             </div>

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1,6 +1,6 @@
 import chartStyles from "./bench-chart.module.css";
 import { type Dispatch, type SetStateAction, type ReactNode, type CSSProperties, useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { Alert, Badge, Button, HelpText, Icon, Input, Label, Modal, Select, SettingsPage } from "~/components/ui";
+import { Alert, Badge, Button, HelpText, Icon, Input, Label, Modal, Select, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Checkbox } from "~/components/ui/form";
 import { subscribeWebsocketTopics, useWebsocketTopic } from "~/utils/shared-websocket";
 import { isMaskedSecret } from "~/utils/config-mask";
@@ -404,33 +404,57 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
     // view
     return (
         <SettingsPage>
-            <div className={'space-y-4'}>
-                <div className={'flex items-center justify-between text-lg font-semibold text-base-content'}>
-                    <div>Usenet Providers</div>
-                    <Button variant="primary" size="small" onClick={handleAddProvider}>
-                        <Icon name="add" className="!text-[18px]" />
-                        Add
-                    </Button>
+            <SettingsIntro>
+                Configure NNTP providers, decide whether they share load or cascade in priority order, and tune
+                pipelining for faster queue imports.
+            </SettingsIntro>
+
+            <section className="space-y-3">
+                <div className="flex items-end justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-semibold text-base-content">Providers</h2>
+                        <p className="mt-1 text-xs leading-relaxed text-base-content/50">
+                            Add Usenet accounts, monitor connection usage, and edit credentials.
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="badge badge-ghost badge-sm shrink-0">
+                            {providerConfig.Providers.length}{" "}
+                            {providerConfig.Providers.length === 1 ? "provider" : "providers"}
+                        </span>
+                        <Button variant="primary" size="small" onClick={handleAddProvider}>
+                            <Icon name="add" className="!text-[18px]" />
+                            Add
+                        </Button>
+                    </div>
                 </div>
+
                 {providerConfig.Providers.length === 0 ? (
-                    <p className={'rounded border border-base-content/10 bg-base-200/40 px-3 py-2 text-sm text-base-content/60'}>
-                        No Usenet providers configured.
-                        Click on the "Add" button to get started.
-                    </p>
+                    <div className="rounded-lg border border-dashed border-base-content/15 bg-base-200/20 px-4 py-8 text-center">
+                        <Icon name="cloud_off" className="!text-[28px] text-base-content/35" />
+                        <p className="mt-2 text-sm text-base-content/55">No Usenet providers configured.</p>
+                        <p className="mt-1 text-xs text-base-content/40">
+                            Click Add to connect your first NNTP account.
+                        </p>
+                    </div>
                 ) : (
                     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                     <SortableContext items={providerConfig.Providers.map(providerKey)} strategy={rectSortingStrategy}>
-                    <div className="mb-7 grid grid-cols-1 gap-4 lg:grid-cols-2">
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                         {displayedProviders.map(({ provider, index }) => {
                             const isDisabled = provider.Type === ProviderType.Disabled;
                             return (
                             <SortableItem key={providerKey(provider)} id={providerKey(provider)} disabled={!cascadeEnabled}>
                             {({ setNodeRef, setActivatorNodeRef, attributes, listeners, style, isDragging }) => (
-                            <div ref={setNodeRef} style={style} className={`card border border-base-content/10 bg-base-100 shadow-sm ${isDisabled ? "opacity-60" : ""}`}>
-                                <div className="card-body gap-3 p-4">
+                            <div
+                                ref={setNodeRef}
+                                style={style}
+                                className={`overflow-hidden rounded-lg border border-base-content/10 bg-base-100 ${isDisabled ? "opacity-60" : ""}`}
+                            >
+                                <div className="space-y-3 p-4">
                                     <div className="flex items-start justify-between gap-3">
                                         <div className="min-w-0 flex-1">
-                                            <div className="break-all text-[15px] font-semibold leading-snug tracking-tight text-base-content">
+                                            <div className="break-all text-sm font-semibold leading-snug text-base-content">
                                                 {cascadeEnabled && !isDisabled && (
                                                     <Badge className="badge-ghost badge-sm mr-2 align-middle">#{index + 1}</Badge>
                                                 )}
@@ -438,11 +462,11 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                                 {isDisabled && <Badge className="badge-ghost badge-sm ml-2 align-middle">Disabled</Badge>}
                                             </div>
                                             {provider.Nickname?.trim() && (
-                                                <div className="mb-0.5 break-all text-xs text-base-content/60">
+                                                <div className="mt-0.5 break-all text-xs text-base-content/60">
                                                     {provider.Host}
                                                 </div>
                                             )}
-                                            <div className="text-[10px] font-medium uppercase tracking-wide text-base-content/50">
+                                            <div className="mt-1 text-[10px] font-medium uppercase tracking-wide text-base-content/50">
                                                 Port {provider.Port}
                                             </div>
                                         </div>
@@ -496,24 +520,21 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                         </div>
                                     </div>
 
-                                    <div className={'mt-4 border-t border-base-content/10 pt-3'}>
-                                        <div className={'grid grid-cols-1 gap-3 sm:grid-cols-2'}>
-
-                                            <div className={'relative flex min-w-0 items-center gap-2'}>
-                                                <div className={'text-primary'}>
+                                    <div className="border-t border-base-content/10 pt-3">
+                                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                            <div className="relative flex min-w-0 items-center gap-2">
+                                                <div className="text-primary">
                                                     <Icon name="person" className="!text-[18px]" />
                                                 </div>
-                                                <div className={'flex min-w-0 flex-col'}>
-                                                    <span className={'text-[11px] uppercase tracking-wide text-base-content/50'}>Username</span>
-                                                    <span className={'truncate text-sm text-base-content'}>{provider.User}</span>
+                                                <div className="flex min-w-0 flex-col">
+                                                    <span className="text-[11px] uppercase tracking-wide text-base-content/50">Username</span>
+                                                    <span className="truncate text-sm text-base-content">{provider.User}</span>
                                                 </div>
                                             </div>
 
-                                            <div className="flex items-center gap-2.5 rounded-md border border-base-content/10 bg-base-200/40 px-2.5 py-2">
-                                                <div className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded bg-base-300 text-base-content/60">
-                                                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                                                        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
-                                                    </svg>
+                                            <div className="flex items-center gap-2.5 rounded-lg border border-base-content/10 bg-base-200/40 px-2.5 py-2">
+                                                <div className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-md bg-base-300 text-base-content/60">
+                                                    <Icon name="hub" className="!text-[16px]" />
                                                 </div>
                                                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                                                     <span className="text-[10px] font-medium uppercase tracking-wide text-base-content/50">Connections</span>
@@ -525,20 +546,20 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                                 </div>
                                             </div>
 
-                                            <div className={'relative flex min-w-0 items-center gap-2'}>
-                                                <div className={'text-primary'}>
+                                            <div className="relative flex min-w-0 items-center gap-2">
+                                                <div className="text-primary">
                                                     <Icon name={provider.UseSsl ? "lock" : "lock_open"} className="!text-[18px]" />
                                                 </div>
-                                                <div className={'flex min-w-0 flex-col'}>
-                                                    <span className={'text-[11px] uppercase tracking-wide text-base-content/50'}>Security</span>
-                                                    <span className={'truncate text-sm text-base-content'}>
+                                                <div className="flex min-w-0 flex-col">
+                                                    <span className="text-[11px] uppercase tracking-wide text-base-content/50">Security</span>
+                                                    <span className="truncate text-sm text-base-content">
                                                         {provider.UseSsl ? "SSL Enabled" : "No SSL"}
                                                     </span>
                                                 </div>
                                             </div>
 
-                                            <div className={'relative flex min-w-0 items-center gap-2'}>
-                                                <div className={'text-primary'}>
+                                            <div className="relative flex min-w-0 items-center gap-2">
+                                                <div className="text-primary">
                                                     <Icon name="account_tree" className="!text-[18px]" />
                                                 </div>
                                                 <div className="flex min-w-0 flex-col">
@@ -550,17 +571,16 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                             </div>
 
                                             {provider.StorageGroup?.trim() && (
-                                                <div className={'relative flex min-w-0 items-center gap-2'}>
-                                                    <div className={'text-primary'}>
+                                                <div className="relative flex min-w-0 items-center gap-2">
+                                                    <div className="text-primary">
                                                         <Icon name="storage" className="!text-[18px]" />
                                                     </div>
-                                                    <div className={'flex min-w-0 flex-col'}>
-                                                        <span className={'text-[11px] uppercase tracking-wide text-base-content/50'}>Storage group</span>
-                                                        <span className={'truncate text-sm text-base-content'}>{provider.StorageGroup.trim()}</span>
+                                                    <div className="flex min-w-0 flex-col">
+                                                        <span className="text-[11px] uppercase tracking-wide text-base-content/50">Storage group</span>
+                                                        <span className="truncate text-sm text-base-content">{provider.StorageGroup.trim()}</span>
                                                     </div>
                                                 </div>
                                             )}
-
                                         </div>
 
                                         <UsageRow
@@ -579,15 +599,28 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                     </SortableContext>
                     </DndContext>
                 )}
-            </div>
+            </section>
 
-            <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between gap-3">
-                    <div className="text-base font-semibold text-base-content">Cascade (Optional)</div>
+            <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+                <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                    <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                        <Icon name="tune" className="!text-[20px]" />
+                    </span>
+                    <div>
+                        <h2 className="text-sm font-semibold text-base-content">Global settings</h2>
+                        <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                            Shared routing and pipelining options that apply across all providers.
+                        </p>
+                    </div>
                 </div>
-                <div className="mt-3 flex flex-col gap-1.5">
-                    <label htmlFor="cascade-enabled" className="flex items-center gap-2">
+
+                <div className="space-y-4 p-4">
+                    <label
+                        className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
+                        htmlFor="cascade-enabled"
+                    >
                         <Checkbox
+                            className="checkbox-primary mt-0.5 shrink-0"
                             id="cascade-enabled"
                             checked={cascadeEnabled}
                             onChange={(e) => {
@@ -603,58 +636,66 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                 });
                             }}
                         />
-                        <span className="text-sm text-base-content/80">Enable cascade routing</span>
+                        <span>
+                            <span className="block text-sm font-medium text-base-content">Enable cascade routing</span>
+                            <span className="mt-0.5 block text-xs leading-relaxed text-base-content/50">
+                                Prefer providers in drag order. While off, all enabled providers share work in the pool.
+                            </span>
+                        </span>
                     </label>
-                    <HelpText>
-                        Sets the order your providers are used. Drag the cards to arrange them. While this is off, all
-                        providers are used together.
-                    </HelpText>
-                </div>
-            </div>
 
-            <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between gap-3">
-                    <div className="text-base font-semibold text-base-content">NNTP Pipelining</div>
+                    <div className="border-t border-base-content/10 pt-4">
+                        <Alert className="alert-soft mb-4 items-start py-3 text-sm" variant="warning">
+                            <Icon name="science" className="!text-[20px]" />
+                            <div>
+                                <p className="font-semibold">Speed-test pipelining first</p>
+                                <p className="mt-0.5 text-xs opacity-80">
+                                    Run Auto-tune connections on a provider before enabling this. It measures whether
+                                    pipelining helps on your network.
+                                </p>
+                            </div>
+                        </Alert>
+
+                        <label
+                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
+                            htmlFor="pipelining-enabled"
+                        >
+                            <Checkbox
+                                className="checkbox-primary mt-0.5 shrink-0"
+                                id="pipelining-enabled"
+                                checked={config["usenet.pipelining.enabled"] === "true"}
+                                onChange={(e) => setNewConfig({
+                                    ...config,
+                                    "usenet.pipelining.enabled": e.target.checked ? "true" : "false",
+                                })}
+                            />
+                            <span>
+                                <span className="block text-sm font-medium text-base-content">Enable NNTP pipelining</span>
+                                <span className="mt-0.5 block text-xs leading-relaxed text-base-content/50">
+                                    Batch BODY requests during queue imports and benchmarks. WebDAV streaming has its
+                                    own toggle under WebDAV settings.
+                                </span>
+                            </span>
+                        </label>
+
+                        <div className="mt-4 space-y-2">
+                            <Label htmlFor="pipelining-depth">Default pipeline depth</Label>
+                            <Input
+                                type="text"
+                                id="pipelining-depth"
+                                className={`w-full max-w-[10rem] ${config["usenet.pipelining.depth"] !== undefined && config["usenet.pipelining.depth"] !== "" && !isPositiveInteger(config["usenet.pipelining.depth"]) ? "input-error" : ""}`}
+                                placeholder="8"
+                                value={config["usenet.pipelining.depth"] ?? ""}
+                                onChange={(e) => setNewConfig({ ...config, "usenet.pipelining.depth": e.target.value })}
+                            />
+                            <p className="text-[11px] leading-relaxed text-base-content/45">
+                                Requests kept in flight per connection (1–64). 8 is a good default. Each provider can
+                                override this in its settings.
+                            </p>
+                        </div>
+                    </div>
                 </div>
-                <Alert variant="warning" className="mt-3 text-xs">
-                    Run the <strong>speed test</strong> on a provider (edit → Auto-tune connections) before
-                    enabling this. It measures whether pipelining helps on your network — when it does,
-                    queue imports can be substantially faster.
-                </Alert>
-                <div className="mt-3 flex flex-col gap-1.5">
-                    <label htmlFor="pipelining-enabled" className="flex items-center gap-2">
-                        <Checkbox
-                            id="pipelining-enabled"
-                            checked={config["usenet.pipelining.enabled"] === "true"}
-                            onChange={(e) => setNewConfig({
-                                ...config,
-                                "usenet.pipelining.enabled": e.target.checked ? "true" : "false",
-                            })}
-                        />
-                        <span className="text-sm text-base-content/80">Enable NNTP pipelining</span>
-                    </label>
-                    <HelpText>
-                        Batch BODY requests on a single connection during queue imports and benchmarks.
-                        WebDAV streaming uses the separate <strong>Pipelined article downloads</strong> toggle
-                        under WebDAV settings.
-                    </HelpText>
-                </div>
-                <div className="mt-3 flex flex-col gap-1.5">
-                    <Label htmlFor="pipelining-depth">Default pipeline depth</Label>
-                    <Input
-                        type="text"
-                        id="pipelining-depth"
-                        className={`w-full ${config["usenet.pipelining.depth"] !== undefined && config["usenet.pipelining.depth"] !== "" && !isPositiveInteger(config["usenet.pipelining.depth"]) ? "input-error" : ""}`}
-                        placeholder="8"
-                        value={config["usenet.pipelining.depth"] ?? ""}
-                        onChange={(e) => setNewConfig({ ...config, "usenet.pipelining.depth": e.target.value })}
-                    />
-                    <HelpText>
-                        Requests kept in flight per connection (1–64). 8 is a good default. Each
-                        provider can override this in its own settings.
-                    </HelpText>
-                </div>
-            </div>
+            </section>
 
             <ProviderModal
                 show={showModal}
@@ -693,7 +734,7 @@ function UsageRow({ provider, usage, onReset }: UsageRowProps) {
     const barToneClass = tone === "danger" ? "bg-error" : tone === "warn" ? "bg-warning" : tone === "ok" ? "bg-success" : "bg-base-content/40";
 
     return (
-        <div className="mt-3 flex flex-col gap-2 rounded-md border border-base-content/10 bg-base-200/40 p-3">
+        <div className="mt-3 flex flex-col gap-2 rounded-lg border border-base-content/10 bg-base-200/40 p-3">
             <div className="flex flex-wrap items-center gap-2.5">
                 <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-base-content/50">
                     {hasLimit ? "Data Cap" : "Data Used"}

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using NzbWebDAV.Config;
@@ -13,6 +14,38 @@ namespace NzbWebDAV.Tests.Tasks;
 [Collection(nameof(BaseTaskCollection))]
 public class RemoveUnlinkedFilesTaskTests
 {
+    [Fact]
+    public async Task ProgressHeartbeat_ReportsElapsedUntilCompleted()
+    {
+        var messages = new ConcurrentQueue<string>();
+        var heartbeatReported = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var heartbeat = new RemoveUnlinkedFilesTask.ProgressHeartbeat(message =>
+        {
+            messages.Enqueue(message);
+            if (message.Contains("Elapsed:", StringComparison.Ordinal))
+                heartbeatReported.TrySetResult(message);
+        }, TimeSpan.FromMilliseconds(10));
+
+        try
+        {
+            heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
+
+            var elapsedMessage = await heartbeatReported.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.StartsWith("Scanning all linked files...\nFound 79976...", elapsedMessage);
+            Assert.Contains("Elapsed:", elapsedMessage);
+
+            heartbeat.Complete("Done.");
+            heartbeat.UpdatePhase("Scanning all linked files...\nFound 79977...");
+
+            Assert.Equal("Done.", messages.Last());
+        }
+        finally
+        {
+            await heartbeat.DisposeAsync();
+        }
+    }
+
     [Fact]
     public async Task RemoveEmptyDirectoriesAsync_RemovesNestedEmptyDirsAndTerminates()
     {
@@ -326,11 +359,13 @@ public class RemoveUnlinkedFilesTaskTests
             ]);
 
             var websocket = new WebsocketManager();
+            var messages = new ConcurrentQueue<string>();
             var task = new RemoveUnlinkedFilesTask(
                 config,
                 websocket,
                 isDryRun: true,
-                createContext: () => harness.CreateContext());
+                createContext: () => harness.CreateContext(),
+                progressObserver: messages.Enqueue);
 
             Assert.True(await task.Execute());
 
@@ -338,6 +373,13 @@ public class RemoveUnlinkedFilesTaskTests
             Assert.NotNull(progress);
             Assert.StartsWith("Dry Run - Done.", progress);
             Assert.Contains("Identified 1 unlinked files", progress);
+            AssertMessagesAppearInOrder(
+                messages,
+                "Scanning all linked files",
+                "Indexing 5 linked files",
+                "Searching for unlinked webdav items",
+                "Identifying unlinked files",
+                "Done. Identified 1 unlinked files");
         }
         finally
         {
@@ -412,6 +454,25 @@ public class RemoveUnlinkedFilesTaskTests
     private static DavItem NewDir(Guid id, DavItem parent, string name) =>
         DavItem.New(id, parent, name, null, DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
             null, null, null, null);
+
+    private static void AssertMessagesAppearInOrder(
+        IEnumerable<string> messages,
+        params string[] expectedFragments)
+    {
+        var allMessages = messages.ToList();
+        var searchFrom = 0;
+        foreach (var expected in expectedFragments)
+        {
+            var index = allMessages.FindIndex(
+                searchFrom,
+                message => message.Contains(expected, StringComparison.Ordinal));
+            Assert.True(
+                index >= 0,
+                $"Expected progress containing '{expected}' after index {searchFrom - 1}. " +
+                $"Messages: {string.Join(" | ", allMessages)}");
+            searchFrom = index + 1;
+        }
+    }
 
     private static async Task SeedRootsAsync(DavDatabaseContext ctx)
     {


### PR DESCRIPTION
## Summary
- Keep Remove Orphaned Files dry-run/run progress updating during quiet phases (indexing, SQL, empty-dir sweep) with a 2s phase heartbeat
- Restyle Maintenance, Backup, and Usenet settings to the shared panel chrome
- Combine cascade routing and NNTP pipelining into one Usenet global settings card, with checkboxes on the left

## Test plan
- [ ] Run Remove Orphaned Files dry-run on a large library and confirm progress keeps refreshing with elapsed phase text after the last “Found N” count
- [ ] Confirm focused `RemoveUnlinkedFilesTaskTests` pass
- [ ] Spot-check Maintenance, Backup, and Usenet settings pages at desktop and narrow widths
- [ ] Toggle cascade/pipelining and schedule checkboxes; verify they save and remain easy to find on the left