### PR TITLE
feat(ui): retry failed history items from the queue page

### DIFF
--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.SabControllers.RetryHistory;
+
+public class RetryHistoryController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    QueueManager queueManager,
+    ConfigManager configManager,
+    WebsocketManager websocketManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<RetryHistoryResponse> RetryHistoryAsync(RetryHistoryRequest request)
+    {
+        var historyItem = await dbClient.Ctx.HistoryItems.AsNoTracking()
+            .FirstOrDefaultAsync(item => item.Id == request.NzoId, request.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (historyItem is null)
+            throw new BadHttpRequestException("History item not found.");
+
+        if (historyItem.DownloadStatus != HistoryItem.DownloadStatusOption.Failed)
+            throw new BadHttpRequestException("Only failed history items can be retried.");
+
+        if (historyItem.NzbBlobId is null)
+            throw new BadHttpRequestException("The NZB file could not be found.");
+
+        var blobStream = BlobStore.ReadBlob(historyItem.NzbBlobId.Value);
+        if (blobStream is null)
+            throw new BadHttpRequestException("The NZB file could not be found.");
+
+        var addFileRequest = new AddFileRequest
+        {
+            FileName = historyItem.FileName,
+            ContentType = "application/x-nzb",
+            NzbFileStream = blobStream,
+            Category = historyItem.Category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+            IndexerName = historyItem.IndexerName,
+            ContentGroupKey = historyItem.ContentGroupKey,
+            CancellationToken = request.CancellationToken,
+        };
+
+        var addFileController = new AddFileController(
+            httpContext, dbClient, queueManager, configManager, websocketManager);
+        var addResponse = await addFileController.AddFileAsync(addFileRequest).ConfigureAwait(false);
+        if (addResponse.NzoIds.Count == 0)
+            throw new BadHttpRequestException("Failed to re-queue NZB.");
+
+        return new RetryHistoryResponse
+        {
+            Status = true,
+            NzoId = addResponse.NzoIds[0],
+        };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        var request = RetryHistoryRequest.New(httpContext);
+        return Ok(await RetryHistoryAsync(request).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryRequest.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryRequest.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.SabControllers.RetryHistory;
+
+public class RetryHistoryRequest
+{
+    public Guid NzoId { get; private init; }
+    public CancellationToken CancellationToken { get; private init; }
+
+    public static RetryHistoryRequest New(HttpContext httpContext)
+    {
+        var value = httpContext.GetRequestParam("value");
+        if (string.IsNullOrWhiteSpace(value) || !Guid.TryParse(value, out var nzoId))
+            throw new BadHttpRequestException("Missing or invalid value (nzo_id).");
+
+        return new RetryHistoryRequest
+        {
+            NzoId = nzoId,
+            CancellationToken = SigtermUtil.GetCancellationToken(),
+        };
+    }
+}

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryResponse.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.SabControllers.RetryHistory;
+
+public class RetryHistoryResponse : SabBaseResponse
+{
+    [JsonPropertyName("nzo_id")]
+    public string NzoId { get; set; } = null!;
+}

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -12,6 +12,7 @@ using NzbWebDAV.Api.SabControllers.GetVersion;
 using NzbWebDAV.Api.SabControllers.MoveInQueue;
 using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
+using NzbWebDAV.Api.SabControllers.RetryHistory;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -111,6 +112,10 @@ public class SabApiController(
             case "history":
                 return new GetHistoryController(
                     HttpContext, dbClient, configManager, providerUsageTracker);
+
+            case "retry":
+                return new RetryHistoryController(
+                    HttpContext, dbClient, queueManager, configManager, websocketManager);
 
             default:
                 throw new BadHttpRequestException("Invalid mode");

--- a/frontend/app/routes/queue/components/action-button/action-button.tsx
+++ b/frontend/app/routes/queue/components/action-button/action-button.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Button, Icon } from "~/components/ui";
 
 export type ActionButtonProps = {
-    type: "delete" | "explore" | "menu" | "move-top",
+    type: "delete" | "explore" | "menu" | "move-top" | "retry",
     text?: string,
     disabled?: boolean,
     selected?: boolean,
@@ -14,6 +14,7 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
     const icon = type === "delete" ? "delete"
         : type === "explore" ? "folder"
         : type === "move-top" ? "vertical_align_top"
+        : type === "retry" ? "refresh"
         : "more_horiz";
 
     return (
@@ -22,7 +23,7 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
             size="xsmall"
             disabled={disabled}
             aria-pressed={type === "menu" ? selected : undefined}
-            aria-label={!text ? (type === "move-top" ? "Move to top" : type) : undefined}
+            aria-label={!text ? (type === "move-top" ? "Move to top" : type === "retry" ? "Retry" : type) : undefined}
             className={`${type === "menu" ? "w-[30px] px-1" : ""} ${selected ? "bg-base-content/20 text-base-content" : ""}`}
             onClick={onClick}
         >

--- a/frontend/app/routes/queue/components/history-table/history-retry.test.ts
+++ b/frontend/app/routes/queue/components/history-table/history-retry.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    buildHistoryRetryUrl,
+    canRetryHistorySlot,
+    retryHistoryItem,
+    shouldAcceptRetryClick,
+} from "./history-retry";
+
+describe("canRetryHistorySlot", () => {
+    it("allows retry only for failed rows with an NZB blob", () => {
+        expect(canRetryHistorySlot({ status: "Failed", nzb_blob_id: "abc" })).toBe(true);
+        expect(canRetryHistorySlot({ status: "Failed", nzb_blob_id: null })).toBe(false);
+        expect(canRetryHistorySlot({ status: "Failed" })).toBe(false);
+        expect(canRetryHistorySlot({ status: "Completed", nzb_blob_id: "abc" })).toBe(false);
+    });
+});
+
+describe("shouldAcceptRetryClick", () => {
+    it("rejects duplicate clicks while retrying or removing", () => {
+        expect(shouldAcceptRetryClick(false, false)).toBe(true);
+        expect(shouldAcceptRetryClick(true, false)).toBe(false);
+        expect(shouldAcceptRetryClick(false, true)).toBe(false);
+    });
+});
+
+describe("buildHistoryRetryUrl", () => {
+    it("builds the SAB-compatible retry URL", () => {
+        expect(buildHistoryRetryUrl("nzo-123")).toBe("/api?mode=retry&value=nzo-123");
+        expect(buildHistoryRetryUrl("a b")).toBe("/api?mode=retry&value=a%20b");
+    });
+});
+
+describe("retryHistoryItem", () => {
+    it("posts to the retry endpoint and returns success", async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ status: true, nzo_id: "new-id" }),
+        });
+
+        const result = await retryHistoryItem("old-id", fetchImpl as typeof fetch);
+
+        expect(fetchImpl).toHaveBeenCalledWith("/api?mode=retry&value=old-id", { method: "POST" });
+        expect(result).toEqual({ ok: true, nzoId: "new-id" });
+    });
+
+    it("returns the API error when retry fails", async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            ok: false,
+            json: async () => ({ status: false, error: "The NZB file could not be found." }),
+        });
+
+        const result = await retryHistoryItem("old-id", fetchImpl as typeof fetch);
+
+        expect(result).toEqual({
+            ok: false,
+            error: "The NZB file could not be found.",
+        });
+    });
+
+    it("returns a fallback error when the request throws", async () => {
+        const fetchImpl = vi.fn().mockRejectedValue(new Error("network"));
+
+        const result = await retryHistoryItem("old-id", fetchImpl as typeof fetch);
+
+        expect(result).toEqual({ ok: false, error: "Failed to retry history item." });
+    });
+});

