### PR TITLE
fix(usenet): speed test keeps budget for pipelining and fits results in the provider modal

### DIFF
--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -48,6 +48,11 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         var budget = Math.Max(50_000_000, dataBudgetBytes ?? profile.HardTotalBytes);
         var result = new BenchmarkResult { PipeliningOnly = pipeliningOnly, DataBudgetBytes = budget };
         long Remaining() => Math.Max(0, budget - result.DataUsedBytes);
+        // Hold back enough for baseline + each pipelining depth so a full auto-tune
+        // still produces a depth recommendation instead of burning the whole budget
+        // on the connection sweep.
+        long SweepRemaining(double mbPerSec) =>
+            Math.Max(0, Remaining() - PipeliningReserveBytes(profile, mbPerSec, budget));
 
         using var ladder = new BenchmarkConnectionLadder(provider);
 
@@ -132,7 +137,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 ct.ThrowIfCancellationRequested();
                 var level = levels[i];
 
-                if (Remaining() < MinUsefulBytes(lastMbPerSec, profile))
+                if (SweepRemaining(lastMbPerSec) < MinUsefulBytes(lastMbPerSec, profile))
                 {
                     result.BudgetLimited = true;
                     result.Warnings.Add(
@@ -151,7 +156,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 }
 
                 var sample = await MeasureThroughputAsync(
-                    ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, Remaining(), have),
+                    ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, SweepRemaining(lastMbPerSec), have),
                     profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                     pipeliningDepth: 0, ct).ConfigureAwait(false);
                 result.DataUsedBytes += sample.Bytes;
@@ -160,13 +165,13 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 // Retry once with a properly sized budget before recording the point.
                 if (sample.ExhaustedDuringWarmup
                     && sample.MbPerSec > 0
-                    && Remaining() > MinUsefulBytes(sample.MbPerSec, profile))
+                    && SweepRemaining(sample.MbPerSec) > MinUsefulBytes(sample.MbPerSec, profile))
                 {
                     lastMbPerSec = Math.Max(lastMbPerSec, sample.MbPerSec);
                     Report("sweep", $"Re-measuring {have} connection{(have == 1 ? "" : "s")}…",
                         ProgressPercent(15, 75, i, levels.Count), result, have);
                     var retry = await MeasureThroughputAsync(
-                        ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, Remaining(), have),
+                        ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, SweepRemaining(lastMbPerSec), have),
                         profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                         pipeliningDepth: 0, ct).ConfigureAwait(false);
                     result.DataUsedBytes += retry.Bytes;
@@ -200,6 +205,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             result.StillClimbing = stillClimbing;
 
             // Thorough only: confirm the pick with a second independent window and blend.
+            // Confirm may spend into the pipelining reserve if needed for accuracy.
             if (intensity == BenchmarkIntensity.Thorough
                 && result.RecommendedConnections is int knee
                 && Remaining() > MinUsefulBytes(lastMbPerSec, profile))
@@ -248,6 +254,12 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 result.Pipelining = await MeasurePipeliningAsync(
                     ladder, pool, profile, profile.PipelineDepths, Remaining,
                     bytes => result.DataUsedBytes += bytes, result.Warnings, ct).ConfigureAwait(false);
+            }
+            else if (result.Sweep.Count > 0)
+            {
+                result.Warnings.Add(
+                    "Skipped the pipelining test — not enough data budget left after the connection sweep. " +
+                    "Raise the budget or run \"Only tune pipelining\" separately.");
             }
         }
 
@@ -518,6 +530,18 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         var seconds = profile.WarmupDuration.TotalSeconds + 1.5;
         var bytesPerSec = lastMbPerSec > 0 ? lastMbPerSec * 1_000_000 : 2_000_000;
         return Math.Max(4_000_000, (long)(bytesPerSec * seconds));
+    }
+
+    // Hold back enough for a pipelining baseline + each tested depth. Caps at 25% of
+    // the total budget so small Auto runs still spend most of their quota on the sweep.
+    internal static long PipeliningReserveBytes(
+        BenchmarkProfile profile, double lastMbPerSec, long totalBudget)
+    {
+        var steps = 1 + profile.PipelineDepths.Length;
+        var perStep = MinUsefulBytes(Math.Max(lastMbPerSec, 10), profile);
+        var reserve = perStep * steps;
+        var cap = Math.Max(0, totalBudget / 4);
+        return Math.Min(reserve, cap);
     }
 
     // Target enough bytes that workers never run dry before the wall clock stops the

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1033,7 +1033,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             open={show}
             title={provider ? "Edit Provider" : "Add Provider"}
             onClose={onClose}
