### PR TITLE
fix(deps): bump SharpCompress so deep 7z coder chains fail safely

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-      <PackageReference Include="NzbDav.SharpCompress" Version="0.53.0" />
+      <PackageReference Include="NzbDav.SharpCompress" Version="0.53.1" />
       <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.1" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>

--- a/tests/NzbWebDAV.Tests/Utils/SevenZipUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/SevenZipUtilTests.cs
@@ -33,4 +33,17 @@ public class SevenZipUtilTests
         Assert.Equal(expectedEntryBytes, storedEntryBytes);
         Assert.True(archiveStream.CanRead);
     }
+
+    [Fact]
+    public void GetSevenZipEntries_ThrowsInvalidFormatException_OnCorruptSignature()
+    {
+        // Import must fail as a managed InvalidFormatException so the queue marks
+        // the item failed instead of crashing the process (audit F3 / #477).
+        var archiveBytes = Convert.FromBase64String(StoredArchiveBase64);
+        archiveBytes[0] ^= 0xFF;
+        using var archiveStream = new MemoryStream(archiveBytes);
+
+        Assert.Throws<InvalidFormatException>(() =>
+            SevenZipUtil.GetSevenZipEntries(archiveStream));
+    }
 }


### PR DESCRIPTION
## Summary
- Bump `NzbDav.SharpCompress` to **0.53.1** (bounded 7z decoder-stream recursion)
- Add an import regression asserting corrupt 7z metadata fails with managed `InvalidFormatException`

Fixes #507
Related to #477

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~SevenZipUtilTests -c Release`
- [ ] CI green once NuGet V3 index lists 0.53.1 (package already pushed)