### PR TITLE
feat(nntp): speed up health checks and import existence probes with pipelined STAT

### DIFF
--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -1,4 +1,5 @@
-﻿using NzbWebDAV.Clients.Usenet.Models;
+﻿using System.Runtime.CompilerServices;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using UsenetSharp.Clients;
@@ -15,6 +16,13 @@ namespace NzbWebDAV.Clients.Usenet;
 /// </summary>
 public class BaseNntpClient : NntpClient
 {
+    /// <summary>
+    /// Sweep chunk size for <see cref="StatsPipelinedAsync"/>. UsenetSharp windows STAT
+    /// internally with a sliding MaxPipelineDepth; this bound is only for progress
+    /// reporting and early-stop-on-miss granularity (not BODY pipelining depth).
+    /// </summary>
+    internal const int StatPipelinedSweepChunkSize = 512;
+
     private readonly IUsenetClient _client;
 
     public BaseNntpClient() : this(new UsenetClient(new UsenetClientOptions
@@ -83,6 +91,59 @@ public class BaseNntpClient : NntpClient
         }
 
         throw CreateConnectionLevelException(segmentId, response);
+    }
+
+    public override async IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync(
+        IReadOnlyList<string> segmentIds,
+        int depth,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // `depth` is BODY-oriented interface baggage; STAT sizing uses the fixed sweep
+        // chunk so UsenetSharp's internal MaxPipelineDepth window stays continuously full.
+        _ = depth;
+        if (segmentIds.Count == 0) yield break;
+
+        for (var batchStart = 0; batchStart < segmentIds.Count; batchStart += StatPipelinedSweepChunkSize)
+        {
+            var batchSize = Math.Min(StatPipelinedSweepChunkSize, segmentIds.Count - batchStart);
+            var batchIds = new SegmentId[batchSize];
+            for (var index = 0; index < batchSize; index++)
+                batchIds[index] = PrepareSegmentId(segmentIds[batchStart + index]);
+
+            var responses = await _client.StatPipelinedAsync(batchIds, cancellationToken)
+                .ConfigureAwait(false);
+
+            for (var index = 0; index < responses.Count; index++)
+            {
+                var segmentId = batchIds[index];
+                var response = responses[index];
+
+                // UsenetSharp returns connection-level codes as ordered ArticleExists=false
+                // results — classify like StatAsync so a stale 400 goodbye never looks
+                // like a missing article (false repair/delete).
+                if (response.ResponseType == UsenetResponseType.ArticleExists)
+                {
+                    yield return new PipelinedStatResult
+                    {
+                        SegmentId = segmentId,
+                        Exists = true,
+                    };
+                    continue;
+                }
+
+                if (UsenetArticleAvailability.IsDefinitiveMissing(response))
+                {
+                    yield return new PipelinedStatResult
+                    {
+                        SegmentId = segmentId,
+                        Exists = false,
+                    };
+                    continue;
+                }
+
+                throw CreateConnectionLevelException(segmentId, response);
+            }
+        }
     }
 
     public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -513,7 +513,9 @@ public class MultiConnectionNntpClient(
 
     public override IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync(
         IReadOnlyList<string> segmentIds, int depth, CancellationToken cancellationToken)
-        => RunPipelinedAsync(c => c.StatsPipelinedAsync(segmentIds, depth, cancellationToken), cancellationToken);
+        => RunPipelinedStatAsync(
+            c => c.StatsPipelinedAsync(segmentIds, depth, cancellationToken),
+            cancellationToken);
 
     public override IAsyncEnumerable<PipelinedBodyResult> DecodedBodiesPipelinedAsync(
         IReadOnlyList<string> segmentIds, int depth, CancellationToken cancellationToken)
@@ -522,6 +524,54 @@ public class MultiConnectionNntpClient(
     public override IAsyncEnumerable<PipelinedArticleResult> DecodedArticlesPipelinedAsync(
         IReadOnlyList<string> segmentIds, int depth, CancellationToken cancellationToken)
         => RunPipelinedAsync(c => c.DecodedArticlesPipelinedAsync(segmentIds, depth, cancellationToken), cancellationToken);
+
+    /// <summary>
+    /// STAT pipeline lease: low priority, no circuit-breaker updates (matching single
+    /// StatAsync). Still replaces the connection on hard failure because UsenetSharp
+    /// poisons it mid-batch.
+    /// </summary>
+    private async IAsyncEnumerable<PipelinedStatResult> RunPipelinedStatAsync(
+        Func<INntpClient, IAsyncEnumerable<PipelinedStatResult>> batchFactory,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var connectionLock = await connectionPool
+            .GetConnectionLockAsync(SemaphorePriority.Low, cancellationToken)
+            .ConfigureAwait(false);
+        var completed = false;
+        try
+        {
+            await using var enumerator = batchFactory(connectionLock.Connection)
+                .GetAsyncEnumerator(cancellationToken);
+            while (true)
+            {
+                PipelinedStatResult current;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        completed = true;
+                        break;
+                    }
+
+                    current = enumerator.Current;
+                }
+                catch (Exception e) when (!e.IsCancellationException())
+                {
+                    // Do not RecordFailure — STAT must not feed the breaker — but the
+                    // connection is poisoned and must not return to the pool.
+                    connectionLock.Replace();
+                    throw;
+                }
+
+                yield return current;
+            }
+        }
+        finally
+        {
+            if (!completed) connectionLock.Replace();
+            connectionLock.Dispose();
+        }
+    }
 
     private async IAsyncEnumerable<T> RunPipelinedAsync<T>(
         Func<INntpClient, IAsyncEnumerable<T>> batchFactory,

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -826,9 +826,11 @@ public class MultiProviderNntpClient(
         using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
         var primary = orderedProviders.Count > 0 ? orderedProviders[0] : null;
         if (primary == null) yield break;
-        var effectiveDepth = ResolveDepth(primary, depth);
 
-        await foreach (var result in primary.StatsPipelinedAsync(segmentIds, effectiveDepth, cancellationToken)
+        // Primary-only sweep: STAT chunk sizing is fixed in BaseNntpClient
+        // (UsenetSharp windows internally). Per-provider BODY depth does not apply.
+        // Misses are rechecked with per-STAT failover in CheckAllSegmentsPipelinedAsync.
+        await foreach (var result in primary.StatsPipelinedAsync(segmentIds, depth, cancellationToken)
                            .WithCancellation(cancellationToken).ConfigureAwait(false))
             yield return result;
     }

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -455,18 +455,41 @@ public abstract class NntpClient : INntpClient
         CancellationToken cancellationToken
     )
     {
+        if (segmentIds.Count == 0) return;
+
         var processed = 0;
-        var anyMissing = false;
-        await foreach (var result in StatsPipelinedAsync(segmentIds, depth, cancellationToken)
-                           .WithCancellation(cancellationToken).ConfigureAwait(false))
+        var missing = new List<string>();
+        try
         {
-            progress?.Report(++processed);
-            if (result.Exists) continue;
-            anyMissing = true;
-            break;
+            await foreach (var result in StatsPipelinedAsync(segmentIds, depth, cancellationToken)
+                               .WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                progress?.Report(++processed);
+                if (result.Exists) continue;
+
+                // Exists=false means a definitive miss on the primary (connection-level
+                // codes throw from BaseNntpClient). Collect every miss so backups can
+                // still satisfy individual segments without skipping the rest of the sample.
+                missing.Add(result.SegmentId);
+            }
+        }
+        catch (UsenetUnexpectedResponseException)
+        {
+            // Session hiccup during the primary-only sweep: fall back to the concurrent
+            // path rather than failing the health check (retryable parity with today).
+            await CheckAllSegmentsAsync(segmentIds, fallbackConcurrency, progress, cancellationToken)
+                .ConfigureAwait(false);
+            return;
         }
 
-        if (anyMissing)
-            await CheckAllSegmentsAsync(segmentIds, fallbackConcurrency, progress, cancellationToken).ConfigureAwait(false);
+        if (missing.Count == 0) return;
+
+        // Recheck only the misses so backups can still satisfy those articles.
+        // Continue progress from the already-reported pipelined count.
+        var recheckProgress = progress == null
+            ? null
+            : new Progress<int>(n => progress.Report(processed + n));
+        await CheckAllSegmentsAsync(missing, fallbackConcurrency, recheckProgress, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -22,7 +22,7 @@
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="NzbDav.SharpCompress" Version="0.53.0" />
-      <PackageReference Include="NzbDav.UsenetSharp" Version="3.0.0" />
+      <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.0" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -298,9 +298,23 @@ public class QueueItemProcessor(
                 .Offset(100)
                 .ToPercentage(articlesToCheck.Count);
             var healthCheckConcurrency = configManager.GetHealthCheckConcurrency();
-            await usenetClient
-                .CheckAllSegmentsAsync(articlesToCheck, healthCheckConcurrency, part3Progress, ct)
-                .ConfigureAwait(false);
+            if (configManager.IsPipeliningEnabled())
+            {
+                await usenetClient
+                    .CheckAllSegmentsPipelinedAsync(
+                        articlesToCheck,
+                        configManager.GetPipeliningDepth(),
+                        healthCheckConcurrency,
+                        part3Progress,
+                        ct)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await usenetClient
+                    .CheckAllSegmentsAsync(articlesToCheck, healthCheckConcurrency, part3Progress, ct)
+                    .ConfigureAwait(false);
+            }
             checkedFullHealth = true;
         }
         var msHealth = stepTimer.ElapsedMilliseconds;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -170,7 +170,21 @@ public class HealthCheckService : BackgroundService
 
             // perform health check
             var progress = progressHook.ToPercentage(sampled.Count);
-            await _usenetClient.CheckAllSegmentsAsync(sampled, concurrency, progress, ct).ConfigureAwait(false);
+            if (_configManager.IsPipeliningEnabled())
+            {
+                await _usenetClient.CheckAllSegmentsPipelinedAsync(
+                        sampled,
+                        _configManager.GetPipeliningDepth(),
+                        concurrency,
+                        progress,
+                        ct)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await _usenetClient.CheckAllSegmentsAsync(sampled, concurrency, progress, ct)
+                    .ConfigureAwait(false);
+            }
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
 

--- a/docs/nntp-pipelining.md
+++ b/docs/nntp-pipelining.md
@@ -1,14 +1,14 @@
 # NNTP Pipelining
 
-NzbDav uses **UsenetSharp 3.x** batch BODY requests to pipeline multiple NNTP
-commands on one connection without waiting for each response. Responses are read
-strictly in order with bounded backpressure.
+NzbDav uses **UsenetSharp 3.x** batch BODY requests and pipelined STAT existence
+checks to send multiple NNTP commands on one connection without waiting for each
+response. Responses are read strictly in order with bounded backpressure.
 
 There are **two separate toggles**:
 
 | Setting | Location | Default | What it controls |
 |---------|----------|---------|------------------|
-| `usenet.pipelining.enabled` | Settings → Usenet | off | Queue first-segment fetch and provider benchmark batch downloads |
+| `usenet.pipelining.enabled` | Settings → Usenet | off | Queue first-segment fetch, provider benchmark batch downloads, and pipelined STAT health / import existence checks |
 | `usenet.pipelined-body-requests` | Settings → WebDAV | on | WebDAV streaming read-ahead via `DecodedBodiesAsync` batches |
 
 ## What the Usenet toggle speeds up
@@ -17,33 +17,34 @@ There are **two separate toggles**:
 |------|-------------------|-----------------|
 | Queue first-segment fetch (0→50%) | one `BODY` per file, concurrent across connections | first segments fetched in depth-sized batches on one connection |
 | Provider benchmark | one `BODY` per article | depth-sized `DecodedBodiesAsync` batches |
-| Health check (100→200%) | concurrent `STAT` across the pool | unchanged — always concurrent `STAT` |
+| Health check / import existence | concurrent `STAT` across the pool | primary-provider pipelined `STAT` via `StatPipelinedAsync`, with concurrent failover recheck of any misses |
 
 ## Enabling queue pipelining
 
 Settings → Usenet → **NNTP Pipelining**:
 
 - **Enable NNTP pipelining** — toggles `usenet.pipelining.enabled`.
-- **Pipeline depth** — `usenet.pipelining.depth`, requests per batch (1–64,
-  default 8). Each provider can override this in its own settings.
+- **Pipeline depth** — `usenet.pipelining.depth`, requests per BODY batch (1–64,
+  default 8). Each provider can override this in its own settings. STAT sweeps
+  use a larger fixed chunk and UsenetSharp's internal `MaxPipelineDepth` window;
+  BODY depth does not size STAT batches.
 
 For WebDAV playback, use Settings → WebDAV → **Pipelined article downloads**
 (`usenet.pipelined-body-requests`).
 
 ## How it's built
 
-UsenetSharp exposes batch pipelining through `DecodedBodiesAsync`. nzbdav routes
-`*PipelinedAsync` body paths through that API in batches of the configured
-depth. The client chain is:
+UsenetSharp exposes batch BODY pipelining through `DecodedBodiesAsync` and
+pipelined existence checks through `StatPipelinedAsync`. nzbdav routes
+`*PipelinedAsync` paths through those APIs. The client chain is:
 
-- `BaseNntpClient` — delegates batch calls to UsenetSharp
-- `MultiConnectionNntpClient` — leases one connection per batch
+- `BaseNntpClient` — delegates batch calls to UsenetSharp; classifies STAT
+  replies so connection-level codes (e.g. buffered 400) throw instead of looking
+  like missing articles
+- `MultiConnectionNntpClient` — leases one connection per batch (STAT path does
+  not feed the circuit breaker)
 - `MultiProviderNntpClient` — provider selection and byte counting
 - `DownloadingNntpClient` / `WrappingNntpClient` — permits and delegation
-
-`StatsPipelinedAsync` remains a sequential fallback because UsenetSharp 3.x does
-not ship a pipelined `STAT` API. Health checks always use concurrent `STAT`
-across the connection pool.
 
 ## Testing
 
@@ -58,7 +59,8 @@ pipelining helps at your connection count.
   and retries individual misses on the primary (then backups) before yielding
   `Found = false`. Queue first-segment rescue still re-fetches any remaining null
   slots with full per-article failover.
-- **`StatsPipelinedAsync` remains primary-only.** Health checks use concurrent
-  per-segment `STAT` with failover elsewhere, so this does not affect correctness.
+- **Pipelined STAT sweeps are primary-only.** Misses are rechecked with concurrent
+  per-segment `STAT` (full failover) so backups can still satisfy articles.
+  Connection-level errors during the sweep fall back to the concurrent path.
 - The per-queue-item article cache bypasses pipelined queue paths when caching is
   enabled (pre-existing; first segments may be re-fetched during RAR header parse).

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -684,7 +684,8 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                             <span>
                                 <span className="block text-sm font-medium text-base-content">Enable NNTP pipelining</span>
                                 <span className="mt-0.5 block text-xs leading-relaxed text-base-content/50">
-                                    Batch BODY requests during queue imports and benchmarks. WebDAV streaming has its
+                                    Batch BODY requests during queue imports and benchmarks, and pipeline STAT
+                                    existence checks for import health and background repairs. WebDAV streaming has its
                                     own toggle under WebDAV settings.
                                 </span>
                             </span>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
@@ -66,6 +66,90 @@ public class BaseNntpClientStatTests
     }
 
     [Fact]
+    public async Task StatsPipelinedAsync_WithMixedExistsAndMisses_PreservesOrder()
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient([223, 430, 223, 451]));
+
+        var results = new List<(string Id, bool Exists)>();
+        await foreach (var result in client.StatsPipelinedAsync(
+                           ["a@example", "b@example", "c@example", "d@example"],
+                           depth: 8,
+                           CancellationToken.None))
+        {
+            results.Add((result.SegmentId, result.Exists));
+        }
+
+        Assert.Equal(
+            [("a@example", true), ("b@example", false), ("c@example", true), ("d@example", false)],
+            results);
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(480)]
+    [InlineData(503)]
+    public async Task StatsPipelinedAsync_WithConnectionLevelCode_ThrowsAndNeverReportsMiss(int responseCode)
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient([223, responseCode, 223]));
+
+        var reported = new List<bool>();
+        var exception = await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(async () =>
+        {
+            await foreach (var result in client.StatsPipelinedAsync(
+                               ["a@example", "b@example", "c@example"],
+                               depth: 8,
+                               CancellationToken.None))
+            {
+                reported.Add(result.Exists);
+            }
+        });
+
+        Assert.Equal("b@example", exception.SegmentId);
+        Assert.Equal([true], reported);
+        Assert.DoesNotContain(false, reported);
+    }
+
+    [Fact]
+    public async Task StatsPipelinedAsync_With480_UsesClearAuthRequiredMessage()
+    {
+        using var client = new BaseNntpClient(new ScriptedUsenetClient([480]));
+
+        var exception = await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(async () =>
+        {
+            await foreach (var _ in client.StatsPipelinedAsync(
+                               ["seg@example"], 8, CancellationToken.None))
+            {
+            }
+        });
+
+        Assert.Contains("requires authentication", exception.Message);
+    }
+
+    [Fact]
+    public async Task StatsPipelinedAsync_ChunksLargeBatches()
+    {
+        var codes = Enumerable.Repeat(223, BaseNntpClient.StatPipelinedSweepChunkSize + 3).ToArray();
+        var underlying = new ScriptedUsenetClient(codes);
+        using var client = new BaseNntpClient(underlying);
+
+        var segmentIds = Enumerable.Range(0, codes.Length)
+            .Select(i => $"seg{i}@example")
+            .ToArray();
+        var count = 0;
+        await foreach (var result in client.StatsPipelinedAsync(segmentIds, depth: 1, CancellationToken.None))
+        {
+            Assert.True(result.Exists);
+            count++;
+        }
+
+        Assert.Equal(codes.Length, count);
+        Assert.Equal(2, underlying.StatPipelinedCallCount);
+        Assert.Equal(
+            [BaseNntpClient.StatPipelinedSweepChunkSize, 3],
+            underlying.StatPipelinedBatchSizes);
+    }
+
+    [Fact]
     public void Dispose_PrefersUnderlyingAsyncDispose()
     {
         var underlying = new ScriptedUsenetClient(223);
@@ -76,9 +160,23 @@ public class BaseNntpClientStatTests
         Assert.True(underlying.AsyncDisposed);
     }
 
