### PR TITLE
fix(queue): queue processing starts only after the web host is healthy

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -250,7 +250,6 @@ class Program
             var app = builder.Build();
             // Must run before anything that reads Scheme/Host/RemoteIpAddress.
             app.UseForwardedHeaders();
-            _ = app.Services.GetRequiredService<QueueManager>();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
             app.MapHealthChecks("/health");
@@ -268,6 +267,10 @@ class Program
                 UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
                     configManager.GetUsenetProviderConfig(),
                     SigtermUtil.GetCancellationToken())));
+            // Start the queue only after Kestrel is serving so /health can answer
+            // before the first BODY decode (which can crash on a bad native lib).
+            app.Lifetime.ApplicationStarted.Register(() =>
+                app.Services.GetRequiredService<QueueManager>().StartProcessing());
             await app.RunAsync().ConfigureAwait(false);
         }
         catch (Exception exception)

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -30,6 +30,7 @@ public class QueueManager : IDisposable
 
     private CancellationTokenSource _sleepingQueueToken = new();
     private readonly Lock _sleepingQueueLock = new();
+    private int _loopStarted;
 
     // Overridable in tests so persistent-failure / idle-sleep behaviour can be
     // exercised without a real database.
@@ -50,7 +51,7 @@ public class QueueManager : IDisposable
         BenchmarkGate benchmarkGate
     ) : this(
         usenetClient, configManager, websocketManager, providerUsageTracker,
-        watchdogLog, sourceTracker, benchmarkGate, startLoop: true)
+        watchdogLog, sourceTracker, benchmarkGate, startLoop: false)
     {
     }
 
@@ -75,7 +76,18 @@ public class QueueManager : IDisposable
         _cancellationTokenSource = CancellationTokenSource
             .CreateLinkedTokenSource(SigtermUtil.GetCancellationToken());
         if (startLoop)
-            _ = ProcessQueueAsync(_cancellationTokenSource.Token);
+            StartProcessing();
+    }
+
+    /// <summary>
+    /// Starts the background queue loop. Safe to call more than once; only the
+    /// first call starts processing. DI construction leaves the loop stopped so
+    /// Kestrel can bind before the first BODY decode.
+    /// </summary>
+    public void StartProcessing()
+    {
+        if (Interlocked.Exchange(ref _loopStarted, 1) == 1) return;
+        _ = ProcessQueueAsync(_cancellationTokenSource!.Token);
     }
 
     public (QueueItem? queueItem, int? progress) GetInProgressQueueItem()


### PR DESCRIPTION
## Summary
- DI no longer starts the queue loop from the `QueueManager` constructor
- `StartProcessing()` runs on `ApplicationStarted` so `/health` can answer before the first BODY decode

Fixes #503
Related to #477

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~QueueManagerLoopTests -c Release`
- [ ] Local smoke: seed a queue item, confirm it processes after startup