### PR TITLE
fix(nntp): timed-out provider handshakes report as connect or login failures

### DIFF
--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
@@ -20,18 +20,20 @@ public class TestUsenetConnectionController(ConfigManager configManager) : BaseA
         }
         catch (CouldNotConnectToUsenetException e)
         {
-            var inner = e.InnerException?.Message ?? e.Message;
+            // Prefer known outer/cause messages; InnerException alone is often a bare OCE
+            // ("A task was canceled") when CreateNewConnection wraps a handshake timeout.
+            var error = e.TryGetKnownErrorMessage(out var reason) ? reason : e.Message;
             Log.Warning(
                 "Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): connect error: {Error}",
-                request.Host, request.Port, request.UseSsl, request.User, inner);
+                request.Host, request.Port, request.UseSsl, request.User, error);
             return new TestUsenetConnectionResponse { Status = true, Connected = false };
         }
         catch (CouldNotLoginToUsenetException e)
         {
-            var inner = e.InnerException?.Message ?? e.Message;
+            var error = e.TryGetKnownErrorMessage(out var reason) ? reason : e.Message;
             Log.Warning(
                 "Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): login error: {Error}",
-                request.Host, request.Port, request.UseSsl, request.User, inner);
+                request.Host, request.Port, request.UseSsl, request.User, error);
             return new TestUsenetConnectionResponse { Status = true, Connected = false };
         }
         catch (Exception e) when (!e.IsCancellationException())

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -261,10 +261,13 @@ public class UsenetStreamingClient : WrappingNntpClient
                     connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
                     timeoutCts.Token).ConfigureAwait(false);
             }
-            catch (Exception e) when (e.IsCancellationException() && !ct.IsCancellationRequested)
+            catch (Exception e) when (e.IsCancellationException() &&
+                                      timeoutCts.IsCancellationRequested &&
+                                      !ct.IsCancellationRequested)
             {
-                // Local handshake timeout, not caller abort — typed so Test Connection /
-                // middleware / breaker paths see a connect failure rather than bare OCE.
+                // Only the CancelAfter deadline — not an unrelated internal cancel, and
+                // not caller abort. Typed so Test Connection / middleware / breaker paths
+                // see a connect failure rather than bare OCE.
                 throw new CouldNotConnectToUsenetException(
                     $"Connection to {connectionDetails.Host}:{connectionDetails.Port} " +
                     $"timed out after {ConnectTimeout.TotalSeconds:F0}s.",
@@ -280,7 +283,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                         connectionDetails.User, connectionDetails.Pass,
                         timeoutCts.Token).ConfigureAwait(false);
                 }
-                catch (Exception e) when (e.IsCancellationException() && !ct.IsCancellationRequested)
+                catch (Exception e) when (e.IsCancellationException() &&
+                                          timeoutCts.IsCancellationRequested &&
+                                          !ct.IsCancellationRequested)
                 {
                     throw new CouldNotLoginToUsenetException(
                         $"Authentication to {connectionDetails.Host}:{connectionDetails.Port} " +

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -2,6 +2,8 @@
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
@@ -253,16 +255,40 @@ public class UsenetStreamingClient : WrappingNntpClient
         {
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeoutCts.CancelAfter(ConnectTimeout);
-            await connection.ConnectAsync(
-                connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
-                timeoutCts.Token).ConfigureAwait(false);
+            try
+            {
+                await connection.ConnectAsync(
+                    connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
+                    timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e.IsCancellationException() && !ct.IsCancellationRequested)
+            {
+                // Local handshake timeout, not caller abort — typed so Test Connection /
+                // middleware / breaker paths see a connect failure rather than bare OCE.
+                throw new CouldNotConnectToUsenetException(
+                    $"Connection to {connectionDetails.Host}:{connectionDetails.Port} " +
+                    $"timed out after {ConnectTimeout.TotalSeconds:F0}s.",
+                    e);
+            }
+
             if (!string.IsNullOrEmpty(connectionDetails.User) ||
                 !string.IsNullOrEmpty(connectionDetails.Pass))
             {
-                await connection.AuthenticateAsync(
-                    connectionDetails.User, connectionDetails.Pass,
-                    timeoutCts.Token).ConfigureAwait(false);
+                try
+                {
+                    await connection.AuthenticateAsync(
+                        connectionDetails.User, connectionDetails.Pass,
+                        timeoutCts.Token).ConfigureAwait(false);
+                }
+                catch (Exception e) when (e.IsCancellationException() && !ct.IsCancellationRequested)
+                {
+                    throw new CouldNotLoginToUsenetException(
+                        $"Authentication to {connectionDetails.Host}:{connectionDetails.Port} " +
+                        $"timed out after {ConnectTimeout.TotalSeconds:F0}s.",
+                        e);
+                }
             }
+
             return connection;
         }
         catch

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
@@ -2,6 +2,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using UsenetSharp.Models;
 
@@ -36,12 +37,62 @@ public class CreateNewConnectionTests
             var details = MakeDetails();
             var sw = System.Diagnostics.Stopwatch.StartNew();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            var ex = await Assert.ThrowsAsync<CouldNotConnectToUsenetException>(async () =>
                 await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None));
 
             sw.Stop();
+            Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("nntp.example:563", ex.Message, StringComparison.Ordinal);
+            Assert.True(ex.InnerException!.IsCancellationException());
             Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
                 $"Expected timeout well under OS connect default; elapsed={sw.Elapsed}");
+            Assert.Equal(1, fake.DisposeCount);
+        }
+        finally
+        {
+            UsenetStreamingClient.ConnectTimeout = previous;
+        }
+    }
+
+    [Fact]
+    public async Task CreateNewConnection_TimesOutHungAuthenticate()
+    {
+        var previous = UsenetStreamingClient.ConnectTimeout;
+        UsenetStreamingClient.ConnectTimeout = TimeSpan.FromMilliseconds(100);
+        try
+        {
+            var fake = new HandshakeNntpClient { HangAuthenticate = true };
+            var details = MakeDetails();
+
+            var ex = await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(async () =>
+                await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None));
+
+            Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("nntp.example:563", ex.Message, StringComparison.Ordinal);
+            Assert.True(ex.InnerException!.IsCancellationException());
+            Assert.True(fake.Connected);
+            Assert.Equal(1, fake.DisposeCount);
+        }
+        finally
+        {
+            UsenetStreamingClient.ConnectTimeout = previous;
+        }
+    }
+
+    [Fact]
+    public async Task CreateNewConnection_PropagatesCallerCancellationAsOperationCanceled()
+    {
+        var previous = UsenetStreamingClient.ConnectTimeout;
+        UsenetStreamingClient.ConnectTimeout = TimeSpan.FromSeconds(30);
+        using var cts = new CancellationTokenSource();
+        try
+        {
+            var fake = new HandshakeNntpClient { HangConnect = true };
+            var details = MakeDetails();
+            var connectTask = UsenetStreamingClient.CreateNewConnection(details, () => fake, cts.Token);
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await connectTask);
             Assert.Equal(1, fake.DisposeCount);
         }
         finally