-    private sealed class ScriptedUsenetClient(int responseCode) : IUsenetClient, IAsyncDisposable
+    private sealed class ScriptedUsenetClient : IUsenetClient, IAsyncDisposable
     {
+        private readonly int[] _responseCodes;
+        private int _statIndex;
+
+        public ScriptedUsenetClient(int responseCode) : this([responseCode])
+        {
+        }
+
+        public ScriptedUsenetClient(int[] responseCodes)
+        {
+            _responseCodes = responseCodes;
+        }
+
         public bool AsyncDisposed { get; private set; }
+        public int StatPipelinedCallCount { get; private set; }
+        public List<int> StatPipelinedBatchSizes { get; } = [];
         public bool IsConnected => true;
         public bool IsHealthy => true;
 
@@ -89,13 +187,23 @@ public class BaseNntpClientStatTests
             string user, string pass, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
-        public Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken) =>
-            Task.FromResult(new UsenetStatResponse
-            {
-                ResponseCode = responseCode,
-                ResponseMessage = $"{responseCode} <{segmentId}>",
-                ArticleExists = responseCode == (int)UsenetResponseType.ArticleExists,
-            });
+        public Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            var responseCode = NextCode();
+            return Task.FromResult(MakeStat(responseCode, segmentId));
+        }
+
+        public Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            CancellationToken cancellationToken)
+        {
+            StatPipelinedCallCount++;
+            StatPipelinedBatchSizes.Add(segmentIds.Count);
+            var results = new UsenetStatResponse[segmentIds.Count];
+            for (var i = 0; i < segmentIds.Count; i++)
+                results[i] = MakeStat(NextCode(), segmentIds[i]);
+            return Task.FromResult<IReadOnlyList<UsenetStatResponse>>(results);
+        }
 
         public Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
