### PR TITLE
fix(nntp): health checks and import probes stay fast when NNTP pipelining is on

### DIFF
--- a/backend/Clients/Usenet/ArticleExistenceChecker.cs
+++ b/backend/Clients/Usenet/ArticleExistenceChecker.cs
@@ -1,0 +1,16 @@
+namespace NzbWebDAV.Clients.Usenet;
+
+internal static class ArticleExistenceChecker
+{
+    /// <summary>
+    /// Checks health/import existence concurrently across the connection pool.
+    /// BODY pipelining settings must not collapse these probes onto one connection.
+    /// </summary>
+    public static Task CheckAsync(
+        INntpClient client,
+        IReadOnlyList<string> segmentIds,
+        int concurrency,
+        IProgress<int>? progress,
+        CancellationToken cancellationToken) =>
+        client.CheckAllSegmentsAsync(segmentIds, concurrency, progress, cancellationToken);
+}

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -298,23 +298,9 @@ public class QueueItemProcessor(
                 .Offset(100)
                 .ToPercentage(articlesToCheck.Count);
             var healthCheckConcurrency = configManager.GetHealthCheckConcurrency();
-            if (configManager.IsPipeliningEnabled())
-            {
-                await usenetClient
-                    .CheckAllSegmentsPipelinedAsync(
-                        articlesToCheck,
-                        configManager.GetPipeliningDepth(),
-                        healthCheckConcurrency,
-                        part3Progress,
-                        ct)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                await usenetClient
-                    .CheckAllSegmentsAsync(articlesToCheck, healthCheckConcurrency, part3Progress, ct)
-                    .ConfigureAwait(false);
-            }
+            await ArticleExistenceChecker
+                .CheckAsync(usenetClient, articlesToCheck, healthCheckConcurrency, part3Progress, ct)
+                .ConfigureAwait(false);
             checkedFullHealth = true;
         }
         var msHealth = stepTimer.ElapsedMilliseconds;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -190,21 +190,8 @@ public class HealthCheckService : BackgroundService
 
             // perform health check
             var progress = progressHook.ToPercentage(sampled.Count);
-            if (_configManager.IsPipeliningEnabled())
-            {
-                await _usenetClient.CheckAllSegmentsPipelinedAsync(
-                        sampled,
-                        _configManager.GetPipeliningDepth(),
-                        concurrency,
-                        progress,
-                        ct)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                await _usenetClient.CheckAllSegmentsAsync(sampled, concurrency, progress, ct)
-                    .ConfigureAwait(false);
-            }
+            await ArticleExistenceChecker.CheckAsync(_usenetClient, sampled, concurrency, progress, ct)
+                .ConfigureAwait(false);
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
 

--- a/docs/nntp-pipelining.md
+++ b/docs/nntp-pipelining.md
@@ -1,14 +1,14 @@
 # NNTP Pipelining
 
-NzbDav uses **UsenetSharp 3.x** batch BODY requests and pipelined STAT existence
-checks to send multiple NNTP commands on one connection without waiting for each
-response. Responses are read strictly in order with bounded backpressure.
+NzbDav uses **UsenetSharp 3.x** batch BODY requests to send multiple NNTP
+commands on one connection without waiting for each response. Responses are read
+strictly in order with bounded backpressure.
 
 There are **two separate toggles**:
 
 | Setting | Location | Default | What it controls |
 |---------|----------|---------|------------------|
-| `usenet.pipelining.enabled` | Settings → Usenet | off | Queue first-segment fetch, provider benchmark batch downloads, and pipelined STAT health / import existence checks |
+| `usenet.pipelining.enabled` | Settings → Usenet | off | Queue first-segment fetch and provider benchmark batch downloads |
 | `usenet.pipelined-body-requests` | Settings → WebDAV | on | WebDAV streaming read-ahead via `DecodedBodiesAsync` batches |
 
 ## What the Usenet toggle speeds up
@@ -17,7 +17,9 @@ There are **two separate toggles**:
 |------|-------------------|-----------------|
 | Queue first-segment fetch (0→50%) | one `BODY` per file, concurrent across connections | first segments fetched in depth-sized batches on one connection |
 | Provider benchmark | one `BODY` per article | depth-sized `DecodedBodiesAsync` batches |
-| Health check / import existence | concurrent `STAT` across the pool | primary-provider pipelined `STAT` via `StatPipelinedAsync`, with concurrent failover recheck of any misses |
+
+Health checks and import existence checks always run concurrent `STAT` requests
+across the connection pool. They are not affected by this toggle.
 
 ## Enabling queue pipelining
 
@@ -25,32 +27,26 @@ Settings → Usenet → **NNTP Pipelining**:
 
 - **Enable NNTP pipelining** — toggles `usenet.pipelining.enabled`.
 - **Pipeline depth** — `usenet.pipelining.depth`, requests per BODY batch (1–64,
-  default 8). Each provider can override this in its own settings. STAT sweeps
-  use a larger fixed chunk and UsenetSharp's internal `MaxPipelineDepth` window;
-  BODY depth does not size STAT batches.
+  default 8). Each provider can override this in its own settings.
 
 For WebDAV playback, use Settings → WebDAV → **Pipelined article downloads**
 (`usenet.pipelined-body-requests`).
 
 ## How it's built
 
