### PR TITLE
fix(queue): fail dead NZBs as soon as the first missing RAR is confirmed

### DIFF
--- a/backend/Queue/DeadNzbFailFast.cs
+++ b/backend/Queue/DeadNzbFailFast.cs
@@ -1,0 +1,38 @@
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Queue;
+
+/// <summary>
+/// Shared helpers for aborting dead/DMCA'd NZBs when important files are permanently missing.
+/// </summary>
+public static class DeadNzbFailFast
+{
+    public static readonly HashSet<string> UnimportantExtensions =
+        [".par2", ".nfo", ".txt", ".sfv", ".nzb", ".srr"];
+
+    public static bool IsUnimportantFileName(string fileName) =>
+        UnimportantExtensions.Contains(Path.GetExtension(fileName).ToLowerInvariant());
+
+    public static bool IsImportantFileName(string fileName) => !IsUnimportantFileName(fileName);
+
+    public static bool IsImportantNzbFile(NzbFile nzbFile) =>
+        IsImportantFileName(nzbFile.GetSubjectFileName());
+
+    /// <summary>
+    /// Records the missing first segment for step-0 cache and throws a non-retryable failure.
+    /// </summary>
+    public static void FailMissingImportantFile(NzbFile nzbFile)
+    {
+        HealthCheckService.AddMissingSegmentIds([nzbFile.Segments[0].MessageId]);
+
+        var fileName = nzbFile.GetSubjectFileName();
+        if (string.IsNullOrEmpty(fileName))
+            fileName = nzbFile.Subject;
+
+        throw new NonRetryableDownloadException(
+            $"Missing articles: 1 important file(s) have missing segments " +
+            $"across all providers (e.g. {fileName}). NZB is likely DMCA'd or expired.");
+    }
+}

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -30,10 +30,43 @@ public static class FetchFirstSegmentsStep
             return await FetchFirstSegmentsPipelined(
                 files, usenetClient, configManager, cancellationToken, progress).ConfigureAwait(false);
 
-        return await files
-            .Select(x => FetchFirstSegment(x, usenetClient, cancellationToken))
-            .WithConcurrencyAsync(Math.Min(configManager.GetMaxQueueConnections() + 5, 50))
-            .GetAllAsync(cancellationToken, progress).ConfigureAwait(false);
+        return await FetchFirstSegmentsConcurrent(
+            files, usenetClient, configManager, cancellationToken, progress).ConfigureAwait(false);
+    }
+
+    private static async Task<List<NzbFileWithFirstSegment>> FetchFirstSegmentsConcurrent
+    (
+        List<NzbFile> files,
+        INntpClient usenetClient,
+        ConfigManager configManager,
+        CancellationToken cancellationToken,
+        IProgress<int>? progress
+    )
+    {
+        using var abortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var results = new List<NzbFileWithFirstSegment>(files.Count);
+        var completed = 0;
+
+        await foreach (var result in files
+                           .Select(x => FetchFirstSegment(x, usenetClient, abortCts.Token))
+                           .WithConcurrencyAsync(
+                               Math.Min(configManager.GetMaxQueueConnections() + 5, 50),
+                               abortCts.Token)
+                           .WithCancellation(abortCts.Token)
+                           .ConfigureAwait(false))
+        {
+            results.Add(result);
+            progress?.Report(++completed);
+
+            if (result.MissingFirstSegment && DeadNzbFailFast.IsImportantNzbFile(result.NzbFile))
+            {
+                Log.Warning("First segment for `{FileName}` missing across all providers",
+                    result.NzbFile.GetSubjectFileName());
+                AbortRemainingFirstSegmentChecks(result.NzbFile, abortCts);
+            }
+        }
+
+        return results;
     }
 
     private static async Task<List<NzbFileWithFirstSegment>> FetchFirstSegmentsPipelined
@@ -56,11 +89,13 @@ public static class FetchFirstSegmentsStep
                 indexBySegmentId.TryAdd(key, i);
         }
         var completed = 0;
