### PR TITLE
fix(nntp): stop provider selection spending the half-open probe slot

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -12,11 +12,13 @@ namespace NzbWebDAV.Clients.Usenet.Connections;
 /// clears the window and fully resets the cooldown ladder (same recovery
 /// semantics as the former consecutive-failure breaker). After tripping, the
 /// provider enters a cooldown during which it is skipped and additional
-/// failures are ignored (latched). When the cooldown expires, exactly one
-/// half-open probe is admitted; other callers keep seeing the provider as
-/// tripped until that probe records success or failure. A failed probe
-/// re-trips with the doubled cooldown. An abandoned probe (no outcome within
-/// <see cref="ProbeAbandonTimeout"/>) can be retaken.
+/// failures are ignored (latched). When the cooldown expires the trip stays
+/// latched and the provider is half-open. Any recorded failure then re-trips
+/// immediately with the doubled cooldown and any recorded success closes the
+/// circuit. <see cref="GetSnapshot"/> reports that state without altering it.
+/// <see cref="IsTripped"/> reports it while also admitting exactly one half-open
+/// probe per cooldown lapse, and an abandoned probe with no outcome within
+/// <see cref="ProbeAbandonTimeout"/> can be retaken.
 /// </para>
 /// </summary>
 public class ProviderCircuitBreaker
@@ -181,22 +183,20 @@ public class ProviderCircuitBreaker
             if (_trippedUntilMs > 0 && now < _trippedUntilMs)
                 return;
 
-            // Half-open probe failed → re-trip immediately with the current
-            // (already doubled from the previous trip) cooldown, then advance ladder.
-            if (Volatile.Read(ref _halfOpenProbeInFlight) == 1)
+            // Half-open once a probe is claimed or once the cooldown lapses with the trip
+            // still latched. A failure here reopens on the current cooldown rather than
+            // joining the sampling window below, which would return a provider that is
+            // still down to normal rotation until that window tripped again.
+            if (Volatile.Read(ref _halfOpenProbeInFlight) == 1 || _trippedUntilMs > 0)
             {
                 Volatile.Write(ref _halfOpenProbeInFlight, 0);
                 Volatile.Write(ref _probeStartedMs, 0);
+                Interlocked.Increment(ref _failureCount);
                 Trip(now, reason is null
-                    ? "half-open probe failure"
-                    : $"half-open probe failure ({reason})");
+                    ? "half-open failure"
+                    : $"half-open failure ({reason})");
                 return;
             }
-
-            // Cooldown expired (or never tripped); clear a stale trip marker so
-            // success recovery logging stays accurate.
-            if (_trippedUntilMs > 0)
-                _trippedUntilMs = 0;
 
             EvictOldEntries(now);
             _window.Enqueue((now, true));

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -84,6 +84,10 @@ public class MultiConnectionNntpClient(
     // this provider should be skipped when it has exhausted its block.
     public long? ByteLimit { get; } = byteLimit;
     public long BytesUsedOffset { get; } = bytesUsedOffset;
+    /// <summary>
+    /// Claims the half-open probe slot as a side effect of being read. Use
+    /// <see cref="GetCircuitBreakerSnapshot"/> to inspect state without altering it.
+    /// </summary>
     public bool IsTripped => circuitBreaker.IsTripped;
     public ProviderCircuitBreakerSnapshot GetCircuitBreakerSnapshot() => circuitBreaker.GetSnapshot();
     public int LiveConnections => connectionPool.LiveConnections;

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -759,13 +759,29 @@ public class MultiProviderNntpClient(
                 .Where(x => !IsOverLimit(x))
                 .ToList();
 
-            var healthy = enabled.Where(x => !x.IsTripped).ToList();
-            var pool = healthy.Count > 0 ? healthy : enabled;
+            // Reading state here must not claim the half-open probe slot. IsTripped claims
+            // it, so one selection ends up holding a probe it may never dispatch while
+            // every other selection treats the provider as tripped.
+            var circuitStates = new Dictionary<MultiConnectionNntpClient, ProviderCircuitState>(enabled.Count);
+            foreach (var provider in enabled)
+                circuitStates[provider] = provider.GetCircuitBreakerSnapshot().State;
 
+            var selectable = enabled
+                .Where(x => circuitStates[x] != ProviderCircuitState.Open)
+                .ToList();
+            var pool = selectable.Count > 0 ? selectable : enabled;
+
+            // Half-open sorts behind the healthy providers of its own tier and keeps that
+            // tier, so a recovering primary is still tried ahead of a backup or block
+            // account. A provider that may still be down should not stall a request a
+            // healthy peer would serve. The failover walk reaches it and any command it
+            // completes resets the breaker.
             var byTier = pool.OrderBy(x => x.ProviderType);
+            var byRecovery = byTier.ThenBy(x =>
+                circuitStates[x] == ProviderCircuitState.HalfOpen ? 1 : 0);
             var prioritized = cascadeEnabled?.Invoke() == true
-                ? byTier.ThenBy(EffectivePriority)
-                : byTier;
+                ? byRecovery.ThenBy(EffectivePriority)
+                : byRecovery;
             var ordered = prioritized
                 .ThenByDescending(x => GetRemainingBytes(x))
                 .ThenBy(EstimatedDeliveryScore)

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -131,7 +131,7 @@ function circuitLabel(state: ProviderCircuitState, cooldownRemainingSeconds?: nu
             ? `Tripped · ${cooldownRemainingSeconds}s`
             : "Tripped";
     }
-    if (state === "halfOpen") return "Probing";
+    if (state === "halfOpen") return "Recovering";
     return "Healthy";
 }
 
@@ -142,7 +142,7 @@ function buildProviderTooltip(p: ProviderRow, state: ProviderCircuitState) {
         if (p.cooldownRemainingSeconds != null && p.cooldownRemainingSeconds > 0)
             lines.push(`Retry in about ${p.cooldownRemainingSeconds}s.`);
     } else if (state === "halfOpen") {
-        lines.push("Circuit half-open — one probe request may test recovery.");
+        lines.push("Circuit half-open. Tried after the healthy providers of its tier until a request confirms it.");
     } else {
         lines.push("Circuit closed — provider is healthy.");
     }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -589,19 +589,204 @@ public class MultiProviderNntpClientTests
         Assert.False(backupProvider.IsTripped);
     }
 
