### PR TITLE
feat(db)!: search links keep working after restarts and have a configurable lifetime

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -90,6 +90,7 @@ public static class ConfigKeys
     public const string PlayMaxAttempts = "play.max-attempts";
     public const string PlayMaxCandidates = "play.max-candidates";
     public const string PlayPreferSubtitles = "play.prefer-subtitles";
+    public const string PlayResolutionCacheTtlHours = "play.resolution-cache-ttl-hours";
     public const string PlayTotalBudgetSeconds = "play.total-budget-seconds";
     public const string PlayVerifyMode = "play.verify-mode";
     public const string PlayVerifySampleCount = "play.verify-sample-count";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -170,6 +170,7 @@ public class ConfigManager
                 case ConfigKeys.PlayMaxAttempts:
                 case ConfigKeys.PlayVerifySampleCount:
                 case ConfigKeys.PlayCandidateNegativeCacheMinutes:
+                case ConfigKeys.PlayResolutionCacheTtlHours:
                 case ConfigKeys.GrabStallFailoverWindowSeconds:
                 case ConfigKeys.GrabStallFailoverCeilingSeconds:
                 case ConfigKeys.SearchExcludeSyncRefreshMinutes:
@@ -640,6 +641,18 @@ public class ConfigManager
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayCandidateNegativeCacheMinutes));
         if (v == null) return TimeSpan.FromMinutes(5);
         return int.TryParse(v, out var n) ? TimeSpan.FromMinutes(Math.Clamp(n, 1, 60 * 24)) : TimeSpan.FromMinutes(5);
+    }
+
+    /// <summary>
+    /// Lifetime of play tokens served in search results. Config key wins over
+    /// RESOLUTION_CACHE_TTL_HOURS; default 7 days to outlive consumer search caches.
+    /// </summary>
+    public TimeSpan GetPlayResolutionCacheTtl()
+    {
+        var raw = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.PlayResolutionCacheTtlHours))
+                  ?? EnvironmentUtil.GetEnvironmentVariable("RESOLUTION_CACHE_TTL_HOURS");
+        if (int.TryParse(raw, out var hours)) return TimeSpan.FromHours(Math.Clamp(hours, 1, 720));
+        return TimeSpan.FromHours(168);
     }
 
     public bool IsPlaySubtitlePreferenceEnabled()

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -62,6 +62,7 @@ public sealed class DavDatabaseContext : DbContext
     public DbSet<IndexerApiHit> IndexerApiHits => Set<IndexerApiHit>();
     public DbSet<ListSource> ListSources => Set<ListSource>();
     public DbSet<WantedItem> WantedItems => Set<WantedItem>();
+    public DbSet<NzbResolutionGroup> NzbResolutionGroups => Set<NzbResolutionGroup>();
 
     // Pending blob writes for the current unit of work (flushed in SaveChangesAsync).
     private readonly List<DavNzbFile> _blobNzbFiles = [];
@@ -695,6 +696,23 @@ public sealed class DavDatabaseContext : DbContext
             e.HasIndex(i => i.NextCheckAtUnix);
             e.HasIndex(i => i.State);
             e.HasIndex(i => i.UpdatedAtUnix);
+        });
+
+        // NzbResolutionGroup
+        b.Entity<NzbResolutionGroup>(e =>
+        {
+            e.ToTable("NzbResolutionGroups");
+            e.HasKey(i => i.Id);
+
+            e.Property(i => i.Id).ValueGeneratedNever();
+            e.Property(i => i.Type).IsRequired();
+            e.Property(i => i.ProfileToken).IsRequired();
+            e.Property(i => i.SearchId).IsRequired();
+            e.Property(i => i.CandidatesJson).IsRequired();
+            e.Property(i => i.TokensJson).IsRequired();
+            e.Property(i => i.CreatedAtUnix).IsRequired();
+
+            e.HasIndex(i => i.CreatedAtUnix);
         });
     }
 

--- a/backend/Database/Migrations/20260718000000_Add-NzbResolutionGroups-Table.cs
+++ b/backend/Database/Migrations/20260718000000_Add-NzbResolutionGroups-Table.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(DavDatabaseContext))]
+    [Migration("20260718000000_Add-NzbResolutionGroups-Table")]
+    public partial class AddNzbResolutionGroupsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NzbResolutionGroups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Type = table.Column<string>(type: "TEXT", nullable: false),
+                    ProfileToken = table.Column<string>(type: "TEXT", nullable: false),
+                    SearchId = table.Column<string>(type: "TEXT", nullable: false),
+                    CandidatesJson = table.Column<string>(type: "TEXT", nullable: false),
+                    TokensJson = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAtUnix = table.Column<long>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NzbResolutionGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NzbResolutionGroups_CreatedAtUnix",
+                table: "NzbResolutionGroups",
+                column: "CreatedAtUnix");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "NzbResolutionGroups");
+        }
+    }
+}

