### PR TITLE
fix(webdav): getlastmodified and Last-Modified no longer shift by timezone offset

### DIFF
--- a/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
@@ -38,7 +38,7 @@ public class BaseStoreCollectionPropertyManager() : PropertyManager<BaseStoreCol
         },
         new DavGetLastModified<BaseStoreCollection>
         {
-            Getter = x => x.CreatedAt
+            Getter = x => x.CreatedAt.ToUniversalTime()
         },
         new Win32FileAttributes<BaseStoreCollection>
         {

--- a/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
@@ -23,7 +23,7 @@ public class BaseStoreItemPropertyManager() : PropertyManager<BaseStoreItem>(Dav
         },
         new DavGetLastModified<BaseStoreItem>
         {
-            Getter = x => x.CreatedAt
+            Getter = x => x.CreatedAt.ToUniversalTime()
         },
         new Win32FileAttributes<BaseStoreItem>
         {

--- a/tests/NzbWebDAV.Tests/WebDav/GetLastModifiedPropertyTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetLastModifiedPropertyTests.cs
@@ -1,0 +1,73 @@
+using System.Runtime.CompilerServices;
+using NWebDav.Server.Props;
+using NWebDav.Server.Stores;
+using NzbWebDAV.WebDav.Base;
+using NzbWebDAV.WebDav.Requests;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+public class GetLastModifiedPropertyTests
+{
+    [Theory]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public async Task Item_GetLastModified_IsTrueGmt(DateTimeKind kind)
+    {
+        var createdAt = new DateTime(2026, 1, 15, 12, 0, 0, kind);
+        var item = new StubStoreItem(createdAt);
+
+        var value = (string?)await item.PropertyManager!
+            .GetPropertyAsync(item, DavGetLastModified<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(createdAt.ToUniversalTime().ToString("R"), value);
+
+        if (TimeZoneInfo.Local.GetUtcOffset(createdAt) != TimeSpan.Zero)
+            Assert.NotEqual(createdAt.ToString("R"), value);
+    }
+
+    [Theory]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public async Task Collection_GetLastModified_IsTrueGmt(DateTimeKind kind)
+    {
+        var createdAt = new DateTime(2026, 1, 15, 12, 0, 0, kind);
+        var collection = new StubStoreCollection(createdAt);
+
+        var value = (string?)await collection.PropertyManager!
+            .GetPropertyAsync(collection, DavGetLastModified<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(createdAt.ToUniversalTime().ToString("R"), value);
+
+        if (TimeZoneInfo.Local.GetUtcOffset(createdAt) != TimeSpan.Zero)
+            Assert.NotEqual(createdAt.ToString("R"), value);
+    }
+
+    private sealed class StubStoreItem(DateTime createdAt) : BaseStoreReadonlyItem
+    {
+        public override string Name => "stub.bin";
+        public override string UniqueKey => "stub-item";
+        public override long FileSize => 0;
+        public override DateTime CreatedAt => createdAt;
+
+        public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
+            => Task.FromResult<Stream>(new MemoryStream([]));
+    }
+
+    private sealed class StubStoreCollection(DateTime createdAt) : BaseStoreReadonlyCollection
+    {
+        public override string Name => "stub-dir";
+        public override string UniqueKey => "stub-collection";
+        public override DateTime CreatedAt => createdAt;
+
+        protected override Task<IStoreItem?> GetItemAsync(GetItemRequest request)
+            => Task.FromResult<IStoreItem?>(null);
+
+        protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.CompletedTask.ConfigureAwait(false);
+            yield break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Convert `CreatedAt` with `ToUniversalTime()` in item and collection `DavGetLastModified` getters so PROPFIND `getlastmodified` and GET/HEAD `Last-Modified` are true GMT (RFC 4918 / RFC 9110), independent of container `TZ`.
- Adds property-manager unit tests for `DateTimeKind.Local` and `Unspecified` (SQLite round-trip).

Fixes #556

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter GetLastModifiedPropertyTests`
- [ ] Optional: run backend with `TZ=America/New_York`, PROPFIND/GET an item, confirm `getlastmodified` / `Last-Modified` match UTC wall time (not local).