### PR TITLE
feat(queue): move NZB downloads to the top of the queue

### DIFF
--- a/backend/Api/SabControllers/MoveInQueue/MoveInQueueController.cs
+++ b/backend/Api/SabControllers/MoveInQueue/MoveInQueueController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.SabControllers.MoveInQueue;
+
+public class MoveInQueueController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    WebsocketManager websocketManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<MoveInQueueResponse> MoveInQueue(MoveInQueueRequest request)
+    {
+        if (request.NzoIds.Count == 0)
+            return new MoveInQueueResponse { Status = true };
+
+        if (!request.MoveToTop)
+            throw new BadHttpRequestException("Only move-to-top is supported.");
+
+        var movedIds = await dbClient
+            .MoveQueueItemsToTopAsync(request.NzoIds, request.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (movedIds.Count > 0)
+            _ = websocketManager.SendMessage(WebsocketTopic.QueueItemMoved, string.Join(",", movedIds));
+
+        return new MoveInQueueResponse { Status = true };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        var request = await MoveInQueueRequest.New(httpContext).ConfigureAwait(false);
+        return Ok(await MoveInQueue(request).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/MoveInQueue/MoveInQueueRequest.cs
+++ b/backend/Api/SabControllers/MoveInQueue/MoveInQueueRequest.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.SabControllers.MoveInQueue;
+
+public class MoveInQueueRequest
+{
+    public List<Guid> NzoIds { get; init; } = [];
+    public bool MoveToTop { get; init; }
+    public CancellationToken CancellationToken { get; init; }
+
+    public static async Task<MoveInQueueRequest> New(HttpContext httpContext)
+    {
+        var cancellationToken = SigtermUtil.GetCancellationToken();
+        var queryIds = ParseNzoIds(httpContext);
+        var bodyIds = await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false);
+        var position = httpContext.GetRequestParam("value2");
+
+        return new MoveInQueueRequest
+        {
+            NzoIds = queryIds.Concat(bodyIds).Distinct().ToList(),
+            MoveToTop = IsMoveToTop(position),
+            CancellationToken = cancellationToken
+        };
+    }
+
+    /// <summary>
+    /// SABnzbd uses absolute index 0 or the token "top" for move-to-top.
+    /// Missing value2 defaults to top so a simple move call is enough for our UI.
+    /// </summary>
+    internal static bool IsMoveToTop(string? position)
+    {
+        if (string.IsNullOrWhiteSpace(position))
+            return true;
+
+        if (position.Equals("top", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (int.TryParse(position, out var index) && index == 0)
+            return true;
+
+        throw new BadHttpRequestException(
+            "Only move-to-top is supported (value2=0 or value2=top).");
+    }
+
+    private static List<Guid> ParseNzoIds(HttpContext httpContext)
+    {
+        var ids = new List<Guid>();
+        var seen = new HashSet<Guid>();
+        foreach (var token in httpContext.GetQueryParamValues("value")
+                     .SelectMany(value => value.Split(',', StringSplitOptions.TrimEntries |
+                                                          StringSplitOptions.RemoveEmptyEntries)))
+        {
+            if (Guid.TryParse(token, out var id) && seen.Add(id))
+                ids.Add(id);
+        }
+
+        return ids;
+    }
+
+    private static async Task<List<Guid>> NzoIdsFromRequestBody(HttpContext httpContext, CancellationToken ct)
+    {
+        try
+        {
+            await using var stream = httpContext.Request.Body;
+            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(stream, cancellationToken: ct)
+                .ConfigureAwait(false);
+            return deserialized?.NzoIds ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private class RequestBody
+    {
+        [JsonPropertyName("nzo_ids")]
+        public List<Guid> NzoIds { get; set; } = [];
+    }
+}

--- a/backend/Api/SabControllers/MoveInQueue/MoveInQueueResponse.cs
+++ b/backend/Api/SabControllers/MoveInQueue/MoveInQueueResponse.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Api.SabControllers.MoveInQueue;
+
+public class MoveInQueueResponse : SabBaseResponse
+{
+}

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -9,6 +9,7 @@ using NzbWebDAV.Api.SabControllers.GetHistory;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Api.SabControllers.GetStatus;
 using NzbWebDAV.Api.SabControllers.GetVersion;
+using NzbWebDAV.Api.SabControllers.MoveInQueue;
 using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
 using NzbWebDAV.Auth;
@@ -97,6 +98,9 @@ public class SabApiController(
             case "queue" when HttpContext.GetRequestParam("name") == "delete":
                 return new RemoveFromQueueController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager);
+            case "queue" when HttpContext.GetRequestParam("name") == "move":
+                return new MoveInQueueController(
+                    HttpContext, dbClient, configManager, websocketManager);
             case "queue":
                 return new GetQueueController(
                     HttpContext, dbClient, queueManager, configManager, providerUsageTracker);

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -248,6 +248,47 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         await CascadeWatchdogEntriesAsync(ids, groupKeys, ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the given queue items to the front of the queue by setting
+    /// <see cref="QueueItem.PriorityOption.Force"/> and assigning earlier
+    /// <see cref="QueueItem.CreatedAt"/> values. Preserves the relative order
+    /// of <paramref name="ids"/> (first id becomes the absolute top among
+    /// moved items). Does not preempt an already in-progress download.
+    /// </summary>
+    /// <returns>The ids that were actually updated (unknown ids are skipped).</returns>
+    public async Task<List<Guid>> MoveQueueItemsToTopAsync(List<Guid> ids, CancellationToken ct = default)
+    {
+        if (ids.Count == 0)
+            return [];
+
+        var idSet = ids.ToHashSet();
+        var items = await Ctx.QueueItems
+            .Where(q => idSet.Contains(q.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        if (items.Count == 0)
+            return [];
+
+        var byId = items.ToDictionary(q => q.Id);
+        var ordered = ids.Where(byId.ContainsKey).Distinct().ToList();
+
+        var earliest = await Ctx.QueueItems
+            .MinAsync(q => q.CreatedAt, ct)
+            .ConfigureAwait(false);
+        // Place moved items strictly before every other queue item.
+        var baseTime = earliest.AddTicks(-ordered.Count);
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var item = byId[ordered[i]];
+            item.Priority = QueueItem.PriorityOption.Force;
+            item.CreatedAt = baseTime.AddTicks(i);
+        }
+
+        await Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        return ordered;
+    }
+
     // Delete watchdog attempts that were tied to the deleted queue/history items.
     // - QueueItemId match: direct link (queue-processor flow).
     // - ContentGroupKey match: orphaned group — no remaining queue or history item

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -21,6 +21,7 @@ public class WebsocketTopic
     // Eventful topics
     public static readonly WebsocketTopic QueueItemAdded = new("qa", TopicType.Event);
     public static readonly WebsocketTopic QueueItemRemoved = new("qr", TopicType.Event);
+    public static readonly WebsocketTopic QueueItemMoved = new("qm", TopicType.Event);
     public static readonly WebsocketTopic HistoryItemAdded = new("ha", TopicType.Event);
     public static readonly WebsocketTopic HistoryItemRemoved = new("hr", TopicType.Event);
     public static readonly WebsocketTopic LogEntryAdded = new("log", TopicType.Event);

--- a/frontend/app/routes/queue/components/action-button/action-button.tsx
+++ b/frontend/app/routes/queue/components/action-button/action-button.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Button, Icon } from "~/components/ui";
 
 export type ActionButtonProps = {
-    type: "delete" | "explore" | "menu",
+    type: "delete" | "explore" | "menu" | "move-top",
     text?: string,
     disabled?: boolean,
     selected?: boolean,
@@ -11,7 +11,10 @@ export type ActionButtonProps = {
 
 export function ActionButton({ type, text, disabled, selected, onClick }: ActionButtonProps): ReactNode {
     const variant = type === "delete" ? "danger" : type === "explore" ? "warning" : "secondary";
-    const icon = type === "delete" ? "delete" : type === "explore" ? "folder" : "more_horiz";
+    const icon = type === "delete" ? "delete"
+        : type === "explore" ? "folder"
+        : type === "move-top" ? "vertical_align_top"
+        : "more_horiz";
 
     return (
         <Button
@@ -19,7 +22,7 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
             size="xsmall"
             disabled={disabled}
             aria-pressed={type === "menu" ? selected : undefined}
-            aria-label={!text ? type : undefined}
+            aria-label={!text ? (type === "move-top" ? "Move to top" : type) : undefined}
             className={`${type === "menu" ? "w-[30px] px-1" : ""} ${selected ? "bg-base-content/20 text-base-content" : ""}`}
             onClick={onClick}
         >

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -22,7 +22,27 @@ export type QueueTableProps = {
     onIsSelectedChanged: (nzo_ids: Set<string>, isSelected: boolean) => void,
     onIsRemovingChanged: (nzo_ids: Set<string>, isRemoving: boolean) => void,
     onRemoved: (nzo_ids: Set<string>) => void,
+    onMovedToTop: (nzo_ids: Set<string>) => void,
     onUploadClicked?: () => void;
+}
+
+async function moveQueueItemsToTop(nzoIds: string[]): Promise<boolean> {
+    if (nzoIds.length === 0) return false;
+    try {
+        const url = `/api?mode=queue&name=move&value2=0`;
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json;charset=UTF-8',
+            },
+            body: JSON.stringify({ nzo_ids: nzoIds }),
+        });
+        if (!response.ok) return false;
+        const data = await response.json();
+        return data.status === true;
+    } catch {
+        return false;
+    }
 }
 
 export function QueueTable({
@@ -37,11 +57,16 @@ export function QueueTable({
     onIsSelectedChanged,
     onIsRemovingChanged,
     onRemoved,
+    onMovedToTop,
     onUploadClicked,
 }: QueueTableProps) {
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
     const selectedCount = queueSlots.filter(x => !!x.isSelected).length;
     const headerCheckboxState: TriCheckboxState = selectedCount === 0 ? 'none' : selectedCount === queueSlots.length ? 'all' : 'some';
+    const selectedMovableIds = useMemo(
+        () => queueSlots.filter(x => !!x.isSelected && !x.isUploading).map(x => x.nzo_id),
+        [queueSlots],
+    );
 
     // row events
     const onRowIsSelectedChanged = useCallback((id: string, isSelected: boolean) => {
@@ -55,6 +80,11 @@ export function QueueTable({
     const onRowRemoved = useCallback((id: string) => {
         onRemoved(new Set([id]));
     }, [onRemoved]);
+
+    const onRowMovedToTop = useCallback((id: string) => {
+        onMovedToTop(new Set([id]));
+        if (!isLive) onPageSelected(1);
+    }, [onMovedToTop, isLive, onPageSelected]);
 
     // table events
     const onSelectAll = useCallback((isSelected: boolean) => {
@@ -98,6 +128,14 @@ export function QueueTable({
         onIsRemovingChanged(queued_nzo_ids, false);
     }, [queueSlots, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
+    const onMoveSelectedToTop = useCallback(async () => {
+        if (selectedMovableIds.length === 0) return;
+        const ok = await moveQueueItemsToTop(selectedMovableIds);
+        if (!ok) return;
+        onMovedToTop(new Set(selectedMovableIds));
+        if (!isLive) onPageSelected(1);
+    }, [selectedMovableIds, onMovedToTop, isLive, onPageSelected]);
+
 
     // view
     const categoryDropdown = useMemo(() => (
@@ -112,7 +150,14 @@ export function QueueTable({
                 Queue
             </h2>
             {headerCheckboxState !== 'none' &&
-                <ActionButton type="delete" onClick={onRemove} />
+                <>
+                    {selectedMovableIds.length > 0 &&
+                        <Tooltip content="Move selected to top of queue">
+                            <ActionButton type="move-top" onClick={onMoveSelectedToTop} />
+                        </Tooltip>
+                    }
+                    <ActionButton type="delete" onClick={onRemove} />
+                </>
             }
             <div className="ml-2.5 hidden min-[450px]:block">
                 {categoryDropdown}
@@ -146,6 +191,7 @@ export function QueueTable({
                             onIsSelectedChanged={onRowIsSelectedChanged}
                             onIsRemovingChanged={onRowIsRemovingChanged}
                             onRemoved={onRowRemoved}
+                            onMovedToTop={onRowMovedToTop}
                         />
                     )}
                 </PageTable>
@@ -165,12 +211,14 @@ type QueueRowProps = {
     slot: PresentationQueueSlot
     onIsSelectedChanged: (nzo_id: string, isSelected: boolean) => void,
     onIsRemovingChanged: (nzo_id: string, isRemoving: boolean) => void,
-    onRemoved: (nzo_id: string) => void
+    onRemoved: (nzo_id: string) => void,
+    onMovedToTop: (nzo_id: string) => void,
 }
 
-export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, onRemoved }: QueueRowProps) => {
+export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, onRemoved, onMovedToTop }: QueueRowProps) => {
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
+    const [isMoving, setIsMoving] = useState(false);
     const isActivelyUploading = slot.isUploading && slot.status == "uploading";
 
     // events
@@ -207,6 +255,17 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
         onIsRemovingChanged(slot.nzo_id, false);
     }, [slot.nzo_id, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
+    const onMoveToTop = useCallback(async () => {
+        if (slot.isUploading || isMoving) return;
+        setIsMoving(true);
+        try {
+            const ok = await moveQueueItemsToTop([slot.nzo_id]);
+            if (ok) onMovedToTop(slot.nzo_id);
+        } finally {
+            setIsMoving(false);
+        }
+    }, [slot.isUploading, slot.nzo_id, isMoving, onMovedToTop]);
+
     // view
     return (
         <>
@@ -219,7 +278,20 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                 status={slot.status}
                 percentage={slot.true_percentage}
                 fileSizeBytes={Number(slot.mb) * 1024 * 1024}
-                actions={<ActionButton type="delete" disabled={!!slot.isRemoving || isActivelyUploading} onClick={onRemove} />}
+                actions={
+                    <div className="flex items-center justify-center gap-1">
+                        {!slot.isUploading &&
+                            <Tooltip content="Move to top">
+                                <ActionButton
+                                    type="move-top"
+                                    disabled={!!slot.isRemoving || isMoving}
+                                    onClick={onMoveToTop}
+                                />
+                            </Tooltip>
+                        }
+                        <ActionButton type="delete" disabled={!!slot.isRemoving || isActivelyUploading} onClick={onRemove} />
+                    </div>
+                }
                 onRowSelectionChanged={isSelected => onIsSelectedChanged(slot.nzo_id, isSelected)}
                 error={slot.error}
                 indexer={slot.indexer}

--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -7,6 +7,7 @@ export type QueueEvents = {
     onSelectQueueSlots: (ids: Set<string>, isSelected: boolean) => void,
     onRemovingQueueSlots: (ids: Set<string>, isRemoving: boolean) => void,
     onRemoveQueueSlots: (ids: Set<string>) => void,
+    onMoveQueueSlotsToTop: (ids: Set<string>) => void,
     onChangeQueueSlotStatus: (message: string) => void,
     onChangeQueueSlotPercentage: (message: string) => void,
     onChangeQueueSlotProviders: (message: string) => void
@@ -23,7 +24,8 @@ export function useQueueEvents(
     setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void,
     setQueueSlots: (value: React.SetStateAction<PresentationQueueSlot[]>) => void,
     uploadQueueRef: React.RefObject<UploadingFile[]>,
-    pageSize: number
+    pageSize: number,
+    isQueueLive: boolean,
 ) {
     const onAddQueueSlot = useCallback((queueSlot: QueueSlot) => {
         uploadQueueRef.current = uploadQueueRef.current.filter(x => x.queueSlot.status === "uploading" || x.queueSlot.filename !== queueSlot.filename);
@@ -45,6 +47,35 @@ export function useQueueEvents(
         setUploadingFiles(files => files.filter(x => x.queueSlot.status === "uploading" || !ids.has(x.queueSlot.nzo_id)));
         setQueueSlots(slots => slots.filter(x => !ids.has(x.nzo_id)));
     }, [setQueueSlots]);
+
+    const onMoveQueueSlotsToTop = useCallback((ids: Set<string>) => {
+        if (ids.size === 0) return;
+
+        // Older pages only show a window of the queue; moved items leave that window.
+        if (!isQueueLive) {
+            setQueueSlots(slots => slots.filter(x => !ids.has(x.nzo_id)));
+            return;
+        }
+
+        setQueueSlots(slots => {
+            const moved: PresentationQueueSlot[] = [];
+            const remaining: PresentationQueueSlot[] = [];
+            for (const slot of slots) {
+                if (ids.has(slot.nzo_id)) moved.push({ ...slot, isSelected: false });
+                else remaining.push(slot);
+            }
+            if (moved.length === 0) return slots;
+
+            // Keep an in-progress download pinned at the front (matches GetQueueController).
+            const insertAt = remaining.findIndex(s => s.status !== "Downloading");
+            const index = insertAt < 0 ? remaining.length : insertAt;
+            return [
+                ...remaining.slice(0, index),
+                ...moved,
+                ...remaining.slice(index),
+            ].slice(0, pageSize);
+        });
+    }, [setQueueSlots, isQueueLive, pageSize]);
 
     const onChangeQueueSlotStatus = useCallback((message: string) => {
         const [nzo_id, status] = message.split('|');
@@ -77,6 +108,7 @@ export function useQueueEvents(
         onSelectQueueSlots,
         onRemovingQueueSlots,
         onRemoveQueueSlots,
+        onMoveQueueSlotsToTop,
         onChangeQueueSlotStatus,
         onChangeQueueSlotPercentage,
         onChangeQueueSlotProviders

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -8,6 +8,7 @@ const topicNames = {
     queueItemProviders: 'qpv',
     queueItemAdded: 'qa',
     queueItemRemoved: 'qr',
+    queueItemMoved: 'qm',
     historyItemAdded: 'ha',
     historyItemRemoved: 'hr',
 };
@@ -18,6 +19,7 @@ const topicSubscriptions = {
     [topicNames.queueItemProviders]: 'state',
     [topicNames.queueItemAdded]: 'event',
     [topicNames.queueItemRemoved]: 'event',
+    [topicNames.queueItemMoved]: 'event',
     [topicNames.historyItemAdded]: 'event',
     [topicNames.historyItemRemoved]: 'event',
 } as const;
@@ -34,6 +36,9 @@ export function initializeQueueHistoryWebsocket(
         }
         else if (topic == topicNames.queueItemRemoved) {
             if (isQueueLive) queueEvents.onRemoveQueueSlots(new Set<string>(message.split(',')));
+        }
+        else if (topic == topicNames.queueItemMoved) {
+            queueEvents.onMoveQueueSlotsToTop(new Set<string>(message.split(',').filter(Boolean)));
         }
         else if (topic == topicNames.queueItemStatus)
             queueEvents.onChangeQueueSlotStatus(message);

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -84,7 +84,7 @@ export default function Queue(props: Route.ComponentProps) {
         : queueSlots;
 
     // queue/history events
-    const queueEvents = useQueueEvents(setUploadingFiles, setQueueSlots, uploadQueueRef, pageSize);
+    const queueEvents = useQueueEvents(setUploadingFiles, setQueueSlots, uploadQueueRef, pageSize, isQueueLive);
     const historyEvents = useHistoryEvents(setHistorySlots, pageSize);
 
     // websocket
@@ -121,6 +121,7 @@ export default function Queue(props: Route.ComponentProps) {
                         onIsSelectedChanged={queueEvents.onSelectQueueSlots}
                         onIsRemovingChanged={queueEvents.onRemovingQueueSlots}
                         onRemoved={queueEvents.onRemoveQueueSlots}
+                        onMovedToTop={queueEvents.onMoveQueueSlotsToTop}
                         onUploadClicked={dropzone.open}
                     />
                 </div>

--- a/tests/NzbWebDAV.Tests/Api/MoveInQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/MoveInQueueRequestTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.MoveInQueue;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class MoveInQueueRequestTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("top")]
+    [InlineData("TOP")]
+    public void IsMoveToTop_AcceptsTopPositions(string? position)
+    {
+        Assert.True(MoveInQueueRequest.IsMoveToTop(position));
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("bottom")]
+    [InlineData("-1")]
+    public void IsMoveToTop_RejectsOtherPositions(string position)
+    {
+        Assert.Throws<BadHttpRequestException>(() => MoveInQueueRequest.IsMoveToTop(position));
+    }
+
+    [Fact]
+    public async Task New_ParsesCommaSeparatedAndBodyIds()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var third = Guid.NewGuid();
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?value={first},{second}&value2=0");
+        context.Request.Body = new MemoryStream(
+            System.Text.Encoding.UTF8.GetBytes($$"""{"nzo_ids":["{{third}}"]}"""));
+        context.Request.ContentType = "application/json";
+
+        var request = await MoveInQueueRequest.New(context);
+
+        Assert.True(request.MoveToTop);
+        Assert.Equal(3, request.NzoIds.Count);
+        Assert.Contains(first, request.NzoIds);
+        Assert.Contains(second, request.NzoIds);
+        Assert.Contains(third, request.NzoIds);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -77,6 +77,49 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task MoveQueueItemsToTopAsync_BumpsPriorityAndCreatedAt()
+    {
+        var first = CreateQueueItem("first.nzb", DateTime.UtcNow.AddMinutes(-30), QueueItem.PriorityOption.Normal);
+        var second = CreateQueueItem("second.nzb", DateTime.UtcNow.AddMinutes(-20), QueueItem.PriorityOption.Normal);
+        var third = CreateQueueItem("third.nzb", DateTime.UtcNow.AddMinutes(-10), QueueItem.PriorityOption.High);
+
+        _context.QueueItems.AddRange(first, second, third);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var before = await _client.GetQueueItems(null);
+        Assert.Equal([third.Id, first.Id, second.Id], before.Select(q => q.Id));
+
+        var moved = await _client.MoveQueueItemsToTopAsync([second.Id]);
+        Assert.Equal([second.Id], moved);
+        _context.ChangeTracker.Clear();
+
+        var after = await _client.GetQueueItems(null);
+        Assert.Equal([second.Id, third.Id, first.Id], after.Select(q => q.Id));
+        Assert.Equal(QueueItem.PriorityOption.Force, after[0].Priority);
+    }
+
+    [Fact]
+    public async Task MoveQueueItemsToTopAsync_PreservesRelativeOrderOfMovedIds()
+    {
+        var first = CreateQueueItem("first.nzb", DateTime.UtcNow.AddMinutes(-30), QueueItem.PriorityOption.Normal);
+        var second = CreateQueueItem("second.nzb", DateTime.UtcNow.AddMinutes(-20), QueueItem.PriorityOption.Normal);
+        var third = CreateQueueItem("third.nzb", DateTime.UtcNow.AddMinutes(-10), QueueItem.PriorityOption.Normal);
+
+        _context.QueueItems.AddRange(first, second, third);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        // Request order: third then second → third should be absolute top.
+        await _client.MoveQueueItemsToTopAsync([third.Id, second.Id]);
+        _context.ChangeTracker.Clear();
+
+        var after = await _client.GetQueueItems(null);
+        Assert.Equal([third.Id, second.Id, first.Id], after.Select(q => q.Id));
+        Assert.All(after.Take(2), q => Assert.Equal(QueueItem.PriorityOption.Force, q.Priority));
+    }
+
+    [Fact]
     public async Task CompletedSymlinkCategoryChildren_AreDistinctAndOrdered()
     {
         var zetaDirectory = DavItem.New(
@@ -198,6 +241,25 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
             Category = "movies",
             DownloadStatus = status,
             DownloadDirId = downloadDirId
+        };
+    }
+
+    private static QueueItem CreateQueueItem(
+        string fileName,
+        DateTime createdAt,
+        QueueItem.PriorityOption priority)
+    {
+        return new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            NzbFileSize = 100,
+            TotalSegmentBytes = 200,
+            Category = "movies",
+            Priority = priority,
+            PostProcessing = QueueItem.PostProcessingOption.None
         };
     }
 


### PR DESCRIPTION
## Summary
- Adds SABnzbd-compatible `mode=queue&name=move` (move-to-top only) that sets `Priority=Force` and an earlier `CreatedAt` so items jump to the front of the queue.
- Queue UI gains per-row and bulk “Move to top” actions; live clients get a `qm` websocket event so page 1 reorders (and older pages drop the moved rows / jump to page 1).
- Does not preempt an already downloading job — it runs next after the current one finishes.

Closes #436

## Test plan
- [ ] Enqueue several NZBs, move one from a later page to the top — it appears near the top of page 1 (after any in-progress item).
- [ ] Bulk-select multiple items and move to top — relative order among selected is preserved.
- [ ] Confirm a currently downloading item is not interrupted; the moved item starts after it completes.
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~MoveQueueItemsToTop|FullyQualifiedName~MoveInQueueRequest"`
- [ ] Frontend typecheck passes.