+    [Fact]
+    public async Task Selection_DoesNotSpendTheHalfOpenProbeSlot()
+    {
+        var recovering = HalfOpenBreaker("a.example");
+        var healthyConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(
+                new ScriptedNntpClient
+                {
+                    BatchResponseCode = 223,
+                    SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+                },
+                host: "a.example", circuitBreaker: recovering),
+            CreateProvider(healthyConnection, host: "b.example"),
+        ]);
+
+        for (var i = 0; i < 5; i++)
+            await client.StatAsync($"segment-{i}", CancellationToken.None);
+
+        // Selection must leave the slot unclaimed, otherwise the one admission the
+        // recovering provider gets is burned by a request served elsewhere.
+        Assert.Equal(ProviderCircuitState.HalfOpen, recovering.GetSnapshot().State);
+        Assert.False(recovering.IsTripped);
+    }
+
+    [Fact]
+    public async Task Selection_PrefersAHealthyProviderOverAHalfOpenOne()
+    {
+        var recoveringConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        var healthyConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(recoveringConnection, host: "a.example",
+                circuitBreaker: HalfOpenBreaker("a.example")),
+            CreateProvider(healthyConnection, host: "b.example"),
+        ]);
+
+        var response = await client.StatAsync("segment", CancellationToken.None);
+
+        Assert.True(response.ArticleExists);
+        Assert.Equal(0, recoveringConnection.SingularRequests);
+        Assert.True(healthyConnection.SingularRequests >= 1);
+    }
+
+    [Fact]
+    public async Task Selection_StillUsesAHalfOpenProviderWhenItIsTheOnlyOne()
+    {
+        var recoveringConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(recoveringConnection, host: "a.example",
+                circuitBreaker: HalfOpenBreaker("a.example")),
+        ]);
+
+        var response = await client.StatAsync("segment", CancellationToken.None);
+
+        Assert.True(response.ArticleExists);
+        Assert.True(recoveringConnection.SingularRequests >= 1);
+    }
+
+    [Fact]
+    public async Task Selection_SkipsAProviderStillInsideItsCooldown()
+    {
+        var openConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        var healthyConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(openConnection, host: "a.example", circuitBreaker: OpenBreaker("a.example")),
+            CreateProvider(healthyConnection, host: "b.example"),
+        ]);
+
+        await client.StatAsync("segment", CancellationToken.None);
+
+        Assert.Equal(0, openConnection.SingularRequests);
+        Assert.True(healthyConnection.SingularRequests >= 1);
+    }
+
+    [Fact]
+    public async Task Selection_KeepsAHalfOpenPrimaryAheadOfAHealthyBackup()
+    {
+        var recoveringPrimary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        var healthyBackup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(recoveringPrimary, host: "a.example",
+                circuitBreaker: HalfOpenBreaker("a.example")),
+            CreateProvider(healthyBackup, host: "b.example",
+                providerType: ProviderType.BackupOnly),
+        ]);
+
+        await client.StatAsync("segment", CancellationToken.None);
+
+        // Demotion must not invert the tiers. A recovering primary is still a better
+        // first choice than a metered block account.
+        Assert.True(recoveringPrimary.SingularRequests >= 1);
+        Assert.Equal(0, healthyBackup.SingularRequests);
+    }
+
+    [Fact]
+    public async Task Selection_HalfOpenProviderClosesItsBreakerOnceTheFailoverWalkReachesIt()
+    {
+        var recovering = HalfOpenBreaker("b.example");
+        var failingConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 400,
+            SingularException = segmentId =>
+                new UsenetUnexpectedResponseException(segmentId, "400 idle timeout"),
+        };
+        var recoveredConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 223,
+            SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(failingConnection, host: "a.example"),
+            CreateProvider(recoveredConnection, host: "b.example", circuitBreaker: recovering),
+        ]);
+
+        var response = await client.StatAsync("segment", CancellationToken.None);
+
+        // Pins that a half-open provider stays in the pool rather than being excluded,
+        // which is the shape a naive fix gets wrong. It does not discriminate the
+        // demotion ordering, since the probe slot admits the provider either way.
+        Assert.True(response.ArticleExists);
+        Assert.True(recoveredConnection.SingularRequests >= 1);
+        Assert.Equal(ProviderCircuitState.Closed, recovering.GetSnapshot().State);
+    }
+
     private static MultiConnectionNntpClient CreateProvider(
         INntpClient connection,
         string host = "test",
-        string storageGroup = "")
+        string storageGroup = "",
+        ProviderCircuitBreaker? circuitBreaker = null,
+        ProviderType providerType = ProviderType.Pooled)
     {
         var pool = new ConnectionPool<INntpClient>(
             maxConnections: 1, _ => ValueTask.FromResult(connection));
         return new MultiConnectionNntpClient(
             pool,
-            ProviderType.Pooled,
-            new ProviderCircuitBreaker(host),
+            providerType,
+            circuitBreaker ?? new ProviderCircuitBreaker(host),
             host,
             storageGroup: storageGroup);
+    }
+
+    /// <summary>Trips a breaker and lets its cooldown lapse so it lands half-open.</summary>
+    private static ProviderCircuitBreaker HalfOpenBreaker(string host)
+    {
+        var breaker = new ProviderCircuitBreaker(host);
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.ExpireCooldownForTests();
+        return breaker;
+    }
+
+    /// <summary>Trips a breaker and leaves it inside its cooldown, fully open.</summary>
+    private static ProviderCircuitBreaker OpenBreaker(string host)
+    {
+        var breaker = new ProviderCircuitBreaker(host);
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        return breaker;
     }
 
     private sealed class ScriptedNntpClient : NntpClient

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerHalfOpenTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerHalfOpenTests.cs
@@ -1,0 +1,64 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ProviderCircuitBreakerHalfOpenTests
+{
+    [Fact]
+    public void RecordFailure_WhileHalfOpen_ReopensInsteadOfClearingTheTrip()
+    {
+        var breaker = HalfOpen();
+
+        breaker.RecordFailure("still down");
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.True(snapshot.CooldownRemainingSeconds > 0);
+    }
+
+    [Fact]
+    public void RecordFailure_WhileHalfOpen_DoesNotNeedAFreshWindowToReopen()
+    {
+        var breaker = HalfOpen();
+
+        // A single failure is enough. Falling through to the sampling window would
+        // hand a provider that is still down more requests before it reopened.
+        breaker.RecordFailure();
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+    }
+
+    [Fact]
+    public void RecordFailure_WhileHalfOpen_AdvancesTheCooldownLadder()
+    {
+        var breaker = HalfOpen();
+        var firstCooldown = breaker.CurrentCooldown;
+
+        breaker.RecordFailure();
+
+        Assert.True(breaker.CurrentCooldown > firstCooldown);
+    }
+
+    [Fact]
+    public void RecordSuccess_WhileHalfOpen_StillCloses()
+    {
+        var breaker = HalfOpen();
+
+        breaker.RecordSuccess();
+
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+    }
+
+    /// <summary>Trips a breaker and lets its cooldown lapse so it lands half-open.</summary>
+    private static ProviderCircuitBreaker HalfOpen()
+    {
+        var breaker = new ProviderCircuitBreaker("half-open-test");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.ExpireCooldownForTests();
+        Assert.Equal(ProviderCircuitState.HalfOpen, breaker.GetSnapshot().State);
+        return breaker;
+    }
+}


### PR DESCRIPTION
Follow-on from #482. I had a provider sit in "Probing" for two and a half hours after its 60 second cooldown, taking zero requests the whole time while everything failed over to another provider.

The check for whether a provider is tripped is also what hands out its one half-open probe, so just asking the question uses it up. Provider selection was asking on every request. If the ordering then picked a healthier provider, which it usually did, the probe was already gone and nothing had actually been sent to the recovering one. Anything selecting at the same time saw it as still tripped and skipped it entirely.

Selection now checks the state without spending the probe. Recovering providers stay in the list and sort last within their own tier, so a recovering primary is still tried before a backup or block account.

Once nothing was spending the probe, a failure from a recovering provider stopped re-tripping it and started clearing its tripped state instead, putting a provider that was still down straight back into rotation. Fixed that as well.

A recovering provider only gets traffic once the ones ahead of it fail or miss, so it can take a while to come back on its own. And a slow request that started before the trip but finishes after it now counts as a failed probe.

I also updated the UI, it still said "Probing" and "one probe request may test recovery" which isn't what happens.

`IsTripped` has no production callers left after this, but I left it in rather than grow the PR, just put a note on the wrapper that reading it mutates state. Happy to pull it out separately if you'd rather.