### PR TITLE
fix(ui): stop the read sessions panel overflowing at full width

### DIFF
--- a/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
+++ b/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
@@ -26,7 +26,7 @@ export function SessionsBlock({ sessions, window }: SessionsBlockProps) {
                 {sessions.count === 0 ? (
                     <p className="text-sm text-base-content/50">No completed read sessions yet.</p>
                 ) : (
-                    <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow sm:stats-horizontal sm:flex-wrap">
+                    <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow sm:stats-horizontal">
                         <Stat label="Sessions" value={formatNumber(sessions.count)} />
                         <Stat label="Bytes served" value={formatBytes(sessions.totalBytesServed)} />
                         <Stat label="Avg duration" value={formatDuration(sessions.avgDurationMs)} />
@@ -41,7 +41,7 @@ export function SessionsBlock({ sessions, window }: SessionsBlockProps) {
 
 function Stat({ label, value }: { label: string, value: string }) {
     return (
-        <div className="stat py-3">
+        <div className="stat px-3 py-3">
             <div className="stat-title text-xs">{label}</div>
             <div className="stat-value font-mono text-xl md:text-2xl">{value}</div>
         </div>


### PR DESCRIPTION
Fix a horizontal scrollbar issue with the "Read Session" section, now it's consistent with the appearance of other sections on the page (like Catalogue) at full size and when resizing the browser.

Before:
<img width="659" height="163" alt="Screenshot 2026-07-19 141314" src="https://github.com/user-attachments/assets/91b7dd48-cb6c-4f6e-91d8-e78f04c2f90d" />
After:
<img width="665" height="168" alt="Screenshot 2026-07-19 151002" src="https://github.com/user-attachments/assets/dff2dfa9-bfe6-4402-a462-fb45133d96e7" />
