### PR TITLE
fix(nntp): fail fast on broken yEnc natives and catch Alpine decode crashes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,32 @@ jobs:
           name: backend-coverage
           path: TestResults/**/coverage.cobertura.xml
           if-no-files-found: ignore
+
+  alpine-yenc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Publish backend for linux-musl-x64
+        run: |
+          dotnet publish backend/NzbWebDAV.csproj \
+            -c Release \
+            -r linux-musl-x64 \
+            --self-contained false \
+            -o ./publish-musl
+
+      - name: yEnc native self-test on Alpine
+        run: |
+          docker run --rm \
+            -v "$PWD/publish-musl:/app:ro" \
+            -w /app \
+            mcr.microsoft.com/dotnet/aspnet:10.0-alpine \
+            sh -c 'apk add --no-cache libc6-compat >/dev/null && ./NzbWebDAV --yenc-self-test'

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -2,6 +2,7 @@
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
 using UsenetSharp.Clients;
 using UsenetSharp.Models;
 
@@ -28,7 +29,9 @@ public class BaseNntpClient : NntpClient
 
     public BaseNntpClient() : this(new UsenetClient(new UsenetClientOptions
     {
-        CrcValidation = YencCrcValidationMode.WhenPresent,
+        CrcValidation = EnvironmentUtil.GetEnvironmentVariable("USENET_DISABLE_CRC_VALIDATION") == "1"
+            ? YencCrcValidationMode.Off
+            : YencCrcValidationMode.WhenPresent,
     }))
     {
     }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -98,6 +98,12 @@ class Program
                 return;
             }
 
+            if (args.Contains("--yenc-self-test"))
+            {
+                RunYencNativeSelfTest();
+                return;
+            }
+
             // initialize database
             await using var databaseContext = new DavDatabaseContext();
             await databaseContext.Database
@@ -118,6 +124,8 @@ class Program
             // initialize the config-manager
             var configManager = new ConfigManager();
             await configManager.LoadConfig().ConfigureAwait(false);
+
+            RunYencNativeSelfTest();
 
             // Assign stable ProviderIds (persisting if needed) before the streaming
             // client is built. Cheap and non-fatal; the heavy legacy-metrics remap
@@ -284,6 +292,35 @@ class Program
     private static LogEventLevel AtLeast(LogEventLevel configured, LogEventLevel minimum)
     {
         return configured > minimum ? configured : minimum;
+    }
+
+    /// <summary>
+    /// Exercises P/Invoke into rapidyenc. Managed failures become Log.Fatal; a hard
+    /// native crash still leaves the preceding Information line as a smoking gun.
+    /// </summary>
+    private static void RunYencNativeSelfTest()
+    {
+        Log.Information("Running yEnc native self-test (rapidyenc {Version:X})",
+            RapidYencSharp.Version.GetVersion());
+        try
+        {
+            ReadOnlySpan<byte> sample = "nzbdav rapidyenc startup self-test"u8;
+            var encoded = RapidYencSharp.YencEncoder.Encode(sample);
+            var decoded = RapidYencSharp.YencDecoder.Decode(encoded);
+            if (!decoded.AsSpan().SequenceEqual(sample))
+                throw new InvalidOperationException("yEnc roundtrip mismatch");
+            _ = RapidYencSharp.Crc32.Compute(sample);
+            Log.Information(
+                "yEnc native kernels — encode: 0x{Encode:X}, decode: 0x{Decode:X}, crc32: 0x{Crc:X}",
+                RapidYencSharp.YencEncoder.Kernel,
+                RapidYencSharp.YencDecoder.Kernel,
+                RapidYencSharp.Crc32.Kernel);
+        }
+        catch (Exception e)
+        {
+            Log.Fatal(e, "yEnc native library failed its startup self-test; downloads cannot work on this platform");
+            throw;
+        }
     }
 
     private static void ApplyTrustedProxyCidrs(ForwardedHeadersOptions options)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -142,6 +142,8 @@ The image runs two processes: the frontend and public proxy on port `3000`, and 
 
     Small, memory-constrained deployments can override the backend thread-pool limits with `THREADPOOL_MIN_THREADS` and `THREADPOOL_MAX_THREADS` in the container environment. When unset, NzbDav retains the existing defaults: `max(2 × processor count, 50)` minimum threads and `max(50 × processor count, 1000)` maximum threads. Lowering the minimum may reduce reserved stack memory but can also reduce streaming responsiveness under load; restart the container after changing either value.
 
+    If a native yEnc CRC fault is suspected after a UsenetSharp upgrade, set `USENET_DISABLE_CRC_VALIDATION=1` as an emergency escape hatch. Decode still uses the native library; only CRC validation is skipped. Remove the variable once the underlying issue is fixed.
+
 
 ### 2. Core configuration
 


### PR DESCRIPTION
## Summary
- Run a logged yEnc encode/decode/CRC self-test at startup (and via `--yenc-self-test` for CI)
- Add `USENET_DISABLE_CRC_VALIDATION=1` emergency escape hatch
- Add an Alpine/`linux-musl-x64` CI job that runs the self-test inside `aspnet:10.0-alpine` + `libc6-compat`
- Bump `NzbDav.UsenetSharp` to **3.1.3** (pulls RapidYencSharp 3.0.0 with musl natives)

Fixes #498
Related to #477

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [ ] Alpine CI job passes with musl natives
- [ ] Local: `./NzbWebDAV --yenc-self-test` where rapidyenc is available