+        NzbFile? abortFile = null;
+        using var abortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         try
         {
-            await foreach (var article in usenetClient.DecodedArticlesPipelinedAsync(segmentIds, depth, cancellationToken)
-                               .WithCancellation(cancellationToken).ConfigureAwait(false))
+            await foreach (var article in usenetClient.DecodedArticlesPipelinedAsync(segmentIds, depth, abortCts.Token)
+                               .WithCancellation(abortCts.Token).ConfigureAwait(false))
             {
                 var key = NntpClient.NormalizeSegmentId(article.SegmentId);
                 if (key.Length == 0 || !indexBySegmentId.TryGetValue(key, out var i))
@@ -78,18 +113,26 @@ public static class FetchFirstSegmentsStep
 
                 if (article.Found && article.Stream != null)
                 {
-                    results[i] = await BuildFirstSegment(files[i], article.Stream, article.ArticleHeaders, cancellationToken)
+                    results[i] = await BuildFirstSegment(files[i], article.Stream, article.ArticleHeaders, abortCts.Token)
                         .ConfigureAwait(false);
                     progress?.Report(++completed);
                 }
                 else if (article.DefinitivelyMissing)
                 {
                     // The batch failover already tried every provider; a rescue pass would
-                    // just repeat the same misses. Record and move on.
+                    // just repeat the same misses. Record and move on — unless this is an
+                    // important file, in which case remaining checks cannot help.
                     Log.Warning("First segment for `{FileName}` missing across all providers",
                         files[i].GetSubjectFileName());
                     results[i] = BuildMissingFirstSegment(files[i]);
                     progress?.Report(++completed);
+
+                    if (DeadNzbFailFast.IsImportantNzbFile(files[i]))
+                    {
+                        abortFile = files[i];
+                        abortCts.Cancel();
+                        break;
+                    }
                 }
                 else if (article.Stream != null)
                 {
@@ -98,27 +141,51 @@ public static class FetchFirstSegmentsStep
                 }
             }
         }
+        catch (Exception e) when (e.IsCancellationException() && abortFile is not null)
+        {
+            // Expected when cancelling the pipeline after an important miss.
+        }
         catch (Exception e) when (!e.IsCancellationException())
         {
             Log.Debug($"Pipelined first-segment fetch aborted early ({e.Message}); " +
                       "falling back to per-article failover for the remainder.");
         }
 
+        if (abortFile is not null)
+            AbortRemainingFirstSegmentChecks(abortFile, abortCts: null);
+
         var pending = Enumerable.Range(0, files.Count).Where(i => results[i] is null).ToList();
         if (pending.Count > 0)
         {
-            var rescued = await pending
-                .Select(i => RescueFirstSegment(i, files[i], usenetClient, cancellationToken))
-                .WithConcurrencyAsync(Math.Min(configManager.GetMaxQueueConnections() + 5, 50))
-                .GetAllAsync(cancellationToken).ConfigureAwait(false);
-            foreach (var (i, result) in rescued)
+            using var rescueAbortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            await foreach (var (i, result) in pending
+                               .Select(i => RescueFirstSegment(i, files[i], usenetClient, rescueAbortCts.Token))
+                               .WithConcurrencyAsync(
+                                   Math.Min(configManager.GetMaxQueueConnections() + 5, 50),
+                                   rescueAbortCts.Token)
+                               .WithCancellation(rescueAbortCts.Token)
+                               .ConfigureAwait(false))
             {
                 results[i] = result;
                 progress?.Report(++completed);
+
+                if (result.MissingFirstSegment && DeadNzbFailFast.IsImportantNzbFile(result.NzbFile))
+                    AbortRemainingFirstSegmentChecks(result.NzbFile, rescueAbortCts);
             }
         }
 
         return results.Select(x => x!).ToList();