--- a/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
@@ -547,6 +547,41 @@ namespace NzbWebDAV.Database.Migrations
                     b.ToTable("WantedItems", (string)null);
                 });
 
+            modelBuilder.Entity("NzbWebDAV.Database.Models.NzbResolutionGroup", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("CandidatesJson")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("CreatedAtUnix")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("ProfileToken")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("SearchId")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("TokensJson")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedAtUnix");
+
+                    b.ToTable("NzbResolutionGroups", (string)null);
+                });
+
             modelBuilder.Entity("NzbWebDAV.Database.Models.QueueItem", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/Database/Models/NzbResolutionGroup.cs
+++ b/backend/Database/Models/NzbResolutionGroup.cs
@@ -1,0 +1,12 @@
+namespace NzbWebDAV.Database.Models;
+
+public class NzbResolutionGroup
+{
+    public Guid Id { get; set; }
+    public string Type { get; set; } = "";
+    public string ProfileToken { get; set; } = "";
+    public string SearchId { get; set; } = "";
+    public string CandidatesJson { get; set; } = "";
+    public string TokensJson { get; set; } = "";
+    public long CreatedAtUnix { get; set; }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -174,7 +174,7 @@ class Program
                     sp.GetRequiredService<UsenetStreamingClient>(),
                     sp.GetRequiredService<ConfigManager>()))
                 .AddSingleton<QueueManager>()
-                .AddSingleton<NzbResolutionCache>()
+                .AddSingleton(_ => new NzbResolutionCache(() => new DavDatabaseContext()))
                 .AddSingleton<PreferredOrderStore>()
                 .AddSingleton<NzbFetchCoalescer>()
                 .AddSingleton<PlayResolutionCoalescer>()

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -219,6 +219,7 @@ class Program
                 .AddHostedService<NzbBackupRetentionService>()
                 .AddHostedService<HistoryCleanupService>()
                 .AddHostedService<HistoryRetentionService>()
+                .AddHostedService<NzbResolutionCacheRetentionService>()
                 .AddHostedService<WatchdogPurgeService>()
                 .AddHostedService<DavCleanupService>()
                 .AddHostedService<UsenetFileToBlobstoreMigrationService>()

--- a/backend/Services/NzbResolutionCache.cs
+++ b/backend/Services/NzbResolutionCache.cs
@@ -1,47 +1,143 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using Serilog;
 
 namespace NzbWebDAV.Services;
 
-public class NzbResolutionCache
+public class NzbResolutionCache(Func<DavDatabaseContext> contextFactory)
 {
-    private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
     private readonly ConcurrentDictionary<string, Entry> _entries = new();
 
     /// <summary>
     /// Register a candidate group and return one token per candidate. Each token's entry
     /// points at the same ordered Candidates list with its own StartIndex, so the play
     /// handler can iterate from any starting position for fast-fail + fallback.
+    /// Persists the group to SQLite so tokens survive restarts.
     /// </summary>
-    public string[] AddGroup(IReadOnlyList<Candidate> candidates, string type, string profileToken, string id)
+    public async Task<string[]> AddGroupAsync(
+        IReadOnlyList<Candidate> candidates, string type, string profileToken, string id)
     {
-        Cleanup();
         var tokens = new string[candidates.Count];
         for (var i = 0; i < candidates.Count; i++)
+            tokens[i] = GenerateToken();
+
+        var createdAt = DateTime.UtcNow;
+        try
         {
-            var token = GenerateToken();
-            _entries[token] = new Entry
+            await using var ctx = contextFactory();
+            ctx.NzbResolutionGroups.Add(new NzbResolutionGroup
+            {
+                Id = Guid.NewGuid(),
+                Type = type,
+                ProfileToken = profileToken,
+                SearchId = id,
+                CandidatesJson = JsonSerializer.Serialize(candidates),
+                TokensJson = JsonSerializer.Serialize(tokens),
+                CreatedAtUnix = new DateTimeOffset(createdAt).ToUnixTimeMilliseconds(),
+            });
+            await ctx.SaveChangesAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to persist play-token group; tokens will not survive a restart");
+        }
+
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            _entries[tokens[i]] = new Entry
             {
                 Candidates = candidates,
                 StartIndex = i,
                 Type = type,
                 ProfileToken = profileToken,
                 Id = id,
-                CreatedAt = DateTime.UtcNow,
+                CreatedAt = createdAt,
             };
-            tokens[i] = token;
         }
+
         return tokens;
     }
 
     public Entry? Get(string token) => _entries.TryGetValue(token, out var e) ? e : null;
 
