### PR TITLE
feat(usenet)!: allow trusted providers and indexers with invalid TLS certificates

### DIFF
--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionRequest.cs
@@ -12,6 +12,7 @@ public class BenchmarkUsenetConnectionRequest
     public string Pass { get; init; }
     public int Port { get; init; }
     public bool UseSsl { get; init; }
+    public bool SkipTlsVerification { get; init; }
 
     /// <summary>The provider's currently-configured max connections (the sweep probes a bit above it).</summary>
     public int MaxConnections { get; init; }
@@ -44,6 +45,7 @@ public class BenchmarkUsenetConnectionRequest
             Pass = "";
             Port = 0;
             UseSsl = false;
+            SkipTlsVerification = false;
             MaxConnections = 1;
             Intensity = BenchmarkIntensity.Quick;
             return;
@@ -72,6 +74,10 @@ public class BenchmarkUsenetConnectionRequest
         UseSsl = !bool.TryParse(useSsl, out var useSslValue)
             ? throw new BadHttpRequestException("Invalid use-ssl value")
             : useSslValue;
+
+        var skipTlsVerification = context.Request.Form["skip-tls-verification"].FirstOrDefault();
+        SkipTlsVerification = bool.TryParse(skipTlsVerification, out var skipTlsVerificationValue)
+                              && skipTlsVerificationValue;
 
         // Optional knobs — fall back to sensible defaults rather than rejecting.
         var maxConnections = context.Request.Form["max-connections"].FirstOrDefault();
@@ -103,6 +109,7 @@ public class BenchmarkUsenetConnectionRequest
             Pass = Pass,
             Port = Port,
             UseSsl = UseSsl,
+            SkipTlsVerification = UseSsl && SkipTlsVerification,
             MaxConnections = 1,
             Type = ProviderType.Disabled
         };

