### PR TITLE
ci: add curated lts git and Docker image tags

### DIFF
--- a/.github/workflows/promote-lts.yml
+++ b/.github/workflows/promote-lts.yml
@@ -1,0 +1,80 @@
+name: Promote LTS
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic version to promote (e.g. 0.6.5)
+        required: true
+
+concurrency:
+  group: promote-lts-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Resolve version and verify release tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION="${RAW_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version '${RAW_VERSION}'. Expected semantic version like 0.6.5"
+            exit 1
+          fi
+          REF="v${VERSION}"
+          if ! gh api "repos/${{ github.repository }}/git/ref/tags/${REF}" >/dev/null 2>&1; then
+            echo "Git tag ${REF} does not exist. Promote only published release versions."
+            exit 1
+          fi
+          SHA=$(gh api "repos/${{ github.repository }}/commits/${REF}" --jq .sha)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${REF} -> ${SHA}"
+
+      - name: Move git lts tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+          REF: ${{ steps.resolve.outputs.ref }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${{ github.repository }}/git/ref/tags/lts" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/lts" \
+              -f sha="$SHA" \
+              -F force=true
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/lts" \
+              -f sha="$SHA"
+          fi
+          echo "Moved refs/tags/lts -> $SHA (from ${REF})"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Retag Docker image as lts
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          SOURCE="ghcr.io/${{ github.repository }}:v${VERSION}"
+          TARGET="ghcr.io/${{ github.repository }}:lts"
+          docker buildx imagetools create --tag "$TARGET" "$SOURCE"
+          echo "Retagged ${SOURCE} -> ${TARGET}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,6 +322,7 @@ Skip this handoff if there are no local changes and nothing to push or PR. Do no
 | `pre-release.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../nzbdav:dev` and moves the git `dev` tag to that commit |
 | `release.yml` | Push to `main` | release-please versioning; publishes release and `dev` Docker tags when a release is created; moves git `dev` tag |
 | `release.yml` | Manual `workflow_dispatch` | Republishes release and `dev` Docker tags to GHCR for an existing version; moves git `dev` tag |
+| `promote-lts.yml` | Manual `workflow_dispatch` | Moves git `lts` and GHCR `:lts` to an existing published version (no rebuild) |
 | `dependency-submission.yml` | GitHub Release `published` (plus manual `workflow_dispatch`) | Dependency graph submission (NuGet + npm) |
 | `docker-build-push.yml` | Reusable (called by pre-release/release) | Multi-arch Docker build with GHA cache |
 | `move-dev-tag.yml` | Reusable (called by pre-release/release) | Force-moves the movable git `dev` tag to a given commit |
@@ -336,6 +337,7 @@ Docker image builds are shared via the reusable workflow. Branch and dependabot 
 - When release-please creates a release on merge to `main`, the same workflow run builds and pushes Docker images to `ghcr.io` (`latest`, `dev`, exact `vMAJOR.MINOR.PATCH`, and rolling `vMAJOR` / `vMAJOR.MINOR` tags) and moves the git `dev` tag to that release commit.
 - To republish images for an existing release (e.g. after fixing CI), run **Release** workflow manually with the `version` input (e.g. `0.6.5`); this also moves the git `dev` tag to that version.
 - Between releases, update the pre-release Docker image (`:dev`) and git `dev` tag on demand via **Actions → Pre-release → Run workflow**.
+- Promote a curated LTS pointer (`:lts` on GHCR and git tag `lts`) to an existing version via **Actions → Promote LTS → Run workflow** with a `version` input (e.g. `0.6.5`). This retags the existing multi-arch image (no rebuild) and is not updated automatically on release.
 - Dependency graph submission runs when a GitHub Release is published (and can be re-run manually via `workflow_dispatch`). Keep GitHub **Automatic dependency submission** disabled to avoid duplicates.
 
 ## Coding guidelines


### PR DESCRIPTION
## Summary
- Adds a manual **Promote LTS** workflow that moves the movable git `lts` tag and GHCR `:lts` image to an existing published version (retag only, no rebuild).
- Documents the workflow in `AGENTS.md` for operators and agents.

Closes #430

## Test plan
- [ ] Run **Actions → Promote LTS** with a known published version (e.g. current release)
- [ ] Confirm git tag `lts` points at the same commit as `vX.Y.Z`
- [ ] Confirm `ghcr.io/nzbdav/nzbdav:lts` matches the digest of `:vX.Y.Z`
- [ ] Re-run with a different version and confirm both tags move