### PR TITLE
fix(webdav): incomplete RAR streams no longer return endless HTTP 500 without repair

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -141,6 +141,42 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             Log.Error("File {FilePath} could not connect to usenet provider: {ErrorMessage}", filePath, e.Message);
             AbortStartedResponse(context);
         }
+        catch (Exception e) when (
+            IsDavItemRequest(context) &&
+            e.TryGetCausingException(out CorruptRarException? corruptRar))
+        {
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 404;
+            }
+
+            var filePath = GetRequestFilePath(context);
+            var seekPosition = context.Request.GetRange()?.Start?.ToString() ?? "0";
+            var reason = corruptRar!.Message;
+            var dedupeKey = $"{filePath}|{seekPosition}|{reason}";
+            LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Error(
+                        "File {FilePath} contains a corrupt RAR at byte position {SeekPosition}: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        seekPosition,
+                        reason,
+                        suppressed);
+                else
+                    Log.Error(
+                        "File {FilePath} contains a corrupt RAR at byte position {SeekPosition}: {Reason}",
+                        filePath,
+                        seekPosition,
+                        reason);
+            });
+
+            if (context.Items["DavItem"] is DavItem davItem)
+                ScheduleRepair(davItem.Id);
+
+            AbortStartedResponse(context);
+        }
         catch (Exception e) when (IsDavItemRequest(context))
         {
             if (!context.Response.HasStarted)

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -147,9 +147,9 @@ public class HealthCheckService : BackgroundService
         CancellationToken ct
     )
     {
-        // Urgent sentinel set by ExceptionMiddleware when streaming hits a missing article.
-        // Streaming already confirmed a BODY miss across providers — skip STAT-only recheck
-        // (STAT can pass while BODY returns 430; see nzbdav-dev#209) and repair immediately.
+        // Urgent sentinel set by ExceptionMiddleware when streaming confirms a permanent failure.
+        // Skip the STAT-only recheck and repair immediately: STAT can pass while BODY returns 430
+        // (see nzbdav-dev#209), and structurally corrupt archives can have every article present.
         var isUrgentRepair = davItem.NextHealthCheck == DateTimeOffset.UnixEpoch;
         if (isUrgentRepair)
         {
@@ -498,7 +498,7 @@ public class HealthCheckService : BackgroundService
                 HealthCheckResult.HealthResult.Unhealthy,
                 HealthCheckResult.RepairAction.ActionNeeded,
                 string.Join(" ", [
-                    "File had missing articles during streaming.",
+                    "File failed during streaming.",
                     $"Streaming failure count: {failureCount}/{threshold}.",
                     "Auto-remove deferred until the failure threshold is reached."
                 ]), ct).ConfigureAwait(false);
@@ -530,7 +530,7 @@ public class HealthCheckService : BackgroundService
                 DeletionAuditLog.Record(
                     "health-repair",
                     davItem,
-                    "missing articles; filename matches blocklist pattern");
+                    "health validation failed; filename matches blocklist pattern");
                 dbClient.Ctx.Items.Remove(davItem);
                 _failureTracker.ClearFailure(davItem.Id);
                 await RecordHealthResult(
@@ -538,7 +538,7 @@ public class HealthCheckService : BackgroundService
                     HealthCheckResult.HealthResult.Unhealthy,
                     HealthCheckResult.RepairAction.Deleted,
                     string.Join(" ", [
-                        "File had missing articles.",
+                        "File failed health validation.",
                         "Filename pattern is marked in settings as an ignored (unwanted) file.",
                         "Deleted file."
                     ]), ct).ConfigureAwait(false);
@@ -555,9 +555,9 @@ public class HealthCheckService : BackgroundService
 
                 var auditReason = forceDelete
                     ? streamingFailureCount is > 0
-                        ? $"missing articles; auto-removed after repeated streaming failures (count={streamingFailureCount})"
-                        : "missing articles; auto-removed after repeated streaming failures"
-                    : "missing articles; orphaned (no library symlink/strm)";
+                        ? $"auto-removed after repeated streaming failures (count={streamingFailureCount})"
+                        : "auto-removed after repeated streaming failures"
+                    : "health validation failed; orphaned (no library symlink/strm)";
                 DeletionAuditLog.Record("health-repair", davItem, auditReason);
 
                 dbClient.Ctx.Items.Remove(davItem);
