### PR TITLE
fix(usenet): Verify at N connections no longer reports 0 MB/s on fast lines

### DIFF
--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -121,18 +121,28 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             Report("sweep", $"Verifying {vc} connection{(vc == 1 ? "" : "s")}…", 40, result, vc);
             var have = await ladder.EnsureAsync(vc, ct).ConfigureAwait(false);
 
-            var bootstrap = await MeasureThroughputAsync(
-                ladder, pool, Math.Min(profile.PerLevelBytes, Remaining()),
-                profile.WarmupDuration, TimeSpan.FromSeconds(1.5), profile.PerLevelMaxDuration,
-                pipeliningDepth: 0, ct).ConfigureAwait(false);
-            result.DataUsedBytes += bootstrap.Bytes;
-
-            Report("sweep", $"Measuring {have} connection{(have == 1 ? "" : "s")}…", 65, result, have);
+            // Size the target for this concurrency from the start. A fixed PerLevelBytes
+            // bootstrap (e.g. 20 MB) finishes during warmup on fast lines at high
+            // connection counts, leaving a 0 MB/s measure window.
             var sample = await MeasureThroughputAsync(
-                ladder, pool, AdaptiveTargetBytes(bootstrap.MegaBytesPerSec, profile, Remaining(), have),
+                ladder, pool, AdaptiveTargetBytes(0, profile, Remaining(), have),
                 profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
                 pipeliningDepth: 0, ct).ConfigureAwait(false);
             result.DataUsedBytes += sample.Bytes;
+
+            if (sample.ExhaustedDuringWarmup
+                && sample.MegaBytesPerSec > 0
+                && Remaining() > MinUsefulBytes(sample.MegaBytesPerSec, profile))
+            {
+                Report("sweep", $"Re-measuring {have} connection{(have == 1 ? "" : "s")}…", 65, result, have);
+                var retry = await MeasureThroughputAsync(
+                    ladder, pool, AdaptiveTargetBytes(sample.MegaBytesPerSec, profile, Remaining(), have),
+                    profile.WarmupDuration, profile.MeasureWindow, profile.PerLevelMaxDuration,
+                    pipeliningDepth: 0, ct).ConfigureAwait(false);
+                result.DataUsedBytes += retry.Bytes;
+                if (retry.MegaBytesPerSec > 0)
+                    sample = retry;
+            }
 
             result.Sweep.Add(new BenchmarkSweepPoint
             {
@@ -140,10 +150,16 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 MegaBytesPerSec = Math.Round(sample.MegaBytesPerSec, 2),
                 Cv = Math.Round(sample.Cv, 3),
             });
-            result.RecommendedConnections = have;
+            result.RecommendedConnections = have > 0 ? have : vc;
             result.VerificationRun = true;
-            if (have < vc)
+            if (have == 0)
+                result.Warnings.Add("Could not open any connections for the verification run.");
+            else if (have < vc)
                 result.Warnings.Add($"Only {have} of {vc} connections could be opened for the verification run.");
+            if (sample.MegaBytesPerSec < 0.5)
+                result.Warnings.Add(
+                    "Verification measured almost no throughput. The line may have been busy, or the test " +
+                    "article pool was exhausted — try again when idle, or re-run a full speed test.");
         }
         else
         {

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -938,6 +938,9 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
 
         // Progress + terminal result over the websocket. The POST may be dropped by
         // an intermediary timeout on large budgets; the done frame still finishes the UI.
+        // Ignore a replayed previous "done" (state topics resend lastMessage on subscribe)
+        // until we've seen live progress from this run.
+        let sawLiveProgress = false;
         unsubscribeProgress = subscribeWebsocketTopics(
             { bench: "state" },
             (topic, message) => {
@@ -945,9 +948,11 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                 try {
                     const update = JSON.parse(message) as BenchmarkProgress;
                     if (update.phase === "done") {
+                        if (!sawLiveProgress) return;
                         finish(update.result ?? null, update.error ?? null);
                         return;
                     }
+                    sawLiveProgress = true;
                     setBenchmarkProgress(update);
                 } catch { /* ignore malformed progress */ }
             },
@@ -1585,12 +1590,27 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                         )
                     ) : result.verificationRun && result.sweep[0] ? (
                         <div className="mt-4 text-sm leading-relaxed text-base-content/80">
-                            Verified: <strong className="font-semibold text-base-content">
-                                {result.sweep[0].megaBytesPerSec} MB/s
-                            </strong>{" "}
-                            at <strong className="font-semibold text-base-content">
-                                {result.sweep[0].connections} connection{result.sweep[0].connections === 1 ? "" : "s"}
-                            </strong>.
+                            {result.sweep[0].megaBytesPerSec < 0.5 ? (
+                                <>
+                                    Verification at <strong className="font-semibold text-base-content">
+                                        {result.sweep[0].connections} connection{result.sweep[0].connections === 1 ? "" : "s"}
+                                    </strong>{" "}
+                                    didn’t measure usable throughput
+                                    {result.sweep[0].megaBytesPerSec > 0
+                                        ? <> (<strong className="font-semibold text-base-content">{result.sweep[0].megaBytesPerSec} MB/s</strong>)</>
+                                        : null}
+                                    . Re-run when idle, or run a full speed test again.
+                                </>
+                            ) : (
+                                <>
+                                    Verified: <strong className="font-semibold text-base-content">
+                                        {result.sweep[0].megaBytesPerSec} MB/s
+                                    </strong>{" "}
+                                    at <strong className="font-semibold text-base-content">
+                                        {result.sweep[0].connections} connection{result.sweep[0].connections === 1 ? "" : "s"}
+                                    </strong>.
+                                </>
+                            )}
                         </div>
                     ) : result.throughputTested && recommended ? (
                         <div className="stats stats-vertical mt-4 w-full max-w-full border border-base-content/10 bg-base-300 sm:stats-horizontal">


### PR DESCRIPTION
## Summary
- Size the verify-at-N byte target for connection count (and retry on warmup exhaustion) so fast lines no longer finish the budget during warmup and record 0 MB/s.
- Ignore a replayed websocket `done` from the previous run until live progress arrives for the new run.
- Show a clear failure message instead of “Verified: 0 MB/s” when verification measures no usable throughput.

## Test plan
- [ ] Run a Thorough auto-tune on a fast provider (e.g. 20 GB) and note the recommended connection count
- [ ] Click **Verify at N connections** and confirm progress appears and a non-zero MB/s result is reported
- [ ] Confirm a second Verify still works (no immediate finish from a stale websocket `done`)
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter Benchmark`