### PR TITLE
refactor(health): resolve depth to an enum instead of a sentinel double

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -14,8 +14,8 @@ public class ConfigManager
 {
     public static readonly string AppVersion = EnvironmentUtil.GetEnvironmentVariable("NZBDAV_VERSION") ?? "0.0.0";
 
-    // Sampling curve multiplier used by a background health check when none is configured.
-    public const double DefaultHealthCheckDepth = 0.5;
+    // Depth a background health check uses when none is configured.
+    public const HealthCheckDepth DefaultHealthCheckDepth = HealthCheckDepth.Standard;
 
     private readonly Dictionary<string, string> _config = new();
     private readonly Dictionary<(string Name, Type Type), object?> _deserializedConfig = new();
@@ -1119,17 +1119,17 @@ public class ConfigManager
     }
 
     /// <summary>
-    /// How much of each file a health check reads, as a multiplier on the sampling curve.
-    /// Returns 0 for "complete", which turns sampling off so every segment is checked.
+    /// How much of each file a health check reads. Unrecognized values fall back to the
+    /// default rather than throwing, so a hand-edited database cannot stop health checks.
     /// </summary>
-    public double GetHealthCheckDepth()
+    public HealthCheckDepth GetHealthCheckDepth()
     {
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckDepth));
         return configured?.ToLowerInvariant() switch
         {
-            "enhanced" => 1.0,
-            "deep" => 2.0,
-            "complete" => 0,
+            "enhanced" => HealthCheckDepth.Enhanced,
+            "deep" => HealthCheckDepth.Deep,
+            "complete" => HealthCheckDepth.Complete,
             _ => DefaultHealthCheckDepth,
         };
     }

--- a/backend/Config/HealthCheckDepth.cs
+++ b/backend/Config/HealthCheckDepth.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// How much of each file a health check verifies. Standard through Deep scale the
+/// sampling curve. Complete skips sampling and STATs every segment.
+/// </summary>
+public enum HealthCheckDepth
+{
+    Standard,
+    Enhanced,
+    Deep,
+    Complete,
+}

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -290,14 +290,27 @@ public class HealthCheckService : BackgroundService
     /// <summary>
     /// How many segments to STAT for one file. Files up to the floor are checked in full,
     /// larger ones are sampled based on their size, and an optional age scales the result
-    /// down from there. Depth 0 will bypass this and do a full check.
+    /// down from there. <see cref="HealthCheckDepth.Complete"/> skips all of it.
     /// </summary>
-    public static int SampleTarget(int segmentCount, double depth, TimeSpan? age = null)
+    public static int SampleTarget(int segmentCount, HealthCheckDepth depth, TimeSpan? age = null)
     {
-        if (depth <= 0) return segmentCount;
-        var curve = Math.Max(SampleFloor, depth * Math.Sqrt((double)SampleFloor * segmentCount));
+        if (depth == HealthCheckDepth.Complete) return segmentCount;
+        var multiplier = CurveMultiplier(depth);
+        var curve = Math.Max(SampleFloor, multiplier * Math.Sqrt((double)SampleFloor * segmentCount));
         return (int)Math.Min(segmentCount, curve * AgeWeight(age));
     }
+
+    /// <summary>
+    /// What each depth multiplies the sampling curve by. Complete has no multiplier because
+    /// it never reaches the curve.
+    /// </summary>
+    private static double CurveMultiplier(HealthCheckDepth depth) => depth switch
+    {
+        HealthCheckDepth.Standard => 0.5,
+        HealthCheckDepth.Enhanced => 1.0,
+        HealthCheckDepth.Deep => 2.0,
+        _ => throw new ArgumentOutOfRangeException(nameof(depth), depth, "Depth has no curve multiplier."),
+    };
 
     /// <summary>
     /// Scales coverage down as a release ages with the same square root curve used for size.