-            className="!max-w-2xl"
+            className="!max-w-4xl"
             footer={
                 <>
                     <Button variant="outline" onClick={onClose}>
@@ -1545,29 +1545,42 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                             </strong>.
                         </div>
                     ) : result.throughputTested && recommended ? (
-                        <div className="stats stats-vertical mt-4 w-full border border-base-content/10 bg-base-300 sm:stats-horizontal">
-                            <div className="stat py-3">
+                        <div className="stats stats-vertical mt-4 w-full max-w-full border border-base-content/10 bg-base-300 sm:stats-horizontal">
+                            <div className="stat min-w-0 py-3">
                                 <div className="stat-title text-[10px] uppercase tracking-wide">Recommended</div>
                                 <div className="stat-value text-xl font-mono">{recommended}</div>
                                 <div className="stat-desc font-mono tabular-nums">
                                     connection{recommended === 1 ? "" : "s"}{bestSpeed != null ? ` · ≈ ${bestSpeed.toFixed(1)} MB/s` : ""}
                                 </div>
                             </div>
+                            <div className="stat min-w-0 py-3">
+                                <div className="stat-title text-[10px] uppercase tracking-wide">Pipelining</div>
+                                <div className="stat-value text-sm font-mono">
+                                    {pipe
+                                        ? (pipe.recommendEnabled ? `Depth ${pipe.recommendedDepth}` : "Off")
+                                        : "—"}
+                                </div>
+                                <div className="stat-desc font-mono tabular-nums">
+                                    {pipe
+                                        ? (pipe.recommendEnabled ? `≈ +${pipeGainPct}% vs off` : "no real gain")
+                                        : "not tested"}
+                                </div>
+                            </div>
                             {result.latency && (
-                                <div className="stat py-3">
+                                <div className="stat min-w-0 py-3">
                                     <div className="stat-title text-[10px] uppercase tracking-wide">Latency</div>
                                     <div className="stat-value text-sm font-mono">{result.latency.avgMs} ms</div>
                                     <div className="stat-desc font-mono tabular-nums">{result.latency.minMs} ms min</div>
                                 </div>
                             )}
                             {result.providerConnectionCap != null && (
-                                <div className="stat py-3">
+                                <div className="stat min-w-0 py-3">
                                     <div className="stat-title text-[10px] uppercase tracking-wide">Provider cap</div>
                                     <div className="stat-value text-sm font-mono">{result.providerConnectionCap}</div>
                                     <div className="stat-desc">max at once</div>
                                 </div>
                             )}
-                            <div className="stat py-3">
+                            <div className="stat min-w-0 py-3">
                                 <div className="stat-title text-[10px] uppercase tracking-wide">Data used</div>
                                 <div className="stat-value text-sm font-mono">{formatBytes(result.dataUsedBytes)}</div>
                             </div>
@@ -1583,6 +1596,11 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                             {pipe.recommendEnabled
                                 ? <>Turn on <strong className="font-semibold text-base-content">NNTP pipelining</strong> at depth <strong className="font-semibold text-base-content">{pipe.recommendedDepth}</strong> — measurably faster on this connection.</>
                                 : <>NNTP pipelining didn’t help here — leave it off.</>}
+                        </div>
+                    )}
+                    {!result.pipeliningOnly && !pipe && result.throughputTested && recommended != null && (
+                        <div className="mt-3 text-sm leading-relaxed text-base-content/80">
+                            Pipelining wasn’t tested this run. Raise the data budget, or use <strong className="font-semibold text-base-content">Only tune pipelining</strong> after applying the connection count.
                         </div>
                     )}
 

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
@@ -151,6 +151,19 @@ public class BenchmarkMathTests
         Assert.Equal(25_000_000, UsenetBenchmarkService.MinUsefulBytes(10, profile));
     }
 
+    [Fact]
+    public void PipeliningReserveBytes_ScalesWithSpeedAndCapsAtQuarterBudget()
+    {
+        var profile = BenchmarkProfile.For(BenchmarkIntensity.Thorough);
+
+        var reserve = UsenetBenchmarkService.PipeliningReserveBytes(profile, 100, 10_000_000_000);
+        // 4 steps (baseline + 3 depths) × MinUseful(100) = 4 × 300MB = 1.2GB, under 25% of 10GB
+        Assert.Equal(1_200_000_000, reserve);
+
+        var capped = UsenetBenchmarkService.PipeliningReserveBytes(profile, 100, 1_000_000_000);
+        Assert.Equal(250_000_000, capped);
+    }
+
     [Theory]
     [InlineData(0.1, false, false, false, true, "high")]
     [InlineData(0.2, false, false, false, true, "medium")]


### PR DESCRIPTION
## Summary
- Reserve up to 25% of the auto-tune data budget for the pipelining phase so a full connection sweep doesn’t skip depth recommendations.
- Always show a Pipelining tile in the speed-test results (depth / off / not tested), with guidance when the phase was skipped.
- Widen the Edit Provider modal so the results stats card (including Data used) is no longer clipped.

## Test plan
- [ ] Run Auto-tune with a mid-size budget (e.g. 10–20 GB) and confirm a pipelining depth recommendation appears when the line benefits from it
- [ ] Confirm a warning appears if pipelining is still skipped after a budget-limited sweep
- [ ] Open Edit Provider after a completed speed test and verify Recommended / Pipelining / Latency / Data used all fit without horizontal clipping
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter BenchmarkMathTests`