### PR TITLE
fix(nntp): health checks no longer fail when a pipelined STAT session dies mid-sweep

### DIFF
--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -19,7 +19,8 @@ public class BaseNntpClient : NntpClient
     /// <summary>
     /// Sweep chunk size for <see cref="StatsPipelinedAsync"/>. UsenetSharp windows STAT
     /// internally with a sliding MaxPipelineDepth; this bound is only for progress
-    /// reporting and early-stop-on-miss granularity (not BODY pipelining depth).
+    /// reporting and call batching (not BODY pipelining depth). The sweep drains the
+    /// full enumerable — misses are collected for failover recheck, not early-stopped.
     /// </summary>
     internal const int StatPipelinedSweepChunkSize = 512;
 

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -473,11 +473,16 @@ public abstract class NntpClient : INntpClient
                 missing.Add(result.SegmentId);
             }
         }
-        catch (UsenetUnexpectedResponseException)
+        catch (Exception e) when (!e.IsCancellationException())
         {
-            // Session hiccup during the primary-only sweep: fall back to the concurrent
-            // path rather than failing the health check (retryable parity with today).
-            await CheckAllSegmentsAsync(segmentIds, fallbackConcurrency, progress, cancellationToken)
+            // Session/protocol/transport failure during the primary-only sweep (e.g.
+            // UsenetUnexpectedResponseException for a buffered 400 goodbye, or
+            // UsenetSharp UsenetProtocolException when the connection dies mid-batch):
+            // fall back to the concurrent path rather than failing the check.
+            var fallbackProgress = progress == null
+                ? null
+                : new Progress<int>(n => progress.Report(Math.Max(processed, n)));
+            await CheckAllSegmentsAsync(segmentIds, fallbackConcurrency, fallbackProgress, cancellationToken)
                 .ConfigureAwait(false);
             return;
         }

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -479,6 +479,11 @@ public abstract class NntpClient : INntpClient
             // UsenetUnexpectedResponseException for a buffered 400 goodbye, or
             // UsenetSharp UsenetProtocolException when the connection dies mid-batch):
             // fall back to the concurrent path rather than failing the check.
+            Log.Debug(
+                e,
+                "Pipelined STAT sweep failed after {Processed}/{Total} segments; falling back to concurrent STAT",
+                processed,
+                segmentIds.Count);
             var fallbackProgress = progress == null
                 ? null
                 : new Progress<int>(n => progress.Report(Math.Max(processed, n)));

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -1,6 +1,7 @@
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
+using UsenetSharp.Exceptions;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -101,13 +102,49 @@ public class NntpClientCheckAllSegmentsTests
         var client = new TrackingPipelinedStatClient(
             pipelinedExists: null,
             recheckCodes: [223, 223],
-            throwUnexpectedOnSweep: true);
+            sweepException: new UsenetUnexpectedResponseException("a@example", "400 idle timeout"));
 
         await client.CheckAllSegmentsPipelinedAsync(
             ["a@example", "b@example"], 8, 2, null, CancellationToken.None);
 
         Assert.Equal(1, client.CheckAllSegmentsCallCount);
         Assert.Equal(["a@example", "b@example"], client.RecheckedSegmentIds);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsPipelinedAsync_SweepThrowsProtocol_FallsBackToFullConcurrentPath()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: null,
+            recheckCodes: [223, 223],
+            sweepException: new UsenetProtocolException(
+                "The NNTP connection closed before all pipelined STAT responses were received."));
+
+        await client.CheckAllSegmentsPipelinedAsync(
+            ["a@example", "b@example"], 8, 2, null, CancellationToken.None);
+
+        Assert.Equal(1, client.CheckAllSegmentsCallCount);
+        Assert.Equal(["a@example", "b@example"], client.RecheckedSegmentIds);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsPipelinedAsync_SweepThrowsAfterProgress_FallbackProgressIsMonotonic()
+    {
+        var reports = new List<int>();
+        var progress = new Progress<int>(n => reports.Add(n));
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: [true, true, true],
+            recheckCodes: [223, 223, 223],
+            sweepException: new UsenetProtocolException("connection closed mid-sweep"),
+            throwAfterYieldCount: 2);
+
+        await client.CheckAllSegmentsPipelinedAsync(
+            ["a@example", "b@example", "c@example"], 8, 2, progress, CancellationToken.None);
+
+        Assert.Equal(1, client.CheckAllSegmentsCallCount);
+        Assert.Equal(["a@example", "b@example", "c@example"], client.RecheckedSegmentIds);
+        // Pipelined reports 1,2 then throw; fallback clamps so n=1,2 stay at 2 before advancing to 3.
+        Assert.Equal([1, 2, 2, 2, 3], reports);
     }
 
     [Fact]
@@ -128,7 +165,8 @@ public class NntpClientCheckAllSegmentsTests
     private sealed class TrackingPipelinedStatClient(
         bool[]? pipelinedExists,
         int[] recheckCodes,
-        bool throwUnexpectedOnSweep = false) : NntpClient
+        Exception? sweepException = null,
+        int throwAfterYieldCount = 0) : NntpClient
     {
         private int _recheckIndex;
 
@@ -141,11 +179,14 @@ public class NntpClientCheckAllSegmentsTests
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
-            if (throwUnexpectedOnSweep)
-                throw new UsenetUnexpectedResponseException(segmentIds[0], "400 idle timeout");
+            if (sweepException != null && throwAfterYieldCount <= 0)
+                throw sweepException;
 
             for (var i = 0; i < segmentIds.Count; i++)
             {
+                if (sweepException != null && i == throwAfterYieldCount)
+                    throw sweepException;
+
                 yield return new PipelinedStatResult
                 {
                     SegmentId = segmentIds[i],


### PR DESCRIPTION
## Summary
- When a pipelined STAT health/import sweep hits a mid-session failure (`UsenetProtocolException`, transport errors, etc.), fall back to the concurrent STAT path instead of failing the check.
- Keep the health-check progress bar from jumping backwards during that full fallback.
- Correct the `StatPipelinedSweepChunkSize` comment (no early-stop-on-miss).

Follow-up to review feedback on #472.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter CheckAllSegmentsPipelined`
- [ ] Health check with pipelining on: kill/idle a connection mid-sweep and confirm it completes via concurrent failover (same healthy/unhealthy outcome)
- [ ] Progress bar does not jump backwards when a mid-sweep failover occurs