### PR TITLE
feat(sab): allow NZB grabs from LAN indexers like Prowlarr and NZBHydra2

### DIFF
--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -14,6 +14,7 @@ namespace NzbWebDAV.Api.SabControllers.AddUrl;
 public class AddUrlRequest() : AddFileRequest
 {
     private static readonly HttpClient DirectHttpClient = InitializeHttpClient();
+    private static readonly HttpRequestOptionsKey<TrustedHostsMatcher> TrustedHostsOptionKey = new("TrustedHosts");
     private const int MaxAutomaticRedirections = 10;
     private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(60);
 
@@ -26,6 +27,7 @@ public class AddUrlRequest() : AddFileRequest
 
         var userAgent = IndexerConfig.PerIndexerRetrieveUserAgent(matchedIndexer) ?? configManager.GetUserAgent();
         var proxyUrl = StringUtil.EmptyToNull(matchedIndexer?.ProxyUrl) ?? indexerConfig.ProxyUrl;
+        var trustedHosts = TrustedHostsMatcher.Parse(configManager.GetAddUrlTrustedHosts());
 
         if (matchedIndexer is not null)
         {
@@ -41,7 +43,7 @@ public class AddUrlRequest() : AddFileRequest
         }
 
         var nzbFile = await GetNzbFile(
-            nzbUrl, nzbName, userAgent, proxyUrl, context.RequestAborted).ConfigureAwait(false);
+            nzbUrl, nzbName, userAgent, proxyUrl, trustedHosts, context.RequestAborted).ConfigureAwait(false);
         if (matchedIndexer is not null)
             _ = hitTracker.RecordAsync(matchedIndexer.Name, IndexerApiHit.HitType.Download, CancellationToken.None);
         return new AddUrlRequest()
@@ -79,6 +81,7 @@ public class AddUrlRequest() : AddFileRequest
         string? nzbName,
         string userAgent,
         string? proxyUrl,
+        TrustedHostsMatcher trustedHosts,
         CancellationToken cancellationToken)
     {
         try
@@ -87,7 +90,7 @@ public class AddUrlRequest() : AddFileRequest
                 throw new Exception($"The url is invalid.");
 
             var response = await GetAsync(
-                url, userAgent, proxyUrl, cancellationToken).ConfigureAwait(false);
+                url, userAgent, proxyUrl, trustedHosts, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 response.Dispose();
@@ -130,6 +133,7 @@ public class AddUrlRequest() : AddFileRequest
         string url,
         string userAgent,
         string? proxyUrl,
+        TrustedHostsMatcher trustedHosts,
         CancellationToken cancellationToken
     )
     {
@@ -146,8 +150,9 @@ public class AddUrlRequest() : AddFileRequest
             // Validate the destination before every request, including requests sent through
             // an indexer proxy. The direct client repeats this check at connect time to
             // protect against DNS rebinding between validation and socket creation.
-            await EnsurePublicHostAsync(currentUri, ct).ConfigureAwait(false);
+            await EnsurePublicHostAsync(currentUri, trustedHosts, ct).ConfigureAwait(false);
             using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
+            request.Options.Set(TrustedHostsOptionKey, trustedHosts);
             if (!string.IsNullOrWhiteSpace(userAgent))
                 request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
 
@@ -203,15 +208,21 @@ public class AddUrlRequest() : AddFileRequest
         return new HttpClient(handler);
     }
 
-    private static async Task EnsurePublicHostAsync(Uri uri, CancellationToken cancellationToken)
+    private static async Task EnsurePublicHostAsync(
+        Uri uri,
+        TrustedHostsMatcher trustedHosts,
+        CancellationToken cancellationToken)
     {
+        if (trustedHosts.IsTrustedHost(uri.Host))
+            return;
+
         var addresses = IPAddress.TryParse(uri.Host, out var literalAddress)
             ? [literalAddress]
             : await Dns.GetHostAddressesAsync(uri.Host, cancellationToken).ConfigureAwait(false);
 
         if (addresses.Length == 0)
             throw new HttpRequestException($"The host `{uri.Host}` did not resolve to an IP address.");
-        if (addresses.Any(address => !IsPublicAddress(address)))
+        if (addresses.Any(address => !IsPublicAddress(address) && !trustedHosts.IsTrustedAddress(address)))
             throw new HttpRequestException($"The host `{uri.Host}` resolved to a non-public IP address.");
     }
 
