### PR TITLE
fix(sab): Sonarr re-adds no longer fail when the previous NZB is still in the queue

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -1,6 +1,8 @@
 ﻿using System.Xml;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -9,6 +11,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
+using Serilog;
 
 namespace NzbWebDAV.Api.SabControllers.AddFile;
 
@@ -26,11 +29,29 @@ public class AddFileController(
         DtdProcessing = DtdProcessing.Ignore
     };
 
+    /// <summary>
+    /// Creates a short-lived context for conflict removal without flushing
+    /// pending Added entities on the request-scoped context. Tests can override
+    /// this to target the same temporary database as the request context.
+    /// </summary>
+    internal Func<DavDatabaseContext> FreshContextFactory { get; set; } = static () => new DavDatabaseContext();
+
+    /// <summary>
+    /// Test hook invoked after the duplicate pre-check and before the blob is written,
+    /// so the UNIQUE retry path can be exercised without a real concurrent request.
+    /// </summary>
+    internal Func<Task>? AfterDuplicatePreCheckHook { get; set; }
+
     public async Task<AddFileResponse> AddFileAsync(AddFileRequest request)
     {
         var id = Guid.NewGuid();
         var category = StringUtil.EmptyToNull(request.Category)
                        ?? configManager.GetManualUploadCategory();
+
+        await ReplaceExistingQueueItemIfNeededAsync(request.FileName, category, request.CancellationToken)
+            .ConfigureAwait(false);
+        if (AfterDuplicatePreCheckHook is not null)
+            await AfterDuplicatePreCheckHook().ConfigureAwait(false);
 
         // write the file to the blob-store
         await using var stream = request.NzbFileStream;
@@ -78,16 +99,31 @@ public class AddFileController(
                 FileName = request.FileName
             };
 
-            // save
+            // save — never Clear() the change tracker here: WebDAV watch-folder create
+            // reads the new QueueItem from the tracker after AddFileAsync returns.
             dbClient.Ctx.QueueItems.Add(queueItem);
             dbClient.Ctx.NzbNames.Add(nzbName);
-            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+            try
+            {
+                await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateException ex) when (IsCategoryFileNameUniqueViolation(ex))
+            {
+                // TOCTOU: another insert landed after our pre-check. Remove via a fresh
+                // context so this request context's pending Added entities are not flushed
+                // by RemoveQueueItemsAsync's inner SaveChangesAsync, then retry once.
+                await RemoveConflictingQueueItemViaFreshContextAsync(
+                        request.FileName, category, request.CancellationToken)
+                    .ConfigureAwait(false);
+                await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+            }
+
             _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
         }
         catch
         {
             // in case of any errors writing to the database
-            // delete the nzb file blob
+            // delete the nzb file blob (only after UNIQUE retry has also failed)
             BlobStore.Delete(id);
             throw;
         }
@@ -105,6 +141,82 @@ public class AddFileController(
             Status = true,
             NzoIds = [queueItem.Id.ToString()],
         };
