### PR TITLE
chore: auto-set labels and issue types on bug and feature forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,8 @@
 name: Bug report
 description: Report a reproducible problem in NzbDav
 title: "[Bug]: "
+labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,8 @@
 name: Feature request
 description: Suggest an improvement to NzbDav
 title: "[Feature]: "
+labels: ["enhancement"]
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
- Bug reports from the issue form now get the `bug` label and `Bug` issue type
- Feature requests now get the `enhancement` label and `Feature` issue type
- Validated both templates against SchemaStore `github-issue-forms.json`

## Test plan
- [ ] Open a new Bug report via the template chooser and confirm label `bug` and type `Bug` are pre-applied
- [ ] Open a new Feature request and confirm label `enhancement` and type `Feature` are pre-applied