### PR TITLE
fix(nntp): connection permit release no longer throws from download callbacks

### DIFF
--- a/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
+++ b/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
@@ -1,4 +1,5 @@
-﻿using UsenetSharp.Concurrency;
+﻿using Serilog;
+using UsenetSharp.Concurrency;
 
 namespace NzbWebDAV.Clients.Usenet.Concurrency;
 
@@ -86,8 +87,8 @@ public class PrioritizedSemaphore : IDisposable
         TaskCompletionSource<bool>? toRelease;
         lock (_lock)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(AsyncSemaphore));
+            // Release runs inside NNTP completion callbacks; never throw.
+            if (_disposed) return;
 
             if (_enteredCount > _maxAllowed)
             {
@@ -132,7 +133,9 @@ public class PrioritizedSemaphore : IDisposable
                 _enteredCount--;
                 if (_enteredCount < 0)
                 {
-                    throw new InvalidOperationException("The semaphore cannot be further released.");
+                    _enteredCount = 0;
+                    Log.Error("PrioritizedSemaphore over-released; permit accounting bug upstream");
+                    return;
                 }
 
                 return;

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
@@ -375,4 +375,27 @@ public class ConcurrencyTests
 
         await Assert.ThrowsAsync<ObjectDisposedException>(() => waiter);
     }
+
+    [Fact]
+    public void PrioritizedSemaphore_ReleaseAfterDispose_DoesNotThrow()
+    {
+        var semaphore = new PrioritizedSemaphore(initialAllowed: 1, maxAllowed: 1);
+        semaphore.Dispose();
+
+        var exception = Record.Exception(() => semaphore.Release());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task PrioritizedSemaphore_OverRelease_DoesNotThrow_AndWaitStillWorks()
+    {
+        using var semaphore = new PrioritizedSemaphore(initialAllowed: 1, maxAllowed: 1);
+        semaphore.Release(); // over-release with nobody entered beyond the free permit
+
+        var exception = Record.Exception(() => semaphore.Release());
+        Assert.Null(exception);
+
+        await semaphore.WaitAsync(SemaphorePriority.High);
+        semaphore.Release();
+    }
 }


### PR DESCRIPTION
## Summary
- `PrioritizedSemaphore.Release()` is a no-op after dispose instead of throwing
- Over-release clamps permit accounting and logs instead of throwing (completion callbacks must stay non-throwing)

Fixes #501
Related to #477

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~PrioritizedSemaphore -c Release`