### PR TITLE
feat: gzip NZB ingest, nested RAR extraction, SAB API conformance, provider outage history, and CRC-verified downloads

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -200,6 +200,7 @@ public class GetOverviewStatsController(
         await using var metricsA = new MetricsDbContext();
         await using var metricsB = new MetricsDbContext();
         await using var metricsLive = new MetricsDbContext();
+        await using var metricsEvents = new MetricsDbContext();
 
         var sessionsTask = metricsSessions.ReadSessions
             .Where(x => x.EndedAt >= windowStart)
@@ -220,6 +221,20 @@ public class GetOverviewStatsController(
                     && x.Status != SegmentFetch.FetchStatus.Missing),
             })
             .FirstOrDefaultAsync();
+        var circuitEventsTask = metricsEvents.MetricEvents
+            .Where(item =>
+                item.Kind == "circuit" &&
+                item.Tag1 != null &&
+                item.Tag2 != null &&
+                item.At >= Math.Max(0, windowStart - OneDay))
+            .Select(item => new
+            {
+                item.At,
+                Provider = item.Tag1!,
+                State = item.Tag2!,
+                CooldownMs = item.Num,
+            })
+            .ToListAsync();
 
         List<(long At, string Provider, long Saves)> rescues;
         List<(string From, SegmentFetch.FetchStatus Reason, long Count)> misses;
@@ -334,10 +349,66 @@ public class GetOverviewStatsController(
             providers,
             usenetStreamingClient.GetProviderCircuitSnapshots(),
             labelsByMetricsKey);
+        var circuitEvents = await circuitEventsTask.ConfigureAwait(false);
+        ApplyOutageSparks(
+            providers,
+            circuitEvents.Select(item => new CircuitOutageSparkBuilder.Event(
+                item.At,
+                item.Provider,
+                item.State,
+                item.CooldownMs)),
+            windowStart,
+            window,
+            nowMs,
+            useRollups);
 
         return new WindowSectionResult(
             tiles, throughput, bucketSize, providers, sessionsBlock, heatmap, failover,
             totalArticles, totalMisses, totalErrors, totalBytesFetched);
