### PR TITLE
ci: keep the git `dev` tag in sync with the `dev` container image

### DIFF
--- a/.github/workflows/move-dev-tag.yml
+++ b/.github/workflows/move-dev-tag.yml
@@ -1,0 +1,33 @@
+name: Move dev tag
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit SHA or git ref to point the movable dev tag at
+        required: true
+        type: string
+
+jobs:
+  tag-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Recreate dev tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh api "repos/${{ github.repository }}/commits/${REF}" --jq .sha)
+          if gh api "repos/${{ github.repository }}/git/ref/tags/dev" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/dev" \
+              -f sha="$SHA" \
+              -F force=true
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/dev" \
+              -f sha="$SHA"
+          fi
+          echo "Moved refs/tags/dev -> $SHA (from ${REF})"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,3 +18,11 @@ jobs:
       nzbdav_version: pre-${{ github.run_number }}
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+
+  tag-dev:
+    needs: build
+    uses: ./.github/workflows/move-dev-tag.yml
+    permissions:
+      contents: write
+    with:
+      ref: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,25 @@ jobs:
       checkout_ref: ${{ needs.resolve-version.outputs.ref }}
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+
+  tag-dev:
+    if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'
+    needs:
+      - release-please
+      - deploy
+    uses: ./.github/workflows/move-dev-tag.yml
+    permissions:
+      contents: write
+    with:
+      ref: ${{ needs.release-please.outputs.sha }}
+
+  tag-dev-manual:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs:
+      - resolve-version
+      - deploy-manual
+    uses: ./.github/workflows/move-dev-tag.yml
+    permissions:
+      contents: write
+    with:
+      ref: ${{ needs.resolve-version.outputs.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,11 +277,12 @@ Skip this handoff if there are no local changes and nothing to push or PR. Do no
 | `ci.yml` | PRs and pushes to `main` | Frontend lint/typecheck/build/tests + backend build/tests |
 | `docs.yml` | PRs and pushes to `main` | Zensical docs build (`zensical build --clean --strict`); deploys to GitHub Pages on `main` |
 | `codeql.yml` | PRs, pushes to `main`, and weekly schedule | CodeQL security analysis for C#, TypeScript, and GitHub Actions |
-| `pre-release.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../nzbdav:dev` |
-| `release.yml` | Push to `main` | release-please versioning; publishes release and `dev` Docker tags when a release is created |
-| `release.yml` | Manual `workflow_dispatch` | Republishes release and `dev` Docker tags to GHCR for an existing version |
+| `pre-release.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../nzbdav:dev` and moves the git `dev` tag to that commit |
+| `release.yml` | Push to `main` | release-please versioning; publishes release and `dev` Docker tags when a release is created; moves git `dev` tag |
+| `release.yml` | Manual `workflow_dispatch` | Republishes release and `dev` Docker tags to GHCR for an existing version; moves git `dev` tag |
 | `dependency-submission.yml` | GitHub Release `published` (plus manual `workflow_dispatch`) | Dependency graph submission (NuGet + npm) |
 | `docker-build-push.yml` | Reusable (called by pre-release/release) | Multi-arch Docker build with GHA cache |
+| `move-dev-tag.yml` | Reusable (called by pre-release/release) | Force-moves the movable git `dev` tag to a given commit |
 
 Docker image builds are shared via the reusable workflow. Branch and dependabot image pipelines were removed — PRs are validated by `ci.yml` instead of publishing throwaway images.
 
@@ -289,9 +290,9 @@ Docker image builds are shared via the reusable workflow. Branch and dependabot 
 
 - Merging to `main` triggers **release-please** (`.github/workflows/release.yml`) which maintains `CHANGELOG.md` + `version.txt` and creates GitHub releases.
 - `feat` → minor bump; `fix` → patch bump (pre-1.0 rules in `.release-please-config.json`). Other conventional types (`perf`, `chore`, `docs`, `ci`, `test`, `refactor`, `style`, `revert`, `build`) appear in changelog sections but do not bump the version by themselves.
-- When release-please creates a release on merge to `main`, the same workflow run builds and pushes Docker images to `ghcr.io` (`latest`, `dev`, exact `vMAJOR.MINOR.PATCH`, and rolling `vMAJOR` / `vMAJOR.MINOR` tags).
-- To republish images for an existing release (e.g. after fixing CI), run **Release** workflow manually with the `version` input (e.g. `0.6.5`).
-- Between releases, update the pre-release Docker image (`:dev`) on demand via **Actions → Pre-release → Run workflow**; the next release moves `:dev` to that release.
+- When release-please creates a release on merge to `main`, the same workflow run builds and pushes Docker images to `ghcr.io` (`latest`, `dev`, exact `vMAJOR.MINOR.PATCH`, and rolling `vMAJOR` / `vMAJOR.MINOR` tags) and moves the git `dev` tag to that release commit.
+- To republish images for an existing release (e.g. after fixing CI), run **Release** workflow manually with the `version` input (e.g. `0.6.5`); this also moves the git `dev` tag to that version.
+- Between releases, update the pre-release Docker image (`:dev`) and git `dev` tag on demand via **Actions → Pre-release → Run workflow**.
 - Dependency graph submission runs when a GitHub Release is published (and can be re-run manually via `workflow_dispatch`). Keep GitHub **Automatic dependency submission** disabled to avoid duplicates.
 
 ## Coding guidelines


### PR DESCRIPTION
## Summary
- After a successful `:dev` image publish, force-move `refs/tags/dev` to that commit
- Shared via reusable `move-dev-tag.yml`, called from pre-release and both release paths
- Documents the behavior in AGENTS.md

## Test plan
- [ ] Run **Pre-release** workflow and confirm `refs/tags/dev` points at the built commit
- [ ] Confirm a release (or manual Release republish) also moves `refs/tags/dev` after the image push
- [ ] Confirm `git checkout dev` / `git fetch origin tag dev` resolves to the same SHA as the published image