### PR TITLE
fix(queue): stop advertising huge sentinel sizes for multipart RAR files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,15 @@ When a task that changed the repo is done (unless the user explicitly said not t
 3. **Open a PR** to `main` with `gh pr create` (short summary + test plan). Report the PR URL in the final response.
 4. **Reset the workspace** for the next agent: `git checkout main` && `git pull`, then confirm a clean working tree on `main`.
 
+### Never merge pull requests
+
+**Agents must never merge a pull request** — not with `gh pr merge`, the GitHub UI/API, auto-merge, squash/rebase merge, or any equivalent — **in this repository or any sibling NzbDAV ecosystem repo** (including `sharpcompress`, `UsenetSharp`, and related packages).
+
+- Opening a PR and reporting its URL is the end of the handoff.
+- Do **not** merge even if CI is green, the user seems impatient, a release is blocked on the merge, or merging would unblock downstream work.
+- Do **not** enable auto-merge.
+- Only a human maintainer merges. If a merge is needed, stop and ask the user to merge.
+
 ### PR titles
 
 PR titles use the same `<type>(<scope>): <description>` format as commits, but write the description for **end users, not maintainers**: say what is fixed or introduced from the user's perspective, not how it was implemented. Commit messages carry the technical detail; the PR title is what people skim in the PR list and release notes.

--- a/backend/Exceptions/UnsupportedRarUnknownSizeException.cs
+++ b/backend/Exceptions/UnsupportedRarUnknownSizeException.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Exceptions;
+
+public class UnsupportedRarUnknownSizeException(string message) : NonRetryableDownloadException(message)
+{
+}

--- a/backend/Extensions/RarHeaderExtensions.cs
+++ b/backend/Extensions/RarHeaderExtensions.cs
@@ -15,7 +15,8 @@ public static class RarHeaderExtensions
         {
             Key = derived.Key,
             Iv = derived.Iv,
-            DecodedSize = header.UncompressedSize,
+            // Never persist SharpCompress's unknown-size unpack sentinel as a real length.
+            DecodedSize = header.IsUncompressedSizeUnknown ? 0 : header.UncompressedSize,
         };
     }
 }

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-      <PackageReference Include="NzbDav.SharpCompress" Version="0.53.1" />
+      <PackageReference Include="NzbDav.SharpCompress" Version="0.54.0" />
       <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.3" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -231,6 +231,7 @@ class Program
                 .AddHostedService<WatchdogPurgeService>()
                 .AddHostedService<DavCleanupService>()
                 .AddHostedService<UsenetFileToBlobstoreMigrationService>()
+                .AddHostedService<MultipartFileSizeRepairService>()
                 .AddHostedService<RemoveOrphanedFilesSchedulerService>()
                 .AddHostedService<ActiveReadsBroadcaster>()
                 .AddSingleton<WatchtowerStore>()

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Queue.FileProcessors;
@@ -91,8 +92,7 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             // Initialize dav-item fields
             var pathWithinArchive = archiveFile.Key;
             var fileParts = SortByPartNumber(archiveFile.Value);
-            var aesParams = fileParts.Select(x => x.AesParams).FirstOrDefault(x => x != null);
-            var fileSize = aesParams?.DecodedSize ?? fileParts.Sum(x => x.ByteRangeWithinPart.Count);
+            var (fileSize, aesParams) = ResolvePublishedSizeAndAes(fileParts);
             var parentDirectory = EnsureParentDirectory(pathWithinArchive);
             var name = SanitizeDavName(Path.GetFileName(pathWithinArchive));
 