--- a/frontend/app/routes/queue/components/history-table/history-retry.ts
+++ b/frontend/app/routes/queue/components/history-table/history-retry.ts
@@ -1,0 +1,46 @@
+export type RetryableHistorySlot = {
+    status: string;
+    nzb_blob_id?: string | null;
+};
+
+export function canRetryHistorySlot(slot: RetryableHistorySlot): boolean {
+    return slot.status === "Failed" && !!slot.nzb_blob_id;
+}
+
+export function shouldAcceptRetryClick(isRetrying: boolean, isRemoving?: boolean): boolean {
+    return !isRetrying && !isRemoving;
+}
+
+export function buildHistoryRetryUrl(nzoId: string): string {
+    return `/api?mode=retry&value=${encodeURIComponent(nzoId)}`;
+}
+
+export type HistoryRetryResult =
+    | { ok: true; nzoId?: string }
+    | { ok: false; error: string };
+
+export async function retryHistoryItem(
+    nzoId: string,
+    fetchImpl: typeof fetch = fetch,
+): Promise<HistoryRetryResult> {
+    try {
+        const response = await fetchImpl(buildHistoryRetryUrl(nzoId), { method: "POST" });
+        let data: { status?: boolean; error?: string; nzo_id?: string } | null = null;
+        try {
+            data = await response.json();
+        } catch {
+            data = null;
+        }
+
+        if (response.ok && data?.status === true) {
+            return { ok: true, nzoId: data.nzo_id };
+        }
+
+        return {
+            ok: false,
+            error: data?.error || "Failed to retry history item.",
+        };
+    } catch {
+        return { ok: false, error: "Failed to retry history item." };
+    }
+}

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -10,6 +10,7 @@ import { PageSection } from "../page-section/page-section"
 import { Pagination } from "../pagination/pagination"
 import { DropdownOptions } from "~/routes/explore/dropdown-options/dropdown-options"
 import { ExportNzb, Remove } from "~/routes/explore/item-menu/item-menu"
