### PR TITLE
feat(health): smooth out stat cliff bug, add aging function

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -63,6 +63,7 @@ public static class ConfigKeys
     public const string RepairEnable = "repair.enable";
     public const string RepairHealthcheckConcurrency = "repair.healthcheck-concurrency";
     public const string RepairHealthcheckDepth = "repair.healthcheck-depth";
+    public const string RepairHealthcheckAging = "repair.healthcheck-aging";
     public const string RepairAutoRemoveAfterFailures = "repair.auto-remove-after-failures";
     public const string RepairAutoRemoveUnlinkedOnly = "repair.auto-remove-unlinked-only";
     public const string ArrInstances = "arr.instances";

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -62,6 +62,7 @@ public static class ConfigKeys
     public const string MediaLibraryDir = "media.library-dir";
     public const string RepairEnable = "repair.enable";
     public const string RepairHealthcheckConcurrency = "repair.healthcheck-concurrency";
+    public const string RepairHealthcheckDepth = "repair.healthcheck-depth";
     public const string RepairAutoRemoveAfterFailures = "repair.auto-remove-after-failures";
     public const string RepairAutoRemoveUnlinkedOnly = "repair.auto-remove-unlinked-only";
     public const string ArrInstances = "arr.instances";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1125,7 +1125,7 @@ public class ConfigManager
     public double GetHealthCheckDepth()
     {
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckDepth));
-        return configured switch
+        return configured?.ToLowerInvariant() switch
         {
             "enhanced" => 1.0,
             "deep" => 2.0,

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -14,6 +14,9 @@ public class ConfigManager
 {
     public static readonly string AppVersion = EnvironmentUtil.GetEnvironmentVariable("NZBDAV_VERSION") ?? "0.0.0";
 
+    // Sampling curve multiplier used by a background health check when none is configured.
+    public const double DefaultHealthCheckDepth = 0.5;
+
     private readonly Dictionary<string, string> _config = new();
     private readonly Dictionary<(string Name, Type Type), object?> _deserializedConfig = new();
     // Compiled exclude patterns are cached and rebuilt only when an exclude-related
@@ -1101,6 +1104,22 @@ public class ConfigManager
             ?? "50"
         );
         return Math.Clamp(configured, 1, Math.Max(1, poolSize));
+    }
+
+    /// <summary>
+    /// How much of each file a health check reads, as a multiplier on the sampling curve.
+    /// Returns 0 for "complete", which turns sampling off so every segment is checked.
+    /// </summary>
+    public double GetHealthCheckDepth()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckDepth));
+        return configured switch
+        {
+            "enhanced" => 1.0,
+            "deep" => 2.0,
+            "complete" => 0,
+            _ => DefaultHealthCheckDepth,
+        };
     }
 
     /// <summary>

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -238,12 +238,17 @@ public class ConfigManager
                 case ConfigKeys.WardenHideDead:
                 case ConfigKeys.WardenBackboneScope:
                 case ConfigKeys.RepairEnable:
+                case ConfigKeys.RepairHealthcheckAging:
                 case ConfigKeys.RepairAutoRemoveUnlinkedOnly:
                 case ConfigKeys.RcloneRcEnabled:
                 case ConfigKeys.DbIsStartupVacuumEnabled:
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled:
                 case ConfigKeys.BackupScheduleEnabled:
                     RequireBool(item.ConfigName, value);
+                    break;
+
+                case ConfigKeys.RepairHealthcheckDepth:
+                    RequireOneOf(item.ConfigName, value, "standard", "enhanced", "deep", "complete");
                     break;
 
                 case ConfigKeys.UsenetProviders:
@@ -276,6 +281,13 @@ public class ConfigManager
         {
             if (!bool.TryParse(value, out _))
                 throw new ArgumentException($"Config value for '{key}' must be 'true' or 'false', but was '{value}'.");
+        }
+
+        static void RequireOneOf(string key, string value, params string[] allowed)
+        {
+            if (!allowed.Contains(value, StringComparer.OrdinalIgnoreCase))
+                throw new ArgumentException(
+                    $"Config value for '{key}' must be one of '{string.Join("', '", allowed)}', but was '{value}'.");
         }
 
         static void RequireJson<T>(string key, string value)
@@ -1120,6 +1132,16 @@ public class ConfigManager
             "complete" => 0,
             _ => DefaultHealthCheckDepth,
         };