@@ -259,13 +259,78 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
     internal static void ValidateVolumes(List<RarProcessor.StoredFileSegment> storedFileSegments)
     {
         if (storedFileSegments.Count == 0) return;
-        var distinctUncompressedSizes = storedFileSegments.Select(x => x.FileUncompressedSize).Distinct().ToList();
-        if (distinctUncompressedSizes.Count != 1)
+
+        var knownSizes = storedFileSegments
+            .Where(x => !x.IsUncompressedSizeUnknown)
+            .Select(x => x.FileUncompressedSize)
+            .Distinct()
+            .ToList();
+
+        if (knownSizes.Count > 1)
             throw new InvalidDataException("Inconsistent rar file size detected.");
-        var expected = distinctUncompressedSizes[0];
+
         var actual = storedFileSegments.Sum(x => x.ByteRangeWithinPart.Count);
-        if (Math.Abs(actual - expected) > 16)
-            throw new InvalidDataException("Missing rar volumes detected.");
+        if (knownSizes.Count == 1)
+        {
+            var expected = knownSizes[0];
+            if (Math.Abs(actual - expected) > 16)
+                throw new InvalidDataException("Missing rar volumes detected.");
+            return;
+        }
+
+        // All declarations unknown: stored unencrypted can use packed sum; encrypted cannot.
+        var isEncrypted = storedFileSegments.Any(x => x.AesParams is not null);
+        if (isEncrypted)
+        {
+            throw new UnsupportedRarUnknownSizeException(
+                "Encrypted RAR with unknown uncompressed size is not supported.");
+        }
+    }
+
+    internal static long ResolvePublishedFileSize(IReadOnlyList<RarProcessor.StoredFileSegment> fileParts)
+        => ResolvePublishedSizeAndAes(fileParts).FileSize;
+
+    internal static (long FileSize, AesParams? AesParams) ResolvePublishedSizeAndAes(
+        IReadOnlyList<RarProcessor.StoredFileSegment> fileParts)
+    {
+        if (fileParts.Count == 0)
+            throw new InvalidDataException("RAR archive has no file parts.");
+
+        var packedSum = fileParts.Sum(x => x.ByteRangeWithinPart.Count);
+        var knownSizes = fileParts
+            .Where(x => !x.IsUncompressedSizeUnknown
+                        && x.FileUncompressedSize > 0
+                        && x.FileUncompressedSize != long.MaxValue)
+            .Select(x => x.FileUncompressedSize)
+            .Distinct()
+            .ToList();
+
+        var aesParams = fileParts.Select(x => x.AesParams).FirstOrDefault(x => x != null);
+        if (aesParams is null)
+            return (knownSizes.Count == 1 ? knownSizes[0] : packedSum, null);
+
+        long decoded;
+        if (aesParams.DecodedSize > 0 && aesParams.DecodedSize != long.MaxValue)
+            decoded = aesParams.DecodedSize;
+        else if (knownSizes.Count == 1)
+            decoded = knownSizes[0];
+        else
+        {
+            throw new UnsupportedRarUnknownSizeException(
+                "Encrypted RAR with unknown uncompressed size is not supported.");
+        }
+
+        if (aesParams.DecodedSize != decoded)
+        {
+            aesParams = new AesParams
+            {
+                Key = aesParams.Key,
+                Iv = aesParams.Iv,
+                DecodedSize = decoded,
+            };
+        }
+
+        return (decoded, aesParams);
     }
 
     [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -107,8 +107,23 @@ public class LazyRarProcessor(
             return null;
         }
 
+        if (fileHeader.IsUncompressedSizeUnknown)
+        {
+            Log.Information(
+                "LazyRarProcessor: {File} has unknown uncompressed size, falling back to eager",
+                firstInfo.FileName);
+            return null;
+        }
+
         var aesParams = fileHeader.GetAesParams(password);
         var totalFileSize = aesParams?.DecodedSize ?? fileHeader.UncompressedSize;
+        if (totalFileSize <= 0)
+        {
+            Log.Information(
+                "LazyRarProcessor: {File} has non-positive size {Size}, falling back to eager",
+                firstInfo.FileName, totalFileSize);
+            return null;
+        }
 
         // Inner-file-vs-NZB-size sanity check (replaces the dropped
         // multi-file count check). Only compares when we have PAR2 sizes

--- a/backend/Queue/FileProcessors/RarProcessor.cs
+++ b/backend/Queue/FileProcessors/RarProcessor.cs
@@ -40,6 +40,7 @@ public class RarProcessor(
                     ),
                     AesParams = x.GetAesParams(password),
                     FileUncompressedSize = x.UncompressedSize,
+                    IsUncompressedSizeUnknown = x.IsUncompressedSizeUnknown,
                     ReleaseDate = fileInfo.ReleaseDate,
                 }).ToArray(),
         };
@@ -124,6 +125,8 @@ public class RarProcessor(
         public required AesParams? AesParams { get; init; }
 
         public required long FileUncompressedSize { get; init; }
+
+        public bool IsUncompressedSizeUnknown { get; init; }
     }
 
     public record PartNumber

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -225,7 +225,8 @@ public static class NestedRarExpansionStep
                     partNumber,
                     header.GetAesParams(password),
                     header.UncompressedSize,
