### PR TITLE
fix(usenet): stop dumping stacks for known yEnc CRC mismatches

### DIFF
--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -106,26 +106,29 @@ public class QueueItemProcessor(
             try
             {
                 var attempt = retryAttempts.AddOrUpdate(queueItem.Id, 1, (_, prev) => prev + 1);
+                e.TryGetKnownErrorMessage(out var reason);
                 if (attempt > MaxProviderRetryAttempts)
                 {
                     Log.Error(
-                        e,
-                        "Giving up on queue item {JobName} after {Attempts} provider-connection failures",
+                        "Giving up on queue item {JobName} after {Attempts} provider-connection failures. Reason: {Reason}",
                         queueItem.JobName,
-                        attempt - 1);
+                        attempt - 1,
+                        reason);
+                    Log.Debug(e, "Queue item give-up stack for {JobName}", queueItem.JobName);
                     await MarkQueueItemCompleted(startTime, error: e.Message).ConfigureAwait(false);
                     return;
                 }
 
                 var backoff = GetProviderRetryBackoff(attempt);
                 Log.Warning(
-                    e,
                     "Provider connection issue for queue item {JobName} (attempt {Attempt}/{MaxAttempts}); " +
-                    "retrying in {BackoffSeconds:0} seconds",
+                    "retrying in {BackoffSeconds:0} seconds. Reason: {Reason}",
                     queueItem.JobName,
                     attempt,
                     MaxProviderRetryAttempts,
-                    backoff.TotalSeconds);
+                    backoff.TotalSeconds,
+                    reason);
+                Log.Debug(e, "Queue item retry stack for {JobName}", queueItem.JobName);
                 dbClient.Ctx.ClearChangeTracker();
                 queueItem.PauseUntil = DateTime.Now + backoff;
                 dbClient.Ctx.QueueItems.Attach(queueItem);

--- a/backend/Streams/CorruptionDetectingYencStream.cs
+++ b/backend/Streams/CorruptionDetectingYencStream.cs
@@ -47,8 +47,13 @@ public sealed class CorruptionDetectingYencStream(
         if (Interlocked.Exchange(ref _reported, 1) == 0)
         {
             Log.Warning(
+                "Provider {Provider} returned corrupt yEnc data for segment {SegmentId}. Reason: {Reason}",
+                providerKey,
+                segmentId,
+                exception.Message);
+            Log.Debug(
                 exception,
-                "Provider {Provider} returned corrupt yEnc data for segment {SegmentId}",
+                "Corrupt yEnc data stack for provider {Provider} segment {SegmentId}",
                 providerKey,
                 segmentId);
         }

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -57,6 +57,19 @@ public class ExceptionExtensionsTests
     }
 
     [Fact]
+    public void TryGetKnownErrorMessage_RecognizesCorruptArticle()
+    {
+        var ex = new UsenetCorruptArticleException(
+            "segment@example",
+            "provider-a",
+            new InvalidDataException("The decoded yEnc CRC32 was d58e29bc, but the trailer expected df0ce5f8."));
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Contains("corrupt yEnc", reason);
+        Assert.True(ex.IsRetryableDownloadException());
+    }
+
+    [Fact]
     public void TryGetKnownErrorMessage_RecognizesArticleNotFound()
     {
         var ex = new UsenetArticleNotFoundException("<missing@example>");


### PR DESCRIPTION
## Summary
- Log corrupt yEnc CRC mismatches from `CorruptionDetectingYencStream` as a human-friendly Warning with provider/segment/`Reason`, and keep the stack at Debug.
- Do the same for queue retryable give-up/retry logs in `QueueItemProcessor`.
- Add a known-error classification test for `UsenetCorruptArticleException`.

Closes #541

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~CorruptionDetectionTests|FullyQualifiedName~ExceptionExtensionsTests"`
- [ ] Confirm a CRC mismatch in logs shows Warning without a stack at default log level
- [ ] Confirm Debug log level still includes the stack for maintainers