+    }
+
+    private async Task ReplaceExistingQueueItemIfNeededAsync(
+        string fileName,
+        string category,
+        CancellationToken ct)
+    {
+        var existingId = await dbClient.Ctx.QueueItems.AsNoTracking()
+            .Where(q => q.Category == category && q.FileName == fileName)
+            .Select(q => (Guid?)q.Id)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        if (existingId is null) return;
+
+        var (inProgress, _) = queueManager.GetInProgressQueueItem();
+        var wasInProgress = inProgress?.Id == existingId.Value;
+        Log.Warning(
+            "Replacing existing queue item {QueueItemId} ({FileName} in {Category}) on re-add{InProgressSuffix}",
+            existingId.Value,
+            fileName,
+            category,
+            wasInProgress ? "; cancelling in-progress download" : "");
+
+        await queueManager.RemoveQueueItemsAsync([existingId.Value], dbClient, ct).ConfigureAwait(false);
+        _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, existingId.Value.ToString());
+        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+    }
+
+    private async Task RemoveConflictingQueueItemViaFreshContextAsync(
+        string fileName,
+        string category,
+        CancellationToken ct)
+    {
+        await using var freshCtx = FreshContextFactory();
+        var freshClient = new DavDatabaseClient(freshCtx);
+        var conflictingId = await freshCtx.QueueItems.AsNoTracking()
+            .Where(q => q.Category == category && q.FileName == fileName)
+            .Select(q => (Guid?)q.Id)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        if (conflictingId is null) return;
+
+        var (inProgress, _) = queueManager.GetInProgressQueueItem();
+        var wasInProgress = inProgress?.Id == conflictingId.Value;
+        Log.Warning(
+            "Replacing existing queue item {QueueItemId} ({FileName} in {Category}) after UNIQUE conflict on re-add{InProgressSuffix}",
+            conflictingId.Value,
+            fileName,
+            category,
+            wasInProgress ? "; cancelling in-progress download" : "");
+
+        await queueManager.RemoveQueueItemsAsync([conflictingId.Value], freshClient, ct).ConfigureAwait(false);
+        _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, conflictingId.Value.ToString());
+        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+    }
+
+    internal static bool IsCategoryFileNameUniqueViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is not SqliteException sqlite) continue;
+            if (sqlite.SqliteErrorCode is not 19) continue; // SQLITE_CONSTRAINT
+
+            var message = sqlite.Message;
+            if (message.Contains("IX_QueueItems_Category_FileName", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (message.Contains("QueueItems.Category", StringComparison.OrdinalIgnoreCase)
+                && message.Contains("QueueItems.FileName", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (message.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                && message.Contains("Category", StringComparison.OrdinalIgnoreCase)
+                && message.Contains("FileName", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     protected override async Task<IActionResult> Handle()

--- a/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
@@ -1,0 +1,223 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-addfile-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+    private WebsocketManager _websocketManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        _websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task AddFileAsync_ReplacesExistingQueueItemWithSameCategoryAndFileName()
+    {
+        var existingId = Guid.NewGuid();
+        const string fileName = "Sliders.S01E01.part.1.Pilot.nzb";
+        const string category = "tv";
+
+        _context.QueueItems.Add(new QueueItem
+        {
+            Id = existingId,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            FileName = fileName,
+            JobName = "Sliders.S01E01.part.1.Pilot",
+            NzbFileSize = 10,
+            TotalSegmentBytes = 10,
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        });
+        _context.NzbNames.Add(new NzbName { Id = existingId, FileName = fileName });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var controller = CreateController();
+        var response = await controller.AddFileAsync(CreateRequest(fileName, category));
+
+        Assert.True(response.Status);
+        Assert.Single(response.NzoIds);
+        var newId = Guid.Parse(response.NzoIds[0]);
+        Assert.NotEqual(existingId, newId);
+
+        Assert.Null(await _context.QueueItems.AsNoTracking()
+            .SingleOrDefaultAsync(q => q.Id == existingId));
+        var replacement = await _context.QueueItems.AsNoTracking()
+            .SingleAsync(q => q.Category == category && q.FileName == fileName);
+        Assert.Equal(newId, replacement.Id);
+
+        // Watch-folder create reads the new QueueItem from the request change tracker.
+        Assert.Contains(_context.ChangeTracker.Entries<QueueItem>(),
+            e => e.Entity.Id == newId);
+        Assert.NotNull(BlobStore.ReadBlob(newId));
+    }
+
+    [Fact]
+    public async Task AddFileAsync_RetriesSaveAfterUniqueConflictInsertedBetweenPreCheckAndSave()
+    {
+        const string fileName = "Sliders.S01E01.part.2.Pilot.nzb";
+        const string category = "tv";
+        var conflictingId = Guid.NewGuid();
+
+        var controller = CreateController();
+        controller.AfterDuplicatePreCheckHook = async () =>
+        {
+            await using var raceCtx = new DavDatabaseContext(_options);
+            raceCtx.QueueItems.Add(new QueueItem
+            {
+                Id = conflictingId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = fileName,
+                JobName = "Sliders.S01E01.part.2.Pilot",
+                NzbFileSize = 10,
+                TotalSegmentBytes = 10,
+                Category = category,
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            });
+            raceCtx.NzbNames.Add(new NzbName { Id = conflictingId, FileName = fileName });
+            await raceCtx.SaveChangesAsync();
+        };
+
+        var response = await controller.AddFileAsync(CreateRequest(fileName, category));
+
+        Assert.True(response.Status);
+        var newId = Guid.Parse(Assert.Single(response.NzoIds));
+        Assert.NotEqual(conflictingId, newId);
+
+        Assert.Null(await _context.QueueItems.AsNoTracking()
+            .SingleOrDefaultAsync(q => q.Id == conflictingId));
+        Assert.Equal(newId, (await _context.QueueItems.AsNoTracking()
+            .SingleAsync(q => q.Category == category && q.FileName == fileName)).Id);
+        Assert.NotNull(BlobStore.ReadBlob(newId));
+        Assert.Contains(_context.ChangeTracker.Entries<QueueItem>(),
+            e => e.Entity.Id == newId);
+    }
+
+    [Fact]
+    public void IsCategoryFileNameUniqueViolation_DetectsSqliteConstraintMessage()
+    {
+        var sqlite = new Microsoft.Data.Sqlite.SqliteException(
+            "SQLite Error 19: 'UNIQUE constraint failed: QueueItems.Category, QueueItems.FileName'.",
+            19);
+        var update = new DbUpdateException("save failed", sqlite);
+        Assert.True(AddFileController.IsCategoryFileNameUniqueViolation(update));
+    }
+
+    private AddFileController CreateController()
+    {
+        var controller = new AddFileController(
+            new DefaultHttpContext(),
+            _dbClient,
+            _queueManager,
+            _configManager,
+            _websocketManager)
+        {
+            FreshContextFactory = () => new DavDatabaseContext(_options),
+        };
+        return controller;
+    }
+
+    private static AddFileRequest CreateRequest(string fileName, string category)
+    {
+        var nzb = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+              <file subject="test">
+                <groups><group>alt.binaries.test</group></groups>
+                <segments>
+                  <segment bytes="100" number="1">seg@example.com</segment>
+                </segments>
+              </file>
+            </nzb>
+            """;
+        return new AddFileRequest
+        {
+            FileName = fileName,
+            ContentType = "application/x-nzb",
+            NzbFileStream = new MemoryStream(Encoding.UTF8.GetBytes(nzb)),
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+            CancellationToken = CancellationToken.None,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- SAB `addfile` previously crashed with `UNIQUE constraint failed: QueueItems.Category, QueueItems.FileName` when Sonarr re-grabbed a release while the prior queue row was still present (common after Arr `RemoveAndBlocklistAndSearch`).
- On duplicate `(Category, FileName)`, NzbDav now removes the existing queue item and inserts the new NZB, with a single TOCTOU retry via a fresh DB context if a race still hits the unique index.
- Adds SQLite-backed coverage for the pre-check replace path, the UNIQUE retry path, and the watch-folder change-tracker invariant.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~AddFileDuplicateReplaceTests`
- [ ] Reproduce Arr stuck-queue `RemoveAndBlocklistAndSearch` for an episode that still has a same-named NZB queued; confirm `addfile` succeeds and the old item is replaced
- [ ] Confirm queue UI shows remove + add websocket updates when a duplicate name is re-added