### PR TITLE
ci: post Discord notifications for releases and :dev refreshes

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,3 +26,30 @@ jobs:
       contents: write
     with:
       ref: ${{ github.sha }}
+
+  announce-dev:
+    needs:
+      - build
+      - tag-dev
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Post :dev refresh to Discord
+        env:
+          DISCORD_DEVELOPMENT_WEBHOOK_URL: ${{ secrets.DISCORD_DEVELOPMENT_WEBHOOK_URL }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_DEVELOPMENT_WEBHOOK_URL}" ]; then
+            echo "DISCORD_DEVELOPMENT_WEBHOOK_URL secret is not set" >&2
+            exit 1
+          fi
+
+          SHORT_SHA="${SHA:0:7}"
+          ANNOUNCEMENT_BODY=$(printf '**Dev image refreshed**\n`ghcr.io/%s:dev` and git tag `dev` now point to `%s`.\nRun: %s' "${REPO}" "${SHORT_SHA}" "${RUN_URL}")
+          ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
+          curl --fail-with-body -sS -H "Content-Type: application/json" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            "$DISCORD_DEVELOPMENT_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,3 +124,44 @@ jobs:
       contents: write
     with:
       ref: ${{ needs.resolve-version.outputs.ref }}
+
+  announce:
+    if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'
+    needs:
+      - release-please
+      - deploy
+      - tag-dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-please.outputs.sha }}
+
+      - name: Post announcement to Discord
+        env:
+          DISCORD_ANNOUNCEMENTS_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
+          VERSION: ${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_ANNOUNCEMENTS_WEBHOOK_URL}" ]; then
+            echo "DISCORD_ANNOUNCEMENTS_WEBHOOK_URL secret is not set" >&2
+            exit 1
+          fi
+
+          RELEASE_NOTES=$(sed -n '/^## \[[0-9]\+\.[0-9]\+\.[0-9]\+\](/,$p' CHANGELOG.md | sed -n '1!{/^## \[/q;p}')
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
+          ANNOUNCEMENT_BODY=$(printf '**New Release: v%s**\n%s\n\n%s' "${VERSION}" "${RELEASE_NOTES}" "${RELEASE_URL}")
+
+          MAX_LEN=1900
+          if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then
+            ANNOUNCEMENT_BODY="${ANNOUNCEMENT_BODY:0:$((MAX_LEN - 3))}..."
+          fi
+
+          ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
+          curl --fail-with-body -sS -H "Content-Type: application/json" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"

--- a/.github/workflows/test-discord-announcements.yml
+++ b/.github/workflows/test-discord-announcements.yml
@@ -1,0 +1,36 @@
+name: Test Discord Announcements
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: Message to post to the announcements Discord channel
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test-announcements-webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post test message to Discord announcements
+        env:
+          DISCORD_ANNOUNCEMENTS_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_ANNOUNCEMENTS_WEBHOOK_URL}" ]; then
+            echo "DISCORD_ANNOUNCEMENTS_WEBHOOK_URL secret is not set" >&2
+            exit 1
+          fi
+          if [ -z "${MESSAGE}" ]; then
+            echo "message input is empty" >&2
+            exit 1
+          fi
+
+          ESCAPED_BODY=$(printf '%s' "$MESSAGE" | jq -Rsa .)
+          curl --fail-with-body -sS -H "Content-Type: application/json" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- Announce new stable releases (after image deploy + `dev` tag move) to Discord via `DISCORD_ANNOUNCEMENTS_WEBHOOK_URL`, including truncated changelog notes and a release link
- Announce manual Pre-release `:dev` image refreshes to Discord via `DISCORD_DEVELOPMENT_WEBHOOK_URL` with short SHA + Actions run link
- Add **Test Discord Announcements** (`workflow_dispatch`) with a custom `message` input to verify the announcements webhook

## Test plan
- [ ] Confirm repo secrets `DISCORD_ANNOUNCEMENTS_WEBHOOK_URL` and `DISCORD_DEVELOPMENT_WEBHOOK_URL` are set
- [ ] Run **Actions → Test Discord Announcements → Run workflow** with a short test message; confirm it appears in the announcements channel
- [ ] Optionally run **Pre-release** and confirm the development channel gets a `:dev` refresh notice
- [ ] Next stable release-please merge should post to announcements (no announce on manual Release republish)