### PR TITLE
feat(ui): add 35 GB and 50 GB options to the Usenet speed test

### DIFF
--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1459,6 +1459,8 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                         <option value="5000">5 GB</option>
                         <option value="10000">10 GB</option>
                         <option value="20000">20 GB</option>
+                        <option value="35000">35 GB</option>
+                        <option value="50000">50 GB</option>
                     </Select>
                     <Button variant="primary" onClick={onRun} disabled={!canBenchmark || isBenchmarking}>
                         {isBenchmarking && <span className="loading loading-spinner loading-xs" />}


### PR DESCRIPTION
## Summary
- Adds 35 GB and 50 GB choices to the speed-test data budget dropdown so multi-gigabit lines can run larger sweeps.

## Test plan
- [ ] Open Settings → Usenet → provider speed test panel
- [ ] Confirm the data budget select lists 35 GB and 50 GB after 20 GB
- [ ] Selecting either value submits `data-budget-mb` as 35000 / 50000 (no backend validation errors)