### PR TITLE
docs: show when features shipped with since-version pills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,6 +422,16 @@ else
 - **Streaming changes:** run the focused backend tests and retain manual range, rclone scrubbing, and encrypted-archive playback checks for behavior not covered by automation.
 - **Stack dumps for known failures:** do not dismiss an attached exception trace as “expected” without a remediation that catches it and logs a human-friendly event (see [Stack dumps and human-friendly log events](#stack-dumps-and-human-friendly-log-events)).
 
+## Docs version pills
+
+When documenting a **new user-visible** feature or setting, mark the introducing release with a `since` pill so readers on older images know the minimum version:
+
+```markdown
+## Feature heading [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }
+```
+
+Use the first stable release that shipped the capability (not every patch). Style lives in `docs/stylesheets/extra.css` (`.nzbdav-since`). Do not archaeology-tag every historical setting — focus on capabilities readers might try from docs while still on an older tag.
+
 ## Useful references
 
 - [README.md](README.md) — product overview

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -43,7 +43,7 @@ Precedence for fallbacks: **saved Settings value wins** over env, which wins ove
 | `STREAM_TRACE_EVENTS` | `0` (off) | Opt-in stream trace capacity; local scripts set `20000` |
 | `TRUSTED_PROXY_CIDRS` | loopback | Comma-separated IPs/CIDRs trusted for forwarded headers |
 | `DISABLE_WEBDAV_AUTH` | unset | Disables WebDAV auth (**dangerous**) |
-| `USENET_DISABLE_CRC_VALIDATION` | unset | `1` skips yEnc CRC checks (emergency) |
+| `USENET_DISABLE_CRC_VALIDATION` [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | unset | `1` skips yEnc CRC checks (emergency) |
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |
 | `MAX_REQUEST_BODY_SIZE` | 100 MiB | Max request body bytes |
@@ -58,11 +58,11 @@ Precedence for fallbacks: **saved Settings value wins** over env, which wins ove
 | `CATEGORIES` | Categories | `audio,software,tv,movies` |
 | `NZB_GRAB_USER_AGENT` | User Agent / retrieve UA | `nzbdav/{version}` |
 | `NZB_SEARCH_USER_AGENT` | Search User-Agent | `nzbdav/{version}` |
-| `TRUSTED_INTERNAL_HOSTS` | Trusted local hosts | none |
+| `TRUSTED_INTERNAL_HOSTS` [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | Trusted local hosts | none |
 | `MOUNT_DIR` | Rclone Mount Directory | `/mnt/nzbdav` |
 | `WEBDAV_USER` | WebDAV User | `admin` |
 | `WEBDAV_PASSWORD` | WebDAV Password | none (hashed when set) |
-| `RESOLUTION_CACHE_TTL_HOURS` | Search link lifetime | `168` |
+| `RESOLUTION_CACHE_TTL_HOURS` [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | Search link lifetime | `168` |
 | `DATABASE_HISTORY_RETENTION_DAYS` | History retention | `90` |
 | `DATABASE_HEALTHCHECK_RETENTION_DAYS` | Health-check retention | `30` |
 | `DATABASE_MAINTENANCE_INTERVAL_HOURS` | Retention sweep cadence | `6` |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -4,6 +4,10 @@ Day-to-day settings live in the admin UI (**Settings**) and persist in SQLite un
 
 For headless / container bootstrap, see **[Environment variables](environment-variables.md)** — the schema of env vars that configure NzbDAV without the UI (or as fallbacks when a UI value is empty).
 
+!!! note "Docs track latest"
+
+    Settings marked [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } (or another version) were introduced in that release. Older images will not show those controls.
+
 ## Settings hub
 
 <div class="grid cards" markdown>

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -22,6 +22,6 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | Recreate STRM Files | Refresh sidecars | Needs STRM strategy + completed dir + base URL |
 | Migrate blobs to blobstore | Background optimization | Usually automatic |
 | Reset Health-Check Statistics | Clear HC history | Cannot undo |
-| Reset Overview Statistics | Clear overview metrics | Cannot undo |
+| Reset Overview Statistics [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | Clear overview metrics | Cannot undo |
 
 [Retention](../operations/retention-cleanup.md) · [Deletion audit](../operations/deletion-audit.md)

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -22,4 +22,4 @@ Treat each generated **token** as a secret. Adapter URLs look like:
 
     Fallback queries spend per-indexer hit/rate limits.
 
-Play link lifetime is under [Watchdog](watchdog.md) (`play.resolution-cache-ttl-hours`).
+Play link lifetime is under [Watchdog](watchdog.md) (`play.resolution-cache-ttl-hours`) [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }.

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -7,7 +7,7 @@ Background health monitoring and replacement of unhealthy library items.
 | Enable Background Repairs | `repair.enable` | off | Needs library dir + *Arr |
 | Health Check Concurrency | `repair.healthcheck-concurrency` | `50` | STAT connections; capped by pool |
 | Health Check Depth | `repair.healthcheck-depth` | `standard` | standard / enhanced / deep / complete |
-| Check older releases less thoroughly | `repair.healthcheck-aging` | off | Aging taper |
+| Check older releases less thoroughly [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | `repair.healthcheck-aging` | off | Aging taper |
 | Auto-Remove After Streaming Failures | `repair.auto-remove-after-failures` | `0` | `0` = disabled |
 | Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | Linked → *Arr remove-and-search |
 | Library Directory | `media.library-dir` | empty | Organized media path in container |

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -14,7 +14,7 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Ignored Files | `api.download-file-blocklist` | `*.nfo, *.par2, …` | Glob blocklist for mounts |
 | Behavior for Duplicate NZBs | `api.duplicate-nzb-behavior` | `increment` | increment / mark-failed |
 | User Agent | `api.user-agent` | env/default | `addurl` NZB fetch |
-| Trusted local hosts | `api.addurl-trusted-hosts` | env `TRUSTED_INTERNAL_HOSTS` | SSRF allowlist for private addurl |
+| Trusted local hosts [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | `api.addurl-trusted-hosts` | env `TRUSTED_INTERNAL_HOSTS` | SSRF allowlist for private addurl |
 | Fail downloads without video | `api.ensure-importable-video` | on | Reject non-video NZBs |
 | Fail when non-video missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-video by default | |
 | Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category; may be slow |

--- a/docs/configuration/watchdog.md
+++ b/docs/configuration/watchdog.md
@@ -13,7 +13,7 @@ Playback failover, stall failover, and size-variant retention when a release can
 | Total candidates per request | `play.max-attempts` | `10` | 1–200 |
 | Verify mode | `play.verify-mode` | `none` | `stat` / `body` / `none` |
 | Negative-cache TTL (minutes) | `play.candidate-negative-cache-minutes` | `5` | Skip recently failed |
-| Search link lifetime (hours) | `play.resolution-cache-ttl-hours` | `168` | Play links in search results (env fallback) |
+| Search link lifetime (hours) [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | `play.resolution-cache-ttl-hours` | `168` | Play links in search results (env fallback) |
 | Prefer releases with subtitles | `play.prefer-subtitles` | on | Reorder only |
 
 ## Stall failover

--- a/docs/features/archives.md
+++ b/docs/features/archives.md
@@ -2,6 +2,6 @@
 
 NzbDAV can stream from inside **RAR** and **7z** archives, including many password-protected releases, without extracting the full archive to disk first.
 
-Queue processing aggregates multi-volume sets and mounts the inner video (or other) files on the WebDAV tree. Lazy RAR parsing reduces work until content is needed.
+Queue processing aggregates multi-volume sets and mounts the inner video (or other) files on the WebDAV tree. Lazy RAR parsing reduces work until content is needed. Nested RAR extraction and more resilient handling of obfuscated multi-volume sets [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }.
 
 If a release is archive-only and *Arr cannot import, check Automatic Queue Management rules and ignored-file globs under [SABnzbd settings](../configuration/sabnzbd.md).

--- a/docs/features/indexer-search.md
+++ b/docs/features/indexer-search.md
@@ -12,7 +12,7 @@ Each profile selects indexers and optional adapters:
 | Addon | Manifest at `/adapters/addon/{token}/manifest.json` |
 | JSON | `GET /api/search/{token}/lookup?...` |
 
-Treat profile tokens as secrets. Play links in results have a configurable lifetime (**Watchdog → Search link lifetime**).
+Treat profile tokens as secrets. Play links in results have a configurable lifetime (**Watchdog → Search link lifetime**) [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }.
 
 ## Filters
 

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -20,7 +20,7 @@ Queue and history filters accept both `cat` and `category`. The default category
 - **Ignore SAB history limit** can ignore a client's `limit`; NzbDAV still enforces a server-side maximum page size.
 - Authentication failures use HTTP error status codes instead of always returning HTTP 200 with an error body.
 
-## `addurl` and private / LAN hosts
+## `addurl` and private / LAN hosts [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }
 
 `mode=addurl` fetches the NZB from the URL the download client supplies. Before each hop (including redirects), NzbDAV rejects destinations that resolve to a non-public IP — an SSRF guard that also blocks Docker DNS / RFC1918 indexers unless allowlisted.
 

--- a/docs/getting-started/connect-arr.md
+++ b/docs/getting-started/connect-arr.md
@@ -14,7 +14,7 @@ In Radarr or Sonarr → **Settings** → **Download Clients** → **Add** → **
 | API Key | NzbDAV **Settings → SABnzbd → API Key** |
 | Category | Match categories you configured (e.g. `movies`, `tv`) |
 
-Test the connection. Prefer `addfile` when clients can upload NZB bytes; `addurl` to private indexers needs [Trusted local hosts](../configuration/sabnzbd.md).
+Test the connection. Prefer `addfile` when clients can upload NZB bytes; `addurl` to private indexers needs [Trusted local hosts](../configuration/sabnzbd.md) [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }.
 
 ## Register *Arr in NzbDAV
 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -58,7 +58,7 @@ Long one-time maintenance does not mark the Compose healthcheck unhealthy — it
     - Allow HTTP Upgrade on **same-origin** `/ws` (Overview/Queue live updates).
     - Set `SECURE_COOKIES=true` when the UI is HTTPS-only.
     - Set **Base URL** in Settings (or `TRUST_PROXY=1` so forwarded headers rewrite correctly) for STRM/adapter absolute URLs.
-    - For `addurl` to Docker-internal indexers, configure [Trusted local hosts](../configuration/sabnzbd.md) or `TRUSTED_INTERNAL_HOSTS`.
+    - For `addurl` to Docker-internal indexers, configure [Trusted local hosts](../configuration/sabnzbd.md) or `TRUSTED_INTERNAL_HOSTS` [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }.
 
 ## Optional environment
 
@@ -66,7 +66,7 @@ Long one-time maintenance does not mark the Compose healthcheck unhealthy — it
 |----------|---------|
 | `TRUST_PROXY=1` | Honor proxy `X-Forwarded-*` when rewriting scheme/host |
 | `TRUSTED_PROXY_CIDRS` | Widen backend proxy trust (split-container) |
-| `TRUSTED_INTERNAL_HOSTS` | Allowlist for private `addurl` targets |
+| `TRUSTED_INTERNAL_HOSTS` [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | Allowlist for private `addurl` targets |
 | `SESSION_KEY` | Stable session secret (else persisted under `/config`) |
 | `THREADPOOL_MIN_THREADS` / `THREADPOOL_MAX_THREADS` | Memory-constrained hosts |
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,5 +1,9 @@
 # Getting started
 
+!!! note "Docs track latest"
+
+    These pages describe the **latest** NzbDAV release. Features and settings marked with a [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } pill (or similar) need at least that version — check your image tag or **Settings → About** before following a new workflow.
+
 Choose a path based on where you are:
 
 <div class="grid cards" markdown>

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -20,7 +20,7 @@
 - STRM: Base URL reachable from Emby/Jellyfin?
 - Check Automatic Queue Management rules — [Arrs](../configuration/arrs.md).
 
-## `addurl` SSRF / private indexer
+## `addurl` SSRF / private indexer [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }
 
 Allow Docker DNS or LAN hosts under **Trusted local hosts** — [SABnzbd API](../features/sab-api.md).
 

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -10,7 +10,7 @@ Requires:
 - At least one configured Radarr/Sonarr instance
 - **Enable Background Repairs**
 
-Tune concurrency, health-check depth, aging, and auto-remove thresholds — [Repairs settings](../configuration/repairs.md).
+Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }, and auto-remove thresholds — [Repairs settings](../configuration/repairs.md).
 
 ## Health-check retention
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -106,3 +106,41 @@
 .md-footer-meta__inner {
   align-items: center;
 }
+
+/* Version availability pills — minimum release that shipped a feature */
+.md-typeset a.nzbdav-since,
+.md-typeset .nzbdav-since {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.35em;
+  padding: 0.1em 0.55em;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--md-primary-fg-color) 45%, transparent);
+  background: color-mix(in srgb, var(--md-primary-fg-color) 14%, transparent);
+  color: var(--md-primary-fg-color);
+  font-size: 0.65em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.md-typeset a.nzbdav-since:hover,
+.md-typeset a.nzbdav-since:focus {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 24%, transparent);
+  color: var(--md-primary-fg-color--dark);
+  text-decoration: none;
+}
+
+[data-md-color-scheme="slate"] .md-typeset a.nzbdav-since:hover,
+[data-md-color-scheme="slate"] .md-typeset a.nzbdav-since:focus {
+  color: var(--md-primary-fg-color--light);
+}
+
+.md-typeset h1 .nzbdav-since,
+.md-typeset h2 .nzbdav-since,
+.md-typeset h3 .nzbdav-since {
+  font-size: 0.55em;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Adds branded `since X.Y.Z` pills (CSS + markdown convention) so docs readers on older images can see the minimum version for a feature.
- Annotates documented 0.8.0 capabilities (Trusted local hosts / LAN `addurl`, search link lifetime, health-check aging, CRC env, Overview stats reset, nested RAR notes) and notes that docs track latest.
- Documents the authoring pattern in `AGENTS.md`.

## Test plan
- [x] `python3 -m zensical build --clean --strict`
- [ ] Spot-check Getting Started note + SABnzbd Trusted local hosts heading for pill styling (light + slate)
- [ ] Confirm pills link to https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0