### PR TITLE
feat(search): per-indexer Zyclops health-proxy toggle

### DIFF
--- a/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
+++ b/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
@@ -46,7 +46,7 @@ public class SearchIndexersController(
                 var proxy = string.IsNullOrWhiteSpace(x.ProxyUrl) ? globalProxy : x.ProxyUrl;
                 var timeout = indexerConfig.GetEffectiveTimeoutSeconds(x);
                 await rateLimiter.WaitAsync(x.Name, x.MaxRequestsPerMinute, ct).ConfigureAwait(false);
-                var client = new NewznabClient(x.Url, x.ApiKey, ua, proxy, timeout, x.SkipTlsVerification);
+                var client = new NewznabClient(x.Url, x.ApiKey, ua, proxy, timeout, x.SkipTlsVerification, x.UseHealthProxy);
                 var items = await client.SearchAsync(request.Query, request.Limit, ct).ConfigureAwait(false);
                 _ = hitTracker.RecordAsync(x.Name, IndexerApiHit.HitType.Search, CancellationToken.None);
                 var mapped = items

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
@@ -25,7 +25,8 @@ public class TestIndexerConnectionController(NzbWebDAV.Config.ConfigManager conf
                 ua,
                 proxy,
                 timeout,
-                request.SkipTlsVerification);
+                request.SkipTlsVerification,
+                request.UseHealthProxy);
             var ok = await client.TestAsync(HttpContext.RequestAborted).ConfigureAwait(false);
             return Ok(new TestIndexerConnectionResponse { Status = true, Connected = ok });
         }

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
@@ -10,6 +10,7 @@ public class TestIndexerConnectionRequest
     public string? ProxyUrl { get; init; }
     public int? TimeoutSeconds { get; init; }
     public bool SkipTlsVerification { get; init; }
+    public bool UseHealthProxy { get; init; }
 
     public TestIndexerConnectionRequest(HttpContext context)
     {
@@ -27,5 +28,8 @@ public class TestIndexerConnectionRequest
             context.Request.Form["skipTlsVerification"].FirstOrDefault(),
             out var skipTlsVerification)
             && skipTlsVerification;
