### PR TITLE
fix(nntp): stabilize pipelined STAT progress reporting in CI

### DIFF
--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -484,9 +484,11 @@ public abstract class NntpClient : INntpClient
                 "Pipelined STAT sweep failed after {Processed}/{Total} segments; falling back to concurrent STAT",
                 processed,
                 segmentIds.Count);
+            // Use a synchronous adapter — Progress<T> posts asynchronously and can
+            // reorder or race progress observers (and tests collecting reports).
             var fallbackProgress = progress == null
                 ? null
-                : new Progress<int>(n => progress.Report(Math.Max(processed, n)));
+                : new MappedProgress(progress, n => Math.Max(processed, n));
             await CheckAllSegmentsAsync(segmentIds, fallbackConcurrency, fallbackProgress, cancellationToken)
                 .ConfigureAwait(false);
             return;
@@ -498,8 +500,13 @@ public abstract class NntpClient : INntpClient
         // Continue progress from the already-reported pipelined count.
         var recheckProgress = progress == null
             ? null
-            : new Progress<int>(n => progress.Report(processed + n));
+            : new MappedProgress(progress, n => processed + n);
         await CheckAllSegmentsAsync(missing, fallbackConcurrency, recheckProgress, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private sealed class MappedProgress(IProgress<int> target, Func<int, int> map) : IProgress<int>
+    {
+        public void Report(int value) => target.Report(map(value));
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -131,7 +131,9 @@ public class NntpClientCheckAllSegmentsTests
     public async Task CheckAllSegmentsPipelinedAsync_SweepThrowsAfterProgress_FallbackProgressIsMonotonic()
     {
         var reports = new List<int>();
-        var progress = new Progress<int>(n => reports.Add(n));
+        // Collect synchronously — System.Progress<T> posts via the sync context / thread
+        // pool and races List enumeration in Assert.Equal.
+        var progress = new CollectingProgress(reports);
         var client = new TrackingPipelinedStatClient(
             pipelinedExists: [true, true, true],
             recheckCodes: [223, 223, 223],
@@ -145,6 +147,11 @@ public class NntpClientCheckAllSegmentsTests
         Assert.Equal(["a@example", "b@example", "c@example"], client.RecheckedSegmentIds);
         // Pipelined reports 1,2 then throw; fallback clamps so n=1,2 stay at 2 before advancing to 3.
         Assert.Equal([1, 2, 2, 2, 3], reports);
+    }
+
+    private sealed class CollectingProgress(List<int> reports) : IProgress<int>
+    {
+        public void Report(int value) => reports.Add(value);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Backend CI on the [0.8.0 release PR](https://github.com/nzbdav/nzbdav/pull/443) failed on `CheckAllSegmentsPipelinedAsync_SweepThrowsAfterProgress_FallbackProgressIsMonotonic` with `Collection was modified; enumeration operation may not execute`.
- Replace nested `Progress<T>` adapters in `CheckAllSegmentsPipelinedAsync` with a synchronous `MappedProgress`, and collect test reports via a sync `IProgress<int>` so fallback progress is deterministic.

## Test plan
- [x] `dotnet test` filtered to `NntpClientCheckAllSegmentsTests` (11 passed)
- [x] Stress-ran the previously flaky test 50× with no failures
- [ ] Confirm backend CI is green on this PR, then re-check #443 after merge (release-please will refresh)