### PR TITLE
chore: triage issues with Priority/Effort custom fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,11 @@ Use **GitHub Issue Types** for kind — not kind labels:
 
 - Do **not** use (or recreate) `bug` / `enhancement` labels — they were removed; Issue Type is the source of truth.
 - Do **not** put `[Bug]:` / `[Feature]:` in issue titles; the type field already conveys that.
-- Triage / meta labels are fine: `priority:P*`, `effort:*`, `performance`, `cataloged`, `more-info-required`, and source tags (`upstream-audit`, `elfhosted`, etc.).
+- Use Issue custom fields for triage severity and complexity — **not** labels:
+  - **Priority**: `Urgent` / `High` / `Medium` / `Low` (former `priority:P0`–`P3`)
+  - **Effort**: `High` / `Medium` / `Low` (former `effort:L` / `M` / `S`)
+- Do **not** recreate `priority:*` or `effort:*` labels.
+- Other triage / meta labels are fine: `performance`, `cataloged`, `more-info-required`, and source tags (`upstream-audit`, `elfhosted`, etc.).
 
 Bug and feature issue templates set Issue Type only (no kind labels, no title prefix).
 


### PR DESCRIPTION
## Summary
- Document that issue **Priority** and **Effort** are org Issue custom fields (not labels).
- All open/closed issues were migrated from `priority:P*` / `effort:*` labels to the equivalent field values; those seven labels were deleted.

## Mapping
| Former label | Field value |
|---|---|
| `priority:P0`–`P3` | Priority Urgent / High / Medium / Low |
| `effort:L` / `M` / `S` | Effort High / Medium / Low |

## Test plan
- [x] Spot-checked migrated issues (e.g. #515 Priority=High, Effort=Low)
- [x] Confirmed `priority:*` / `effort:*` labels no longer exist
- [x] Confirmed zero remaining issues with those labels
- [ ] Review AGENTS.md Issue tracking section reads correctly for agents