### PR TITLE
ci: Discord release announcements no longer fail on large changelogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,15 @@ jobs:
             exit 1
           fi
 
-          RELEASE_NOTES=$(sed -n '/^## \[[0-9]\+\.[0-9]\+\.[0-9]\+\](/,$p' CHANGELOG.md | sed -n '1!{/^## \[/q;p}')
+          # Single-process extract: a sed|sed pipeline SIGPIPEs under pipefail when the
+          # second sed quits at the next ## [version] heading on a large CHANGELOG.
+          RELEASE_NOTES=$(awk '
+            /^## \[[0-9]+\.[0-9]+\.[0-9]+\]\(/ {
+              if (seen++) exit
+              next
+            }
+            seen { print }
+          ' CHANGELOG.md)
           RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
           ANNOUNCEMENT_BODY=$(printf '**New Release: v%s**\n%s\n\n%s' "${VERSION}" "${RELEASE_NOTES}" "${RELEASE_URL}")
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,48 +161,29 @@ jobs:
             }
             seen { print }
           ' CHANGELOG.md)
+
+          # Discord-friendly notes: drop markdown noise and per-commit parentheticals.
+          RELEASE_NOTES=$(printf '%s\n' "${RELEASE_NOTES}" | sed -E \
+            -e 's/^### //' \
+            -e 's/^\* \*\*([^*]+):\*\* /\1: /' \
+            -e 's/^\* //' \
+            -e 's/ \(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[^)]+\)\)//g' \
+            -e 's/ \(\[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)\)//g' \
+            -e 's/, closes \[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)//g' \
+            | awk 'NF { blank=0; print; next } !blank++')
+
           RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
-          ANNOUNCEMENT_BODY=$(printf '**New Release: v%s**\n%s\n\n%s' "${VERSION}" "${RELEASE_NOTES}" "${RELEASE_URL}")
-
-          # Discord content limit is 2000; split on newlines instead of truncating.
+          HEADER=$(printf '**New Release: v%s**' "${VERSION}")
+          # Discord content limit is 2000; keep a single message and prefer the release URL.
           MAX_LEN=1900
