### PR TITLE
chore(deps): bump UsenetSharp to 3.1.1

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -22,7 +22,7 @@
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="NzbDav.SharpCompress" Version="0.53.0" />
-      <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.0" />
+      <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.1" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bump `NzbDav.UsenetSharp` from 3.1.0 to 3.1.1 to pick up the CoalescedReadTimeout timer use-after-dispose fix under AUTH storms.

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj` restores 3.1.1 and succeeds
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (803 passed locally; 1 prefetch-budget failure is macOS-only — RapidYencSharp has no osx-arm64 native assets)
- [ ] CI backend build/tests on Linux