+
+        UseHealthProxy = string.Equals(
+            context.Request.Form["useHealthProxy"].FirstOrDefault(), "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/backend/Clients/Indexers/NewznabClient.cs
+++ b/backend/Clients/Indexers/NewznabClient.cs
@@ -9,9 +9,18 @@ public class NewznabClient(
     string userAgent = "NzbDav",
     string? proxyUrl = null,
     int timeoutSeconds = 30,
-    bool skipTlsVerification = false)
+    bool skipTlsVerification = false,
+    bool useHealthProxy = false)
 {
     private static readonly XNamespace Newznab = "http://www.newznab.com/DTD/2010/feeds/attributes/";
+
+    // Health-proxy transform: when this indexer opts in (and isn't the
+    // proxy itself, and provider hosts are known), API calls target the
+    // proxy with the original indexer as `target`.
+    private readonly string? _healthProxyProviderHosts =
+        useHealthProxy ? NewznabHealthProxy.ResolveProviderHostsFor(baseUrl) : null;
+
+    private bool UseHealthProxy => _healthProxyProviderHosts is not null;
 
     private readonly Uri _apiUri = NormalizeApiUri(baseUrl);
     private readonly HttpClient _http = ProxyHttpClientPool.GetClient(proxyUrl, skipTlsVerification);
@@ -43,6 +52,33 @@ public class NewznabClient(
         }
         foreach (var kv in extraParams)
             parts.Add($"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}");
+
+        if (UseHealthProxy)
+        {
+            // Route through the health proxy: standard Newznab params stay
+            // (apikey passes through to the upstream indexer), the
+            // normalized indexer API endpoint becomes `target` (its own
+            // query params, if any, already travel in `parts` above), and
+            // results are backbone-filtered by provider_host. `t=caps` is
+            // answered by the proxy itself.
+            var target = new UriBuilder(_apiUri) { Query = "" }.Uri.ToString();
+            parts.Add($"target={Uri.EscapeDataString(target)}");
+            parts.Add($"provider_host={Uri.EscapeDataString(_healthProxyProviderHosts!)}");
+            if (NewznabHealthProxy.ShowUnknown)
+            {
+                // Both spellings are sent — proxy versions differ on which
+                // control name they read; the unused one is ignored.
+                parts.Add("showUnknown=true");
+                parts.Add("show_unknown=true");
+            }
+            var proxyUri = NewznabHealthProxy.GetProxyUri();
+            var proxyBuilder = new UriBuilder(proxyUri);
+            var existingProxyQuery = proxyBuilder.Query.TrimStart('?');
+            proxyBuilder.Query = existingProxyQuery.Length == 0
+                ? string.Join("&", parts)
+                : existingProxyQuery + "&" + string.Join("&", parts);
+            return proxyBuilder.Uri.ToString();
+        }
 
         var builder = new UriBuilder(_apiUri) { Query = string.Join("&", parts) };
         return builder.Uri.ToString();

--- a/backend/Clients/Indexers/NewznabHealthProxy.cs
+++ b/backend/Clients/Indexers/NewznabHealthProxy.cs
@@ -1,0 +1,109 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Clients.Indexers;
+
+/// <summary>
+/// Optional Newznab health-proxy transform. When enabled, indexer API
+/// calls are rewritten to go through the Zyclops community NZB health
+/// proxy (https://zyclops.elfhosted.com): the proxy forwards the query to
+/// the original indexer (`target` param, apikey passes through), annotates
+/// results against its crowd-sourced NZB health database, and returns only
+/// releases known to be retrievable on the caller's NNTP backbone(s) —
+/// dead posts never reach the queue.
+///
+/// The endpoint is deliberately a constant, not configuration: the value
+/// of the health database comes from every participant using the SAME
+/// public service (shared verdicts, consistent per-IP rate limiting and
+/// abuse controls). There is nothing to gain from pointing this elsewhere.
+///
+/// Enabled per indexer via the "health proxy" toggle in Settings →
+/// Indexers (off by default — private/boutique indexers whose releases
+/// the health database rarely covers would otherwise return thin
+/// results).
+///
+/// Env:
+///   NEWZNAB_HEALTH_PROXY_PROVIDER_HOSTS — comma-joined NNTP hostnames to
+///                                         filter health by; defaults to the
+///                                         hosts of this instance's enabled
+///                                         usenet providers.
+///   NEWZNAB_HEALTH_PROXY_SHOW_UNKNOWN   — "true" to include releases the
+///                                         health database has not tested
+///                                         yet (default: only known-good).
+///
+/// Note: in proxy mode the health service is in the search path — if it is
+/// unreachable, searches fail rather than falling back to the raw indexer.
+/// That is the intended trade-off of this mode (guaranteed-healthy results);
+/// deployments wanting fail-open behavior should leave this disabled.
+/// </summary>
+public static class NewznabHealthProxy
+{
+    private const string ProxyEndpoint = "https://zyclops.elfhosted.com/api/v1/newznab/proxy";
+
+    private static readonly Uri ProxyEndpointUri = new(ProxyEndpoint);
+
+    /// <summary>
+    /// Supplies the instance's NNTP provider hostnames for the
+    /// provider_host filter. Wired at startup from ConfigManager so it
+    /// tracks runtime provider changes; the env override wins when set.
+    /// </summary>
+    public static Func<IEnumerable<string>>? ProviderHostsSource { get; set; }
+
+    public static bool ShowUnknown =>
+        string.Equals(EnvironmentUtil.GetEnvironmentVariable("NEWZNAB_HEALTH_PROXY_SHOW_UNKNOWN"),
+            "true", StringComparison.OrdinalIgnoreCase);
+
+    public static Uri GetProxyUri() => ProxyEndpointUri;
+
+    /// <summary>
+    /// True when the given indexer URL already points at the proxy —
+    /// double-wrapping would forward the proxy to itself and mangle auth.
+    /// </summary>
+    public static bool IsProxyEndpoint(string baseUrl)
+    {
+        var proxy = ProxyEndpointUri;
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri)) return false;
+        // Full-endpoint match (authority + path prefix), not host-only: an
+        // unrelated indexer sharing the proxy's reverse-proxy hostname must
+        // still be transformed.
+        if (!string.Equals(uri.GetLeftPart(UriPartial.Authority), proxy.GetLeftPart(UriPartial.Authority),
+                StringComparison.OrdinalIgnoreCase))
+            return false;
+        var proxyPath = proxy.AbsolutePath.TrimEnd('/');
+        if (proxyPath.Length == 0) return true;
+        var indexerPath = uri.AbsolutePath.TrimEnd('/');
+        // Exact match or a match at a path-segment boundary — "/proxy-alt"
+        // must not be mistaken for "/proxy".
+        return indexerPath.Equals(proxyPath, StringComparison.OrdinalIgnoreCase)
+               || indexerPath.StartsWith(proxyPath + "/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the provider_host value to use when transforming the given
+    /// indexer, or null when the transform must not apply (indexer already
+    /// points at the proxy, or no provider hosts known — the proxy
+    /// requires provider_host). Callers gate on the indexer's per-indexer
+    /// UseHealthProxy setting before calling this.
+    /// </summary>
+    public static string? ResolveProviderHostsFor(string baseUrl)
+    {
+        if (IsProxyEndpoint(baseUrl)) return null;
+        return GetProviderHosts();
+    }
+
+    /// <summary>
+    /// Comma-joined provider hostnames, or null when none are known (the
+    /// proxy requires provider_host, so the transform is skipped then).
+    /// </summary>
+    public static string? GetProviderHosts()
+    {
+        var overrideHosts = EnvironmentUtil.GetEnvironmentVariable("NEWZNAB_HEALTH_PROXY_PROVIDER_HOSTS");
+        if (!string.IsNullOrWhiteSpace(overrideHosts)) return overrideHosts.Trim();
+
+        var hosts = ProviderHostsSource?.Invoke()
+            ?.Where(h => !string.IsNullOrWhiteSpace(h))
+            .Select(h => h.Trim().ToLowerInvariant())
+            .Distinct()
+            .ToList();
+        return hosts is { Count: > 0 } ? string.Join(",", hosts) : null;
+    }
+}

--- a/backend/Config/IndexerConfig.cs
+++ b/backend/Config/IndexerConfig.cs
@@ -65,6 +65,10 @@ public class IndexerConfig
         public bool SkipTlsVerification { get; set; } = false;
         public int MaxRequestsPerMinute { get; set; } = 0;
         public bool EnableStrictMatching { get; set; } = false;
+        // Route this indexer's API calls through the Zyclops community NZB
+        // health proxy so only known-retrievable releases are returned.
+        // Off by default; toggled per indexer in Settings → Indexers.
+        public bool UseHealthProxy { get; set; } = false;
         // Per-indexer HTTP(S) proxy URL. Overrides the global ProxyUrl. Empty/null = inherit global.
         public string? ProxyUrl { get; set; }
         // Per-indexer HTTP timeout (seconds). Overrides the global TimeoutSeconds.

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -148,6 +148,14 @@ class Program
                 return;
             }
 