-                    releaseDate);
+                    releaseDate,
+                    header.IsUncompressedSizeUnknown);
                 expanded.AddRange(mapped);
             }
 

--- a/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
@@ -18,7 +18,8 @@ public static class NestedRarRangeMapper
         RarProcessor.PartNumber partNumber,
         AesParams? aesParams,
         long fileUncompressedSize,
-        DateTimeOffset releaseDate)
+        DateTimeOffset releaseDate,
+        bool isUncompressedSizeUnknown = false)
     {
         if (sortedOuterSegments.Length == 0)
             return [];
@@ -73,6 +74,7 @@ public static class NestedRarRangeMapper
                     partCount),
                 AesParams = aesParams,
                 FileUncompressedSize = fileUncompressedSize,
+                IsUncompressedSizeUnknown = isUncompressedSizeUnknown,
             });
         }
 

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -29,6 +30,13 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
     // Test seam: when set, volume opens skip NzbFileStream/yEnc so unit tests
     // can feed a crafted RAR with an understated Length without rapidyenc.
     internal Func<string[], long, Stream>? VolumeStreamFactory { get; set; }
+
+    // Test seam for FileSize reconciliation after a lazy archive becomes complete.
+    internal Func<Guid, DavMultipartFile.Meta, CancellationToken, Task>? ReconcileFileSizeAsync
+    {
+        get;
+        set;
+    }
 
     private sealed class Persistor
     {
@@ -280,20 +288,18 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
                 PendingParts = newPending,
             };
 
+            var becameComplete = meta.IsLazy && newPending.Length == 0;
+
             mpf.Metadata = newMeta;
-            _ = SchedulePersistAsync(mpf);
+            _ = SchedulePersistAsync(mpf, becameComplete);
             return newMeta;
         }
     }
 
-    private static long SumResolvedBytes(DavMultipartFile.Meta meta)
-    {
-        var sum = 0L;
-        foreach (var p in meta.FileParts ?? []) sum += p.FilePartByteRange.Count;
-        return sum;
-    }
+    private static long SumResolvedBytes(DavMultipartFile.Meta meta) =>
+        MultipartFileSizeReconciler.SumResolvedBytes(meta);
 
