### PR TITLE
fix(nntp): stop providers getting stuck in the probing state

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -74,6 +74,13 @@ public class ProviderCircuitBreaker
         }
     }
 
+    /// <summary>
+    /// True once a trip has latched, whether still cooling down or waiting on a probe.
+    /// Unlike <see cref="IsTripped"/> this claims no probe slot, so callers can read it
+    /// without altering state.
+    /// </summary>
+    public bool IsLatched => Volatile.Read(ref _trippedUntilMs) != 0;
+
     /// <summary>TickCount64 deadline while latched open; 0 when not tripped. For tests.</summary>
     internal long TrippedUntilMs => Volatile.Read(ref _trippedUntilMs);
 

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -53,6 +53,10 @@ public class MultiConnectionNntpClient(
     private static readonly ConcurrentDictionary<string, int> TimeoutCounts = new();
     private static long _lastTimeoutFlushTicks = DateTime.UtcNow.Ticks;
 
+    // Commands that transfer an article body. Only these feed the circuit breaker, so the
+    // failure and success paths share one definition rather than each listing commands.
+    private static bool IsBodyCommand(string name) => name is "BODY" or "ARTICLE";
+
     private static void IncrementTimeoutCount(string provider)
     {
         TimeoutCounts.AddOrUpdate(provider, 1, (_, existing) => existing + 1);
@@ -412,7 +416,7 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
-            catch (Exception e) when (name is "BODY" or "ARTICLE" && e.TryGetCausingException(out TimeoutException? _))
+            catch (Exception e) when (IsBodyCommand(name) && e.TryGetCausingException(out TimeoutException? _))
             {
                 // Read-timeout on BODY/ARTICLE means the provider stopped responding
                 // mid-command. A fresh socket to the same provider is unlikely to fare
@@ -432,7 +436,9 @@ public class MultiConnectionNntpClient(
             {
                 deferredCallback.Discard();
                 var wasReused = connectionLock?.WasReused ?? false;
-                if (!wasReused)
+                // stat, head, and date do not feed the circuit breaker. The success path
+                // already skips them so a failure recorded here would never be reset.
+                if (!wasReused && IsBodyCommand(name))
                     circuitBreaker.RecordFailure($"cmd-setup-{name}-{e.GetType().Name}");
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
@@ -465,8 +471,13 @@ public class MultiConnectionNntpClient(
             // stat, head, and date — do not feed the circuit breaker.
             // STAT/HEAD/DATE successes were resetting BODY failure streaks and
             // preventing trips under mixed traffic (STAT-ok/BODY-fail providers).
-            if (name is "STAT" or "HEAD" or "DATE")
+            if (!IsBodyCommand(name))
             {
+                // Once latched the breaker is no longer tracking a streak, it is waiting
+                // for proof the provider answers at all. A provider that sees little body
+                // traffic would otherwise stay latched with nothing able to close it.
+                if (circuitBreaker.IsLatched)
+                    circuitBreaker.RecordSuccess();
                 deferredCallback.Discard();
                 LogException(() => connectionLock?.Dispose());
             }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -6,6 +6,7 @@ using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
+using NzbWebDAV.Tests.Fakes;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -160,6 +161,76 @@ public class StreamingTimeoutTests
 
         Assert.True(breaker.IsTripped);
         Assert.True(breaker.TrippedUntilMs > 0);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_StatCommandFailure_DoesNotTripBreaker()
+    {
+        var breaker = new ProviderCircuitBreaker("stat-failure");
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ => ValueTask.FromResult<INntpClient>(new HangingNntpClient()));
+
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "stat-failure");
+
+        // HangingNntpClient throws from StatAsync. The loop runs well past the
+        // trip threshold that body commands are held to.
+        for (var i = 0; i < 5; i++)
+        {
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                client.StatAsync($"seg-{i}", CancellationToken.None));
+        }
+
+        Assert.False(breaker.IsTripped);
+        Assert.Equal(0, breaker.TrippedUntilMs);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_StatSuccess_ClosesLatchedBreaker()
+    {
+        var breaker = new ProviderCircuitBreaker("stat-success-latched");
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ => ValueTask.FromResult<INntpClient>(
+                new FakeNntpClient(new Dictionary<string, byte[]> { ["seg"] = [1, 2, 3] })));
+
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "stat-success-latched");
+
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.True(breaker.IsLatched);
+
+        await client.StatAsync("seg", CancellationToken.None);
+
+        Assert.False(breaker.IsLatched);
+        Assert.Equal(0, breaker.TrippedUntilMs);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_StatSuccess_DoesNotClearFailureStreakWhileClosed()
+    {
+        var breaker = new ProviderCircuitBreaker("stat-success-closed");
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ => ValueTask.FromResult<INntpClient>(
+                new FakeNntpClient(new Dictionary<string, byte[]> { ["seg"] = [1, 2, 3] })));
+
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "stat-success-closed");
+
+        // Two failures leave the breaker closed and one short of tripping.
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.False(breaker.IsLatched);
+
+        await client.StatAsync("seg", CancellationToken.None);
+
+        // The streak has to survive the stat, so the next failure still trips.
+        breaker.RecordFailure();
+        Assert.True(breaker.IsTripped);
     }
 
     [Fact]


### PR DESCRIPTION
Bumped into this bug where a provider gets stuck in "Probing" state because a STAT failure trips the breaker but a STAT success never resets it. This makes the failure side match the success path, which already skips stat, head, and date.

update: Expanded so a successful stat, head, or date now closes the breaker when it's already latched, so a provider that sees little body traffic can recover on its own. Left get-connection alone as suggested, it stops being a trap now that a stat can close what it latched.

<img width="242" height="314" alt="Screenshot 2026-07-19 110131" src="https://github.com/user-attachments/assets/5690e9eb-4d7c-4d40-a42d-27a27eb5ef03" />
