### PR TITLE
fix(webdav): small files no longer fail to play when players request a range past the end of the file

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -104,7 +104,9 @@ public class GetWebdavItemController(
 
         if (rangeStart is not null)
         {
-            var end = rangeEnd ?? (fileSize - 1);
+            // clamp a range end that runs past the file to the last byte
+            // so the response headers stay valid.
+            var end = Math.Min(rangeEnd ?? (fileSize - 1), fileSize - 1);
 
             // Syntactically valid but unsatisfiable → 416 (mirror WebDAV handler).
             if (rangeStart.Value < 0 || rangeStart.Value >= fileSize || rangeStart.Value > end)


### PR DESCRIPTION
Fixes #448

Fixes an issue where small files can fail if the client requests a range past the end of the file (web player and Jellyfin STRM).