-    private async Task SchedulePersistAsync(DavMultipartFile mpf)
+    private async Task SchedulePersistAsync(DavMultipartFile mpf, bool reconcileFileSize)
     {
         var p = _persistors.GetOrAdd(mpf.Id, _ => new Persistor());
         var myStamp = Interlocked.Increment(ref p.LatestStamp);
@@ -303,6 +309,12 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         {
             if (Volatile.Read(ref p.LatestStamp) != myStamp) return;
             await BlobStore.WriteBlob(mpf.Id, mpf).ConfigureAwait(false);
+
+            if (reconcileFileSize)
+            {
+                await ReconcileDavItemFileSizeAsync(mpf.Id, mpf.Metadata, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
         }
         catch (Exception e)
         {
@@ -313,6 +325,43 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         finally
         {
             p.Sem.Release();
+        }
+    }
+
+    private async Task ReconcileDavItemFileSizeAsync(
+        Guid fileBlobId,
+        DavMultipartFile.Meta meta,
+        CancellationToken ct)
+    {
+        var size = MultipartFileSizeReconciler.TryGetPublishedSize(meta);
+        if (size is null) return;
+
+        if (ReconcileFileSizeAsync is not null)
+        {
+            await ReconcileFileSizeAsync(fileBlobId, meta, ct).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            await using var ctx = new DavDatabaseContext();
+            var updated = await ctx.Items
+                .Where(i => i.FileBlobId == fileBlobId && i.FileSize != size.Value)
+                .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, size.Value), ct)
+                .ConfigureAwait(false);
+            if (updated > 0)
+            {
+                Log.Information(
+                    "Reconciled DavItem FileSize for multipart blob {BlobId} to {Size}",
+                    fileBlobId, size.Value);
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Warning(
+                "Failed to reconcile DavItem FileSize for multipart blob {BlobId} after resolve. Reason: {Reason}",
+                fileBlobId, e.Message);
+            Log.Debug(e, "Lazy RAR FileSize reconcile known failure stack");
         }
     }
 }

--- a/backend/Services/MultipartFileSizeReconciler.cs
+++ b/backend/Services/MultipartFileSizeReconciler.cs
@@ -1,0 +1,47 @@
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Computes the logical WebDAV/DB file size for a multipart archive.
+/// AES uses the finite decoded size; stored (non-AES) uses packed part ranges.
+/// </summary>
+public static class MultipartFileSizeReconciler
+{
+    /// <summary>
+    /// Returns the publishable size when it can be determined safely; otherwise null.
+    /// </summary>
+    public static long? TryGetPublishedSize(DavMultipartFile.Meta meta)
+    {
+        if (meta.IsLazy || (meta.PendingParts?.Length ?? 0) > 0)
+            return null;
+
+        var parts = meta.FileParts ?? [];
+        if (parts.Length == 0)
+            return null;
+
+        var packedSum = SumResolvedBytes(parts);
+        var decoded = meta.AesParams?.DecodedSize;
+        if (decoded is long d && d > 0 && d != long.MaxValue)
+            return d;
+
+        if (meta.AesParams is not null)
+        {
+            // Encrypted with unknown/sentinel decoded size — do not guess from ciphertext.
+            return null;
+        }
+
+        return packedSum;
+    }
+
+    public static long SumResolvedBytes(IEnumerable<DavMultipartFile.FilePart> parts)
+    {
+        var sum = 0L;
+        foreach (var p in parts)
+            sum += p.FilePartByteRange.Count;
+        return sum;
+    }
+
+    public static long SumResolvedBytes(DavMultipartFile.Meta meta) =>
+        SumResolvedBytes(meta.FileParts ?? []);
+}

--- a/backend/Services/MultipartFileSizeRepairService.cs
+++ b/backend/Services/MultipartFileSizeRepairService.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// One-shot startup repair for multipart DavItems that still advertise
+/// <see cref="long.MaxValue"/> as FileSize (issue #537).
+/// </summary>
+public class MultipartFileSizeRepairService : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await using var ctx = new DavDatabaseContext();
+            await RepairAsync(ctx, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // shutdown
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Unexpected error repairing multipart FileSize sentinels: {Message}", e.Message);
+        }
+    }
+
+    internal static async Task<(int Repaired, int SkippedLazy, int SkippedUnsafe, int Missing)> RepairAsync(
+        DavDatabaseContext ctx,
+        CancellationToken ct)
+    {
+        var dbClient = new DavDatabaseClient(ctx);
+
+        var broken = await ctx.Items
+            .AsNoTracking()
+            .Where(i =>
+                i.Type == DavItem.ItemType.UsenetFile
+                && i.SubType == DavItem.ItemSubType.MultipartFile
+                && i.FileSize == long.MaxValue)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (broken.Count == 0)
+        {
+            Log.Information("MultipartFileSizeRepair: no Int64.MaxValue FileSize rows found");
+            return (0, 0, 0, 0);
+        }
+
+        var repaired = 0;
+        var skippedLazy = 0;
+        var skippedUnsafe = 0;
+        var missing = 0;
+
+        foreach (var item in broken)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            DavMultipartFile? multipart;
+            try
+            {
+                multipart = await dbClient.GetDavMultipartFileAsync(item, ct).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                missing++;
+                Log.Warning(
+                    "MultipartFileSizeRepair: failed to load multipart for {ItemId} ({Path}). Reason: {Reason}",
+                    item.Id, item.Path, e.Message);
+                Log.Debug(e, "MultipartFileSizeRepair load failure stack");
+                continue;
+            }
+
+            if (multipart?.Metadata is null)
+            {
+                missing++;
+                Log.Warning(
+                    "MultipartFileSizeRepair: missing multipart blob for {ItemId} ({Path})",
+                    item.Id, item.Path);
+                continue;
+            }
+
+            var meta = multipart.Metadata;
+            if (meta.IsLazy || (meta.PendingParts?.Length ?? 0) > 0)
+            {
+                skippedLazy++;
+                continue;
+            }
+
+            var size = MultipartFileSizeReconciler.TryGetPublishedSize(meta);
+            if (size is null)
+            {
+                skippedUnsafe++;
+                Log.Warning(
+                    "MultipartFileSizeRepair: cannot safely repair encrypted/unknown size for {ItemId} ({Path})",
+                    item.Id, item.Path);
+                continue;
+            }
+
+            var updated = await ctx.Items
+                .Where(i => i.Id == item.Id && i.FileSize == long.MaxValue)
+                .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, size.Value), ct)
+                .ConfigureAwait(false);
+            if (updated > 0)
+                repaired++;
+        }
+
+        Log.Information(
+            "MultipartFileSizeRepair: repaired={Repaired} skippedLazy={SkippedLazy} " +
+            "skippedUnsafe={SkippedUnsafe} missing={Missing} candidates={Candidates}",
+            repaired, skippedLazy, skippedUnsafe, missing, broken.Count);
+
+        return (repaired, skippedLazy, skippedUnsafe, missing);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -16,6 +16,26 @@ namespace NzbWebDAV.Tests.Queue;
 public class LazyRarProcessorTests
 {
     [Fact]
+    public async Task ProcessAsync_UnknownUncompressedSize_ReturnsNull()
+    {
+        const int packed = 200;
+        var volumeBytes = BuildRar4SplitFirstVolume(
+            "movie.mkv", packed, unchecked((int)0xffffffff));
+        var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
+        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task ProcessAsync_SingleVolumeCannotCoverUncompressedSize_ReturnsNull()
     {
         const int packed = 200;

--- a/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
@@ -119,6 +119,66 @@ public class RarAggregatorTests
             () => RarAggregator.ValidateVolumes([segment]));
     }
 
+    [Fact]
+    public void ValidateVolumes_AllowsMixedUnknownAndKnownMatchingPackedSum()
+    {
+        var unknown = Segment(headerPart: 0, filenamePart: 1, start: 0, length: 40);
+        unknown = WithSize(unknown, fileUncompressedSize: long.MaxValue, unknown: true);
+        var known = Segment(headerPart: 1, filenamePart: 2, start: 40, length: 60);
+        known = WithSize(known, fileUncompressedSize: 100, unknown: false);
+
+        RarAggregator.ValidateVolumes([unknown, known]);
+        Assert.Equal(100, RarAggregator.ResolvePublishedFileSize([unknown, known]));
+    }
+
+    [Fact]
+    public void ResolvePublishedFileSize_AllUnknownUnencrypted_UsesPackedSum()
+    {
+        var a = WithSize(Segment(headerPart: 0, filenamePart: 1, start: 0, length: 40),
+            long.MaxValue, unknown: true);
+        var b = WithSize(Segment(headerPart: 1, filenamePart: 2, start: 40, length: 60),
+            long.MaxValue, unknown: true);
+
+        RarAggregator.ValidateVolumes([a, b]);
+        Assert.Equal(100, RarAggregator.ResolvePublishedFileSize([a, b]));
+    }
+
+    [Fact]
+    public void ResolvePublishedFileSize_AllUnknownEncrypted_Throws()
+    {
+        var aes = new AesParams { Key = new byte[16], Iv = new byte[16], DecodedSize = 0 };
+        var a = WithSize(Segment(headerPart: 0, filenamePart: 1, start: 0, length: 40),
+            long.MaxValue, unknown: true, aes);
+        var b = WithSize(Segment(headerPart: 1, filenamePart: 2, start: 40, length: 60),
+            long.MaxValue, unknown: true, aes);
+
+        Assert.Throws<NzbWebDAV.Exceptions.UnsupportedRarUnknownSizeException>(
+            () => RarAggregator.ValidateVolumes([a, b]));
+        Assert.Throws<NzbWebDAV.Exceptions.UnsupportedRarUnknownSizeException>(
+            () => RarAggregator.ResolvePublishedFileSize([a, b]));
+    }
+
+    private static RarProcessor.StoredFileSegment WithSize(
+        RarProcessor.StoredFileSegment segment,
+        long fileUncompressedSize,
+        bool unknown,
+        AesParams? aes = null)
+    {
+        return new RarProcessor.StoredFileSegment
+        {
+            NzbFile = segment.NzbFile,
+            PartSize = segment.PartSize,
+            ArchiveName = segment.ArchiveName,
+            PartNumber = segment.PartNumber,
+            ReleaseDate = segment.ReleaseDate,
+            PathWithinArchive = segment.PathWithinArchive,
+            ByteRangeWithinPart = segment.ByteRangeWithinPart,
+            AesParams = aes,
+            FileUncompressedSize = fileUncompressedSize,
+            IsUncompressedSizeUnknown = unknown,
+        };
+    }
+
     private static RarProcessor.StoredFileSegment Segment(
         int headerPart, int filenamePart, long start, long length)
         => SegmentNullable(headerPart, filenamePart, start, length);

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -3,14 +3,17 @@ using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Utils;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Services;
 
+[Collection(nameof(ConfigPathCollection))]
 public class LazyRarResolverTests
 {
     [Fact]
@@ -86,6 +89,82 @@ public class LazyRarResolverTests
         Assert.Equal(resolved.FilePartByteRange.StartInclusive + packedSize,
             resolved.SegmentIdByteRange.Count);
         Assert.Equal(0, client.MeasuredSizeRequests);
+    }
+
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_ReconcilesFileSizeAfterBlobPersist()
+    {
+        const string pathInArchive = "movie.mkv";
+        const int packedSize = 1000;
+        var volumeBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize);
+        const string segmentId = "vol2-seg0";
+        var client = new MeasuringNntpClient(segmentId, volumeBytes.Length);
+        Guid? reconciledBlobId = null;
+        long? reconciledSize = null;
+        var reconcileSawPersistedBlob = false;
+
+        var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        var configRoot = Path.Combine(Path.GetTempPath(), $"nzbdav-lazy-reconcile-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", configRoot);
+        try
+        {
+            var mpf = new DavMultipartFile
+            {
+                Id = Guid.NewGuid(),
+                Metadata = new DavMultipartFile.Meta
+                {
+                    IsLazy = true,
+                    PathInArchive = pathInArchive,
+                    FileParts =
+                    [
+                        new DavMultipartFile.FilePart
+                        {
+                            SegmentIds = ["vol1-seg0"],
+                            SegmentIdByteRange = LongRange.FromStartAndSize(0, 100),
+                            FilePartByteRange = LongRange.FromStartAndSize(10, 90),
+                        }
+                    ],
+                    PendingParts =
+                    [
+                        new DavMultipartFile.PendingPart
+                        {
+                            SegmentIds = [segmentId],
+                            SegmentIdByteRange = LongRange.FromStartAndSize(0, volumeBytes.Length),
+                            EstimatedDataSize = packedSize,
+                        }
+                    ],
+                }
+            };
+
+            var resolver = new LazyRarResolver(client, new ConfigManager())
+            {
+                VolumeStreamFactory = (_, size) => new BoundedLengthStream(volumeBytes, size),
+                ReconcileFileSizeAsync = (blobId, meta, _) =>
+                {
+                    reconcileSawPersistedBlob =
+                        BlobStore.ReadBlob<DavMultipartFile>(blobId) is not null;
+                    reconciledBlobId = blobId;
+                    reconciledSize = MultipartFileSizeReconciler.TryGetPublishedSize(meta);
+                    return Task.CompletedTask;
+                },
+            };
+
+            var meta = await resolver.EnsureResolvedThroughAsync(mpf, long.MaxValue, CancellationToken.None);
+            Assert.False(meta.IsLazy);
+
+            for (var i = 0; i < 100 && reconciledSize is null; i++)
+                await Task.Delay(20);
+
+            Assert.True(reconcileSawPersistedBlob);
+            Assert.Equal(mpf.Id, reconciledBlobId);
+            Assert.Equal(90 + packedSize, reconciledSize);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
+            try { Directory.Delete(configRoot, recursive: true); } catch { /* best effort */ }
+        }
     }
 
     // Minimal RAR4 multi-volume continuation: mark + archive(VOLUME) +

