### PR TITLE
feat(ui): show queue totals and selectable page sizes on the Queue page

### DIFF
--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -15,15 +15,31 @@ export type HistoryTableProps = {
     historySlots: PresentationHistorySlot[],
     totalHistoryCount: number,
     pageNumber: number,
+    pageSize: number,
+    pageSizeOptions: readonly number[],
     totalPages: number,
     isLive: boolean,
     onPageSelected: (page: number) => void,
+    onPageSizeSelected: (pageSize: number) => void,
     onIsSelectedChanged: (nzo_ids: Set<string>, isSelected: boolean) => void,
     onIsRemovingChanged: (nzo_ids: Set<string>, isRemoving: boolean) => void,
     onRemoved: (nzo_ids: Set<string>) => void,
 }
 
-export function HistoryTable({ historySlots, totalHistoryCount, pageNumber, totalPages, isLive, onPageSelected, onIsSelectedChanged, onIsRemovingChanged, onRemoved }: HistoryTableProps) {
+export function HistoryTable({
+    historySlots,
+    totalHistoryCount,
+    pageNumber,
+    pageSize,
+    pageSizeOptions,
+    totalPages,
+    isLive,
+    onPageSelected,
+    onPageSizeSelected,
+    onIsSelectedChanged,
+    onIsRemovingChanged,
+    onRemoved,
+}: HistoryTableProps) {
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
     const selectedCount = historySlots.filter(x => !!x.isSelected).length;
     const headerCheckboxState: TriCheckboxState = selectedCount === 0 ? 'none' : selectedCount === historySlots.length ? 'all' : 'some';
@@ -73,15 +89,26 @@ export function HistoryTable({ historySlots, totalHistoryCount, pageNumber, tota
         </div>
     );
 
-    const footer = totalPages > 1 ? (
+    const footer = totalHistoryCount > 0 ? (
         <div className="flex flex-col items-center gap-2 text-xs text-base-content/60">
             {!isLive && <span>Live updates pause on older pages. Go to page 1 for live.</span>}
-            <Pagination pageNumber={pageNumber} totalPages={totalPages} onPageSelected={onPageSelected} />
+            <Pagination
+                pageNumber={pageNumber}
+                totalPages={totalPages}
+                totalCount={totalHistoryCount}
+                pageSize={pageSize}
+                pageSizeOptions={pageSizeOptions}
+                onPageSelected={onPageSelected}
+                onPageSizeSelected={onPageSizeSelected}
+            />
         </div>
     ) : undefined;
 
     return (
-        <PageSection title={sectionTitle}>
+        <PageSection
+            title={sectionTitle}
+            badgeText={totalHistoryCount > 0 ? String(totalHistoryCount) : undefined}
+        >
             <PageTable headerCheckboxState={headerCheckboxState} onHeaderCheckboxChange={onSelectAll} footer={footer} showCompleted>
                 {historySlots.map(slot =>
                     <HistoryRow

--- a/frontend/app/routes/queue/components/page-section/page-section.tsx
+++ b/frontend/app/routes/queue/components/page-section/page-section.tsx
@@ -16,7 +16,7 @@ export function PageSection({ title, subTitle, badgeText, children }: PageTableP
                     <div className="mb-2.5 flex flex-wrap items-center justify-between gap-4">
                         {title}
                         {badgeText &&
-                            <Badge className="badge-outline text-base-content/60 text-xs font-medium">
+                            <Badge className="badge-ghost badge-sm font-mono tabular-nums">
                                 {badgeText}
                             </Badge>
                         }

--- a/frontend/app/routes/queue/components/pagination/pagination.tsx
+++ b/frontend/app/routes/queue/components/pagination/pagination.tsx
@@ -5,10 +5,22 @@ import { Icon } from "~/components/ui";
 export type PaginationProps = {
     pageNumber: number,
     totalPages: number,
+    totalCount: number,
+    pageSize: number,
+    pageSizeOptions: readonly number[],
     onPageSelected?: (page: number) => void,
+    onPageSizeSelected?: (pageSize: number) => void,
 }
 
-export const Pagination = memo(({ pageNumber, totalPages, onPageSelected }: PaginationProps) => {
+export const Pagination = memo(({
+    pageNumber,
+    totalPages,
+    totalCount,
+    pageSize,
+    pageSizeOptions,
+    onPageSelected,
+    onPageSizeSelected,
+}: PaginationProps) => {
     const handlePageClick = (page: number) => {
         if (onPageSelected && page !== pageNumber && page >= 1 && page <= totalPages) {
             onPageSelected(page);
@@ -22,38 +34,74 @@ export const Pagination = memo(({ pageNumber, totalPages, onPageSelected }: Pagi
         }
     };
 
+    const handlePageSizeChange = (value: string) => {
+        const size = parseInt(value, 10);
+        if (onPageSizeSelected && !isNaN(size) && size !== pageSize) {
+            onPageSizeSelected(size);
+        }
+    };
+
+    const start = totalCount === 0 ? 0 : (pageNumber - 1) * pageSize + 1;
+    const end = Math.min(pageNumber * pageSize, totalCount);
     const pageOptions = Array.from({ length: totalPages }, (_, i) => String(i + 1));
+    const sizeOptions = pageSizeOptions.map(String);
 
     return (
-        <div className="join join-horizontal flex flex-wrap items-center justify-center">
-            <button
-                type="button"
-                className="btn btn-ghost btn-xs join-item"
-                disabled={pageNumber <= 1}
-                onClick={() => handlePageClick(pageNumber - 1)}
-            >
-                <Icon name="chevron_left" className="!text-[16px]" /> Prev
-            </button>
-
-            <div className="join-item flex items-center gap-2 border-x border-base-content/10 px-3 text-xs font-medium text-base-content/60">
-                <span>Page</span>
-                <SimpleDropdown
-                    type="bordered"
-                    options={pageOptions}
-                    value={String(pageNumber)}
-                    onChange={handleDropdownChange}
-                />
-                <span>of {totalPages}</span>
+        <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center justify-center gap-3 text-xs text-base-content/60 sm:justify-start">
+                <span>
+                    Showing{" "}
+                    <span className="font-mono tabular-nums">{start}</span>
+                    –
+                    <span className="font-mono tabular-nums">{end}</span>
+                    {" "}of{" "}
+                    <span className="font-mono tabular-nums">{totalCount}</span>
+                </span>
+                <label className="flex items-center gap-2">
+                    <span>Per page</span>
+                    <SimpleDropdown
+                        type="bordered"
+                        options={sizeOptions}
+                        value={String(pageSize)}
+                        onChange={handlePageSizeChange}
+                        ariaLabel="Items per page"
+                    />
+                </label>
             </div>
 
-            <button
-                type="button"
-                className="btn btn-ghost btn-xs join-item"
-                disabled={pageNumber >= totalPages}
-                onClick={() => handlePageClick(pageNumber + 1)}
-            >
-                Next <Icon name="chevron_right" className="!text-[16px]" />
-            </button>
+            {totalPages > 1 && (
+                <div className="join join-horizontal flex flex-wrap items-center justify-center">
+                    <button
+                        type="button"
+                        className="btn btn-ghost btn-xs join-item"
+                        disabled={pageNumber <= 1}
+                        onClick={() => handlePageClick(pageNumber - 1)}
+                    >
+                        <Icon name="chevron_left" className="!text-[16px]" /> Prev
+                    </button>
+
+                    <div className="join-item flex items-center gap-2 border-x border-base-content/10 px-3 text-xs font-medium text-base-content/60">
+                        <span>Page</span>
+                        <SimpleDropdown
+                            type="bordered"
+                            options={pageOptions}
+                            value={String(pageNumber)}
+                            onChange={handleDropdownChange}
+                            ariaLabel="Page number"
+                        />
+                        <span>of {totalPages}</span>
+                    </div>
+
+                    <button
+                        type="button"
+                        className="btn btn-ghost btn-xs join-item"
+                        disabled={pageNumber >= totalPages}
+                        onClick={() => handlePageClick(pageNumber + 1)}
+                    >
+                        Next <Icon name="chevron_right" className="!text-[16px]" />
+                    </button>
+                </div>
+            )}
         </div>
     );
 });

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -14,9 +14,12 @@ export type QueueTableProps = {
     queueSlots: PresentationQueueSlot[],
     totalQueueCount: number,
     pageNumber: number,
+    pageSize: number,
+    pageSizeOptions: readonly number[],
     totalPages: number,
     isLive: boolean,
     onPageSelected: (page: number) => void,
+    onPageSizeSelected: (pageSize: number) => void,
     categories: string[],
     manualCategoryRef: React.RefObject<string>,
     onIsSelectedChanged: (nzo_ids: Set<string>, isSelected: boolean) => void,
@@ -49,9 +52,12 @@ export function QueueTable({
     queueSlots,
     totalQueueCount,
     pageNumber,
+    pageSize,
+    pageSizeOptions,
     totalPages,
     isLive,
     onPageSelected,
+    onPageSizeSelected,
     categories,
     manualCategoryRef,
     onIsSelectedChanged,
@@ -171,15 +177,27 @@ export function QueueTable({
         </div>
     );
 
-    const footer = totalPages > 1 ? (
+    const footer = totalQueueCount > 0 ? (
         <div className="flex flex-col items-center gap-2 text-xs text-base-content/60">
             {!isLive && <span>Live updates pause on older pages. Go to page 1 for live.</span>}
-            <Pagination pageNumber={pageNumber} totalPages={totalPages} onPageSelected={onPageSelected} />
+            <Pagination
+                pageNumber={pageNumber}
+                totalPages={totalPages}
+                totalCount={totalQueueCount}
+                pageSize={pageSize}
+                pageSizeOptions={pageSizeOptions}
+                onPageSelected={onPageSelected}
+                onPageSizeSelected={onPageSizeSelected}
+            />
         </div>
     ) : undefined;
 
     return (
-        <PageSection title={sectionTitle} subTitle={sectionSubTitle}>
+        <PageSection
+            title={sectionTitle}
+            subTitle={sectionSubTitle}
+            badgeText={totalQueueCount > 0 ? String(totalQueueCount) : undefined}
+        >
             {queueSlots?.length == 0 ? (
                 <EmptyQueue onUploadClicked={onUploadClicked} />
             ) : (

--- a/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.tsx
+++ b/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.tsx
@@ -7,9 +7,10 @@ export type SimpleDropdownProps = {
     value?: string,
     onChange?: (value: string) => void,
     valueRef?: RefObject<string>,
+    ariaLabel?: string,
 }
 
-export const SimpleDropdown = memo(({ type, options, value, onChange, valueRef }: SimpleDropdownProps) => {
+export const SimpleDropdown = memo(({ type, options, value, onChange, valueRef, ariaLabel }: SimpleDropdownProps) => {
     if (!valueRef && (!value || !onChange)) {
         throw new Error("SimpleDropdown requires either the valueRef prop or both the value and onChange props.")
     }
@@ -28,7 +29,7 @@ export const SimpleDropdown = memo(({ type, options, value, onChange, valueRef }
 
     return (
         <Select
-            aria-label="Select option"
+            aria-label={ariaLabel ?? "Select option"}
             className={`select-xs w-auto min-w-20 ${type === "bordered" ? "" : "select-ghost"}`.trim()}
             value={renderedValue}
             onChange={handleNativeChange}

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -10,19 +10,27 @@ import { initializeUploadController } from "./controllers/nzb-upload-controller"
 import { useQueueDropzone } from "./controllers/dropzone-controller";
 import { Alert } from "~/components/ui";
 
-const pageSize = 100;
+export const PAGE_SIZE_OPTIONS = [25, 50, 100, 250] as const;
+const DEFAULT_PAGE_SIZE = 100;
 
 function parsePage(value: string | null): number {
     const page = parseInt(value ?? "1", 10);
     return Number.isFinite(page) && page > 0 ? page : 1;
 }
 
+function parsePageSize(value: string | null): number {
+    const size = parseInt(value ?? String(DEFAULT_PAGE_SIZE), 10);
+    return (PAGE_SIZE_OPTIONS as readonly number[]).includes(size) ? size : DEFAULT_PAGE_SIZE;
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
     const url = new URL(request.url);
     const queuePage = parsePage(url.searchParams.get("qp"));
     const historyPage = parsePage(url.searchParams.get("hp"));
-    const queuePromise = backendClient.getQueue(pageSize, (queuePage - 1) * pageSize);
-    const historyPromise = backendClient.getHistory(pageSize, (historyPage - 1) * pageSize);
+    const queuePageSize = parsePageSize(url.searchParams.get("qps"));
+    const historyPageSize = parsePageSize(url.searchParams.get("hps"));
+    const queuePromise = backendClient.getQueue(queuePageSize, (queuePage - 1) * queuePageSize);
+    const historyPromise = backendClient.getHistory(historyPageSize, (historyPage - 1) * historyPageSize);
     const configPromise = backendClient.getConfig(["api.categories", "api.manual-category"])
     const queue = await queuePromise;
     const history = await historyPromise;
@@ -47,12 +55,13 @@ export async function loader({ request }: Route.LoaderArgs) {
         manualCategory: manualCategory,
         queuePage: queuePage,
         historyPage: historyPage,
-        pageSize: pageSize,
+        queuePageSize,
+        historyPageSize,
     }
 }
 
 export default function Queue(props: Route.ComponentProps) {
-    const { pageSize, queuePage, historyPage, totalQueueCount, totalHistoryCount } = props.loaderData;
+    const { queuePageSize, historyPageSize, queuePage, historyPage, totalQueueCount, totalHistoryCount } = props.loaderData;
     const [queueSlots, setQueueSlots] = useState<PresentationQueueSlot[]>(props.loaderData.queueSlots);
     const [historySlots, setHistorySlots] = useState<PresentationHistorySlot[]>(props.loaderData.historySlots);
     const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
@@ -64,8 +73,8 @@ export default function Queue(props: Route.ComponentProps) {
     useEffect(() => { setQueueSlots(props.loaderData.queueSlots); }, [props.loaderData.queueSlots]);
     useEffect(() => { setHistorySlots(props.loaderData.historySlots); }, [props.loaderData.historySlots]);
 
-    const queueTotalPages = Math.max(1, Math.ceil(totalQueueCount / pageSize));
-    const historyTotalPages = Math.max(1, Math.ceil(totalHistoryCount / pageSize));
+    const queueTotalPages = Math.max(1, Math.ceil(totalQueueCount / queuePageSize));
+    const historyTotalPages = Math.max(1, Math.ceil(totalHistoryCount / historyPageSize));
     const isQueueLive = queuePage === 1;
     const isHistoryLive = historyPage === 1;
 
@@ -79,13 +88,30 @@ export default function Queue(props: Route.ComponentProps) {
     const onQueuePageSelected = useCallback((page: number) => setPageParam("qp", page), [setPageParam]);
     const onHistoryPageSelected = useCallback((page: number) => setPageParam("hp", page), [setPageParam]);
 
+    const setPageSizeParam = useCallback((sizeKey: string, pageKey: string, size: number) => {
+        setSearchParams(prev => {
+            const next = new URLSearchParams(prev);
+            next.set(sizeKey, String(size));
+            next.set(pageKey, "1");
+            return next;
+        }, { preventScrollReset: true });
+    }, [setSearchParams]);
+    const onQueuePageSizeSelected = useCallback(
+        (size: number) => setPageSizeParam("qps", "qp", size),
+        [setPageSizeParam],
+    );
+    const onHistoryPageSizeSelected = useCallback(
+        (size: number) => setPageSizeParam("hps", "hp", size),
+        [setPageSizeParam],
+    );
+
     const combinedQueueSlots = isQueueLive
         ? [...uploadingFiles.map(file => file.queueSlot), ...queueSlots]
         : queueSlots;
 
     // queue/history events
-    const queueEvents = useQueueEvents(setUploadingFiles, setQueueSlots, uploadQueueRef, pageSize, isQueueLive);
-    const historyEvents = useHistoryEvents(setHistorySlots, pageSize);
+    const queueEvents = useQueueEvents(setUploadingFiles, setQueueSlots, uploadQueueRef, queuePageSize, isQueueLive);
+    const historyEvents = useHistoryEvents(setHistorySlots, historyPageSize);
 
     // websocket
     initializeQueueHistoryWebsocket(queueEvents, historyEvents, isQueueLive, isHistoryLive);
@@ -113,9 +139,12 @@ export default function Queue(props: Route.ComponentProps) {
                         queueSlots={combinedQueueSlots}
                         totalQueueCount={props.loaderData.totalQueueCount + uploadingFiles.length}
                         pageNumber={queuePage}
+                        pageSize={queuePageSize}
+                        pageSizeOptions={PAGE_SIZE_OPTIONS}
                         totalPages={queueTotalPages}
                         isLive={isQueueLive}
                         onPageSelected={onQueuePageSelected}
+                        onPageSizeSelected={onQueuePageSizeSelected}
                         categories={props.loaderData.categories}
                         manualCategoryRef={manualCategoryRef}
                         onIsSelectedChanged={queueEvents.onSelectQueueSlots}
@@ -133,9 +162,12 @@ export default function Queue(props: Route.ComponentProps) {
                     historySlots={historySlots}
                     totalHistoryCount={props.loaderData.totalHistoryCount}
                     pageNumber={historyPage}
+                    pageSize={historyPageSize}
+                    pageSizeOptions={PAGE_SIZE_OPTIONS}
                     totalPages={historyTotalPages}
                     isLive={isHistoryLive}
                     onPageSelected={onHistoryPageSelected}
+                    onPageSizeSelected={onHistoryPageSizeSelected}
                     onIsSelectedChanged={historyEvents.onSelectHistorySlots}
                     onIsRemovingChanged={historyEvents.onRemovingHistorySlots}
                     onRemoved={historyEvents.onRemoveHistorySlots}


### PR DESCRIPTION
## Summary
- Show total item counts as badges on Queue and History sections
- Display `Showing X–Y of Z` with selectable page sizes (25 / 50 / 100 / 250)
- Persist page size in URL params (`qps` / `hps`) alongside existing page params; changing size resets to page 1

Closes #494

## Test plan
- [ ] Open Queue with a small queue — badge and “Showing 1–N of N” appear; Per page selector works
- [ ] With >100 items (or lower page size), paginate and confirm range text / page nav
- [ ] Change page size (e.g. 25 → 250) — resets to page 1; URL has `qps`/`hps`
- [ ] Confirm History gets the same UX when history is non-empty
- [ ] Page 1 live updates still work after changing page size
- [ ] Empty queue still shows EmptyQueue without misleading “Showing 0–0”