### PR TITLE
fix(queue): import obfuscated multi-volume RAR sets with duplicate subjects or incomplete volumes

### DIFF
--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -11,6 +11,23 @@ public static class ExceptionExtensions
         return exception is RetryableDownloadException;
     }
 
+    /// <summary>
+    /// True when the exception chain indicates a transient transport failure that
+    /// should pause-and-retry the queue item. Already-classified download exceptions
+    /// return false (do not re-wrap retryable; never soften non-retryable).
+    /// </summary>
+    public static bool IsTransientTransportException(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is RetryableDownloadException or NonRetryableDownloadException)
+                return false;
+            if (current is TimeoutException or SocketException or IOException)
+                return true;
+        }
+        return false;
+    }
+
     public static bool IsNonRetryableDownloadException(this Exception exception)
     {
         return exception is NonRetryableDownloadException

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -313,6 +313,13 @@ public static class FetchFirstSegmentsStep
         {
             return BuildMissingFirstSegment(nzbFile);
         }
+        catch (Exception e) when (
+            e.IsTransientTransportException() && !e.IsCancellationException())
+        {
+            throw new RetryableDownloadException(
+                $"Transient provider error fetching first segment of " +
+                $"`{nzbFile.GetSubjectFileName()}`: {e.Message}", e);
+        }
     }
 
     public class NzbFileWithFirstSegment

--- a/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
+++ b/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Par2Recovery.Packets;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
 using NzbWebDAV.Utils;
+using Serilog;
 
 namespace NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
 
@@ -18,11 +19,20 @@ public static class GetFileInfosStep
     {
         using var md5 = MD5.Create();
         var hashToFileDescMap = GetHashToFileDescMap(par2FileDescriptors);
-        var filesInfos = files
-            .Select(x => GetFileInfo(x, hashToFileDescMap, md5))
-            .ToList();
+        var picks = files.Select(x =>
+        {
+            var fileDesc = GetMatchingFileDescriptor(x, hashToFileDescMap, md5);
+            return new NamePick
+            {
+                Info = GetFileInfo(x, fileDesc),
+                HeaderName = x.Header?.FileName ?? "",
+                // Usable PAR2 name only — null descriptor or empty FileName does not count.
+                HasPar2Name = !string.IsNullOrWhiteSpace(fileDesc?.FileName),
+            };
+        }).ToList();
 
-        return filesInfos;
+        RepairRarGroupNames(picks);
+        return picks.Select(p => p.Info).ToList();
     }
 
     private static Dictionary<string, LinkedList<FileDesc>> GetHashToFileDescMap(List<FileDesc> par2FileDescriptors)
