### PR TITLE
perf(queue): limit first-segment import pipelining to reduce memory spikes

### DIFF
--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -78,7 +78,9 @@ public static class FetchFirstSegmentsStep
         IProgress<int>? progress
     )
     {
-        var depth = configManager.GetPipeliningDepth();
+        // Import fetches don't benefit from deep BODY windows; cap to bound
+        // peak decoded-article memory at boot (~750 KB × depth per connection).
+        var depth = Math.Min(configManager.GetPipeliningDepth(), 16);
         var segmentIds = files.Select(x => x.Segments[0].MessageId).ToList();
         var results = new NzbFileWithFirstSegment?[files.Count];
         var indexBySegmentId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary
- Cap pipelined first-segment fetch depth at 16 so import does not hold large decoded-article windows at boot

Fixes #505
Related to #477

## Test plan
- [ ] Existing `FetchFirstSegmentsStep` tests still pass
- [ ] With pipelining enabled, import still completes for multi-file NZBs