+    }
+
+    private static void ApplyOutageSparks(
+        List<GetOverviewStatsResponse.ProviderRow> providers,
+        IEnumerable<CircuitOutageSparkBuilder.Event> events,
+        long windowStart,
+        GetOverviewStatsRequest.OverviewWindow window,
+        long nowMs,
+        bool useRollups)
+    {
+        var (bucketCount, bucketSize, sparkStart) = ResolveProviderSparkGeometry(
+            windowStart, window, nowMs, useRollups);
+        var sparks = CircuitOutageSparkBuilder.Build(
+            events,
+            providers.Select(provider => provider.Provider),
+            sparkStart,
+            bucketSize,
+            bucketCount,
+            nowMs);
+        foreach (var provider in providers)
+            provider.OutageSpark = sparks.GetValueOrDefault(provider.Provider) ?? [];
+    }
+
+    private static (int BucketCount, long BucketSize, long SparkStart) ResolveProviderSparkGeometry(
+        long windowStart,
+        GetOverviewStatsRequest.OverviewWindow window,
+        long nowMs,
+        bool useRollups)
+    {
+        if (useRollups)
+        {
+            const long sparkSize = OneDay;
+            var totalSpan = nowMs - windowStart;
+            var sparkBuckets = Math.Max(1, (int)Math.Min(60, totalSpan / sparkSize + 1));
+            return (sparkBuckets, sparkSize, windowStart - windowStart % sparkSize);
+        }
+
+        var (bucketCount, bucketSize) = window switch
+        {
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour => (60, OneMinute),
+            GetOverviewStatsRequest.OverviewWindow.Last7Days => (168, OneHour),
+            _ => (24, OneHour),
+        };
+        return (bucketCount, bucketSize, windowStart - windowStart % bucketSize);
     }
 
     private static async Task<long?> LoadPreviousFailoverSavesAsync(

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -72,6 +72,8 @@ public class GetOverviewStatsResponse
         public List<long> ErrorSpark { get; init; } = new();
         /// <summary>Segment-fetch retry counts per spark bucket (same sizing as <see cref="Spark"/>).</summary>
         public List<long> RetrySpark { get; init; } = new();
+        /// <summary>Percentage of each spark bucket spent with the provider circuit open.</summary>
+        public List<int> OutageSpark { get; set; } = new();
         public string CircuitState { get; init; } = "closed";
         public int? CooldownRemainingSeconds { get; init; }
         public string? LastFailureReason { get; init; }

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -53,14 +53,26 @@ public class AddFileController(
         if (AfterDuplicatePreCheckHook is not null)
             await AfterDuplicatePreCheckHook().ConfigureAwait(false);
 
-        // write the file to the blob-store
-        await using var stream = request.NzbFileStream;
-        await BlobStore.WriteBlob(id, stream);
-
-        // save the queue item to the database
+        await using var sourceStream = request.NzbFileStream;
         QueueItem? queueItem;
         try
         {
+            var prepared = await NzbStreamUtil.OpenMaybeCompressedAsync(
+                    sourceStream, request.CancellationToken)
+                .ConfigureAwait(false);
+            await using var nzbInputStream = prepared.Stream;
+            try
+            {
+                // Store normalized XML so every downstream parser remains
+                // compression-agnostic.
+                await BlobStore.WriteBlob(id, nzbInputStream, request.CancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (InvalidDataException exception) when (prepared.IsGzip)
+            {
+                throw new BadHttpRequestException("The uploaded gzip NZB is invalid.", exception);
+            }
+
             // backup the nzb file if enabled
             if (configManager.IsNzbBackupEnabled())
             {
@@ -73,7 +85,17 @@ public class AddFileController(
 
             // compute the total segment bytes
             await using var nzbFileStream = BlobStore.ReadBlob(id)!;
-            var totalSegmentBytes = ComputeTotalSegmentBytes(nzbFileStream);
+            long totalSegmentBytes;
+            try
+            {
+                totalSegmentBytes = ComputeTotalSegmentBytes(nzbFileStream);
+            }
+            catch (XmlException exception) when (prepared.IsGzip)
+            {
+                throw new BadHttpRequestException(
+                    "The uploaded gzip file does not contain a valid NZB document.",
+                    exception);
+            }
 
             // create the queue item record
             queueItem = new QueueItem
@@ -122,8 +144,7 @@ public class AddFileController(
         }
         catch
         {
-            // in case of any errors writing to the database
-            // delete the nzb file blob (only after UNIQUE retry has also failed)
+            // Delete partial or unreferenced blobs after ingest/database failures.
             BlobStore.Delete(id);
             throw;
         }

--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -2,6 +2,7 @@
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.SabControllers.AddFile;
 
@@ -48,14 +49,12 @@ public class AddFileRequest()
     /// </summary>
     internal static string ResolveFileName(string? nzbName, string? formFileName)
     {
-        var fileName = !string.IsNullOrWhiteSpace(nzbName)
-            ? (nzbName.EndsWith(".nzb", StringComparison.OrdinalIgnoreCase) ? nzbName : $"{nzbName}.nzb")
-            : formFileName;
+        var fileName = !string.IsNullOrWhiteSpace(nzbName) ? nzbName : formFileName;
 
         if (string.IsNullOrWhiteSpace(fileName))
             throw new BadHttpRequestException("NZB filename could not be determined.");
 
-        return fileName;
+        return NzbStreamUtil.NormalizeFileName(fileName);
     }
 
     protected static QueueItem.PriorityOption MapPriorityOption(string? priority)

--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -35,7 +35,8 @@ public class AddFileRequest()
             FileName = fileName,
             ContentType = file.ContentType,
             NzbFileStream = file.OpenReadStream(),
-            Category = context.GetRequestParam("cat") ?? configManager.GetManualUploadCategory(),
+            Category = SabCategoryResolver.GetCategory(context, configManager)
+                       ?? configManager.GetManualUploadCategory(),
             Priority = MapPriorityOption(context.GetRequestParam("priority")),
             PostProcessing = MapPostProcessingOption(context.GetRequestParam("pp")),
             CancellationToken = context.RequestAborted

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -96,10 +96,11 @@ public class AddUrlRequest() : AddFileRequest
 
             var contentType = response.Content.Headers.ContentType?.MediaType;
 
-            var fileName = AddNzbExtension(nzbName)
-                           ?? GetFilenameFromResponseHeader(response)
-                           ?? GetFilenameFromUrl(url)
-                           ?? throw new Exception("Nzb filename could not be determined.");
+            var resolvedFileName = nzbName
+                                   ?? GetFilenameFromResponseHeader(response)
+                                   ?? GetFilenameFromUrl(url)
+                                   ?? throw new Exception("Nzb filename could not be determined.");
+            var fileName = NzbStreamUtil.NormalizeFileName(resolvedFileName);
 
             var fileStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
@@ -122,9 +123,7 @@ public class AddUrlRequest() : AddFileRequest
 
     private static string? AddNzbExtension(string? nzbName)
     {
-        return nzbName == null ? null
-            : nzbName.ToLower().EndsWith("nzb") ? nzbName
-            : $"{nzbName}.nzb";
+        return nzbName == null ? null : NzbStreamUtil.NormalizeFileName(nzbName);
     }
 
     private static async Task<HttpResponseMessage> GetAsync(

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -49,7 +49,8 @@ public class AddUrlRequest() : AddFileRequest
             FileName = nzbFile.FileName,
             ContentType = nzbFile.ContentType,
             NzbFileStream = nzbFile.FileStream,
-            Category = context.GetRequestParam("cat") ?? configManager.GetManualUploadCategory(),
+            Category = SabCategoryResolver.GetCategory(context, configManager)
+                       ?? configManager.GetManualUploadCategory(),
             Priority = MapPriorityOption(context.GetRequestParam("priority")),
             PostProcessing = MapPostProcessingOption(context.GetRequestParam("pp")),
             CancellationToken = context.RequestAborted

--- a/backend/Api/SabControllers/GetCategories/GetCategoriesController.cs
+++ b/backend/Api/SabControllers/GetCategories/GetCategoriesController.cs
@@ -1,11 +1,6 @@
-﻿using System.Text.Json;
-using System.Text.Json.Nodes;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
-using NzbWebDAV.Database.Models;
-using NzbWebDAV.Extensions;
-using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.SabControllers.GetCategories;
 
@@ -14,10 +9,18 @@ public class GetCategoriesController(
     ConfigManager configManager
 ) : SabApiController.BaseController(httpContext, configManager)
 {
-    protected override async Task<IActionResult> Handle()
+    protected override Task<IActionResult> Handle()
     {
-        var categories = configManager.GetApiCategories();
+        var categories = BuildCategories(configManager);
         var response = new { categories };
-        return Ok(response);
+        return Task.FromResult<IActionResult>(Ok(response));
+    }
+
+    internal static List<string> BuildCategories(ConfigManager configManager)
+    {
+        return configManager.GetApiCategories()
+            .Where(category => category != "*")
+            .Prepend("*")
+            .ToList();
     }
 }

--- a/backend/Api/SabControllers/GetConfig/GetConfigController.cs
+++ b/backend/Api/SabControllers/GetConfig/GetConfigController.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
-using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.SabControllers.GetConfig;
@@ -24,7 +23,7 @@ public class GetConfigController(
         var root = JsonNode.Parse(config)!;
 
         // update the complete_dir
-        root["config"]!["misc"]!["complete_dir"] = GetCompletedDir();
+        root["config"]!["misc"]!["complete_dir"] = SabPathResolver.GetCompletedDir(configManager);
 
         // update the categories
         var categoriesRoot = root["config"]?["categories"]?.AsArray()!;
@@ -47,12 +46,5 @@ public class GetConfigController(
         var options = new JsonSerializerOptions { WriteIndented = true };
         var response = root.ToJsonString(options);
         return Content(response, "application/json");
-    }
-
-    private string GetCompletedDir()
-    {
-        return configManager.GetImportStrategy() == "strm"
-            ? configManager.GetStrmCompletedDownloadDir()
-            : Path.Join(configManager.GetRcloneMountDir(), DavItem.SymlinkFolder.Name);
     }
 }

--- a/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
+++ b/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
-using NzbWebDAV.Database.Models;
 
 namespace NzbWebDAV.Api.SabControllers.GetFullStatus;
 
@@ -15,9 +14,9 @@ public class GetFullStatusController(
         // mimic sabnzbd fullstatus
         var status = new GetFullStatusResponse()
         {
-            Status = new GetFullStatusResponse.FullStatusObject()
+            Status = new SabStatusObject
             {
-                CompleteDir = Path.Join(configManager.GetRcloneMountDir(), DavItem.SymlinkFolder.Name),
+                CompleteDir = SabPathResolver.GetCompletedDir(configManager),
             }
         };
 

--- a/backend/Api/SabControllers/GetFullStatus/GetFullStatusResponse.cs
+++ b/backend/Api/SabControllers/GetFullStatus/GetFullStatusResponse.cs
@@ -5,11 +5,5 @@ namespace NzbWebDAV.Api.SabControllers.GetFullStatus;
 public class GetFullStatusResponse
 {
     [JsonPropertyName("status")]
-    public required FullStatusObject Status { get; init; }
-
-    public class FullStatusObject
-    {
-        [JsonPropertyName("completedir")]
-        public required string CompleteDir { get; init; }
-    }
+    public required SabStatusObject Status { get; init; }
 }

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -19,7 +19,7 @@ public class GetHistoryRequest
         var limitParam = context.GetRequestParam("limit");
         var pageSizeParam = context.GetRequestParam("pageSize");
         var nzoIdsParam = context.GetRequestParam("nzo_ids");
-        Category = context.GetRequestParam("category");
+        Category = SabCategoryResolver.GetCategory(context, configManager);
         CancellationToken = context.RequestAborted;
 
         if (startParam is not null)

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -91,7 +91,7 @@ public class GetQueueController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = new GetQueueRequest(httpContext);
+        var request = new GetQueueRequest(httpContext, configManager);
         return Ok(await GetQueueAsync(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.SabControllers.GetQueue;
@@ -11,11 +12,11 @@ public class GetQueueRequest
     public CancellationToken CancellationToken { get; init; }
 
 
-    public GetQueueRequest(HttpContext context)
+    public GetQueueRequest(HttpContext context, ConfigManager configManager)
     {
         var startParam = context.GetRequestParam("start");
         var limitParam = context.GetRequestParam("limit");
-        Category = context.GetRequestParam("category");
+        Category = SabCategoryResolver.GetCategory(context, configManager);
         CancellationToken = context.RequestAborted;
 
         if (startParam is not null)

--- a/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using NzbWebDAV.Database.Models;
 
@@ -73,6 +74,7 @@ public class GetQueueResponse : SabBaseResponse
             IReadOnlyDictionary<string, (string Host, string? Nickname)>? displayByMetricsKey = null
         )
         {
+            var sabProgressPercentage = Math.Clamp(progressPercentage, 0, 100);
             return new QueueSlot
             {
                 Index = index,
@@ -80,12 +82,13 @@ public class GetQueueResponse : SabBaseResponse
                 Priority = queueItem.Priority.ToString(),
                 Filename = queueItem.FileName,
                 Category = queueItem.Category,
-                Percentage = (progressPercentage % 100).ToString(),
-                TruePercentage = progressPercentage.ToString(),
+                Percentage = sabProgressPercentage.ToString(CultureInfo.InvariantCulture),
+                TruePercentage = progressPercentage.ToString(CultureInfo.InvariantCulture),
                 Status = status,
                 TimeLeft = TimeSpan.Zero,
                 SizeInMB = FormatSizeMB(queueItem.TotalSegmentBytes),
-                SizeLeftInMB = FormatSizeMB((100 - progressPercentage) * queueItem.TotalSegmentBytes / 100),
+                SizeLeftInMB = FormatSizeMB(
+                    (100 - sabProgressPercentage) * queueItem.TotalSegmentBytes / 100),
                 Indexer = queueItem.IndexerName,
                 Providers = providerUsage is { Count: > 0 }
                     ? providerUsage
@@ -115,7 +118,7 @@ public class GetQueueResponse : SabBaseResponse
         private static string FormatSizeMB(long bytes)
         {
             var megabytes = bytes / (1024.0 * 1024.0);
-            return megabytes.ToString("0.00");
+            return megabytes.ToString("0.00", CultureInfo.InvariantCulture);
         }
     }
 

--- a/backend/Api/SabControllers/GetStatus/GetStatusController.cs
+++ b/backend/Api/SabControllers/GetStatus/GetStatusController.cs
@@ -11,7 +11,13 @@ public class GetStatusController(
 {
     protected override Task<IActionResult> Handle()
     {
-        var response = new GetStatusResponse() { Status = true };
+        var response = new GetStatusResponse
+        {
+            Status = new SabStatusObject
+            {
+                CompleteDir = SabPathResolver.GetCompletedDir(configManager),
+            },
+        };
         return Task.FromResult<IActionResult>(Ok(response));
     }
 }

--- a/backend/Api/SabControllers/GetStatus/GetStatusResponse.cs
+++ b/backend/Api/SabControllers/GetStatus/GetStatusResponse.cs
@@ -1,5 +1,9 @@
-﻿namespace NzbWebDAV.Api.SabControllers.GetStatus;
+﻿using System.Text.Json.Serialization;
 
-public class GetStatusResponse : SabBaseResponse
+namespace NzbWebDAV.Api.SabControllers.GetStatus;
+
+public class GetStatusResponse
 {
+    [JsonPropertyName("status")]
+    public required SabStatusObject Status { get; init; }
 }

--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -17,7 +17,25 @@ public class RemoveFromHistoryController(
 {
     public async Task<RemoveFromHistoryResponse> RemoveFromHistory(RemoveFromHistoryRequest request)
     {
-        await dbClient.RemoveHistoryItemsAsync(request.NzoIds, request.DeleteCompletedFiles, request.CancellationToken).ConfigureAwait(false);
+        var historyQuery = dbClient.Ctx.HistoryItems.AsNoTracking();
+        var ids = request.DeleteAll
+            ? await historyQuery.Select(item => item.Id)
+                .ToListAsync(request.CancellationToken)
+                .ConfigureAwait(false)
+            : request.DeleteFailed
+                ? await historyQuery
+                    .Where(item => item.DownloadStatus == HistoryItem.DownloadStatusOption.Failed)
+                    .Select(item => item.Id)
+                    .ToListAsync(request.CancellationToken)
+                    .ConfigureAwait(false)
+                : request.NzoIds;
+
+        if (ids.Count > 0)
+        {
+            await dbClient.RemoveHistoryItemsAsync(
+                    ids, request.DeleteCompletedFiles, request.CancellationToken)
+                .ConfigureAwait(false);
+        }
         try
         {
             await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
@@ -40,7 +58,7 @@ public class RemoveFromHistoryController(
 
             await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
         }
-        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", request.NzoIds));
+        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", ids));
         return new RemoveFromHistoryResponse() { Status = true };
     }
 

--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryRequest.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryRequest.cs
@@ -9,35 +9,29 @@ namespace NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 public class RemoveFromHistoryRequest
 {
     public List<Guid> NzoIds { get; private init; } = [];
+    public bool DeleteAll { get; private init; }
+    public bool DeleteFailed { get; private init; }
+    public bool DeleteFailedFilesRequested { get; private init; }
     public bool DeleteCompletedFiles { get; private init; }
     public CancellationToken CancellationToken { get; private init; }
 
     public static async Task<RemoveFromHistoryRequest> New(HttpContext httpContext)
     {
-        // Note: The official SABnzbd api has a query param named `del_files`
-        // which only applies to Failed jobs and does not apply to Completed jobs.
-        // However, Failed jobs in nzbdav never add anything to the webdav anyway,
-        // so there is never anything to delete for Failed jobs. For this reason,
-        // the `del_files` query param from SABnzbd is not needed here at all.
-        //
-        // Instead, a non-standard `del_completed_files` query param is added.
-        // It applies to Completed jobs and does not apply to Failed jobs. It is
-        // only used by the nzbdav web-ui when manually clearing History items to
-        // provide users the option to delete all related files.
         var cancellationToken = SigtermUtil.GetCancellationToken();
+        var query = SabDeleteValueParser.Parse(httpContext, allowFailed: true);
+        var bodyIds = await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false);
         return new RemoveFromHistoryRequest()
         {
-            NzoIds = NzoIdsFromQueryParam(httpContext)
-                .Concat(await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false))
-                .ToList(),
+            NzoIds = query.NzoIds.Concat(bodyIds).Distinct().ToList(),
+            DeleteAll = query.DeleteAll,
+            DeleteFailed = query.DeleteFailed,
+            // SAB's del_files applies to failed-job files. Failed NzbDav jobs
+            // never mount WebDAV content, so accepting the flag is a no-op.
+            DeleteFailedFilesRequested = httpContext.Request.Query["del_files"] == "1",
+            // NzbDav's UI-specific flag intentionally controls completed mounts.
             DeleteCompletedFiles = httpContext.GetRequestParam("del_completed_files") == "1",
             CancellationToken = cancellationToken
         };
-    }
-
-    private static IEnumerable<Guid> NzoIdsFromQueryParam(HttpContext httpContext)
-    {
-        return httpContext.GetQueryParamValues("value").Select(Guid.Parse);
     }
 
     private static async Task<List<Guid>> NzoIdsFromRequestBody(HttpContext httpContext, CancellationToken ct)

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Queue;
@@ -17,8 +18,18 @@ public class RemoveFromQueueController(
 {
     public async Task<RemoveFromQueueResponse> RemoveFromQueue(RemoveFromQueueRequest request)
     {
-        await queueManager.RemoveQueueItemsAsync(request.NzoIds, dbClient, request.CancellationToken).ConfigureAwait(false);
-        _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, string.Join(",", request.NzoIds));
+        var ids = request.DeleteAll
+            ? await dbClient.Ctx.QueueItems.AsNoTracking()
+                .Select(item => item.Id)
+                .ToListAsync(request.CancellationToken)
+                .ConfigureAwait(false)
+            : request.NzoIds;
+        if (ids.Count > 0)
+        {
+            await queueManager.RemoveQueueItemsAsync(ids, dbClient, request.CancellationToken)
+                .ConfigureAwait(false);
+        }
+        _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, string.Join(",", ids));
         _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
         return new RemoveFromQueueResponse() { Status = true };
     }

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueRequest.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
-using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.SabControllers.RemoveFromQueue;
@@ -9,23 +8,22 @@ namespace NzbWebDAV.Api.SabControllers.RemoveFromQueue;
 public class RemoveFromQueueRequest()
 {
     public List<Guid> NzoIds { get; init; } = [];
+    public bool DeleteAll { get; init; }
+    public bool DeleteFilesRequested { get; init; }
     public CancellationToken CancellationToken { get; init; }
 
     public static async Task<RemoveFromQueueRequest> New(HttpContext httpContext)
     {
         var cancellationToken = SigtermUtil.GetCancellationToken();
+        var query = SabDeleteValueParser.Parse(httpContext, allowFailed: false);
+        var bodyIds = await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false);
         return new RemoveFromQueueRequest()
         {
-            NzoIds = NzoIdsFromQueryParam(httpContext)
-                .Concat(await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false))
-                .ToList(),
+            NzoIds = query.NzoIds.Concat(bodyIds).Distinct().ToList(),
+            DeleteAll = query.DeleteAll,
+            DeleteFilesRequested = httpContext.Request.Query["del_files"] == "1",
             CancellationToken = cancellationToken
         };
-    }
-
-    private static IEnumerable<Guid> NzoIdsFromQueryParam(HttpContext httpContext)
-    {
-        return httpContext.GetQueryParamValues("value").Select(Guid.Parse);
     }
 
     private static async Task<List<Guid>> NzoIdsFromRequestBody(HttpContext httpContext, CancellationToken ct)

--- a/backend/Api/SabControllers/SabCategoryResolver.cs
+++ b/backend/Api/SabControllers/SabCategoryResolver.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+internal static class SabCategoryResolver
+{
+    internal static string? GetCategory(HttpContext context, ConfigManager configManager)
+    {
+        var category = context.GetRequestParam("cat")
+                       ?? context.GetRequestParam("category");
+        return category == "*"
+            ? configManager.GetManualUploadCategory()
+            : category;
+    }
+}

--- a/backend/Api/SabControllers/SabDeleteValueParser.cs
+++ b/backend/Api/SabControllers/SabDeleteValueParser.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+internal static class SabDeleteValueParser
+{
+    internal sealed record Result(
+        List<Guid> NzoIds,
+        bool DeleteAll,
+        bool DeleteFailed);
+
+    internal static Result Parse(HttpContext context, bool allowFailed)
+    {
+        var ids = new HashSet<Guid>();
+        var deleteAll = false;
+        var deleteFailed = false;
+
+        foreach (var token in context.GetQueryParamValues("value")
+                     .SelectMany(value => value.Split(',', StringSplitOptions.TrimEntries |
+                                                          StringSplitOptions.RemoveEmptyEntries)))
+        {
+            if (token.Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                deleteAll = true;
+                continue;
+            }
+
+            if (allowFailed && token.Equals("failed", StringComparison.OrdinalIgnoreCase))
+            {
+                deleteFailed = true;
+                continue;
+            }
+
+            if (Guid.TryParse(token, out var id))
+                ids.Add(id);
+        }
+
+        if (deleteAll)
+            return new Result([], DeleteAll: true, DeleteFailed: false);
+        if (deleteFailed)
+            return new Result([], DeleteAll: false, DeleteFailed: true);
+        return new Result(ids.ToList(), DeleteAll: false, DeleteFailed: false);
+    }
+}

--- a/backend/Api/SabControllers/SabPathResolver.cs
+++ b/backend/Api/SabControllers/SabPathResolver.cs
@@ -1,0 +1,14 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+internal static class SabPathResolver
+{
+    internal static string GetCompletedDir(ConfigManager configManager)
+    {
+        return configManager.GetImportStrategy() == "strm"
+            ? configManager.GetStrmCompletedDownloadDir()
+            : Path.Join(configManager.GetRcloneMountDir(), DavItem.SymlinkFolder.Name);
+    }
+}

--- a/backend/Api/SabControllers/SabStatusObject.cs
+++ b/backend/Api/SabControllers/SabStatusObject.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+public sealed class SabStatusObject
+{
+    [JsonPropertyName("completedir")]
+    public required string CompleteDir { get; init; }
+}

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -3,7 +3,6 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using UsenetSharp.Clients;
 using UsenetSharp.Models;
-using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Clients.Usenet;
 
@@ -18,7 +17,10 @@ public class BaseNntpClient : NntpClient
 {
     private readonly IUsenetClient _client;
 
-    public BaseNntpClient() : this(new UsenetClient())
+    public BaseNntpClient() : this(new UsenetClient(new UsenetClientOptions
+    {
+        CrcValidation = YencCrcValidationMode.WhenPresent,
+    }))
     {
     }
 
@@ -160,18 +162,25 @@ public class BaseNntpClient : NntpClient
     )
     {
         segmentId = PrepareSegmentId(segmentId);
-        var articleResponse = await _client.ArticleAsync(segmentId, onConnectionReadyAgain, cancellationToken);
+        var headResponse = await _client.HeadAsync(segmentId, cancellationToken).ConfigureAwait(false);
+        if (headResponse.ResponseType != UsenetResponseType.ArticleRetrievedHeadFollows)
+            throw CreateArticleFetchException(segmentId, headResponse);
 
-        if (articleResponse.ResponseType != UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
-            throw CreateArticleFetchException(segmentId, articleResponse);
+        // UsenetSharp validates CRCs on decoded BODY responses. Pair HEAD + BODY
+        // instead of locally decoding ARTICLE so first-segment metadata probes get
+        // the same corruption detection as normal streaming.
+        var bodyResponse = await _client.DecodedBodyAsync(
+            segmentId, onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
+        if (bodyResponse.ResponseType != UsenetResponseType.ArticleRetrievedBodyFollows)
+            throw CreateArticleFetchException(segmentId, bodyResponse);
 
         return new UsenetDecodedArticleResponse()
         {
-            SegmentId = articleResponse.SegmentId,
-            ResponseCode = articleResponse.ResponseCode,
-            ResponseMessage = articleResponse.ResponseMessage,
-            ArticleHeaders = articleResponse.ArticleHeaders!,
-            Stream = new YencStream(articleResponse.Stream!),
+            SegmentId = bodyResponse.SegmentId,
+            ResponseCode = bodyResponse.ResponseCode,
+            ResponseMessage = bodyResponse.ResponseMessage,
+            ArticleHeaders = headResponse.ArticleHeaders!,
+            Stream = bodyResponse.Stream!,
         };
     }
 

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -214,8 +214,17 @@ public class BaseNntpClient : NntpClient
 
     public override void Dispose()
     {
-        if (_client is IDisposable disposable)
+        if (_client is IAsyncDisposable asyncDisposable)
+        {
+            // UsenetSharp sends a best-effort QUIT only from DisposeAsync.
+            // Pool disposal already runs off the request path, so wait here to
+            // release strict providers' connection slots before reconnecting.
+            asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+        else if (_client is IDisposable disposable)
+        {
             disposable.Dispose();
+        }
         GC.SuppressFinalize(this);
     }
 }

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -30,6 +30,7 @@ public class ProviderCircuitBreaker
     private static readonly TimeSpan DefaultProbeAbandonTimeout = TimeSpan.FromSeconds(60);
 
     private readonly string _providerName;
+    private readonly Action<ProviderCircuitTransition>? _onTransition;
     private readonly object _lock = new();
     private readonly Queue<(long AtMs, bool Failed)> _window = new();
 
@@ -42,9 +43,12 @@ public class ProviderCircuitBreaker
     private long _failureCount;
     private long _articleMissCount;
 
-    public ProviderCircuitBreaker(string providerName)
+    public ProviderCircuitBreaker(
+        string providerName,
+        Action<ProviderCircuitTransition>? onTransition = null)
     {
         _providerName = providerName;
+        _onTransition = onTransition;
     }
 
     /// <summary>How long an unanswered half-open probe may hold the slot. For tests.</summary>
@@ -96,7 +100,8 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
-            if (_window.Count > 0 || _trippedUntilMs > 0 || _halfOpenProbeInFlight != 0)
+            var wasCircuitActive = _trippedUntilMs > 0 || _halfOpenProbeInFlight != 0;
+            if (_window.Count > 0 || wasCircuitActive)
                 Log.Information("Provider {Provider} recovered — circuit breaker reset.", _providerName);
 
             _window.Clear();
@@ -105,6 +110,8 @@ public class ProviderCircuitBreaker
             _lastFailureReason = null;
             Volatile.Write(ref _halfOpenProbeInFlight, 0);
             Volatile.Write(ref _probeStartedMs, 0);
+            if (wasCircuitActive)
+                NotifyTransition(ProviderCircuitTransitionState.Closed, cooldown: null);
         }
     }
 
@@ -202,16 +209,41 @@ public class ProviderCircuitBreaker
 
     private void Trip(long nowMs, string reason)
     {
+        var appliedCooldown = _currentCooldown;
         _lastFailureReason = reason;
         Interlocked.Increment(ref _tripCount);
-        _trippedUntilMs = nowMs + (long)_currentCooldown.TotalMilliseconds;
+        _trippedUntilMs = nowMs + (long)appliedCooldown.TotalMilliseconds;
         Log.Warning(
             "Provider {Provider} tripped ({Reason}). Skipping for {Cooldown}s.",
-            _providerName, reason, _currentCooldown.TotalSeconds);
+            _providerName, reason, appliedCooldown.TotalSeconds);
+        NotifyTransition(ProviderCircuitTransitionState.Open, appliedCooldown);
 
         _window.Clear();
         _currentCooldown = TimeSpan.FromMilliseconds(
             Math.Min(_currentCooldown.TotalMilliseconds * 2, MaxCooldown.TotalMilliseconds));
+    }
+
+    private void NotifyTransition(
+        ProviderCircuitTransitionState state,
+        TimeSpan? cooldown)
+    {
+        if (_onTransition is null)
+            return;
+
+        try
+        {
+            _onTransition(new ProviderCircuitTransition(
+                state,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                cooldown));
+        }
+        catch (Exception exception)
+        {
+            Log.Warning(
+                exception,
+                "Provider {Provider} circuit transition callback failed",
+                _providerName);
+        }
     }
 
     private void EvictOldEntries(long nowMs)

--- a/backend/Clients/Usenet/Models/ProviderCircuitTransition.cs
+++ b/backend/Clients/Usenet/Models/ProviderCircuitTransition.cs
@@ -1,0 +1,12 @@
+namespace NzbWebDAV.Clients.Usenet.Models;
+
+public enum ProviderCircuitTransitionState
+{
+    Open,
+    Closed,
+}
+
+public sealed record ProviderCircuitTransition(
+    ProviderCircuitTransitionState State,
+    long AtUnixMilliseconds,
+    TimeSpan? Cooldown);

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -13,6 +13,7 @@ using NzbWebDAV.Streams;
 using Serilog;
 using Serilog.Context;
 using UsenetSharp.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Clients.Usenet;
 
@@ -244,7 +245,7 @@ public class MultiProviderNntpClient(
                 _usageTracker.RecordSuccess(primaryProvider.MetricsKey);
                 RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Ok,
                     primaryStopwatch.ElapsedMilliseconds, 0);
-                return WrapStreamForByteCounting(response, primaryProvider.MetricsKey);
+                return WrapProviderResponse(response, primaryProvider.MetricsKey);
             }
 
             if (response != null && UsenetArticleAvailability.IsDefinitiveMissing(response))
@@ -304,7 +305,7 @@ public class MultiProviderNntpClient(
                             _usageTracker.RecordFailoverSave();
                             RecordFailoverMisses(priorMisses, provider.MetricsKey);
                         }
-                        response = WrapStreamForByteCounting(response, provider.MetricsKey);
+                        response = WrapProviderResponse(response, provider.MetricsKey);
                         fallbackCompletionOwnedByTransfer = true;
                         deferredCallback.Activate(result =>
                         {
@@ -501,7 +502,7 @@ public class MultiProviderNntpClient(
                         _usageTracker.RecordFailoverSave();
                         RecordFailoverMisses(priorMisses, provider.MetricsKey);
                     }
-                    result = WrapStreamForByteCounting(result, provider.MetricsKey);
+                    result = WrapProviderResponse(result, provider.MetricsKey);
                     deferredCallback.Activate(onConnectionReadyAgain ?? (_ => { }));
                     return result;
                 }
@@ -630,7 +631,7 @@ public class MultiProviderNntpClient(
                         _usageTracker.RecordFailoverSave();
                         RecordFailoverMisses(priorMisses, rescuer: provider.MetricsKey);
                     }
-                    result = WrapStreamForByteCounting(result, provider.MetricsKey);
+                    result = WrapProviderResponse(result, provider.MetricsKey);
                 }
                 else if (result is UsenetDecodedBodyResponse or UsenetDecodedArticleResponse)
                 {
@@ -713,17 +714,30 @@ public class MultiProviderNntpClient(
         }
     }
 
-    private T WrapStreamForByteCounting<T>(T result, string metricsKey) where T : UsenetResponse
+    private T WrapProviderResponse<T>(T result, string metricsKey) where T : UsenetResponse
     {
-        if (bytesTracker == null) return result;
         return result switch
         {
             UsenetDecodedBodyResponse b
-                => (T)(object)(b with { Stream = new CountingYencStream(b.Stream!, bytesTracker, metricsKey, activeReadRegistry) }),
+                => (T)(object)(b with
+                {
+                    Stream = WrapProviderStream(b.Stream!, b.SegmentId, metricsKey)
+                }),
             UsenetDecodedArticleResponse a
-                => (T)(object)(a with { Stream = new CountingYencStream(a.Stream!, bytesTracker, metricsKey, activeReadRegistry) }),
+                => (T)(object)(a with
+                {
+                    Stream = WrapProviderStream(a.Stream!, a.SegmentId, metricsKey)
+                }),
             _ => result,
         };
+    }
+
+    private YencStream WrapProviderStream(YencStream stream, SegmentId segmentId, string metricsKey)
+    {
+        YencStream wrapped = new CorruptionDetectingYencStream(stream, segmentId, metricsKey);
+        if (bytesTracker != null)
+            wrapped = new CountingYencStream(wrapped, bytesTracker, metricsKey, activeReadRegistry);
+        return wrapped;
     }
 
     private static SegmentFetch.FetchStatus ClassifyException(Exception ex)

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -409,7 +409,7 @@ public abstract class NntpClient : INntpClient
     internal static bool IsValidSegmentId(string? id)
     {
         var value = NormalizeSegmentId(id);
-        if (value.Length is < 3 or > 495) return false;
+        if (value.Length is < 3 or > 248) return false;
         if (value[0] == '@' || value[^1] == '@' || !value.Contains('@')) return false;
         if (value.Contains('<') || value.Contains('>')) return false;
         foreach (var character in value)

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -1,6 +1,7 @@
 ﻿using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
@@ -118,7 +119,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             .Select((provider, index) => CreateProviderClient(
                 provider,
                 connectionPoolStats.GetOnConnectionPoolChanged(index),
-                idleTimeoutSeconds
+                idleTimeoutSeconds,
+                metricsWriter
             ))
             .ToList();
         return new MultiProviderNntpClient(
@@ -132,7 +134,8 @@ public class UsenetStreamingClient : WrappingNntpClient
     (
         UsenetProviderConfig.ConnectionDetails connectionDetails,
         EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
-        int idleTimeoutSeconds
+        int idleTimeoutSeconds,
+        MetricsWriter metricsWriter
     )
     {
         var maxConnections = connectionDetails.MaxConnections;
@@ -163,10 +166,24 @@ public class UsenetStreamingClient : WrappingNntpClient
             onConnectionPoolChanged,
             idleTimeoutSeconds
         );
-        var circuitBreaker = new ProviderCircuitBreaker(connectionDetails.Host);
         // Ensure a metrics key even if startup backfill was skipped somehow.
         if (connectionDetails.ProviderId == Guid.Empty)
             connectionDetails.ProviderId = Guid.NewGuid();
+        var metricsKey = UsenetProviderIdentity.MetricsKey(connectionDetails);
+        var circuitBreaker = new ProviderCircuitBreaker(
+            connectionDetails.Host,
+            transition => metricsWriter.RecordEvent(new MetricEvent
+            {
+                At = transition.AtUnixMilliseconds,
+                Kind = "circuit",
+                Tag1 = metricsKey,
+                Tag2 = transition.State == ProviderCircuitTransitionState.Open
+                    ? "open"
+                    : "closed",
+                Num = transition.Cooldown is { } cooldown
+                    ? (long)cooldown.TotalMilliseconds
+                    : null,
+            }));
         return new MultiConnectionNntpClient(
             connectionPool,
             connectionDetails.Type,
@@ -177,7 +194,7 @@ public class UsenetStreamingClient : WrappingNntpClient
             connectionDetails.Priority,
             connectionDetails.PipeliningDepth,
             connectionDetails.StorageGroup,
-            UsenetProviderIdentity.MetricsKey(connectionDetails)
+            metricsKey
         );
     }
 

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -43,10 +43,13 @@ public class BlobStore
         return fileStream;
     }
 
-    public static async Task WriteBlob(Guid id, Stream stream)
+    public static async Task WriteBlob(
+        Guid id,
+        Stream stream,
+        CancellationToken cancellationToken = default)
     {
         await using var fileStream = OpenBlobWrite(id);
-        await stream.CopyToAsync(fileStream);
+        await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
         MetadataCache.Remove(id);
     }
 

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -1,4 +1,5 @@
-﻿using MemoryPack;
+﻿using System.Runtime.CompilerServices;
+using MemoryPack;
 using Microsoft.Extensions.Caching.Memory;
 using NzbWebDAV.Database.Models;
 using ZstdSharp;
@@ -43,6 +44,9 @@ public class BlobStore
         return fileStream;
     }
 
+    // Prefer this overload over WriteBlob<T> when the argument is a Stream;
+    // an optional CancellationToken otherwise loses to the generic method.
+    [OverloadResolutionPriority(1)]
     public static async Task WriteBlob(
         Guid id,
         Stream stream,

--- a/backend/Exceptions/UsenetCorruptArticleException.cs
+++ b/backend/Exceptions/UsenetCorruptArticleException.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Exceptions;
+
+public sealed class UsenetCorruptArticleException(
+    string segmentId,
+    string providerKey,
+    Exception innerException)
+    : RetryableDownloadException(
+        $"Provider {providerKey} returned corrupt yEnc data for segment {segmentId}.",
+        innerException)
+{
+    public string SegmentId { get; } = segmentId;
+    public string ProviderKey { get; } = providerKey;
+}

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -22,7 +22,7 @@
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="NzbDav.SharpCompress" Version="0.53.0" />
-      <PackageReference Include="NzbDav.UsenetSharp" Version="2.0.2" />
+      <PackageReference Include="NzbDav.UsenetSharp" Version="3.0.0" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>
 

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -99,6 +99,14 @@ public class LazyRarProcessor(
         }
 
         var pathInArchive = fileHeader.FileName;
+        if (FilenameUtil.IsRarFile(Path.GetFileName(pathInArchive)))
+        {
+            Log.Information(
+                "LazyRarProcessor: inner path {Inner} is RAR, falling back to eager",
+                pathInArchive);
+            return null;
+        }
+
         var aesParams = fileHeader.GetAesParams(password);
         var totalFileSize = aesParams?.DecodedSize ?? fileHeader.UncompressedSize;
 

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -1,0 +1,319 @@
+using System.Text.RegularExpressions;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Queue.FileAggregators;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Utils;
+using Serilog;
+using SharpCompress.Common.Rar.Headers;
+
+namespace NzbWebDAV.Queue.NestedRarExpansion;
+
+/// <summary>
+/// Expands stored nested RAR members into their inner files before
+/// <see cref="RarAggregator"/> runs. Failures fall back to mounting the
+/// opaque <c>.rar</c> member exactly as before.
+/// </summary>
+public static class NestedRarExpansionStep
+{
+    public const int DefaultMaxDepth = 3;
+    public const int MaxInnerFilesPerArchive = 500;
+
+    public static async Task<List<BaseProcessor.Result>> ExpandAsync(
+        List<BaseProcessor.Result> processorResults,
+        INntpClient usenetClient,
+        string? password,
+        CancellationToken ct,
+        int maxDepth = DefaultMaxDepth)
+    {
+        return await ExpandAsync(
+            processorResults,
+            (segments, token) => OpenComposedStreamAsync(segments, usenetClient, token),
+            password,
+            ct,
+            maxDepth).ConfigureAwait(false);
+    }
+
+    /// <summary>Test seam that injects a composed-stream factory.</summary>
+    internal static async Task<List<BaseProcessor.Result>> ExpandAsync(
+        List<BaseProcessor.Result> processorResults,
+        Func<RarProcessor.StoredFileSegment[], CancellationToken, Task<Stream>> openComposedStream,
+        string? password,
+        CancellationToken ct,
+        int maxDepth = DefaultMaxDepth)
+    {
+        var passthrough = processorResults
+            .Where(result => result is not RarProcessor.Result)
+            .ToList();
+        var segments = processorResults
+            .OfType<RarProcessor.Result>()
+            .SelectMany(result => result.StoredFileSegments)
+            .ToList();
+
+        if (segments.Count == 0)
+            return processorResults;
+
+        var expanded = await ExpandSegmentsAsync(
+            segments, openComposedStream, password, ct, maxDepth).ConfigureAwait(false);
+
+        var results = new List<BaseProcessor.Result>(passthrough.Count + 1);
+        results.AddRange(passthrough);
+        if (expanded.Count > 0)
+        {
+            results.Add(new RarProcessor.Result
+            {
+                StoredFileSegments = expanded.ToArray(),
+            });
+        }
+
+        return results;
+    }
+
+    internal static async Task<List<RarProcessor.StoredFileSegment>> ExpandSegmentsAsync(
+        List<RarProcessor.StoredFileSegment> segments,
+        Func<RarProcessor.StoredFileSegment[], CancellationToken, Task<Stream>> openComposedStream,
+        string? password,
+        CancellationToken ct,
+        int maxDepth = DefaultMaxDepth)
+    {
+        var current = segments;
+        for (var depth = 0; depth < maxDepth; depth++)
+        {
+            var nestedGroups = current
+                .GroupBy(segment => segment.PathWithinArchive, StringComparer.Ordinal)
+                .Where(group => FilenameUtil.IsRarFile(Path.GetFileName(group.Key)))
+                .ToList();
+            if (nestedGroups.Count == 0)
+                break;
+
+            var next = new List<RarProcessor.StoredFileSegment>(current.Count);
+            var expandedAny = false;
+
+            foreach (var group in current.GroupBy(segment => segment.PathWithinArchive, StringComparer.Ordinal))
+            {
+                var members = group.ToList();
+                if (!FilenameUtil.IsRarFile(Path.GetFileName(group.Key)))
+                {
+                    next.AddRange(members);
+                    continue;
+                }
+
+                var expanded = await TryExpandGroupAsync(
+                    members, openComposedStream, password, ct).ConfigureAwait(false);
+                if (expanded is null)
+                {
+                    next.AddRange(members);
+                    continue;
+                }
+
+                expandedAny = true;
+                next.AddRange(expanded);
+            }
+
+            current = next;
+            if (!expandedAny)
+                break;
+        }
+
+        return current;
+    }
+
+    private static async Task<List<RarProcessor.StoredFileSegment>?> TryExpandGroupAsync(
+        List<RarProcessor.StoredFileSegment> members,
+        Func<RarProcessor.StoredFileSegment[], CancellationToken, Task<Stream>> openComposedStream,
+        string? password,
+        CancellationToken ct)
+    {
+        var path = members[0].PathWithinArchive;
+        if (members.Any(member => member.AesParams is not null))
+        {
+            Log.Information(
+                "NestedRarExpansion: skipping encrypted nested archive {Path}",
+                path);
+            return null;
+        }
+
+        RarProcessor.StoredFileSegment[] sorted;
+        try
+        {
+            RarAggregator.ValidateVolumes(members);
+            sorted = RarAggregator.SortByPartNumber(members);
+        }
+        catch (Exception e)
+        {
+            Log.Information(e,
+                "NestedRarExpansion: outer volume set for {Path} is incomplete; keeping opaque",
+                path);
+            return null;
+        }
+
+        var outerSize = sorted.Sum(segment => segment.ByteRangeWithinPart.Count);
+        try
+        {
+            await using var stream = await openComposedStream(sorted, ct).ConfigureAwait(false);
+            var headers = await RarUtil.GetRarHeadersAsync(stream, password, ct).ConfigureAwait(false);
+            var fileHeaders = headers
+                .OfType<IRarFileHeader>()
+                .Where(header => !header.IsDirectory)
+                .ToList();
+
+            if (fileHeaders.Count == 0)
+            {
+                Log.Information(
+                    "NestedRarExpansion: no files in nested archive {Path}; keeping opaque",
+                    path);
+                return null;
+            }
+
+            if (fileHeaders.Count > MaxInnerFilesPerArchive)
+            {
+                Log.Information(
+                    "NestedRarExpansion: nested archive {Path} has {Count} files (limit {Limit}); keeping opaque",
+                    path, fileHeaders.Count, MaxInnerFilesPerArchive);
+                return null;
+            }
+
+            if (fileHeaders.Any(header => !header.IsStored || header.IsSolid))
+            {
+                Log.Information(
+                    "NestedRarExpansion: nested archive {Path} uses compression/solid; keeping opaque",
+                    path);
+                return null;
+            }
+
+            var declaredUncompressed = fileHeaders.Sum(header => header.UncompressedSize);
+            if (declaredUncompressed > outerSize * 2)
+            {
+                Log.Information(
+                    "NestedRarExpansion: nested archive {Path} declares {Declared} bytes (outer {Outer}); keeping opaque",
+                    path, declaredUncompressed, outerSize);
+                return null;
+            }
+
+            var archiveName = GetArchiveName(Path.GetFileName(path));
+            var partNumber = new RarProcessor.PartNumber
+            {
+                PartNumberFromHeader = GetPartNumberFromHeaders(headers),
+                PartNumberFromFilename = GetPartNumberFromFilename(Path.GetFileName(path)),
+            };
+            var releaseDate = sorted[0].ReleaseDate;
+            var expanded = new List<RarProcessor.StoredFileSegment>();
+
+            foreach (var header in fileHeaders)
+            {
+                var innerPath = NormalizeInnerPath(header.FileName);
+                if (string.IsNullOrWhiteSpace(innerPath) ||
+                    innerPath.Split('/', '\\').Any(segment => segment is ".." or "."))
+                {
+                    Log.Information(
+                        "NestedRarExpansion: rejecting unsafe inner path {Inner} in {Path}",
+                        header.FileName, path);
+                    return null;
+                }
+
+                var range = LongRange.FromStartAndSize(
+                    header.DataStartPosition,
+                    header.AdditionalDataSize);
+                var mapped = NestedRarRangeMapper.Map(
+                    range,
+                    sorted,
+                    innerPath,
+                    archiveName,
+                    partNumber,
+                    header.GetAesParams(password),
+                    header.UncompressedSize,
+                    releaseDate);
+                expanded.AddRange(mapped);
+            }
+
+            if (expanded.Count == 0)
+                return null;
+
+            Log.Information(
+                "NestedRarExpansion: expanded {Path} into {Count} inner file segment(s)",
+                path, expanded.Count);
+            return expanded;
+        }
+        catch (Exception e) when (!e.IsCancellationException())
+        {
+            Log.Information(e,
+                "NestedRarExpansion: failed to expand {Path}; keeping opaque",
+                path);
+            return null;
+        }
+    }
+
+    private static async Task<Stream> OpenComposedStreamAsync(
+        RarProcessor.StoredFileSegment[] sorted,
+        INntpClient usenetClient,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        var fileParts = sorted.Select(segment => new DavMultipartFile.FilePart
+        {
+            SegmentIds = segment.NzbFile.GetSegmentIds(),
+            SegmentIdByteRange = LongRange.FromStartAndSize(0, segment.PartSize),
+            FilePartByteRange = segment.ByteRangeWithinPart,
+            SegmentByteRanges = segment.NzbFile.GetSegmentByteRanges(),
+            SegmentFallbackIds = segment.NzbFile.GetSegmentFallbackIds(),
+        }).ToArray();
+
+        var multipart = new DavMultipartFile
+        {
+            Id = Guid.NewGuid(),
+            Metadata = new DavMultipartFile.Meta
+            {
+                FileParts = fileParts,
+            },
+        };
+
+        return new DavMultipartFileStream(
+            multipart,
+            usenetClient,
+            articleBufferSize: 0,
+            resolver: null,
+            usePipelinedBodyRequests: false);
+    }
+
+    private static string GetArchiveName(string fileName)
+    {
+        var sansExtension = Path.GetFileNameWithoutExtension(fileName);
+        return Regex.Replace(sansExtension, @"\.part\d+$", "", RegexOptions.IgnoreCase);
+    }
+
+    private static int? GetPartNumberFromHeaders(List<IRarHeader> headers)
+    {
+        var archiveHeader = headers.OfType<IRarArchiveHeader>().FirstOrDefault();
+        if (archiveHeader?.VolumeNumber != null) return archiveHeader.VolumeNumber.Value;
+
+        var endHeader = headers.OfType<IRarEndArchiveHeader>().FirstOrDefault();
+        if (endHeader?.VolumeNumber != null) return endHeader.VolumeNumber.Value;
+
+        if (archiveHeader?.IsFirstVolume == true) return -1;
+        return null;
+    }
+
+    private static int? GetPartNumberFromFilename(string filename)
+    {
+        var partMatch = Regex.Match(filename, @"\.part(\d+)\.rar$", RegexOptions.IgnoreCase);
+        if (partMatch.Success)
+            return int.Parse(partMatch.Groups[1].Value);
+
+        var rMatch = Regex.Match(filename, @"\.r(\d+)$", RegexOptions.IgnoreCase);
+        if (rMatch.Success)
+            return int.Parse(rMatch.Groups[1].Value);
+
+        if (filename.EndsWith(".rar", StringComparison.OrdinalIgnoreCase))
+            return -1;
+
+        return null;
+    }
+
+    private static string NormalizeInnerPath(string path)
+    {
+        return path.Replace('\\', '/').TrimStart('/');
+    }
+}

--- a/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
@@ -1,0 +1,100 @@
+using NzbWebDAV.Models;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Queue.NestedRarExpansion;
+
+/// <summary>
+/// Maps a byte range within a composed outer-archive member onto the
+/// underlying NZB volume segments (SevenZip-style interpolation).
+/// </summary>
+public static class NestedRarRangeMapper
+{
+    public static RarProcessor.StoredFileSegment[] Map(
+        LongRange rangeWithinComposed,
+        RarProcessor.StoredFileSegment[] sortedOuterSegments,
+        string pathWithinArchive,
+        string archiveName,
+        RarProcessor.PartNumber partNumber,
+        AesParams? aesParams,
+        long fileUncompressedSize,
+        DateTimeOffset releaseDate)
+    {
+        if (sortedOuterSegments.Length == 0)
+            return [];
+
+        var partLayouts = BuildLayouts(sortedOuterSegments);
+        var composedSize = partLayouts[^1].ComposedRange.EndExclusive;
+
+        var (startIndex, startComposedRange) = InterpolationSearch.Find(
+            rangeWithinComposed.StartInclusive,
+            new LongRange(0, partLayouts.Length),
+            new LongRange(0, composedSize),
+            guess => partLayouts[guess].ComposedRange);
+
+        var (endIndex, endComposedRange) = InterpolationSearch.Find(
+            rangeWithinComposed.EndExclusive - 1,
+            new LongRange(0, partLayouts.Length),
+            new LongRange(0, composedSize),
+            guess => partLayouts[guess].ComposedRange);
+
+        var results = new List<RarProcessor.StoredFileSegment>(endIndex - startIndex + 1);
+        for (var index = startIndex; index <= endIndex; index++)
+        {
+            var layout = partLayouts[index];
+            var partStart = index == startIndex
+                ? rangeWithinComposed.StartInclusive - startComposedRange.StartInclusive
+                : 0;
+            var partEnd = index == endIndex
+                ? rangeWithinComposed.EndExclusive - endComposedRange.StartInclusive
+                : layout.Outer.ByteRangeWithinPart.Count;
+            var partCount = partEnd - partStart;
+            if (partCount <= 0)
+                continue;
+
+            // Single outer segment: this group is one complete inner volume
+            // (shape B) — use the nested archive's part identity. Multiple outer
+            // segments: the nested archive is itself split across outer volumes
+            // (shape A) — inherit each outer volume's part number.
+            var mappedPartNumber = sortedOuterSegments.Length == 1
+                ? partNumber
+                : layout.Outer.PartNumber;
+
+            results.Add(new RarProcessor.StoredFileSegment
+            {
+                NzbFile = layout.Outer.NzbFile,
+                PartSize = layout.Outer.PartSize,
+                ArchiveName = archiveName,
+                PartNumber = mappedPartNumber,
+                ReleaseDate = releaseDate,
+                PathWithinArchive = pathWithinArchive,
+                ByteRangeWithinPart = LongRange.FromStartAndSize(
+                    layout.Outer.ByteRangeWithinPart.StartInclusive + partStart,
+                    partCount),
+                AesParams = aesParams,
+                FileUncompressedSize = fileUncompressedSize,
+            });
+        }
+
+        return results.ToArray();
+    }
+
+    private static PartLayout[] BuildLayouts(RarProcessor.StoredFileSegment[] sortedOuterSegments)
+    {
+        var layouts = new PartLayout[sortedOuterSegments.Length];
+        long offset = 0;
+        for (var i = 0; i < sortedOuterSegments.Length; i++)
+        {
+            var outer = sortedOuterSegments[i];
+            var count = outer.ByteRangeWithinPart.Count;
+            layouts[i] = new PartLayout(outer, LongRange.FromStartAndSize(offset, count));
+            offset += count;
+        }
+
+        return layouts;
+    }
+
+    private readonly record struct PartLayout(
+        RarProcessor.StoredFileSegment Outer,
+        LongRange ComposedRange);
+}

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -16,6 +16,7 @@ using NzbWebDAV.Queue.DeobfuscationSteps._2.GetPar2FileDescriptors;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
 using NzbWebDAV.Queue.FileAggregators;
 using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Queue.NestedRarExpansion;
 using NzbWebDAV.Queue.PostProcessors;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
@@ -252,6 +253,12 @@ public class QueueItemProcessor(
         {
             var lazyProc = new LazyRarProcessor(rarFiles, usenetClient, archivePassword, ct);
             lazyRarResult = await lazyProc.ProcessAsync().ConfigureAwait(false) as LazyRarProcessor.Result;
+            // Nested archives need the full eager pass + NestedRarExpansionStep.
+            if (lazyRarResult is not null &&
+                FilenameUtil.IsRarFile(Path.GetFileName(lazyRarResult.PathInArchive)))
+            {
+                lazyRarResult = null;
+            }
         }
         var msRar = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
@@ -273,6 +280,8 @@ public class QueueItemProcessor(
             .Select(x => x!)
             .ToList();
         if (lazyRarResult is not null) fileProcessingResults.Add(lazyRarResult);
+        fileProcessingResults = await NestedRarExpansionStep.ExpandAsync(
+            fileProcessingResults, usenetClient, archivePassword, ct).ConfigureAwait(false);
         var msProcessors = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
 

--- a/backend/Services/Metrics/CircuitOutageSparkBuilder.cs
+++ b/backend/Services/Metrics/CircuitOutageSparkBuilder.cs
@@ -1,0 +1,89 @@
+namespace NzbWebDAV.Services.Metrics;
+
+public static class CircuitOutageSparkBuilder
+{
+    public sealed record Event(
+        long At,
+        string Provider,
+        string State,
+        long? CooldownMs);
+
+    public static Dictionary<string, List<int>> Build(
+        IEnumerable<Event> events,
+        IEnumerable<string> providerKeys,
+        long sparkStart,
+        long bucketSize,
+        int bucketCount,
+        long nowMs)
+    {
+        var result = providerKeys
+            .Distinct(StringComparer.Ordinal)
+            .ToDictionary(
+                key => key,
+                _ => new long[bucketCount],
+                StringComparer.Ordinal);
+
+        foreach (var group in events
+                     .Where(item => result.ContainsKey(item.Provider))
+                     .GroupBy(item => item.Provider, StringComparer.Ordinal))
+        {
+            var outageMs = result[group.Key];
+            long? openAt = null;
+            long openUntil = 0;
+
+            foreach (var item in group.OrderBy(item => item.At))
+            {
+                if (item.State.Equals("open", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (openAt is { } previousOpen)
+                        AddInterval(outageMs, previousOpen, Math.Min(openUntil, item.At));
+
+                    openAt = item.At;
+                    openUntil = item.At + Math.Max(0, item.CooldownMs ?? 0);
+                    continue;
+                }
+
+                if (!item.State.Equals("closed", StringComparison.OrdinalIgnoreCase) ||
+                    openAt is not { } started)
+                {
+                    continue;
+                }
+
+                AddInterval(outageMs, started, Math.Min(openUntil, item.At));
+                openAt = null;
+            }
+
+            if (openAt is { } stillOpen)
+                AddInterval(outageMs, stillOpen, Math.Min(openUntil, nowMs));
+
+            void AddInterval(long[] buckets, long start, long end)
+            {
+                start = Math.Max(start, sparkStart);
+                end = Math.Min(end, sparkStart + bucketSize * bucketCount);
+                if (end <= start)
+                    return;
+
+                var first = Math.Max(0, (int)((start - sparkStart) / bucketSize));
+                var last = Math.Min(bucketCount - 1, (int)((end - 1 - sparkStart) / bucketSize));
+                for (var index = first; index <= last; index++)
+                {
+                    var bucketStart = sparkStart + index * bucketSize;
+                    var bucketEnd = bucketStart + bucketSize;
+                    buckets[index] += Math.Max(
+                        0,
+                        Math.Min(end, bucketEnd) - Math.Max(start, bucketStart));
+                }
+            }
+        }
+
+        return result.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value
+                .Select(duration => (int)Math.Clamp(
+                    Math.Round(duration * 100d / bucketSize),
+                    0,
+                    100))
+                .ToList(),
+            StringComparer.Ordinal);
+    }
+}

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -272,12 +272,16 @@ public class MetricsWriter : BackgroundService
     }
 
     /// <summary>
-    /// Drops queued rows belonging to one provider (fetches and failover misses;
-    /// events and sessions are not provider-keyed). Drop counters are untouched.
+    /// Drops queued rows belonging to one provider. Circuit events use Tag1 as
+    /// their provider key; unrelated/global events and sessions are preserved.
+    /// Drop counters are untouched.
     /// </summary>
     public void DiscardQueuedForProvider(string providerKey)
     {
         FilterQueue(_fetches, f => !string.Equals(f.Provider, providerKey, StringComparison.Ordinal));
+        FilterQueue(_events, e =>
+            !string.Equals(e.Kind, "circuit", StringComparison.Ordinal)
+            || !string.Equals(e.Tag1, providerKey, StringComparison.Ordinal));
         FilterQueue(_failoverMisses, m =>
             !string.Equals(m.FromProvider, providerKey, StringComparison.Ordinal)
             && !string.Equals(m.ToProvider, providerKey, StringComparison.Ordinal));

--- a/backend/Services/Metrics/OverviewStatsReset.cs
+++ b/backend/Services/Metrics/OverviewStatsReset.cs
@@ -89,8 +89,8 @@ public static class OverviewStatsReset
 
     /// <summary>
     /// Deletes rows attributable to one provider. Global rollups
-    /// (ThroughputMinutes, ReadSessions, MetricEvents, CatalogueDaily) are
-    /// left intact because their rows cannot be split by provider.
+    /// (ThroughputMinutes, ReadSessions, non-circuit MetricEvents, CatalogueDaily)
+    /// are left intact because their rows cannot be split by provider.
     /// Deletes commit per statement (and per batch for SegmentFetches), so a
     /// cancelled run is harmless and re-running completes the remainder.
     /// </summary>
@@ -118,6 +118,9 @@ public static class OverviewStatsReset
             .Where(x => x.Provider == providerKey).ExecuteDeleteAsync(ct).ConfigureAwait(false);
         deleted += await db.ProviderHourly
             .Where(x => x.Provider == providerKey).ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.MetricEvents
+            .Where(x => x.Kind == "circuit" && x.Tag1 == providerKey)
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
         deleted += await db.FailoverMisses
             .Where(x => x.FromProvider == providerKey || x.ToProvider == providerKey)
             .ExecuteDeleteAsync(ct).ConfigureAwait(false);

--- a/backend/Streams/CorruptionDetectingYencStream.cs
+++ b/backend/Streams/CorruptionDetectingYencStream.cs
@@ -1,0 +1,65 @@
+using NzbWebDAV.Exceptions;
+using Serilog;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Adds provider and segment context to decoded yEnc validation failures.
+/// </summary>
+public sealed class CorruptionDetectingYencStream(
+    YencStream inner,
+    string segmentId,
+    string providerKey) : YencStream(Null)
+{
+    private int _reported;
+
+    public override async ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await inner.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidDataException exception)
+        {
+            throw Map(exception);
+        }
+    }
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidDataException exception)
+        {
+            throw Map(exception);
+        }
+    }
+
+    private UsenetCorruptArticleException Map(InvalidDataException exception)
+    {
+        if (Interlocked.Exchange(ref _reported, 1) == 0)
+        {
+            Log.Warning(
+                exception,
+                "Provider {Provider} returned corrupt yEnc data for segment {SegmentId}",
+                providerKey,
+                segmentId);
+        }
+
+        return new UsenetCorruptArticleException(segmentId, providerKey, exception);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            inner.Dispose();
+        base.Dispose(disposing);
+    }
+}

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -16,6 +16,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 {
     private const int BodyPipelineBatchSize = 4;
     private const int MaxBodyRetries = 2;
+    private const int MaxCorruptionRetries = 3;
     private const int MaxConsecutiveZeroFills = 3;
 
     private readonly Memory<string> _segmentIds;
@@ -273,6 +274,20 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     e.SegmentId,
                     e);
             }
+            catch (UsenetCorruptArticleException e) when (!cancellationToken.IsCancellationRequested)
+            {
+                if (attempt >= MaxCorruptionRetries)
+                    throw;
+
+                Log.Debug(
+                    e,
+                    "Corrupt segment {SegmentId} from provider {Provider}; retrying to allow provider failover (attempt {Attempt}).",
+                    segmentId,
+                    e.ProviderKey,
+                    attempt + 1);
+                await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), cancellationToken)
+                    .ConfigureAwait(false);
+            }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested)
             {
                 if (attempt < MaxBodyRetries)
@@ -328,6 +343,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 e.SegmentId,
                 e);
         }
+        catch (UsenetCorruptArticleException e) when (!cancellationToken.IsCancellationRequested)
+        {
+            var stream = await RetryCorruptSegmentAsync(
+                    segmentId, e, cancellationToken)
+                .ConfigureAwait(false);
+            return SegmentDownloadResult.Success(stream);
+        }
         catch (Exception e) when (!cancellationToken.IsCancellationRequested)
         {
             if (_failFastOnFirstSegment && isFirstSegment) throw;
@@ -335,6 +357,40 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 "Segment {SegmentId} unavailable while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
                 segmentId, e);
         }
+    }
+
+    private async Task<Stream> RetryCorruptSegmentAsync(
+        string segmentId,
+        UsenetCorruptArticleException initialFailure,
+        CancellationToken cancellationToken)
+    {
+        var failure = initialFailure;
+        for (var attempt = 1; attempt <= MaxCorruptionRetries; attempt++)
+        {
+            Log.Debug(
+                failure,
+                "Corrupt pipelined segment {SegmentId} from provider {Provider}; retrying to allow provider failover (attempt {Attempt}).",
+                segmentId,
+                failure.ProviderKey,
+                attempt);
+            await Task.Delay(TimeSpan.FromMilliseconds(250 * attempt), cancellationToken)
+                .ConfigureAwait(false);
+
+            try
+            {
+                var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                    .ConfigureAwait(false);
+                return await DrainSegmentAsync(response.Stream!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (UsenetCorruptArticleException exception)
+            {
+                failure = exception;
+            }
+        }
+
+        ExceptionDispatchInfo.Capture(failure).Throw();
+        throw new InvalidOperationException("Unreachable after rethrowing a corrupt segment failure.");
     }
 
     /// <summary>

--- a/backend/Utils/NzbStreamUtil.cs
+++ b/backend/Utils/NzbStreamUtil.cs
@@ -1,0 +1,111 @@
+using System.IO.Compression;
+
+namespace NzbWebDAV.Utils;
+
+public static class NzbStreamUtil
+{
+    public sealed record OpenResult(Stream Stream, bool IsGzip);
+
+    public static async ValueTask<OpenResult> OpenMaybeCompressedAsync(
+        Stream source,
+        CancellationToken cancellationToken = default)
+    {
+        var prefix = new byte[2];
+        var prefixLength = 0;
+        while (prefixLength < prefix.Length)
+        {
+            var read = await source.ReadAsync(
+                    prefix.AsMemory(prefixLength, prefix.Length - prefixLength),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+                break;
+            prefixLength += read;
+        }
+
+        var replay = new PrefixReadStream(source, prefix, prefixLength);
+        var isGzip = prefixLength == 2 && prefix[0] == 0x1f && prefix[1] == 0x8b;
+        return isGzip
+            ? new OpenResult(
+                new GZipStream(replay, CompressionMode.Decompress, leaveOpen: false),
+                IsGzip: true)
+            : new OpenResult(replay, IsGzip: false);
+    }
+
+    public static string NormalizeFileName(string fileName)
+    {
+        var normalized = fileName.Trim();
+        if (normalized.EndsWith(".gz", StringComparison.OrdinalIgnoreCase))
+            normalized = normalized[..^3];
+        if (!normalized.EndsWith(".nzb", StringComparison.OrdinalIgnoreCase))
+            normalized += ".nzb";
+        return normalized;
+    }
+
+    private sealed class PrefixReadStream(
+        Stream source,
+        byte[] prefix,
+        int prefixLength) : Stream
+    {
+        private int _prefixPosition;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var copied = CopyPrefix(buffer.AsSpan(offset, count));
+            return copied > 0 ? copied : source.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var copied = CopyPrefix(buffer);
+            return copied > 0 ? copied : source.Read(buffer);
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var copied = CopyPrefix(buffer.Span);
+            return copied > 0
+                ? copied
+                : await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        private int CopyPrefix(Span<byte> destination)
+        {
+            var remaining = prefixLength - _prefixPosition;
+            if (remaining <= 0 || destination.IsEmpty)
+                return 0;
+            var count = Math.Min(remaining, destination.Length);
+            prefix.AsSpan(_prefixPosition, count).CopyTo(destination);
+            _prefixPosition += count;
+            return count;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+    }
+}

--- a/docs/nntp-pipelining.md
+++ b/docs/nntp-pipelining.md
@@ -1,6 +1,6 @@
 # NNTP Pipelining
 
-NzbDav uses **UsenetSharp 2.x** batch BODY requests to pipeline multiple NNTP
+NzbDav uses **UsenetSharp 3.x** batch BODY requests to pipeline multiple NNTP
 commands on one connection without waiting for each response. Responses are read
 strictly in order with bounded backpressure.
 
@@ -41,7 +41,7 @@ depth. The client chain is:
 - `MultiProviderNntpClient` — provider selection and byte counting
 - `DownloadingNntpClient` / `WrappingNntpClient` — permits and delegation
 
-`StatsPipelinedAsync` remains a sequential fallback because UsenetSharp 2.x does
+`StatsPipelinedAsync` remains a sequential fallback because UsenetSharp 3.x does
 not ship a pipelined `STAT` API. Health checks always use concurrent `STAT`
 across the connection pool.
 

--- a/docs/sab-api.md
+++ b/docs/sab-api.md
@@ -1,0 +1,45 @@
+# SABnzbd API compatibility
+
+NzbDav implements the SABnzbd-compatible operations used by Sonarr, Radarr, and
+similar download clients. It is not a complete replacement for SABnzbd's
+administrative API.
+
+## Supported operations
+
+- `version`, `status`, `fullstatus`, `get_config`, and `get_cats`
+- `addfile` and `addurl`
+- `queue` listing and `queue&name=delete`
+- `history` listing and `history&name=delete`
+
+Queue and history filters accept both `cat` and `category`. The default category
+sentinel returned by `get_cats` is `*`.
+
+## Intentional differences
+
+- Job identifiers are UUIDs rather than `SABnzbd_nzo_*` strings. Treat them as
+  opaque values and return them unchanged in later requests.
+- Responses are JSON. The `output=xml` option is not implemented.
+- Queue and history roots contain the fields needed by supported download
+  clients rather than every SABnzbd UI field.
+- History has no separate archive tier. `history&name=delete` permanently
+  removes matching history rows whether `archive` is omitted, `1`, or `0`.
+- The configured **Ignore SAB history limit** option can ignore a client's
+  `limit` value. NzbDav still enforces its server-side maximum page size.
+- Authentication failures use HTTP error status codes instead of always
+  returning HTTP 200 with an error body.
+
+## Delete behavior
+
+Queue delete accepts a UUID, comma-separated UUIDs, repeated `value`
+parameters, or `value=all`. The SAB `del_files=1` flag is accepted but has no
+additional effect because NzbDav does not keep an incomplete-download
+directory.
+
+History delete accepts UUIDs, comma-separated UUIDs, `value=all`, or
+`value=failed`. SAB's `del_files=1` applies only to failed-job files; failed
+NzbDav jobs never mount WebDAV content, so the flag has no additional effect.
+
+The NzbDav admin UI can explicitly delete mounted content for completed jobs
+with the NzbDav-specific `del_completed_files=1` parameter. Download clients
+should not send this parameter after importing a symlink or STRM file, because
+the mounted source must remain available for playback.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -490,6 +490,21 @@ Go to the **Save & Install** tab, click **Save**, and then install the addon to 
 
 Search profiles expose selected NzbDav indexers through token-scoped endpoints. Create and manage profiles under `Settings` → `Profiles`, and treat each generated token as a secret.
 
+### Search link lifetime
+
+Play links embedded in search results are persisted in NzbDav's database, so they
+remain valid across container restarts. Their lifetime defaults to 168 hours
+(7 days) and can be changed under `Settings` → `Watchdog` → **Search link
+lifetime (hours)**, with a supported range of 1–720 hours.
+
+Set the lifetime at least as high as the result-cache lifetime of every search
+client that consumes these links. AIOStreams defaults to 7 days. Docker
+operators can set the fallback with `RESOLUTION_CACHE_TTL_HOURS`; a saved
+`play.resolution-cache-ttl-hours` setting takes precedence.
+
+Links created before upgrading to the persistent cache were never stored and
+must be refreshed by searching again.
+
 ### 1. Newznab adapter for Prowlarr, Sonarr, or Radarr
 
 1. Add a custom Newznab indexer.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -636,7 +636,7 @@ Mounted content under `/content` can vanish for several independent reasons. Rep
 
 | Cause | Trigger | What happens |
 | --- | --- | --- |
-| History delete with delete-files | SAB API / UI history delete with `del_files=1` | Mounted DavItems for that history row are deleted (download dir immediately; children via background cleanup). |
+| History delete with delete-files | Admin UI history delete, or the NzbDav-specific `del_completed_files=1` API parameter | Mounted DavItems for that completed history row are deleted (download dir immediately; children via background cleanup). SAB's `del_files=1` applies only to failed jobs, which never mount content in NzbDav. |
 | Cascading child sweep | Any deleted directory | Children are deleted in the background (`DavCleanupService`). |
 | Health repair | `repair.enable` + missing Usenet articles | Orphaned/blocklisted items are deleted; linked items may be removed after *Arr remove-and-search. Unreachable *Arr instances defer deletion (fail safe). |
 | Remove Orphaned Files | Scheduled or manual task | Deletes Usenet files with **no library symlink/STRM** (and empty dirs). Uses library links, **not** SAB history. Aborts if fewer than 5 linked files are found or if more than 90% of deletable items look unlinked. |

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -673,6 +673,7 @@ export type ProviderRow = {
     spark: number[],
     errorSpark?: number[],
     retrySpark?: number[],
+    outageSpark?: number[],
     circuitState?: ProviderCircuitState,
     cooldownRemainingSeconds?: number | null,
     lastFailureReason?: string | null,

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -23,11 +23,16 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                     <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
                 ) : (
                     <div className="overflow-x-auto">
-                        <table className="table table-sm min-w-[560px]">
+                        <table className="table table-sm min-w-[680px]">
                             <thead>
                                 <tr>
                                     <th>Provider</th>
                                     <th className="w-[120px]">Activity</th>
+                                    <th
+                                        className="w-[120px]"
+                                        title="Percentage of each interval that the provider circuit was open and skipped">
+                                        Outages
+                                    </th>
                                     <th>Articles</th>
                                     <th>Read</th>
                                     <th>Share</th>
@@ -59,6 +64,12 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                             </td>
                                             <td>
                                                 <Sparkline values={p.spark} tone="success" />
+                                            </td>
+                                            <td title="Provider circuit-open time">
+                                                <Sparkline
+                                                    values={p.outageSpark ?? []}
+                                                    tone="error"
+                                                    fixedMax={100} />
                                             </td>
                                             <td className="font-mono tabular-nums">{formatNumber(p.articles)}</td>
                                             <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>
@@ -154,11 +165,19 @@ function ShareBar({ share }: { share: number }) {
     );
 }
 
-function Sparkline({ values, tone = "success" }: { values: number[], tone?: "success" | "error" | "warning" }) {
+function Sparkline({
+    values,
+    tone = "success",
+    fixedMax,
+}: {
+    values: number[],
+    tone?: "success" | "error" | "warning",
+    fixedMax?: number,
+}) {
     if (values.length === 0) return <div className="h-[22px] w-[110px] rounded-sm bg-base-content/[0.04]" />;
     const w = 110;
     const h = 22;
-    const max = Math.max(1, ...values);
+    const max = fixedMax ?? Math.max(1, ...values);
     const step = values.length > 1 ? w / (values.length - 1) : 0;
     const y = (v: number) => h - (v / max) * (h - 4) - 2;
     const path = values

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -75,6 +75,7 @@ describe("mergeOverviewStats", () => {
                 spark: [1, 2],
                 errorSpark: [0, 1],
                 retrySpark: [2, 0],
+                outageSpark: [0, 50],
             }],
             [{
                 provider: "11111111-1111-1111-1111-111111111111",
@@ -91,6 +92,7 @@ describe("mergeOverviewStats", () => {
         expect(providers[0]?.articles).toBe(12);
         expect(providers[0]?.errorSpark).toEqual([0, 1]);
         expect(providers[0]?.retrySpark).toEqual([2, 0]);
+        expect(providers[0]?.outageSpark).toEqual([0, 50]);
         expect(providers[0]?.circuitState).toBe("open");
         expect(providers[0]?.cooldownRemainingSeconds).toBe(30);
     });

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -142,6 +142,7 @@ export function mergeProviderCircuitBreakers(
                 spark: [],
                 errorSpark: [],
                 retrySpark: [],
+                outageSpark: [],
             }),
             circuitState: breaker.circuitState,
             cooldownRemainingSeconds: breaker.cooldownRemainingSeconds,

--- a/frontend/app/routes/queue/controllers/dropzone-controller.ts
+++ b/frontend/app/routes/queue/controllers/dropzone-controller.ts
@@ -9,7 +9,8 @@ function isIosUserAgent(): boolean {
 }
 
 function isNzbFile(file: File): boolean {
-    return file.name.toLowerCase().endsWith(".nzb");
+    const name = file.name.toLowerCase();
+    return name.endsWith(".nzb") || name.endsWith(".nzb.gz");
 }
 
 export function useQueueDropzone(
@@ -84,7 +85,7 @@ export function useQueueDropzone(
         const rejected = selected.length - nzbFiles.length;
         setRejectMessage(
             rejected > 0
-                ? `Skipped ${rejected} non-.nzb file${rejected === 1 ? "" : "s"}.`
+                ? `Skipped ${rejected} ${rejected === 1 ? "file that was" : "files that were"} not .nzb or .nzb.gz.`
                 : null,
         );
         enqueueFiles(nzbFiles);
@@ -105,7 +106,7 @@ export function useQueueDropzone(
         getInputProps: () => ({
             ref: inputRef,
             type: "file",
-            accept: ".nzb,application/x-nzb",
+            accept: ".nzb,.nzb.gz,application/x-nzb,application/gzip",
             multiple: true,
             hidden: true,
             onChange: onInputChange,

--- a/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
@@ -17,6 +17,15 @@ public class AddFileRequestTests
         Assert.Equal("My.Release.nzb", AddFileRequest.ResolveFileName("My.Release.nzb", "upload.nzb"));
     }
 
+    [Theory]
+    [InlineData("My.Release.nzb.gz", "My.Release.nzb")]
+    [InlineData("My.Release.gz", "My.Release.nzb")]
+    public void ResolveFileName_NormalizesGzipNames(string input, string expected)
+    {
+        Assert.Equal(expected, AddFileRequest.ResolveFileName(input, "upload.nzb"));
+        Assert.Equal(expected, AddFileRequest.ResolveFileName(null, input));
+    }
+
     [Fact]
     public void ResolveFileName_FallsBackToFormFileName()
     {

--- a/tests/NzbWebDAV.Tests/Api/GetQueueResponseTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueResponseTests.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetQueueResponseTests
+{
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(50, "50")]
+    [InlineData(100, "100")]
+    [InlineData(150, "100")]
+    [InlineData(200, "100")]
+    public void FromQueueItem_ClampsSabPercentage(int progress, string expected)
+    {
+        var slot = GetQueueResponse.QueueSlot.FromQueueItem(
+            CreateQueueItem(),
+            progressPercentage: progress);
+
+        Assert.Equal(expected, slot.Percentage);
+        Assert.Equal(progress.ToString(CultureInfo.InvariantCulture), slot.TruePercentage);
+    }
+
+    [Fact]
+    public void FromQueueItem_ReportsNoBytesLeftAfterDownloadPhase()
+    {
+        var slot = GetQueueResponse.QueueSlot.FromQueueItem(
+            CreateQueueItem(),
+            progressPercentage: 150);
+
+        Assert.Equal("0.00", slot.SizeLeftInMB);
+    }
+
+    private static QueueItem CreateQueueItem() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            FileName = "release.nzb",
+            JobName = "release",
+            Category = "movies",
+            TotalSegmentBytes = 2 * 1024 * 1024,
+        };
+}

--- a/tests/NzbWebDAV.Tests/Api/SabCategoryTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabCategoryTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Api.SabControllers.GetCategories;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class SabCategoryTests
+{
+    [Fact]
+    public void CategoryResolver_AcceptsCategoryAlias()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?category=movies");
+
+        Assert.Equal("movies", SabCategoryResolver.GetCategory(context, new ConfigManager()));
+    }
+
+    [Fact]
+    public void CategoryResolver_PrefersCatWhenBothAliasesArePresent()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?cat=tv&category=movies");
+
+        Assert.Equal("tv", SabCategoryResolver.GetCategory(context, new ConfigManager()));
+    }
+
+    [Fact]
+    public void CategoryResolver_MapsStarToManualCategory()
+    {
+        var config = CreateConfig();
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?cat=*");
+
+        var request = new GetQueueRequest(context, config);
+
+        Assert.Equal("manual", request.Category);
+    }
+
+    [Fact]
+    public void GetCategories_PrependsStarWithoutAddingAWebDavCategory()
+    {
+        var config = CreateConfig();
+
+        var apiCategories = GetCategoriesController.BuildCategories(config);
+
+        Assert.Equal(["*", "manual", "movies", "tv"], apiCategories);
+        Assert.Equal(["manual", "movies", "tv"], config.GetApiCategories());
+    }
+
+    private static ConfigManager CreateConfig()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiManualCategory,
+                ConfigValue = "manual",
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiCategories,
+                ConfigValue = "movies,tv",
+            },
+        ]);
+        return config;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/SabDeleteRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabDeleteRequestTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
+using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class SabDeleteRequestTests
+{
+    [Fact]
+    public async Task QueueDelete_ParsesCommaSeparatedAndRepeatedIds()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var third = Guid.NewGuid();
+        var context = CreateContext(
+            $"?value={first},{second}&value={third}&value=not-a-guid&del_files=1");
+
+        var request = await RemoveFromQueueRequest.New(context);
+
+        Assert.Equal([first, second, third], request.NzoIds);
+        Assert.False(request.DeleteAll);
+        Assert.True(request.DeleteFilesRequested);
+    }
+
+    [Fact]
+    public async Task QueueDelete_AllOverridesExplicitIds()
+    {
+        var context = CreateContext($"?value={Guid.NewGuid()},all");
+
+        var request = await RemoveFromQueueRequest.New(context);
+
+        Assert.True(request.DeleteAll);
+        Assert.Empty(request.NzoIds);
+    }
+
+    [Fact]
+    public async Task HistoryDelete_ParsesFailedTokenAndAcceptsDelFiles()
+    {
+        var context = CreateContext("?value=failed&del_files=1");
+
+        var request = await RemoveFromHistoryRequest.New(context);
+
+        Assert.True(request.DeleteFailed);
+        Assert.False(request.DeleteAll);
+        Assert.True(request.DeleteFailedFilesRequested);
+        Assert.False(request.DeleteCompletedFiles);
+    }
+
+    [Fact]
+    public async Task HistoryDelete_AllTakesPrecedenceOverFailed()
+    {
+        var context = CreateContext("?value=failed,all&del_completed_files=1");
+
+        var request = await RemoveFromHistoryRequest.New(context);
+
+        Assert.True(request.DeleteAll);
+        Assert.False(request.DeleteFailed);
+        Assert.True(request.DeleteCompletedFiles);
+    }
+
+    private static DefaultHttpContext CreateContext(string queryString)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(queryString);
+        context.Request.Body = Stream.Null;
+        return context;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/SabStatusTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabStatusTests.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Api.SabControllers.GetStatus;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class SabStatusTests
+{
+    [Fact]
+    public void StatusResponse_SerializesStatusAsObject()
+    {
+        var response = new GetStatusResponse
+        {
+            Status = new SabStatusObject { CompleteDir = "/downloads/complete" },
+        };
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(response));
+
+        Assert.Equal(JsonValueKind.Object, json.RootElement.GetProperty("status").ValueKind);
+        Assert.Equal(
+            "/downloads/complete",
+            json.RootElement.GetProperty("status").GetProperty("completedir").GetString());
+    }
+
+    [Fact]
+    public void CompletedDir_UsesStrmDirectoryForStrmImports()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiImportStrategy,
+                ConfigValue = "strm",
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiCompletedDownloadsDir,
+                ConfigValue = "/data/strm",
+            },
+        ]);
+
+        Assert.Equal("/data/strm", SabPathResolver.GetCompletedDir(config));
+    }
+
+    [Fact]
+    public void CompletedDir_UsesSymlinkFolderForSymlinkImports()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.RcloneMountDir,
+                ConfigValue = "/mnt/nzbdav",
+            },
+        ]);
+
+        Assert.Equal(
+            Path.Join("/mnt/nzbdav", DavItem.SymlinkFolder.Name),
+            SabPathResolver.GetCompletedDir(config));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
@@ -65,8 +65,20 @@ public class BaseNntpClientStatTests
         Assert.Contains("requires authentication", exception.Message);
     }
 
-    private sealed class ScriptedUsenetClient(int responseCode) : IUsenetClient
+    [Fact]
+    public void Dispose_PrefersUnderlyingAsyncDispose()
     {
+        var underlying = new ScriptedUsenetClient(223);
+        var client = new BaseNntpClient(underlying);
+
+        client.Dispose();
+
+        Assert.True(underlying.AsyncDisposed);
+    }
+
+    private sealed class ScriptedUsenetClient(int responseCode) : IUsenetClient, IAsyncDisposable
+    {
+        public bool AsyncDisposed { get; private set; }
         public bool IsConnected => true;
         public bool IsHealthy => true;
 
@@ -122,5 +134,11 @@ public class BaseNntpClientStatTests
 
         public Task WaitForReadyAsync(CancellationToken cancellationToken) =>
             Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            AsyncDisposed = true;
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
@@ -26,6 +26,63 @@ public class ConcurrencyTests
     }
 
     [Fact]
+    public void ProviderCircuitBreaker_EmitsOneOpenAndClosedTransition()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("events", transitions.Add);
+
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.Empty(transitions);
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.Single(transitions);
+        breaker.RecordSuccess();
+        breaker.RecordSuccess();
+
+        Assert.Collection(
+            transitions,
+            opened =>
+            {
+                Assert.Equal(ProviderCircuitTransitionState.Open, opened.State);
+                Assert.Equal(TimeSpan.FromSeconds(60), opened.Cooldown);
+                Assert.True(opened.AtUnixMilliseconds > 0);
+            },
+            closed =>
+            {
+                Assert.Equal(ProviderCircuitTransitionState.Closed, closed.State);
+                Assert.Null(closed.Cooldown);
+                Assert.True(closed.AtUnixMilliseconds >= transitions[0].AtUnixMilliseconds);
+            });
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_DoesNotEmitClosedForTransientFailures()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("events", transitions.Add);
+
+        breaker.RecordFailure();
+        breaker.RecordSuccess();
+
+        Assert.Empty(transitions);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_ContainsTransitionCallbackFailures()
+    {
+        var breaker = new ProviderCircuitBreaker(
+            "events",
+            _ => throw new InvalidOperationException("metrics unavailable"));
+
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+
+        Assert.True(breaker.IsTripped);
+    }
+
+    [Fact]
     public void ProviderCircuitBreaker_BurstOfFailuresProducesExactlyOneTrip()
     {
         var breaker = new ProviderCircuitBreaker("burst");

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -60,15 +60,15 @@ public class NntpClientPipelinedMappingTests
     }
 
     [Fact]
-    public void IsValidSegmentId_RejectsBareIdsLongerThan495Octets()
+    public void IsValidSegmentId_RejectsBareIdsLongerThan248Octets()
     {
-        // With client-added angle brackets the wire argument must stay ≤ 497 octets.
-        var tooLong = new string('a', 492) + "@x.y"; // 496 octets
-        Assert.Equal(496, tooLong.Length);
+        // RFC 5536 limits a message-id to 250 octets including client-added brackets.
+        var tooLong = new string('a', 245) + "@x.y"; // 249 octets
+        Assert.Equal(249, tooLong.Length);
         Assert.False(NntpClient.IsValidSegmentId(tooLong));
 
-        var maxOk = new string('a', 491) + "@x.y"; // 495 octets
-        Assert.Equal(495, maxOk.Length);
+        var maxOk = new string('a', 244) + "@x.y"; // 248 octets
+        Assert.Equal(248, maxOk.Length);
         Assert.True(NntpClient.IsValidSegmentId(maxOk));
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
@@ -1,0 +1,303 @@
+using System.Buffers.Binary;
+using System.Text;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Queue.NestedRarExpansion;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class NestedRarExpansionStepTests
+{
+    [Fact]
+    public void RangeMapper_MapsSpanAcrossOuterVolumes()
+    {
+        var first = Segment("inner.rar", headerPart: 0, filenamePart: 1, start: 10, length: 50, uncompressed: 90);
+        var second = Segment("inner.rar", headerPart: 1, filenamePart: 2, start: 0, length: 40, uncompressed: 90);
+
+        var mapped = NestedRarRangeMapper.Map(
+            LongRange.FromStartAndSize(40, 30),
+            [first, second],
+            pathWithinArchive: "movie.mkv",
+            archiveName: "inner",
+            partNumber: new RarProcessor.PartNumber { PartNumberFromHeader = -1, PartNumberFromFilename = -1 },
+            aesParams: null,
+            fileUncompressedSize: 30,
+            releaseDate: DateTimeOffset.UnixEpoch);
+
+        Assert.Equal(2, mapped.Length);
+        Assert.Equal(LongRange.FromStartAndSize(50, 10), mapped[0].ByteRangeWithinPart);
+        Assert.Equal(first.PartNumber, mapped[0].PartNumber);
+        Assert.Equal(LongRange.FromStartAndSize(0, 20), mapped[1].ByteRangeWithinPart);
+        Assert.Equal(second.PartNumber, mapped[1].PartNumber);
+        Assert.All(mapped, segment => Assert.Equal("movie.mkv", segment.PathWithinArchive));
+    }
+
+    [Fact]
+    public async Task Expand_ReplacesStoredNestedRarWithInnerFiles()
+    {
+        var moviePayload = "hello-nested-mkv"u8.ToArray();
+        // Composed stream for a nested member is the member payload itself
+        // (already sliced out of the outer archive by RarProcessor).
+        var nestedRar = BuildRar4FirstVolume("movie.mkv", moviePayload);
+        var nested = Segment(
+            "inner.rar",
+            headerPart: -1,
+            filenamePart: -1,
+            start: 0,
+            length: nestedRar.Length,
+            uncompressed: nestedRar.Length,
+            partSize: nestedRar.Length);
+
+        var expanded = await NestedRarExpansionStep.ExpandSegmentsAsync(
+            [nested],
+            (_, _) => Task.FromResult<Stream>(new MemoryStream(nestedRar, writable: false)),
+            password: null,
+            CancellationToken.None);
+
+        Assert.DoesNotContain(expanded, segment => FilenameUtil.IsRarFile(segment.PathWithinArchive));
+        var movie = Assert.Single(expanded, segment => segment.PathWithinArchive == "movie.mkv");
+        Assert.Equal(moviePayload.Length, movie.FileUncompressedSize);
+        Assert.Equal(moviePayload.Length, movie.ByteRangeWithinPart.Count);
+    }
+
+    [Fact]
+    public async Task Expand_KeepsOpaqueWhenInnerIsCompressed()
+    {
+        var payload = "compressed-payload"u8.ToArray();
+        var compressedNested = BuildRar4FirstVolume("movie.mkv", payload, method: 0x31);
+        var nested = Segment(
+            "inner.rar",
+            headerPart: -1,
+            filenamePart: -1,
+            start: 0,
+            length: compressedNested.Length,
+            uncompressed: compressedNested.Length,
+            partSize: compressedNested.Length);
+
+        var expanded = await NestedRarExpansionStep.ExpandSegmentsAsync(
+            [nested],
+            (_, _) => Task.FromResult<Stream>(new MemoryStream(compressedNested, writable: false)),
+            password: null,
+            CancellationToken.None);
+
+        var kept = Assert.Single(expanded);
+        Assert.Equal("inner.rar", kept.PathWithinArchive);
+    }
+
+    [Fact]
+    public async Task Expand_SkipsEncryptedOuterMembers()
+    {
+        var outer = Segment(
+            "secret.rar",
+            headerPart: -1,
+            filenamePart: -1,
+            start: 0,
+            length: 32,
+            uncompressed: 32);
+        outer = new RarProcessor.StoredFileSegment
+        {
+            NzbFile = outer.NzbFile,
+            PartSize = outer.PartSize,
+            ArchiveName = outer.ArchiveName,
+            PartNumber = outer.PartNumber,
+            ReleaseDate = outer.ReleaseDate,
+            PathWithinArchive = outer.PathWithinArchive,
+            ByteRangeWithinPart = outer.ByteRangeWithinPart,
+            AesParams = new AesParams { Key = new byte[16], Iv = new byte[16], DecodedSize = 32 },
+            FileUncompressedSize = outer.FileUncompressedSize,
+        };
+
+        var expanded = await NestedRarExpansionStep.ExpandSegmentsAsync(
+            [outer],
+            (_, _) => throw new InvalidOperationException("should not open encrypted nested rar"),
+            password: null,
+            CancellationToken.None);
+
+        Assert.Same(outer, Assert.Single(expanded));
+    }
+
+    [Fact]
+    public async Task Expand_RespectsDepthLimit()
+    {
+        var leaf = "leaf"u8.ToArray();
+        var midRar = BuildRar4FirstVolume("movie.mkv", leaf);
+        var outerNested = BuildRar4FirstVolume("mid.rar", midRar);
+        var outer = Segment(
+            "outer.rar",
+            headerPart: -1,
+            filenamePart: -1,
+            start: 0,
+            length: outerNested.Length,
+            uncompressed: outerNested.Length,
+            partSize: outerNested.Length);
+
+        // Depth 1: outer.rar → mid.rar (still rar, stop)
+        var depthOne = await NestedRarExpansionStep.ExpandSegmentsAsync(
+            [outer],
+            (_, _) => Task.FromResult<Stream>(new MemoryStream(outerNested, writable: false)),
+            password: null,
+            CancellationToken.None,
+            maxDepth: 1);
+        Assert.Equal("mid.rar", Assert.Single(depthOne).PathWithinArchive);
+
+        // Depth 2: reconstruct mid.rar from remapped ranges for the second open.
+        var opens = 0;
+        var depthTwo = await NestedRarExpansionStep.ExpandSegmentsAsync(
+            [outer],
+            (segments, _) =>
+            {
+                opens++;
+                if (opens == 1)
+                    return Task.FromResult<Stream>(new MemoryStream(outerNested, writable: false));
+
+                var composed = new MemoryStream();
+                foreach (var segment in segments)
+                {
+                    var slice = outerNested.AsSpan(
+                        (int)segment.ByteRangeWithinPart.StartInclusive,
+                        (int)segment.ByteRangeWithinPart.Count);
+                    composed.Write(slice);
+                }
+
+                composed.Position = 0;
+                return Task.FromResult<Stream>(composed);
+            },
+            password: null,
+            CancellationToken.None,
+            maxDepth: 2);
+
+        Assert.Equal("movie.mkv", Assert.Single(depthTwo).PathWithinArchive);
+        Assert.Equal(2, opens);
+    }
+
+    [Fact]
+    public async Task ExpandAsync_PreservesNonRarProcessorResults()
+    {
+        var moviePayload = "x"u8.ToArray();
+        var nestedRar = BuildRar4FirstVolume("movie.mkv", moviePayload);
+        var nested = Segment(
+            "inner.rar",
+            headerPart: -1,
+            filenamePart: -1,
+            start: 0,
+            length: nestedRar.Length,
+            uncompressed: nestedRar.Length,
+            partSize: nestedRar.Length);
+
+        var other = new FileProcessorResultMarker();
+        var results = await NestedRarExpansionStep.ExpandAsync(
+            [
+                other,
+                new RarProcessor.Result { StoredFileSegments = [nested] },
+            ],
+            (_, _) => Task.FromResult<Stream>(new MemoryStream(nestedRar, writable: false)),
+            password: null,
+            CancellationToken.None);
+
+        Assert.Contains(other, results);
+        var rar = Assert.Single(results.OfType<RarProcessor.Result>());
+        Assert.Equal("movie.mkv", Assert.Single(rar.StoredFileSegments).PathWithinArchive);
+    }
+
+    private sealed class FileProcessorResultMarker : BaseProcessor.Result;
+
+    private static RarProcessor.StoredFileSegment Segment(
+        string pathWithinArchive,
+        int headerPart,
+        int filenamePart,
+        long start,
+        long length,
+        long uncompressed,
+        long? partSize = null)
+    {
+        return new RarProcessor.StoredFileSegment
+        {
+            NzbFile = new NzbFile { Subject = "archive" },
+            PartSize = partSize ?? length,
+            ArchiveName = "archive",
+            PartNumber = new RarProcessor.PartNumber
+            {
+                PartNumberFromHeader = headerPart,
+                PartNumberFromFilename = filenamePart,
+            },
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+            PathWithinArchive = pathWithinArchive,
+            ByteRangeWithinPart = LongRange.FromStartAndSize(start, length),
+            AesParams = null,
+            FileUncompressedSize = uncompressed,
+        };
+    }
+
+    private static byte[] BuildRar4FirstVolume(string fileName, byte[] payload, byte method = 0x30)
+    {
+        using var ms = new MemoryStream();
+        ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
+
+        // Archive header (HEAD_SIZE=13 including CRC).
+        {
+            Span<byte> body = stackalloc byte[11];
+            body[0] = 0x73;
+            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], 0x0000);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
+            WriteHeader(ms, body);
+        }
+
+        var nameBytes = Encoding.ASCII.GetBytes(fileName);
+        var headSize = (ushort)(32 + nameBytes.Length);
+        {
+            var body = new byte[headSize - 2];
+            var o = 0;
+            body[o++] = 0x74;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), 0x8000); // HAS_DATA
+            o += 2;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)payload.Length); // ADD_SIZE
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)payload.Length); // UNP_SIZE
+            o += 4;
+            body[o++] = 2; // HostOS Unix
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileCRC
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileTime
+            o += 4;
+            body[o++] = 20; // UnpVer
+            body[o++] = method;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), (ushort)nameBytes.Length);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // Attr
+            o += 4;
+            nameBytes.CopyTo(body.AsSpan(o));
+            WriteHeader(ms, body);
+        }
+
+        ms.Write(payload);
+        return ms.ToArray();
+    }
+
+    private static void WriteHeader(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
+    {
+        var crc = RarCrc16(bodyWithoutCrc);
+        Span<byte> hdr = stackalloc byte[bodyWithoutCrc.Length + 2];
+        BinaryPrimitives.WriteUInt16LittleEndian(hdr, crc);
+        bodyWithoutCrc.CopyTo(hdr[2..]);
+        stream.Write(hdr);
+    }
+
+    private static ushort RarCrc16(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (var i = 0; i < 8; i++)
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+        }
+
+        return (ushort)(~crc);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/CircuitOutageSparkBuilderTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/CircuitOutageSparkBuilderTests.cs
@@ -1,0 +1,76 @@
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+public class CircuitOutageSparkBuilderTests
+{
+    private const long Minute = 60_000;
+
+    [Fact]
+    public void Build_SplitsOpenIntervalAcrossBuckets()
+    {
+        var result = CircuitOutageSparkBuilder.Build(
+            [
+                new CircuitOutageSparkBuilder.Event(
+                    At: 30_000,
+                    Provider: "provider-a",
+                    State: "open",
+                    CooldownMs: Minute),
+            ],
+            ["provider-a"],
+            sparkStart: 0,
+            bucketSize: Minute,
+            bucketCount: 3,
+            nowMs: 3 * Minute);
+
+        Assert.Equal([50, 50, 0], result["provider-a"]);
+    }
+
+    [Fact]
+    public void Build_ClosesIntervalBeforeCooldownDeadline()
+    {
+        var result = CircuitOutageSparkBuilder.Build(
+            [
+                new CircuitOutageSparkBuilder.Event(0, "provider-a", "open", Minute),
+                new CircuitOutageSparkBuilder.Event(15_000, "provider-a", "closed", null),
+            ],
+            ["provider-a"],
+            sparkStart: 0,
+            bucketSize: Minute,
+            bucketCount: 1,
+            nowMs: Minute);
+
+        Assert.Equal([25], result["provider-a"]);
+    }
+
+    [Fact]
+    public void Build_CapsUnclosedIntervalAtPersistedCooldown()
+    {
+        var result = CircuitOutageSparkBuilder.Build(
+            [
+                new CircuitOutageSparkBuilder.Event(0, "provider-a", "open", Minute),
+            ],
+            ["provider-a"],
+            sparkStart: 0,
+            bucketSize: Minute,
+            bucketCount: 3,
+            nowMs: 3 * Minute);
+
+        Assert.Equal([100, 0, 0], result["provider-a"]);
+    }
+
+    [Fact]
+    public void Build_ReturnsAlignedZerosForProvidersWithoutEvents()
+    {
+        var result = CircuitOutageSparkBuilder.Build(
+            [],
+            ["provider-a", "provider-b"],
+            sparkStart: 0,
+            bucketSize: Minute,
+            bucketCount: 2,
+            nowMs: Minute);
+
+        Assert.Equal([0, 0], result["provider-a"]);
+        Assert.Equal([0, 0], result["provider-b"]);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
@@ -87,6 +87,10 @@ public class OverviewStatsResetTests
         db.ProviderHourly.AddRange(
             new ProviderHourly { Hour = now, Provider = target, Articles = 1 },
             new ProviderHourly { Hour = now, Provider = other, Articles = 2 });
+        db.MetricEvents.AddRange(
+            new MetricEvent { At = now, Kind = "circuit", Tag1 = target, Tag2 = "open" },
+            new MetricEvent { At = now, Kind = "circuit", Tag1 = other, Tag2 = "open" },
+            new MetricEvent { At = now, Kind = "global" });
         db.FailoverMisses.AddRange(
             new FailoverMiss
             {
@@ -139,6 +143,9 @@ public class OverviewStatsResetTests
         Assert.Equal(1, await db.ProviderMinutes.CountAsync(x => x.Provider == other));
         Assert.Equal(0, await db.ProviderHourly.CountAsync(x => x.Provider == target));
         Assert.Equal(1, await db.ProviderHourly.CountAsync(x => x.Provider == other));
+        Assert.Equal(0, await db.MetricEvents.CountAsync(x =>
+            x.Kind == "circuit" && x.Tag1 == target));
+        Assert.Equal(2, await db.MetricEvents.CountAsync());
         Assert.Equal(0, await db.FailoverMisses.CountAsync(x =>
             x.FromProvider == target || x.ToProvider == target));
         Assert.Equal(1, await db.FailoverMisses.CountAsync());

--- a/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
@@ -1,0 +1,164 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class CorruptionDetectionTests
+{
+    [Fact]
+    public async Task CorruptionDetectingStream_AddsSegmentAndProviderContext()
+    {
+        await using var stream = new CorruptionDetectingYencStream(
+            new ThrowingYencStream(new InvalidDataException("CRC mismatch")),
+            "segment@example",
+            "provider-a");
+
+        var exception = await Assert.ThrowsAsync<UsenetCorruptArticleException>(async () =>
+            await stream.ReadExactlyAsync(new byte[1]));
+
+        Assert.Equal("segment@example", exception.SegmentId);
+        Assert.Equal("provider-a", exception.ProviderKey);
+        Assert.IsType<InvalidDataException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task BufferedStream_RetriesCorruptionWithoutZeroFilling()
+    {
+        var expected = "validated payload"u8.ToArray();
+        using var client = new CorruptThenValidNntpClient(expected, corruptResponses: 3);
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "segment@example" }.AsMemory(),
+            client,
+            articleBufferSize: 1,
+            expectedSegmentSize: expected.Length,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None);
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(expected, output.ToArray());
+        Assert.Equal(4, client.BodyRequestCount);
+    }
+
+    private sealed class ThrowingYencStream(Exception exception) : YencStream(Null)
+    {
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<int>(exception);
+    }
+
+    private sealed class BytesYencStream(byte[] bytes) : YencStream(Null)
+    {
+        private int _position;
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_position >= bytes.Length)
+                return ValueTask.FromResult(0);
+            var count = Math.Min(buffer.Length, bytes.Length - _position);
+            bytes.AsMemory(_position, count).CopyTo(buffer);
+            _position += count;
+            return ValueTask.FromResult(count);
+        }
+    }
+
+    private sealed class CorruptThenValidNntpClient(
+        byte[] validPayload,
+        int corruptResponses) : NntpClient
+    {
+        public int BodyRequestCount { get; private set; }
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            CancellationToken cancellationToken) =>
+            CreateResponse(segmentId);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            CreateResponse(segmentId);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            CreateResponse(segmentId);
+
+        private Task<UsenetDecodedBodyResponse> CreateResponse(SegmentId segmentId)
+        {
+            BodyRequestCount++;
+            YencStream stream = BodyRequestCount <= corruptResponses
+                ? new ThrowingYencStream(
+                    new UsenetCorruptArticleException(segmentId, "provider-a",
+                        new InvalidDataException("CRC mismatch")))
+                : new BytesYencStream(validPayload);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "body follows",
+                Stream = stream,
+            });
+        }
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/NzbStreamUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/NzbStreamUtilTests.cs
@@ -1,0 +1,62 @@
+using System.IO.Compression;
+using System.Text;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class NzbStreamUtilTests
+{
+    [Fact]
+    public async Task OpenMaybeCompressedAsync_ReplaysPlainStreamPrefix()
+    {
+        var expected = Encoding.UTF8.GetBytes("<?xml version=\"1.0\"?><nzb />");
+        await using var source = new MemoryStream(expected);
+
+        var result = await NzbStreamUtil.OpenMaybeCompressedAsync(source);
+        await using var stream = result.Stream;
+        using var output = new MemoryStream();
+        await stream.CopyToAsync(output);
+
+        Assert.False(result.IsGzip);
+        Assert.Equal(expected, output.ToArray());
+    }
+
+    [Fact]
+    public async Task OpenMaybeCompressedAsync_DetectsGzipByMagicBytes()
+    {
+        var expected = Encoding.UTF8.GetBytes("<?xml version=\"1.0\"?><nzb />");
+        await using var source = new MemoryStream();
+        await using (var gzip = new GZipStream(source, CompressionMode.Compress, leaveOpen: true))
+            await gzip.WriteAsync(expected);
+        source.Position = 0;
+
+        var result = await NzbStreamUtil.OpenMaybeCompressedAsync(source);
+        await using var stream = result.Stream;
+        using var output = new MemoryStream();
+        await stream.CopyToAsync(output);
+
+        Assert.True(result.IsGzip);
+        Assert.Equal(expected, output.ToArray());
+    }
+
+    [Fact]
+    public async Task OpenMaybeCompressedAsync_InvalidGzipFailsDuringRead()
+    {
+        await using var source = new MemoryStream([0x1f, 0x8b, 0x00, 0x01]);
+        var result = await NzbStreamUtil.OpenMaybeCompressedAsync(source);
+        await using var stream = result.Stream;
+
+        await Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await stream.CopyToAsync(Stream.Null));
+    }
+
+    [Theory]
+    [InlineData("release", "release.nzb")]
+    [InlineData("release.nzb", "release.nzb")]
+    [InlineData("release.nzb.gz", "release.nzb")]
+    [InlineData("release.GZ", "release.nzb")]
+    public void NormalizeFileName_ProducesPlainNzbName(string input, string expected)
+    {
+        Assert.Equal(expected, NzbStreamUtil.NormalizeFileName(input));
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -12,6 +12,7 @@ copyright = "NzbDav is released under the MIT License"
 nav = [
   { "Home" = "index.md" },
   { "Setup guide" = "setup-guide.md" },
+  { "SABnzbd API compatibility" = "sab-api.md" },
   { "Watchtower" = "watchtower.md" },
   { "NNTP pipelining" = "nntp-pipelining.md" },
   { "Contributing" = "contributing.md" },


### PR DESCRIPTION
## Summary
- Document persistent search-link lifetime behavior (runtime fix already on main via #452).
- Close healthy idle NNTP sessions with QUIT and fail over when yEnc CRC validation detects corruption.
- Improve SABnzbd API conformance (queue %, bulk delete tokens, structured status/`completedir`, category aliases + `*` sentinel) and document intentional divergences including hard-delete vs archive.
- Accept gzip-compressed NZB uploads at the addfile chokepoint.
- Persist provider circuit open/close transitions and show outage history sparklines on the overview.
- Expand stored nested RAR members into inner files before aggregation, with opaque fallback.

Closes #445
Closes #441
Closes #413
Closes #396
Closes #393
Closes #85
Closes #84

**Out of scope:** #42 remains upstream-first (measure/benchmark; not closed by this PR).

## Test plan
- [x] Backend focused suites: NestedRarExpansion, CorruptionDetection, CircuitOutage, NzbStreamUtil, SAB API, NzbBlobCleanup
- [x] Frontend `typecheck` + `test` + `build`
- [ ] CI green on this PR
- [ ] Manual: rclone/range playback after CRC-enabled downloads
- [ ] Manual: *Arr add → import smoke with gzip NZB and nested-RAR sample when available