+            // let the newznab health-proxy transform derive provider_host
+            // from this instance's enabled usenet providers (env override
+            // wins inside the resolver; reads live so provider edits apply)
+            Clients.Indexers.NewznabHealthProxy.ProviderHostsSource = () => configManager
+                .GetUsenetProviderConfig().Providers
+                .Where(p => p.Type != Models.ProviderType.Disabled)
+                .Select(p => p.Host);
+
             RunYencNativeSelfTest();
 
             // Assign stable ProviderIds (persisting if needed) before the streaming

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -634,7 +634,8 @@ public class SearchProfileService(
                     searchUa,
                     proxy,
                     timeout,
-                    x.SkipTlsVerification);
+                    x.SkipTlsVerification,
+                    x.UseHealthProxy);
                 var baseQuery = ApplyIndexerCategoryOverrides(queryParams, x);
 
                 // Page through the indexer (offset += 100) until we've gathered `target` results,

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -60,6 +60,7 @@ interface ConnectionDetails {
     SkipTlsVerification?: boolean;
     MaxRequestsPerMinute?: number;
     EnableStrictMatching?: boolean;
+    UseHealthProxy?: boolean;
     ProxyUrl?: string;
     TimeoutSeconds?: number;
     SearchResultLimit?: number;
@@ -870,6 +871,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     const [hitResetTime, setHitResetTime] = useState("");
     const [enabled, setEnabled] = useState(true);
     const [strict, setStrict] = useState(false);
+    const [useHealthProxy, setUseHealthProxy] = useState(false);
     const [extraMovieCategories, setExtraMovieCategories] = useState("");
     const [extraTvCategories, setExtraTvCategories] = useState("");
     const [ignoreCategoryFilter, setIgnoreCategoryFilter] = useState(false);
@@ -918,6 +920,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             );
             setEnabled(indexer?.Enabled ?? true);
             setStrict(indexer?.EnableStrictMatching ?? false);
+            setUseHealthProxy(indexer?.UseHealthProxy ?? false);
             setExtraMovieCategories(indexer?.ExtraMovieCategories ?? "");
             setExtraTvCategories(indexer?.ExtraTvCategories ?? "");
             setIgnoreCategoryFilter(indexer?.IgnoreCategoryFilter ?? false);
@@ -933,7 +936,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
         }
     }, [show, indexer]);
 