+import { canRetryHistorySlot, retryHistoryItem, shouldAcceptRetryClick } from "./history-retry"
 
 export type HistoryTableProps = {
     historySlots: PresentationHistorySlot[],
@@ -143,6 +144,8 @@ type HistoryRowProps = {
 export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onRemoved }: HistoryRowProps) {
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
+    const [isRetrying, setIsRetrying] = useState(false);
+    const [retryError, setRetryError] = useState<string | null>(null);
 
     // events
     const onRemove = useCallback(() => {
@@ -172,6 +175,20 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
         onIsRemovingChanged(slot.nzo_id, false);
     }, [slot.nzo_id, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
+    const onRetry = useCallback(async () => {
+        if (!shouldAcceptRetryClick(isRetrying, slot.isRemoving)) return;
+        setRetryError(null);
+        setIsRetrying(true);
+        try {
+            const result = await retryHistoryItem(slot.nzo_id);
+            if (!result.ok) {
+                setRetryError(result.error);
+            }
+        } finally {
+            setIsRetrying(false);
+        }
+    }, [isRetrying, slot.isRemoving, slot.nzo_id]);
+
     const folderLink = getExploreContentLink(slot.storage, slot.category);
     const nameHref = folderLink && !slot.isRemoving && !slot.fail_message ? folderLink : null;
 
@@ -189,7 +206,23 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                 fileSizeBytes={slot.bytes}
                 completed={slot.completed}
                 showCompleted
-                actions={<Actions slot={slot} onRemove={onRemove} />}
+                actions={
+                    <div className="flex flex-col items-end gap-1">
+                        <div className="flex flex-col items-end justify-center gap-2.5 min-[410px]:flex-row min-[410px]:items-center">
+                            <Actions
+                                slot={slot}
+                                isRetrying={isRetrying}
+                                onRemove={onRemove}
+                                onRetry={onRetry}
+                            />
+                        </div>
+                        {retryError &&
+                            <span role="alert" className="max-w-[180px] text-left text-xs text-error">
+                                {retryError}
+                            </span>
+                        }
+                    </div>
+                }
                 onRowSelectionChanged={isSelected => onIsSelectedChanged(slot.nzo_id, isSelected)}
                 indexer={slot.indexer}
                 providers={slot.providers}
@@ -206,7 +239,17 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
     )
 }
 
-export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onRemove: () => void }) {
+export function Actions({
+    slot,
+    isRetrying = false,
+    onRemove,
+    onRetry,
+}: {
+    slot: PresentationHistorySlot,
+    isRetrying?: boolean,
+    onRemove: () => void,
+    onRetry?: () => void,
+}) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
     const folderLink = getExploreContentLink(slot.storage, slot.category);
@@ -218,6 +261,7 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
 
     // determine whether explore action should be disabled
     const isFolderDisabled = !folderLink || !!slot.isRemoving || !!slot.fail_message;
+    const showRetry = canRetryHistorySlot(slot);
 
     const onMenuClick = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
@@ -229,8 +273,20 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
         onRemove?.();
     }, [onRemove]);
 