-UsenetSharp exposes batch BODY pipelining through `DecodedBodiesAsync` and
-pipelined existence checks through `StatPipelinedAsync`. nzbdav routes
-`*PipelinedAsync` paths through those APIs. The client chain is:
+UsenetSharp exposes batch BODY pipelining through `DecodedBodiesAsync`. The
+client chain is:
 
-- `BaseNntpClient` — delegates batch calls to UsenetSharp; classifies STAT
-  replies so connection-level codes (e.g. buffered 400) throw instead of looking
-  like missing articles
-- `MultiConnectionNntpClient` — leases one connection per batch (STAT path does
-  not feed the circuit breaker)
+- `BaseNntpClient` — delegates batch calls to UsenetSharp
+- `MultiConnectionNntpClient` — leases one connection per batch
 - `MultiProviderNntpClient` — provider selection and byte counting
 - `DownloadingNntpClient` / `WrappingNntpClient` — permits and delegation
 
 ## Testing
 
 Validate with the Usenet toggle **on** against your providers before relying on
-it for queue imports. The provider benchmark can recommend a depth and whether
-pipelining helps at your connection count.
+it for queue first-segment fetches. The provider benchmark can recommend a depth
+and whether pipelining helps at your connection count.
 
 ## Limitations
 
@@ -59,8 +55,5 @@ pipelining helps at your connection count.
   and retries individual misses on the primary (then backups) before yielding
   `Found = false`. Queue first-segment rescue still re-fetches any remaining null
   slots with full per-article failover.
-- **Pipelined STAT sweeps are primary-only.** Misses are rechecked with concurrent
-  per-segment `STAT` (full failover) so backups can still satisfy articles.
-  Connection-level errors during the sweep fall back to the concurrent path.
 - The per-queue-item article cache bypasses pipelined queue paths when caching is
   enabled (pre-existing; first segments may be re-fetched during RAR header parse).

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -418,7 +418,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
         <SettingsPage>
             <SettingsIntro>
                 Configure NNTP providers, decide whether they share load or cascade in priority order, and tune
-                pipelining for faster queue imports.
+                pipelining for faster queue first-segment fetches.
             </SettingsIntro>
 
             <section className="space-y-3">
@@ -684,9 +684,9 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                             <span>
                                 <span className="block text-sm font-medium text-base-content">Enable NNTP pipelining</span>
                                 <span className="mt-0.5 block text-xs leading-relaxed text-base-content/50">
-                                    Batch BODY requests during queue imports and benchmarks, and pipeline STAT
-                                    existence checks for import health and background repairs. WebDAV streaming has its
-                                    own toggle under WebDAV settings.
+                                    Batch first-segment BODY requests during queue imports and provider benchmarks.
+                                    Health and import existence checks continue using the connection pool. WebDAV
+                                    streaming has its own toggle under WebDAV settings.
                                 </span>
                             </span>
                         </label>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -49,6 +49,26 @@ public class NntpClientCheckAllSegmentsTests
     }
 
     [Fact]
+    public async Task ArticleExistenceChecker_UsesConcurrentPoolPath()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: [true, true],
+            recheckCodes: [223, 223]);
+
+        await ArticleExistenceChecker.CheckAsync(
+            client,
+            ["a@example", "b@example"],
+            concurrency: 7,
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(1, client.CheckAllSegmentsCallCount);
+        Assert.Equal(0, client.PipelinedStatsCallCount);
+        Assert.Equal(7, client.LastConcurrency);
+        Assert.Equal(["a@example", "b@example"], client.RecheckedSegmentIds);
+    }
+
+    [Fact]
     public async Task CheckAllSegmentsPipelinedAsync_WithAllExists_SucceedsWithoutFailoverRecheck()
     {
         var client = new TrackingPipelinedStatClient(
@@ -178,6 +198,8 @@ public class NntpClientCheckAllSegmentsTests
         private int _recheckIndex;
 
         public int CheckAllSegmentsCallCount { get; private set; }
+        public int PipelinedStatsCallCount { get; private set; }
+        public int? LastConcurrency { get; private set; }
         public List<string> RecheckedSegmentIds { get; } = [];
 
         public override async IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync(
@@ -186,6 +208,7 @@ public class NntpClientCheckAllSegmentsTests
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
+            PipelinedStatsCallCount++;
             if (sweepException != null && throwAfterYieldCount <= 0)
                 throw sweepException;
 
@@ -209,6 +232,7 @@ public class NntpClientCheckAllSegmentsTests
             CancellationToken cancellationToken)
         {
             CheckAllSegmentsCallCount++;
+            LastConcurrency = concurrency;
             var list = segmentIds.ToList();
             RecheckedSegmentIds.AddRange(list);
 


### PR DESCRIPTION
## Summary
- keep background health checks and import existence probes on concurrent pooled STAT requests even when NNTP pipelining is enabled
- retain BODY pipelining for queue first-segment fetches and provider benchmarks, with matching UI and documentation updates
- add a regression test that prevents existence checks from returning to the single-connection pipelined path

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~FetchFirstSegmentsStepTests|FullyQualifiedName~NntpClientPipelinedMappingTests|FullyQualifiedName~NntpClientCheckAllSegmentsTests\"` (48 passed)
- [x] `cd frontend && npm run typecheck && npm test && npm run build`
- [ ] Compare health-check wall time with NNTP pipelining on and off against a live provider

Full backend run reached 803 passed / 11 skipped; one unrelated test could not load the local `rapidyenc.dylib` native dependency.