### PR TITLE
fix(webdav): stop per-property PROPFIND log spam on client cancellation

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -64,6 +64,18 @@ class Program
             .MinimumLevel.Override("Microsoft.AspNetCore.Routing", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Server.Kestrel", AtLeast(level, LogEventLevel.Error))
             .MinimumLevel.Override("Microsoft.AspNetCore.DataProtection", AtLeast(level, LogEventLevel.Error))
+            // Suppress NWebDav's per-property "raised an exception" Errors when
+            // the cause is client cancellation. When a WebDAV client disconnects
+            // mid-PROPFIND, PropFindHandler keeps iterating its property list
+            // and every remaining property's getter throws
+            // OperationCanceledException against the now-cancelled token. Each
+            // one logs an Error with a full stack trace — ~10 lines for a
+            // single cancelled PROPFIND, and clients like Plex/Jellyfin/rclone
+            // cancel slow PROPFINDs routinely. Client cancellation is normal
+            // behaviour, not an error worth alerting on.
+            .Filter.ByExcluding(e =>
+                e.Exception is OperationCanceledException
+                && e.MessageTemplate.Text.StartsWith("Property "))
             .WriteTo.Console(new ExpressionTemplate(
                 "[{@t:HH:mm:ss} {@l:u3}] " +
                 "{#if SourceContext is not null}" +


### PR DESCRIPTION
When a WebDAV client disconnects mid-PROPFIND, NWebDav's PropFindHandler keeps iterating its property list and every remaining property getter throws `OperationCanceledException` against the now-cancelled token — each logged as an Error with a full stack trace. A single cancelled PROPFIND produces ~10 of these, and Plex/Jellyfin/rclone cancel slow PROPFINDs routinely, so busy instances burn log volume and CPU serialising stack traces for completely normal client behaviour.

This adds a Serilog filter dropping events whose exception is `OperationCanceledException` and whose message template starts with `Property ` — NWebDav's per-property error format, which nothing else in the codebase matches. Real property-getter failures (non-cancellation) still log as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)