### PR TITLE
fix(ui): Outages sparkline no longer hides brief provider circuit trips

### DIFF
--- a/backend/Services/Metrics/CircuitOutageSparkBuilder.cs
+++ b/backend/Services/Metrics/CircuitOutageSparkBuilder.cs
@@ -23,11 +23,19 @@ public static class CircuitOutageSparkBuilder
                 _ => new long[bucketCount],
                 StringComparer.Ordinal);
 
+        var tripBuckets = providerKeys
+            .Distinct(StringComparer.Ordinal)
+            .ToDictionary(
+                key => key,
+                _ => new bool[bucketCount],
+                StringComparer.Ordinal);
+
         foreach (var group in events
                      .Where(item => result.ContainsKey(item.Provider))
                      .GroupBy(item => item.Provider, StringComparer.Ordinal))
         {
             var outageMs = result[group.Key];
+            var trips = tripBuckets[group.Key];
             long? openAt = null;
             long openUntil = 0;
 
@@ -38,6 +46,7 @@ public static class CircuitOutageSparkBuilder
                     if (openAt is { } previousOpen)
                         AddInterval(outageMs, previousOpen, Math.Min(openUntil, item.At));
 
+                    MarkTripBucket(trips, item.At);
                     openAt = item.At;
                     openUntil = item.At + Math.Max(0, item.CooldownMs ?? 0);
                     continue;
@@ -74,16 +83,36 @@ public static class CircuitOutageSparkBuilder
                         Math.Min(end, bucketEnd) - Math.Max(start, bucketStart));
                 }
             }
+
+            void MarkTripBucket(bool[] buckets, long at)
+            {
+                if (at < sparkStart || at >= sparkStart + bucketSize * bucketCount)
+                    return;
+                var index = (int)((at - sparkStart) / bucketSize);
+                if (index >= 0 && index < bucketCount)
+                    buckets[index] = true;
+            }
         }
 
         return result.ToDictionary(
             pair => pair.Key,
-            pair => pair.Value
-                .Select(duration => (int)Math.Clamp(
-                    Math.Round(duration * 100d / bucketSize),
-                    0,
-                    100))
-                .ToList(),
+            pair =>
+            {
+                var trips = tripBuckets[pair.Key];
+                return pair.Value
+                    .Select((duration, index) =>
+                    {
+                        var percent = (int)Math.Clamp(
+                            Math.Round(duration * 100d / bucketSize),
+                            0,
+                            100);
+                        // Keep recorded trips visible when occupancy rounds below 1%.
+                        if (percent == 0 && trips[index])
+                            return 1;
+                        return percent;
+                    })
+                    .ToList();
+            },
             StringComparer.Ordinal);
     }
 }

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -30,7 +30,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                     <th className="w-[120px]">Activity</th>
                                     <th
                                         className="w-[120px]"
-                                        title="Percentage of each interval that the provider circuit was open and skipped">
+                                        title="Relative circuit-open history for each interval (scaled to the window’s peak)">
                                         Outages
                                     </th>
                                     <th>Articles</th>
@@ -65,11 +65,10 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                             <td>
                                                 <Sparkline values={p.spark} tone="success" />
                                             </td>
-                                            <td title="Provider circuit-open time">
+                                            <td title="Relative provider circuit-open history">
                                                 <Sparkline
                                                     values={p.outageSpark ?? []}
-                                                    tone="error"
-                                                    fixedMax={100} />
+                                                    tone="error" />
                                             </td>
                                             <td className="font-mono tabular-nums">{formatNumber(p.articles)}</td>
                                             <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>

--- a/tests/NzbWebDAV.Tests/Services/Metrics/CircuitOutageSparkBuilderTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/CircuitOutageSparkBuilderTests.cs
@@ -5,6 +5,7 @@ namespace NzbWebDAV.Tests.Services.Metrics;
 public class CircuitOutageSparkBuilderTests
 {
     private const long Minute = 60_000;
+    private const long Hour = 60 * Minute;
 
     [Fact]
     public void Build_SplitsOpenIntervalAcrossBuckets()
@@ -72,5 +73,57 @@ public class CircuitOutageSparkBuilderTests
 
         Assert.Equal([0, 0], result["provider-a"]);
         Assert.Equal([0, 0], result["provider-b"]);
+    }
+
+    [Fact]
+    public void Build_PreservesOnePercentSentinelForSubHalfPercentTrip()
+    {
+        // 200ms open in a 1h bucket ≈ 0.0056% → rounds to 0 without a sentinel.
+        var result = CircuitOutageSparkBuilder.Build(
+            [
+                new CircuitOutageSparkBuilder.Event(0, "provider-a", "open", Hour),
+                new CircuitOutageSparkBuilder.Event(200, "provider-a", "closed", null),
+            ],
+            ["provider-a"],
+            sparkStart: 0,
+            bucketSize: Hour,
+            bucketCount: 1,
+            nowMs: Hour);
+
+        Assert.Equal([1], result["provider-a"]);
+    }
+
+    [Fact]
+    public void Build_PreservesOnePercentSentinelForSameMillisecondOpenClosed()
+    {
+        var result = CircuitOutageSparkBuilder.Build(
+            [
+                new CircuitOutageSparkBuilder.Event(10_000, "provider-a", "open", Minute),
+                new CircuitOutageSparkBuilder.Event(10_000, "provider-a", "closed", null),
+            ],
+            ["provider-a"],
+            sparkStart: 0,
+            bucketSize: Minute,
+            bucketCount: 1,
+            nowMs: Minute);
+
+        Assert.Equal([1], result["provider-a"]);
+    }
+
+    [Fact]
+    public void Build_KeepsCalculatedPercentForNormalIntervals()
+    {
+        var result = CircuitOutageSparkBuilder.Build(
+            [
+                new CircuitOutageSparkBuilder.Event(0, "provider-a", "open", Minute),
+                new CircuitOutageSparkBuilder.Event(30_000, "provider-a", "closed", null),
+            ],
+            ["provider-a"],
+            sparkStart: 0,
+            bucketSize: Minute,
+            bucketCount: 1,
+            nowMs: Minute);
+
+        Assert.Equal([50], result["provider-a"]);
     }
 }


### PR DESCRIPTION
## Summary
- Preserve a 1% sentinel in `CircuitOutageSparkBuilder` when a recorded trip’s occupancy would otherwise round to 0
- Render the Overview Outages spark adaptively (like Activity/Errors/Retries) so small values stay visible
- Add coverage for sub-half-percent and same-millisecond open/closed intervals

Closes #526

## Test plan
- [x] `dotnet test` filter `CircuitOutageSparkBuilder|ProviderCircuitBreaker_Emits`
- [x] Frontend `npm run typecheck`
- [ ] Force a provider trip, wait for metrics flush + next 30s window poll
- [ ] Confirm a visible red spike on 1h and 24h Outages
- [ ] Confirm provider recovery timing / selection behavior unchanged