@@ -44,11 +54,9 @@ public static class GetFileInfosStep
 
     private static FileInfo GetFileInfo(
         FetchFirstSegmentsStep.NzbFileWithFirstSegment file,
-        Dictionary<string, LinkedList<FileDesc>> hashToFiledescMap,
-        MD5 md5
+        FileDesc? fileDesc
     )
     {
-        var fileDesc = GetMatchingFileDescriptor(file, hashToFiledescMap, md5);
         var subjectFileName = file.NzbFile.GetSubjectFileName();
         var headerFileName = file.Header?.FileName ?? "";
         var par2FileName = fileDesc?.FileName ?? "";
@@ -99,6 +107,44 @@ public static class GetFileInfosStep
     {
         var range = new LongRange(95 * totalYencodedSize / 100, totalYencodedSize);
         return range.Contains(fileSize);
+    }
+
+    /// <summary>
+    /// When RAR volumes share colliding subject-derived names (no distinct part
+    /// identity) but yEnc headers restore distinct .partN/.rNN identity, prefer
+    /// the header names. Skipped when any volume already has a PAR2 name.
+    /// </summary>
+    internal static void RepairRarGroupNames(List<NamePick> picks)
+    {
+        // Magic-based group: every real RAR volume carries the signature, so this
+        // does not depend on the (possibly colliding) FileName.
+        var group = picks.Where(x => x.Info.IsRar).ToList();
+        if (group.Count < 2) return;
+        // Keep PAR2 authoritative; never mix PAR2 + header repairs in one group.
+        if (group.Any(x => x.HasPar2Name)) return;
+        if (HasDistinctRarParts(group.Select(x => x.Info.FileName))) return;
+        if (!HasDistinctRarParts(group.Select(x => x.HeaderName))) return;
+
+        Log.Information(
+            "Repairing {Count} RAR volume names without distinct part identity using yEnc header names",
+            group.Count);
+        foreach (var pick in group)
+            pick.Info = pick.Info with { FileName = pick.HeaderName };
+    }
+
+    private static bool HasDistinctRarParts(IEnumerable<string> names)
+    {
+        var parts = names.Select(FilenameUtil.GetRarPartOrdinal).ToList();
+        return parts.Count > 0
+               && parts.All(p => p is not null)
+               && parts.Distinct().Count() == parts.Count;
+    }
+
+    internal sealed class NamePick
+    {
+        public required FileInfo Info { get; set; }
+        public required string HeaderName { get; init; }
+        public required bool HasPar2Name { get; init; }
     }
 
     public record FileInfo

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -228,11 +228,16 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             }
 
             var first = entries[0].Segment;
+            var firstMessageId = first.NzbFile.Segments[0].MessageId;
             var allIdentical = entries.All(e =>
                 e.Segment.PartSize == first.PartSize
                 && e.Segment.ByteRangeWithinPart == first.ByteRangeWithinPart
                 && e.Segment.PathWithinArchive == first.PathWithinArchive
-                && e.Segment.FileUncompressedSize == first.FileUncompressedSize);
+                && e.Segment.FileUncompressedSize == first.FileUncompressedSize
+                && string.Equals(
+                    e.Segment.NzbFile.Segments[0].MessageId,
+                    firstMessageId,
+                    StringComparison.Ordinal));
 
             if (allIdentical)
             {

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -143,6 +143,7 @@ public class LazyRarProcessor(
 
         var pending = new List<DavMultipartFile.PendingPart>(trailingInfos.Count);
         var pendingSum = 0L;
+        var pendingStreamSum = 0L;
         for (var i = 0; i < trailingInfos.Count; i++)
         {
             var partInfo = trailingInfos[i];
@@ -160,7 +161,22 @@ public class LazyRarProcessor(
                 EstimatedDataSize = estimate,
                 SegmentFallbackIds = partInfo.NzbFile.GetSegmentFallbackIds(),
             });
+            pendingStreamSum += streamLength;
             pendingSum += estimate;
+        }
+
+        // Encoded/packed size is a strict upper bound on decoded bytes. Undershoot means
+        // volumes are missing — fall back to eager (ValidateVolumes fails loudly) instead
+        // of inflating the last PendingPart to claim full TotalFileSize.
+        const long coverageTolerance = 16; // matches RarAggregator.ValidateVolumes
+        var maxCoverage = firstPartByteRange.Count + pendingStreamSum;
+        if (maxCoverage < totalFileSize - coverageTolerance)
+        {
+            Log.Information(
+                "LazyRarProcessor: volumes cover at most {Max} of {Total} bytes for {File}, " +
+                "likely missing volumes — falling back to eager",
+                maxCoverage, totalFileSize, firstInfo.FileName);
+            return null;
         }
 
         // Force the sum of estimates to match the inner file size exactly by

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -39,6 +39,21 @@ public partial class FilenameUtil
                || Regex.IsMatch(filename, @"\.r(\d+)$", RegexOptions.IgnoreCase);
     }
 