--- a/tests/NzbWebDAV.Tests/Services/MultipartFileSizeReconcilerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/MultipartFileSizeReconcilerTests.cs
@@ -1,0 +1,79 @@
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class MultipartFileSizeReconcilerTests
+{
+    [Fact]
+    public void TryGetPublishedSize_UnencryptedResolved_SumsPackedRanges()
+    {
+        var meta = new DavMultipartFile.Meta
+        {
+            IsLazy = false,
+            FileParts =
+            [
+                Part(40),
+                Part(60),
+            ],
+        };
+
+        Assert.Equal(100, MultipartFileSizeReconciler.TryGetPublishedSize(meta));
+    }
+
+    [Fact]
+    public void TryGetPublishedSize_FiniteAesDecodedSize_PreferredOverPackedSum()
+    {
+        var meta = new DavMultipartFile.Meta
+        {
+            IsLazy = false,
+            AesParams = new AesParams { Key = new byte[16], Iv = new byte[16], DecodedSize = 80 },
+            FileParts = [Part(96)],
+        };
+
+        Assert.Equal(80, MultipartFileSizeReconciler.TryGetPublishedSize(meta));
+    }
+
+    [Fact]
+    public void TryGetPublishedSize_AesSentinel_ReturnsNull()
+    {
+        var meta = new DavMultipartFile.Meta
+        {
+            IsLazy = false,
+            AesParams = new AesParams { Key = new byte[16], Iv = new byte[16], DecodedSize = long.MaxValue },
+            FileParts = [Part(96)],
+        };
+
+        Assert.Null(MultipartFileSizeReconciler.TryGetPublishedSize(meta));
+    }
+
+    [Fact]
+    public void TryGetPublishedSize_StillLazy_ReturnsNull()
+    {
+        var meta = new DavMultipartFile.Meta
+        {
+            IsLazy = true,
+            FileParts = [Part(40)],
+            PendingParts =
+            [
+                new DavMultipartFile.PendingPart
+                {
+                    SegmentIds = ["p"],
+                    SegmentIdByteRange = LongRange.FromStartAndSize(0, 10),
+                    EstimatedDataSize = 10,
+                }
+            ],
+        };
+
+        Assert.Null(MultipartFileSizeReconciler.TryGetPublishedSize(meta));
+    }
+
+    private static DavMultipartFile.FilePart Part(long count) => new()
+    {
+        SegmentIds = ["seg"],
+        SegmentIdByteRange = LongRange.FromStartAndSize(0, count),
+        FilePartByteRange = LongRange.FromStartAndSize(0, count),
+    };
+}

