### PR TITLE
fix(usenet): speed test uses MB correctly and survives long 20 GB runs

### DIFF
--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
@@ -12,6 +12,7 @@ namespace NzbWebDAV.Api.Controllers.BenchmarkUsenetConnection;
 public class BenchmarkUsenetConnectionController(
     UsenetBenchmarkService benchmarkService,
     BenchmarkGate benchmarkGate,
+    BenchmarkRunControl runControl,
     ActiveReadRegistry activeReads,
     QueueManager queueManager,
     ConfigManager configManager
@@ -23,12 +24,23 @@ public class BenchmarkUsenetConnectionController(
 
     private async Task<BenchmarkUsenetConnectionResponse> BenchmarkAsync(BenchmarkUsenetConnectionRequest request)
     {
+        if (request.Cancel)
+        {
+            runControl.Cancel();
+            return new BenchmarkUsenetConnectionResponse { Status = true };
+        }
+
         if (!await SingleFlight.WaitAsync(TimeSpan.Zero).ConfigureAwait(false))
             return new BenchmarkUsenetConnectionResponse
             {
                 Status = false,
                 Error = "A speed test is already running. Wait for it to finish (or cancel it) and try again."
             };
+
+        // Do not link to HttpContext.RequestAborted: intermediaries often drop the
+        // long-lived POST (~30s TTFB/idle) while the UI is still watching websocket
+        // progress. Only an explicit cancel (Cancel button / modal close) aborts.
+        var ct = runControl.Begin();
 
         try
         {
@@ -49,7 +61,7 @@ public class BenchmarkUsenetConnectionController(
                 request.PipeliningOnly,
                 request.DataBudgetBytes,
                 request.VerifyConnections,
-                HttpContext.RequestAborted
+                ct
             ).ConfigureAwait(false);
 
             var streamsAfter = activeReads.Count;
@@ -63,20 +75,32 @@ public class BenchmarkUsenetConnectionController(
 
             return new BenchmarkUsenetConnectionResponse { Status = true, Result = result };
         }
-        catch (CouldNotConnectToUsenetException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             return new BenchmarkUsenetConnectionResponse
             {
                 Status = false,
-                Error = "Couldn't connect to the provider. Check the host, port and SSL settings."
+                Error = "Speed test cancelled."
+            };
+        }
+        catch (CouldNotConnectToUsenetException)
+        {
+            const string error = "Couldn't connect to the provider. Check the host, port and SSL settings.";
+            benchmarkService.ReportFailure(error);
+            return new BenchmarkUsenetConnectionResponse
+            {
+                Status = false,
+                Error = error
             };
         }
         catch (CouldNotLoginToUsenetException)
         {
+            const string error = "Couldn't log in to the provider. Check the username and password.";
+            benchmarkService.ReportFailure(error);
             return new BenchmarkUsenetConnectionResponse
             {
                 Status = false,
-                Error = "Couldn't log in to the provider. Check the username and password."
+                Error = error
             };
         }
         finally

--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
@@ -27,8 +27,28 @@ public class BenchmarkUsenetConnectionRequest
     /// <summary>When set, skip the sweep and just measure this single connection count.</summary>
     public int? VerifyConnections { get; init; }
 
+    /// <summary>When true, cancel the in-flight speed test instead of starting a new one.</summary>
+    public bool Cancel { get; init; }
+
     public BenchmarkUsenetConnectionRequest(HttpContext context, ConfigManager configManager)
     {
+        Cancel = string.Equals(
+            context.Request.Form["cancel"].FirstOrDefault(),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        if (Cancel)
+        {
+            // Cancel requests only need the flag — skip credential validation.
+            Host = "";
+            User = "";
+            Pass = "";
+            Port = 0;
+            UseSsl = false;
+            MaxConnections = 1;
+            Intensity = BenchmarkIntensity.Quick;
+            return;
+        }
+
         Host = context.Request.Form["host"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Usenet host is required");
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -159,6 +159,7 @@ class Program
                 .AddSingleton(logBufferSink)
                 .AddSingleton(streamTraceBuffer)
                 .AddSingleton<BenchmarkGate>()
+                .AddSingleton<NzbWebDAV.Services.Benchmark.BenchmarkRunControl>()
                 .AddHostedService<LogBroadcaster>()
                 .AddSingleton<ActiveReadRegistry>()
                 .AddSingleton<ProviderUsageTracker>(sp =>

--- a/backend/Services/Benchmark/BenchmarkModels.cs
+++ b/backend/Services/Benchmark/BenchmarkModels.cs
@@ -81,7 +81,7 @@ public sealed class BenchmarkLatency
 public sealed class BenchmarkSweepPoint
 {
     public int Connections { get; set; }
-    public double MbPerSec { get; set; }
+    public double MegaBytesPerSec { get; set; }
 
     /// <summary>Coefficient of variation of throughput across sampling buckets (0 = perfectly steady).</summary>
     public double Cv { get; set; }
@@ -90,13 +90,13 @@ public sealed class BenchmarkSweepPoint
 public sealed class BenchmarkPipeliningPoint
 {
     public int Depth { get; set; }
-    public double MbPerSec { get; set; }
+    public double MegaBytesPerSec { get; set; }
 }
 
 public sealed class BenchmarkPipelining
 {
     public int TestedAtConnections { get; set; }
-    public double BaselineMbPerSec { get; set; }
+    public double BaselineMegaBytesPerSec { get; set; }
     public List<BenchmarkPipeliningPoint> Tested { get; set; } = [];
     public bool RecommendEnabled { get; set; }
     public int RecommendedDepth { get; set; }
@@ -165,4 +165,10 @@ public sealed class BenchmarkProgressUpdate
     public long DataUsedBytes { get; init; }
     public long DataBudgetBytes { get; init; }
     public List<BenchmarkSweepPoint> Sweep { get; init; } = [];
+
+    /// <summary>Set on the terminal <c>done</c> frame so the UI can finish even if the HTTP POST was dropped.</summary>
+    public BenchmarkResult? Result { get; init; }
+
+    /// <summary>Set on the terminal <c>done</c> frame when the run failed after starting.</summary>
+    public string? Error { get; init; }
 }

--- a/backend/Services/Benchmark/BenchmarkRunControl.cs
+++ b/backend/Services/Benchmark/BenchmarkRunControl.cs
@@ -1,0 +1,34 @@
+namespace NzbWebDAV.Services.Benchmark;
+
+/// <summary>
+/// Process-wide cancellation for the in-flight speed test. The HTTP request that
+/// started the run may be dropped by an intermediary timeout while the test is
+/// still going; we must not treat that disconnect as user cancel. Explicit
+/// cancel (UI Cancel / modal close) calls <see cref="Cancel"/> instead.
+/// </summary>
+public sealed class BenchmarkRunControl
+{
+    private readonly object _lock = new();
+    private CancellationTokenSource? _cts;
+
+    /// <summary>Starts a new run token, cancelling any previous one.</summary>
+    public CancellationToken Begin()
+    {
+        lock (_lock)
+        {
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = new CancellationTokenSource();
+            return _cts.Token;
+        }
+    }
+
+    /// <summary>Cancels the current run, if any.</summary>
+    public void Cancel()
+    {
+        lock (_lock)
+        {
+            _cts?.Cancel();
+        }
+    }
+}

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -35,6 +35,25 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
+    /// <summary>
+    /// Publishes a terminal websocket frame when the run fails before a
+    /// <see cref="BenchmarkResult"/> exists (connect/login errors, cancel, etc.).
+    /// </summary>
+    public void ReportFailure(string error)
+    {
+        var update = new BenchmarkProgressUpdate
+        {
+            Phase = "done",
+            Status = error,
+            Percent = 100,
+            DataUsedBytes = 0,
+            DataBudgetBytes = 0,
+            Sweep = [],
+            Error = error,
+        };
+        _ = websocketManager.SendMessage(WebsocketTopic.BenchmarkProgress, JsonSerializer.Serialize(update, JsonOptions));
+    }
+
     public async Task<BenchmarkResult> RunAsync(
         UsenetProviderConfig.ConnectionDetails provider,
         int configuredMaxConnections,
@@ -51,8 +70,8 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         // Hold back enough for baseline + each pipelining depth so a full auto-tune
         // still produces a depth recommendation instead of burning the whole budget
         // on the connection sweep.
-        long SweepRemaining(double mbPerSec) =>
-            Math.Max(0, Remaining() - PipeliningReserveBytes(profile, mbPerSec, budget));
+        long SweepRemaining(double megaBytesPerSec) =>
+            Math.Max(0, Remaining() - PipeliningReserveBytes(profile, megaBytesPerSec, budget));
 
         using var ladder = new BenchmarkConnectionLadder(provider);
 
@@ -71,7 +90,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             result.Warnings.Add(
                 "No downloaded articles were available to measure speed, so only latency was tested. " +
                 "Download something first, then re-run to get a connection recommendation.");
-            Report("done", "Done — latency only.", 100, result, null);
+            Report("done", "Done — latency only.", 100, result, null, includeResult: true);
             return result;
         }
 
@@ -110,7 +129,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
 
             Report("sweep", $"Measuring {have} connection{(have == 1 ? "" : "s")}…", 65, result, have);
             var sample = await MeasureThroughputAsync(
-                ladder, pool, AdaptiveTargetBytes(bootstrap.MbPerSec, profile, Remaining(), have),
+                ladder, pool, AdaptiveTargetBytes(bootstrap.MegaBytesPerSec, profile, Remaining(), have),
                 profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                 pipeliningDepth: 0, ct).ConfigureAwait(false);
             result.DataUsedBytes += sample.Bytes;
@@ -118,7 +137,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             result.Sweep.Add(new BenchmarkSweepPoint
             {
                 Connections = have,
-                MbPerSec = Math.Round(sample.MbPerSec, 2),
+                MegaBytesPerSec = Math.Round(sample.MegaBytesPerSec, 2),
                 Cv = Math.Round(sample.Cv, 3),
             });
             result.RecommendedConnections = have;
@@ -131,13 +150,13 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             // 3) Throughput sweep — climb connection counts until the knee or the cap.
             var levels = BuildLevels(configuredMaxConnections, profile);
             int? providerCap = null;
-            double lastMbPerSec = 0;
+            double lastMegaBytesPerSec = 0;
             for (var i = 0; i < levels.Count; i++)
             {
                 ct.ThrowIfCancellationRequested();
                 var level = levels[i];
 
-                if (SweepRemaining(lastMbPerSec) < MinUsefulBytes(lastMbPerSec, profile))
+                if (SweepRemaining(lastMegaBytesPerSec) < MinUsefulBytes(lastMegaBytesPerSec, profile))
                 {
                     result.BudgetLimited = true;
                     result.Warnings.Add(
@@ -156,7 +175,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 }
 
                 var sample = await MeasureThroughputAsync(
-                    ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, SweepRemaining(lastMbPerSec), have),
+                    ladder, pool, AdaptiveTargetBytes(lastMegaBytesPerSec, profile, SweepRemaining(lastMegaBytesPerSec), have),
                     profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                     pipeliningDepth: 0, ct).ConfigureAwait(false);
                 result.DataUsedBytes += sample.Bytes;
@@ -164,30 +183,30 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 // Tiny bootstrap target finished in warmup → rate recovered but noisy.
                 // Retry once with a properly sized budget before recording the point.
                 if (sample.ExhaustedDuringWarmup
-                    && sample.MbPerSec > 0
-                    && SweepRemaining(sample.MbPerSec) > MinUsefulBytes(sample.MbPerSec, profile))
+                    && sample.MegaBytesPerSec > 0
+                    && SweepRemaining(sample.MegaBytesPerSec) > MinUsefulBytes(sample.MegaBytesPerSec, profile))
                 {
-                    lastMbPerSec = Math.Max(lastMbPerSec, sample.MbPerSec);
+                    lastMegaBytesPerSec = Math.Max(lastMegaBytesPerSec, sample.MegaBytesPerSec);
                     Report("sweep", $"Re-measuring {have} connection{(have == 1 ? "" : "s")}…",
                         ProgressPercent(15, 75, i, levels.Count), result, have);
                     var retry = await MeasureThroughputAsync(
-                        ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, SweepRemaining(lastMbPerSec), have),
+                        ladder, pool, AdaptiveTargetBytes(lastMegaBytesPerSec, profile, SweepRemaining(lastMegaBytesPerSec), have),
                         profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                         pipeliningDepth: 0, ct).ConfigureAwait(false);
                     result.DataUsedBytes += retry.Bytes;
-                    if (retry.MbPerSec > 0)
+                    if (retry.MegaBytesPerSec > 0)
                         sample = retry;
                 }
 
-                lastMbPerSec = Math.Max(lastMbPerSec, sample.MbPerSec);
+                lastMegaBytesPerSec = Math.Max(lastMegaBytesPerSec, sample.MegaBytesPerSec);
 
                 result.Sweep.Add(new BenchmarkSweepPoint
                 {
                     Connections = have,
-                    MbPerSec = Math.Round(sample.MbPerSec, 2),
+                    MegaBytesPerSec = Math.Round(sample.MegaBytesPerSec, 2),
                     Cv = Math.Round(sample.Cv, 3),
                 });
-                Report("sweep", $"{have} conn → {sample.MbPerSec:0.0} MB/s",
+                Report("sweep", $"{have} conn → {sample.MegaBytesPerSec:0.0} MB/s",
                     ProgressPercent(15, 75, i + 1, levels.Count), result, have);
 
                 if (have < level)
@@ -208,31 +227,31 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             // Confirm may spend into the pipelining reserve if needed for accuracy.
             if (intensity == BenchmarkIntensity.Thorough
                 && result.RecommendedConnections is int knee
-                && Remaining() > MinUsefulBytes(lastMbPerSec, profile))
+                && Remaining() > MinUsefulBytes(lastMegaBytesPerSec, profile))
             {
                 Report("sweep", $"Confirming {knee} connection{(knee == 1 ? "" : "s")}…", 80, result, knee);
                 ladder.ShrinkTo(knee);
                 if (ladder.Count > 0)
                 {
                     var confirm = await MeasureThroughputAsync(
-                        ladder, pool, AdaptiveTargetBytes(lastMbPerSec, profile, Remaining(), knee),
+                        ladder, pool, AdaptiveTargetBytes(lastMegaBytesPerSec, profile, Remaining(), knee),
                         profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                         pipeliningDepth: 0, ct).ConfigureAwait(false);
                     result.DataUsedBytes += confirm.Bytes;
                     var point = result.Sweep.FirstOrDefault(p => p.Connections == knee);
-                    if (point != null && confirm.MbPerSec > 0)
+                    if (point != null && confirm.MegaBytesPerSec > 0)
                     {
-                        if (point.MbPerSec > 0)
+                        if (point.MegaBytesPerSec > 0)
                         {
                             result.ConfirmDeltaPct = Math.Round(
-                                Math.Abs(confirm.MbPerSec - point.MbPerSec) / point.MbPerSec * 100, 1);
+                                Math.Abs(confirm.MegaBytesPerSec - point.MegaBytesPerSec) / point.MegaBytesPerSec * 100, 1);
                             if (result.ConfirmDeltaPct > 20)
                                 result.Warnings.Add(
                                     "The confirmation run didn't reproduce the measured speed closely, " +
                                     "so the recommendation may shift slightly between runs.");
                         }
 
-                        point.MbPerSec = Math.Round((point.MbPerSec + confirm.MbPerSec) / 2, 2);
+                        point.MegaBytesPerSec = Math.Round((point.MegaBytesPerSec + confirm.MegaBytesPerSec) / 2, 2);
                         point.Cv = Math.Round(Math.Max(point.Cv, confirm.Cv), 3);
                         result.RecommendedConnections = DetectKnee(
                             result.Sweep, providerCap, [], out stillClimbing);
@@ -242,7 +261,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             }
 
             // 4) Pipelining — compare off vs. a few depths at a moderate concurrency.
-            if (result.Sweep.Count > 0 && Remaining() > MinUsefulBytes(lastMbPerSec, profile))
+            if (result.Sweep.Count > 0 && Remaining() > MinUsefulBytes(lastMegaBytesPerSec, profile))
             {
                 var pipeConns = Math.Min(result.RecommendedConnections ?? 1, profile.PipelineTestConnections);
                 if (providerCap.HasValue) pipeConns = Math.Min(pipeConns, providerCap.Value);
@@ -276,7 +295,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 "Downloading something recent refreshes the test pool.");
 
         result.Confidence = ComputeConfidence(result);
-        Report("done", "Done.", 100, result, null);
+        Report("done", "Done.", 100, result, null, includeResult: true);
         return result;
     }
 
@@ -318,11 +337,11 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
             pipeliningDepth: 0, ct).ConfigureAwait(false);
         addData(baseline.Bytes);
-        last = baseline.MbPerSec;
-        result.BaselineMbPerSec = Math.Round(baseline.MbPerSec, 2);
+        last = baseline.MegaBytesPerSec;
+        result.BaselineMegaBytesPerSec = Math.Round(baseline.MegaBytesPerSec, 2);
         if (baseline.OpenedConnections == 0) return result;
 
-        var bestMbps = baseline.MbPerSec;
+        var bestMegaBytesPerSec = baseline.MegaBytesPerSec;
         var bestDepth = 0;
         foreach (var depth in depths)
         {
@@ -338,13 +357,13 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                 depth, ct).ConfigureAwait(false);
             addData(sample.Bytes);
-            last = Math.Max(last, sample.MbPerSec);
-            result.Tested.Add(new BenchmarkPipeliningPoint { Depth = depth, MbPerSec = Math.Round(sample.MbPerSec, 2) });
-            if (sample.MbPerSec > bestMbps) { bestMbps = sample.MbPerSec; bestDepth = depth; }
+            last = Math.Max(last, sample.MegaBytesPerSec);
+            result.Tested.Add(new BenchmarkPipeliningPoint { Depth = depth, MegaBytesPerSec = Math.Round(sample.MegaBytesPerSec, 2) });
+            if (sample.MegaBytesPerSec > bestMegaBytesPerSec) { bestMegaBytesPerSec = sample.MegaBytesPerSec; bestDepth = depth; }
         }
 
         // Only recommend turning it on if it's a clear (>10%) win over the baseline.
-        if (bestDepth > 0 && baseline.MbPerSec > 0 && bestMbps >= baseline.MbPerSec * 1.10)
+        if (bestDepth > 0 && baseline.MegaBytesPerSec > 0 && bestMegaBytesPerSec >= baseline.MegaBytesPerSec * 1.10)
         {
             result.RecommendEnabled = true;
             result.RecommendedDepth = bestDepth;
@@ -361,7 +380,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
     // ---- Throughput core -------------------------------------------------
 
     private readonly record struct ThroughputSample(
-        double MbPerSec,
+        double MegaBytesPerSec,
         double Cv,
         long Bytes,
         int OpenedConnections,
@@ -525,20 +544,20 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
     // ---- Helpers ---------------------------------------------------------
 
     // Bytes needed to keep the pipe busy through warm-up plus a minimally-useful (~1.5s) window.
-    internal static long MinUsefulBytes(double lastMbPerSec, BenchmarkProfile profile)
+    internal static long MinUsefulBytes(double lastMegaBytesPerSec, BenchmarkProfile profile)
     {
         var seconds = profile.WarmupDuration.TotalSeconds + 1.5;
-        var bytesPerSec = lastMbPerSec > 0 ? lastMbPerSec * 1_000_000 : 2_000_000;
+        var bytesPerSec = lastMegaBytesPerSec > 0 ? lastMegaBytesPerSec * 1_000_000 : 2_000_000;
         return Math.Max(4_000_000, (long)(bytesPerSec * seconds));
     }
 
     // Hold back enough for a pipelining baseline + each tested depth. Caps at 25% of
     // the total budget so small Auto runs still spend most of their quota on the sweep.
     internal static long PipeliningReserveBytes(
-        BenchmarkProfile profile, double lastMbPerSec, long totalBudget)
+        BenchmarkProfile profile, double lastMegaBytesPerSec, long totalBudget)
     {
         var steps = 1 + profile.PipelineDepths.Length;
-        var perStep = MinUsefulBytes(Math.Max(lastMbPerSec, 10), profile);
+        var perStep = MinUsefulBytes(Math.Max(lastMegaBytesPerSec, 10), profile);
         var reserve = perStep * steps;
         var cap = Math.Max(0, totalBudget / 4);
         return Math.Min(reserve, cap);
@@ -549,13 +568,13 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
     // have no speed estimate yet, scale the floor with connection count so parallel
     // workers can't burn a tiny budget during warmup alone.
     internal static long AdaptiveTargetBytes(
-        double lastMbPerSec, BenchmarkProfile profile, long remainingBudget, int connections = 1)
+        double lastMegaBytesPerSec, BenchmarkProfile profile, long remainingBudget, int connections = 1)
     {
         var seconds = (profile.WarmupDuration + profile.MeasureWindow).TotalSeconds;
         long est;
-        if (lastMbPerSec > 0)
+        if (lastMegaBytesPerSec > 0)
         {
-            est = (long)(lastMbPerSec * 1_000_000 * 2.0 * seconds);
+            est = (long)(lastMegaBytesPerSec * 1_000_000 * 2.0 * seconds);
         }
         else
         {
@@ -573,7 +592,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
     // are ignored so ARTICLE RTT holes don't force a median of 0. Falls back to the
     // whole-window mean when there aren't enough positive buckets, or when the median
     // is ~0 despite bytes moving in the window.
-    internal static (double MbPerSec, double Cv) ComputeSteadyRate(
+    internal static (double MegaBytesPerSec, double Cv) ComputeSteadyRate(
         IReadOnlyList<(long Bytes, double Seconds)> buckets,
         long fallbackBytes,
         double fallbackSeconds)
@@ -681,12 +700,12 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
 
         // A mostly-zero sweep (poisoned sockets / failed measure windows) must not
         // recommend the lone spike at the connection ceiling.
-        const double minMeaningfulMbPerSec = 0.5;
-        var topTwo = ordered.OrderByDescending(p => p.MbPerSec).Take(2).ToList();
+        const double minMeaningfulMegaBytesPerSec = 0.5;
+        var topTwo = ordered.OrderByDescending(p => p.MegaBytesPerSec).Take(2).ToList();
         if (topTwo.Count < 2
-            || topTwo[0].MbPerSec <= minMeaningfulMbPerSec
-            || topTwo[1].MbPerSec <= minMeaningfulMbPerSec
-            || topTwo[1].MbPerSec < topTwo[0].MbPerSec * 0.10)
+            || topTwo[0].MegaBytesPerSec <= minMeaningfulMegaBytesPerSec
+            || topTwo[1].MegaBytesPerSec <= minMeaningfulMegaBytesPerSec
+            || topTwo[1].MegaBytesPerSec < topTwo[0].MegaBytesPerSec * 0.10)
         {
             warnings.Add(
                 "The speed test couldn't get steady throughput at enough connection levels " +
@@ -696,18 +715,18 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
 
         // Reference peak = mean of the two best points so a single lucky spike can't
         // drag the recommendation around between runs.
-        var peakRef = (topTwo[0].MbPerSec + topTwo[1].MbPerSec) / 2.0;
+        var peakRef = (topTwo[0].MegaBytesPerSec + topTwo[1].MegaBytesPerSec) / 2.0;
         if (peakRef <= 0) return null;
 
-        var knee = ordered.First(p => p.MbPerSec >= 0.92 * peakRef).Connections;
+        var knee = ordered.First(p => p.MegaBytesPerSec >= 0.92 * peakRef).Connections;
         if (providerCap.HasValue) knee = Math.Min(knee, providerCap.Value);
 
-        var best = ordered.Max(p => p.MbPerSec);
+        var best = ordered.Max(p => p.MegaBytesPerSec);
         var peak = ordered[^1];
-        if (peak.MbPerSec >= best - 1e-9 && ordered.Count >= 2)
+        if (peak.MegaBytesPerSec >= best - 1e-9 && ordered.Count >= 2)
         {
             var prev = ordered[^2];
-            if (prev.MbPerSec > 0 && (peak.MbPerSec - prev.MbPerSec) / prev.MbPerSec > 0.08)
+            if (prev.MegaBytesPerSec > 0 && (peak.MegaBytesPerSec - prev.MegaBytesPerSec) / prev.MegaBytesPerSec > 0.08)
             {
                 stillClimbing = true;
                 warnings.Add("Speed was still climbing at the highest level tested — a faster line or even more connections may help.");
@@ -740,7 +759,14 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
     private static int ProgressPercent(int start, int end, int step, int totalSteps) =>
         start + (int)((end - start) * (double)step / Math.Max(1, totalSteps));
 
-    private void Report(string phase, string status, int percent, BenchmarkResult result, int? currentConnections)
+    private void Report(
+        string phase,
+        string status,
+        int percent,
+        BenchmarkResult result,
+        int? currentConnections,
+        string? error = null,
+        bool includeResult = false)
     {
         var update = new BenchmarkProgressUpdate
         {
@@ -753,9 +779,11 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             Sweep = result.Sweep.Select(p => new BenchmarkSweepPoint
             {
                 Connections = p.Connections,
-                MbPerSec = p.MbPerSec,
+                MegaBytesPerSec = p.MegaBytesPerSec,
                 Cv = p.Cv,
             }).ToList(),
+            Result = includeResult ? result : null,
+            Error = error,
         };
         // Fire-and-forget: progress is best-effort and must not block the run.
         _ = websocketManager.SendMessage(WebsocketTopic.BenchmarkProgress, JsonSerializer.Serialize(update, JsonOptions));

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -26,11 +26,11 @@ const USAGE_POLL_INTERVAL_MS = 10_000;
 
 // Mirrors the camelCase JSON the backend benchmark endpoint + websocket emit.
 type BenchmarkLatency = { minMs: number; avgMs: number; samples: number };
-type BenchmarkSweepPoint = { connections: number; mbPerSec: number; cv?: number };
-type BenchmarkPipeliningPoint = { depth: number; mbPerSec: number };
+type BenchmarkSweepPoint = { connections: number; megaBytesPerSec: number; cv?: number };
+type BenchmarkPipeliningPoint = { depth: number; megaBytesPerSec: number };
 type BenchmarkPipelining = {
     testedAtConnections: number;
-    baselineMbPerSec: number;
+    baselineMegaBytesPerSec: number;
     tested: BenchmarkPipeliningPoint[];
     recommendEnabled: boolean;
     recommendedDepth: number;
@@ -60,6 +60,8 @@ type BenchmarkProgress = {
     dataUsedBytes: number;
     dataBudgetBytes?: number;
     sweep: BenchmarkSweepPoint[];
+    result?: BenchmarkResult | null;
+    error?: string | null;
 };
 type BenchmarkIntensity = "quick" | "thorough";
 
@@ -849,9 +851,21 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
     // Stop any in-flight speed test when the modal closes or unmounts so it
     // aborts on the backend and frees its connections immediately.
     useEffect(() => {
-        if (!show) benchmarkAbortRef.current?.abort();
+        if (!show) {
+            benchmarkAbortRef.current?.abort();
+            void fetch('/api/benchmark-usenet-connection', {
+                method: 'POST',
+                body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
+            }).catch(() => { /* best-effort cancel */ });
+        }
     }, [show]);
-    useEffect(() => () => benchmarkAbortRef.current?.abort(), []);
+    useEffect(() => () => {
+        benchmarkAbortRef.current?.abort();
+        void fetch('/api/benchmark-usenet-connection', {
+            method: 'POST',
+            body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
+        }).catch(() => { /* best-effort cancel */ });
+    }, []);
 
     const handleTestConnection = useCallback(async () => {
         setIsTestingConnection(true);
@@ -892,25 +906,49 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
     const handleAutoTune = useCallback(async (verifyConnections?: number) => {
         // Abort any previous run still in flight before starting a new one.
         benchmarkAbortRef.current?.abort();
+        await fetch('/api/benchmark-usenet-connection', {
+            method: 'POST',
+            body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
+        }).catch(() => { /* best-effort */ });
+
         const controller = new AbortController();
         benchmarkAbortRef.current = controller;
+        let finished = false;
+        let unsubscribeProgress = () => {};
+        const finish = (result?: BenchmarkResult | null, error?: string | null) => {
+            if (finished) return;
+            finished = true;
+            if (result) {
+                setBenchmarkResult(result);
+                setConnectionTested(true);
+                setBenchmarkError(null);
+            } else if (error) {
+                setBenchmarkError(error);
+            }
+            setIsBenchmarking(false);
+            setBenchmarkProgress(null);
+            if (benchmarkAbortRef.current === controller) benchmarkAbortRef.current = null;
+            unsubscribeProgress();
+        };
 
         setIsBenchmarking(true);
         setBenchmarkError(null);
         setBenchmarkResult(null);
         setBenchmarkProgress({ phase: "latency", status: "Starting speed test…", percent: 0, dataUsedBytes: 0, sweep: [] });
 
-        // Live progress over the websocket — best-effort eye-candy; the POST
-        // below returns the authoritative result regardless.
-        const unsubscribeProgress = subscribeWebsocketTopics(
+        // Progress + terminal result over the websocket. The POST may be dropped by
+        // an intermediary timeout on large budgets; the done frame still finishes the UI.
+        unsubscribeProgress = subscribeWebsocketTopics(
             { bench: "state" },
             (topic, message) => {
                 if (topic !== "bench") return;
                 try {
                     const update = JSON.parse(message) as BenchmarkProgress;
-                    // Ignore the terminal "done" frame (incl. any replayed from a
-                    // previous run) so the bar doesn't flash to 100% then restart.
-                    if (update.phase !== "done") setBenchmarkProgress(update);
+                    if (update.phase === "done") {
+                        finish(update.result ?? null, update.error ?? null);
+                        return;
+                    }
+                    setBenchmarkProgress(update);
                 } catch { /* ignore malformed progress */ }
             },
         );
@@ -932,27 +970,31 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                 method: 'POST', body: formData, signal: controller.signal,
             });
             const data = await response.json().catch(() => null);
-            if (!response.ok) {
-                setBenchmarkError(data?.error || "The speed test couldn't run. Please try again.");
+            if (finished) return;
+
+            if (response.ok && data?.status && data.result) {
+                finish(data.result as BenchmarkResult, null);
                 return;
             }
-            if (!data?.status || !data.result) {
-                setBenchmarkError(data?.error || "The speed test couldn't run.");
+            if (data?.error) {
+                finish(null, data.error);
                 return;
             }
-            setBenchmarkResult(data.result as BenchmarkResult);
-            setConnectionTested(true); // a successful benchmark also proves the connection
+            // POST dropped or returned an empty body (common when a proxy hits an
+            // idle/TTFB limit). Keep listening for the websocket done frame.
+            setBenchmarkProgress(prev => prev
+                ? { ...prev, status: "Speed test still running…" }
+                : { phase: "sweep", status: "Speed test still running…", percent: 50, dataUsedBytes: 0, sweep: [] });
         } catch (error) {
             if (error instanceof DOMException && error.name === 'AbortError') {
-                // Cancelled by the user (Cancel button or closing the modal) — not an error.
-                setBenchmarkProgress(null);
-            } else {
-                setBenchmarkError("Network error: " + (error instanceof Error ? error.message : "Unknown error"));
+                // Cancelled by the user (Cancel button or closing the modal).
+                if (!finished) finish(null, null);
+                return;
             }
-        } finally {
-            setIsBenchmarking(false);
-            if (benchmarkAbortRef.current === controller) benchmarkAbortRef.current = null;
-            unsubscribeProgress();
+            // Network / proxy drop mid-run: keep listening for the websocket done frame.
+            setBenchmarkProgress(prev => prev
+                ? { ...prev, status: "Speed test still running…" }
+                : { phase: "sweep", status: "Speed test still running…", percent: 50, dataUsedBytes: 0, sweep: [] });
         }
     }, [host, port, useSsl, user, pass, maxConnections, intensity, pipeliningOnly, dataBudget]);
 
@@ -971,6 +1013,12 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
 
     const handleCancelBenchmark = useCallback(() => {
         benchmarkAbortRef.current?.abort();
+        void fetch('/api/benchmark-usenet-connection', {
+            method: 'POST',
+            body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
+        }).catch(() => { /* best-effort cancel */ });
+        setIsBenchmarking(false);
+        setBenchmarkProgress(null);
     }, []);
 
     const handleSave = useCallback(() => {
@@ -1335,11 +1383,11 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
     const recommended = result?.recommendedConnections ?? null;
     const livePoints = isBenchmarking ? (progress?.sweep ?? []) : (result?.sweep ?? []);
     const bestSpeed = result?.throughputTested && result.sweep.length > 0
-        ? Math.max(...result.sweep.map(p => p.mbPerSec))
+        ? Math.max(...result.sweep.map(p => p.megaBytesPerSec))
         : null;
     const pipe = result?.pipelining ?? null;
-    const pipeBest = pipe && pipe.tested.length > 0 ? Math.max(...pipe.tested.map(t => t.mbPerSec)) : (pipe?.baselineMbPerSec ?? 0);
-    const pipeGainPct = pipe && pipe.baselineMbPerSec > 0 ? Math.round((pipeBest / pipe.baselineMbPerSec - 1) * 100) : 0;
+    const pipeBest = pipe && pipe.tested.length > 0 ? Math.max(...pipe.tested.map(t => t.megaBytesPerSec)) : (pipe?.baselineMegaBytesPerSec ?? 0);
+    const pipeGainPct = pipe && pipe.baselineMegaBytesPerSec > 0 ? Math.round((pipeBest / pipe.baselineMegaBytesPerSec - 1) * 100) : 0;
     const canApply = !!result && result.throughputTested && (recommended != null || (result.pipeliningOnly && !!pipe));
     const phaseIndex = progress
         ? Math.max(0, BENCH_PHASES.findIndex(p => p.id === progress.phase))
@@ -1538,7 +1586,7 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                     ) : result.verificationRun && result.sweep[0] ? (
                         <div className="mt-4 text-sm leading-relaxed text-base-content/80">
                             Verified: <strong className="font-semibold text-base-content">
-                                {result.sweep[0].mbPerSec} MB/s
+                                {result.sweep[0].megaBytesPerSec} MB/s
                             </strong>{" "}
                             at <strong className="font-semibold text-base-content">
                                 {result.sweep[0].connections} connection{result.sweep[0].connections === 1 ? "" : "s"}
@@ -1636,22 +1684,22 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
 }
 
 function SweepChart({ points, recommended }: { points: BenchmarkSweepPoint[]; recommended: number | null }) {
-    const max = Math.max(...points.map(p => p.mbPerSec), 0.0001);
+    const max = Math.max(...points.map(p => p.megaBytesPerSec), 0.0001);
     return (
         <div className="mt-4">
             <div className="flex h-[150px] items-end gap-2">
                 {points.map((p, i) => {
                     const isRec = recommended != null && p.connections === recommended;
-                    const height = Math.max(4, Math.round((p.mbPerSec / max) * 104));
+                    const height = Math.max(4, Math.round((p.megaBytesPerSec / max) * 104));
                     return (
                         <div key={i} className="flex min-w-0 flex-1 flex-col items-center gap-1.5">
                             <span className={`font-mono text-[10.5px] tabular-nums whitespace-nowrap ${isRec ? "font-semibold text-primary" : "text-base-content/45"}`}>
-                                {p.mbPerSec >= 10 ? p.mbPerSec.toFixed(0) : p.mbPerSec.toFixed(1)}
+                                {p.megaBytesPerSec >= 10 ? p.megaBytesPerSec.toFixed(0) : p.megaBytesPerSec.toFixed(1)}
                             </span>
                             <div
                                 className={`w-full max-w-8 rounded-t transition-all duration-200 ease-in-out ${isRec ? "bg-primary" : "bg-base-content/25"}`}
                                 style={{ height: `${height}px` }}
-                                title={`${p.connections} connections → ${p.mbPerSec.toFixed(1)} MB/s`}
+                                title={`${p.connections} connections → ${p.megaBytesPerSec.toFixed(1)} MB/s`}
                             />
                             <span className={`font-mono text-[11px] tabular-nums ${isRec ? "font-semibold text-primary" : "text-base-content/45"}`}>
                                 {p.connections}
@@ -1670,28 +1718,28 @@ function SweepChart({ points, recommended }: { points: BenchmarkSweepPoint[]; re
 
 function DepthChart({ pipe }: { pipe: BenchmarkPipelining }) {
     const points = [
-        { label: "Off", mbPerSec: pipe.baselineMbPerSec, rec: !pipe.recommendEnabled },
+        { label: "Off", megaBytesPerSec: pipe.baselineMegaBytesPerSec, rec: !pipe.recommendEnabled },
         ...pipe.tested.map(t => ({
             label: String(t.depth),
-            mbPerSec: t.mbPerSec,
+            megaBytesPerSec: t.megaBytesPerSec,
             rec: pipe.recommendEnabled && t.depth === pipe.recommendedDepth,
         })),
     ];
-    const max = Math.max(...points.map(p => p.mbPerSec), 0.0001);
+    const max = Math.max(...points.map(p => p.megaBytesPerSec), 0.0001);
     return (
         <div className="mt-4">
             <div className="flex h-[150px] items-end gap-2">
                 {points.map((p, i) => {
-                    const height = Math.max(4, Math.round((p.mbPerSec / max) * 104));
+                    const height = Math.max(4, Math.round((p.megaBytesPerSec / max) * 104));
                     return (
                         <div key={i} className="flex min-w-0 flex-1 flex-col items-center gap-1.5">
                             <span className={`font-mono text-[10.5px] tabular-nums whitespace-nowrap ${p.rec ? "font-semibold text-primary" : "text-base-content/45"}`}>
-                                {p.mbPerSec >= 10 ? p.mbPerSec.toFixed(0) : p.mbPerSec.toFixed(1)}
+                                {p.megaBytesPerSec >= 10 ? p.megaBytesPerSec.toFixed(0) : p.megaBytesPerSec.toFixed(1)}
                             </span>
                             <div
                                 className={`w-full max-w-8 rounded-t transition-all duration-200 ease-in-out ${p.rec ? "bg-primary" : "bg-base-content/25"}`}
                                 style={{ height: `${height}px` }}
-                                title={`${p.label} → ${p.mbPerSec.toFixed(1)} MB/s`}
+                                title={`${p.label} → ${p.megaBytesPerSec.toFixed(1)} MB/s`}
                             />
                             <span className={`font-mono text-[11px] tabular-nums ${p.rec ? "font-semibold text-primary" : "text-base-content/45"}`}>
                                 {p.label}

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -108,6 +108,11 @@ if (DEVELOPMENT) {
 
 // Create both the http and websocket servers
 const server = http.createServer(app);
+// Allow long-lived proxied API calls (Usenet speed tests can run for many
+// minutes on large data budgets). Node defaults are 5 minutes / 60s headers.
+const LONG_RUNNING_REQUEST_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
+server.requestTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS;
+server.headersTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS + 1000;
 setWebsocketServer(new WebSocketServer({ server, maxPayload: 64 * 1024 }));
 
 // Begin listening for connections

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -49,10 +49,19 @@ function logProxyFailure(message: string, error: unknown) {
   }
 }
 
+// Speed tests (and some maintenance tasks) can run for many minutes while the
+ // HTTP request stays open. Default intermediary idle/TTFB limits are often ~30s
+ // and would abort those calls with a generic UI error.
+const LONG_RUNNING_PROXY_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
+
 // Proxy all webdav and api requests to the backend
 const forwardToBackend = createProxyMiddleware({
   target: process.env.BACKEND_URL,
   changeOrigin: true,
+  // httpxy only enforces these when set; pin them high so long POSTs (e.g.
+  // /api/benchmark-usenet-connection with a 20 GB budget) are not cut off.
+  proxyTimeout: LONG_RUNNING_PROXY_TIMEOUT_MS,
+  timeout: LONG_RUNNING_PROXY_TIMEOUT_MS,
   on: {
     proxyReq: (proxyReq, req) => {
       applyCanonicalForwardedHeaders(proxyReq, req as express.Request, { trustProxy });

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
@@ -14,9 +14,9 @@ public class BenchmarkMathTests
             (11_000_000, 0.5),
         };
 
-        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(buckets, 0, 0);
+        var (megaBytesPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(buckets, 0, 0);
 
-        Assert.Equal(22, mbPerSec, 6);
+        Assert.Equal(22, megaBytesPerSec, 6);
         Assert.InRange(cv, 0.07, 0.08);
     }
 
@@ -39,10 +39,10 @@ public class BenchmarkMathTests
             (12_000_000, 0.5),
         };
 
-        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
+        var (megaBytesPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
             buckets, fallbackBytes: 9_000_000, fallbackSeconds: 0.5);
 
-        Assert.Equal(18, mbPerSec, 6);
+        Assert.Equal(18, megaBytesPerSec, 6);
         Assert.True(cv >= 0.5);
     }
 
@@ -59,10 +59,10 @@ public class BenchmarkMathTests
             (11_000_000, 0.5),
         };
 
-        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
+        var (megaBytesPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
             buckets, fallbackBytes: 33_000_000, fallbackSeconds: 3.0);
 
-        Assert.Equal(22, mbPerSec, 6);
+        Assert.Equal(22, megaBytesPerSec, 6);
         Assert.InRange(cv, 0.07, 0.08);
     }
 
@@ -79,20 +79,20 @@ public class BenchmarkMathTests
             (1_000, 0.5),
         };
 
-        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
+        var (megaBytesPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
             buckets, fallbackBytes: 30_000_000, fallbackSeconds: 1.5);
 
-        Assert.Equal(20, mbPerSec, 6);
+        Assert.Equal(20, megaBytesPerSec, 6);
         Assert.Equal(0.5, cv);
     }
 
     [Fact]
     public void ComputeSteadyRate_ZeroDurationFallbackReturnsZero()
     {
-        var (mbPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
+        var (megaBytesPerSec, cv) = UsenetBenchmarkService.ComputeSteadyRate(
             [], fallbackBytes: 9_000_000, fallbackSeconds: 0);
 
-        Assert.Equal(0, mbPerSec);
+        Assert.Equal(0, megaBytesPerSec);
         Assert.Equal(1, cv);
     }
 
@@ -187,7 +187,7 @@ public class BenchmarkMathTests
             BudgetLimited = budgetLimited,
             StillClimbing = stillClimbing,
             RecommendedConnections = 1,
-            Sweep = [new BenchmarkSweepPoint { Connections = 1, MbPerSec = 10, Cv = cv }],
+            Sweep = [new BenchmarkSweepPoint { Connections = 1, MegaBytesPerSec = 10, Cv = cv }],
         };
 
         Assert.Equal(expected, UsenetBenchmarkService.ComputeConfidence(result));
@@ -202,9 +202,9 @@ public class BenchmarkMathTests
             RecommendedConnections = 16,
             Sweep =
             [
-                new BenchmarkSweepPoint { Connections = 1, MbPerSec = 10, Cv = 0.8 },
-                new BenchmarkSweepPoint { Connections = 8, MbPerSec = 80, Cv = 0.05 },
-                new BenchmarkSweepPoint { Connections = 16, MbPerSec = 100, Cv = 0.08 },
+                new BenchmarkSweepPoint { Connections = 1, MegaBytesPerSec = 10, Cv = 0.8 },
+                new BenchmarkSweepPoint { Connections = 8, MegaBytesPerSec = 80, Cv = 0.05 },
+                new BenchmarkSweepPoint { Connections = 16, MegaBytesPerSec = 100, Cv = 0.08 },
             ],
         };
 
@@ -220,7 +220,7 @@ public class BenchmarkMathTests
             WrappedPool = true,
             ConfirmDeltaPct = 3,
             RecommendedConnections = 8,
-            Sweep = [new BenchmarkSweepPoint { Connections = 8, MbPerSec = 40, Cv = 0.05 }],
+            Sweep = [new BenchmarkSweepPoint { Connections = 8, MegaBytesPerSec = 40, Cv = 0.05 }],
         };
 
         Assert.Equal("high", UsenetBenchmarkService.ComputeConfidence(result));
@@ -234,7 +234,7 @@ public class BenchmarkMathTests
             ThroughputTested = true,
             ConfirmDeltaPct = 25,
             RecommendedConnections = 8,
-            Sweep = [new BenchmarkSweepPoint { Connections = 8, MbPerSec = 40, Cv = 0.05 }],
+            Sweep = [new BenchmarkSweepPoint { Connections = 8, MegaBytesPerSec = 40, Cv = 0.05 }],
         };
 
         Assert.Equal("medium", UsenetBenchmarkService.ComputeConfidence(result));
@@ -251,8 +251,8 @@ public class BenchmarkMathTests
             RecommendedConnections = 8,
             Sweep =
             [
-                new BenchmarkSweepPoint { Connections = 4, MbPerSec = 38, Cv = 0.05 },
-                new BenchmarkSweepPoint { Connections = 8, MbPerSec = 40, Cv = 0.05 },
+                new BenchmarkSweepPoint { Connections = 4, MegaBytesPerSec = 38, Cv = 0.05 },
+                new BenchmarkSweepPoint { Connections = 8, MegaBytesPerSec = 40, Cv = 0.05 },
             ],
         };
 

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
@@ -111,10 +111,10 @@ public class DetectKneeTests
         Assert.False(stillClimbing);
     }
 
-    private static List<BenchmarkSweepPoint> Sweep(params (int Connections, double MbPerSec)[] points) =>
+    private static List<BenchmarkSweepPoint> Sweep(params (int Connections, double MegaBytesPerSec)[] points) =>
         points.Select(point => new BenchmarkSweepPoint
         {
             Connections = point.Connections,
-            MbPerSec = point.MbPerSec,
+            MegaBytesPerSec = point.MegaBytesPerSec,
         }).ToList();
 }


### PR DESCRIPTION
## Summary
- Rename speed-test rate fields from `MbPerSec` to `MegaBytesPerSec` so identifiers match decimal megabyte throughput; UI labels stay `MB/s`.
- Raise frontend proxy and Node request timeouts to 3 hours so large-budget auto-tune POSTs are not cut off.
- Stop treating HTTP disconnect as cancel; explicit Cancel / modal close aborts the run.
- Deliver the final result on the websocket `done` frame so the UI can finish even if an intermediary drops the long POST (~30s).

## Test plan
- [ ] Run a Thorough speed test with a 20 GB budget and confirm it continues past ~30s with live progress
- [ ] Confirm results appear when the run completes (including if the POST is dropped mid-run)
- [ ] Cancel mid-run and confirm the test stops without a false error
- [ ] Confirm chart/stats still show `MB/s` (not `Mb/s`)
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter Benchmark`