+    /// <summary>
+    /// Injective ordinal for RAR volume identity checks.
+    /// .partN.rar → N, .rNN → N + 100_000, bare .rar → -1, else null.
+    /// </summary>
+    public static int? GetRarPartOrdinal(string? filename)
+    {
+        if (string.IsNullOrEmpty(filename)) return null;
+        var partMatch = Regex.Match(filename, @"\.part(\d+)\.rar$", RegexOptions.IgnoreCase);
+        if (partMatch.Success) return int.Parse(partMatch.Groups[1].Value);
+        var rMatch = Regex.Match(filename, @"\.r(\d+)$", RegexOptions.IgnoreCase);
+        if (rMatch.Success) return int.Parse(rMatch.Groups[1].Value) + 100_000;
+        if (filename.EndsWith(".rar", StringComparison.OrdinalIgnoreCase)) return -1;
+        return null;
+    }
+
     public static bool Is7zFile(string? filename)
     {
         if (string.IsNullOrEmpty(filename)) return false;

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -64,4 +64,39 @@ public class ExceptionExtensionsTests
         Assert.True(ex.TryGetKnownErrorMessage(out var reason));
         Assert.Contains("<missing@example>", reason);
     }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(TimeoutException))]
+    public void IsTransientTransportException_RecognizesBareTransportErrors(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType, "blip")!;
+        Assert.True(ex.IsTransientTransportException());
+    }
+
+    [Fact]
+    public void IsTransientTransportException_RecognizesSocketException()
+    {
+        Assert.True(new SocketException((int)SocketError.ConnectionReset).IsTransientTransportException());
+    }
+
+    [Fact]
+    public void IsTransientTransportException_RecognizesNestedIoOverSocket()
+    {
+        var nested = new IOException("reset", new SocketException((int)SocketError.ConnectionReset));
+        Assert.True(nested.IsTransientTransportException());
+    }
+
+    [Fact]
+    public void IsTransientTransportException_RejectsArticleNotFound()
+    {
+        Assert.False(new UsenetArticleNotFoundException("<missing@example>").IsTransientTransportException());
+    }
+
+    [Fact]
+    public void IsTransientTransportException_RejectsAlreadyRetryable()
+    {
+        Assert.False(new RetryableDownloadException("already classified", new IOException("inner"))
+            .IsTransientTransportException());
+    }
 }

--- a/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
@@ -127,10 +127,46 @@ public class FetchFirstSegmentsStepTests
             CreateFile("a@example.com", "\"a.rar\" yEnc"),
         };
 
-        var ex = await Assert.ThrowsAsync<IOException>(() =>
+        var ex = await Assert.ThrowsAsync<RetryableDownloadException>(() =>
             FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
 
-        Assert.Equal("provider blip", ex.Message);
+        Assert.IsType<IOException>(ex.InnerException);
+        Assert.Equal("provider blip", ex.InnerException!.Message);
+        Assert.Contains("a.rar", ex.Message);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_ConcurrentNestedSocketError_IsRetryable()
+    {
+        var config = CreatePipeliningConfig(enabled: false, depth: 4);
+        using var client = new TransientErrorNntpClient(nestedSocket: true);
+        var files = new List<NzbFile>
+        {
+            CreateFile("a@example.com", "\"a.rar\" yEnc"),
+        };
+
+        var ex = await Assert.ThrowsAsync<RetryableDownloadException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
+
+        Assert.IsType<IOException>(ex.InnerException);
+        Assert.IsType<System.Net.Sockets.SocketException>(ex.InnerException!.InnerException);
+    }
+
+    [Fact]
+    public async Task FetchFirstSegments_PipelinedRescueTransientError_IsRetryable()
+    {
+        var config = CreatePipeliningConfig(enabled: true, depth: 4);
+        using var client = new PipelinedFailThenRescueTransientNntpClient();
+        var files = new List<NzbFile>
+        {
+            CreateFile("a@example.com", "\"a.rar\" yEnc"),
+        };
+
+        var ex = await Assert.ThrowsAsync<RetryableDownloadException>(() =>
+            FetchFirstSegmentsStep.FetchFirstSegments(files, client, config, CancellationToken.None));
+
+        Assert.IsType<IOException>(ex.InnerException);
+        Assert.Equal(1, client.ArticleFetches);
     }
 
     [Fact]
@@ -387,7 +423,7 @@ public class FetchFirstSegmentsStepTests
         }
     }
 
