### PR TITLE
fix(deps): bump UsenetSharp so Alpine images get musl-native yEnc decode

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -22,7 +22,7 @@
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="NzbDav.SharpCompress" Version="0.53.0" />
-      <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.1" />
+      <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.3" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bump `NzbDav.UsenetSharp` from 3.1.1 → **3.1.3** (pulls RapidYencSharp 3.0.0 with `linux-musl-*` natives)

The self-test / CRC / Alpine CI work landed in #508 without this package bump. This completes the #477 F1 chain for Alpine.

Related to #477 / #498

## Test plan
- [x] `dotnet restore backend/NzbWebDAV.csproj`
- [ ] Alpine CI / `--yenc-self-test` passes on musl after image rebuild