### PR TITLE
fix(docker): container shutdown logs the backend exit code and fatal signal

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -635,6 +635,21 @@ docker compose logs --tail=200 -f nzbdav
 docker compose logs --tail=200 -f nzbdav_rclone
 ```
 
+When the backend or frontend process exits, the entrypoint logs the exit code. Values above `128` encode a fatal signal (`128+N`) — for example `139` is SIGSEGV (native crash) and `132` is SIGILL (illegal instruction). Use that hint when reporting unexpected container shutdowns.
+
+### Capture a .NET crash dump (opt-in)
+
+Minidumps are **not** enabled by default (they can be large and may contain downloaded-article data). To capture a dump on the next backend crash, add these environment variables to the NzbDav service and reproduce once:
+
+```yaml
+environment:
+  - DOTNET_DbgEnableMiniDump=1
+  - DOTNET_DbgMiniDumpType=2
+  - DOTNET_DbgMiniDumpName=/config/dump.%p
+```
+
+Inspect the dump under `/config` with `dotnet-dump analyze` after the crash, then remove the env vars and any dump files you no longer need.
+
 If the Rclone mount fails, first verify that `/dev/fuse` exists on the host, the sidecar has started after NzbDav became healthy, and the WebDAV username/password in `rclone.conf` match `Settings` → `WebDAV`. If Rclone specifically rejects `--allow-other`, enable `user_allow_other` in the FUSE configuration available inside the sidecar. If **Test Conn** on `Settings` → `Rclone Server` fails, confirm the sidecar has the `--rc*` flags, the host is `http://nzbdav_rclone:5572`, and the RC user/password match.
 
 ### Korean / Japanese (CJK) filenames

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -176,11 +176,23 @@ while true; do
         continue
     fi
 
-    # Determine which process exited
+    # Determine which process exited. Exit codes >128 encode a fatal signal
+    # (128+N) — log it so native crashes (SIGSEGV/SIGILL) are diagnosable.
+    SIGNAL_HINT=""
+    if [ "$EXIT_CODE" -gt 128 ] 2>/dev/null; then
+        SIG=$((EXIT_CODE - 128))
+        case "$SIG" in
+            4)  SIGNAL_HINT=" (SIGILL: illegal instruction — broken native library or unsupported CPU)" ;;
+            6)  SIGNAL_HINT=" (SIGABRT: abort — native assertion or runtime failure)" ;;
+            9)  SIGNAL_HINT=" (SIGKILL: killed — often the OOM killer)" ;;
+            11) SIGNAL_HINT=" (SIGSEGV: segmentation fault — native crash)" ;;
+            *)  SIGNAL_HINT=" (terminated by signal $SIG)" ;;
+        esac
+    fi
     if [ "$EXITED_PID" -eq "$FRONTEND_PID" ]; then
-        echo "The web-frontend has exited. Shutting down the web-backend..."
+        echo "The web-frontend has exited with code $EXIT_CODE$SIGNAL_HINT. Shutting down the web-backend..."
     else
-        echo "The web-backend has exited. Shutting down the web-frontend..."
+        echo "The web-backend has exited with code $EXIT_CODE$SIGNAL_HINT. Shutting down the web-frontend..."
     fi
 
     # Kill the remaining process


### PR DESCRIPTION
## Summary
- Log the exit code when the backend or frontend process exits in `entrypoint.sh`
- Map exit codes above 128 to signal hints (SIGSEGV/SIGILL/SIGABRT/SIGKILL) so native crashes are diagnosable from container logs
- Document opt-in .NET minidump env vars in the setup guide

Fixes #496
Related to #477

## Test plan
- [ ] `sh -n entrypoint.sh` passes
- [ ] Docs render the new minidump section
- [ ] (Optional) Force-kill backend with `kill -SEGV` inside a container and confirm the SIGSEGV hint appears in logs