+    }
+
+    /// <summary>
+    /// Whether coverage tapers as a release ages. Off by default, so every release is
+    /// checked at the depth its size earns regardless of how long the post has survived.
+    /// </summary>
+    public bool IsHealthCheckAgingEnabled()
+    {
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckAging));
+        return configValue != null && bool.Parse(configValue);
     }
 
     /// <summary>

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -21,6 +21,14 @@ namespace NzbWebDAV.Services;
 public class HealthCheckService : BackgroundService
 {
     private const int MaximumMissingSegmentIds = 100_000;
+
+    // Files at or below this many segments are always checked in full.
+    public const int SampleFloor = 8000;
+
+    // A release keeps full depth for its first year, then tapers until it stops aging at ten.
+    private const double FullDepthDays = 365;
+    private const double MinDepthDays = 3650;
+
     private readonly ConfigManager _configManager;
     private readonly INntpClient _usenetClient;
     private readonly WebsocketManager _websocketManager;
@@ -166,7 +174,8 @@ public class HealthCheckService : BackgroundService
 
             // sample large files to reduce NNTP load while keeping head/tail/stride coverage
             var totalSegments = segments.Count;
-            var sampled = SampleSegments(segments);
+            var age = davItem.ReleaseDate is { } posted ? DateTimeOffset.UtcNow - posted : (TimeSpan?)null;
+            var sampled = SampleSegments(segments, _configManager.GetHealthCheckDepth(), age);
 
             // setup progress tracking
             var progressHook = new Progress<int>();
@@ -290,30 +299,62 @@ public class HealthCheckService : BackgroundService
     }
 
     /// <summary>
-    /// For files with more than 4000 segments, returns a stratified sample:
-    /// first 100, last 100, and evenly-spaced middle segments (~4000 total).
-    /// Small files are checked in full.
+    /// How many segments to STAT for one file. Small files are checked in full,
+    /// larger ones are sampled based on their size, with an aging function applied on top.
+    /// Depth 0 will bypass this and do a full check.
     /// </summary>
-    public static List<string> SampleSegments(List<string> segments)
+    public static int SampleTarget(int segmentCount, double depth, TimeSpan? age = null)
     {
-        const int threshold = 4000;
-        if (segments.Count <= threshold) return segments;
+        if (depth <= 0) return segmentCount;
+        var curve = Math.Max(SampleFloor, depth * Math.Sqrt((double)SampleFloor * segmentCount));
+        return (int)Math.Min(segmentCount, curve * AgeWeight(age));
+    }
+
+    /// <summary>
+    /// Scales coverage down as a release ages with the same square root curve used for size.
+    /// A post that has survived its first year is far less likely to be broken, so it
+    /// gets a lighter check. The taper stops at ten years so nothing decays toward zero.
+    /// </summary>
+    private static double AgeWeight(TimeSpan? age)
+    {
+        if (age is not { } posted) return 1.0;
+        return Math.Sqrt(FullDepthDays / Math.Clamp(posted.TotalDays, FullDepthDays, MinDepthDays));
+    }
+
+    /// <summary>
+    /// Returns a stratified sample of <paramref name="segments"/>: first 100, last 100, and
+    /// evenly spaced middle segments, sized by <see cref="SampleTarget"/>.
+    /// </summary>
+    public static List<string> SampleSegments(
+        List<string> segments,
+        double depth = ConfigManager.DefaultHealthCheckDepth,
+        TimeSpan? age = null)
+    {
+        var count = segments.Count;
+        var target = SampleTarget(count, depth, age);
+        if (count <= target) return segments;
 
         const int headCount = 100;
         const int tailCount = 100;
-        const int strideTarget = 4000;
 
         var result = new HashSet<int>();
 
-        for (var i = 0; i < Math.Min(headCount, segments.Count); i++)
+        for (var i = 0; i < Math.Min(headCount, count); i++)
             result.Add(i);
 
-        for (var i = Math.Max(0, segments.Count - tailCount); i < segments.Count; i++)
+        for (var i = Math.Max(0, count - tailCount); i < count; i++)
             result.Add(i);
 
-        var stride = Math.Max(1, segments.Count / strideTarget);
-        for (var i = 0; i < segments.Count; i += stride)
+        // Spread `target` picks across the file with a running remainder, so the sample lands
+        // on the target instead of on the nearest whole number stride.
+        var carry = 0L;
+        for (var i = 0; i < count; i++)
+        {
+            carry += target;
+            if (carry < count) continue;
+            carry -= count;
             result.Add(i);
+        }
 
         return result.OrderBy(i => i).Select(i => segments[i]).ToList();
     }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -22,7 +22,7 @@ public class HealthCheckService : BackgroundService
 {
     private const int MaximumMissingSegmentIds = 100_000;
 
-    // Files at or below this many segments are always checked in full.
+    // Files at or below this many segments are checked in full, before any aging taper.
     public const int SampleFloor = 8000;
 
     // A release keeps full depth for its first year, then tapers until it stops aging at ten.
@@ -174,7 +174,9 @@ public class HealthCheckService : BackgroundService
 
             // sample large files to reduce NNTP load while keeping head/tail/stride coverage
             var totalSegments = segments.Count;
-            var age = davItem.ReleaseDate is { } posted ? DateTimeOffset.UtcNow - posted : (TimeSpan?)null;
+            var age = _configManager.IsHealthCheckAgingEnabled() && davItem.ReleaseDate is { } posted
+                ? DateTimeOffset.UtcNow - posted
+                : (TimeSpan?)null;
             var sampled = SampleSegments(segments, _configManager.GetHealthCheckDepth(), age);
 
             // setup progress tracking
@@ -299,9 +301,9 @@ public class HealthCheckService : BackgroundService
     }
 
     /// <summary>