@@ -140,5 +248,20 @@ public class BaseNntpClientStatTests
             AsyncDisposed = true;
             return ValueTask.CompletedTask;
         }
+
+        private int NextCode()
+        {
+            if (_statIndex >= _responseCodes.Length)
+                throw new InvalidOperationException("Unexpected extra STAT request.");
+            return _responseCodes[_statIndex++];
+        }
+
+        private static UsenetStatResponse MakeStat(int responseCode, SegmentId segmentId) =>
+            new()
+            {
+                ResponseCode = responseCode,
+                ResponseMessage = $"{responseCode} <{segmentId}>",
+                ArticleExists = responseCode == (int)UsenetResponseType.ArticleExists,
+            };
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionStatsPipelinedTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionStatsPipelinedTests.cs
@@ -1,0 +1,115 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class MultiConnectionStatsPipelinedTests
+{
+    [Fact]
+    public async Task StatsPipelinedAsync_DoesNotRecordCircuitBreakerSuccess()
+    {
+        var inner = new ExistsStatClient();
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1, _ => ValueTask.FromResult<INntpClient>(inner));
+
+        var breaker = new ProviderCircuitBreaker("stat-pipeline");
+        breaker.RecordFailure("seed-1");
+        breaker.RecordFailure("seed-2");
+        breaker.RecordFailure("seed-3");
+        Assert.True(breaker.IsTripped);
+
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            breaker,
+            "stat-pipeline");
+
+        var results = new List<PipelinedStatResult>();
+        await foreach (var result in client.StatsPipelinedAsync(
+                           ["a@example", "b@example"], depth: 8, CancellationToken.None))
+        {
+            results.Add(result);
+        }
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.True(r.Exists));
+        // STAT must not feed the breaker — a successful sweep must not clear a trip.
+        Assert.True(breaker.IsTripped);
+    }
+
+    private sealed class ExistsStatClient : NntpClient
+    {
+        public override async IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync(
+            IReadOnlyList<string> segmentIds,
+            int depth,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            foreach (var segmentId in segmentIds)
+            {
+                yield return new PipelinedStatResult
+                {
+                    SegmentId = segmentId,
+                    Exists = true,
+                };
+            }
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = 223,
+                ResponseMessage = $"223 <{segmentId}>",
+                ArticleExists = true,
+            });
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -48,6 +48,69 @@ public class NntpClientCheckAllSegmentsTests
     }
 
     [Fact]
