### PR TITLE
chore(ci): restore Bug and Feature issue forms in the New issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report a reproducible problem in NzbDav
-title: ""
 type: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Suggest an improvement to NzbDav
-title: ""
 type: Feature
 body:
   - type: markdown


### PR DESCRIPTION
## Summary
- GitHub rejects `title: ""` in issue form YAML and hides those templates from the chooser
- Remove the empty `title` keys from the bug and feature forms so they appear again; Issue Types (`Bug` / `Feature`) are unchanged

## Test plan
- [ ] Open `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` on GitHub — no red “problem with this template” banner
- [ ] Visit https://github.com/nzbdav/nzbdav/issues/new/choose — Bug report and Feature request appear
- [ ] Create a test issue from each form — blank title for the reporter, Issue Type set correctly