@@ -128,6 +179,7 @@ public class CreateNewConnectionTests
     private sealed class HandshakeNntpClient : NntpClient
     {
         public bool HangConnect { get; init; }
+        public bool HangAuthenticate { get; init; }
         public Exception? AuthenticateException { get; init; }
         public bool Connected { get; private set; }
         public int DisposeCount { get; private set; }
@@ -148,20 +200,26 @@ public class CreateNewConnectionTests
             Connected = true;
         }
 
-        public override Task<UsenetResponse> AuthenticateAsync(
+        public override async Task<UsenetResponse> AuthenticateAsync(
             string user, string pass, CancellationToken cancellationToken)
         {
+            if (HangAuthenticate)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return default!;
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             AuthenticateCount++;
             LastAuthUser = user;
             LastAuthPass = pass;
             if (AuthenticateException is not null)
                 throw AuthenticateException;
-            return Task.FromResult(new UsenetResponse
+            return new UsenetResponse
             {
                 ResponseCode = (int)UsenetResponseType.AuthenticationAccepted,
                 ResponseMessage = "281 Ok",
-            });
+            };
         }
 
         public override Task<UsenetStatResponse> StatAsync(

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
@@ -102,6 +102,31 @@ public class CreateNewConnectionTests
     }
 
     [Fact]
+    public async Task CreateNewConnection_DoesNotTypeUnrelatedCancellationAsConnectTimeout()
+    {
+        var previous = UsenetStreamingClient.ConnectTimeout;
+        UsenetStreamingClient.ConnectTimeout = TimeSpan.FromSeconds(30);
+        try
+        {
+            var fake = new HandshakeNntpClient
+            {
+                ConnectException = new OperationCanceledException("internal cancel"),
+            };
+            var details = MakeDetails();
+
+            var ex = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await UsenetStreamingClient.CreateNewConnection(details, () => fake, CancellationToken.None));
+
+            Assert.Equal("internal cancel", ex.Message);
+            Assert.Equal(1, fake.DisposeCount);
+        }
+        finally
+        {
+            UsenetStreamingClient.ConnectTimeout = previous;
+        }
+    }
+
+    [Fact]
     public async Task CreateNewConnection_ReturnsLiveConnectionOnSuccess()
     {
         var fake = new HandshakeNntpClient();
@@ -180,6 +205,7 @@ public class CreateNewConnectionTests
     {
         public bool HangConnect { get; init; }
         public bool HangAuthenticate { get; init; }
+        public Exception? ConnectException { get; init; }
         public Exception? AuthenticateException { get; init; }
         public bool Connected { get; private set; }
         public int DisposeCount { get; private set; }
@@ -195,6 +221,9 @@ public class CreateNewConnectionTests
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 return;
             }
+
+            if (ConnectException is not null)
+                throw ConnectException;
 
             cancellationToken.ThrowIfCancellationRequested();
             Connected = true;


### PR DESCRIPTION
## Summary
- Local connect/auth handshake timeouts in `CreateNewConnection` now throw `CouldNotConnectToUsenetException` / `CouldNotLoginToUsenetException` instead of a bare `OperationCanceledException`.
- True caller cancellation is still propagated as cancellation so request aborts are not misclassified.
- Extends unit coverage for hung connect, hung authenticate, and caller cancel.

Follow-up from review of #529: hang prevention already exists via the 15s `CreateNewConnection` deadline (#363); this only improves exception typing for operator UX (Test Connection / middleware).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~CreateNewConnectionTests'`
- [ ] Manually: settings Test Connection against a black-holed / unreachable host returns Connected=false (not a cancel/500)
- [ ] Confirm cancelling a request mid-handshake still aborts cleanly without a connect/login exception