--- a/tests/NzbWebDAV.Tests/Services/MultipartFileSizeRepairServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/MultipartFileSizeRepairServiceTests.cs
@@ -1,0 +1,206 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class MultipartFileSizeRepairServiceTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-filesize-repair-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task RepairAsync_FixesFullyResolvedUnencryptedMaxValueRow()
+    {
+        var blobId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        await SeedMultipartAsync(
+            itemId,
+            blobId,
+            fileSize: long.MaxValue,
+            isLazy: false,
+            aes: null,
+            packedParts: [40, 60]);
+
+        var (repaired, skippedLazy, skippedUnsafe, missing) =
+            await MultipartFileSizeRepairService.RepairAsync(_context, CancellationToken.None);
+
+        Assert.Equal(1, repaired);
+        Assert.Equal(0, skippedLazy);
+        Assert.Equal(0, skippedUnsafe);
+        Assert.Equal(0, missing);
+
+        _context.ChangeTracker.Clear();
+        var item = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == itemId);
+        Assert.Equal(100, item.FileSize);
+    }
+
+    [Fact]
+    public async Task RepairAsync_IsIdempotent()
+    {
+        var blobId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        await SeedMultipartAsync(
+            itemId,
+            blobId,
+            fileSize: long.MaxValue,
+            isLazy: false,
+            aes: null,
+            packedParts: [25, 25]);
+
+        Assert.Equal(1, (await MultipartFileSizeRepairService.RepairAsync(_context, CancellationToken.None)).Repaired);
+        Assert.Equal(0, (await MultipartFileSizeRepairService.RepairAsync(_context, CancellationToken.None)).Repaired);
+    }
+
+    [Fact]
+    public async Task RepairAsync_SkipsStillLazyRows()
+    {
+        var blobId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        await SeedMultipartAsync(
+            itemId,
+            blobId,
+            fileSize: long.MaxValue,
+            isLazy: true,
+            aes: null,
+            packedParts: [40]);
+
+        var result = await MultipartFileSizeRepairService.RepairAsync(_context, CancellationToken.None);
+        Assert.Equal(0, result.Repaired);
+        Assert.Equal(1, result.SkippedLazy);
+
+        _context.ChangeTracker.Clear();
+        var item = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == itemId);
+        Assert.Equal(long.MaxValue, item.FileSize);
+    }
+
+    [Fact]
+    public async Task RepairAsync_SkipsAesSentinelWithoutGuessing()
+    {
+        var blobId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        await SeedMultipartAsync(
+            itemId,
+            blobId,
+            fileSize: long.MaxValue,
+            isLazy: false,
+            aes: new AesParams { Key = new byte[16], Iv = new byte[16], DecodedSize = long.MaxValue },
+            packedParts: [40, 60]);
+
+        var result = await MultipartFileSizeRepairService.RepairAsync(_context, CancellationToken.None);
+        Assert.Equal(0, result.Repaired);
+        Assert.Equal(1, result.SkippedUnsafe);
+
+        _context.ChangeTracker.Clear();
+        var item = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == itemId);
+        Assert.Equal(long.MaxValue, item.FileSize);
+    }
+
+    [Fact]
+    public async Task RepairAsync_UsesFiniteAesDecodedSize()
+    {
+        var blobId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        await SeedMultipartAsync(
+            itemId,
+            blobId,
+            fileSize: long.MaxValue,
+            isLazy: false,
+            aes: new AesParams { Key = new byte[16], Iv = new byte[16], DecodedSize = 80 },
+            packedParts: [96]); // ciphertext longer than plaintext
+
+        var result = await MultipartFileSizeRepairService.RepairAsync(_context, CancellationToken.None);
+        Assert.Equal(1, result.Repaired);
+
+        _context.ChangeTracker.Clear();
+        var item = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == itemId);
+        Assert.Equal(80, item.FileSize);
+    }
+
+    private async Task SeedMultipartAsync(
+        Guid itemId,
+        Guid blobId,
+        long fileSize,
+        bool isLazy,
+        AesParams? aes,
+        int[] packedParts)
+    {
+        var multipart = new DavMultipartFile
+        {
+            Id = blobId,
+            Metadata = new DavMultipartFile.Meta
+            {
+                AesParams = aes,
+                IsLazy = isLazy,
+                PathInArchive = "movie.mkv",
+                FileParts = packedParts.Select((count, i) => new DavMultipartFile.FilePart
+                {
+                    SegmentIds = [$"seg-{i}"],
+                    SegmentIdByteRange = LongRange.FromStartAndSize(0, count),
+                    FilePartByteRange = LongRange.FromStartAndSize(0, count),
+                }).ToArray(),
+                PendingParts = isLazy
+                    ?
+                    [
+                        new DavMultipartFile.PendingPart
+                        {
+                            SegmentIds = ["pending"],
+                            SegmentIdByteRange = LongRange.FromStartAndSize(0, 10),
+                            EstimatedDataSize = 10,
+                        }
+                    ]
+                    : [],
+            }
+        };
+        await BlobStore.WriteBlob(blobId, multipart);
+
+        _context.Items.Add(new DavItem
+        {
+            Id = itemId,
+            IdPrefix = itemId.ToString("N")[..5],
+            CreatedAt = DateTime.UtcNow,
+            Name = "movie.mkv",
+            FileSize = fileSize,
+            Type = DavItem.ItemType.UsenetFile,
+            SubType = DavItem.ItemSubType.MultipartFile,
+            Path = "/content/movie.mkv",
+            FileBlobId = blobId,
+        });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+    }
+}


### PR DESCRIPTION
## Summary
- Bump to `NzbDav.SharpCompress` 0.54.0 and honor `IsUncompressedSizeUnknown` so lazy RAR import falls back instead of persisting `long.MaxValue` as `DavItems.FileSize`.
- Eager aggregation derives a safe size from known headers / packed ranges; encrypted archives with no known size fail with a clear non-retryable error.
- After lazy multipart resolution finishes, persist the blob then reconcile `DavItem.FileSize`; a one-shot startup repair fixes existing MaxValue rows when metadata is fully resolved.

Fixes #537

## Test plan
- [x] Focused tests: `RarAggregatorTests`, `LazyRarProcessorTests`, `LazyRarResolverTests`, `MultipartFileSizeReconcilerTests`, `MultipartFileSizeRepairServiceTests`
- [ ] CI green
- [ ] After upgrade, confirm no `DavItems.FileSize = 9223372036854775807` rows remain for fully resolved unencrypted multiparts
- [ ] If Sonarr previously cached the sentinel size, rescan / refresh rclone dir cache after NzbDAV reports the corrected size