+    public async Task CheckAllSegmentsPipelinedAsync_WithAllExists_SucceedsWithoutFailoverRecheck()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: [true, true],
+            recheckCodes: []);
+
+        await client.CheckAllSegmentsPipelinedAsync(
+            ["a@example", "b@example"], depth: 8, fallbackConcurrency: 2, progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(0, client.CheckAllSegmentsCallCount);
+        Assert.Empty(client.RecheckedSegmentIds);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsPipelinedAsync_RechecksOnlyMisses()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: [true, false, true, false],
+            recheckCodes: [223, 223]);
+
+        await client.CheckAllSegmentsPipelinedAsync(
+            ["a@example", "b@example", "c@example", "d@example"],
+            depth: 8,
+            fallbackConcurrency: 2,
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(1, client.CheckAllSegmentsCallCount);
+        Assert.Equal(["b@example", "d@example"], client.RecheckedSegmentIds);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsPipelinedAsync_MissConfirmedOnFailover_ThrowsArticleNotFound()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: [true, false],
+            recheckCodes: [430]);
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.CheckAllSegmentsPipelinedAsync(
+                ["a@example", "b@example"], 8, 1, null, CancellationToken.None));
+
+        Assert.Equal("b@example", exception.SegmentId);
+        Assert.Equal(["b@example"], client.RecheckedSegmentIds);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsPipelinedAsync_SweepThrowsUnexpected_FallsBackToFullConcurrentPath()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: null,
+            recheckCodes: [223, 223],
+            throwUnexpectedOnSweep: true);
+
+        await client.CheckAllSegmentsPipelinedAsync(
+            ["a@example", "b@example"], 8, 2, null, CancellationToken.None);
+
+        Assert.Equal(1, client.CheckAllSegmentsCallCount);
+        Assert.Equal(["a@example", "b@example"], client.RecheckedSegmentIds);
+    }
+
+    [Fact]
     public async Task MapPipelinedBodyResult_With451_ReportsNotFound()
     {
         var client = new BodyCodeClient(451);
@@ -60,6 +123,109 @@ public class NntpClientCheckAllSegmentsTests
         Assert.NotNull(result);
         Assert.False(result.Found);
         Assert.Null(result.Stream);
+    }
+
+    private sealed class TrackingPipelinedStatClient(
+        bool[]? pipelinedExists,
+        int[] recheckCodes,
+        bool throwUnexpectedOnSweep = false) : NntpClient
+    {
+        private int _recheckIndex;
+
+        public int CheckAllSegmentsCallCount { get; private set; }
+        public List<string> RecheckedSegmentIds { get; } = [];
+
+        public override async IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync(
+            IReadOnlyList<string> segmentIds,
+            int depth,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            if (throwUnexpectedOnSweep)
+                throw new UsenetUnexpectedResponseException(segmentIds[0], "400 idle timeout");
+
+            for (var i = 0; i < segmentIds.Count; i++)
+            {
+                yield return new PipelinedStatResult
+                {
+                    SegmentId = segmentIds[i],
+                    Exists = pipelinedExists![i],
+                };
+            }
+        }
+
+        public override async Task CheckAllSegmentsAsync(
+            IEnumerable<string> segmentIds,
+            int concurrency,
+            IProgress<int>? progress,
+            CancellationToken cancellationToken)
+        {
+            CheckAllSegmentsCallCount++;
+            var list = segmentIds.ToList();
+            RecheckedSegmentIds.AddRange(list);
+
+            var processed = 0;
+            foreach (var segmentId in list)
+            {
+                progress?.Report(++processed);
+                var code = recheckCodes[_recheckIndex++];
+                if (code == (int)UsenetResponseType.ArticleExists) continue;
+                if (code is 430 or 451)
+                    throw new UsenetArticleNotFoundException(segmentId, $"{code} missing");
+                throw new UsenetUnexpectedResponseException(segmentId, $"{code} unexpected");
+            }
+
+            await Task.CompletedTask;
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
     }
 
     private sealed class StatCodeClient(int responseCode) : NntpClient


### PR DESCRIPTION
## Summary
- Bumps `NzbDav.UsenetSharp` to **3.1.0** and wires `StatPipelinedAsync` for article existence checks.
- When **NNTP pipelining** is enabled, queue import existence checks and background health checks use a primary-provider pipelined STAT sweep, then recheck only misses with the existing concurrent failover path.
- Classifies batch STAT replies like single `StatAsync` (223 exists, 430/451 miss, other codes throw) so a stale connection goodbye cannot look like a missing article.

Closes #60

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (STAT-focused tests pass; one unrelated macOS rapidyenc native-lib env failure in prefetch budget tests)
- [ ] Large NZB import with ensure-existence + pipelining on/off: compare wall time
- [ ] Health check on 4k+ segment file: faster with pipelining on; same healthy/unhealthy outcome
- [ ] Multi-provider: article only on backup still succeeds via miss recheck failover