--- a/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
@@ -9,6 +10,7 @@ namespace NzbWebDAV.Api.Controllers.Profiles.Adapters;
 [ApiController]
 [Route("api/search/{token}/nzb/{playToken}.nzb")]
 public class NzbProxyController(
+    ConfigManager configManager,
     SearchProfileService searchService,
     NzbResolutionCache cache,
     NzbFetchCoalescer nzbFetchCoalescer
@@ -37,19 +39,25 @@ public class NzbProxyController(
         byte[]? bytes;
         try
         {
-            bytes = await nzbFetchCoalescer.GetOrFetchAsync(candidate.NzbUrl, async innerCt =>
-            {
-                using var req = new HttpRequestMessage(HttpMethod.Get, candidate.NzbUrl);
-                req.Headers.TryAddWithoutValidation("User-Agent", candidate.IndexerUserAgent);
-                var client = ProxyHttpClientPool.GetClient(candidate.ProxyUrl);
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
-                cts.CancelAfter(FetchTimeout);
-                using var resp = await client
-                    .SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token)
-                    .ConfigureAwait(false);
-                if (!resp.IsSuccessStatusCode) return null;
-                return await resp.Content.ReadAsByteArrayAsync(cts.Token).ConfigureAwait(false);
-            }, HttpContext.RequestAborted).ConfigureAwait(false);
+            var skipTlsVerification = configManager.GetIndexerConfig().ShouldSkipTlsVerification(candidate.IndexerName);
+            bytes = await nzbFetchCoalescer.GetOrFetchAsync(
+                candidate.NzbUrl,
+                candidate.ProxyUrl,
+                skipTlsVerification,
+                async innerCt =>
+                {
+                    using var req = new HttpRequestMessage(HttpMethod.Get, candidate.NzbUrl);
+                    req.Headers.TryAddWithoutValidation("User-Agent", candidate.IndexerUserAgent);
+                    var client = ProxyHttpClientPool.GetClient(candidate.ProxyUrl, skipTlsVerification);
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
+                    cts.CancelAfter(FetchTimeout);
+                    using var resp = await client
+                        .SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token)
+                        .ConfigureAwait(false);
+                    if (!resp.IsSuccessStatusCode) return null;
+                    return await resp.Content.ReadAsByteArrayAsync(cts.Token).ConfigureAwait(false);
+                },
+                HttpContext.RequestAborted).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -813,7 +813,8 @@ public class ProfilePlayController(
         var preflighted = preflightCache.Get(c.NzbUrl);
         if (preflighted?.NzbBytes is { } cachedBytes) return cachedBytes;
 
-        return await nzbFetchCoalescer.GetOrFetchAsync(c.NzbUrl, async innerCt =>
+        var skipTlsVerification = configManager.GetIndexerConfig().ShouldSkipTlsVerification(c.IndexerName);
+        return await nzbFetchCoalescer.GetOrFetchAsync(c.NzbUrl, c.ProxyUrl, skipTlsVerification, async innerCt =>
         {
             try
             {
@@ -838,7 +839,7 @@ public class ProfilePlayController(
 
                 using var req = new HttpRequestMessage(HttpMethod.Get, c.NzbUrl);
                 req.Headers.TryAddWithoutValidation("User-Agent", c.IndexerUserAgent);
-                var client = ProxyHttpClientPool.GetClient(c.ProxyUrl);
+                var client = ProxyHttpClientPool.GetClient(c.ProxyUrl, skipTlsVerification);
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
                 cts.CancelAfter(NzbFetchTimeout);
                 using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);

--- a/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
+++ b/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
@@ -46,7 +46,7 @@ public class SearchIndexersController(
                 var proxy = string.IsNullOrWhiteSpace(x.ProxyUrl) ? globalProxy : x.ProxyUrl;
                 var timeout = indexerConfig.GetEffectiveTimeoutSeconds(x);
                 await rateLimiter.WaitAsync(x.Name, x.MaxRequestsPerMinute, ct).ConfigureAwait(false);
-                var client = new NewznabClient(x.Url, x.ApiKey, ua, proxy, timeout);
+                var client = new NewznabClient(x.Url, x.ApiKey, ua, proxy, timeout, x.SkipTlsVerification);
                 var items = await client.SearchAsync(request.Query, request.Limit, ct).ConfigureAwait(false);
                 _ = hitTracker.RecordAsync(x.Name, IndexerApiHit.HitType.Search, CancellationToken.None);
                 var mapped = items

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
@@ -19,7 +19,13 @@ public class TestIndexerConnectionController(NzbWebDAV.Config.ConfigManager conf
                 : request.ProxyUrl;
             var timeout = request.TimeoutSeconds
                           ?? (indexerConfig.TimeoutSeconds is int g && g > 0 ? g : NzbWebDAV.Config.IndexerConfig.DefaultTimeoutSeconds);
-            var client = new NewznabClient(request.Url, request.ApiKey, ua, proxy, timeout);
+            var client = new NewznabClient(
+                request.Url,
+                request.ApiKey,
+                ua,
+                proxy,
+                timeout,
+                request.SkipTlsVerification);
             var ok = await client.TestAsync(HttpContext.RequestAborted).ConfigureAwait(false);
             return Ok(new TestIndexerConnectionResponse { Status = true, Connected = ok });
         }

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
@@ -9,6 +9,7 @@ public class TestIndexerConnectionRequest
     public string? UserAgent { get; init; }
     public string? ProxyUrl { get; init; }
     public int? TimeoutSeconds { get; init; }
+    public bool SkipTlsVerification { get; init; }
 
     public TestIndexerConnectionRequest(HttpContext context)
     {
@@ -22,5 +23,9 @@ public class TestIndexerConnectionRequest
         ProxyUrl = context.Request.Form["proxyUrl"].FirstOrDefault();
         var rawTimeout = context.Request.Form["timeoutSeconds"].FirstOrDefault();
         TimeoutSeconds = int.TryParse(rawTimeout, out var t) && t > 0 ? t : null;
+        SkipTlsVerification = bool.TryParse(
+            context.Request.Form["skipTlsVerification"].FirstOrDefault(),
+            out var skipTlsVerification)
+            && skipTlsVerification;
     }
 }

--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionRequest.cs
@@ -11,6 +11,7 @@ public class TestUsenetConnectionRequest
     public string Pass { get; init; }
     public int Port { get; init; }
     public bool UseSsl { get; init; }
+    public bool SkipTlsVerification { get; init; }
 
     public TestUsenetConnectionRequest(HttpContext context, ConfigManager configManager)
     {
@@ -37,6 +38,10 @@ public class TestUsenetConnectionRequest
         UseSsl = !bool.TryParse(useSsl, out bool useSslValue)
             ? throw new BadHttpRequestException("Invalid use-ssl value")
             : useSslValue;
+
+        var skipTlsVerification = context.Request.Form["skip-tls-verification"].FirstOrDefault();
+        SkipTlsVerification = bool.TryParse(skipTlsVerification, out var skipTlsVerificationValue)
+                              && skipTlsVerificationValue;
     }
 
     public UsenetProviderConfig.ConnectionDetails ToConnectionDetails()
@@ -48,6 +53,7 @@ public class TestUsenetConnectionRequest
             Pass = Pass,
             Port = Port,
             UseSsl = UseSsl,
+            SkipTlsVerification = UseSsl && SkipTlsVerification,
             MaxConnections = 1,
             Type = ProviderType.Disabled
         };

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -13,7 +13,8 @@ namespace NzbWebDAV.Api.SabControllers.AddUrl;
 
 public class AddUrlRequest() : AddFileRequest
 {
-    private static readonly HttpClient DirectHttpClient = InitializeHttpClient();
+    private static readonly HttpClient StrictDirectHttpClient = InitializeHttpClient(skipTlsVerification: false);
+    private static readonly HttpClient PermissiveDirectHttpClient = InitializeHttpClient(skipTlsVerification: true);
     private static readonly HttpRequestOptionsKey<TrustedHostsMatcher> TrustedHostsOptionKey = new("TrustedHosts");
     private const int MaxAutomaticRedirections = 10;
     private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(60);
@@ -27,6 +28,7 @@ public class AddUrlRequest() : AddFileRequest
 
         var userAgent = IndexerConfig.PerIndexerRetrieveUserAgent(matchedIndexer) ?? configManager.GetUserAgent();
         var proxyUrl = StringUtil.EmptyToNull(matchedIndexer?.ProxyUrl) ?? indexerConfig.ProxyUrl;
+        var skipTlsVerification = matchedIndexer?.SkipTlsVerification == true;
         var trustedHosts = TrustedHostsMatcher.Parse(configManager.GetAddUrlTrustedHosts());
 
         if (matchedIndexer is not null)
@@ -43,7 +45,13 @@ public class AddUrlRequest() : AddFileRequest
         }
 
         var nzbFile = await GetNzbFile(
-            nzbUrl, nzbName, userAgent, proxyUrl, trustedHosts, context.RequestAborted).ConfigureAwait(false);
+            nzbUrl,
+            nzbName,
+            userAgent,
+            proxyUrl,
+            skipTlsVerification,
+            trustedHosts,
+            context.RequestAborted).ConfigureAwait(false);
         if (matchedIndexer is not null)
             _ = hitTracker.RecordAsync(matchedIndexer.Name, IndexerApiHit.HitType.Download, CancellationToken.None);
         return new AddUrlRequest()
@@ -81,6 +89,7 @@ public class AddUrlRequest() : AddFileRequest
         string? nzbName,
         string userAgent,
         string? proxyUrl,
+        bool skipTlsVerification,
         TrustedHostsMatcher trustedHosts,
         CancellationToken cancellationToken)
     {
@@ -90,7 +99,7 @@ public class AddUrlRequest() : AddFileRequest
                 throw new Exception($"The url is invalid.");
 
             var response = await GetAsync(
-                url, userAgent, proxyUrl, trustedHosts, cancellationToken).ConfigureAwait(false);
+                url, userAgent, proxyUrl, skipTlsVerification, trustedHosts, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 response.Dispose();
@@ -133,6 +142,7 @@ public class AddUrlRequest() : AddFileRequest
         string url,
         string userAgent,
         string? proxyUrl,
+        bool skipTlsVerification,
         TrustedHostsMatcher trustedHosts,
         CancellationToken cancellationToken
     )
@@ -142,8 +152,8 @@ public class AddUrlRequest() : AddFileRequest
         var ct = timeoutCts.Token;
         var currentUri = ValidateHttpUri(url);
         var httpClient = string.IsNullOrWhiteSpace(proxyUrl)
-            ? DirectHttpClient
-            : ProxyHttpClientPool.GetClient(proxyUrl);
+            ? (skipTlsVerification ? PermissiveDirectHttpClient : StrictDirectHttpClient)
+            : ProxyHttpClientPool.GetClient(proxyUrl, skipTlsVerification);
 
         for (var redirectCount = 0; ; redirectCount++)
         {
@@ -197,7 +207,7 @@ public class AddUrlRequest() : AddFileRequest
         }
     }
 
-    private static HttpClient InitializeHttpClient()
+    private static HttpClient InitializeHttpClient(bool skipTlsVerification)
     {
         var handler = new SocketsHttpHandler
         {
@@ -205,6 +215,13 @@ public class AddUrlRequest() : AddFileRequest
             UseProxy = false,
             ConnectCallback = ConnectToValidatedAddress,
         };
+        if (skipTlsVerification)
+        {
+            handler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
+            {
+                RemoteCertificateValidationCallback = static (_, _, _, _) => true,
+            };
+        }
         return new HttpClient(handler);
     }
 

--- a/backend/Clients/Indexers/NewznabClient.cs
+++ b/backend/Clients/Indexers/NewznabClient.cs
@@ -8,12 +8,13 @@ public class NewznabClient(
     string apiKey,
     string userAgent = "NzbDav",
     string? proxyUrl = null,
-    int timeoutSeconds = 30)
+    int timeoutSeconds = 30,
+    bool skipTlsVerification = false)
 {
     private static readonly XNamespace Newznab = "http://www.newznab.com/DTD/2010/feeds/attributes/";
 
     private readonly Uri _apiUri = NormalizeApiUri(baseUrl);
-    private readonly HttpClient _http = ProxyHttpClientPool.GetClient(proxyUrl);
+    private readonly HttpClient _http = ProxyHttpClientPool.GetClient(proxyUrl, skipTlsVerification);
     private readonly int _timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 30;
 
     private static Uri NormalizeApiUri(string baseUrl)

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -27,11 +27,16 @@ public class BaseNntpClient : NntpClient
 
     private readonly IUsenetClient _client;
 
-    public BaseNntpClient() : this(new UsenetClient(new UsenetClientOptions
+    public BaseNntpClient() : this(skipTlsVerification: false)
+    {
+    }
+
+    public BaseNntpClient(bool skipTlsVerification) : this(new UsenetClient(new UsenetClientOptions
     {
         CrcValidation = EnvironmentUtil.GetEnvironmentVariable("USENET_DISABLE_CRC_VALIDATION") == "1"
             ? YencCrcValidationMode.Off
             : YencCrcValidationMode.WhenPresent,
+        SkipTlsVerification = skipTlsVerification,
     }))
     {
     }

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -162,6 +162,16 @@ public class UsenetStreamingClient : WrappingNntpClient
                 label);
         }
 
+        if (connectionDetails.UseSsl && connectionDetails.SkipTlsVerification)
+        {
+            var label = string.IsNullOrWhiteSpace(connectionDetails.Nickname)
+                ? connectionDetails.Host
+                : connectionDetails.Nickname;
+            Log.Warning(
+                "Provider '{Provider}' skips TLS certificate verification. The connection is encrypted but vulnerable to server impersonation.",
+                label);
+        }
+
         var connectionPool = CreateNewConnectionPool(
             maxConnections: maxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
@@ -232,7 +242,10 @@ public class UsenetStreamingClient : WrappingNntpClient
     (
         UsenetProviderConfig.ConnectionDetails connectionDetails,
         CancellationToken ct
-    ) => CreateNewConnection(connectionDetails, static () => new BaseNntpClient(), ct);
+    ) => CreateNewConnection(
+        connectionDetails,
+        () => new BaseNntpClient(connectionDetails.UseSsl && connectionDetails.SkipTlsVerification),
+        ct);
 
     internal static async ValueTask<INntpClient> CreateNewConnection
     (

--- a/backend/Config/IndexerConfig.cs
+++ b/backend/Config/IndexerConfig.cs
@@ -37,6 +37,13 @@ public class IndexerConfig
         return DefaultSearchResultLimit;
     }
 
+    public bool ShouldSkipTlsVerification(string indexerName)
+    {
+        return Indexers.FirstOrDefault(x => x.Enabled &&
+                                            string.Equals(x.Name, indexerName, StringComparison.Ordinal))
+            ?.SkipTlsVerification == true;
+    }
+
     public static string? PerIndexerSearchUserAgent(ConnectionDetails? indexer)
         => indexer is null ? null : FirstNonBlank(indexer.SearchUserAgent, indexer.UserAgent);
 
@@ -55,6 +62,7 @@ public class IndexerConfig
         public string? UserAgent { get; set; }
         public string? SearchUserAgent { get; set; }
         public string? RetrieveUserAgent { get; set; }
+        public bool SkipTlsVerification { get; set; } = false;
         public int MaxRequestsPerMinute { get; set; } = 0;
         public bool EnableStrictMatching { get; set; } = false;
         // Per-indexer HTTP(S) proxy URL. Overrides the global ProxyUrl. Empty/null = inherit global.

--- a/backend/Config/UsenetProviderConfig.cs
+++ b/backend/Config/UsenetProviderConfig.cs
@@ -24,6 +24,7 @@ public class UsenetProviderConfig
         public required string Host { get; set; }
         public required int Port { get; set; }
         public required bool UseSsl { get; set; }
+        public bool SkipTlsVerification { get; set; } = false;
         public required string User { get; set; }
         public required string Pass { get; set; }
         public required int MaxConnections { get; set; }

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -22,7 +22,7 @@
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="NzbDav.SharpCompress" Version="0.54.0" />
-      <PackageReference Include="NzbDav.UsenetSharp" Version="3.1.3" />
+      <PackageReference Include="NzbDav.UsenetSharp" Version="3.2.0" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>
 

--- a/backend/Services/NzbFetchCoalescer.cs
+++ b/backend/Services/NzbFetchCoalescer.cs
@@ -8,22 +8,25 @@ public class NzbFetchCoalescer
     private static readonly TimeSpan HardFetchCap = TimeSpan.FromSeconds(90);
     private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(1);
 
-    private readonly ConcurrentDictionary<string, Lazy<Task<byte[]?>>> _inFlight = new();
-    private readonly ConcurrentDictionary<string, Entry> _cache = new();
+    private readonly ConcurrentDictionary<FetchKey, Lazy<Task<byte[]?>>> _inFlight = new();
+    private readonly ConcurrentDictionary<FetchKey, Entry> _cache = new();
     private DateTimeOffset _lastSweep = DateTimeOffset.UtcNow;
 
     public async Task<byte[]?> GetOrFetchAsync(
         string url,
+        string? proxyUrl,
+        bool skipTlsVerification,
         Func<CancellationToken, Task<byte[]?>> fetch,
         CancellationToken ct)
     {
-        if (TryGetCached(url, out var cached)) return cached;
+        var key = new FetchKey(url, proxyUrl ?? "", skipTlsVerification);
+        if (TryGetCached(key, out var cached)) return cached;
 
-        var lazy = _inFlight.GetOrAdd(url, u => new Lazy<Task<byte[]?>>(() => RunSharedAsync(u, fetch)));
+        var lazy = _inFlight.GetOrAdd(key, k => new Lazy<Task<byte[]?>>(() => RunSharedAsync(k, fetch)));
         return await lazy.Value.WaitAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task<byte[]?> RunSharedAsync(string url, Func<CancellationToken, Task<byte[]?>> fetch)
+    private async Task<byte[]?> RunSharedAsync(FetchKey key, Func<CancellationToken, Task<byte[]?>> fetch)
     {
         try
         {
@@ -31,24 +34,24 @@ public class NzbFetchCoalescer
             var bytes = await fetch(cts.Token).ConfigureAwait(false);
             if (bytes is not null)
             {
-                _cache[url] = new Entry(bytes, DateTimeOffset.UtcNow + CacheTtl);
+                _cache[key] = new Entry(bytes, DateTimeOffset.UtcNow + CacheTtl);
                 SweepIfDue();
             }
             return bytes;
         }
         finally
         {
-            _inFlight.TryRemove(url, out _);
+            _inFlight.TryRemove(key, out _);
         }
     }
 
-    private bool TryGetCached(string url, out byte[]? bytes)
+    private bool TryGetCached(FetchKey key, out byte[]? bytes)
     {
         bytes = null;
-        if (!_cache.TryGetValue(url, out var e)) return false;
+        if (!_cache.TryGetValue(key, out var e)) return false;
         if (DateTimeOffset.UtcNow > e.ExpiresAt)
         {
-            _cache.TryRemove(url, out _);
+            _cache.TryRemove(key, out _);
             return false;
         }
         bytes = e.Bytes;
@@ -65,4 +68,5 @@ public class NzbFetchCoalescer
     }
 
     private readonly record struct Entry(byte[] Bytes, DateTimeOffset ExpiresAt);
+    private readonly record struct FetchKey(string Url, string ProxyUrl, bool SkipTlsVerification);
 }

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -141,13 +141,14 @@ public class PreflightOrchestrator(
         NzbResolutionCache.Candidate c,
         CancellationToken ct)
     {
-        return nzbFetchCoalescer.GetOrFetchAsync(c.NzbUrl, async innerCt =>
+        var skipTlsVerification = configManager.GetIndexerConfig().ShouldSkipTlsVerification(c.IndexerName);
+        return nzbFetchCoalescer.GetOrFetchAsync(c.NzbUrl, c.ProxyUrl, skipTlsVerification, async innerCt =>
         {
             try
             {
                 using var req = new HttpRequestMessage(HttpMethod.Get, c.NzbUrl);
                 req.Headers.TryAddWithoutValidation("User-Agent", c.IndexerUserAgent);
-                var client = ProxyHttpClientPool.GetClient(c.ProxyUrl);
+                var client = ProxyHttpClientPool.GetClient(c.ProxyUrl, skipTlsVerification);
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
                 cts.CancelAfter(FetchTimeout);
                 using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -628,7 +628,13 @@ public class SearchProfileService(
                 var proxy = string.IsNullOrWhiteSpace(x.ProxyUrl) ? globalProxy : x.ProxyUrl;
                 var timeout = indexerConfig.GetEffectiveTimeoutSeconds(x);
                 var target = indexerConfig.GetEffectiveSearchResultLimit(x);
-                var client = new NewznabClient(x.Url, x.ApiKey, searchUa, proxy, timeout);
+                var client = new NewznabClient(
+                    x.Url,
+                    x.ApiKey,
+                    searchUa,
+                    proxy,
+                    timeout,
+                    x.SkipTlsVerification);
                 var baseQuery = ApplyIndexerCategoryOverrides(queryParams, x);
 
                 // Page through the indexer (offset += 100) until we've gathered `target` results,

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -1108,7 +1108,8 @@ public class WatchtowerService(
 
     private Task<byte[]?> FetchNzbBytesAsync(NzbResolutionCache.Candidate c, CancellationToken ct)
     {
-        return nzbFetchCoalescer.GetOrFetchAsync(c.NzbUrl, async innerCt =>
+        var skipTlsVerification = configManager.GetIndexerConfig().ShouldSkipTlsVerification(c.IndexerName);
+        return nzbFetchCoalescer.GetOrFetchAsync(c.NzbUrl, c.ProxyUrl, skipTlsVerification, async innerCt =>
         {
             try
             {
@@ -1135,7 +1136,7 @@ public class WatchtowerService(
 
                     using var req = new HttpRequestMessage(HttpMethod.Get, c.NzbUrl);
                     req.Headers.TryAddWithoutValidation("User-Agent", c.IndexerUserAgent);
-                    var client = ProxyHttpClientPool.GetClient(c.ProxyUrl);
+                    var client = ProxyHttpClientPool.GetClient(c.ProxyUrl, skipTlsVerification);
                     using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
                     cts.CancelAfter(NzbFetchTimeout);
                     using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);

--- a/backend/Utils/ProxyHttpClientPool.cs
+++ b/backend/Utils/ProxyHttpClientPool.cs
@@ -1,21 +1,22 @@
 using System.Collections.Concurrent;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
 
 namespace NzbWebDAV.Utils;
 
 /// <summary>
-/// One shared HttpClient per distinct proxy URL (or "" for direct). Returned clients
+/// One shared HttpClient per distinct proxy URL and TLS-validation policy. Returned clients
 /// have an infinite Timeout because they're shared across callers with different
 /// budgets; each caller enforces its own per-request timeout via CancellationToken.
 /// </summary>
 public static class ProxyHttpClientPool
 {
-    private static readonly ConcurrentDictionary<string, HttpClient> Clients = new();
+    private static readonly ConcurrentDictionary<ClientKey, HttpClient> Clients = new();
 
-    public static HttpClient GetClient(string? proxyUrl)
+    public static HttpClient GetClient(string? proxyUrl, bool skipTlsVerification = false)
     {
-        var key = Normalize(proxyUrl) ?? "";
+        var key = new ClientKey(Normalize(proxyUrl) ?? "", skipTlsVerification);
         return Clients.GetOrAdd(key, k =>
         {
             var handler = new SocketsHttpHandler
@@ -25,7 +26,7 @@ public static class ProxyHttpClientPool
                 ConnectTimeout = TimeSpan.FromSeconds(15),
             };
 
-            if (k.Length > 0 && Uri.TryCreate(k, UriKind.Absolute, out var uri))
+            if (k.ProxyUrl.Length > 0 && Uri.TryCreate(k.ProxyUrl, UriKind.Absolute, out var uri))
             {
                 var address = new UriBuilder(uri) { UserName = "", Password = "" }.Uri;
                 var proxy = new WebProxy(address) { BypassProxyOnLocal = false };
@@ -45,9 +46,19 @@ public static class ProxyHttpClientPool
                 handler.ConnectCallback = KeepAliveConnectAsync;
             }
 
+            if (k.SkipTlsVerification)
+            {
+                handler.SslOptions = new SslClientAuthenticationOptions
+                {
+                    RemoteCertificateValidationCallback = static (_, _, _, _) => true,
+                };
+            }
+
             return new HttpClient(handler, disposeHandler: true) { Timeout = Timeout.InfiniteTimeSpan };
         });
     }
+
+    private readonly record struct ClientKey(string ProxyUrl, bool SkipTlsVerification);
 
     private static async ValueTask<Stream> KeepAliveConnectAsync(
         SocketsHttpConnectionContext context, CancellationToken ct)

--- a/docs/configuration/indexers.md
+++ b/docs/configuration/indexers.md
@@ -24,6 +24,7 @@ Synced patterns take precedence; last-good cache survives temporary URL failures
 | Name / URL / API Key | Newznab endpoint |
 | Search / Retrieve User-Agent | Optional overrides |
 | Proxy URL | Optional override |
+| Skip TLS certificate verification | Accept an invalid HTTPS certificate; off by default |
 | Max requests / minute | `0` = unlimited |
 | API hit / download limits + reset hour | Cap usage; blank reset = rolling 24h |
 | Enabled | Include in searches |
@@ -31,5 +32,15 @@ Synced patterns take precedence; last-good cache survives temporary URL failures
 | Extra movie/TV categories | Appended to 2000/2070 or 5000/5070 |
 | Ignore category filter | Omit `cat=` |
 | Result filtering | Skip passworded, min grabs, grace period, age/zero-download drops, rank by grabs |
+
+## Invalid indexer certificates [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
+
+Leave **Skip TLS certificate verification** disabled unless a trusted HTTPS
+indexer has a certificate it cannot correct. The setting keeps traffic encrypted
+but accepts untrusted, expired, and hostname-mismatched certificates, exposing
+API keys and NZB requests to man-in-the-middle attacks. It applies to the
+indexer's API and its resolved NZB download URLs. SAB `addurl` requests inherit
+the setting only when their initial URL exactly matches an enabled indexer's
+configured host.
 
 [Indexer search feature](../features/indexer-search.md)

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -16,6 +16,7 @@ Add one or more accounts. Each provider supports:
 | Pipeline depth | Per-provider override when pipelining on | blank = global `8` |
 | Type | Disabled / Pool Connections / Backup Only | Pool |
 | Use SSL | TLS for NNTP | on |
+| Skip TLS certificate verification | Accept an invalid provider certificate | off |
 | Data Cap | Block-account limit; auto-pauses near ~95% | uncapped |
 | Already Used | Seed usage when migrating mid-block | empty |
 | Auto-tune | Speed test → recommend connections + pipelining | action |
@@ -25,6 +26,13 @@ Persisted as `usenet.providers` JSON.
 !!! warning "Cleartext"
 
     Disabling SSL stores/sends credentials in cleartext on the wire — only for trusted networks.
+
+## Invalid provider certificates [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
+
+Leave **Skip TLS certificate verification** disabled unless a trusted provider has
+a certificate it cannot correct. It keeps the NNTP connection encrypted but
+accepts an untrusted, expired, or hostname-mismatched certificate. This permits
+a man-in-the-middle attacker to impersonate the provider and read credentials.
 
 ## Routing and pipelining
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -489,6 +489,7 @@ export type TestUsenetConnectionRequest = {
     host: string,
     port: string,
     useSsl: string,
+    skipTlsVerification: string,
     user: string,
     pass: string
 }

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -52,6 +52,7 @@ interface ConnectionDetails {
     UserAgent?: string;
     SearchUserAgent?: string;
     RetrieveUserAgent?: string;
+    SkipTlsVerification?: boolean;
     MaxRequestsPerMinute?: number;
     EnableStrictMatching?: boolean;
     ProxyUrl?: string;
@@ -814,6 +815,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     const [name, setName] = useState("");
     const [url, setUrl] = useState("");
     const [apiKey, setApiKey] = useState("");
+    const [skipTlsVerification, setSkipTlsVerification] = useState(false);
     const [searchUserAgent, setSearchUserAgent] = useState("");
     const [retrieveUserAgent, setRetrieveUserAgent] = useState("");
     const [proxyUrl, setProxyUrl] = useState("");
@@ -853,6 +855,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             setName(indexer?.Name || "");
             setUrl(indexer?.Url || "");
             setApiKey(indexer?.ApiKey || "");
+            setSkipTlsVerification(indexer?.SkipTlsVerification ?? false);
             setSearchUserAgent(indexer?.SearchUserAgent || indexer?.UserAgent || "");
             setRetrieveUserAgent(indexer?.RetrieveUserAgent || indexer?.UserAgent || "");
             setProxyUrl(indexer?.ProxyUrl || "");
@@ -887,7 +890,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
         }
     }, [show, indexer]);
 
-    useEffect(() => { setTestState('idle'); }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds]);
+    useEffect(() => { setTestState('idle'); }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
 
     const handleTest = useCallback(async () => {
         if (!url.trim() || !apiKey.trim() || apiKeyIsMasked) return;
@@ -899,13 +902,14 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             if (searchUserAgent.trim()) fd.append('userAgent', searchUserAgent);
             if (proxyUrl.trim()) fd.append('proxyUrl', proxyUrl);
             if (timeoutSeconds.trim()) fd.append('timeoutSeconds', timeoutSeconds);
+            fd.append('skipTlsVerification', skipTlsVerification.toString());
             const r = await fetch('/api/test-indexer-connection', { method: 'POST', body: fd });
             const data = await r.json();
             setTestState(data.status && data.connected ? 'success' : 'error');
         } catch {
             setTestState('error');
         }
-    }, [url, apiKey, apiKeyIsMasked, searchUserAgent, proxyUrl, timeoutSeconds]);
+    }, [url, apiKey, apiKeyIsMasked, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
 
     const handleSave = useCallback(() => {
         const rpm = parseInt(maxRpm || "0", 10);
@@ -936,6 +940,9 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             UserAgent: undefined,
             SearchUserAgent: searchUserAgent.trim() || undefined,
             RetrieveUserAgent: retrieveUserAgent.trim() || undefined,
+            SkipTlsVerification: url.trim().toLowerCase().startsWith("https://") && skipTlsVerification
+                ? true
+                : undefined,
             ProxyUrl: proxyUrl.trim() || undefined,
             TimeoutSeconds: Number.isFinite(timeout) && timeout > 0 ? timeout : undefined,
             SearchResultLimit: Number.isFinite(srl) && srl > 0 ? srl : undefined,
@@ -956,7 +963,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                 PreferDownloaded: filterPreferDownloaded,
             },
         });
-    }, [name, url, apiKey, searchUserAgent, retrieveUserAgent, proxyUrl, timeoutSeconds, searchResultLimit, maxRpm, hitLimit, downloadLimit, hitResetTime, enabled, strict,
+    }, [name, url, apiKey, searchUserAgent, retrieveUserAgent, skipTlsVerification, proxyUrl, timeoutSeconds, searchResultLimit, maxRpm, hitLimit, downloadLimit, hitResetTime, enabled, strict,
         extraMovieCategories, extraTvCategories, ignoreCategoryFilter,
         filterEnabled, filterSkipPassworded, filterMinGrabs, filterGrabsGraceHours,
         filterMaxAgeDaysWithoutGrabs, filterPreferDownloaded, onSave]);
@@ -965,6 +972,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
         if (!url.trim()) return false;
         try { new URL(url); return true; } catch { return false; }
     })();
+    const isHttpsUrl = url.trim().toLowerCase().startsWith("https://");
     const isRpmValid = (() => {
         const n = Number(maxRpm);
         return Number.isInteger(n) && n >= 0 && maxRpm.trim() === n.toString();
@@ -1044,6 +1052,24 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                                 onChange={e => setUrl(e.target.value)}
                             />
                         </div>
+                        {isHttpsUrl && (
+                            <div className="flex flex-col gap-1.5 sm:col-span-2">
+                                <label htmlFor="indexer-skip-tls-verification" className="flex items-center gap-2">
+                                    <Checkbox
+                                        id="indexer-skip-tls-verification"
+                                        checked={skipTlsVerification}
+                                        onChange={e => setSkipTlsVerification(e.target.checked)}
+                                    />
+                                    <span className="text-sm text-base-content/80">Skip TLS certificate verification</span>
+                                </label>
+                                {skipTlsVerification && (
+                                    <Alert variant="warning" className="text-xs">
+                                        TLS remains encrypted, but this accepts an untrusted or mismatched certificate.
+                                        Only enable it for an indexer you trust.
+                                    </Alert>
+                                )}
+                            </div>
+                        )}
 
                         <div className="flex flex-col gap-1.5 sm:col-span-2">
                             <Label htmlFor="indexer-apikey">API Key</Label>

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -84,6 +84,7 @@ type ConnectionDetails = {
     Host: string;
     Port: number;
     UseSsl: boolean;
+    SkipTlsVerification?: boolean;
     User: string;
     Pass: string;
     MaxConnections: number;
@@ -806,6 +807,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
     const [host, setHost] = useState(provider?.Host || "");
     const [port, setPort] = useState(provider?.Port?.toString() || "");
     const [useSsl, setUseSsl] = useState(provider?.UseSsl ?? true);
+    const [skipTlsVerification, setSkipTlsVerification] = useState(provider?.SkipTlsVerification ?? false);
     const [user, setUser] = useState(provider?.User || "");
     const [pass, setPass] = useState(provider?.Pass || "");
     const [maxConnections, setMaxConnections] = useState(provider?.MaxConnections?.toString() || "");
@@ -843,6 +845,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             setHost(provider?.Host || "");
             setPort(provider?.Port?.toString() || "");
             setUseSsl(provider?.UseSsl ?? true);
+            setSkipTlsVerification(provider?.SkipTlsVerification ?? false);
             setUser(provider?.User || "");
             setPass(provider?.Pass || "");
             setMaxConnections(provider?.MaxConnections?.toString() || "");
@@ -896,6 +899,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             formData.append('host', host);
             formData.append('port', port);
             formData.append('use-ssl', useSsl.toString());
+            formData.append('skip-tls-verification', skipTlsVerification.toString());
             formData.append('user', user);
             formData.append('pass', pass);
 
@@ -921,7 +925,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
         } finally {
             setIsTestingConnection(false);
         }
-    }, [host, port, useSsl, user, pass]);
+    }, [host, port, useSsl, skipTlsVerification, user, pass]);
 
     const handleAutoTune = useCallback(async (verifyConnections?: number) => {
         // Abort any previous run still in flight before starting a new one.
@@ -983,6 +987,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             formData.append('host', host);
             formData.append('port', port);
             formData.append('use-ssl', useSsl.toString());
+            formData.append('skip-tls-verification', skipTlsVerification.toString());
             formData.append('user', user);
             formData.append('pass', pass);
             formData.append('max-connections', maxConnections || "10");
@@ -1021,7 +1026,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                 ? { ...prev, status: "Speed test still running…" }
                 : { phase: "sweep", status: "Speed test still running…", percent: 50, dataUsedBytes: 0, sweep: [] });
         }
-    }, [host, port, useSsl, user, pass, maxConnections, intensity, pipeliningOnly, dataBudget]);
+    }, [host, port, useSsl, skipTlsVerification, user, pass, maxConnections, intensity, pipeliningOnly, dataBudget]);
 
     const handleApplyRecommendation = useCallback(() => {
         if (!benchmarkResult) return;
@@ -1068,6 +1073,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             Host: host,
             Port: parseInt(port, 10),
             UseSsl: useSsl,
+            SkipTlsVerification: useSsl && skipTlsVerification,
             User: user,
             Pass: pass,
             MaxConnections: parseInt(maxConnections, 10),
@@ -1080,7 +1086,7 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
             BytesUsedOffset: offsetToPersist,
             BytesUsedResetAt: resetAtToPersist,
         });