@@ -571,7 +571,7 @@ public class HealthCheckService : BackgroundService
                 {
                     var forceDeleteLinkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
                     deleteMessage = string.Join(" ", [
-                        "File had missing articles.",
+                        "File failed during streaming.",
                         $"Auto-removed after repeated streaming failures.{failureNote}",
                         $"Deleted the webdav-file and {forceDeleteLinkType}."
                     ]);
@@ -579,7 +579,7 @@ public class HealthCheckService : BackgroundService
                 else if (forceDelete)
                 {
                     deleteMessage = string.Join(" ", [
-                        "File had missing articles.",
+                        "File failed during streaming.",
                         $"Auto-removed after repeated streaming failures.{failureNote}",
                         "Deleted file."
                     ]);
@@ -587,7 +587,7 @@ public class HealthCheckService : BackgroundService
                 else
                 {
                     deleteMessage = string.Join(" ", [
-                        "File had missing articles.",
+                        "File failed health validation.",
                         "Could not find corresponding symlink or strm-file within Library Dir.",
                         "Deleted file."
                     ]);
@@ -614,7 +614,7 @@ public class HealthCheckService : BackgroundService
                 DeletionAuditLog.Record(
                     "health-repair",
                     davItem,
-                    "missing articles; Arr remove-and-search triggered");
+                    "health validation failed; Arr remove-and-search triggered");
                 dbClient.Ctx.Items.Remove(davItem);
                 _failureTracker.ClearFailure(davItem.Id);
                 await RecordHealthResult(
@@ -622,7 +622,7 @@ public class HealthCheckService : BackgroundService
                     HealthCheckResult.HealthResult.Unhealthy,
                     HealthCheckResult.RepairAction.Repaired,
                     string.Join(" ", [
-                        "File had missing articles.",
+                        "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir.",
                         "Triggered new Arr search."
                     ]), ct).ConfigureAwait(false);
@@ -642,7 +642,7 @@ public class HealthCheckService : BackgroundService
                     HealthCheckResult.HealthResult.Unhealthy,
                     HealthCheckResult.RepairAction.ActionNeeded,
                     string.Join(" ", [
-                        "File had missing articles.",
+                        "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir,",
                         "but at least one Arr instance could not be reached or fully queried, so ownership",
                         "of the file could not be determined. Leaving the file in place rather than deleting it."
@@ -656,7 +656,7 @@ public class HealthCheckService : BackgroundService
             DeletionAuditLog.Record(
                 "health-repair",
                 davItem,
-                "missing articles; library link present but no Arr media-item (confirmed orphan)");
+                "health validation failed; library link present but no Arr media-item (confirmed orphan)");
             dbClient.Ctx.Items.Remove(davItem);
             _failureTracker.ClearFailure(davItem.Id);
             await RecordHealthResult(
@@ -664,7 +664,7 @@ public class HealthCheckService : BackgroundService
                 HealthCheckResult.HealthResult.Unhealthy,
                 HealthCheckResult.RepairAction.Deleted,
                 string.Join(" ", [
-                    "File had missing articles.",
+                    "File failed health validation.",
                     $"Corresponding {linkType} found within Library Dir.",
                     "Could not find corresponding Radarr/Sonarr media-item to trigger a new search.",
                     $"Deleted the webdav-file and {linkType}."

--- a/backend/Services/StreamingFailureTracker.cs
+++ b/backend/Services/StreamingFailureTracker.cs
@@ -3,7 +3,8 @@ using System.Collections.Concurrent;
 namespace NzbWebDAV.Services;
 
 /// <summary>
-/// In-memory counter of consecutive streaming failures (missing usenet articles) per
+/// In-memory counter of consecutive permanent streaming failures (missing usenet articles
+/// or structurally corrupt archives) per
 /// <c>DavItem</c>. Incremented by <c>ExceptionMiddleware</c> whenever it schedules an urgent
 /// repair for an item; consulted (and cleared) by <c>HealthCheckService</c> to power the
 /// opt-in "auto-remove after N failures" repair policy (see <c>repair.auto-remove-after-failures</c>).

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -71,7 +71,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     value={autoRemoveAfter}
                     onChange={e => setNewConfig({ ...config, "repair.auto-remove-after-failures": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-after-failures-help">
-                    After this many streaming playback failures (missing articles), urgent repair will
+                    After this many streaming playback failures (missing articles or corrupt archives), urgent repair will
                     auto-remove the broken file. Set to 0 to disable (default). Example: 3 removes an
                     unlinked file on the third failure.
                 </p>

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Middlewares;
 using NzbWebDAV.Services;
@@ -36,12 +38,60 @@ public class ExceptionMiddlewareTests
         Assert.False(lifetimeFeature.Aborted);
     }
 
-    private static ExceptionMiddleware CreateMiddleware(RequestDelegate next)
+    [Fact]
+    public async Task CorruptRarAfterResponseStarted_AbortsConnection()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new CorruptRarException("missing continuation header"));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task CorruptRarBeforeResponseStarted_ReturnsNotFoundWithoutAborting()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new CorruptRarException("missing continuation header"));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task CorruptRarWithDavItem_RecordsStreamingFailure()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var configManager = CreateRepairEnabledConfig();
+        var middleware = CreateMiddleware(
+            _ => throw new CorruptRarException("missing continuation header"),
+            configManager,
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    private static ExceptionMiddleware CreateMiddleware(
+        RequestDelegate next,
+        ConfigManager? configManager = null,
+        StreamingFailureTracker? failureTracker = null)
     {
         return new ExceptionMiddleware(
             next,
-            new ConfigManager(),
-            new StreamingFailureTracker());
+            configManager ?? new ConfigManager(),
+            failureTracker ?? new StreamingFailureTracker());
     }
 
     private static DefaultHttpContext CreateContext(
@@ -52,6 +102,53 @@ public class ExceptionMiddlewareTests
         context.Features.Set<IHttpResponseFeature>(new TestHttpResponseFeature(hasStarted));
         context.Features.Set<IHttpRequestLifetimeFeature>(lifetimeFeature);
         return context;
+    }
+
+    private static DefaultHttpContext CreateDavItemContext(
+        bool hasStarted,
+        TestHttpRequestLifetimeFeature lifetimeFeature)
+    {
+        var context = CreateContext(hasStarted, lifetimeFeature);
+        var id = Guid.NewGuid();
+        context.Items["DavItem"] = new DavItem
+        {
+            Id = id,
+            IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+            CreatedAt = DateTime.UtcNow,
+            Name = "video.mkv",
+            Path = "/content/video.mkv",
+            Type = DavItem.ItemType.UsenetFile,
+            SubType = DavItem.ItemSubType.MultipartFile,
+        };
+        return context;
+    }
+
+    private static ConfigManager CreateRepairEnabledConfig()
+    {
+        var arrConfig = new ArrConfig
+        {
+            SonarrInstances =
+            [
+                new ArrConfig.ConnectionDetails
+                {
+                    Host = "http://sonarr.invalid",
+                    ApiKey = "test-api-key",
+                },
+            ],
+        };
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = "/tmp/library" },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ArrInstances,
+                ConfigValue = JsonSerializer.Serialize(arrConfig),
+            },
+        ]);
+        Assert.True(configManager.IsRepairJobEnabled());
+        return configManager;
     }
 
     private sealed class TestHttpResponseFeature(bool hasStarted) : IHttpResponseFeature


### PR DESCRIPTION
## Summary
- return 404 for permanent corrupt-RAR WebDAV failures instead of a retryable HTTP 500
- count these failures and schedule urgent repair so configured Arr replacement/auto-remove policy can act
- generalize repair audit/UI wording to include structurally corrupt archives
- add middleware coverage for pre-started responses, started responses, and repair failure tracking

Fixes #478

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~ExceptionMiddlewareTests` (5 passed)
- [x] backend suite excluding `MultiSegmentStreamPrefetchBudgetTests.ReadBudget_CapsPrefetchBelowArticleBufferSize` (743 passed, 11 skipped)
- [x] full backend suite attempted; its only failure is the excluded test because local macOS lacks `rapidyenc.dylib`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm test` (209 passed)

## Known limitation
A normal scheduled STAT health check can still clear the in-memory failure counter for a corrupt archive whose articles are all present. Playback failures recur rapidly and reschedule urgent repair; making those counters durable is outside this fix.