-    private void Cleanup()
+    /// <summary>
+    /// Load non-expired groups from SQLite into the in-memory dictionary.
+    /// Deserializes each group's candidates list once and shares it across that group's tokens.
+    /// </summary>
+    public async Task HydrateAsync(TimeSpan ttl, CancellationToken ct)
     {
-        var cutoff = DateTime.UtcNow - Ttl;
+        var cutoffUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - (long)ttl.TotalMilliseconds;
+        await using var ctx = contextFactory();
+        var rows = await ctx.NzbResolutionGroups
+            .AsNoTracking()
+            .Where(g => g.CreatedAtUnix >= cutoffUnixMs)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var loaded = 0;
+        foreach (var row in rows)
+        {
+            try
+            {
+                var candidates = JsonSerializer.Deserialize<List<Candidate>>(row.CandidatesJson);
+                var tokens = JsonSerializer.Deserialize<string[]>(row.TokensJson);
+                if (candidates is null || tokens is null || tokens.Length != candidates.Count)
+                {
+                    Log.Debug(
+                        "Skipping resolution group {Id}: candidates/tokens deserialize mismatch",
+                        row.Id);
+                    continue;
+                }
+
+                var createdAt = DateTimeOffset.FromUnixTimeMilliseconds(row.CreatedAtUnix).UtcDateTime;
+                for (var i = 0; i < tokens.Length; i++)
+                {
+                    _entries[tokens[i]] = new Entry
+                    {
+                        Candidates = candidates,
+                        StartIndex = i,
+                        Type = row.Type,
+                        ProfileToken = row.ProfileToken,
+                        Id = row.SearchId,
+                        CreatedAt = createdAt,
+                    };
+                }
+
+                loaded++;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Skipping resolution group {Id}: failed to deserialize", row.Id);
+            }
+        }
+
+        if (loaded > 0)
+            Log.Information("Hydrated {Groups} play-token group(s) ({Tokens} tokens)", loaded, _entries.Count);
+    }
+
+    /// <summary>
+    /// Evict expired in-memory entries and delete expired rows from SQLite.
+    /// </summary>
+    public async Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct)
+    {
+        var cutoffDateTime = DateTime.UtcNow - ttl;
+        var cutoffUnixMs = new DateTimeOffset(cutoffDateTime).ToUnixTimeMilliseconds();
+
         foreach (var kv in _entries)
-            if (kv.Value.CreatedAt < cutoff)
+        {
+            if (kv.Value.CreatedAt < cutoffDateTime)
                 _entries.TryRemove(kv.Key, out _);
+        }
+
+        await using var ctx = contextFactory();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "DELETE FROM NzbResolutionGroups WHERE CreatedAtUnix < {0}",
+            cutoffUnixMs)
+            .ConfigureAwait(false);
     }
 
     private static string GenerateToken()

--- a/backend/Services/NzbResolutionCacheRetentionService.cs
+++ b/backend/Services/NzbResolutionCacheRetentionService.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Hydrates the in-memory play-token cache from SQLite on startup, then
+/// hourly purges groups older than the configured TTL.
+/// </summary>
+public class NzbResolutionCacheRetentionService(
+    NzbResolutionCache cache, ConfigManager configManager) : BackgroundService
+{
+    private static readonly TimeSpan TickInterval = TimeSpan.FromHours(1);
+
+    // Hydrate before the server accepts requests so pre-restart tokens
+    // never 404 during startup.
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await cache.HydrateAsync(configManager.GetPlayResolutionCacheTtl(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to hydrate play-token cache; starting empty");
+        }
+
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TickInterval, stoppingToken).ConfigureAwait(false);
+                await cache.PurgeExpiredAsync(configManager.GetPlayResolutionCacheTtl(), stoppingToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Play-token retention sweep failed");
+            }
+        }
+    }
+}

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -490,7 +490,7 @@ public class SearchProfileService(
             if (alive.Count > 0) candidates = alive;
         }
 