@@ -316,7 +329,7 @@ public class HealthCheckService : BackgroundService
     /// </summary>
     public static List<string> SampleSegments(
         List<string> segments,
-        double depth = ConfigManager.DefaultHealthCheckDepth,
+        HealthCheckDepth depth = ConfigManager.DefaultHealthCheckDepth,
         TimeSpan? age = null)
     {
         var count = segments.Count;

--- a/tests/NzbWebDAV.Tests/Config/HealthCheckDepthConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/HealthCheckDepthConfigTests.cs
@@ -7,15 +7,15 @@ public class HealthCheckDepthConfigTests
 {
     [Theory]
     [InlineData("standard", ConfigManager.DefaultHealthCheckDepth)]
-    [InlineData("enhanced", 1.0)]
-    [InlineData("deep", 2.0)]
-    [InlineData("complete", 0)]
+    [InlineData("enhanced", HealthCheckDepth.Enhanced)]
+    [InlineData("deep", HealthCheckDepth.Deep)]
+    [InlineData("complete", HealthCheckDepth.Complete)]
     // Validation accepts any casing, so the getter has to resolve it the same way
     // rather than falling through to the default and quietly under-checking.
-    [InlineData("Deep", 2.0)]
-    [InlineData("COMPLETE", 0)]
+    [InlineData("Deep", HealthCheckDepth.Deep)]
+    [InlineData("COMPLETE", HealthCheckDepth.Complete)]
     [InlineData("nonsense", ConfigManager.DefaultHealthCheckDepth)]
-    public void GetHealthCheckDepth_ResolvesRegardlessOfCasing(string value, double expected)
+    public void GetHealthCheckDepth_ResolvesRegardlessOfCasing(string value, HealthCheckDepth expected)
     {
         var config = new ConfigManager();
         config.UpdateValues(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
@@ -5,9 +5,9 @@ namespace NzbWebDAV.Tests.Services;
 
 public class HealthCheckSampleSegmentsTests
 {
-    private const double Standard = ConfigManager.DefaultHealthCheckDepth;
-    private const double Enhanced = 1.0;
-    private const double Deep = 2.0;
+    // Named for the default rather than the member, so these cases keep testing whatever
+    // depth ships as the default.
+    private const HealthCheckDepth Standard = ConfigManager.DefaultHealthCheckDepth;
 
     private static List<string> Segments(int count) =>
         Enumerable.Range(0, count).Select(i => $"seg-{i}").ToList();
@@ -38,11 +38,11 @@ public class HealthCheckSampleSegmentsTests
     }
 
     [Fact]
-    public void SampleSegments_ZeroDepthChecksEverySegment()
+    public void SampleSegments_CompleteChecksEverySegment()
     {
         var segments = Segments(50_000);
 
-        Assert.Same(segments, HealthCheckService.SampleSegments(segments, depth: 0));
+        Assert.Same(segments, HealthCheckService.SampleSegments(segments, HealthCheckDepth.Complete));
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class HealthCheckSampleSegmentsTests
     {
         const int count = 20_000;
 
-        var ancient = HealthCheckService.SampleTarget(count, depth: 0, TimeSpan.FromDays(7300));
+        var ancient = HealthCheckService.SampleTarget(count, HealthCheckDepth.Complete, TimeSpan.FromDays(7300));
 
         Assert.Equal(count, ancient);
     }
@@ -132,7 +132,7 @@ public class HealthCheckSampleSegmentsTests
     {
         var segments = Segments(50_000);
 
-        var sampled = HealthCheckService.SampleSegments(segments, depth: 0, TimeSpan.FromDays(7300));
+        var sampled = HealthCheckService.SampleSegments(segments, HealthCheckDepth.Complete, TimeSpan.FromDays(7300));
 
         Assert.Same(segments, sampled);
     }
@@ -168,8 +168,8 @@ public class HealthCheckSampleSegmentsTests
         var segments = Segments(count);
 
         var standard = HealthCheckService.SampleSegments(segments, Standard).Count;
-        var enhanced = HealthCheckService.SampleSegments(segments, Enhanced).Count;
-        var deep = HealthCheckService.SampleSegments(segments, Deep).Count;
+        var enhanced = HealthCheckService.SampleSegments(segments, HealthCheckDepth.Enhanced).Count;
+        var deep = HealthCheckService.SampleSegments(segments, HealthCheckDepth.Deep).Count;
 
         Assert.True(standard < enhanced, $"standard {standard} !< enhanced {enhanced}");
         Assert.True(enhanced < deep, $"enhanced {enhanced} !< deep {deep}");


### PR DESCRIPTION
Follow-up to the review on #470 that suggested health check depth be an enum instead of a double.