### PR TITLE
chore: ignore local SQLite runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,13 @@ BenchmarkDotNet.Artifacts/
 #################
 
 /site/
+#######################
+# Local runtime state #
+#######################
+
+db.sqlite
+db.sqlite-shm
+db.sqlite-wal
+metrics.sqlite
+metrics.sqlite-shm
+metrics.sqlite-wal


### PR DESCRIPTION
Running the backend with `CONFIG_PATH` pointed inside the repo (an easy default during local development) drops `db.sqlite`, `metrics.sqlite`, and their WAL/SHM siblings into the working tree, where they show up as untracked noise and are one `git add .` away from being committed. This ignores all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)