-        var tokens = cache.AddGroup(candidates, type, profileToken, id);
+        var tokens = await cache.AddGroupAsync(candidates, type, profileToken, id).ConfigureAwait(false);
         if (startPreflight)
             preflightOrchestrator.Start(profileToken, type, id, candidates);
 

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -78,6 +78,7 @@ const defaultConfig = {
     "play.max-attempts": "10",
     "play.verify-mode": "none",
     "play.candidate-negative-cache-minutes": "5",
+    "play.resolution-cache-ttl-hours": "168",
     "play.prefer-subtitles": "true",
     "grab.stall-failover-enabled": "true",
     "grab.stall-failover-window-seconds": "2",

--- a/frontend/app/routes/settings/watchdog/watchdog.tsx
+++ b/frontend/app/routes/settings/watchdog/watchdog.tsx
@@ -144,6 +144,22 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
+                <Form.Label>Search link lifetime (hours)</Form.Label>
+                <Form.Control
+                    className="w-full max-w-md"
+                    type="number"
+                    min={1}
+                    max={720}
+                    value={config["play.resolution-cache-ttl-hours"] ?? "168"}
+                    onChange={e => set("play.resolution-cache-ttl-hours", e.target.value)} />
+                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
+                    How long play links embedded in search results stay valid. Set at or above your search
+                    client's result-cache lifetime (AIOStreams defaults to 7 days). Links now also survive
+                    restarts. Default 168 (7 days).
+                </p>
+            </Form.Group>
+
+            <Form.Group className="flex flex-col gap-2">
                 <Form.Check
                     type="switch"
                     id="play-prefer-subtitles"
@@ -353,6 +369,7 @@ export function isWatchdogSettingsUpdated(config: Record<string, string>, newCon
         || config["play.max-attempts"] !== newConfig["play.max-attempts"]
         || config["play.verify-mode"] !== newConfig["play.verify-mode"]
         || config["play.candidate-negative-cache-minutes"] !== newConfig["play.candidate-negative-cache-minutes"]
+        || config["play.resolution-cache-ttl-hours"] !== newConfig["play.resolution-cache-ttl-hours"]
         || config["play.prefer-subtitles"] !== newConfig["play.prefer-subtitles"]
         || config["grab.stall-failover-enabled"] !== newConfig["grab.stall-failover-enabled"]
         || config["grab.stall-failover-window-seconds"] !== newConfig["grab.stall-failover-window-seconds"]

--- a/tests/NzbWebDAV.Tests/Services/NzbResolutionCachePersistenceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbResolutionCachePersistenceTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class NzbResolutionCachePersistenceTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-resolution-cache-{Guid.NewGuid():N}.sqlite");
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch { /* best effort */ }
+    }
+
+    private NzbResolutionCache NewCache() =>
+        new(() => new DavDatabaseContext(_options));
+
+    private static List<NzbResolutionCache.Candidate> MakeCandidates(int count) =>
+        Enumerable.Range(0, count).Select(i => new NzbResolutionCache.Candidate
+        {
+            IndexerName = $"indexer-{i}",
+            IndexerUserAgent = "test-agent",
+            NzbUrl = $"https://example.com/nzb/{i}",
+            Title = $"Title {i}",
+            Size = 1000 + i,
+        }).ToList();
+
+    [Fact]
+    public async Task AddGroupAsync_ThenHydrate_RestoresSharedCandidatesAndStartIndex()
+    {
+        var candidates = MakeCandidates(3);
+        var cacheA = NewCache();
+        var tokens = await cacheA.AddGroupAsync(candidates, "movie", "profile-tok", "tt123");
+
+        Assert.Equal(3, tokens.Length);
+        Assert.NotNull(cacheA.Get(tokens[1]));
+        Assert.Equal(1, cacheA.Get(tokens[1])!.StartIndex);
+
+        var cacheB = NewCache();
+        await cacheB.HydrateAsync(TimeSpan.FromDays(7), CancellationToken.None);
+
+        var entry0 = cacheB.Get(tokens[0]);
+        var entry1 = cacheB.Get(tokens[1]);
+        var entry2 = cacheB.Get(tokens[2]);
+
+        Assert.NotNull(entry0);
+        Assert.NotNull(entry1);
+        Assert.NotNull(entry2);
+        Assert.Equal(0, entry0.StartIndex);
+        Assert.Equal(1, entry1.StartIndex);
+        Assert.Equal(2, entry2.StartIndex);
+        Assert.Equal("https://example.com/nzb/1", entry1.Primary.NzbUrl);
+        Assert.Equal("movie", entry1.Type);
+        Assert.Equal("profile-tok", entry1.ProfileToken);
+        Assert.Equal("tt123", entry1.Id);
+        Assert.Same(entry0.Candidates, entry2.Candidates);
+    }
+
+    [Fact]
+    public async Task HydrateAndPurge_SkipAndRemoveExpiredGroups()
+    {
+        var cacheWriter = NewCache();
+        var freshTokens = await cacheWriter.AddGroupAsync(MakeCandidates(1), "movie", "p", "fresh");
+
+        var oldToken = "deadbeefcafebabe";
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.NzbResolutionGroups.Add(new NzbResolutionGroup
+            {
+                Id = Guid.NewGuid(),
+                Type = "movie",
+                ProfileToken = "p",
+                SearchId = "old",
+                CandidatesJson = System.Text.Json.JsonSerializer.Serialize(MakeCandidates(1)),
+                TokensJson = System.Text.Json.JsonSerializer.Serialize(new[] { oldToken }),
+                CreatedAtUnix = DateTimeOffset.UtcNow.AddDays(-8).ToUnixTimeMilliseconds(),
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        // Hydrate with a long TTL so the aged row loads into memory with its old CreatedAt.
+        var cache = NewCache();
+        await cache.HydrateAsync(TimeSpan.FromDays(30), CancellationToken.None);
+        Assert.NotNull(cache.Get(freshTokens[0]));
+        Assert.NotNull(cache.Get(oldToken));
+
+        // Short hydrate on a fresh instance should skip the aged row.
+        var shortHydrate = NewCache();
+        await shortHydrate.HydrateAsync(TimeSpan.FromDays(7), CancellationToken.None);
+        Assert.NotNull(shortHydrate.Get(freshTokens[0]));
+        Assert.Null(shortHydrate.Get(oldToken));
+
+        // Purge with 7d TTL: evict aged memory entry and delete aged DB row.
+        await cache.PurgeExpiredAsync(TimeSpan.FromDays(7), CancellationToken.None);
+        Assert.NotNull(cache.Get(freshTokens[0]));
+        Assert.Null(cache.Get(oldToken));
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            Assert.Equal(0, await ctx.NzbResolutionGroups.CountAsync(g => g.SearchId == "old"));
+            Assert.True(await ctx.NzbResolutionGroups.AnyAsync(g => g.SearchId == "fresh"));
+        }
+    }
+
+    [Fact]
+    public async Task AddGroupAsync_PersistenceFailure_StillReturnsTokens()
+    {
+        var cache = new NzbResolutionCache(() => throw new InvalidOperationException("db down"));
+        var candidates = MakeCandidates(2);
+        var tokens = await cache.AddGroupAsync(candidates, "series", "p", "tt9");
+
+        Assert.Equal(2, tokens.Length);
+        Assert.NotNull(cache.Get(tokens[0]));
+        Assert.Equal("https://example.com/nzb/0", cache.Get(tokens[0])!.Primary.NzbUrl);
+        Assert.Same(cache.Get(tokens[0])!.Candidates, cache.Get(tokens[1])!.Candidates);
+    }
+}


### PR DESCRIPTION
## Summary

- Persist Newznab/JSON play-token groups to SQLite so search links survive NzbDav restarts ([#445](https://github.com/nzbdav/nzbdav/issues/445))
- Make the play-token lifetime configurable (`play.resolution-cache-ttl-hours` / `RESOLUTION_CACHE_TTL_HOURS`), defaulting to **7 days** to outlive typical consumer search caches (e.g. AIOStreams)
- Hydrate tokens at startup before the server accepts requests; purge expired groups hourly

**Upgrade notes**
- **Back up `/config` before upgrading** — this release includes a database migration (`NzbResolutionGroups`)
- Tokens minted *before* this upgrade were never persisted, so one final round of "Link expired, re-search" is expected right after upgrading
- Default lifetime changes from 24h (hardcoded) to 7 days; lower it in Settings → Watchdog if needed

## Test plan

- [x] `dotnet test` focused `NzbResolutionCachePersistenceTests` (round-trip hydrate, purge, persistence-failure tolerance)
- [x] Frontend `typecheck` / `build` / `test`
- [ ] Manual: search via a profile → note a `.nzb` play URL → restart backend → fetch URL → expect 200 instead of 404
- [ ] Manual: set `play.resolution-cache-ttl-hours` in Watchdog settings and confirm it persists