### PR TITLE
fix(ui): live Overview and Queue updates no longer stall until refresh

### DIFF
--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -74,7 +74,7 @@ public class WebsocketManager
         {
             if (session.TryEnqueue(topic, bytes)) continue;
 
-            Log.Debug("Disconnecting websocket client because its outbound event queue is full");
+            Log.Warning("Disconnecting websocket client because its outbound event queue is full");
             AbortSocket(session);
         }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -141,6 +141,8 @@ Then open `http://localhost:3000`, create your admin account, and head to the **
 
     Port `3000` serves plain HTTP. If NzbDav will be reachable outside your trusted network, put it behind an HTTPS reverse proxy and do not expose the container port directly to the internet. WebDAV uses Basic authentication, so TLS is essential for remote access. When the proxy runs on the Docker host, bind the port to localhost with `127.0.0.1:3000:3000`.
 
+    Live Overview/Queue updates use a same-origin WebSocket at `/ws`. Ensure your reverse proxy allows HTTP Upgrade on that path (see [setup guide](setup-guide.md)).
+
 
 You'll also want to set a username and password for the WebDAV server itself.
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -137,6 +137,8 @@ The image runs two processes: the frontend and public proxy on port `3000`, and 
 
     Frontend session cookies: set `SECURE_COOKIES=true` when the UI is only served over HTTPS. Optionally set `SESSION_KEY` to a long random secret (otherwise a stable key is persisted under `CONFIG_PATH/session.key` so restarts do not log everyone out). Optionally set `SESSION_MAX_AGE` in seconds (default one year).
 
+    Live UI updates (Overview, Queue, Connections) use a WebSocket on the **same origin** at path `/ws` (for example `wss://nzbdav.example.com/ws`). Reverse proxies such as Traefik, Caddy, nginx, or Pangolin must allow HTTP Upgrade on that path — not only on the backend's internal `:8080/ws`. When the UI is HTTPS-only, also set `SECURE_COOKIES=true` so the session cookie is sent with the WebSocket handshake.
+
 
 !!! note "Note"
 

--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type LiveUsenetConnectionsProps = {
     hasUsenetProviders: boolean,
 };
 
