### PR TITLE
fix(ui): keep Test Connection available when editing Usenet providers

### DIFF
--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -888,6 +888,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
 
     const handleTestConnection = useCallback(async () => {
         setIsTestingConnection(true);
+        setConnectionTested(false);
         setTestError(null);
 
         try {
@@ -1111,6 +1112,15 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                     <Button variant="outline" onClick={onClose}>
                         Cancel
                     </Button>
+                    {canSave && type !== ProviderType.Disabled && (
+                        <Button
+                            variant="outline"
+                            onClick={handleTestConnection}
+                            disabled={!isFormValid || isTestingConnection}
+                        >
+                            {isTestingConnection ? "Testing..." : "Test Connection"}
+                        </Button>
+                    )}
                     {!canSave ? (
                         <Button
                             variant="primary"


### PR DESCRIPTION
## Summary
- On the Usenet provider modal, once Save is unlocked (edit with masked password, or after a successful create-time test), **Test Connection** is shown again as an outline button beside **Save Provider** so credentials can be re-checked at will.
- Re-tests clear the prior success alert at start so failed re-checks do not leave a stale success message.
- Create-flow gating is unchanged: new providers still require a successful test before Save (unless Type is Disabled).

Closes #553

## Test plan
- [ ] Settings → Usenet → Add Provider: Test Connection still required before Save; after success, both Test + Save appear; re-test works
- [ ] Edit existing provider (masked password): both Test + Save on open; Test with unchanged credentials succeeds
- [ ] Edit + change password: must Test again before Save
- [ ] Type = Disabled: Save only, no Test button
- [ ] Failed re-test shows error and does not leave the green success alert