-    useEffect(() => { setTestState('idle'); }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
+    useEffect(() => { setTestState('idle'); }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification, useHealthProxy]);
 
     const handleTest = useCallback(async () => {
         if (!url.trim() || !apiKey.trim() || apiKeyIsMasked) return;
@@ -946,13 +949,14 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             if (proxyUrl.trim()) fd.append('proxyUrl', proxyUrl);
             if (timeoutSeconds.trim()) fd.append('timeoutSeconds', timeoutSeconds);
             fd.append('skipTlsVerification', skipTlsVerification.toString());
+            if (useHealthProxy) fd.append('useHealthProxy', 'true');
             const r = await fetch('/api/test-indexer-connection', { method: 'POST', body: fd });
             const data = await r.json();
             setTestState(data.status && data.connected ? 'success' : 'error');
         } catch {
             setTestState('error');
         }
-    }, [url, apiKey, apiKeyIsMasked, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
+    }, [url, apiKey, apiKeyIsMasked, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification, useHealthProxy]);
 
     const handleSave = useCallback(() => {
         const rpm = parseInt(maxRpm || "0", 10);
@@ -994,6 +998,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             DownloadLimit: Number.isFinite(dl) && dl > 0 ? dl : undefined,
             HitLimitResetTime: Number.isFinite(hr) && hr >= 0 && hr <= 23 ? hr : undefined,
             EnableStrictMatching: strict,
+            UseHealthProxy: useHealthProxy || undefined,
             ExtraMovieCategories: normaliseCategoryList(extraMovieCategories),
             ExtraTvCategories: normaliseCategoryList(extraTvCategories),
             IgnoreCategoryFilter: ignoreCategoryFilter || undefined,
@@ -1006,7 +1011,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                 PreferDownloaded: filterPreferDownloaded,
             },
         });
-    }, [name, url, apiKey, searchUserAgent, retrieveUserAgent, skipTlsVerification, proxyUrl, timeoutSeconds, searchResultLimit, maxRpm, hitLimit, downloadLimit, hitResetTime, enabled, strict,
+    }, [name, url, apiKey, searchUserAgent, retrieveUserAgent, skipTlsVerification, proxyUrl, timeoutSeconds, searchResultLimit, maxRpm, hitLimit, downloadLimit, hitResetTime, enabled, strict, useHealthProxy,
         extraMovieCategories, extraTvCategories, ignoreCategoryFilter,
         filterEnabled, filterSkipPassworded, filterMinGrabs, filterGrabsGraceHours,
         filterMaxAgeDaysWithoutGrabs, filterPreferDownloaded, onSave]);
@@ -1275,6 +1280,18 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                                 />
                                 <Label htmlFor="indexer-strict" className="text-sm font-normal text-base-content/80">
                                     Strict matching <span className="text-[11px] font-normal text-base-content/45">(drop results whose title doesn't match the request)</span>
+                                </Label>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    id="indexer-health-proxy"
+                                    className="checkbox checkbox-sm"
+                                    checked={useHealthProxy}
+                                    onChange={e => setUseHealthProxy(e.target.checked)}
+                                />
+                                <Label htmlFor="indexer-health-proxy" className="text-sm font-normal text-base-content/80">
+                                    Zyclops health proxy <span className="text-[11px] font-normal text-base-content/45">(search via the community NZB-health proxy; returns only releases known retrievable on your usenet providers)</span>
                                 </Label>
                             </div>
                         </div>


### PR DESCRIPTION
This adds an opt-in, per-indexer **'Zyclops health proxy'** toggle to Settings → Indexers (off by default). When enabled for an indexer, its API calls route through the [Zyclops](https://zyclops.elfhosted.com) community NZB health proxy: the query is forwarded to the original indexer (`target` param; the apikey passes through untouched), and the results are filtered against a crowd-sourced database of NNTP `STAT`-verified releases — keyed to *this instance's own usenet backbones*, which are derived automatically from the enabled providers. Only releases known to be retrievable come back, so dead/DMCA'd posts never reach the queue or a player.

### Why this helps nzbdav users
A large share of failed imports and dead Stremio streams trace back to posts that were removed from the backbone after indexing. Zyclops continuously STAT-samples releases per backbone (it's the health layer several usenet streaming tools already use), so routing search through it turns "import, wait, fail, retry" into "never see the dead release at all". The database is public, free, and gets better for everyone as more instances use it — queries against unknown releases feed its testing queue.

### Design notes
- **Per-indexer and off by default** — private or boutique indexers whose releases the health corpus rarely covers would return thin results through a filtering proxy; users choose per indexer.
- **The endpoint is a constant, not configuration** — the value of a community health database comes from every participant querying the *same* public service, with uniform per-IP rate limiting and abuse controls. (Happy to discuss this trade-off.)
- The **connection test honors the toggle**, so users see the proxied round-trip before saving.
- Double-wrap guard: an indexer already pointing at the proxy is never re-wrapped.
- `t=caps` is answered by the proxy itself; standard Newznab params are forwarded unchanged.
- Indexers with the toggle off are byte-for-byte unchanged, and the proxy being unreachable only affects toggled indexers (documented in the class header).
- Optional `NEWZNAB_HEALTH_PROXY_PROVIDER_HOSTS` env override for deployments whose NNTP hostnames don't match their provider config (resellers with vanity hostnames).

Backend + frontend tests pass (`dotnet test`, `npm run typecheck && npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)