### PR TITLE
feat(ui): reset Overview statistics (all or per provider) from Maintenance settings

### DIFF
--- a/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsController.cs
+++ b/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsController.cs
@@ -27,26 +27,45 @@ public class ClearOverviewStatsController(
                 p.ProviderId != Guid.Empty && UsenetProviderIdentity.MetricsKey(p) == providerKey))
             throw new BadHttpRequestException("Unknown provider");
 
-        // 1. Preserve data-cap gauges before the tracker and ProviderHourly are zeroed.
+        // 1. Snapshot usage before clearing the tracker so the data-cap gauge
+        //    can be preserved after ResetCounters without double-counting.
+        var usageSnapshot = OverviewStatsReset.SnapshotUsage(providerConfig, bytesTracker, providerKey);
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        if (OverviewStatsReset.FoldUsageIntoOffsets(providerConfig, bytesTracker, nowMs, providerKey))
-            await UsenetProviderIdentity.SaveProvidersAsync(configManager, providerConfig, ct)
-                .ConfigureAwait(false);
 
-        // 2. Drop unflushed rows so they don't reappear after the wipe.
-        if (providerKey == null) metricsWriter.DiscardQueuedAndResetStats();
-        else metricsWriter.DiscardQueuedForProvider(providerKey);
+        // 2. Pause flushes and abandon any in-flight drained batch, then drop
+        //    queued rows so they cannot reappear after the wipe.
+        metricsWriter.BeginReset();
+        try
+        {
+            if (providerKey == null) metricsWriter.DiscardQueuedAndResetStats();
+            else metricsWriter.DiscardQueuedForProvider(providerKey);
 
-        // 3. Wipe metrics tables (all, or provider-keyed rows only).
-        await using var db = new MetricsDbContext();
-        var deletedRows = providerKey == null
-            ? await OverviewStatsReset.WipeAsync(db, ct).ConfigureAwait(false)
-            : await OverviewStatsReset.WipeProviderAsync(db, providerKey, ct).ConfigureAwait(false);
+            // 3. Wipe metrics tables (all, or provider-keyed rows only).
+            await using var db = new MetricsDbContext();
+            var deletedRows = providerKey == null
+                ? await OverviewStatsReset.WipeAsync(db, ct).ConfigureAwait(false)
+                : await OverviewStatsReset.WipeProviderAsync(db, providerKey, ct).ConfigureAwait(false);
 
-        // 4. Zero in-memory lifetime counters and pending minute buckets.
-        if (providerKey == null) bytesTracker.ResetCounters();
-        else bytesTracker.ResetProvider(providerKey);
+            // 4. Zero in-memory lifetime counters and pending minute buckets.
+            if (providerKey == null) bytesTracker.ResetCounters();
+            else bytesTracker.ResetProvider(providerKey);
 
-        return Ok(new ClearOverviewStatsResponse { Status = true, DeletedRows = deletedRows });
+            // 5. Fold the pre-wipe usage snapshot into BytesUsedOffset and
+            //    persist. Done after the wipe so SeedTrackerAsync cannot read
+            //    stale ProviderHourly rows or double-count live tracker bytes.
+            if (OverviewStatsReset.FoldUsageIntoOffsets(providerConfig, usageSnapshot, nowMs, providerKey))
+                await UsenetProviderIdentity.SaveProvidersAsync(configManager, providerConfig, ct)
+                    .ConfigureAwait(false);
+
+            // 6. Drop anything enqueued during the wipe window.
+            if (providerKey == null) metricsWriter.DiscardQueuedAndResetStats();
+            else metricsWriter.DiscardQueuedForProvider(providerKey);
+
+            return Ok(new ClearOverviewStatsResponse { Status = true, DeletedRows = deletedRows });
+        }
+        finally
+        {
+            metricsWriter.EndReset();
+        }
     }
 }

--- a/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsController.cs
+++ b/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsController.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Api.Controllers.ClearOverviewStats;
+
+[ApiController]
+[Route("api/clear-overview-stats")]
+public class ClearOverviewStatsController(
+    ConfigManager configManager,
+    MetricsWriter metricsWriter,
+    ProviderBytesTracker bytesTracker
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var ct = HttpContext.RequestAborted;
+        var request = new ClearOverviewStatsRequest(HttpContext);
+        var providerKey = request.ProviderKey;
+
+        // Validate the key against configured providers so a stale UI cannot
+        // silently no-op (deleted providers require a full reset instead).
+        var providerConfig = configManager.GetUsenetProviderConfig();
+        if (providerKey != null && !providerConfig.Providers.Any(p =>
+                p.ProviderId != Guid.Empty && UsenetProviderIdentity.MetricsKey(p) == providerKey))
+            throw new BadHttpRequestException("Unknown provider");
+
+        // 1. Preserve data-cap gauges before the tracker and ProviderHourly are zeroed.
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (OverviewStatsReset.FoldUsageIntoOffsets(providerConfig, bytesTracker, nowMs, providerKey))
+            await UsenetProviderIdentity.SaveProvidersAsync(configManager, providerConfig, ct)
+                .ConfigureAwait(false);
+
+        // 2. Drop unflushed rows so they don't reappear after the wipe.
+        if (providerKey == null) metricsWriter.DiscardQueuedAndResetStats();
+        else metricsWriter.DiscardQueuedForProvider(providerKey);
+
+        // 3. Wipe metrics tables (all, or provider-keyed rows only).
+        await using var db = new MetricsDbContext();
+        var deletedRows = providerKey == null
+            ? await OverviewStatsReset.WipeAsync(db, ct).ConfigureAwait(false)
+            : await OverviewStatsReset.WipeProviderAsync(db, providerKey, ct).ConfigureAwait(false);
+
+        // 4. Zero in-memory lifetime counters and pending minute buckets.
+        if (providerKey == null) bytesTracker.ResetCounters();
+        else bytesTracker.ResetProvider(providerKey);
+
+        return Ok(new ClearOverviewStatsResponse { Status = true, DeletedRows = deletedRows });
+    }
+}

--- a/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsRequest.cs
+++ b/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsRequest.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.Controllers.ClearOverviewStats;
+
+public class ClearOverviewStatsRequest
+{
+    /// <summary>Metrics key (ProviderId "N" format) or null for a full reset.</summary>
+    public string? ProviderKey { get; }
+
+    public ClearOverviewStatsRequest(HttpContext context)
+    {
+        var raw = context.GetQueryParam("provider");
+        ProviderKey = string.IsNullOrWhiteSpace(raw) ? null : raw;
+    }
+}

