### PR TITLE
fix(webdav): stop returning 500 for malformed or non-bytes Range headers

### DIFF
--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -5,6 +5,7 @@ using NWebDav.Server.Handlers;
 using NWebDav.Server.Helpers;
 using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
+using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Services;
@@ -61,8 +62,9 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         // Determine if we are invoked as HEAD
         var isHeadRequest = request.Method == HttpMethods.Head;
 
-        // Determine the requested range
-        var range = request.GetRange();
+        // Determine the requested range (ignore malformed / non-bytes / HEAD)
+        var rangeHeader = request.Headers["Range"].FirstOrDefault() ?? "";
+        var range = TryResolveRange(isHeadRequest, rangeHeader);
         var copyStart = 0L;
         long? copyEnd = null;
 
@@ -235,6 +237,29 @@ public class GetAndHeadHandlerPatch : IRequestHandler
             }
         }
         return true;
+    }
+
+    /// <summary>
+    /// Resolve a single bytes Range for GET. Returns null for HEAD, missing,
+    /// malformed, non-bytes, multi-range, or overflow so the caller serves full content.
+    /// Suffix form <c>bytes=-N</c> maps to <c>Start=null</c>, <c>End=N</c>.
+    /// </summary>
+    internal static NWebDav.Server.Helpers.Range? TryResolveRange(bool isHeadRequest, string rangeHeader)
+    {
+        if (isHeadRequest)
+            return null;
+
+        if (!GetWebdavItemRequest.TryParseRangeHeader(
+                rangeHeader, out var rStart, out var rEnd, out var rSuffix))
+            return null;
+
+        if (rStart is not null)
+            return new NWebDav.Server.Helpers.Range { Start = rStart, End = rEnd };
+
+        if (rSuffix is not null)
+            return new NWebDav.Server.Helpers.Range { Start = null, End = rSuffix };
+
+        return null;
     }
 
     private void FinishRange(Guid sessionId, ReadSession.EndReasonCode reason, string? message = null)

--- a/tests/NzbWebDAV.Tests/Api/GetWebdavItemRequestRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetWebdavItemRequestRangeTests.cs
@@ -24,6 +24,7 @@ public class GetWebdavItemRequestRangeTests
     [InlineData("bytes=0-99,200-299")]
     [InlineData("bytes=0-xx")]
     [InlineData("items=0-10")]
+    [InlineData("npt=0.000-")]
     [InlineData("bytes=-")]
     public void TryParseRangeHeader_IgnoresMalformed(string header)
     {

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -1,0 +1,45 @@
+using NzbWebDAV.WebDav.Base;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+public class GetAndHeadHandlerRangeTests
+{
+    [Theory]
+    [InlineData("npt=0.000-")]
+    [InlineData("bytes=99999999999999999999-")]
+    [InlineData("bytes=-")]
+    [InlineData("bytes=0-1,5-9")]
+    [InlineData("items=0-9")]
+    [InlineData("")]
+    public void TryResolveRange_IgnoresMalformedOrMultiRange(string header)
+    {
+        Assert.Null(GetAndHeadHandlerPatch.TryResolveRange(isHeadRequest: false, header));
+    }
+
+    [Fact]
+    public void TryResolveRange_ParsesByteRange()
+    {
+        var range = GetAndHeadHandlerPatch.TryResolveRange(isHeadRequest: false, "bytes=0-499");
+        Assert.NotNull(range);
+        Assert.Equal(0L, range!.Start);
+        Assert.Equal(499L, range.End);
+    }
+
+    [Fact]
+    public void TryResolveRange_ParsesSuffixRange()
+    {
+        var range = GetAndHeadHandlerPatch.TryResolveRange(isHeadRequest: false, "bytes=-500");
+        Assert.NotNull(range);
+        Assert.Null(range!.Start);
+        Assert.Equal(500L, range.End);
+    }
+
+    [Theory]
+    [InlineData("bytes=0-0")]
+    [InlineData("bytes=-500")]
+    [InlineData("npt=0.000-")]
+    public void TryResolveRange_IgnoresRangeOnHead(string header)
+    {
+        Assert.Null(GetAndHeadHandlerPatch.TryResolveRange(isHeadRequest: true, header));
+    }
+}


### PR DESCRIPTION
## Summary
- WebDAV GET/HEAD no longer throws on malformed, non-`bytes`, overflow, empty (`bytes=-`), or multi-range `Range` headers — those now serve full content (`200`) like `/view`.
- HEAD ignores `Range` entirely (RFC 9110); valid `bytes=` ranges on GET still return `206`.
- Fixes #555.

## Test plan
- [x] `dotnet test … --filter "FullyQualifiedName~Range"` (40 passed)
- [ ] `curl -H 'Range: npt=0.000-' -I <webdav-file>` → 200, full Content-Length, no Content-Range
- [ ] `curl -H 'Range: bytes=99999999999999999999-' -I <webdav-file>` → 200
- [ ] `curl -H 'Range: bytes=-' -I <webdav-file>` → 200
- [ ] `curl -H 'Range: bytes=0-499' -I <webdav-file>` → 206
- [ ] `curl -H 'Range: bytes=-500' -I <webdav-file>` → 206
- [ ] HEAD with `Range: bytes=0-0` → 200, no Content-Range