-    /// How many segments to STAT for one file. Small files are checked in full,
-    /// larger ones are sampled based on their size, with an aging function applied on top.
-    /// Depth 0 will bypass this and do a full check.
+    /// How many segments to STAT for one file. Files up to the floor are checked in full,
+    /// larger ones are sampled based on their size, and an optional age scales the result
+    /// down from there. Depth 0 will bypass this and do a full check.
     /// </summary>
     public static int SampleTarget(int segmentCount, double depth, TimeSpan? age = null)
     {
@@ -317,8 +319,8 @@ public class HealthCheckService : BackgroundService
     /// </summary>
     private static double AgeWeight(TimeSpan? age)
     {
-        if (age is not { } posted) return 1.0;
-        return Math.Sqrt(FullDepthDays / Math.Clamp(posted.TotalDays, FullDepthDays, MinDepthDays));
+        if (age is not { } elapsed) return 1.0;
+        return Math.Sqrt(FullDepthDays / Math.Clamp(elapsed.TotalDays, FullDepthDays, MinDepthDays));
     }
 
     /// <summary>

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -76,10 +76,10 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </Select>
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-depth-help">
                     How much of each file a health check verifies. Files up to 8000 segments are
-                    checked in full. Above that, larger files are sampled from the start, end, and evenly
-                    spaced points in between, so a big release costs a bounded number of STAT commands.
-                    Deeper settings verify more of each file and use more usenet traffic. Complete checks
-                    every segment.
+                    checked in full, unless the aging option below is turned on. Above that, larger files
+                    are sampled from the start, end, and evenly spaced points in between, so a big release
+                    costs a bounded number of STAT commands. Deeper settings verify more of each file and
+                    use more usenet traffic. Complete checks every segment.
                 </p>
             </div>
             <div className="space-y-2">

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -75,11 +75,27 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     <option value="complete">Complete</option>
                 </Select>
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-depth-help">
-                    How much of each file a health check verifies. Files up to 8000 segments are always
+                    How much of each file a health check verifies. Files up to 8000 segments are
                     checked in full. Above that, larger files are sampled from the start, end, and evenly
                     spaced points in between, so a big release costs a bounded number of STAT commands.
                     Deeper settings verify more of each file and use more usenet traffic. Complete checks
                     every segment.
+                </p>
+            </div>
+            <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm text-base-content/80">
+                    <Checkbox
+                    id="healthcheck-aging-checkbox"
+                    aria-describedby="healthcheck-aging-help"
+                    checked={(config["repair.healthcheck-aging"] ?? "false") === "true"}
+                    onChange={e => setNewConfig({ ...config, "repair.healthcheck-aging": "" + e.target.checked })}  />
+                    <span>Check older releases less thoroughly</span>
+                </label>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-aging-help">
+                    Off by default. When enabled, coverage tapers for releases past their first year, on
+                    the basis that a post which has already survived that long is less likely to break.
+                    The taper stops at ten years. Useful for large libraries where most of the catalogue
+                    is long-since posted and rechecking it in full costs more than it finds.
                 </p>
             </div>
             <hr />
@@ -138,6 +154,7 @@ export function isRepairsSettingsUpdated(config: Record<string, string>, newConf
     return config["repair.enable"] !== newConfig["repair.enable"]
         || config["repair.healthcheck-concurrency"] !== newConfig["repair.healthcheck-concurrency"]
         || config["repair.healthcheck-depth"] !== newConfig["repair.healthcheck-depth"]
+        || config["repair.healthcheck-aging"] !== newConfig["repair.healthcheck-aging"]
         || config["repair.auto-remove-after-failures"] !== newConfig["repair.auto-remove-after-failures"]
         || config["repair.auto-remove-unlinked-only"] !== newConfig["repair.auto-remove-unlinked-only"]
         || config["media.library-dir"] !== newConfig["media.library-dir"];

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -1,5 +1,5 @@
 import { SettingsPage } from "~/components/ui";
-import { Checkbox, Input } from "~/components/ui/form";
+import { Checkbox, Input, Select } from "~/components/ui/form";
 import { type Dispatch, type SetStateAction } from "react";
 import { isPositiveInteger } from "../usenet/usenet";
 
@@ -61,6 +61,29 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             <hr />
             <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="healthcheck-depth-input">Health Check Depth</label>
+                <Select
+                    className="w-full"
+                    id="healthcheck-depth-input"
+                    aria-describedby="healthcheck-depth-help"
+                    value={config["repair.healthcheck-depth"] ?? "standard"}
+                    onChange={e => setNewConfig({ ...config, "repair.healthcheck-depth": e.target.value })}
+                >
+                    <option value="standard">Standard</option>
+                    <option value="enhanced">Enhanced</option>
+                    <option value="deep">Deep</option>
+                    <option value="complete">Complete</option>
+                </Select>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-depth-help">
+                    How much of each file a health check verifies. Files up to 8000 segments are always
+                    checked in full. Above that, larger files are sampled from the start, end, and evenly
+                    spaced points in between, so a big release costs a bounded number of STAT commands.
+                    Deeper settings verify more of each file and use more usenet traffic. Complete checks
+                    every segment.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Auto-Remove After Streaming Failures</label>
                 <Input
                     className={`w-full ${!isNonNegativeInteger(autoRemoveAfter || "0") ? "input-error" : ""}`}
@@ -114,6 +137,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
 export function isRepairsSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["repair.enable"] !== newConfig["repair.enable"]
         || config["repair.healthcheck-concurrency"] !== newConfig["repair.healthcheck-concurrency"]
+        || config["repair.healthcheck-depth"] !== newConfig["repair.healthcheck-depth"]
         || config["repair.auto-remove-after-failures"] !== newConfig["repair.auto-remove-after-failures"]
         || config["repair.auto-remove-unlinked-only"] !== newConfig["repair.auto-remove-unlinked-only"]
         || config["media.library-dir"] !== newConfig["media.library-dir"];

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -100,6 +100,7 @@ const defaultConfig = {
     "preflight.indexer-max-wait-seconds": "5",
     "repair.enable": "false",
     "repair.healthcheck-concurrency": "50",
+    "repair.healthcheck-depth": "standard",
     "repair.auto-remove-after-failures": "0",
     "repair.auto-remove-unlinked-only": "true",
     "db.is-startup-vacuum-enabled": "false",

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -101,6 +101,7 @@ const defaultConfig = {
     "repair.enable": "false",
     "repair.healthcheck-concurrency": "50",
     "repair.healthcheck-depth": "standard",
+    "repair.healthcheck-aging": "false",
     "repair.auto-remove-after-failures": "0",
     "repair.auto-remove-unlinked-only": "true",
     "db.is-startup-vacuum-enabled": "false",

--- a/tests/NzbWebDAV.Tests/Config/HealthCheckDepthConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/HealthCheckDepthConfigTests.cs
@@ -1,0 +1,57 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class HealthCheckDepthConfigTests
+{
+    [Theory]
+    [InlineData("standard", ConfigManager.DefaultHealthCheckDepth)]
+    [InlineData("enhanced", 1.0)]
+    [InlineData("deep", 2.0)]
+    [InlineData("complete", 0)]
+    // Validation accepts any casing, so the getter has to resolve it the same way
+    // rather than falling through to the default and quietly under-checking.
+    [InlineData("Deep", 2.0)]
+    [InlineData("COMPLETE", 0)]
+    [InlineData("nonsense", ConfigManager.DefaultHealthCheckDepth)]
+    public void GetHealthCheckDepth_ResolvesRegardlessOfCasing(string value, double expected)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.RepairHealthcheckDepth,
+                ConfigValue = value,
+            },
+        ]);
+
+        Assert.Equal(expected, config.GetHealthCheckDepth());
+    }
+
+    [Theory]
+    [InlineData("Deep")]
+    [InlineData("COMPLETE")]
+    [InlineData("standard")]
+    public void ValidateConfigItems_AcceptsAnyCasingTheGetterResolves(string value)
+    {
+        var items = new[]
+        {
+            new ConfigItem { ConfigName = ConfigKeys.RepairHealthcheckDepth, ConfigValue = value },
+        };
+
+        ConfigManager.ValidateConfigItems(items);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_RejectsAnUnknownDepth()
+    {
+        var items = new[]
+        {
+            new ConfigItem { ConfigName = ConfigKeys.RepairHealthcheckDepth, ConfigValue = "thorough" },
+        };
+
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(items));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
@@ -24,6 +24,20 @@ public class HealthCheckSampleSegmentsTests
     }
 
     [Fact]
+    public void SampleTarget_FloorAppliesBeforeAgingNotAfter()
+    {
+        const int count = HealthCheckService.SampleFloor;
+
+        var whenNew = HealthCheckService.SampleTarget(count, Standard, TimeSpan.Zero);
+        var whenOld = HealthCheckService.SampleTarget(count, Standard, TimeSpan.FromDays(3650));
+
+        // A new file at the floor is checked in full, but the floor is the curve's
+        // minimum rather than a guarantee that survives aging.
+        Assert.Equal(count, whenNew);
+        Assert.InRange(100.0 * whenOld / count, 31, 33);
+    }
+
+    [Fact]
     public void SampleSegments_ZeroDepthChecksEverySegment()
     {
         var segments = Segments(50_000);
@@ -130,6 +144,19 @@ public class HealthCheckSampleSegmentsTests
         var unknown = HealthCheckService.SampleTarget(20_000, Standard, age: null);
 
         Assert.Equal(known, unknown);
+    }
+
+    [Fact]
+    public void SampleTarget_WithAgingDisabledMatchesANewRelease()
+    {
+        // Disabling the taper means the caller passes no age, so an ancient release is
+        // sampled exactly as deeply as a fresh one of the same size.
+        var aged = HealthCheckService.SampleTarget(20_000, Standard, TimeSpan.FromDays(3650));
+        var ageless = HealthCheckService.SampleTarget(20_000, Standard, age: null);
+        var fresh = HealthCheckService.SampleTarget(20_000, Standard, TimeSpan.Zero);
+
+        Assert.Equal(fresh, ageless);
+        Assert.True(aged < ageless, $"aged {aged} should sample less than ageless {ageless}");
     }
 
     [Theory]

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
@@ -1,40 +1,44 @@
+using NzbWebDAV.Config;
 using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Tests.Services;
 
 public class HealthCheckSampleSegmentsTests
 {
-    [Fact]
-    public void SampleSegments_ReturnsUnchangedWhenAtOrBelowThreshold()
+    private const double Standard = ConfigManager.DefaultHealthCheckDepth;
+    private const double Enhanced = 1.0;
+    private const double Deep = 2.0;
+
+    private static List<string> Segments(int count) =>
+        Enumerable.Range(0, count).Select(i => $"seg-{i}").ToList();
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(4000)]
+    [InlineData(HealthCheckService.SampleFloor)]
+    public void SampleSegments_ChecksSmallFilesInFull(int count)
     {
-        var segments = Enumerable.Range(0, 4000).Select(i => $"seg-{i}").ToList();
+        var segments = Segments(count);
 
-        var sampled = HealthCheckService.SampleSegments(segments);
-
-        Assert.Same(segments, sampled);
-        Assert.Equal(4000, sampled.Count);
+        Assert.Same(segments, HealthCheckService.SampleSegments(segments, Standard));
     }
 
     [Fact]
-    public void SampleSegments_ReturnsUnchangedForSmallFiles()
+    public void SampleSegments_ZeroDepthChecksEverySegment()
     {
-        var segments = Enumerable.Range(0, 100).Select(i => $"seg-{i}").ToList();
+        var segments = Segments(50_000);
 
-        var sampled = HealthCheckService.SampleSegments(segments);
-
-        Assert.Equal(100, sampled.Count);
-        Assert.Equal(segments, sampled);
+        Assert.Same(segments, HealthCheckService.SampleSegments(segments, depth: 0));
     }
 
     [Fact]
     public void SampleSegments_StratifiesLargeFilesAndPreservesOrder()
     {
-        var segments = Enumerable.Range(0, 50_000).Select(i => $"seg-{i}").ToList();
+        var segments = Segments(50_000);
 
-        var sampled = HealthCheckService.SampleSegments(segments);
+        var sampled = HealthCheckService.SampleSegments(segments, Standard);
 
         Assert.True(sampled.Count < segments.Count);
-        Assert.InRange(sampled.Count, 4000, 4500);
         Assert.Equal("seg-0", sampled[0]);
         Assert.Equal("seg-49999", sampled[^1]);
         Assert.Equal(sampled, sampled.OrderBy(s => int.Parse(s["seg-".Length..])).ToList());
@@ -43,14 +47,105 @@ public class HealthCheckSampleSegmentsTests
     [Fact]
     public void SampleSegments_IncludesHeadAndTail()
     {
-        var segments = Enumerable.Range(0, 10_000).Select(i => $"seg-{i}").ToList();
+        var segments = Segments(50_000);
 
-        var sampled = HealthCheckService.SampleSegments(segments);
+        var sampled = HealthCheckService.SampleSegments(segments, Standard);
         var indices = sampled.Select(s => int.Parse(s["seg-".Length..])).ToHashSet();
 
         for (var i = 0; i < 100; i++)
             Assert.Contains(i, indices);
-        for (var i = 9900; i < 10_000; i++)
+        for (var i = 49_900; i < 50_000; i++)
             Assert.Contains(i, indices);
+    }
+
+    [Fact]
+    public void SampleSegments_CoverageTapersInsteadOfSteppingDown()
+    {
+        double Coverage(int count) =>
+            (double)HealthCheckService.SampleSegments(Segments(count), Standard).Count / count;
+
+        var justUnder = Coverage(HealthCheckService.SampleFloor - 100);
+        var justOver = Coverage(HealthCheckService.SampleFloor + 100);
+        Assert.True(justUnder - justOver < 0.05, $"step of {justUnder - justOver:P0} at the floor");
+
+        var sizes = new[] { 10_000, 20_000, 40_000, 80_000 };
+        var coverages = sizes.Select(Coverage).ToList();
+        Assert.Equal(coverages.OrderByDescending(x => x), coverages);
+    }
+
+    [Theory]
+    [InlineData(7_900, 100)]
+    [InlineData(8_000, 100)]
+    [InlineData(10_000, 80)]
+    [InlineData(20_000, 40)]
+    [InlineData(50_000, 20)]
+    [InlineData(100_000, 14)]
+    public void SampleTarget_StandardFollowsTheDocumentedCurve(int count, int expectedPercent)
+    {
+        var percent = 100.0 * HealthCheckService.SampleTarget(count, Standard) / count;
+
+        Assert.InRange(percent, expectedPercent - 1, expectedPercent + 1);
+    }
+
+    [Theory]
+    [InlineData(0, 40)]
+    [InlineData(365, 40)]
+    [InlineData(730, 28)]
+    [InlineData(1825, 18)]
+    [InlineData(3650, 13)]
+    [InlineData(7300, 13)]
+    public void SampleTarget_TapersWithAgeThenHolds(int ageDays, int expectedPercent)
+    {
+        const int count = 20_000;
+
+        var target = HealthCheckService.SampleTarget(count, Standard, TimeSpan.FromDays(ageDays));
+
+        Assert.InRange(100.0 * target / count, expectedPercent - 1, expectedPercent + 1);
+    }
+
+    [Fact]
+    public void SampleTarget_CompleteIgnoresAge()
+    {
+        const int count = 20_000;
+
+        var ancient = HealthCheckService.SampleTarget(count, depth: 0, TimeSpan.FromDays(7300));
+
+        Assert.Equal(count, ancient);
+    }
+
+    [Fact]
+    public void SampleSegments_CompleteIgnoresAge()
+    {
+        var segments = Segments(50_000);
+
+        var sampled = HealthCheckService.SampleSegments(segments, depth: 0, TimeSpan.FromDays(7300));
+
+        Assert.Same(segments, sampled);
+    }
+
+    [Fact]
+    public void SampleTarget_UnknownAgeGetsFullDepth()
+    {
+        var known = HealthCheckService.SampleTarget(20_000, Standard, TimeSpan.Zero);
+        var unknown = HealthCheckService.SampleTarget(20_000, Standard, age: null);
+
+        Assert.Equal(known, unknown);
+    }
+
+    [Theory]
+    [InlineData(20_000)]
+    [InlineData(50_000)]
+    [InlineData(100_000)]
+    public void SampleSegments_DeeperSettingsCheckMore(int count)
+    {
+        var segments = Segments(count);
+
+        var standard = HealthCheckService.SampleSegments(segments, Standard).Count;
+        var enhanced = HealthCheckService.SampleSegments(segments, Enhanced).Count;
+        var deep = HealthCheckService.SampleSegments(segments, Deep).Count;
+
+        Assert.True(standard < enhanced, $"standard {standard} !< enhanced {enhanced}");
+        Assert.True(enhanced < deep, $"enhanced {enhanced} !< deep {deep}");
+        Assert.True(deep <= count);
     }
 }


### PR DESCRIPTION
Last change from my own repo: after switching from v6 to v7 I noticed health checks were suspiciously fast, and realized there was a stat "cliff" at 8000 segments. v6 did 100% health checks on all files, which was thorough but slow, and v7 doesn't do enough, especially on larger files. To fix the cliff issue I applied a smooth curve so larger files fall off gracefully, as well as an aging function so recently posted items get more thorough health checks and old files get progressively lighter/faster ones. The default "Standard" option is roughly what the current check would do without the cliff, although I mostly run on "Deep" with a large library. I've been running this locally against `0.7.2X` for a while and figured it might be worth pushing up here, but also realize it might be a bit controversial. 


Coverage by depth setting (new releases without aging, note the cliff at 5.7GB in the current logic):

| segments |    size | current/0.7.2X | Standard | Enhanced | Deep | Complete |
|---------:|--------:|---------------:|---------:|---------:|-----:|---------:|
|    7,900 |  5.7 GB |           100% |     100% |     100% | 100% |     100% |
|    8,000 |  5.7 GB |            52% |     100% |     100% | 100% |     100% |
|   10,000 |  7.2 GB |            52% |      80% |      89% | 100% |     100% |
|   15,000 | 10.8 GB |            35% |      53% |      73% | 100% |     100% |
|   20,000 | 14.3 GB |            21% |      40% |      63% | 100% |     100% |
|   25,000 | 17.9 GB |            17% |      32% |      57% | 100% |     100% |
|   30,000 | 21.5 GB |            15% |      27% |      52% | 100% |     100% |
|   40,000 | 28.7 GB |            10% |      22% |      45% |  89% |     100% |
|   50,000 | 35.8 GB |             9% |      20% |      40% |  80% |     100% |
|   75,000 | 53.8 GB |             6% |      16% |      33% |  65% |     100% |
|  100,000 | 71.7 GB |             4% |      14% |      28% |  57% |     100% |


Coverage as a release ages (Standard depth):

| segments |    size |  new |   1y |  2y |  3y |  5y |  7y | 10y+ |
|---------:|--------:|-----:|-----:|----:|----:|----:|----:|-----:|
|    7,900 |  5.7 GB | 100% | 100% | 72% | 58% | 45% | 38% |  32% |
|    8,000 |  5.7 GB | 100% | 100% | 71% | 58% | 45% | 38% |  32% |
|   10,000 |  7.2 GB |  80% |  80% | 57% | 46% | 36% | 30% |  25% |
|   15,000 | 10.8 GB |  53% |  53% | 38% | 31% | 24% | 20% |  17% |
|   20,000 | 14.3 GB |  40% |  40% | 28% | 23% | 18% | 15% |  13% |
|   25,000 | 17.9 GB |  32% |  32% | 23% | 18% | 14% | 12% |  10% |
|   30,000 | 21.5 GB |  27% |  27% | 19% | 15% | 12% | 10% |   8% |
|   40,000 | 28.7 GB |  22% |  22% | 16% | 13% | 10% |  8% |   7% |
|   50,000 | 35.8 GB |  20% |  20% | 14% | 12% |  9% |  8% |   6% |
|   75,000 | 53.8 GB |  16% |  16% | 12% |  9% |  7% |  6% |   5% |
|  100,000 | 71.7 GB |  14% |  14% | 10% |  8% |  6% |  5% |   4% |