+    const onRetryClick = useCallback((e: React.MouseEvent) => {
+        e.stopPropagation();
+        onRetry?.();
+    }, [onRetry]);
+
     return (
         <>
+            {showRetry &&
+                <ActionButton
+                    type="retry"
+                    disabled={!!slot.isRemoving || isRetrying}
+                    onClick={onRetryClick}
+                />
+            }
             {!isFolderDisabled && folderLink &&
                 <Link to={folderLink} discover="none">
                     <ActionButton type="explore" />
@@ -242,7 +298,7 @@ export function Actions({ slot, onRemove }: { slot: PresentationHistorySlot, onR
             <div className="relative">
                 <ActionButton
                     type="menu"
-                    disabled={!!slot.isRemoving}
+                    disabled={!!slot.isRemoving || isRetrying}
                     selected={isMenuOpen}
                     onClick={onMenuClick} />
                 <DropdownOptions

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -1,0 +1,272 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.RetryHistory;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class RetryHistoryControllerTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-retry-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+    private WebsocketManager _websocketManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        _websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_FailedItemWithBlob_CreatesNewQueueItemAndKeepsHistory()
+    {
+        const string fileName = "Show.S01E01.nzb";
+        const string category = "tv";
+        var historyId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(historyId, fileName, category, writeBlob: true);
+
+        var response = await CreateController().RetryHistoryAsync(CreateRequest(historyId));
+
+        Assert.True(response.Status);
+        var newId = Guid.Parse(response.NzoId);
+        Assert.NotEqual(historyId, newId);
+
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking()
+            .SingleOrDefaultAsync(h => h.Id == historyId));
+        var queueItem = await _context.QueueItems.AsNoTracking()
+            .SingleAsync(q => q.Id == newId);
+        Assert.Equal(fileName, queueItem.FileName);
+        Assert.Equal(category, queueItem.Category);
+        Assert.Equal("test-indexer", queueItem.IndexerName);
+        Assert.Equal("group-key", queueItem.ContentGroupKey);
+        Assert.NotNull(BlobStore.ReadBlob(newId));
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_MissingBlob_ThrowsBadRequest()
+    {
+        var historyId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(historyId, "Missing.Blob.nzb", "tv", writeBlob: false);
+
+        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
+            () => CreateController().RetryHistoryAsync(CreateRequest(historyId)));
+        Assert.Equal("The NZB file could not be found.", ex.Message);
+        Assert.Empty(await _context.QueueItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_CompletedHistory_ThrowsBadRequest()
+    {
+        var historyId = Guid.NewGuid();
+        await SeedHistoryAsync(
+            historyId,
+            "Completed.Show.nzb",
+            "tv",
+            HistoryItem.DownloadStatusOption.Completed,
+            writeBlob: true);
+
+        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
+            () => CreateController().RetryHistoryAsync(CreateRequest(historyId)));
+        Assert.Equal("Only failed history items can be retried.", ex.Message);
+        Assert.Empty(await _context.QueueItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_UnknownId_ThrowsBadRequest()
+    {
+        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
+            () => CreateController().RetryHistoryAsync(CreateRequest(Guid.NewGuid())));
+        Assert.Equal("History item not found.", ex.Message);
+    }
+
+    [Fact]
+    public void RetryHistoryRequest_MalformedValue_ThrowsBadRequest()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?value=not-a-guid");
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
+        Assert.Equal("Missing or invalid value (nzo_id).", ex.Message);
+    }
+
+    [Fact]
+    public void RetryHistoryRequest_MissingValue_ThrowsBadRequest()
+    {
+        var context = new DefaultHttpContext();
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
+        Assert.Equal("Missing or invalid value (nzo_id).", ex.Message);
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_WhileAlreadyQueued_ReplacesExistingQueueItem()
+    {
+        const string fileName = "Already.Queued.nzb";
+        const string category = "tv";
+        var historyId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(historyId, fileName, category, writeBlob: true);
+
+        var existingQueueId = Guid.NewGuid();
+        _context.QueueItems.Add(new QueueItem
+        {
+            Id = existingQueueId,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            FileName = fileName,
+            JobName = "Already.Queued",
+            NzbFileSize = 10,
+            TotalSegmentBytes = 10,
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        });
+        _context.NzbNames.Add(new NzbName { Id = existingQueueId, FileName = fileName });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var response = await CreateController().RetryHistoryAsync(CreateRequest(historyId));
+
+        Assert.True(response.Status);
+        var newId = Guid.Parse(response.NzoId);
+        Assert.NotEqual(existingQueueId, newId);
+        Assert.Null(await _context.QueueItems.AsNoTracking()
+            .SingleOrDefaultAsync(q => q.Id == existingQueueId));
+        Assert.Equal(newId, (await _context.QueueItems.AsNoTracking()
+            .SingleAsync(q => q.Category == category && q.FileName == fileName)).Id);
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking()
+            .SingleOrDefaultAsync(h => h.Id == historyId));
+    }
+
+    private RetryHistoryController CreateController() =>
+        new(
+            new DefaultHttpContext(),
+            _dbClient,
+            _queueManager,
+            _configManager,
+            _websocketManager);
+
+    private static RetryHistoryRequest CreateRequest(Guid nzoId)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?value={nzoId}");
+        return RetryHistoryRequest.New(context);
+    }
+
+    private Task SeedFailedHistoryAsync(Guid id, string fileName, string category, bool writeBlob) =>
+        SeedHistoryAsync(id, fileName, category, HistoryItem.DownloadStatusOption.Failed, writeBlob);
+
+    private async Task SeedHistoryAsync(
+        Guid id,
+        string fileName,
+        string category,
+        HistoryItem.DownloadStatusOption status,
+        bool writeBlob)
+    {
+        if (writeBlob)
+        {
+            var nzb = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+                  <file subject="test">
+                    <groups><group>alt.binaries.test</group></groups>
+                    <segments>
+                      <segment bytes="100" number="1">seg@example.com</segment>
+                    </segments>
+                  </file>
+                </nzb>
+                """;
+            await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(nzb));
+            await BlobStore.WriteBlob(id, stream);
+        }
+
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = id,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = category,
+            DownloadStatus = status,
+            TotalSegmentBytes = 100,
+            DownloadTimeSeconds = 5,
+            FailMessage = status == HistoryItem.DownloadStatusOption.Failed
+                ? "Timeout reading from NNTP stream."
+                : null,
+            NzbBlobId = id,
+            IndexerName = "test-indexer",
+            ContentGroupKey = "group-key",
+        });
+        _context.NzbNames.Add(new NzbName { Id = id, FileName = fileName });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds SAB-compatible `mode=retry` that re-queues a failed history item from its stored NZB blob as a **new** queue item (history row kept).
- Adds a Retry button on failed history rows that still have `nzb_blob_id`.
- Covers success, missing blob, non-failed, malformed id, and in-queue replace paths with backend tests; frontend helper tests cover visibility, URL, duplicate-click guard, and API errors.

Closes #123

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter RetryHistory`
- [x] `cd frontend && npm run typecheck && npm test && npm run build`
- [ ] Manual: fail an NZB into history → click Retry → new queue entry appears; history row remains
- [ ] Manual: completed history / missing blob → Retry hidden or shows clear error