--- a/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/ClearOverviewStats/ClearOverviewStatsResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.Controllers.ClearOverviewStats;
+
+public class ClearOverviewStatsResponse : BaseApiResponse
+{
+    [JsonPropertyName("deletedRows")]
+    public required int DeletedRows { get; init; }
+}

--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
@@ -33,6 +33,9 @@ public class GetProviderUsageController(
                     Index = index,
                     Host = provider.Host,
                     Nickname = provider.Nickname,
+                    ProviderId = provider.ProviderId == Guid.Empty
+                        ? null
+                        : UsenetProviderIdentity.MetricsKey(provider),
                     BytesUsed = used,
                     ByteLimit = provider.ByteLimit,
                     OverLimit = ProviderUsageHelper.IsOverLimit(bytesTracker, provider),

--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageResponse.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageResponse.cs
@@ -12,6 +12,11 @@ public class GetProviderUsageResponse : BaseApiResponse
         public int Index { get; set; }
         public string Host { get; set; } = string.Empty;
         public string? Nickname { get; set; }
+        /// <summary>
+        /// Stable metrics key (<c>ProviderId</c> in "N" format). Null when the
+        /// provider has not yet been assigned an id.
+        /// </summary>
+        public string? ProviderId { get; set; }
         public long BytesUsed { get; set; }
         public long? ByteLimit { get; set; }
         public bool OverLimit { get; set; }

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -35,7 +35,9 @@ public static class UsenetProviderIdentity
 
         try
         {
-            await PersistProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);
+            await SaveProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);
+            Log.Information("Assigned and persisted ProviderId for {Count} usenet provider(s).",
+                providerConfig.Providers.Count);
         }
         catch (Exception ex)
         {
@@ -94,7 +96,12 @@ public static class UsenetProviderIdentity
         }
     }
 