-    private sealed class TransientErrorNntpClient : NntpClient
+    private sealed class TransientErrorNntpClient(bool nestedSocket = false) : NntpClient
     {
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>
@@ -399,7 +435,93 @@ public class FetchFirstSegmentsStepTests
             CancellationToken cancellationToken)
         {
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+            if (nestedSocket)
+            {
+                throw new IOException(
+                    "provider blip",
+                    new System.Net.Sockets.SocketException((int)System.Net.Sockets.SocketError.ConnectionReset));
+            }
             throw new IOException("provider blip");
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Pipelined batch yields nothing useful (mismatched ids), then rescue DecodedArticleAsync
+    /// throws a transient IOException — should surface as RetryableDownloadException.
+    /// </summary>
+    private sealed class PipelinedFailThenRescueTransientNntpClient : NntpClient
+    {
+        public int ArticleFetches { get; private set; }
+
+        public override async IAsyncEnumerable<PipelinedArticleResult> DecodedArticlesPipelinedAsync(
+            IReadOnlyList<string> segmentIds,
+            int depth,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var _ in segmentIds)
+            {
+                yield return new PipelinedArticleResult
+                {
+                    SegmentId = "unknown@example.com",
+                    Found = true,
+                    Stream = CreateCachedStream(Encoding.ASCII.GetBytes("wrong")),
+                    ArticleHeaders = null,
+                    DefinitivelyMissing = false,
+                };
+            }
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            ArticleFetches++;
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+            throw new IOException("rescue provider blip");
         }
 
         public override Task ConnectAsync(

--- a/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
@@ -1,11 +1,14 @@
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Queue;
 
 public class GetFileInfosStepTests
 {
+    private static readonly byte[] Rar4Magic = [0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00];
+
     [Fact]
     public void GetFileInfos_UsesSubjectNameAndDetectsRarMagic()
     {
@@ -49,5 +52,121 @@ public class GetFileInfosStepTests
 
         Assert.Equal("video.mkv", result.FileName);
         Assert.False(result.IsRar);
+    }
+
+    [Fact]
+    public void GetFileInfos_RepairsCollidingSubjectsUsingDistinctYencHeaders()
+    {
+        var inputs = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            Seg("Release.Name.rar", "abc123.rar"),
+            Seg("Release.Name.rar", "abc123.r00"),
+            Seg("Release.Name.rar", "abc123.r01"),
+        };
+
+        var results = GetFileInfosStep.GetFileInfos(inputs, []);
+
+        Assert.Equal(["abc123.rar", "abc123.r00", "abc123.r01"], results.Select(x => x.FileName));
+        Assert.All(results, r => Assert.True(r.IsRar));
+    }
+
+    [Fact]
+    public void GetFileInfos_LeavesWellFormedPartNamesUntouched()
+    {
+        var inputs = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            Seg("Release.part1.rar", "hashA.r00"),
+            Seg("Release.part2.rar", "hashB.r01"),
+        };
+
+        var results = GetFileInfosStep.GetFileInfos(inputs, []);
+
+        Assert.Equal(["Release.part1.rar", "Release.part2.rar"], results.Select(x => x.FileName));
+    }
+
+    [Fact]
+    public void GetFileInfos_DeclinesRepairWhenHeadersAlsoCollide()
+    {
+        var inputs = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            Seg("Release.Name.rar", "same.rar"),
+            Seg("Release.Name.rar", "same.rar"),
+        };
+
+        var results = GetFileInfosStep.GetFileInfos(inputs, []);
+
+        Assert.All(results, r => Assert.Equal("Release.Name.rar", r.FileName));
+    }
+
+    [Fact]
+    public void GetFileInfos_DeclinesRepairWhenHeadersLackRarSuffixes()
+    {
+        var inputs = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            Seg("Release.Name.rar", "hashA.bin"),
+            Seg("Release.Name.rar", "hashB.bin"),
+        };
+
+        var results = GetFileInfosStep.GetFileInfos(inputs, []);
+
+        Assert.All(results, r => Assert.Equal("Release.Name.rar", r.FileName));
+    }
+
+    [Fact]
+    public void RepairRarGroupNames_SkipsWhenAnyVolumeHasPar2Name()
+    {
+        var picks = new List<GetFileInfosStep.NamePick>
+        {
+            new()
+            {
+                Info = new GetFileInfosStep.FileInfo
+                {
+                    NzbFile = new NzbFile { Subject = "\"Release.rar\" yEnc" },
+                    FileName = "Release.rar",
+                    ReleaseDate = DateTimeOffset.UnixEpoch,
+                    IsRar = true,
+                },
+                HeaderName = "vol.rar",
+                HasPar2Name = true,
+            },
+            new()
+            {
+                Info = new GetFileInfosStep.FileInfo
+                {
+                    NzbFile = new NzbFile { Subject = "\"Release.rar\" yEnc" },
+                    FileName = "Release.rar",
+                    ReleaseDate = DateTimeOffset.UnixEpoch,
+                    IsRar = true,
+                },
+                HeaderName = "vol.r00",
+                HasPar2Name = false,
+            },
+        };
+
+        GetFileInfosStep.RepairRarGroupNames(picks);
+
+        Assert.All(picks, p => Assert.Equal("Release.rar", p.Info.FileName));
+    }
+
+    private static FetchFirstSegmentsStep.NzbFileWithFirstSegment Seg(
+        string subject, string? headerName, byte[]? first16Kb = null)
+    {
+        return new()
+        {
+            NzbFile = new NzbFile { Subject = $"\"{subject}\" yEnc (1/1)" },
+            Header = headerName is null ? null : new UsenetYencHeader
+            {
+                FileName = headerName,
+                FileSize = 1,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = 1,
+            },
+            First16KB = first16Kb ?? Rar4Magic,
+            MissingFirstSegment = false,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+        };
     }
 }

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -1,0 +1,279 @@
+using System.Buffers.Binary;
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Utils;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class LazyRarProcessorTests
+{
+    [Fact]
+    public async Task ProcessAsync_SingleVolumeCannotCoverUncompressedSize_ReturnsNull()
+    {
+        const int packed = 200;
+        const int uncompressed = 10_000;
+        var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PartialSetCannotCoverUncompressedSize_ReturnsNull()
+    {
+        const int packed = 200;
+        const int uncompressed = 10_000;
+        var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
+        // Pending encoded size far too small to cover remaining uncompressed bytes.
+        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 50, fileSize: null);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CompleteSetWithoutPar2Sizes_Mounts()
+    {
+        const int packed = 1_000;
+        const int uncompressed = 3_000;
+        var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
+        // Encoded trailing size must cover remaining uncompressed bytes, but the
+        // 0.95*encoded estimate (minus header guess) must not overshoot remaining
+        // or LazyRar falls back before the coverage bound matters.
+        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync() as LazyRarProcessor.Result;
+
+        Assert.NotNull(result);
+        Assert.Equal("movie.mkv", result.PathInArchive);
+        Assert.Equal(uncompressed, result.TotalFileSize);
+        Assert.Single(result.PendingParts);
+    }
+
+    [Fact]
+    public async Task BuildRar4SplitFirstVolume_IsFirstVolumeStoredSplit()
+    {
+        var bytes = BuildRar4SplitFirstVolume("movie.mkv", packedSize: 100, uncompressedSize: 500);
+        await using var stream = new MemoryStream(bytes);
+        var headers = await RarUtil.ReadHeadersUntilFirstFileAsync(stream, password: null, CancellationToken.None);
+        var archive = Assert.Single(headers.OfType<SharpCompress.Common.Rar.Headers.IRarArchiveHeader>());
+        var file = Assert.Single(headers.OfType<SharpCompress.Common.Rar.Headers.IRarFileHeader>());
+        Assert.True(archive.IsFirstVolume);
+        Assert.True(file.IsStored);
+        Assert.Equal("movie.mkv", file.FileName);
+        Assert.Equal(500u, file.UncompressedSize);
+        Assert.Equal(100u, file.AdditionalDataSize);
+    }
+
+    private static GetFileInfosStep.FileInfo FileInfoFor(
+        string fileName, string messageId, long encodedBytes, long? fileSize)
+    {
+        return new GetFileInfosStep.FileInfo
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = $"\"{fileName}\" yEnc",
+                Segments =
+                {
+                    new NzbSegment { MessageId = messageId, Bytes = encodedBytes }
+                },
+            },
+            FileName = fileName,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+            FileSize = fileSize,
+            IsRar = true,
+        };
+    }
+
+    // Minimal RAR4 multi-volume first part: mark + archive(VOLUME|FIRSTVOLUME) +
+    // stored file header (HAS_DATA|SPLIT_AFTER) with full UNP_SIZE + packed payload.
+    private static byte[] BuildRar4SplitFirstVolume(string fileName, int packedSize, int uncompressedSize)
+    {
+        using var ms = new MemoryStream();
+        ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
+
+        // Archive header (HEAD_SIZE=13 including CRC).
+        {
+            Span<byte> body = stackalloc byte[11];
+            body[0] = 0x73;
+            // MHD_VOLUME (0x0001) | MHD_FIRSTVOLUME (0x0100)
+            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], 0x0101);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
+            WriteHeader(ms, body);
+        }
+
+        var nameBytes = Encoding.ASCII.GetBytes(fileName);
+        var headSize = (ushort)(32 + nameBytes.Length);
+        {
+            var body = new byte[headSize - 2];
+            var o = 0;
+            body[o++] = 0x74;
+            // LHD_HAS_DATA (0x8000) | LHD_SPLIT_AFTER (0x0002)
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), 0x8002);
+            o += 2;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)packedSize); // ADD_SIZE
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)uncompressedSize); // UNP_SIZE
+            o += 4;
+            body[o++] = 2; // HostOS Unix
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileCRC
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileTime
+            o += 4;
+            body[o++] = 20; // UnpVer
+            body[o++] = 0x30; // store
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), (ushort)nameBytes.Length);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // Attr
+            o += 4;
+            nameBytes.CopyTo(body.AsSpan(o));
+            WriteHeader(ms, body);
+        }
+
+        ms.Write(new byte[packedSize]);
+        return ms.ToArray();
+    }
+
+    private static void WriteHeader(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
+    {
+        var crc = RarCrc16(bodyWithoutCrc);
+        Span<byte> hdr = stackalloc byte[bodyWithoutCrc.Length + 2];
+        BinaryPrimitives.WriteUInt16LittleEndian(hdr, crc);
+        bodyWithoutCrc.CopyTo(hdr[2..]);
+        stream.Write(hdr);
+    }
+
+    private static ushort RarCrc16(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (var i = 0; i < 8; i++)
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+        }
+
+        return (ushort)(~crc);
+    }
+
+    /// <summary>
+    /// Serves raw decoded bytes via CachedYencStream so tests do not depend on
+    /// rapidyenc native (same approach as LazyRarResolverTests).
+    /// </summary>
+    private sealed class MemoryServingNntpClient(IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var key = segmentId.ToString();
+            if (!segments.TryGetValue(key, out var bytes))
+                throw new NzbWebDAV.Exceptions.UsenetArticleNotFoundException(key);
+
+            var headers = new UsenetYencHeader
+            {
+                FileName = "vol.bin",
+                FileSize = bytes.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = bytes.Length,
+            };
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body",
+                Stream = new CachedYencStream(headers, new MemoryStream(bytes, writable: false)),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(id => DecodedBodyAsync(id, cancellationToken))
+                .ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
@@ -71,6 +71,19 @@ public class RarAggregatorTests
     }
 
     [Fact]