-    }, [type, host, port, useSsl, user, pass, maxConnections, pipeliningDepth, nickname, storageGroup, provider, isEditing, limitValue, limitUnit, initialUsedValue, initialUsedUnit, onSave]);
+    }, [type, host, port, useSsl, skipTlsVerification, user, pass, maxConnections, pipeliningDepth, nickname, storageGroup, provider, isEditing, limitValue, limitUnit, initialUsedValue, initialUsedUnit, onSave]);
 
     const isPipeliningDepthValid = pipeliningDepth.trim() === ""
         || (isPositiveInteger(pipeliningDepth) && Number(pipeliningDepth) <= 64);
@@ -1289,6 +1295,27 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                         <Alert variant="warning" className="text-xs">
                             Credentials are sent unencrypted without SSL. Prefer port 563 with SSL enabled.
                         </Alert>
+                    )}
+                    {useSsl && (
+                        <>
+                            <label htmlFor="provider-skip-tls-verification" className="mt-2 flex items-center gap-2">
+                                <Checkbox
+                                    id="provider-skip-tls-verification"
+                                    checked={skipTlsVerification}
+                                    onChange={(e) => {
+                                        setSkipTlsVerification(e.target.checked);
+                                        setConnectionTested(false);
+                                    }}
+                                />
+                                <span className="text-sm text-base-content/80">Skip TLS certificate verification</span>
+                            </label>
+                            {skipTlsVerification && (
+                                <Alert variant="warning" className="text-xs">
+                                    TLS remains encrypted, but this accepts an untrusted or mismatched certificate.
+                                    Only enable it for a provider you trust.
+                                </Alert>
+                            )}
+                        </>
                     )}
                 </div>
 


### PR DESCRIPTION
Flagged as breaking only to trigger 0.9 release.

## Summary
- add off-by-default per-provider and per-indexer TLS certificate verification bypasses with explicit operator warnings
- keep strict and permissive HTTP client, fetch-coalescing, and direct SAB addurl paths isolated
- bump NzbDav.UsenetSharp for provider-level TLS support

Closes #79
Closes #120

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (870 passed; one existing macOS RapidYenc native-library failure)