### PR TITLE
docs: expand Priority and Effort Issue Fields guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,11 +285,25 @@ Use **GitHub Issue Types** for kind — not kind labels:
 
 - Do **not** use (or recreate) `bug` / `enhancement` labels — they were removed; Issue Type is the source of truth.
 - Do **not** put `[Bug]:` / `[Feature]:` in issue titles; the type field already conveys that.
-- Use Issue custom fields for triage severity and complexity — **not** labels:
-  - **Priority**: `Urgent` / `High` / `Medium` / `Low` (former `priority:P0`–`P3`)
-  - **Effort**: `High` / `Medium` / `Low` (former `effort:L` / `M` / `S`)
-- Do **not** recreate `priority:*` or `effort:*` labels.
-- Other triage / meta labels are fine: `performance`, `cataloged`, `more-info-required`, and source tags (`upstream-audit`, `elfhosted`, etc.).
+
+### Priority and Effort (org Issue Fields)
+
+Use the organization **Issue Fields** `Priority` and `Effort` on each issue — not labels and not project-board Size/Priority duplicates. Prefer Issue Fields so ratings travel with the issue across projects and list views.
+
+| Priority | When to use |
+|----------|-------------|
+| `Urgent` | Production-breaking now (crash, data loss, security) |
+| `High` | Core streaming / queue / SAB / *Arr reliability used by many |
+| `Medium` | Real ops/UX value; workaround or narrower audience OK |
+| `Low` | Polish, niche, or conflicts with stream-first identity |
+
+| Effort | Rough size |
+|--------|------------|
+| `Low` | Roughly ≤1–2 days |
+| `Medium` | Roughly a few days to ~1 week |
+| `High` | Multi-week and/or UsenetSharp / SharpCompress / library work |
+
+Do **not** recreate `priority:*` or `effort:*` labels. Other triage / meta labels are fine: `performance`, `cataloged`, `more-info-required`, `next-major`, `library`, and source tags (`upstream-audit`, `elfhosted`, etc.).
 
 Bug and feature issue templates set Issue Type only (no kind labels, no title prefix).
 


### PR DESCRIPTION
## Summary
- Expands AGENTS.md Issue tracking with the org Issue Fields scale for `Priority` (Urgent/High/Medium/Low) and `Effort` (High/Medium/Low).
- Prefers Issue Fields over labels or project-board Size/Priority duplicates; keeps meta labels (`performance`, `cataloged`, source tags, etc.).

## Test plan
- [ ] Skim Issue tracking section against org Settings → Planning → Issue fields
- [ ] Confirm conflict with earlier brief Issue Fields note on main is resolved cleanly