+/** Keep the last known count visible briefly across websocket reconnect flaps. */
+const RECONNECT_GRACE_MS = 8_000;
+
 export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnectionsProps) {
     const [connections, setConnections] = useState<string | null>(null);
+    const [transportDown, setTransportDown] = useState(false);
+    const graceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const parts = (connections || "0|0|0|0|1|0").split("|");
     const [_0, _1, _2, live, max, idle] = parts.map(x => Number(x));
     const active = live - idle;
@@ -14,16 +19,52 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
     useWebsocketTopic(
         "cxs",
         "state",
-        setConnections,
+        (message) => {
+            if (graceTimerRef.current) {
+                clearTimeout(graceTimerRef.current);
+                graceTimerRef.current = null;
+            }
+            setTransportDown(false);
+            setConnections(message);
+        },
         {
             enabled: hasUsenetProviders,
-            onClose: () => setConnections(null),
+            onOpen: () => {
+                if (graceTimerRef.current) {
+                    clearTimeout(graceTimerRef.current);
+                    graceTimerRef.current = null;
+                }
+                setTransportDown(false);
+            },
+            onClose: () => {
+                setTransportDown(true);
+                if (graceTimerRef.current) clearTimeout(graceTimerRef.current);
+                // Keep last value during brief reconnects; only clear after grace.
+                graceTimerRef.current = setTimeout(() => {
+                    setConnections(null);
+                    graceTimerRef.current = null;
+                }, RECONNECT_GRACE_MS);
+            },
         },
     );
 
     useEffect(() => {
-        if (!hasUsenetProviders) setConnections(null);
+        if (!hasUsenetProviders) {
+            if (graceTimerRef.current) {
+                clearTimeout(graceTimerRef.current);
+                graceTimerRef.current = null;
+            }
+            setConnections(null);
+            setTransportDown(false);
+        }
     }, [hasUsenetProviders]);
+
+    useEffect(() => () => {
+        if (graceTimerRef.current) clearTimeout(graceTimerRef.current);
+    }, []);
+
+    const showConnecting = hasUsenetProviders && !connections;
+    const showReconnecting = hasUsenetProviders && !!connections && transportDown;
 
     return (
         <div
@@ -38,14 +79,15 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
                 <div className="stat-value font-mono text-sm leading-tight text-base-content/80">
                     {!hasUsenetProviders && "—"}
                     {hasUsenetProviders && connections && `${live}/${max}`}
-                    {hasUsenetProviders && !connections && (
+                    {showConnecting && (
                         <span className="loading loading-spinner loading-xs" />
                     )}
                 </div>
                 <div className="stat-desc text-[10px] leading-none whitespace-nowrap text-base-content/50">
                     {!hasUsenetProviders && "No providers"}
-                    {hasUsenetProviders && connections && `${active} active`}
-                    {hasUsenetProviders && !connections && "Connecting"}
+                    {hasUsenetProviders && connections && !transportDown && `${active} active`}
+                    {showReconnecting && "Reconnecting"}
+                    {showConnecting && "Connecting"}
                 </div>
             </div>
         </div>

--- a/frontend/app/utils/shared-websocket.ts
+++ b/frontend/app/utils/shared-websocket.ts
@@ -15,7 +15,7 @@ type Subscriber = {
 const RECONNECT_MS = 1000;
 
 function websocketUrl(): string {
-    return globalThis.location.origin.replace(/^http/, "ws");
+    return `${globalThis.location.origin.replace(/^http/, "ws")}/ws`;
 }
 
 /**

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -113,7 +113,7 @@ const server = http.createServer(app);
 const LONG_RUNNING_REQUEST_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
 server.requestTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS;
 server.headersTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS + 1000;
-setWebsocketServer(new WebSocketServer({ server, maxPayload: 64 * 1024 }));
+setWebsocketServer(new WebSocketServer({ server, path: "/ws", maxPayload: 64 * 1024 }));
 
 // Begin listening for connections
 server.listen(PORT, () => {

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import {
-    disconnectBrowserClients,
+    BACKEND_RECONNECT_INITIAL_MS,
+    BACKEND_RECONNECT_MAX_MS,
     MAX_CLIENT_BUFFERED_AMOUNT,
     MAX_TOPICS_PER_SOCKET,
+    nextBackendReconnectDelayMs,
     parseSubscriptionTopics,
     sendToBrowserClient,
 } from "./websocket.server";
@@ -58,26 +60,54 @@ describe("sendToBrowserClient", () => {
     });
 });
 
-describe("disconnectBrowserClients", () => {
-    it("clears stale state and reconnects each browser once", () => {
+describe("nextBackendReconnectDelayMs", () => {
+    it("stays within the exponential cap for early attempts", () => {
+        // random() is treated as [0, 1); 0.999… yields the inclusive upper bound.
+        const almostOne = () => 0.999999;
+        expect(nextBackendReconnectDelayMs(0, almostOne)).toBe(BACKEND_RECONNECT_INITIAL_MS);
+        expect(nextBackendReconnectDelayMs(1, almostOne)).toBe(BACKEND_RECONNECT_INITIAL_MS * 2);
+        expect(nextBackendReconnectDelayMs(2, almostOne)).toBe(BACKEND_RECONNECT_INITIAL_MS * 4);
+    });
+
+    it("caps at BACKEND_RECONNECT_MAX_MS", () => {
+        expect(nextBackendReconnectDelayMs(20, () => 0.999999)).toBe(BACKEND_RECONNECT_MAX_MS);
+    });
+
+    it("uses full jitter so a zero draw yields zero delay", () => {
+        expect(nextBackendReconnectDelayMs(3, () => 0)).toBe(0);
+    });
+});
+
+describe("relay reconnect preserves browser clients", () => {
+    it("fans out backend state to existing subscribers without closing them", () => {
+        const send = vi.fn();
         const close = vi.fn();
         const client = {
             readyState: WebSocket.OPEN,
+            bufferedAmount: 0,
+            send,
             close,
         } as unknown as WebSocket;
-        const subscriptions = new Map([
+
+        const subscriptions = new Map<string, Set<WebSocket>>([
             ["ls", new Set([client])],
             ["cxs", new Set([client])],
         ]);
-        const lastMessage = new Map([
-            ["ls", "live"],
-            ["cxs", "connections"],
+        const lastMessage = new Map<string, string>([
+            ["ls", JSON.stringify({ Topic: "ls", Message: "old" })],
         ]);
 
-        disconnectBrowserClients(subscriptions, lastMessage);
+        // Simulate the hub onmessage path: update cache and fan out.
+        // Browser sockets must remain open across a backend relay reconnect.
+        const rawMessage = JSON.stringify({ Topic: "ls", Message: "fresh" });
+        const topicMessage = JSON.parse(rawMessage) as { Topic: string; Message: string };
+        lastMessage.set(topicMessage.Topic, rawMessage);
+        for (const subscriber of subscriptions.get(topicMessage.Topic) ?? []) {
+            sendToBrowserClient(subscriber, rawMessage);
+        }
 
-        expect(lastMessage.size).toBe(0);
-        expect(close).toHaveBeenCalledOnce();
-        expect(close).toHaveBeenCalledWith(1012, "Backend websocket reconnecting");
+        expect(close).not.toHaveBeenCalled();
+        expect(lastMessage.get("ls")).toBe(rawMessage);
+        expect(send).toHaveBeenCalledWith(rawMessage);
     });
 });

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -7,6 +7,10 @@ export const MAX_WEBSOCKET_PAYLOAD_BYTES = 64 * 1024;
 export const MAX_TOPICS_PER_SOCKET = 100;
 export const WEBSOCKET_HEARTBEAT_INTERVAL_MS = 30_000;
 export const MAX_CLIENT_BUFFERED_AMOUNT = 1024 * 1024;
+export const WEBSOCKET_BROWSER_PATH = "/ws";
+
+export const BACKEND_RECONNECT_INITIAL_MS = 1_000;
+export const BACKEND_RECONNECT_MAX_MS = 30_000;
 
 export type TopicKind = "state" | "stream" | "event";
 
@@ -40,6 +44,21 @@ export function sendToBrowserClient(client: WebSocket, rawMessage: string): void
     client.send(rawMessage);
 }
 
+/**
+ * Exponential backoff with full jitter for the frontend→backend relay.
+ * Attempt 0 → ~1s, then doubles up to BACKEND_RECONNECT_MAX_MS.
+ */
+export function nextBackendReconnectDelayMs(
+    attempt: number,
+    random: () => number = Math.random,
+): number {
+    const exp = Math.min(
+        BACKEND_RECONNECT_MAX_MS,
+        BACKEND_RECONNECT_INITIAL_MS * 2 ** Math.max(0, attempt),
+    );
+    return Math.floor(random() * (exp + 1));
+}
+
 function initializeWebsocketServer(wss: WebSocketServer) {
     // keep track of socket subscriptions
     const websockets = new Map<TrackedSocket, Record<string, TopicKind>>();
@@ -67,6 +86,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
         // browser's immediate onopen subscription is not dropped.
         let authenticated = false;
         let closed = false;
+        const remote = request.socket.remoteAddress ?? "unknown IP";
         const pendingMessages: WebSocket.MessageEvent[] = [];
         ws.isAlive = true;
         ws.on("pong", () => {
@@ -107,7 +127,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
             applySubscription(event);
         };
 
-        ws.onclose = () => {
+        ws.onclose = (event: WebSocket.CloseEvent) => {
             closed = true;
             pendingMessages.length = 0;
             const topics = websockets.get(ws);
@@ -118,17 +138,23 @@ function initializeWebsocketServer(wss: WebSocketServer) {
                     if (topicSubscriptions) topicSubscriptions.delete(ws);
                 }
             }
+            if (authenticated) {
+                logger.info(
+                    `Browser websocket closed from ${remote} (code ${event.code}, reason: ${event.reason || "none"})`,
+                );
+            }
         };
 
         void (async () => {
             try {
                 if (!await isAuthenticated(request)) {
-                    logger.debug(`Rejected unauthenticated websocket connection from ${request.socket.remoteAddress ?? "unknown IP"}`);
+                    logger.warn(`Rejected unauthenticated websocket connection from ${remote}`);
                     ws.close(1008, "Unauthorized");
                     return;
                 }
                 if (closed) return;
                 authenticated = true;
+                logger.info(`Browser websocket connected from ${remote}`);
                 for (const event of pendingMessages.splice(0)) {
                     applySubscription(event);
                 }
@@ -141,7 +167,6 @@ function initializeWebsocketServer(wss: WebSocketServer) {
 }
 
 export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSocket>>, lastMessage: Map<string, string>) {
-    let reconnectRetryDelay = 1000;
     let reconnectTimeout: NodeJS.Timeout | null = null;
     let connected = false;
     let connectionFailures = 0;
@@ -151,7 +176,7 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
     const startupGraceMs = 30_000;
     const url = getBackendWebsocketUrl();
 
-    function logConnectionFailure(message: string, error?: unknown) {
+    function logConnectionFailure(message: string, retryDelayMs: number, error?: unknown) {
         const now = Date.now();
         connectionFailures += 1;
 
@@ -168,7 +193,7 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
         }
 
         if (connectionFailures === 1 || now - lastFailureLogAt >= 60_000) {
-            logger.warn(`${message}; retrying in ${reconnectRetryDelay} ms`, error);
+            logger.warn(`${message}; retrying in ${retryDelayMs} ms`, error);
             lastFailureLogAt = now;
         }
     }
@@ -177,9 +202,8 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
         const socket = new WebSocket(url);
 
         socket.on('error', (error: Error) => {
-            if (!connected) {
-                logConnectionFailure(`Could not connect to backend websocket at ${url}`, error);
-            } else {
+            // Failed-connect errors are logged from onclose to avoid double-counting.
+            if (connected) {
                 logger.warn("Backend websocket error", error);
             }
         });
@@ -218,42 +242,34 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
         };
 
         socket.onclose = (event: WebSocket.CloseEvent) => {
-            if (connected) {
-                connected = false;
+            // Keep browser sockets open and preserve lastMessage. Overview uses
+            // live-stats age for the soft stale banner; when the relay returns,
+            // the backend replays state topics and fan-out resumes without a
+            // mass browser reconnect (see #515).
+            const wasConnected = connected;
+            connected = false;
+            const retryDelayMs = nextBackendReconnectDelayMs(connectionFailures);
+            if (wasConnected) {
                 logConnectionFailure(
                     `Backend websocket closed (code ${event.code}, reason: ${event.reason || "none"})`,
+                    retryDelayMs,
                 );
-            } else if (connectionFailures === 0) {
-                logConnectionFailure(`Could not connect to backend websocket at ${url}`);
+            } else {
+                logConnectionFailure(`Could not connect to backend websocket at ${url}`, retryDelayMs);
             }
-            disconnectBrowserClients(subscriptions, lastMessage);
-            scheduleReconnect();
+            scheduleReconnect(retryDelayMs);
         };
     }
 
-    function scheduleReconnect() {
+    function scheduleReconnect(delayMs: number) {
         if (reconnectTimeout) clearTimeout(reconnectTimeout);
 
         reconnectTimeout = setTimeout(() => {
             connect();
-        }, reconnectRetryDelay);
+        }, delayMs);
     }
 
     connect();
-}
-
-export function disconnectBrowserClients(
-    subscriptions: Map<string, Set<WebSocket>>,
-    lastMessage: Map<string, string>,
-) {
-    lastMessage.clear();
-    const clients = new Set<WebSocket>();
-    subscriptions.forEach(topicClients => topicClients.forEach(client => clients.add(client)));
-    clients.forEach(client => {
-        if (client.readyState === WebSocket.OPEN) {
-            client.close(1012, "Backend websocket reconnecting");
-        }
-    });
 }
 
 function getBackendWebsocketUrl() {


### PR DESCRIPTION
## Summary

- The frontend WebSocket hub no longer force-closes every browser tab when the backend relay drops (and no longer wipes the `lastMessage` replay cache). Browser sockets stay open; the relay reconnects with exponential backoff and state fan-out resumes when the backend replays topics.
- Browser live updates now use same-origin `/ws` (hub bound with `path: "/ws"`) for clearer reverse-proxy routing.
- Connections badge keeps its last value for a short grace period and shows “Reconnecting” instead of instantly reverting to a spinner.
- Backend logs outbound event-queue overflow disconnects at Warning (was Debug), so operators can see relay aborts.
- Docs note the same-origin `/ws` upgrade requirement for reverse proxies.

Fixes #515 (reported by @jjbobzin).

## Test plan

- [x] `cd frontend && npm test -- --run server/websocket.server.test.ts`
- [x] `cd frontend && npm run typecheck`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~Websocket"`
- [ ] Manual: open Overview + Queue; restart only the backend (or briefly break `BACKEND_URL`); confirm Connections/live tiles recover without F5 and without a reconnect storm
- [ ] Manual: Network tab shows a single WS to `/ws` staying open while metrics tick (LAN and reverse-proxied HTTPS)