### PR TITLE
docs: point community Discord at the new server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ NzbDAV is a **WebDAV server** that mounts NZB documents as a browsable virtual f
 
 It also exposes a **SABnzbd-compatible API**, so Sonarr, Radarr, and similar tools can use it as a drop-in download client. Combined with Plex, Emby, or Jellyfin, this lets you build an effectively infinite media library without storing the full media library on your server.
 
-Please add feature requests and issues over on our [Issue Tracker](https://github.com/nzbdav/nzbdav/issues) or join our [Discord `#nzbdav`](https://discord.gg/EJaptcg9UY) to chat with us!
+Please add feature requests and issues over on our [Issue Tracker](https://github.com/nzbdav/nzbdav/issues) or join our [Discord](https://discord.gg/DAya7W6QMa) to chat with us!
+
+> Discord community transition started **July 21**. After joining, use the channel and role selector to enable **NzbDAV - SuperFork** for release notifications and development channels.
 
 ## Why another fork?
 

--- a/docs/community/github.md
+++ b/docs/community/github.md
@@ -8,9 +8,9 @@ Chat with other operators, track development, and contribute.
 
     ---
 
-    Join **`#nzbdav`** for setup help, streaming tips, and informal discussion.
+    Discord community is moving to a new server (transition started **July 21**). Join, then use the channel and role selector to enable **NzbDAV - SuperFork** for release notifications and development channels — plus setup help, streaming tips, and informal discussion.
 
-    [:octicons-arrow-right-24: discord.gg/EJaptcg9UY](https://discord.gg/EJaptcg9UY)
+    [:octicons-arrow-right-24: discord.gg/DAya7W6QMa](https://discord.gg/DAya7W6QMa)
 
 -   :fontawesome-brands-github:{ .lg .middle } __Repository__
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,7 +185,9 @@ Then open `http://localhost:3000` (self-hosted) or your DUMB service URL, create
 
 Chat on Discord, track releases on GitHub, and file issues when you need a durable bug report.
 
-[Join Discord `#nzbdav`](https://discord.gg/EJaptcg9UY){ .md-button .md-button--primary }
+Discord community transition started **July 21**. After joining, use the channel and role selector to enable **NzbDAV - SuperFork** for release notifications and development channels.
+
+[Join Discord](https://discord.gg/DAya7W6QMa){ .md-button .md-button--primary }
 [Repository](https://github.com/nzbdav/nzbdav){ .md-button }
 [Releases](https://github.com/nzbdav/nzbdav/releases){ .md-button }
 [Issues](https://github.com/nzbdav/nzbdav/issues){ .md-button }

--- a/zensical.toml
+++ b/zensical.toml
@@ -136,7 +136,7 @@ name = "GitHub"
 
 [[project.extra.social]]
 icon = "fontawesome/brands/discord"
-link = "https://discord.gg/EJaptcg9UY"
+link = "https://discord.gg/DAya7W6QMa"
 name = "Discord"
 
 [[project.extra.social]]


### PR DESCRIPTION
## Summary
- Replace the old Discord invite with https://discord.gg/DAya7W6QMa in README, docs home, community hub, and site socials
- Document that the community transition started July 21 and that users should enable **NzbDAV - SuperFork** via the channel/role selector for release notifications and development channels

## Test plan
- [ ] Confirm Discord links open https://discord.gg/DAya7W6QMa from README and docs pages
- [ ] Confirm no remaining references to discord.gg/EJaptcg9UY in the repo (except CHANGELOG history)
- [ ] Skim community hub Discord card for clear role-selector instructions