-          post_discord_chunk() {
-            local escaped
-            escaped=$(printf '%s' "$1" | jq -Rsa .)
-            curl --fail-with-body -sS -H "Content-Type: application/json" \
-              -d "{\"content\": ${escaped}, \"flags\": 4}" \
-              "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
-          }
-
-          buf=""
-          first_chunk=1
-          while IFS= read -r line || [ -n "${line}" ]; do
-            if [ -n "${buf}" ]; then
-              candidate="${buf}"$'\n'"${line}"
-            else
-              candidate="${line}"
-            fi
-            if [ "${#candidate}" -le "${MAX_LEN}" ]; then
-              buf="${candidate}"
-              continue
-            fi
-            if [ -n "${buf}" ]; then
-              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
-              post_discord_chunk "${buf}"
-              first_chunk=0
-              buf="${line}"
-            else
-              buf="${line}"
-            fi
-            while [ "${#buf}" -gt "${MAX_LEN}" ]; do
-              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
-              post_discord_chunk "${buf:0:${MAX_LEN}}"
-              first_chunk=0
-              buf="${buf:${MAX_LEN}}"
-            done
-          done <<< "${ANNOUNCEMENT_BODY}"
-
-          if [ -n "${buf}" ]; then
-            if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
-            post_discord_chunk "${buf}"
+          overhead=$((${#HEADER} + ${#RELEASE_URL} + 2))
+          max_notes=$((MAX_LEN - overhead))
+          if [ "${#RELEASE_NOTES}" -gt "${max_notes}" ]; then
+            RELEASE_NOTES="${RELEASE_NOTES:0:$((max_notes - 3))}..."
           fi
+          ANNOUNCEMENT_BODY=$(printf '%s\n%s\n%s' "${HEADER}" "${RELEASE_NOTES}" "${RELEASE_URL}")
+
+          ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
+          curl --fail-with-body -sS -H "Content-Type: application/json" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,45 @@ jobs:
           RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
           ANNOUNCEMENT_BODY=$(printf '**New Release: v%s**\n%s\n\n%s' "${VERSION}" "${RELEASE_NOTES}" "${RELEASE_URL}")
 
+          # Discord content limit is 2000; split on newlines instead of truncating.
           MAX_LEN=1900
-          if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then
-            ANNOUNCEMENT_BODY="${ANNOUNCEMENT_BODY:0:$((MAX_LEN - 3))}..."
-          fi
+          post_discord_chunk() {
+            local escaped
+            escaped=$(printf '%s' "$1" | jq -Rsa .)
+            curl --fail-with-body -sS -H "Content-Type: application/json" \
+              -d "{\"content\": ${escaped}, \"flags\": 4}" \
+              "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
+          }
 
-          ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
-          curl --fail-with-body -sS -H "Content-Type: application/json" \
-            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
-            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
+          buf=""
+          first_chunk=1
+          while IFS= read -r line || [ -n "${line}" ]; do
+            if [ -n "${buf}" ]; then
+              candidate="${buf}"$'\n'"${line}"
+            else
+              candidate="${line}"
+            fi
+            if [ "${#candidate}" -le "${MAX_LEN}" ]; then
+              buf="${candidate}"
+              continue
+            fi
+            if [ -n "${buf}" ]; then
+              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
+              post_discord_chunk "${buf}"
+              first_chunk=0
+              buf="${line}"
+            else
+              buf="${line}"
+            fi
+            while [ "${#buf}" -gt "${MAX_LEN}" ]; do
+              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
+              post_discord_chunk "${buf:0:${MAX_LEN}}"
+              first_chunk=0
+              buf="${buf:${MAX_LEN}}"
+            done
+          done <<< "${ANNOUNCEMENT_BODY}"
+
+          if [ -n "${buf}" ]; then
+            if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
+            post_discord_chunk "${buf}"
+          fi

--- a/.github/workflows/test-discord-announcements.yml
+++ b/.github/workflows/test-discord-announcements.yml
@@ -30,45 +30,7 @@ jobs:
             exit 1
           fi
 
-          # Discord content limit is 2000; split on newlines instead of truncating.
-          MAX_LEN=1900
-          post_discord_chunk() {
-            local escaped
-            escaped=$(printf '%s' "$1" | jq -Rsa .)
-            curl --fail-with-body -sS -H "Content-Type: application/json" \
-              -d "{\"content\": ${escaped}, \"flags\": 4}" \
-              "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
-          }
-
-          buf=""
-          first_chunk=1
-          while IFS= read -r line || [ -n "${line}" ]; do
-            if [ -n "${buf}" ]; then
-              candidate="${buf}"$'\n'"${line}"
-            else
-              candidate="${line}"
-            fi
-            if [ "${#candidate}" -le "${MAX_LEN}" ]; then
-              buf="${candidate}"
-              continue
-            fi
-            if [ -n "${buf}" ]; then
-              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
-              post_discord_chunk "${buf}"
-              first_chunk=0
-              buf="${line}"
-            else
-              buf="${line}"
-            fi
-            while [ "${#buf}" -gt "${MAX_LEN}" ]; do
-              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
-              post_discord_chunk "${buf:0:${MAX_LEN}}"
-              first_chunk=0
-              buf="${buf:${MAX_LEN}}"
-            done
-          done <<< "${MESSAGE}"
-
-          if [ -n "${buf}" ]; then
-            if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
-            post_discord_chunk "${buf}"
-          fi
+          ESCAPED_BODY=$(printf '%s' "$MESSAGE" | jq -Rsa .)
+          curl --fail-with-body -sS -H "Content-Type: application/json" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"

--- a/.github/workflows/test-discord-announcements.yml
+++ b/.github/workflows/test-discord-announcements.yml
@@ -30,7 +30,45 @@ jobs:
             exit 1
           fi
 
-          ESCAPED_BODY=$(printf '%s' "$MESSAGE" | jq -Rsa .)
-          curl --fail-with-body -sS -H "Content-Type: application/json" \
-            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
-            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
+          # Discord content limit is 2000; split on newlines instead of truncating.
+          MAX_LEN=1900
+          post_discord_chunk() {
+            local escaped
+            escaped=$(printf '%s' "$1" | jq -Rsa .)
+            curl --fail-with-body -sS -H "Content-Type: application/json" \
+              -d "{\"content\": ${escaped}, \"flags\": 4}" \
+              "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
+          }
+
+          buf=""
+          first_chunk=1
+          while IFS= read -r line || [ -n "${line}" ]; do
+            if [ -n "${buf}" ]; then
+              candidate="${buf}"$'\n'"${line}"
+            else
+              candidate="${line}"
+            fi
+            if [ "${#candidate}" -le "${MAX_LEN}" ]; then
+              buf="${candidate}"
+              continue
+            fi
+            if [ -n "${buf}" ]; then
+              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
+              post_discord_chunk "${buf}"
+              first_chunk=0
+              buf="${line}"
+            else
+              buf="${line}"
+            fi
+            while [ "${#buf}" -gt "${MAX_LEN}" ]; do
+              if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
+              post_discord_chunk "${buf:0:${MAX_LEN}}"
+              first_chunk=0
+              buf="${buf:${MAX_LEN}}"
+            done
+          done <<< "${MESSAGE}"
+
+          if [ -n "${buf}" ]; then
+            if [ "${first_chunk}" -eq 0 ]; then sleep 1; fi
+            post_discord_chunk "${buf}"
+          fi


### PR DESCRIPTION
## Summary
- Replaces the `sed|sed` CHANGELOG extractor with a single `awk` process so early exit no longer SIGPIPEs under `pipefail`.
- Formats Discord release notes as one message: strip markdown bullets/bold, drop per-commit (and issue) parentheticals, keep section headings + `scope: description` lines.
- Reverts multi-message chunking; truncation is only a safety net if notes still exceed Discord's limit after stripping.

## Test plan
- [x] Locally verified awk extract + strip produces ~1795-char 0.8.1 body with no commit hashes/links
- [x] Re-posted clean single-message v0.8.1 announcement via Test Discord Announcements
- [ ] Merge; next real release should announce once without broken-pipe, chunking, or commit parentheticals