### PR TITLE
chore: use GitHub Issue Types instead of bug/enhancement labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: Report a reproducible problem in NzbDav
-title: "[Bug]: "
-labels: ["bug"]
+title: ""
 type: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Suggest an improvement to NzbDav
-title: "[Feature]: "
-labels: ["enhancement"]
+title: ""
 type: Feature
 body:
   - type: markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,22 @@ Prefer this rhythm:
 
 Do not accumulate a large uncommitted diff across unrelated areas.
 
+## Issue tracking
+
+Use **GitHub Issue Types** for kind — not kind labels:
+
+| Issue Type | Use for |
+|------------|---------|
+| `Bug` | Unexpected problem or incorrect behavior |
+| `Feature` | New capability or improvement request |
+| `Task` | Concrete work item that is neither a bug nor a feature |
+
+- Do **not** use (or recreate) `bug` / `enhancement` labels — they were removed; Issue Type is the source of truth.
+- Do **not** put `[Bug]:` / `[Feature]:` in issue titles; the type field already conveys that.
+- Triage / meta labels are fine: `priority:P*`, `effort:*`, `cataloged`, `more-info-required`, and source tags (`upstream-audit`, `elfhosted`, etc.).
+
+Bug and feature issue templates set Issue Type only (no kind labels, no title prefix).
+
 ## After completing a task
 
 When a task that changed the repo is done (unless the user explicitly said not to commit, push, or open a PR):


### PR DESCRIPTION
## Summary
- Issue templates no longer set `bug`/`enhancement` labels or `[Bug]:`/`[Feature]:` title prefixes; they rely on GitHub Issue Types (`Bug`/`Feature`).
- AGENTS.md documents Issue Types as the kind source of truth and which triage labels remain.

## Already applied on GitHub (not in this PR)
- Set Issue Type Bug/Feature on formerly labeled issues
- Removed `bug`/`enhancement` labels from issues and deleted those labels (plus unused `type:bug`/`type:feature`)
- Stripped `[Bug]:`/`[Feature]:` prefixes from open issue titles

## Test plan
- [ ] Open “Bug report” and “Feature request” forms — blank title, Issue Type set, no kind labels applied
- [ ] Confirm AGENTS.md Issue tracking section matches repo label/type policy
- [ ] Spot-check a few former bug/enhancement issues still have the correct Issue Type