### PR TITLE
feat(ui): show which client is reading files in Active Reads

### DIFF
--- a/backend/Services/ActiveReadsBroadcaster.cs
+++ b/backend/Services/ActiveReadsBroadcaster.cs
@@ -96,6 +96,8 @@ public class ActiveReadsBroadcaster(
                 bytesRead = Interlocked.Read(ref e.BytesRead),
                 currentOffset = Interlocked.Read(ref e.CurrentOffset),
                 fileSize = e.FileSize,
+                clientIp = e.ClientIp,
+                clientUserAgent = e.ClientUserAgent,
                 providers = (usage.GetValueOrDefault(e.Id) ?? new Dictionary<string, long>())
                     .Select(kv =>
                     {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,6 +70,10 @@ Ports: UI `5173` → proxies WebDAV + `/api` → backend `5000`.
 
 While a file is playing, Overview → **Right now** shows a truncated session id (click to copy). After seeking/scrubbing:
 
+!!! tip "Active Reads"
+
+    Overview **Active Reads / Right now** lists any WebDAV byte fetch (not only playback). Sustained high bandwidth with nothing watching usually means rclone VFS/cache thrash or media-server analysis.
+
 ```bash
 # Latest active/recent session (or pass an explicit session id)
 ./scripts/dump-stream-trace.sh

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -164,6 +164,10 @@ Set your username and password.
 | WebDAV Password | Create a password (required for Rclone, AIOStreams, and other WebDAV clients) |
 | Enforce Read-Only | Leave checked, unless you'd like to delete files from a terminal |
 
+!!! tip "Active Reads"
+
+    Overview **Active Reads / Right now** lists any WebDAV byte fetch (not only playback). Sustained high bandwidth with nothing watching usually means rclone VFS/cache thrash or media-server analysis.
+
 ### 3. Choose an import strategy
 
 Go to `Settings` → `SABnzbd` → `Import Strategy`:

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -744,6 +744,8 @@ export type ActiveRead = {
     bytesRead: number,
     currentOffset: number,
     fileSize: number | null,
+    clientIp?: string | null,
+    clientUserAgent?: string | null,
     providers: { host: string, nickname?: string | null, segments: number }[],
 }
 

--- a/frontend/app/routes/_index/components/live-reads/live-reads.tsx
+++ b/frontend/app/routes/_index/components/live-reads/live-reads.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { clientIdentityTooltip, clientLabelFromUserAgent } from "~/utils/client-label";
 import { Icon } from "~/components/ui";
 
 type ProviderUsage = { host: string; nickname?: string | null; segments: number };
@@ -11,6 +12,8 @@ type Read = {
     lastActivityAt: number;
     bytesRead: number;
     fileSize: number | null;
+    clientIp?: string | null;
+    clientUserAgent?: string | null;
     providers: ProviderUsage[];
 };
 type Snapshot = { reads: Read[] };
@@ -49,7 +52,7 @@ export function LiveReads() {
     return (
         <section className="rounded-box border border-base-content/10 bg-base-200 p-3">
             <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-base-content/50">
-                <Icon name="play_circle" className="!text-[16px]" />
+                <Icon name="download" className="!text-[16px]" />
                 Active Reads
             </div>
             <div className="flex flex-col gap-2">
@@ -61,9 +64,16 @@ export function LiveReads() {
 
 function ReadRow({ item }: { item: Read }) {
     const totalSegments = item.providers.reduce((acc, p) => acc + p.segments, 0);
+    const clientLabel = clientLabelFromUserAgent(item.clientUserAgent);
     return (
         <div className="flex flex-col gap-0.5 text-[11px] leading-snug" title={item.fileName}>
             <div className="truncate text-base-content">{shortName(item.fileName)}</div>
+            <div
+                className="truncate text-base-content/50"
+                title={clientIdentityTooltip(item.clientUserAgent, item.clientIp)}
+            >
+                {clientLabel}
+            </div>
             <div className="flex flex-wrap items-center gap-x-1 text-base-content/50">
                 {item.providers.length === 0
                     ? <span className="italic text-base-content/40">buffering…</span>

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import styles from "./live-reads-panel.module.css";
 import type { ActiveRead, ActiveReadsMessage } from "~/clients/backend-client.server";
 import { formatBytes } from "../../utils/format";
+import { clientIdentityTooltip, clientLabelFromUserAgent } from "~/utils/client-label";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 const TOPIC_ACTIVE_READS = "ar";
@@ -69,6 +70,15 @@ export function LiveReadsPanel() {
                             >
                                 <div className="truncate text-sm font-medium text-base-content" title={r.path}>
                                     {r.fileName || lastSegment(r.path)}
+                                </div>
+                                <div
+                                    className="truncate text-xs text-base-content/50"
+                                    title={clientIdentityTooltip(r.clientUserAgent, r.clientIp)}
+                                >
+                                    {clientLabelFromUserAgent(r.clientUserAgent)}
+                                    {r.clientIp ? (
+                                        <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
+                                    ) : null}
                                 </div>
                                 <button
                                     type="button"

--- a/frontend/app/utils/client-label.ts
+++ b/frontend/app/utils/client-label.ts
@@ -1,0 +1,41 @@
+/** Known WebDAV / media clients matched by case-insensitive UA substring. */
+const KNOWN_CLIENTS: readonly { match: string; label: string }[] = [
+    { match: "rclone", label: "rclone" },
+    { match: "plex", label: "Plex" },
+    { match: "emby", label: "Emby" },
+    { match: "jellyfin", label: "Jellyfin" },
+    { match: "infuse", label: "Infuse" },
+    { match: "vlc", label: "VLC" },
+    { match: "kodi", label: "Kodi" },
+];
+
+const UNKNOWN = "Unknown";
+const TRUNCATE_LEN = 28;
+
+/**
+ * Short display label for an Active Reads client, derived from User-Agent.
+ */
+export function clientLabelFromUserAgent(userAgent: string | null | undefined): string {
+    const ua = userAgent?.trim();
+    if (!ua) return UNKNOWN;
+
+    const lower = ua.toLowerCase();
+    for (const { match, label } of KNOWN_CLIENTS) {
+        if (lower.includes(match)) return label;
+    }
+
+    return ua.length <= TRUNCATE_LEN ? ua : ua.slice(0, TRUNCATE_LEN - 1) + "…";
+}
+
+/** Tooltip text: full UA and/or IP when present. */
+export function clientIdentityTooltip(
+    userAgent: string | null | undefined,
+    clientIp: string | null | undefined,
+): string | undefined {
+    const parts: string[] = [];
+    const ua = userAgent?.trim();
+    const ip = clientIp?.trim();
+    if (ua) parts.push(ua);
+    if (ip) parts.push(ip);
+    return parts.length > 0 ? parts.join(" · ") : undefined;
+}

--- a/frontend/app/utils/utils.test.ts
+++ b/frontend/app/utils/utils.test.ts
@@ -1,9 +1,46 @@
 import { describe, expect, it, vi } from "vitest";
+import { clientIdentityTooltip, clientLabelFromUserAgent } from "./client-label";
 import { isMaskedSecret } from "./config-mask";
 import { formatFileSize } from "./file-size";
 import { getExploreContentLink, getLeafDirectoryName, parseExploreWebdavPath } from "./path";
 import { className, classNames } from "./styling";
 import { receiveMessage } from "./websocket-util";
+
+describe("clientLabelFromUserAgent", () => {
+  it.each([
+    [undefined, "Unknown"],
+    [null, "Unknown"],
+    ["", "Unknown"],
+    ["  ", "Unknown"],
+    ["rclone/1.68.0", "rclone"],
+    ["Mozilla/5.0 PlexMediaServer/1.40", "Plex"],
+    ["EmbyServer/4.8", "Emby"],
+    ["Jellyfin-Server/10.9", "Jellyfin"],
+    ["Infuse-Direct/7.0", "Infuse"],
+    ["VLC/3.0.20 LibVLC/3.0.20", "VLC"],
+    ["Kodi/21.0", "Kodi"],
+  ])("maps %s to %s", (ua, expected) => {
+    expect(clientLabelFromUserAgent(ua)).toBe(expected);
+  });
+
+  it("truncates unknown long user agents", () => {
+    const ua = "SomeCustomClient/1.2.3 (very-long-build-id-abcdefghijklmnop)";
+    const label = clientLabelFromUserAgent(ua);
+    expect(label.length).toBe(28);
+    expect(label.endsWith("…")).toBe(true);
+    expect(label.startsWith("SomeCustomClient")).toBe(true);
+  });
+});
+
+describe("clientIdentityTooltip", () => {
+  it("joins UA and IP when both present", () => {
+    expect(clientIdentityTooltip("rclone/1.68", "10.0.0.5")).toBe("rclone/1.68 · 10.0.0.5");
+  });
+
+  it("returns undefined when neither is present", () => {
+    expect(clientIdentityTooltip(null, undefined)).toBeUndefined();
+  });
+});
 
 describe("formatFileSize", () => {
   it.each([


### PR DESCRIPTION
## Summary
- Include `clientIp` and `clientUserAgent` in the Active Reads websocket snapshot (already tracked server-side).
- Show a short client label (rclone, Plex, Emby, …) under the filename on Overview and in the left-nav Active Reads list, with full UA + IP in the tooltip; use a neutral `download` icon.
- Document that Active Reads covers any WebDAV byte fetch — high bandwidth with nothing watching often means VFS/cache thrash or media analysis.

Related to #468

## Test plan
- [ ] Start a WebDAV read (rclone or `/view` play) and confirm Overview → Right now shows client label + IP
- [ ] Confirm left-nav Active Reads shows the same label and uses the download icon
- [ ] Hover label and confirm tooltip includes full User-Agent and IP
- [ ] `cd frontend && npm test -- --run app/utils/utils.test.ts`