### PR TITLE
fix(queue): removing a blocklisted file no longer crashes the queue

### DIFF
--- a/backend/Queue/PostProcessors/BlocklistedFilePostProcessor.cs
+++ b/backend/Queue/PostProcessors/BlocklistedFilePostProcessor.cs
@@ -17,7 +17,8 @@ public class BlocklistedFilePostProcessor(ConfigManager configManager, DavDataba
             .Where(x => x.State == EntityState.Added)
             .Select(x => x.Entity)
             .Where(x => x.Type != DavItem.ItemType.Directory)
-            .Where(x => MatchesAnyPattern(x.Name, blocklistPatterns));
+            .Where(x => MatchesAnyPattern(x.Name, blocklistPatterns))
+            .ToList();
 
         foreach (var blocklistedFile in blocklistedFiles)
             RemoveBlocklistedFile(blocklistedFile);


### PR DESCRIPTION
Fixes #449

Grab a snapshot of the list to avoid "collection was modified" exceptions. I encountered it when importing a release containing a sample.mkv and it crashed the queue post-processing. Nice fork!