+    public void SortByPartNumber_RejectsEqualMetadataVolumesWithDifferentMessageIds()
+    {
+        var first = SegmentNullable(headerPart: 0, filenamePart: 1, start: 0, length: 5,
+            messageId: "vol-a@example.com");
+        var other = SegmentNullable(headerPart: 0, filenamePart: 1, start: 0, length: 5,
+            messageId: "vol-b@example.com");
+
+        var ex = Assert.Throws<InvalidDataException>(
+            () => RarAggregator.SortByPartNumber([first, other]));
+        Assert.Contains("duplicate volume numbers", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void SortByPartNumber_DistinctHeadersUnchanged()
     {
         var parts = Enumerable.Range(0, 3)
@@ -111,11 +124,19 @@ public class RarAggregatorTests
         => SegmentNullable(headerPart, filenamePart, start, length);
 
     private static RarProcessor.StoredFileSegment SegmentNullable(
-        int? headerPart, int? filenamePart, long start, long length)
+        int? headerPart, int? filenamePart, long start, long length,
+        string messageId = "shared@example.com")
     {
         return new RarProcessor.StoredFileSegment
         {
-            NzbFile = new NzbFile { Subject = "archive" },
+            NzbFile = new NzbFile
+            {
+                Subject = "archive",
+                Segments =
+                {
+                    new NzbSegment { MessageId = messageId, Bytes = length }
+                },
+            },
             PartSize = length,
             ArchiveName = "archive",
             PartNumber = new RarProcessor.PartNumber

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -21,6 +21,25 @@ public class UtilityTests
     }
 
     [Theory]
+    [InlineData("archive.part03.rar", 3)]
+    [InlineData("archive.r07", 100007)]
+    [InlineData("x.rar", -1)]
+    [InlineData("X.RAR", -1)]
+    public void GetRarPartOrdinal_ParsesKnownRarSuffixes(string filename, int expected)
+    {
+        Assert.Equal(expected, FilenameUtil.GetRarPartOrdinal(filename));
+    }
+
+    [Theory]
+    [InlineData("x.mkv")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void GetRarPartOrdinal_ReturnsNullForNonRarNames(string? filename)
+    {
+        Assert.Null(FilenameUtil.GetRarPartOrdinal(filename));
+    }
+
+    [Theory]
     [InlineData("Movie {{secret}}.nzb", "Movie", "secret")]
     [InlineData("Movie password=secret.nzb", "Movie", "secret")]
     [InlineData("Movie.nzb", "Movie", null)]


### PR DESCRIPTION
## Summary
- Prefer yEnc header names when RAR volumes share colliding subject-derived names (no PAR2), so distinct `.rNN`/`.partN` identity is preserved.
- Refuse lazy RAR mounts when present volumes cannot cover the declared inner file size, and stop silently dropping distinct volumes that only share equal part metadata.
- Treat transient first-segment transport errors as retryable so connection-pressure blips pause/retry instead of failing the job.

Fixes #463

## Test plan
- [x] `dotnet test` focused filter: GetFileInfosStep, FetchFirstSegments, LazyRar, RarAggregator, ExceptionExtensions, UtilityTests (82 passed)
- [ ] Confirm CI full backend suite on PR
- [ ] Optional: import an obfuscated multi-volume RAR with identical subjects / no PAR2 under a tight connection budget