### PR TITLE
fix(nntp): only log provider recovery when the circuit actually opened

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -107,8 +107,11 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
+            // Only a circuit that opened can recover. Failures that cleared without tripping
+            // are routine, and announcing a recovery for them implies an outage that never
+            // happened. Matches the transition notification below.
             var wasCircuitActive = _trippedUntilMs > 0 || _halfOpenProbeInFlight != 0;
-            if (_window.Count > 0 || wasCircuitActive)
+            if (wasCircuitActive)
                 Log.Information("Provider {Provider} recovered — circuit breaker reset.", _providerName);
 
             _window.Clear();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerLoggingTests.cs
@@ -1,0 +1,85 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public class ProviderCircuitBreakerLoggingTests
+{
+    [Fact]
+    public void RecordSuccess_AfterFailuresThatNeverTripped_DoesNotAnnounceRecovery()
+    {
+        var events = CaptureLogs(breaker =>
+        {
+            // One short of the trip threshold, so the circuit never opened.
+            breaker.RecordFailure();
+            breaker.RecordFailure();
+            Assert.False(breaker.IsTripped);
+
+            breaker.RecordSuccess();
+        });
+
+        Assert.DoesNotContain(events, RecoveryWasAnnounced);
+    }
+
+    [Fact]
+    public void RecordSuccess_AfterATrip_AnnouncesRecovery()
+    {
+        var events = CaptureLogs(breaker =>
+        {
+            breaker.RecordFailure();
+            breaker.RecordFailure();
+            breaker.RecordFailure();
+            Assert.True(breaker.IsTripped);
+
+            breaker.RecordSuccess();
+        });
+
+        Assert.Contains(events, RecoveryWasAnnounced);
+    }
+
+    private static bool RecoveryWasAnnounced(LogEvent logEvent) =>
+        logEvent.MessageTemplate.Text.Contains("recovered", StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<LogEvent> CaptureLogs(Action<ProviderCircuitBreaker> act)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            act(new ProviderCircuitBreaker("logging-test"));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -13,6 +13,7 @@ using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Streams;
 
+[Collection(nameof(GlobalLoggerCollection))]
 public class NzbFileStreamTests
 {
     private static readonly byte[][] SegmentBytes =

--- a/tests/NzbWebDAV.Tests/TestUtils/GlobalLoggerCollection.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/GlobalLoggerCollection.cs
@@ -1,0 +1,9 @@
+namespace NzbWebDAV.Tests.TestUtils;
+
+/// <summary>
+/// Tests that swap the global <c>Log.Logger</c> to capture output belong to this
+/// collection. xUnit runs collections in parallel, so without it two such classes
+/// race on the same static and observe each other's events.
+/// </summary>
+[CollectionDefinition(nameof(GlobalLoggerCollection))]
+public class GlobalLoggerCollection;


### PR DESCRIPTION
My logs had seven "Provider X recovered - circuit breaker reset" lines in three minutes with no matching trip. RecordSuccess was logging whenever there was anything in the failure window to clear, so a single transient failure that never came close to tripping still announced a recovery. Dropped the window check so it only fires when the circuit actually opened, which is the same condition NotifyTransition below it already uses. Also added a shared collection for the two test classes that swap the global Log.Logger, since the suite runs collections in parallel and they would otherwise race.