### PR TITLE
docs: document the performance triage label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ Use **GitHub Issue Types** for kind — not kind labels:
 
 - Do **not** use (or recreate) `bug` / `enhancement` labels — they were removed; Issue Type is the source of truth.
 - Do **not** put `[Bug]:` / `[Feature]:` in issue titles; the type field already conveys that.
-- Triage / meta labels are fine: `priority:P*`, `effort:*`, `cataloged`, `more-info-required`, and source tags (`upstream-audit`, `elfhosted`, etc.).
+- Triage / meta labels are fine: `priority:P*`, `effort:*`, `performance`, `cataloged`, `more-info-required`, and source tags (`upstream-audit`, `elfhosted`, etc.).
 
 Bug and feature issue templates set Issue Type only (no kind labels, no title prefix).
 


### PR DESCRIPTION
## Summary
- Documents the new GitHub `performance` triage/meta label in AGENTS.md
- Label created on the repo and applied to open performance-enhancement issues: #465, #42, #60, #317, #112, #169, #464, #426

## Test plan
- [x] Confirm `performance` label exists with expected color/description
- [x] Confirm the eight issues above carry the label
- [ ] Skim AGENTS.md triage-label sentence for accuracy