+    }
+
+    private static void AbortRemainingFirstSegmentChecks(
+        NzbFile nzbFile,
+        CancellationTokenSource? abortCts)
+    {
+        Log.Warning(
+            "Aborting remaining first-segment checks after missing important file `{FileName}`",
+            nzbFile.GetSubjectFileName());
+        abortCts?.Cancel();
+        DeadNzbFailFast.FailMissingImportantFile(nzbFile);
     }
 
     private static async Task<(int index, NzbFileWithFirstSegment result)> RescueFirstSegment

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -216,14 +216,14 @@ public class QueueItemProcessor(
         // If the first segment is gone across all providers, the rest are too.
         // Exclude known-unimportant extensions rather than matching important ones so
         // obfuscated filenames (common on DMCA'd content) still trigger the fast abort.
-        HashSet<string> unimportantExtensions = [".par2", ".nfo", ".txt", ".sfv", ".nzb", ".srr"];
+        // (FetchFirstSegmentsStep also aborts mid-fetch on the first important miss.)
         var missingNzbFiles = segments
             .Where(x => x.MissingFirstSegment)
             .Select(x => x.NzbFile)
             .ToHashSet();
         var importantFilesMissing = fileInfos
             .Where(x => missingNzbFiles.Contains(x.NzbFile))
-            .Where(x => !unimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .Where(x => DeadNzbFailFast.IsImportantFileName(x.FileName))
             .ToList();
         if (importantFilesMissing.Count > 0)
         {

--- a/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
@@ -1,15 +1,14 @@
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Tests.Queue;
 
 public class FailFastDeadNzbTests
 {
-    private static readonly HashSet<string> UnimportantExtensions =
-        [".par2", ".nfo", ".txt", ".sfv", ".nzb", ".srr"];
-
     [Fact]
     public void ImportantMissingFile_TriggersFailFastCondition()
     {
@@ -26,7 +25,7 @@ public class FailFastDeadNzbTests
 
         var missing = fileInfos
             .Where(x => segment.MissingFirstSegment && ReferenceEquals(x.NzbFile, nzbFile))
-            .Where(x => !UnimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .Where(x => DeadNzbFailFast.IsImportantFileName(x.FileName))
             .ToList();
 
         Assert.Single(missing);
@@ -49,7 +48,7 @@ public class FailFastDeadNzbTests
 
         var missing = fileInfos
             .Where(x => segment.MissingFirstSegment)
-            .Where(x => !UnimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .Where(x => DeadNzbFailFast.IsImportantFileName(x.FileName))
             .ToList();
 
         Assert.Empty(missing);
@@ -72,7 +71,7 @@ public class FailFastDeadNzbTests
 
         var missing = fileInfos
             .Where(x => segment.MissingFirstSegment)
-            .Where(x => !UnimportantExtensions.Contains(Path.GetExtension(x.FileName).ToLowerInvariant()))
+            .Where(x => DeadNzbFailFast.IsImportantFileName(x.FileName))
             .ToList();
 
         Assert.Single(missing);
@@ -84,5 +83,34 @@ public class FailFastDeadNzbTests
         var ex = new UsenetArticleNotFoundException("<seg@example.com>");
         Assert.IsAssignableFrom<NonRetryableDownloadException>(ex);
         Assert.Equal("<seg@example.com>", ex.SegmentId);
+    }
+
+    [Theory]
+    [InlineData("movie.rar", true)]
+    [InlineData("aB3xY9q", true)]
+    [InlineData("release.par2", false)]
+    [InlineData("checksum.sfv", false)]
+    [InlineData("info.nfo", false)]
+    public void IsImportantFileName_MatchesExclusionList(string fileName, bool expectedImportant)
+    {
+        Assert.Equal(expectedImportant, DeadNzbFailFast.IsImportantFileName(fileName));
+    }
+
+    [Fact]
+    public void FailMissingImportantFile_CachesSegmentAndThrowsNonRetryable()
+    {
+        var segmentId = $"cache-me-{Guid.NewGuid():N}@example.com";
+        var nzbFile = new NzbFile
+        {
+            Subject = "\"dead.rar\" yEnc (1/1)",
+            Segments = { new NzbSegment { MessageId = segmentId, Bytes = 100 } },
+        };
+
+        var ex = Assert.Throws<NonRetryableDownloadException>(() =>
+            DeadNzbFailFast.FailMissingImportantFile(nzbFile));
+
+        Assert.Contains("dead.rar", ex.Message);
+        Assert.Throws<UsenetArticleNotFoundException>(() =>
+            HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
     }
 }

--- a/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
@@ -16,7 +16,7 @@ namespace NzbWebDAV.Tests.Queue;
 public class FetchFirstSegmentsStepTests
 {
     [Fact]
-    public async Task FetchFirstSegments_PipelinedDefinitivelyMissing_SkipsRescue()
+    public async Task FetchFirstSegments_PipelinedDefinitivelyMissingImportant_AbortsEarly()
     {
         var config = CreatePipeliningConfig(enabled: true, depth: 4);
         using var client = new MissingPipelinedNntpClient(definitivelyMissing: true);
@@ -24,33 +24,113 @@ public class FetchFirstSegmentsStepTests
         {
             CreateFile("a@example.com", "\"a.rar\" yEnc"),
             CreateFile("b@example.com", "\"b.rar\" yEnc"),
+            CreateFile("c@example.com", "\"c.rar\" yEnc"),
         };
 
-        var results = await FetchFirstSegmentsStep.FetchFirstSegments(
-            files, client, config, CancellationToken.None);
+        var ex = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
 
-        Assert.Equal(2, results.Count);
-        Assert.All(results, r => Assert.True(r.MissingFirstSegment));
+        Assert.Contains("a.rar", ex.Message);
         Assert.Equal(0, client.ArticleFetches);
+        Assert.True(client.PipelinedResultsYielded >= 1);
+        Assert.True(client.PipelinedResultsYielded < files.Count);
     }
 
     [Fact]
-    public async Task FetchFirstSegments_PipelinedNonDefinitiveMiss_StillRescues()
+    public async Task FetchFirstSegments_PipelinedUnimportantMissing_ContinuesThenAbortsOnImportant()
+    {
+        var config = CreatePipeliningConfig(enabled: true, depth: 4);
+        using var client = new MissingPipelinedNntpClient(definitivelyMissing: true);
+        var files = new List<NzbFile>
+        {
+            CreateFile("par@example.com", "\"release.par2\" yEnc"),
+            CreateFile("sfv@example.com", "\"checksum.sfv\" yEnc"),
+            CreateFile("rar@example.com", "\"part01.rar\" yEnc"),
+            CreateFile("rar2@example.com", "\"part02.rar\" yEnc"),
+        };
+
+        var ex = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
+
+        Assert.Contains("part01.rar", ex.Message);
+        Assert.Equal(0, client.ArticleFetches);
+        // Unimportant files + the triggering rar are yielded; later rar must not be.
+        Assert.Equal(3, client.PipelinedResultsYielded);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_PipelinedNonDefinitiveMiss_AbortsOnRescueImportant()
     {
         var config = CreatePipeliningConfig(enabled: true, depth: 4);
         using var client = new MissingPipelinedNntpClient(definitivelyMissing: false);
+        // More files than rescue concurrency (maxQueueConnections+5) so abort can skip the tail.
+        var files = Enumerable.Range(0, 20)
+            .Select(i => CreateFile($"{i}@example.com", $"\"part{i:D2}.rar\" yEnc"))
+            .ToList();
+
+        var ex = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
+
+        Assert.Contains(".rar", ex.Message);
+        Assert.True(client.ArticleFetches >= 1);
+        Assert.True(client.ArticleFetches < files.Count);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_ConcurrentImportantMissing_AbortsFurtherFetches()
+    {
+        var config = CreatePipeliningConfig(enabled: false, depth: 4);
+        // More files than concurrent fetch slots (maxQueueConnections+5) so abort can skip the tail.
+        var missingIds = Enumerable.Range(0, 20).Select(i => $"{i}@example.com").ToArray();
+        using var client = new TrackingArticleNntpClient(missingIds: missingIds);
+        var files = missingIds
+            .Select((id, i) => CreateFile(id, $"\"part{i:D2}.rar\" yEnc"))
+            .ToList();
+
+        var ex = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
+
+        Assert.Contains(".rar", ex.Message);
+        Assert.True(client.RequestedSegmentIds.Count < files.Count);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_ConcurrentUnimportantMissing_FetchesImportantAfter()
+    {
+        var config = CreatePipeliningConfig(enabled: false, depth: 4);
+        using var client = new TrackingArticleNntpClient(
+            missingIds: ["par@example.com"],
+            presentPayload: Encoding.ASCII.GetBytes(new string('x', 64)));
         var files = new List<NzbFile>
         {
-            CreateFile("a@example.com", "\"a.rar\" yEnc"),
-            CreateFile("b@example.com", "\"b.rar\" yEnc"),
+            CreateFile("par@example.com", "\"release.par2\" yEnc"),
+            CreateFile("rar@example.com", "\"movie.rar\" yEnc"),
         };
 
         var results = await FetchFirstSegmentsStep.FetchFirstSegments(
             files, client, config, CancellationToken.None);
 
         Assert.Equal(2, results.Count);
-        Assert.All(results, r => Assert.True(r.MissingFirstSegment));
-        Assert.True(client.ArticleFetches > 0);
+        Assert.True(results[0].MissingFirstSegment);
+        Assert.False(results[1].MissingFirstSegment);
+        Assert.Contains("par@example.com", client.RequestedSegmentIds);
+        Assert.Contains("rar@example.com", client.RequestedSegmentIds);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_ConcurrentTransientError_DoesNotTreatAsMissing()
+    {
+        var config = CreatePipeliningConfig(enabled: false, depth: 4);
+        using var client = new TransientErrorNntpClient();
+        var files = new List<NzbFile>
+        {
+            CreateFile("a@example.com", "\"a.rar\" yEnc"),
+        };
+
+        var ex = await Assert.ThrowsAsync<IOException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
+
+        Assert.Equal("provider blip", ex.Message);
     }
 
     [Fact]
@@ -114,7 +194,7 @@ public class FetchFirstSegmentsStepTests
             new ConfigItem
             {
                 ConfigName = ConfigKeys.UsenetMaxQueueConnections,
-                ConfigValue = "5",
+                ConfigValue = "1",
             },
         ]);
         return config;
@@ -147,6 +227,7 @@ public class FetchFirstSegmentsStepTests
     private sealed class MissingPipelinedNntpClient(bool definitivelyMissing) : NntpClient
     {
         public int ArticleFetches { get; private set; }
+        public int PipelinedResultsYielded { get; private set; }
 
         public override async IAsyncEnumerable<PipelinedArticleResult> DecodedArticlesPipelinedAsync(
             IReadOnlyList<string> segmentIds,
@@ -155,6 +236,8 @@ public class FetchFirstSegmentsStepTests
         {
             foreach (var id in segmentIds)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+                PipelinedResultsYielded++;
                 yield return new PipelinedArticleResult
                 {
                     SegmentId = id,
@@ -175,9 +258,148 @@ public class FetchFirstSegmentsStepTests
             Action<ArticleBodyResult>? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ArticleFetches++;
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotFound);
             throw new UsenetArticleNotFoundException(segmentId.ToString());
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class TrackingArticleNntpClient(
+        IReadOnlyCollection<string> missingIds,
+        byte[]? presentPayload = null) : NntpClient
+    {
+        public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var key = segmentId.ToString();
+            RequestedSegmentIds.Add(key);
+
+            if (missingIds.Contains(key))
+            {
+                onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotFound);
+                throw new UsenetArticleNotFoundException(key);
+            }
+
+            var payload = presentPayload ?? Encoding.ASCII.GetBytes(new string('x', 64));
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedArticleResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220 article",
+                Stream = CreateCachedStream(payload),
+                ArticleHeaders = new UsenetArticleHeader
+                {
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Date"] = DateTimeOffset.UtcNow.ToString("R"),
+                    },
+                },
+            });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class TransientErrorNntpClient : NntpClient
+    {
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+            throw new IOException("provider blip");
         }
 
         public override Task ConnectAsync(


### PR DESCRIPTION
## Summary
- Abort remaining first-segment checks as soon as an important file (e.g. a RAR part) is confirmed missing across all providers, instead of probing every RAR/PAR2/SFV first.
- Share the unimportant-extension list via `DeadNzbFailFast` so mid-fetch abort and step 1b stay in sync; cache the missing segment for fast retries.
- Keep ignoring junk misses (`.par2`, `.sfv`, etc.) and treat transient provider errors as non-permanent.

## Test plan
- [x] `dotnet test` filtered to `FetchFirstSegmentsStepTests` and `FailFastDeadNzbTests` (18 passed)
- [ ] Grab a known-dead multi-part NZB and confirm logs stop after the first missing important file (no minutes of per-part warnings)
- [ ] Confirm a release with only missing `.par2`/`.sfv` still continues processing
- [ ] Confirm a retry of the same dead NZB fails quickly via the missing-segment cache