### PR TITLE
fix(webdav): prevent multipart playback failures from understated volume sizes

### DIFF
--- a/backend/Database/Models/DavRarFile.cs
+++ b/backend/Database/Models/DavRarFile.cs
@@ -45,7 +45,9 @@ public partial class DavRarFile
             FileParts = RarParts.Select(x => new DavMultipartFile.FilePart()
             {
                 SegmentIds = x.SegmentIds,
-                SegmentIdByteRange = LongRange.FromStartAndSize(0, x.PartSize),
+                SegmentIdByteRange = LongRange.FromStartAndSize(
+                    0,
+                    Math.Max(x.PartSize, checked(x.Offset + x.ByteCount))),
                 FilePartByteRange = LongRange.FromStartAndSize(x.Offset, x.ByteCount),
                 SegmentByteRanges = x.SegmentByteRanges,
                 SegmentFallbackIds = x.SegmentFallbackIds,

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -149,7 +149,9 @@ public class LazyRarProcessor(
         var firstPart = new DavMultipartFile.FilePart
         {
             SegmentIds = firstInfo.NzbFile.GetSegmentIds(),
-            SegmentIdByteRange = LongRange.FromStartAndSize(0, firstFileSize),
+            SegmentIdByteRange = LongRange.FromStartAndSize(
+                0,
+                Math.Max(firstFileSize, firstPartByteRange.EndExclusive)),
             FilePartByteRange = firstPartByteRange,
             SegmentFallbackIds = firstInfo.NzbFile.GetSegmentFallbackIds(),
         };

--- a/backend/Queue/FileProcessors/RarProcessor.cs
+++ b/backend/Queue/FileProcessors/RarProcessor.cs
@@ -30,7 +30,10 @@ public class RarProcessor(
                 .Select(x => new StoredFileSegment()
                 {
                     NzbFile = fileInfo.NzbFile,
-                    PartSize = stream.Length,
+                    PartSize = ResolvePartSize(
+                        stream.Length,
+                        x.DataStartPosition,
+                        x.AdditionalDataSize),
                     ArchiveName = archiveName,
                     PartNumber = partNumber,
                     PathWithinArchive = x.FileName,
@@ -45,6 +48,9 @@ public class RarProcessor(
                 }).ToArray(),
         };
     }
+
+    internal static long ResolvePartSize(long declaredSize, long dataStart, long dataSize) =>
+        Math.Max(declaredSize, checked(dataStart + dataSize));
 
     private string GetArchiveName()
     {

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -236,9 +236,30 @@ public class DavMultipartFileStream : Stream
 
     private Stream OpenPart(DavMultipartFile.FilePart part, long extraOffset)
     {
+        if (part.SegmentIdByteRange.StartInclusive != 0 ||
+            part.SegmentIdByteRange.Count < 0 ||
+            part.FilePartByteRange.StartInclusive < 0 ||
+            part.FilePartByteRange.Count < 0 ||
+            extraOffset < 0 ||
+            extraOffset > part.FilePartByteRange.Count)
+        {
+            throw new SeekPositionNotFoundException(
+                $"Corrupt file. Invalid multipart ranges while reading {_fileName ?? "unknown"}.");
+        }
+
+        var effectivePartLength = GetEffectivePartLength(part);
+        if (effectivePartLength > part.SegmentIdByteRange.Count)
+        {
+            Log.Debug(
+                "Multipart volume length {DeclaredLength} was too small for packed range ending at {RequiredLength} while reading {FileName}; using packed range as the length.",
+                part.SegmentIdByteRange.Count,
+                effectivePartLength,
+                _fileName ?? "unknown");
+        }
+
         var stream = _usenetClient.GetFileStream(
             part.SegmentIds,
-            part.SegmentIdByteRange.Count,
+            effectivePartLength,
             _articleBufferSize,
             part.SegmentByteRanges,
             _usePipelinedBodyRequests,
@@ -250,6 +271,9 @@ public class DavMultipartFileStream : Stream
                      ?? $"range:{part.FilePartByteRange.StartInclusive}-{part.FilePartByteRange.EndExclusive}";
         return new PaddedLengthStream(stream, expectedLength, partId, _fileName);
     }
+
+    internal static long GetEffectivePartLength(DavMultipartFile.FilePart part) =>
+        Math.Max(part.SegmentIdByteRange.Count, part.FilePartByteRange.EndExclusive);
 
     private async Task<Stream> ResolveAndOpenAsync(int targetIndex, CancellationToken ct)
     {

--- a/tests/NzbWebDAV.Tests/Database/DavRarFileTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavRarFileTests.cs
@@ -1,0 +1,29 @@
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+public class DavRarFileTests
+{
+    [Fact]
+    public void ToDavMultipartFileMeta_HealsUnderestimatedLegacyPartSize()
+    {
+        var legacy = new DavRarFile
+        {
+            RarParts =
+            [
+                new DavRarFile.RarPart
+                {
+                    SegmentIds = ["segment"],
+                    PartSize = 100,
+                    Offset = 20,
+                    ByteCount = 100,
+                }
+            ],
+        };
+
+        var part = Assert.Single(legacy.ToDavMultipartFileMeta().FileParts);
+
+        Assert.True(part.SegmentIdByteRange.Contains(part.FilePartByteRange));
+        Assert.Equal(120, part.SegmentIdByteRange.Count);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -2,13 +2,15 @@ using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Fakes;
 
 internal sealed class FakeNntpClient(
-    IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    IReadOnlyDictionary<string, byte[]> segments,
+    bool useCachedYencStreams = false) : NntpClient
 {
     public int BatchRequestCount { get; private set; }
     public int BodyRequestCount { get; private set; }
@@ -133,12 +135,26 @@ internal sealed class FakeNntpClient(
         if (!segments.TryGetValue(key, out var bytes))
             throw new UsenetArticleNotFoundException(key, "430 No such article");
 
+        YencStream stream = useCachedYencStreams
+            ? new CachedYencStream(
+                new UsenetYencHeader
+                {
+                    FileName = "fake.bin",
+                    FileSize = bytes.Length,
+                    LineLength = 128,
+                    PartNumber = 1,
+                    TotalParts = 1,
+                    PartOffset = 0,
+                    PartSize = bytes.Length,
+                },
+                new MemoryStream(bytes, writable: false))
+            : new YencStream(new MemoryStream(EncodeYenc(bytes), writable: false));
         return new UsenetDecodedBodyResponse
         {
             SegmentId = key,
             ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
             ResponseMessage = "222 fake body",
-            Stream = new YencStream(new MemoryStream(EncodeYenc(bytes), writable: false))
+            Stream = stream,
         };
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -102,6 +102,34 @@ public class LazyRarProcessorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_UnderestimatedFirstVolumeSize_ContainsPackedRange()
+    {
+        const int packed = 1_000;
+        const int uncompressed = 3_000;
+        var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var underestimatedSize = volumeBytes.Length - 100;
+        var first = FileInfoFor(
+            "vol.rar",
+            "first@example.com",
+            volumeBytes.Length,
+            underestimatedSize);
+        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync() as LazyRarProcessor.Result;
+
+        Assert.NotNull(result);
+        Assert.True(result.FirstPart.SegmentIdByteRange.Contains(result.FirstPart.FilePartByteRange));
+        Assert.Equal(result.FirstPart.FilePartByteRange.EndExclusive, result.FirstPart.SegmentIdByteRange.Count);
+        Assert.True(result.FirstPart.SegmentIdByteRange.Count > underestimatedSize);
+    }
+
+    [Fact]
     public async Task BuildRar4SplitFirstVolume_IsFirstVolumeStoredSplit()
     {
         var bytes = BuildRar4SplitFirstVolume("movie.mkv", packedSize: 100, uncompressedSize: 500);

--- a/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
@@ -8,6 +8,15 @@ namespace NzbWebDAV.Tests.Queue;
 public class RarAggregatorTests
 {
     [Fact]
+    public void ResolvePartSize_ExpandsUnderestimatedSizeToPackedRangeEnd()
+    {
+        Assert.Equal(120, RarProcessor.ResolvePartSize(
+            declaredSize: 100,
+            dataStart: 20,
+            dataSize: 100));
+    }
+
+    [Fact]
     public void SortByPartNumber_NormalizesFilenameNumbersAgainstHeaders()
     {
         var second = Segment(headerPart: 1, filenamePart: 2, start: 5, length: 5);

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -1,0 +1,88 @@
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class DavMultipartFileStreamTests
+{
+    [Fact]
+    public void GetEffectivePartLength_UsesPackedRangeEndForUnderestimatedVolume()
+    {
+        var part = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(0, 8),
+            fileRange: LongRange.FromStartAndSize(4, 12))
+            .Metadata.FileParts[0];
+
+        Assert.Equal(16, DavMultipartFileStream.GetEffectivePartLength(part));
+    }
+
+    [SkippableFact]
+    public async Task ReadAsync_HealsUnderestimatedVolumeLength()
+    {
+        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
+
+        var volumeBytes = Enumerable.Range(0, 16).Select(x => (byte)x).ToArray();
+        using var client = new FakeNntpClient(new Dictionary<string, byte[]>
+        {
+            ["segment"] = volumeBytes,
+        });
+        var multipart = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(0, 8),
+            fileRange: LongRange.FromStartAndSize(4, 12));
+        await using var stream = new DavMultipartFileStream(
+            multipart,
+            client,
+            articleBufferSize: 0,
+            resolver: null,
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv");
+
+        var buffer = new byte[12];
+        var bytesRead = await stream.ReadAsync(buffer);
+
+        Assert.Equal(buffer.Length, bytesRead);
+        Assert.Equal(volumeBytes[4..], buffer);
+    }
+
+    [Fact]
+    public async Task ReadAsync_InvalidSegmentRangeThrowsKnownSeekError()
+    {
+        using var client = new FakeNntpClient(new Dictionary<string, byte[]>());
+        var multipart = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(1, 8),
+            fileRange: LongRange.FromStartAndSize(4, 4));
+        await using var stream = new DavMultipartFileStream(
+            multipart,
+            client,
+            articleBufferSize: 0,
+            resolver: null,
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv");
+
+        await Assert.ThrowsAsync<SeekPositionNotFoundException>(
+            () => stream.ReadAsync(new byte[1], 0, 1));
+    }
+
+    private static DavMultipartFile MultipartFile(LongRange segmentRange, LongRange fileRange) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Metadata = new DavMultipartFile.Meta
+            {
+                FileParts =
+                [
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = ["segment"],
+                        SegmentIdByteRange = segmentRange,
+                        FilePartByteRange = fileRange,
+                    }
+                ],
+            },
+        };
+}

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -3,8 +3,6 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
-using NzbWebDAV.Tests.TestUtils;
-using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Streams;
 
@@ -21,16 +19,14 @@ public class DavMultipartFileStreamTests
         Assert.Equal(16, DavMultipartFileStream.GetEffectivePartLength(part));
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ReadAsync_HealsUnderestimatedVolumeLength()
     {
-        Skip.IfNot(RapidYenc.IsAvailable, "rapidyenc native library not available on this platform");
-
         var volumeBytes = Enumerable.Range(0, 16).Select(x => (byte)x).ToArray();
         using var client = new FakeNntpClient(new Dictionary<string, byte[]>
         {
             ["segment"] = volumeBytes,
-        });
+        }, useCachedYencStreams: true);
         var multipart = MultipartFile(
             segmentRange: LongRange.FromStartAndSize(0, 8),
             fileRange: LongRange.FromStartAndSize(4, 12));


### PR DESCRIPTION
## Summary
- use each packed file range as a lower bound when opening multipart volumes, healing existing stored metadata
- enforce the same containment invariant for lazy, eager, and legacy RAR metadata creation
- map malformed multipart ranges to the existing stack-free seek error path and add deterministic regression coverage

Closes #544.

## Test plan
- [x] Focused multipart/RAR tests (22 passed, 0 skipped)
- [x] Backend suite excluding `MultiSegmentStreamPrefetchBudgetTests` (836 passed; 11 native-dependent tests skipped)
- [ ] Full backend suite in CI, where the `rapidyenc` native dependency is available

Local full-suite note: one pre-existing `MultiSegmentStreamPrefetchBudgetTests` case fails on macOS ARM because `rapidyenc.dylib` is unavailable; it is unrelated to this change.