-    private static async Task PersistProvidersAsync(
+    /// <summary>
+    /// Persists the full usenet.providers config item and refreshes
+    /// <see cref="ConfigManager"/>. Used after assigning ProviderIds and after
+    /// folding usage into BytesUsedOffset during an overview-stats reset.
+    /// </summary>
+    public static async Task SaveProvidersAsync(
         ConfigManager configManager,
         UsenetProviderConfig providerConfig,
         CancellationToken ct)
@@ -120,8 +127,6 @@ public static class UsenetProviderIdentity
 
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
         configManager.UpdateValues([item]);
-        Log.Information("Assigned and persisted ProviderId for {Count} usenet provider(s).",
-            providerConfig.Providers.Count);
     }
 
     public static async Task RemapHostKeyedMetricsAsync(

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -20,6 +20,9 @@ namespace NzbWebDAV.Services.Metrics;
 /// Drop policy: if a queue grows past MaxQueueLength (10 000) new entries are
 /// dropped to protect the process. Drops are counted on the public Stats so
 /// the dashboard can surface metric-system health.
+///
+/// Overview-stats reset uses <see cref="BeginReset"/> / <see cref="EndReset"/>
+/// so an in-flight flush cannot re-insert drained rows after the wipe.
 /// </summary>
 public class MetricsWriter : BackgroundService
 {
@@ -40,6 +43,11 @@ public class MetricsWriter : BackgroundService
     private long _lastFlushLagMs;
     private long _lastSuccessfulFlushAtMs;
     private string? _lastFlushError;
+
+    // Bumped by BeginReset. An in-flight FlushAsync that drained before the bump
+    // must abandon its batch (no write, no requeue) so wiped rows cannot return.
+    private int _resetGeneration;
+    private int _resetting;
 
     public MetricsWriter() : this(static () => new MetricsDbContext())
     {
@@ -63,6 +71,25 @@ public class MetricsWriter : BackgroundService
         LastSuccessfulFlushAtMs: Interlocked.Read(ref _lastSuccessfulFlushAtMs),
         LastFlushError: Volatile.Read(ref _lastFlushError)
     );
+
+    /// <summary>
+    /// Marks the start of an overview-stats reset. Increments the generation so
+    /// any in-flight flush abandons its drained batch, and pauses new flushes
+    /// until <see cref="EndReset"/>.
+    /// </summary>
+    public void BeginReset()
+    {
+        Interlocked.Increment(ref _resetGeneration);
+        Interlocked.Exchange(ref _resetting, 1);
+    }
+
+    /// <summary>
+    /// Ends an overview-stats reset and allows flushes to resume.
+    /// </summary>
+    public void EndReset()
+    {
+        Interlocked.Exchange(ref _resetting, 0);
+    }
 
     public void RecordFetch(SegmentFetch f)
     {
@@ -133,6 +160,12 @@ public class MetricsWriter : BackgroundService
         var deadline = DateTime.UtcNow + FlushInterval;
         while (DateTime.UtcNow < deadline)
         {
+            if (Volatile.Read(ref _resetting) != 0)
+            {
+                await Task.Delay(100, stoppingToken).ConfigureAwait(false);
+                continue;
+            }
+
             if (_fetches.Count >= FlushThreshold ||
                 _events.Count >= FlushThreshold ||
                 _sessions.Count >= FlushThreshold ||
@@ -144,11 +177,27 @@ public class MetricsWriter : BackgroundService
 
     private async Task FlushAsync()
     {
+        // While a reset is in progress, drain+drop so we never write or hold
+        // a batch that could race the wipe. Callers discard queues explicitly too.
+        if (Volatile.Read(ref _resetting) != 0)
+        {
+            Drain(_fetches);
+            Drain(_events);
+            Drain(_sessions);
+            Drain(_failoverMisses);
+            return;
+        }
+
+        var generation = Volatile.Read(ref _resetGeneration);
         var fetches = Drain(_fetches);
         var events = Drain(_events);
         var sessions = Drain(_sessions);
         var failoverMisses = Drain(_failoverMisses);
         if (fetches.Count == 0 && events.Count == 0 && sessions.Count == 0 && failoverMisses.Count == 0) return;
+
+        // BeginReset ran between the pause check and Drain — abandon.
+        if (Volatile.Read(ref _resetGeneration) != generation || Volatile.Read(ref _resetting) != 0)
+            return;
 
         var started = DateTime.UtcNow;
         try
@@ -161,6 +210,10 @@ public class MetricsWriter : BackgroundService
             if (sessions.Count > 0) db.ReadSessions.AddRange(sessions);
             if (failoverMisses.Count > 0) db.FailoverMisses.AddRange(failoverMisses);
 
+            // Reset began while we held the drained batch — roll back and drop it.
+            if (Volatile.Read(ref _resetGeneration) != generation || Volatile.Read(ref _resetting) != 0)
+                return;
+
             await db.SaveChangesAsync().ConfigureAwait(false);
             await tx.CommitAsync().ConfigureAwait(false);
 
@@ -171,10 +224,15 @@ public class MetricsWriter : BackgroundService
         }
         catch (Exception ex)
         {
-            Requeue(_fetches, fetches);
-            Requeue(_events, events);
-            Requeue(_sessions, sessions);
-            Requeue(_failoverMisses, failoverMisses);
+            // Only requeue if this flush still belongs to the current generation.
+            // A reset that started mid-flush must not resurrect wiped rows.
+            if (Volatile.Read(ref _resetGeneration) == generation && Volatile.Read(ref _resetting) == 0)
+            {
+                Requeue(_fetches, fetches);
+                Requeue(_events, events);
+                Requeue(_sessions, sessions);
+                Requeue(_failoverMisses, failoverMisses);
+            }
             Interlocked.Exchange(ref _lastFlushError, ex.GetBaseException().Message);
             throw;
         }

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -195,6 +195,48 @@ public class MetricsWriter : BackgroundService
 
     internal Task FlushNowAsync() => FlushAsync();
 
+    /// <summary>
+    /// Drops all queued-but-unflushed rows and zeroes the drop/flush health
+    /// counters. Used by the overview-stats reset so stale rows don't reappear
+    /// on the next flush tick.
+    /// </summary>
+    public void DiscardQueuedAndResetStats()
+    {
+        while (_fetches.TryDequeue(out _)) { }
+        while (_events.TryDequeue(out _)) { }
+        while (_sessions.TryDequeue(out _)) { }
+        while (_failoverMisses.TryDequeue(out _)) { }
+        Interlocked.Exchange(ref _droppedFetches, 0);
+        Interlocked.Exchange(ref _droppedEvents, 0);
+        Interlocked.Exchange(ref _droppedSessions, 0);
+        Interlocked.Exchange(ref _droppedFailoverMisses, 0);
+        Volatile.Write(ref _lastFlushError, null);
+    }
+
+    /// <summary>
+    /// Drops queued rows belonging to one provider (fetches and failover misses;
+    /// events and sessions are not provider-keyed). Drop counters are untouched.
+    /// </summary>
+    public void DiscardQueuedForProvider(string providerKey)
+    {
+        FilterQueue(_fetches, f => !string.Equals(f.Provider, providerKey, StringComparison.Ordinal));
+        FilterQueue(_failoverMisses, m =>
+            !string.Equals(m.FromProvider, providerKey, StringComparison.Ordinal)
+            && !string.Equals(m.ToProvider, providerKey, StringComparison.Ordinal));
+    }
+
+    private static void FilterQueue<T>(ConcurrentQueue<T> queue, Func<T, bool> keep)
+    {
+        // One pass over the current length: concurrent enqueues during the loop
+        // are newer entries and are simply kept.
+        var count = queue.Count;
+        for (var i = 0; i < count; i++)
+        {
+            if (!queue.TryDequeue(out var item)) break;
+            if (keep(item)) queue.Enqueue(item);
+        }
+    }
+
     public record MetricsStats(
         int QueuedFetches,
         int QueuedEvents,

--- a/backend/Services/Metrics/OverviewStatsReset.cs
+++ b/backend/Services/Metrics/OverviewStatsReset.cs
@@ -18,22 +18,44 @@ public static class OverviewStatsReset
     internal static int SegmentFetchDeleteBatchSize { get; set; } = 50_000;
 
     /// <summary>
-    /// Preserves the per-provider data-cap gauge across the wipe:
-    /// gauge = live tracker bytes + BytesUsedOffset, so folding the current
-    /// usage into the offset keeps the displayed value stable once the
-    /// tracker and ProviderHourly are zeroed. When providerKey is given,
-    /// only matching config entries are folded. Returns true when any
-    /// provider changed.
+    /// Captures the current user-facing usage (tracker lifetime + offset) for
+    /// each provider before the tracker is cleared. Keys are metrics keys.
+    /// </summary>
+    public static Dictionary<string, long> SnapshotUsage(
+        UsenetProviderConfig config, ProviderBytesTracker tracker, string? providerKey = null)
+    {
+        var snapshot = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (var provider in config.Providers)
+        {
+            if (provider.ProviderId == Guid.Empty) continue;
+            var key = UsenetProviderIdentity.MetricsKey(provider);
+            if (providerKey != null && key != providerKey) continue;
+            snapshot[key] = ProviderUsageHelper.ComputeUsage(tracker, provider);
+        }
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Preserves the per-provider data-cap gauge across the wipe by writing a
+    /// pre-captured usage snapshot into BytesUsedOffset. Call this after the
+    /// tracker has been cleared so SeedTrackerAsync cannot double-count.
+    /// When providerKey is given, only matching config entries are folded.
+    /// Returns true when any provider changed.
     /// </summary>
     public static bool FoldUsageIntoOffsets(
-        UsenetProviderConfig config, ProviderBytesTracker tracker, long nowMs, string? providerKey = null)
+        UsenetProviderConfig config,
+        IReadOnlyDictionary<string, long> usageByMetricsKey,
+        long nowMs,
+        string? providerKey = null)
     {
         var changed = false;
         foreach (var provider in config.Providers)
         {
             if (provider.ProviderId == Guid.Empty) continue;
-            if (providerKey != null && UsenetProviderIdentity.MetricsKey(provider) != providerKey) continue;
-            var usage = ProviderUsageHelper.ComputeUsage(tracker, provider);
+            var key = UsenetProviderIdentity.MetricsKey(provider);
+            if (providerKey != null && key != providerKey) continue;
+            if (!usageByMetricsKey.TryGetValue(key, out var usage))
+                usage = provider.BytesUsedOffset;
             if (usage == provider.BytesUsedOffset && provider.BytesUsedResetAt == nowMs) continue;
             provider.BytesUsedOffset = usage;
             provider.BytesUsedResetAt = nowMs;

--- a/backend/Services/Metrics/OverviewStatsReset.cs
+++ b/backend/Services/Metrics/OverviewStatsReset.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+
+namespace NzbWebDAV.Services.Metrics;
+
+/// <summary>
+/// Shared helpers for wiping overview/metrics statistics while preserving
+/// per-provider data-cap gauges. Used by <c>ClearOverviewStatsController</c>.
+/// </summary>
+public static class OverviewStatsReset
+{
+    /// <summary>
+    /// Batch size for chunked SegmentFetches deletes in the per-provider path.
+    /// Exposed for tests so they can prove the loop drains without seeding
+    /// 50k rows.
+    /// </summary>
+    internal static int SegmentFetchDeleteBatchSize { get; set; } = 50_000;
+
+    /// <summary>
+    /// Preserves the per-provider data-cap gauge across the wipe:
+    /// gauge = live tracker bytes + BytesUsedOffset, so folding the current
+    /// usage into the offset keeps the displayed value stable once the
+    /// tracker and ProviderHourly are zeroed. When providerKey is given,
+    /// only matching config entries are folded. Returns true when any
+    /// provider changed.
+    /// </summary>
+    public static bool FoldUsageIntoOffsets(
+        UsenetProviderConfig config, ProviderBytesTracker tracker, long nowMs, string? providerKey = null)
+    {
+        var changed = false;
+        foreach (var provider in config.Providers)
+        {
+            if (provider.ProviderId == Guid.Empty) continue;
+            if (providerKey != null && UsenetProviderIdentity.MetricsKey(provider) != providerKey) continue;
+            var usage = ProviderUsageHelper.ComputeUsage(tracker, provider);
+            if (usage == provider.BytesUsedOffset && provider.BytesUsedResetAt == nowMs) continue;
+            provider.BytesUsedOffset = usage;
+            provider.BytesUsedResetAt = nowMs;
+            changed = true;
+        }
+        return changed;
+    }
+
+    /// <summary>
+    /// Deletes every row from all metrics tables. Each unfiltered
+    /// ExecuteDeleteAsync emits a plain "DELETE FROM t" which hits SQLite's
+    /// truncate optimization, so this stays fast on multi-GB databases.
+    /// Freed pages are reclaimed by the retention service's hourly
+    /// incremental_vacuum; vacuuming here would be the slow part.
+    /// Returns total rows deleted.
+    /// </summary>
+    public static async Task<int> WipeAsync(MetricsDbContext db, CancellationToken ct)
+    {
+        var deleted = 0;
+        deleted += await db.SegmentFetches.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ReadSessions.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.MetricEvents.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ThroughputMinutes.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ProviderMinutes.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ProviderHourly.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.FailoverMisses.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.FailoverHourly.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.CatalogueDaily.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        return deleted;
+    }
+
+    /// <summary>
+    /// Deletes rows attributable to one provider. Global rollups
+    /// (ThroughputMinutes, ReadSessions, MetricEvents, CatalogueDaily) are
+    /// left intact because their rows cannot be split by provider.
+    /// Deletes commit per statement (and per batch for SegmentFetches), so a
+    /// cancelled run is harmless and re-running completes the remainder.
+    /// </summary>
+    public static async Task<int> WipeProviderAsync(MetricsDbContext db, string providerKey, CancellationToken ct)
+    {
+        // SegmentFetches is the only potentially huge provider-keyed table
+        // (24h of raw rows). Chunked deletes keep each write transaction
+        // short so concurrent MetricsWriter flushes never exhaust their
+        // 5s busy_timeout behind us.
+        var deleted = 0;
+        var batchSize = Math.Max(1, SegmentFetchDeleteBatchSize);
+        int batch;
+        do
+        {
+            batch = await db.Database.ExecuteSqlRawAsync(
+                """
+                DELETE FROM SegmentFetches WHERE rowid IN
+                    (SELECT rowid FROM SegmentFetches WHERE Provider = {0} LIMIT {1})
+                """,
+                new object[] { providerKey, batchSize }, ct).ConfigureAwait(false);
+            deleted += batch;
+        } while (batch > 0);
+
+        deleted += await db.ProviderMinutes
+            .Where(x => x.Provider == providerKey).ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ProviderHourly
+            .Where(x => x.Provider == providerKey).ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.FailoverMisses
+            .Where(x => x.FromProvider == providerKey || x.ToProvider == providerKey)
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.FailoverHourly
+            .Where(x => x.FromProvider == providerKey || x.ToProvider == providerKey)
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        return deleted;
+    }
+}

--- a/backend/Services/Metrics/ProviderBytesTracker.cs
+++ b/backend/Services/Metrics/ProviderBytesTracker.cs
@@ -86,6 +86,34 @@ public sealed class ProviderBytesTracker
         return drained;
     }
 
+    /// <summary>
+    /// Clears pending minute buckets and all lifetime counters. Used by the
+    /// overview-stats reset after usage has been folded into BytesUsedOffset.
+    /// Speed EWMAs are kept: they drive failover heuristics, not statistics.
+    /// </summary>
+    public void ResetCounters()
+    {
+        _buckets.Clear();
+        _lifetime.Clear();
+        Interlocked.Exchange(ref _lifetimeAll, 0);
+    }
+
+    /// <summary>
+    /// Clears one provider's pending buckets and lifetime counter, and deducts
+    /// its share from the all-time total. Unlike SetLifetime (config-change
+    /// rehydration), this is a deliberate stats reset, so the overview tile
+    /// dropping is the intended outcome.
+    /// </summary>
+    public void ResetProvider(string providerKey)
+    {
+        if (string.IsNullOrEmpty(providerKey)) return;
+        foreach (var key in _buckets.Keys)
+            if (key.ProviderKey == providerKey)
+                _buckets.TryRemove(key, out _);
+        if (_lifetime.TryRemove(providerKey, out var removed))
+            Interlocked.Add(ref _lifetimeAll, -removed);
+    }
+
     private static long NowMinute()
     {
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -220,6 +220,14 @@ class BackendClient {
         };
     }
 
+    public async clearOverviewStats(providerId?: string): Promise<number> {
+        const query = providerId ? `?provider=${encodeURIComponent(providerId)}` : "";
+        const data = await call(`/api/clear-overview-stats${query}`, "Failed to clear overview statistics", {
+            method: "POST",
+        });
+        return data.deletedRows ?? 0;
+    }
+
     public async getHealthCheckHistory(pageSize?: number): Promise<HealthCheckHistoryResponse> {
         const query = pageSize !== undefined ? `?pageSize=${pageSize}` : "";
         return await call(`/api/get-health-check-history${query}`, "Failed to get health check history", {

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -8,6 +8,7 @@ import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
 import { RecreateStrmFiles } from "./recreate-strm-files/recreate-strm-files";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
 import { ResetHealthCheckStats } from "./reset-health-check-stats/reset-health-check-stats";
+import { ResetOverviewStats } from "./reset-overview-stats/reset-overview-stats";
 
 type MaintenanceProps = {
     savedConfig: Record<string, string>,
@@ -244,7 +245,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                             Run repair, migration, and destructive cleanup tools on demand.
                         </p>
                     </div>
-                    <span className="badge badge-ghost badge-sm shrink-0">6 tools</span>
+                    <span className="badge badge-ghost badge-sm shrink-0">7 tools</span>
                 </div>
                 <div className="space-y-3">
                     <MaintenanceTaskDetails title="Remove Orphaned Files">
@@ -264,6 +265,9 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                     </MaintenanceTaskDetails>
                     <MaintenanceTaskDetails title="Reset Health-Check Statistics">
                         <ResetHealthCheckStats />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Reset Overview Statistics">
+                        <ResetOverviewStats />
                     </MaintenanceTaskDetails>
                 </div>
             </section>

--- a/frontend/app/routes/settings/maintenance/reset-overview-stats/reset-overview-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-overview-stats/reset-overview-stats.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/feedback";
+import { Select } from "~/components/ui/form";
+import { Icon } from "~/components/ui/icon";
+
+type ProviderOption = { providerId: string; label: string };
+
+export function ResetOverviewStats() {
+    const [isRunning, setIsRunning] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [providers, setProviders] = useState<ProviderOption[]>([]);
+    const [target, setTarget] = useState<string>(""); // "" = all providers
+
+    useEffect(() => {
+        let cancelled = false;
+        fetch("/api/get-provider-usage")
+            .then(r => (r.ok ? r.json() : Promise.reject()))
+            .then(data => {
+                if (cancelled) return;
+                setProviders(
+                    (data.providers ?? [])
+                        .filter((p: { providerId?: string }) => p.providerId)
+                        .map((p: { providerId: string; host: string; nickname?: string }) => ({
+                            providerId: p.providerId,
+                            label: p.nickname?.trim() || p.host,
+                        }))
+                );
+            })
+            .catch(() => {
+                /* selector falls back to "All providers" only */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const onReset = useCallback(async () => {
+        const targetLabel = providers.find(p => p.providerId === target)?.label;
+        const prompt = target
+            ? `Reset Overview statistics for "${targetLabel}"? Its scoreboard, ` +
+              "latency, and failover data will be permanently removed. Global " +
+              "throughput charts and session history are unaffected. " +
+              "This cannot be undone."
+            : "Reset all Overview statistics? Throughput history, provider " +
+              "scoreboard, sessions, failover and latency data will be " +
+              "permanently removed. Queue, history, and provider data-cap " +
+              "gauges are not affected. This cannot be undone.";
+        if (!window.confirm(prompt)) return;
+
+        setIsRunning(true);
+        setMessage(null);
+        setError(null);
+        try {
+            const url = target
+                ? `/api/clear-overview-stats?provider=${encodeURIComponent(target)}`
+                : "/api/clear-overview-stats";
+            const response = await fetch(url, { method: "POST" });
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                throw new Error(body.error || `Request failed (${response.status})`);
+            }
+            const data = await response.json();
+            setMessage(`Reset complete. Removed ${data.deletedRows ?? 0} metric row(s).`);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to reset Overview statistics.");
+        } finally {
+            setIsRunning(false);
+        }
+    }, [target, providers]);
+
+    return (
+        <div className="space-y-4">
+            <Alert className="alert-soft items-start py-3 text-sm" variant="warning">
+                <Icon name="warning" className="!text-[20px]" />
+                <div>
+                    <p className="font-semibold">This cannot be undone</p>
+                    <p className="mt-0.5 text-xs opacity-80">
+                        Overview metrics are permanently removed. Queue, history, and
+                        provider data-cap gauges are preserved. A per-provider reset
+                        leaves global throughput charts and session history intact.
+                    </p>
+                </div>
+            </Alert>
+
+            <p className="text-sm leading-relaxed text-base-content/70">
+                Clear Overview statistics for all providers or a single provider.
+                May take a few moments on large databases.
+            </p>
+
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="reset-overview-stats-provider">
+                    Scope
+                </label>
+                <Select
+                    id="reset-overview-stats-provider"
+                    className="w-full max-w-md"
+                    value={target}
+                    disabled={isRunning}
+                    onChange={e => setTarget(e.target.value)}
+                >
+                    <option value="">All providers (full reset)</option>
+                    {providers.map(p => (
+                        <option key={p.providerId} value={p.providerId}>
+                            {p.label}
+                        </option>
+                    ))}
+                </Select>
+            </div>
+
+            <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <Button
+                        type="button"
+                        variant={isRunning ? "secondary" : "danger"}
+                        disabled={isRunning}
+                        className="shrink-0"
+                        onClick={onReset}
+                    >
+                        <Icon
+                            name={isRunning ? "progress_activity" : "delete_sweep"}
+                            className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`}
+                        />
+                        {isRunning ? "Resetting..." : "Reset Statistics"}
+                    </Button>
+                    <div
+                        aria-live="polite"
+                        className={`min-w-0 break-words font-mono text-xs ${
+                            error
+                                ? "text-error"
+                                : message
+                                    ? "text-success"
+                                    : "text-base-content/70"
+                        }`}
+                    >
+                        {error ?? message ?? "Ready to reset."}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
@@ -192,7 +192,7 @@ public class OverviewStatsResetTests
     }
 
     [Fact]
-    public void FoldUsageIntoOffsets_FoldsTrackerAndOffset()
+    public void FoldUsageIntoOffsets_FoldsSnapshotAndOffset()
     {
         var providerId = Guid.NewGuid();
         var key = UsenetProviderIdentity.MetricsKey(providerId);
@@ -206,7 +206,10 @@ public class OverviewStatsResetTests
             ],
         };
 
-        var changed = OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 99);
+        var snapshot = OverviewStatsReset.SnapshotUsage(config, tracker);
+        tracker.ResetCounters(); // fold must use the snapshot, not the cleared tracker
+
+        var changed = OverviewStatsReset.FoldUsageIntoOffsets(config, snapshot, nowMs: 99);
 
         Assert.True(changed);
         Assert.Equal(1_250, config.Providers[0].BytesUsedOffset);
@@ -232,7 +235,8 @@ public class OverviewStatsResetTests
             ],
         };
 
-        var changed = OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 50, providerKey: aKey);
+        var snapshot = OverviewStatsReset.SnapshotUsage(config, tracker, providerKey: aKey);
+        var changed = OverviewStatsReset.FoldUsageIntoOffsets(config, snapshot, nowMs: 50, providerKey: aKey);
 
         Assert.True(changed);
         Assert.Equal(100, config.Providers[0].BytesUsedOffset);
@@ -253,7 +257,9 @@ public class OverviewStatsResetTests
             ],
         };
 
-        Assert.False(OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 1));
+        var emptySnapshot = OverviewStatsReset.SnapshotUsage(config, tracker);
+        Assert.Empty(emptySnapshot);
+        Assert.False(OverviewStatsReset.FoldUsageIntoOffsets(config, emptySnapshot, nowMs: 1));
 
         var providerId = Guid.NewGuid();
         config = new UsenetProviderConfig
@@ -263,7 +269,8 @@ public class OverviewStatsResetTests
                 MakeProvider(providerId, bytesUsedOffset: 0, bytesUsedResetAt: 42),
             ],
         };
-        Assert.False(OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 42));
+        var snapshot = OverviewStatsReset.SnapshotUsage(config, tracker);
+        Assert.False(OverviewStatsReset.FoldUsageIntoOffsets(config, snapshot, nowMs: 42));
     }
 
     [Fact]
@@ -385,6 +392,102 @@ public class OverviewStatsResetTests
         }
     }
 
+    [Fact]
+    public async Task MetricsWriter_BeginReset_DropsQueuedWithoutWriting()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var writer = new MetricsWriter(harness.CreateContext);
+        writer.RecordFetch(new SegmentFetch
+        {
+            At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Provider = "a",
+            Status = SegmentFetch.FetchStatus.Ok,
+        });
+
+        writer.BeginReset();
+        try
+        {
+            await writer.FlushNowAsync();
+            Assert.Equal(0, writer.Stats.QueuedFetches);
+            await using var check = harness.CreateContext();
+            Assert.Equal(0, await check.SegmentFetches.CountAsync());
+        }
+        finally
+        {
+            writer.EndReset();
+        }
+    }
+
+    [Fact]
+    public async Task MetricsWriter_BeginReset_AbandonsFailedFlushBatchWithoutRequeue()
+    {
+        var flushEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowFail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+
+        var writer = new MetricsWriter(() =>
+        {
+            if (Interlocked.Increment(ref callCount) == 1)
+            {
+                flushEntered.TrySetResult();
+                allowFail.Task.GetAwaiter().GetResult();
+                throw new InvalidOperationException("simulated flush failure during reset");
+            }
+
+            throw new InvalidOperationException("unexpected second context create");
+        });
+
+        writer.RecordFetch(new SegmentFetch
+        {
+            At = 1,
+            Provider = "a",
+            Status = SegmentFetch.FetchStatus.Ok,
+        });
+
+        // FlushNowAsync invokes the context factory synchronously before the first
+        // await, so run it off-thread or the test would deadlock on allowFail.
+        var flushTask = Task.Run(() => writer.FlushNowAsync());
+        await flushEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        writer.BeginReset();
+        allowFail.TrySetResult();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => flushTask);
+        Assert.Equal(0, writer.Stats.QueuedFetches);
+
+        writer.DiscardQueuedAndResetStats();
+        writer.EndReset();
+    }
+
+    [Fact]
+    public async Task MetricsWriter_EndReset_AllowsFlushToResume()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var writer = new MetricsWriter(harness.CreateContext);
+
+        writer.BeginReset();
+        writer.RecordFetch(new SegmentFetch
+        {
+            At = 1,
+            Provider = "a",
+            Status = SegmentFetch.FetchStatus.Ok,
+        });
+        await writer.FlushNowAsync(); // drops while resetting
+        Assert.Equal(0, writer.Stats.QueuedFetches);
+        writer.EndReset();
+
+        writer.RecordFetch(new SegmentFetch
+        {
+            At = 2,
+            Provider = "a",
+            Status = SegmentFetch.FetchStatus.Ok,
+        });
+        await writer.FlushNowAsync();
+
+        await using var check = harness.CreateContext();
+        Assert.Equal(1, await check.SegmentFetches.CountAsync());
+        Assert.Equal(2, (await check.SegmentFetches.SingleAsync()).At);
+    }
+
     private static UsenetProviderConfig.ConnectionDetails MakeProvider(
         Guid providerId,
         long bytesUsedOffset = 0,
@@ -418,6 +521,8 @@ public class OverviewStatsResetTests
         }
 
         public MetricsDbContext Context { get; }
+
+        public MetricsDbContext CreateContext() => new(_options);
 
         public static async Task<MetricsHarness> CreateAsync()
         {

--- a/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
@@ -1,0 +1,452 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+public class OverviewStatsResetTests
+{
+    [Fact]
+    public async Task WipeAsync_DeletesAllMetricsTables()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        db.SegmentFetches.Add(new SegmentFetch
+        {
+            At = now,
+            Provider = "a",
+            Status = SegmentFetch.FetchStatus.Ok,
+        });
+        db.ReadSessions.Add(new ReadSession
+        {
+            Id = Guid.NewGuid(),
+            StartedAt = now,
+            EndedAt = now,
+            DurationMs = 1,
+            Path = "/x",
+        });
+        db.MetricEvents.Add(new MetricEvent { At = now, Kind = "test" });
+        db.ThroughputMinutes.Add(new ThroughputMinute { Minute = now, BytesServed = 1 });
+        db.ProviderMinutes.Add(new ProviderMinute { Minute = now, Provider = "a", Articles = 1 });
+        db.ProviderHourly.Add(new ProviderHourly { Hour = now, Provider = "a", Articles = 1 });
+        db.FailoverMisses.Add(new FailoverMiss
+        {
+            At = now,
+            FromProvider = "a",
+            ToProvider = "b",
+            Reason = SegmentFetch.FetchStatus.Missing,
+        });
+        db.FailoverHourly.Add(new FailoverHourly
+        {
+            Hour = now,
+            FromProvider = "a",
+            ToProvider = "b",
+            Reason = SegmentFetch.FetchStatus.Missing,
+            Count = 1,
+        });
+        db.CatalogueDaily.Add(new CatalogueDaily { Day = now, FileCount = 1 });
+        await db.SaveChangesAsync();
+
+        var deleted = await OverviewStatsReset.WipeAsync(db, CancellationToken.None);
+
+        Assert.Equal(9, deleted);
+        Assert.Equal(0, await db.SegmentFetches.CountAsync());
+        Assert.Equal(0, await db.ReadSessions.CountAsync());
+        Assert.Equal(0, await db.MetricEvents.CountAsync());
+        Assert.Equal(0, await db.ThroughputMinutes.CountAsync());
+        Assert.Equal(0, await db.ProviderMinutes.CountAsync());
+        Assert.Equal(0, await db.ProviderHourly.CountAsync());
+        Assert.Equal(0, await db.FailoverMisses.CountAsync());
+        Assert.Equal(0, await db.FailoverHourly.CountAsync());
+        Assert.Equal(0, await db.CatalogueDaily.CountAsync());
+    }
+
+    [Fact]
+    public async Task WipeProviderAsync_DeletesOnlyTargetProviderRows()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        const string target = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const string other = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        db.SegmentFetches.AddRange(
+            new SegmentFetch { At = now, Provider = target, Status = SegmentFetch.FetchStatus.Ok },
+            new SegmentFetch { At = now, Provider = other, Status = SegmentFetch.FetchStatus.Ok });
+        db.ProviderMinutes.AddRange(
+            new ProviderMinute { Minute = now, Provider = target, Articles = 1 },
+            new ProviderMinute { Minute = now, Provider = other, Articles = 2 });
+        db.ProviderHourly.AddRange(
+            new ProviderHourly { Hour = now, Provider = target, Articles = 1 },
+            new ProviderHourly { Hour = now, Provider = other, Articles = 2 });
+        db.FailoverMisses.AddRange(
+            new FailoverMiss
+            {
+                At = now,
+                FromProvider = target,
+                ToProvider = other,
+                Reason = SegmentFetch.FetchStatus.Missing,
+            },
+            new FailoverMiss
+            {
+                At = now,
+                FromProvider = other,
+                ToProvider = "cccccccccccccccccccccccccccccccc",
+                Reason = SegmentFetch.FetchStatus.Missing,
+            });
+        db.FailoverHourly.AddRange(
+            new FailoverHourly
+            {
+                Hour = now,
+                FromProvider = target,
+                ToProvider = other,
+                Reason = SegmentFetch.FetchStatus.Missing,
+                Count = 1,
+            },
+            new FailoverHourly
+            {
+                Hour = now,
+                FromProvider = other,
+                ToProvider = "cccccccccccccccccccccccccccccccc",
+                Reason = SegmentFetch.FetchStatus.Missing,
+                Count = 2,
+            });
+        db.ThroughputMinutes.Add(new ThroughputMinute { Minute = now, BytesServed = 42 });
+        db.ReadSessions.Add(new ReadSession
+        {
+            Id = Guid.NewGuid(),
+            StartedAt = now,
+            EndedAt = now,
+            DurationMs = 1,
+            Path = "/kept",
+        });
+        await db.SaveChangesAsync();
+
+        var deleted = await OverviewStatsReset.WipeProviderAsync(db, target, CancellationToken.None);
+
+        Assert.True(deleted >= 5);
+        Assert.Equal(0, await db.SegmentFetches.CountAsync(x => x.Provider == target));
+        Assert.Equal(1, await db.SegmentFetches.CountAsync(x => x.Provider == other));
+        Assert.Equal(0, await db.ProviderMinutes.CountAsync(x => x.Provider == target));
+        Assert.Equal(1, await db.ProviderMinutes.CountAsync(x => x.Provider == other));
+        Assert.Equal(0, await db.ProviderHourly.CountAsync(x => x.Provider == target));
+        Assert.Equal(1, await db.ProviderHourly.CountAsync(x => x.Provider == other));
+        Assert.Equal(0, await db.FailoverMisses.CountAsync(x =>
+            x.FromProvider == target || x.ToProvider == target));
+        Assert.Equal(1, await db.FailoverMisses.CountAsync());
+        Assert.Equal(0, await db.FailoverHourly.CountAsync(x =>
+            x.FromProvider == target || x.ToProvider == target));
+        Assert.Equal(1, await db.FailoverHourly.CountAsync());
+        Assert.Equal(1, await db.ThroughputMinutes.CountAsync());
+        Assert.Equal(1, await db.ReadSessions.CountAsync());
+    }
+
+    [Fact]
+    public async Task WipeProviderAsync_DrainsSegmentFetchesInBatches()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        const string target = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const string other = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        var previous = OverviewStatsReset.SegmentFetchDeleteBatchSize;
+        OverviewStatsReset.SegmentFetchDeleteBatchSize = 2;
+        try
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                db.SegmentFetches.Add(new SegmentFetch
+                {
+                    At = now + i,
+                    Provider = target,
+                    Status = SegmentFetch.FetchStatus.Ok,
+                });
+            }
+            db.SegmentFetches.Add(new SegmentFetch
+            {
+                At = now,
+                Provider = other,
+                Status = SegmentFetch.FetchStatus.Ok,
+            });
+            await db.SaveChangesAsync();
+
+            var deleted = await OverviewStatsReset.WipeProviderAsync(db, target, CancellationToken.None);
+
+            Assert.Equal(5, deleted);
+            Assert.Equal(0, await db.SegmentFetches.CountAsync(x => x.Provider == target));
+            Assert.Equal(1, await db.SegmentFetches.CountAsync(x => x.Provider == other));
+        }
+        finally
+        {
+            OverviewStatsReset.SegmentFetchDeleteBatchSize = previous;
+        }
+    }
+
+    [Fact]
+    public void FoldUsageIntoOffsets_FoldsTrackerAndOffset()
+    {
+        var providerId = Guid.NewGuid();
+        var key = UsenetProviderIdentity.MetricsKey(providerId);
+        var tracker = new ProviderBytesTracker();
+        tracker.Add(key, 1_000);
+        var config = new UsenetProviderConfig
+        {
+            Providers =
+            [
+                MakeProvider(providerId, bytesUsedOffset: 250, bytesUsedResetAt: 10),
+            ],
+        };
+
+        var changed = OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 99);
+
+        Assert.True(changed);
+        Assert.Equal(1_250, config.Providers[0].BytesUsedOffset);
+        Assert.Equal(99, config.Providers[0].BytesUsedResetAt);
+    }
+
+    [Fact]
+    public void FoldUsageIntoOffsets_ScopedToProviderKey()
+    {
+        var aId = Guid.NewGuid();
+        var bId = Guid.NewGuid();
+        var aKey = UsenetProviderIdentity.MetricsKey(aId);
+        var bKey = UsenetProviderIdentity.MetricsKey(bId);
+        var tracker = new ProviderBytesTracker();
+        tracker.Add(aKey, 100);
+        tracker.Add(bKey, 200);
+        var config = new UsenetProviderConfig
+        {
+            Providers =
+            [
+                MakeProvider(aId, bytesUsedOffset: 0, bytesUsedResetAt: 1),
+                MakeProvider(bId, bytesUsedOffset: 5, bytesUsedResetAt: 1),
+            ],
+        };
+
+        var changed = OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 50, providerKey: aKey);
+
+        Assert.True(changed);
+        Assert.Equal(100, config.Providers[0].BytesUsedOffset);
+        Assert.Equal(50, config.Providers[0].BytesUsedResetAt);
+        Assert.Equal(5, config.Providers[1].BytesUsedOffset);
+        Assert.Equal(1, config.Providers[1].BytesUsedResetAt);
+    }
+
+    [Fact]
+    public void FoldUsageIntoOffsets_SkipsEmptyProviderIdAndUnchanged()
+    {
+        var tracker = new ProviderBytesTracker();
+        var config = new UsenetProviderConfig
+        {
+            Providers =
+            [
+                MakeProvider(Guid.Empty, bytesUsedOffset: 0, bytesUsedResetAt: 0),
+            ],
+        };
+
+        Assert.False(OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 1));
+
+        var providerId = Guid.NewGuid();
+        config = new UsenetProviderConfig
+        {
+            Providers =
+            [
+                MakeProvider(providerId, bytesUsedOffset: 0, bytesUsedResetAt: 42),
+            ],
+        };
+        Assert.False(OverviewStatsReset.FoldUsageIntoOffsets(config, tracker, nowMs: 42));
+    }
+
+    [Fact]
+    public void ProviderBytesTracker_ResetCounters_ClearsLifetimeAndBuckets()
+    {
+        var tracker = new ProviderBytesTracker();
+        tracker.Add("a", 100);
+        tracker.Add("b", 50);
+        tracker.RecordSegmentThroughput("a", 1000, 10);
+
+        tracker.ResetCounters();
+
+        Assert.Equal(0, tracker.LifetimeAll);
+        Assert.Equal(0, tracker.GetLifetime("a"));
+        Assert.Equal(0, tracker.GetLifetime("b"));
+        Assert.Empty(tracker.DrainClosed(long.MaxValue));
+        Assert.True(tracker.GetBytesPerMs("a") > 0);
+    }
+
+    [Fact]
+    public void ProviderBytesTracker_ResetProvider_RemovesOnlyTarget()
+    {
+        var tracker = new ProviderBytesTracker();
+        tracker.Add("a", 100);
+        tracker.Add("b", 50);
+        tracker.RecordSegmentThroughput("a", 1000, 10);
+
+        tracker.ResetProvider("a");
+
+        Assert.Equal(50, tracker.LifetimeAll);
+        Assert.Equal(0, tracker.GetLifetime("a"));
+        Assert.Equal(50, tracker.GetLifetime("b"));
+        Assert.True(tracker.GetBytesPerMs("a") > 0);
+        Assert.DoesNotContain(tracker.DrainClosed(long.MaxValue), x => x.ProviderKey == "a");
+    }
+
+    [Fact]
+    public void MetricsWriter_DiscardQueuedAndResetStats_ClearsQueuesAndDrops()
+    {
+        var invalidParent = Path.GetTempFileName();
+        try
+        {
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={Path.Combine(invalidParent, "metrics.sqlite")}")
+                .Options;
+            var writer = new MetricsWriter(() => new MetricsDbContext(options));
+            writer.RecordFetch(new SegmentFetch
+            {
+                At = 1,
+                Provider = "a",
+                Status = SegmentFetch.FetchStatus.Ok,
+            });
+            writer.RecordFailoverMiss(new FailoverMiss
+            {
+                At = 1,
+                FromProvider = "a",
+                ToProvider = "b",
+                Reason = SegmentFetch.FetchStatus.Missing,
+            });
+
+            writer.DiscardQueuedAndResetStats();
+
+            Assert.Equal(0, writer.Stats.QueuedFetches);
+            Assert.Equal(0, writer.Stats.QueuedFailoverMisses);
+            Assert.Equal(0, writer.Stats.DroppedFetches);
+            Assert.Null(writer.Stats.LastFlushError);
+        }
+        finally
+        {
+            File.Delete(invalidParent);
+        }
+    }
+
+    [Fact]
+    public void MetricsWriter_DiscardQueuedForProvider_KeepsOtherProviders()
+    {
+        var invalidParent = Path.GetTempFileName();
+        try
+        {
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={Path.Combine(invalidParent, "metrics.sqlite")}")
+                .Options;
+            var writer = new MetricsWriter(() => new MetricsDbContext(options));
+            writer.RecordFetch(new SegmentFetch
+            {
+                At = 1,
+                Provider = "a",
+                Status = SegmentFetch.FetchStatus.Ok,
+            });
+            writer.RecordFetch(new SegmentFetch
+            {
+                At = 2,
+                Provider = "b",
+                Status = SegmentFetch.FetchStatus.Ok,
+            });
+            writer.RecordFailoverMiss(new FailoverMiss
+            {
+                At = 1,
+                FromProvider = "a",
+                ToProvider = "b",
+                Reason = SegmentFetch.FetchStatus.Missing,
+            });
+            writer.RecordFailoverMiss(new FailoverMiss
+            {
+                At = 2,
+                FromProvider = "b",
+                ToProvider = "c",
+                Reason = SegmentFetch.FetchStatus.Missing,
+            });
+
+            writer.DiscardQueuedForProvider("a");
+
+            Assert.Equal(1, writer.Stats.QueuedFetches);
+            Assert.Equal(1, writer.Stats.QueuedFailoverMisses);
+        }
+        finally
+        {
+            File.Delete(invalidParent);
+        }
+    }
+
+    private static UsenetProviderConfig.ConnectionDetails MakeProvider(
+        Guid providerId,
+        long bytesUsedOffset = 0,
+        long bytesUsedResetAt = 0)
+    {
+        return new UsenetProviderConfig.ConnectionDetails
+        {
+            ProviderId = providerId,
+            Type = ProviderType.Pooled,
+            Host = "news.example.com",
+            Port = 563,
+            UseSsl = true,
+            User = "user",
+            Pass = "pass",
+            MaxConnections = 10,
+            BytesUsedOffset = bytesUsedOffset,
+            BytesUsedResetAt = bytesUsedResetAt,
+        };
+    }
+
+    private sealed class MetricsHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+        private readonly DbContextOptions<MetricsDbContext> _options;
+
+        private MetricsHarness(string dir, DbContextOptions<MetricsDbContext> options, MetricsDbContext context)
+        {
+            _dir = dir;
+            _options = options;
+            Context = context;
+        }
+
+        public MetricsDbContext Context { get; }
+
+        public static async Task<MetricsHarness> CreateAsync()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"nzbdav-overview-reset-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "metrics.sqlite");
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            return new MetricsHarness(dir, options, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/clear-overview-stats` (optional `?provider=` key) to wipe Overview metrics from `metrics.sqlite`, discard queued writer rows, and reset in-memory lifetime counters.
- Preserves Usenet data-cap gauges by folding current usage into `BytesUsedOffset` before the wipe; queue/history and health-check stats are untouched.
- Adds a Maintenance task panel with an all-providers / per-provider selector and confirmation. Per-provider resets clear provider-keyed scoreboard/latency/failover rows; global throughput charts and sessions require a full reset.

Closes #258.

## Test plan
- [x] `dotnet test` OverviewStatsResetTests (10 passed)
- [x] Frontend typecheck, build, and vitest
- [ ] Populate metrics via downloads; full reset → Overview tiles/charts zero; gauges unchanged
- [ ] Per-provider reset on one of two providers → that scoreboard row zeros; other provider and global throughput survive; gauges unchanged
- [ ] New downloads repopulate metrics without a restart
- [ ] Operational queue/history unchanged after reset