### PR TITLE
fix(ui): remove MaxListenersExceededWarning noise from container logs

### DIFF
--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -14,6 +14,7 @@ import {
   isWithinBackendStartupGrace,
 } from "./startup-grace";
 import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
+import { backendProxyTimeoutOptions } from "./backend-proxy-options";
 
 export const app = express();
 app.disable("x-powered-by");
@@ -49,19 +50,14 @@ function logProxyFailure(message: string, error: unknown) {
   }
 }
 
-// Speed tests (and some maintenance tasks) can run for many minutes while the
- // HTTP request stays open. Default intermediary idle/TTFB limits are often ~30s
- // and would abort those calls with a generic UI error.
-const LONG_RUNNING_PROXY_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
-
-// Proxy all webdav and api requests to the backend
+// Proxy all webdav and api requests to the backend.
+// Long POSTs (e.g. /api/benchmark-usenet-connection) rely on proxyTimeout here
+// plus server.requestTimeout/headersTimeout in server.ts — not httpxy's inbound
+// `timeout` option, which leaks socket listeners under keep-alive (#486).
 const forwardToBackend = createProxyMiddleware({
   target: process.env.BACKEND_URL,
   changeOrigin: true,
-  // httpxy only enforces these when set; pin them high so long POSTs (e.g.
-  // /api/benchmark-usenet-connection with a 20 GB budget) are not cut off.
-  proxyTimeout: LONG_RUNNING_PROXY_TIMEOUT_MS,
-  timeout: LONG_RUNNING_PROXY_TIMEOUT_MS,
+  ...backendProxyTimeoutOptions,
   on: {
     proxyReq: (proxyReq, req) => {
       applyCanonicalForwardedHeaders(proxyReq, req as express.Request, { trustProxy });

--- a/frontend/server/backend-proxy-options.test.ts
+++ b/frontend/server/backend-proxy-options.test.ts
@@ -1,0 +1,130 @@
+import http from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import {
+  backendProxyTimeoutOptions,
+  LONG_RUNNING_PROXY_TIMEOUT_MS,
+} from "./backend-proxy-options";
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo | null;
+      if (!address) {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address.port);
+    });
+    server.on("error", reject);
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function requestOnce(
+  port: number,
+  agent: http.Agent,
+  path: string,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: "GET",
+        agent,
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () => resolve(res.statusCode ?? 0));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("backendProxyTimeoutOptions", () => {
+  it("omits httpxy inbound timeout to avoid keep-alive listener leaks", () => {
+    expect("timeout" in backendProxyTimeoutOptions).toBe(false);
+    expect(backendProxyTimeoutOptions.proxyTimeout).toBe(
+      LONG_RUNNING_PROXY_TIMEOUT_MS,
+    );
+  });
+});
+
+describe("backend proxy keep-alive timeout listeners", () => {
+  const servers: http.Server[] = [];
+  const agents: http.Agent[] = [];
+
+  afterEach(async () => {
+    for (const agent of agents.splice(0)) {
+      agent.destroy();
+    }
+    await Promise.all(servers.splice(0).map((server) => close(server)));
+  });
+
+  it("does not stack timeout listeners on keep-alive client sockets", async () => {
+    const backend = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    });
+    servers.push(backend);
+    const backendPort = await listen(backend);
+
+    const proxy = createProxyMiddleware({
+      target: `http://127.0.0.1:${backendPort}`,
+      changeOrigin: true,
+      ...backendProxyTimeoutOptions,
+    });
+
+    const frontend = http.createServer((req, res) => {
+      void proxy(req, res, (error) => {
+        if (error && !res.headersSent) {
+          res.writeHead(502);
+          res.end("Bad Gateway");
+        }
+      });
+    });
+    servers.push(frontend);
+
+    let inboundSocket: Socket | undefined;
+    frontend.on("connection", (socket) => {
+      if (!inboundSocket) inboundSocket = socket;
+    });
+
+    const frontendPort = await listen(frontend);
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    agents.push(agent);
+
+    const requestCount = 12;
+    const listenerCounts: number[] = [];
+
+    for (let i = 0; i < requestCount; i++) {
+      const status = await requestOnce(frontendPort, agent, `/probe-${i}`);
+      expect(status).toBe(200);
+      expect(inboundSocket).toBeDefined();
+      listenerCounts.push(inboundSocket!.listenerCount("timeout"));
+    }
+
+    // Same TCP connection reused for every request.
+    expect(inboundSocket).toBeDefined();
+    const first = listenerCounts[0]!;
+    for (const count of listenerCounts) {
+      expect(count).toBe(first);
+    }
+    // Must stay well below Node's default MaxListeners of 10.
+    expect(first).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/server/backend-proxy-options.ts
+++ b/frontend/server/backend-proxy-options.ts
@@ -1,0 +1,12 @@
+// httpxy's inbound `timeout` option is deliberately omitted: it calls
+// req.socket.setTimeout(ms, cb) per proxied request, stacking 'timeout'
+// listeners on keep-alive client sockets (issue #486). Inbound long-request
+// protection lives on the HTTP server (requestTimeout/headersTimeout).
+//
+// proxyTimeout aborts hung backend upstream requests and is safe: Node clears
+// the outbound ClientRequest socket listener when the request completes.
+export const LONG_RUNNING_PROXY_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
+
+export const backendProxyTimeoutOptions = {
+  proxyTimeout: LONG_RUNNING_PROXY_TIMEOUT_MS,
+} as const;


### PR DESCRIPTION
## Summary
- Fixes #486: omit httpxy's inbound `timeout` option that stacks `timeout` listeners on keep-alive client sockets (WebDAV/rclone/UI polling).
- Keep `proxyTimeout` and Node `requestTimeout`/`headersTimeout` so long Usenet speed tests are still not cut off around 30s.
- Add a keep-alive regression test that asserts the inbound socket's timeout listener count stays flat across 12+ requests.

## Test plan
- [x] `cd frontend && npm run typecheck && npm run build && npm test`
- [ ] After deploy: confirm container logs no longer show `MaxListenersExceededWarning` / `11 timeout listeners added to [Socket]` under normal WebDAV or UI traffic
- [ ] Confirm a large-budget Usenet speed test still stays open past ~30s