### PR TITLE
docs(docker): explain how to change the published port

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -50,6 +50,12 @@ Precedence for fallbacks: **saved Settings value wins** over env, which wins ove
 | `NZBDAV_VERSION` | `0.0.0` | Reported app version |
 | `DOTNET_DbgEnableMiniDump` | off | Opt-in crash dumps — [Logs](../operations/logs-crash-dumps.md) |
 
+`PORT` and `ASPNETCORE_URLS` control listeners inside the container; they do not
+change Docker's published host port. For normal Compose deployments, leave the
+internal ports unchanged and use a `HOST_PORT:CONTAINER_PORT` mapping. See
+[Change the published port](../getting-started/docker.md#change-the-published-port)
+for bridge networking, host networking, healthcheck, and DUMB examples.
+
 ## Settings fallbacks (when UI empty)
 
 | Variable | Related setting | Default if both empty |

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -41,6 +41,61 @@ docker compose up -d
 
 Set `PUID`/`PGID` from `id` on the host. Map `/mnt` (or your media paths) so completed downloads and library folders share paths with *Arr and media servers.
 
+## Change the published port
+
+Compose port mappings use `HOST_PORT:CONTAINER_PORT`. To open NzbDAV on port
+`3001` without changing the ports inside the container:
+
+```yaml
+ports:
+  - "3001:3000"
+```
+
+Open `http://your-server:3001`. Keep the container-side port at `3000`, including
+the Compose healthcheck at `http://localhost:3000/healthz`. A mapping such as
+`3001:3001` does not work unless the frontend is separately configured to listen
+on `3001`.
+
+!!! tip
+
+    For ordinary bridge-networked Docker and Compose deployments, changing the
+    host side of the port mapping is the recommended approach. Do not set `PORT`
+    just to avoid a host port conflict.
+
+### Host networking and internal port conflicts
+
+With `network_mode: host`, there is no port mapping layer. Set `PORT` if the
+frontend's port conflicts with another host service:
+
+```yaml
+network_mode: host
+environment:
+  PORT: "3001"
+```
+
+The backend remains on `8080`. If that port also conflicts, its listen URL and
+the frontend's backend URL must change together:
+
+```yaml
+network_mode: host
+environment:
+  PORT: "3001"
+  ASPNETCORE_URLS: "http://127.0.0.1:8081"
+  BACKEND_URL: "http://127.0.0.1:8081"
+```
+
+Update the Compose healthcheck to use the effective frontend port
+(`http://localhost:3001/healthz`) and update **Settings → General → Base URL**
+when generated links should use the new public port.
+
+!!! note "DUMB deployments"
+
+    DUMB builds and launches NzbDAV directly rather than using this image's
+    entrypoint. Change DUMB's `nzbdav.frontend_port` and
+    `nzbdav.backend_port` settings instead; DUMB supplies the corresponding
+    process environment automatically. See the
+    [DUMB NzbDAV service guide](https://dumbarr.com/services/core/nzbdav/#configuration-in-dumb_configjson).
+
 ## What the image does
 
 1. Starts the frontend so maintenance progress can be shown.


### PR DESCRIPTION
## Summary
- explain why Docker port mappings should normally use `HOST_PORT:3000`
- document advanced host-network listener overrides and matching healthchecks
- point DUMB users to its `frontend_port` and `backend_port` settings

## Test plan
- [x] `git diff --check`
- [x] `zensical build --clean --strict`

Closes #134