### PR TITLE
fix(ui): show consistent live connection counts on all usenet provider cards

### DIFF
--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -552,9 +552,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                                                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                                                     <span className="text-[10px] font-medium uppercase tracking-wide text-base-content/50">Connections</span>
                                                     <span className="break-all text-sm font-medium text-base-content">
-                                                        {connections[index]
-                                                            ? `${connections[index].live} / ${provider.MaxConnections} max`
-                                                            : `${provider.MaxConnections} max`}
+                                                        {`${connections[index]?.live ?? 0} / ${provider.MaxConnections} max`}
                                                     </span>
                                                 </div>
                                             </div>


### PR DESCRIPTION
## Summary
- Usenet provider cards always show `live / max` for Connections (e.g. `0 / 45 max`) instead of mixing bare `N max` with live counts.
- Live still updates from the `cxs` websocket; until the first update for a provider, live defaults to `0`.

## Test plan
- [ ] Open Settings → Usenet with multiple providers
- [ ] Confirm every card shows `0 / N max` (or `live / N max`) — no bare `N max`
- [ ] Trigger download activity and confirm live counts update per provider
- [ ] Disconnect/reconnect websocket (or refresh) and confirm cards return to consistent `0 / N max` until updates resume