### PR TITLE
fix(queue): queue progress updates no longer crash the backend on a bad callback

### DIFF
--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -272,16 +272,23 @@ public class QueueManager : IDisposable
 
         progressHook.ProgressChanged += (_, progress) =>
         {
-            lock (progressLock)
+            try
             {
-                if (progress > latestProgress) latestProgress = progress;
-                inProgressQueueItem.ProgressPercentage = latestProgress;
-            }
+                lock (progressLock)
+                {
+                    if (progress > latestProgress) latestProgress = progress;
+                    inProgressQueueItem.ProgressPercentage = latestProgress;
+                }
 
-            if (progress is 100 or 200) SendLatestProgress();
-            else debounce(SendLatestProgress);
-            providersDebounce(() => _websocketManager.SendMessage(
-                WebsocketTopic.QueueItemProviders, BuildProvidersMessage(queueItem.Id)));
+                if (progress is 100 or 200) SendLatestProgress();
+                else debounce(SendLatestProgress);
+                providersDebounce(() => _websocketManager.SendMessage(
+                    WebsocketTopic.QueueItemProviders, BuildProvidersMessage(queueItem.Id)));
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Queue progress broadcast failed for {QueueItemId}", queueItem.Id);
+            }
         };
         return inProgressQueueItem;
     }

--- a/backend/Utils/DebounceUtil.cs
+++ b/backend/Utils/DebounceUtil.cs
@@ -1,3 +1,5 @@
+using Serilog;
+
 namespace NzbWebDAV.Utils;
 
 public static class DebounceUtil
@@ -42,14 +44,28 @@ public static class DebounceUtil
                                 pendingAction = null;
                             }
 
-                            trailingAction?.Invoke();
+                            try
+                            {
+                                trailingAction?.Invoke();
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Warning(e, "Debounced trailing action failed");
+                            }
                         });
                         flushTimer.Change(delay, Timeout.InfiniteTimeSpan);
                     }
                 }
             }
 
-            invokeNow?.Invoke();
+            try
+            {
+                invokeNow?.Invoke();
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Debounced action failed");
+            }
         };
     }
 

--- a/tests/NzbWebDAV.Tests/Utils/DebounceUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/DebounceUtilTests.cs
@@ -1,0 +1,35 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class DebounceUtilTests
+{
+    [Fact]
+    public void CreateDebounce_LeadingEdgeThrow_DoesNotPropagate()
+    {
+        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
+
+        var exception = Record.Exception(() =>
+            debounce(() => throw new InvalidOperationException("leading boom")));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task CreateDebounce_TrailingEdgeThrow_DoesNotPropagate_AndSubsequentActionsStillRun()
+    {
+        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(50));
+        var subsequentRan = false;
+
+        // First call runs immediately (leading edge).
+        debounce(() => { });
+        // Second call within the window is scheduled on the timer.
+        debounce(() => throw new InvalidOperationException("trailing boom"));
+
+        await Task.Delay(150);
+
+        // After the window, a new leading-edge call should still work.
+        debounce(() => subsequentRan = true);
+        Assert.True(subsequentRan);
+    }
+}


### PR DESCRIPTION
## Summary
- Contain exceptions from `DebounceUtil` leading-edge and trailing Timer callbacks
- Contain `QueueManager` progress broadcast handlers so ThreadPool/`Progress<T>` failures cannot kill the process

Fixes #499
Related to #477

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~DebounceUtilTests -c Release`
- [ ] Queue an item and confirm progress websocket updates still arrive