### PR TITLE
fix(db): apply pending main-DB migrations on normal startup

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -126,6 +126,26 @@ class Program
                     SigtermUtil.GetCancellationToken())
                 .ConfigureAwait(false);
 
+            // The stock entrypoint runs `--db-migration` (the maintenance
+            // runner) before the server starts, so this is a no-op there.
+            // Deployments that launch the backend directly (e.g. separate
+            // chart-managed containers that bypass entrypoint.sh) would
+            // otherwise never migrate the main database and fail at runtime
+            // with missing tables/columns.
+            var pendingMigrations = (await databaseContext.Database
+                .GetPendingMigrationsAsync(SigtermUtil.GetCancellationToken())
+                .ConfigureAwait(false)).ToList();
+            if (pendingMigrations.Count > 0)
+            {
+                Log.Warning(
+                    "Applying {Count} pending database migrations at startup ({First} .. {Last})",
+                    pendingMigrations.Count, pendingMigrations[0], pendingMigrations[^1]);
+                await databaseContext.Database
+                    .MigrateAsync(SigtermUtil.GetCancellationToken())
+                    .ConfigureAwait(false);
+                Log.Information("Database migrations completed");
+            }
+
             // The metrics database has its own schema and must also be current on
             // normal startup, where the operational migration runner is skipped.
             await using (var metricsBootstrap = new MetricsDbContext())


### PR DESCRIPTION
The stock entrypoint runs `--db-migration` (the maintenance runner) before the server starts, so migrations are guaranteed there. But anything that launches the backend binary directly — `scripts/run-backend.sh` during development, or container setups that run the backend as its own container — skips that step entirely: the metrics database migrates on normal startup, the main database never does, and the server comes up against a stale schema, failing at runtime with errors like `no such column: q.ContentGroupKey`.

This detects pending main-DB migrations during normal startup and applies them, with a log line naming the migration range being applied. It's a no-op when the maintenance runner already brought the schema current, so entrypoint-based deployments see zero change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)