### PR TITLE
fix(queue): Remove Orphaned Files elapsed timer no longer flashes

### DIFF
--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -577,7 +577,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         private readonly TimeSpan _interval;
         private readonly Timer _timer;
         private string? _message;
-        private long _phaseStartedAt;
+        private long _runStartedAt;
         private bool _completed;
         private bool _disposed;
 
@@ -598,9 +598,10 @@ public class RemoveUnlinkedFilesTask : BaseTask
             lock (_sync)
             {
                 if (_disposed || _completed) return;
+                if (_runStartedAt == 0)
+                    _runStartedAt = Stopwatch.GetTimestamp();
                 _message = message;
-                _phaseStartedAt = Stopwatch.GetTimestamp();
-                _report(message);
+                ReportWithElapsed();
                 _timer.Change(_interval, _interval);
             }
         }
@@ -611,7 +612,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
             {
                 if (_disposed || _completed) return;
                 _message = message;
-                _report(message);
+                ReportWithElapsed();
             }
         }
 
@@ -632,9 +633,17 @@ public class RemoveUnlinkedFilesTask : BaseTask
             lock (_sync)
             {
                 if (_disposed || _message is null) return;
-                var elapsed = Stopwatch.GetElapsedTime(_phaseStartedAt);
-                _report($"{_message}\nElapsed: {FormatElapsed(elapsed)}");
+                ReportWithElapsed();
             }
+        }
+
+        private void ReportWithElapsed()
+        {
+            if (_message is null) return;
+            if (_runStartedAt == 0)
+                _runStartedAt = Stopwatch.GetTimestamp();
+            var elapsed = Stopwatch.GetElapsedTime(_runStartedAt);
+            _report($"{_message}\nElapsed: {FormatElapsed(elapsed)}");
         }
 
         private static string FormatElapsed(TimeSpan elapsed) =>

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -23,7 +23,7 @@ public class RemoveUnlinkedFilesTaskTests
         var heartbeat = new RemoveUnlinkedFilesTask.ProgressHeartbeat(message =>
         {
             messages.Enqueue(message);
-            if (message.Contains("Elapsed:", StringComparison.Ordinal))
+            if (messages.Count > 1 && message.Contains("Elapsed:", StringComparison.Ordinal))
                 heartbeatReported.TrySetResult(message);
         }, TimeSpan.FromMilliseconds(10));
 
@@ -31,14 +31,22 @@ public class RemoveUnlinkedFilesTaskTests
         {
             heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
 
+            Assert.True(messages.TryPeek(out var startMessage));
+            Assert.StartsWith("Scanning all linked files...\nFound 79976...", startMessage);
+            Assert.Contains("Elapsed:", startMessage);
+
+            heartbeat.UpdatePhase("Scanning all linked files...\nFound 79977...");
+            Assert.Contains("Elapsed:", messages.Last());
+            Assert.StartsWith("Scanning all linked files...\nFound 79977...", messages.Last());
+
             var elapsedMessage = await heartbeatReported.Task.WaitAsync(TimeSpan.FromSeconds(1));
-            Assert.StartsWith("Scanning all linked files...\nFound 79976...", elapsedMessage);
             Assert.Contains("Elapsed:", elapsedMessage);
 
             heartbeat.Complete("Done.");
-            heartbeat.UpdatePhase("Scanning all linked files...\nFound 79977...");
+            heartbeat.UpdatePhase("Scanning all linked files...\nFound 79978...");
 
             Assert.Equal("Done.", messages.Last());
+            Assert.DoesNotContain("Elapsed:", messages.Last());
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Always include the run elapsed timer on every progress update, not only on the 2s heartbeat
- Keeps the timer continuous across phase changes so it no longer appears/disappears between count updates

## Test plan
- [ ] Run Remove Orphaned Files dry-run and confirm `Elapsed:` stays visible while the Found count updates
- [ ] Confirm the timer keeps increasing across phase transitions (scan → index → search)
- [ ] Confirm terminal `Done`/`Failed`/`Aborted` messages do not include `Elapsed:`
- [ ] `RemoveUnlinkedFilesTaskTests.ProgressHeartbeat_ReportsElapsedUntilCompleted` passes