### PR TITLE
test(debounce): fix flaky trailing-edge throw under delayed timers

### DIFF
--- a/tests/NzbWebDAV.Tests/Utils/DebounceUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/DebounceUtilTests.cs
@@ -18,15 +18,25 @@ public class DebounceUtilTests
     [Fact]
     public async Task CreateDebounce_TrailingEdgeThrow_DoesNotPropagate_AndSubsequentActionsStillRun()
     {
-        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(50));
+        var window = TimeSpan.FromMilliseconds(50);
+        var debounce = DebounceUtil.CreateDebounce(window);
+        using var trailingEdgeFired = new ManualResetEventSlim(false);
         var subsequentRan = false;
 
         // First call runs immediately (leading edge).
         debounce(() => { });
         // Second call within the window is scheduled on the timer.
-        debounce(() => throw new InvalidOperationException("trailing boom"));
+        debounce(() =>
+        {
+            trailingEdgeFired.Set();
+            throw new InvalidOperationException("trailing boom");
+        });
 
-        await Task.Delay(150);
+        // The timer callback stamps the window start, so wait for the throw to
+        // land before timing anything against it. A loaded threadpool can delay
+        // the callback well past the window.
+        Assert.True(trailingEdgeFired.Wait(TimeSpan.FromSeconds(10)), "trailing edge never fired");
+        await Task.Delay(window * 3);
 
         // After the window, a new leading-edge call should still work.
         debounce(() => subsequentRan = true);


### PR DESCRIPTION
Fix for a flickering test (fails maybe 1 in 15 times, seems to happen locally more). The trailing action now signals before it throws and the test waits on that, so the final call is timed from where the window actually started. Also I think debounce is the wrong term here.