### PR TITLE
fix(ui): auto-tune confidence tooltip no longer clipped by the provider modal

### DIFF
--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -31,9 +31,26 @@ export function Spinner({ className = "", size }: { className?: string; size?: s
   return <span className={`loading loading-spinner ${size === "sm" ? "loading-sm" : ""} ${className}`} />;
 }
 
-export function Tooltip({ content, children }: { content: string; children: ReactNode }) {
+type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+const tooltipPlacementClass: Record<TooltipPlacement, string> = {
+  top: "tooltip-top",
+  bottom: "tooltip-bottom",
+  left: "tooltip-left",
+  right: "tooltip-right",
+};
+
+export function Tooltip({
+  content,
+  children,
+  placement = "top",
+}: {
+  content: string;
+  children: ReactNode;
+  placement?: TooltipPlacement;
+}) {
   return (
-    <span className="tooltip" data-tip={content}>
+    <span className={`tooltip ${tooltipPlacementClass[placement]}`} data-tip={content}>
       {children}
     </span>
   );

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1559,7 +1559,10 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
 
                     {result.confidence && (
                         <div className="mt-3">
-                            <Tooltip content="How steady the measurements were (bucket-to-bucket throughput variation, article-pool reuse, and concurrent activity).">
+                            <Tooltip
+                                placement="right"
+                                content="How steady the measurements were (bucket-to-bucket throughput variation, article-pool reuse, and concurrent activity)."
+                            >
                                 <Badge
                                     className={`badge-sm badge-soft font-medium ${
                                         result.confidence === "high"


### PR DESCRIPTION
## Summary
- The Auto-tune “Low/Medium/High confidence” daisyUI tooltip was clipped by the modal’s left edge because it opened upward and centered over a left-aligned badge.
- Shared `Tooltip` now accepts an optional `placement` prop; the confidence badge uses `placement="right"` so the tip opens into the modal.

## Test plan
- [ ] Open Settings → Usenet → edit a provider → run a speed test until a confidence badge appears
- [ ] Hover the confidence badge and confirm the full tip text is readable (not clipped)
- [ ] Confirm other tooltips (queue table, etc.) still default to top placement