@@ -221,6 +232,19 @@ public class AddUrlRequest() : AddFileRequest
     )
     {
         var host = context.DnsEndPoint.Host;
+        var trustedHosts = TrustedHostsMatcher.Empty;
+        if (context.InitialRequestMessage.Options.TryGetValue(TrustedHostsOptionKey, out var requestTrustedHosts)
+            && requestTrustedHosts is not null)
+        {
+            trustedHosts = requestTrustedHosts;
+        }
+
+        if (trustedHosts.IsTrustedHost(host))
+        {
+            return await ConnectToAnyAddressAsync(host, context.DnsEndPoint.Port, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         IPAddress[] addresses;
 
         if (IPAddress.TryParse(host, out var literalAddress))
@@ -235,9 +259,41 @@ public class AddUrlRequest() : AddFileRequest
         if (addresses.Length == 0)
             throw new HttpRequestException($"The host `{host}` did not resolve to an IP address.");
 
-        if (addresses.Any(address => !IsPublicAddress(address)))
+        if (addresses.Any(address => !IsPublicAddress(address) && !trustedHosts.IsTrustedAddress(address)))
             throw new HttpRequestException($"The host `{host}` resolved to a non-public IP address.");
 
+        return await ConnectToAddressesAsync(host, addresses, context.DnsEndPoint.Port, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async ValueTask<Stream> ConnectToAnyAddressAsync(
+        string host,
+        int port,
+        CancellationToken cancellationToken)
+    {
+        IPAddress[] addresses;
+
+        if (IPAddress.TryParse(host, out var literalAddress))
+        {
+            addresses = [literalAddress];
+        }
+        else
+        {
+            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (addresses.Length == 0)
+            throw new HttpRequestException($"The host `{host}` did not resolve to an IP address.");
+
+        return await ConnectToAddressesAsync(host, addresses, port, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<Stream> ConnectToAddressesAsync(
+        string host,
+        IPAddress[] addresses,
+        int port,
+        CancellationToken cancellationToken)
+    {
         Exception? lastException = null;
         foreach (var address in addresses.Distinct())
         {
@@ -249,7 +305,7 @@ public class AddUrlRequest() : AddFileRequest
             try
             {
                 await socket.ConnectAsync(
-                    new IPEndPoint(address, context.DnsEndPoint.Port),
+                    new IPEndPoint(address, port),
                     cancellationToken
                 ).ConfigureAwait(false);
                 return new NetworkStream(socket, ownsSocket: true);

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -29,6 +29,7 @@ public static class ConfigKeys
     public const string ApiSkipNonVideoOnMissingArticles = "api.skip-non-video-on-missing-articles";
     public const string ApiStrmKey = "api.strm-key";
     public const string ApiUserAgent = "api.user-agent";
+    public const string ApiAddUrlTrustedHosts = "api.addurl-trusted-hosts";
 
     // usenet
     public const string UsenetArticleBufferSize = "usenet.article-buffer-size";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1209,6 +1209,17 @@ public class ConfigManager
                ?? defaultValue;
     }
 
+    /// <summary>
+    /// Comma/whitespace-separated hostnames, IP literals, CIDRs, or <c>*</c>
+    /// exempted from the addurl SSRF private-address guard. Falls back to
+    /// <c>TRUSTED_INTERNAL_HOSTS</c> when the config value is empty.
+    /// </summary>
+    public string? GetAddUrlTrustedHosts()
+    {
+        return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiAddUrlTrustedHosts))
+               ?? EnvironmentUtil.GetEnvironmentVariable("TRUSTED_INTERNAL_HOSTS");
+    }
+
     public string GetSearchUserAgent()
     {
         var defaultValue = $"nzbdav/{AppVersion}";

--- a/backend/Utils/TrustedHostsMatcher.cs
+++ b/backend/Utils/TrustedHostsMatcher.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using Serilog;
+
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Parses a comma/whitespace-separated allowlist of hostnames, IP literals, CIDR
+/// ranges, or <c>*</c> used to exempt destinations from the addurl SSRF guard.
+/// </summary>
+public sealed class TrustedHostsMatcher
+{
+    public static readonly TrustedHostsMatcher Empty = new(
+        trustAll: false,
+        hostnames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+        addresses: [],
+        networks: []);
+
+    private readonly bool _trustAll;
+    private readonly HashSet<string> _hostnames;
+    private readonly HashSet<IPAddress> _addresses;
+    private readonly List<IPNetwork> _networks;
+
+    private TrustedHostsMatcher(
+        bool trustAll,
+        HashSet<string> hostnames,
+        HashSet<IPAddress> addresses,
+        List<IPNetwork> networks)
+    {
+        _trustAll = trustAll;
+        _hostnames = hostnames;
+        _addresses = addresses;
+        _networks = networks;
+    }
+
+    public bool IsEmpty => !_trustAll && _hostnames.Count == 0 && _addresses.Count == 0 && _networks.Count == 0;
+
+    public static TrustedHostsMatcher Parse(string? rawEntries)
+    {
+        if (string.IsNullOrWhiteSpace(rawEntries))
+            return Empty;
+
+        var hostnames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var addresses = new HashSet<IPAddress>();
+        var networks = new List<IPNetwork>();
+        var trustAll = false;
+
+        foreach (var part in SplitEntries(rawEntries))
+        {
+            if (part == "*")
+            {
+                trustAll = true;
+                continue;
+            }
+
+            if (part.Contains('/') && IPNetwork.TryParse(part, out var network))
+            {
+                networks.Add(network);
+                continue;
+            }
+
+            if (IPAddress.TryParse(part, out var address))
+            {
+                addresses.Add(Normalize(address));
+                continue;
+            }
+
+            // Reject entries that look like broken CIDR/IP before treating as hostname.
+            if (part.Contains('/') || part.Any(char.IsWhiteSpace))
+            {
+                Log.Warning("Ignoring invalid trusted-hosts entry: {Entry}", part);
+                continue;
+            }
+
+            hostnames.Add(part);
+        }
+
+        if (!trustAll && hostnames.Count == 0 && addresses.Count == 0 && networks.Count == 0)
+            return Empty;
+
+        return new TrustedHostsMatcher(trustAll, hostnames, addresses, networks);
+    }
+
+    public bool IsTrustedHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return false;
+
+        if (_trustAll)
+            return true;
+
+        if (_hostnames.Contains(host))
+            return true;
+
+        // Allow listing an IP literal as a "host" entry to trust that destination by name.
+        if (IPAddress.TryParse(host, out var literal) && IsTrustedAddress(literal))
+            return true;
+
+        return false;
+    }
+
+    public bool IsTrustedAddress(IPAddress address)
+    {
+        if (_trustAll)
+            return true;
+
+        address = Normalize(address);
+
+        if (_addresses.Contains(address))
+            return true;
+
+        foreach (var network in _networks)
+        {
+            if (network.Contains(address))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> SplitEntries(string rawEntries)
+    {
+        return rawEntries
+            .Split([',', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static IPAddress Normalize(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+            return address.MapToIPv4();
+        return address;
+    }
+}

--- a/docs/sab-api.md
+++ b/docs/sab-api.md
@@ -28,6 +28,45 @@ sentinel returned by `get_cats` is `*`.
 - Authentication failures use HTTP error status codes instead of always
   returning HTTP 200 with an error body.
 
+## `addurl` and private / LAN hosts
+
+`mode=addurl` fetches the NZB from the URL the download client supplies. Before
+each hop (including redirects), NzbDav rejects destinations that resolve to a
+non-public IP address. That SSRF guard blocks classic attacks against cloud
+metadata and localhost, but it also blocks the common self-hosted pattern where
+Prowlarr, NZBHydra2, or another indexer is only reachable on Docker DNS or a
+RFC1918 LAN.
+
+Allow specific destinations under **Settings → SABnzbd → Trusted local hosts**
+(`api.addurl-trusted-hosts`). Entries are comma- or whitespace-separated and may
+be:
+
+| Entry | Meaning |
+|-------|---------|
+| `prowlarr` / `hydra.lan` | Hostname matched case-insensitively against the URL host |
+| `192.168.1.50` | Exact IP literal |
+| `192.168.1.0/24` / `fd00::/8` | CIDR range for resolved addresses |
+| `*` | Trust any non-public address (disables the guard) |
+
+Example for a Docker stack where Sportarr/Sonarr send Prowlarr download links:
+
+```text
+prowlarr
+```
+
+Or a whole LAN subnet:
+
+```text
+192.168.1.0/24, hydra.lan
+```
+
+Only list hosts you control. Clients that can download the NZB themselves can
+also avoid this path by posting the file with `mode=addfile` instead of
+`addurl`.
+
+The same allowlist can be set with the `TRUSTED_INTERNAL_HOSTS` environment
+variable when the UI setting is empty; see the [setup guide](setup-guide.md).
+
 ## Delete behavior
 
 Queue delete accepts a UUID, comma-separated UUIDs, repeated `value`

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -126,6 +126,15 @@ The image runs two processes: the frontend and public proxy on port `3000`, and 
 
     For adapter/Newznab absolute links and STRM URLs, set an explicit **Base URL** under Settings (preferred). Without it, public scheme/host come only from trusted forwarded headers: the frontend strips client `X-Forwarded-*` and rewrites canonical values for the backend (which trusts loopback by default). TLS-terminating reverse proxies should set `TRUST_PROXY=1` on the container so Express honors the proxy’s forwarded headers when rewriting, **or** set Base URL explicitly — otherwise generated links may stay `http://`. Split-container topologies can widen backend trust with `TRUSTED_PROXY_CIDRS` (comma-separated IPs or CIDRs).
 
+    When download clients send `mode=addurl` NZB links that point at Docker-internal or LAN indexers (for example `http://prowlarr:9696/...`), set **Settings → SABnzbd → Trusted local hosts**, or set the `TRUSTED_INTERNAL_HOSTS` environment variable when that UI setting is empty. Both accept the same comma-separated hostnames, IP literals, CIDR ranges, or `*`. Example:
+
+    ```yaml
+    environment:
+      - TRUSTED_INTERNAL_HOSTS=prowlarr
+    ```
+
+    See [SABnzbd API compatibility](sab-api.md) for formats and security notes. Only list hosts you control.
+
     Frontend session cookies: set `SECURE_COOKIES=true` when the UI is only served over HTTPS. Optionally set `SESSION_KEY` to a long random secret (otherwise a stable key is persisted under `CONFIG_PATH/session.key` so restarts do not log everyone out). Optionally set `SESSION_MAX_AGE` in seconds (default one year).
 
 

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -38,6 +38,7 @@ const defaultConfig = {
     "api.import-strategy": "symlinks",
     "api.completed-downloads-dir": "",
     "api.user-agent": "",
+    "api.addurl-trusted-hosts": "",
     "api.search-user-agent": "",
     "usenet.providers": "",
     "usenet.max-download-connections": "0",

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -181,6 +181,24 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
             </div>
             <hr />
             <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="addurl-trusted-hosts-input">Trusted local hosts</label>
+                <ExpandingTextInput
+                    className={'w-full'}
+                    id="addurl-trusted-hosts-input"
+                    aria-describedby="addurl-trusted-hosts-help"
+                    value={config["api.addurl-trusted-hosts"]}
+                    placeholder="prowlarr, hydra.lan, 192.168.1.0/24"
+                    onChange={value => setNewConfig({ ...config, "api.addurl-trusted-hosts": value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="addurl-trusted-hosts-help">
+                    By default, <code>addurl</code> refuses NZB URLs that resolve to private or loopback
+                    addresses (SSRF protection). List comma-separated hostnames, IP literals, or CIDR
+                    ranges that should be allowed anyway — for example Docker service names like{" "}
+                    <code>prowlarr</code> or a LAN subnet like <code>192.168.1.0/24</code>. Use{" "}
+                    <code>*</code> to trust every non-public address. Only list hosts you control.
+                </p>
+            </div>
+            <hr />
+            <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
                     id="ensure-importable-video-checkbox"
@@ -361,6 +379,7 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
         || config["api.completed-downloads-dir"] !== newConfig["api.completed-downloads-dir"]
         || config["general.base-url"] !== newConfig["general.base-url"]
         || config["api.user-agent"] !== newConfig["api.user-agent"]
+        || config["api.addurl-trusted-hosts"] !== newConfig["api.addurl-trusted-hosts"]
         || config["api.nzb-backup-enabled"] !== newConfig["api.nzb-backup-enabled"]
         || config["api.nzb-backup-location"] !== newConfig["api.nzb-backup-location"]
         || config["api.nzb-backup-retention-days"] !== newConfig["api.nzb-backup-retention-days"]

--- a/tests/NzbWebDAV.Tests/Utils/TrustedHostsMatcherTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/TrustedHostsMatcherTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class TrustedHostsMatcherTests
+{
+    [Fact]
+    public void Parse_EmptyOrWhitespace_ReturnsEmpty()
+    {
+        Assert.True(TrustedHostsMatcher.Parse(null).IsEmpty);
+        Assert.True(TrustedHostsMatcher.Parse("").IsEmpty);
+        Assert.True(TrustedHostsMatcher.Parse("   ,  \t").IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("prowlarr", "prowlarr")]
+    [InlineData("prowlarr", "PROWLARR")]
+    [InlineData("hydra.lan", "Hydra.LAN")]
+    public void IsTrustedHost_MatchesCaseInsensitively(string entry, string host)
+    {
+        var matcher = TrustedHostsMatcher.Parse(entry);
+        Assert.True(matcher.IsTrustedHost(host));
+    }
+
+    [Fact]
+    public void IsTrustedHost_DoesNotMatchOtherHosts()
+    {
+        var matcher = TrustedHostsMatcher.Parse("prowlarr");
+        Assert.False(matcher.IsTrustedHost("sonarr"));
+        Assert.False(matcher.IsTrustedHost("192.168.1.10"));
+    }
+
+    [Theory]
+    [InlineData("192.168.1.50", "192.168.1.50", true)]
+    [InlineData("192.168.1.50", "192.168.1.51", false)]
+    [InlineData("10.0.0.1", "10.0.0.1", true)]
+    public void IsTrustedAddress_MatchesExactIpLiterals(string entry, string address, bool expected)
+    {
+        var matcher = TrustedHostsMatcher.Parse(entry);
+        Assert.Equal(expected, matcher.IsTrustedAddress(IPAddress.Parse(address)));
+    }
+
+    [Theory]
+    [InlineData("192.168.1.0/24", "192.168.1.1", true)]
+    [InlineData("192.168.1.0/24", "192.168.1.255", true)]
+    [InlineData("192.168.1.0/24", "192.168.2.1", false)]
+    [InlineData("10.0.0.0/8", "10.255.255.255", true)]
+    [InlineData("10.0.0.0/8", "11.0.0.1", false)]
+    public void IsTrustedAddress_MatchesIpv4Cidr(string entry, string address, bool expected)
+    {
+        var matcher = TrustedHostsMatcher.Parse(entry);
+        Assert.Equal(expected, matcher.IsTrustedAddress(IPAddress.Parse(address)));
+    }
+
+    [Theory]
+    [InlineData("fd00::/8", "fd12::1", true)]
+    [InlineData("fd00::/8", "fe80::1", false)]
+    [InlineData("2001:db8::/32", "2001:db8::abcd", true)]
+    [InlineData("2001:db8::/32", "2001:db9::1", false)]
+    public void IsTrustedAddress_MatchesIpv6Cidr(string entry, string address, bool expected)
+    {
+        var matcher = TrustedHostsMatcher.Parse(entry);
+        Assert.Equal(expected, matcher.IsTrustedAddress(IPAddress.Parse(address)));
+    }
+
+    [Fact]
+    public void IsTrustedAddress_NormalizesIpv4MappedIpv6()
+    {
+        var matcher = TrustedHostsMatcher.Parse("192.168.1.50");
+        var mapped = IPAddress.Parse("::ffff:192.168.1.50");
+        Assert.True(matcher.IsTrustedAddress(mapped));
+    }
+
+    [Fact]
+    public void IsTrustedHost_TreatsListedIpLiteralAsTrustedHost()
+    {
+        var matcher = TrustedHostsMatcher.Parse("192.168.1.50");
+        Assert.True(matcher.IsTrustedHost("192.168.1.50"));
+    }
+
+    [Fact]
+    public void Wildcard_TrustsAnyHostAndAddress()
+    {
+        var matcher = TrustedHostsMatcher.Parse("*");
+        Assert.False(matcher.IsEmpty);
+        Assert.True(matcher.IsTrustedHost("prowlarr"));
+        Assert.True(matcher.IsTrustedHost("anything.local"));
+        Assert.True(matcher.IsTrustedAddress(IPAddress.Parse("10.0.0.1")));
+        Assert.True(matcher.IsTrustedAddress(IPAddress.Loopback));
+        Assert.True(matcher.IsTrustedAddress(IPAddress.Parse("fd00::1")));
+    }
+
+    [Fact]
+    public void Parse_SupportsCommaAndWhitespaceSeparatedEntries()
+    {
+        var matcher = TrustedHostsMatcher.Parse("prowlarr, hydra.lan\n192.168.1.0/24\t10.0.0.5");
+        Assert.True(matcher.IsTrustedHost("prowlarr"));
+        Assert.True(matcher.IsTrustedHost("hydra.lan"));
+        Assert.True(matcher.IsTrustedAddress(IPAddress.Parse("192.168.1.42")));
+        Assert.True(matcher.IsTrustedAddress(IPAddress.Parse("10.0.0.5")));
+        Assert.False(matcher.IsTrustedHost("sonarr"));
+    }
+
+    [Fact]
+    public void Parse_IgnoresInvalidEntries()
+    {
+        var matcher = TrustedHostsMatcher.Parse("prowlarr, not-a-cidr/99, 192.168.1.0/24");
+        Assert.True(matcher.IsTrustedHost("prowlarr"));
+        Assert.True(matcher.IsTrustedAddress(IPAddress.Parse("192.168.1.10")));
+        Assert.False(matcher.IsTrustedHost("not-a-cidr/99"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a **Trusted local hosts** allowlist (`api.addurl-trusted-hosts`, env fallback `TRUSTED_INTERNAL_HOSTS`) so `mode=addurl` can fetch NZBs from Docker/LAN destinations (Prowlarr, NZBHydra2, etc.) without turning off the SSRF guard globally.
- Entries may be hostnames, IP literals, CIDR ranges, or `*` (trust all non-public addresses). Applied on every hop and at connect time.
- Documents the UI setting in `docs/sab-api.md` and the env var in `docs/setup-guide.md`.

Fixes #433

## Test plan
- [x] `TrustedHostsMatcherTests` (22 cases: hostname, IP, CIDR, IPv4-mapped IPv6, `*`, invalid entries)
- [x] Frontend `typecheck` / `build` / `test`
- [ ] Manually: with empty allowlist, `addurl` to `http://prowlarr:...` still fails with non-public IP
- [ ] Manually: set Trusted local hosts to `prowlarr` (or `TRUSTED_INTERNAL_HOSTS=prowlarr`) and confirm Sportarr/Sonarr grab succeeds
- [ ] Manually: unlisted private host still rejected; public hosts still work