### PR TITLE
fix(queue): block arr thumbnails by default

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1196,7 +1196,7 @@ public class ConfigManager
 
     public HashSet<string> GetBlocklistedFiles()
     {
-        var defaultValue = "*.nfo, *.par2, *.sfv, *sample.mkv, *unpack.mkv, *.unpack.mp4";
+        var defaultValue = "*.nfo, *.par2, *.sfv, *.jpg, *sample.mkv, *unpack.mkv, *.unpack.mp4";
         return (GetConfigValue(ConfigKeys.ApiDownloadFileBlocklist) ?? defaultValue)
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -33,7 +33,7 @@ const defaultConfig = {
     "api.skip-non-video-on-missing-articles": "true",
     "api.ensure-article-existence-categories": "",
     "api.ignore-history-limit": "true",
-    "api.download-file-blocklist": "*.nfo, *.par2, *.sfv, *sample.mkv, *unpack.mkv, *.unpack.mp4",
+    "api.download-file-blocklist": "*.nfo, *.par2, *.sfv, *.jpg, *sample.mkv, *unpack.mkv, *.unpack.mp4",
     "api.duplicate-nzb-behavior": "increment",
     "api.import-strategy": "symlinks",
     "api.completed-downloads-dir": "",

--- a/tests/NzbWebDAV.Tests/Config/BlocklistDefaultTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/BlocklistDefaultTests.cs
@@ -1,0 +1,28 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Queue.PostProcessors;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class BlocklistDefaultTests
+{
+    [Theory]
+    [InlineData("thumbnail.jpg")]
+    [InlineData("Movie.2020.1080p.BluRay.x264-GRP.nfo")]
+    [InlineData("Movie.2020.1080p.BluRay.x264-GRP.par2")]
+    public void DefaultBlocklist_BlocksNonMediaExtras(string filename)
+    {
+        var patterns = new ConfigManager().GetBlocklistedFiles();
+
+        Assert.True(BlocklistedFilePostProcessor.MatchesAnyPattern(filename, patterns));
+    }
+
+    [Theory]
+    [InlineData("Movie.2020.1080p.BluRay.x264-GRP.mkv")]
+    [InlineData("Show.S01E01.mp4")]
+    public void DefaultBlocklist_KeepsMedia(string filename)
+    {
+        var patterns = new ConfigManager().GetBlocklistedFiles();
+
+        Assert.False(BlocklistedFilePostProcessor.MatchesAnyPattern(filename, patterns));
+    }
+}


### PR DESCRIPTION
Adds .jpg to the blocklist, so `thumbnail.jpg` stops showing up in the health check queue.