### PR TITLE
chore(ci): credit commit authors in release notes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "changelog-path": "CHANGELOG.md",
+  "include-commit-authors": true,
   "changelog-sections": [
     {
       "type": "breaking",


### PR DESCRIPTION
## Summary
- Enable release-please `include-commit-authors` so changelog entries append `(@username)` (or the author name) once upstream author parsing works end-to-end.

## Test plan
- [ ] After merge, wait for the next release-please PR and confirm changelog lines include `(@username)` when authors are available
- [ ] If authors are missing, treat that as known upstream issue [googleapis/release-please#2761](https://github.com/googleapis/release-please/issues/2761), not a config mistake