### PR TITLE
fix(health): playback-triggered repairs no longer wait for SAB history cleanup

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -142,9 +142,14 @@ public class HealthCheckService : BackgroundService
 
     public static IQueryable<DavItem> GetHealthCheckQueueItemsQuery(DavDatabaseClient dbClient)
     {
+        // History-linked files are skipped for routine STAT checks so they do not race SAB
+        // post-processing. UnixEpoch is the playback-triggered urgent sentinel from
+        // ExceptionMiddleware and intentionally overrides only that exclusion.
         return dbClient.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile)
-            .Where(x => x.HistoryItemId == null);
+            .Where(x =>
+                x.HistoryItemId == null ||
+                x.NextHealthCheck == DateTimeOffset.UnixEpoch);
     }
 
     private async Task PerformHealthCheck

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-health-queue-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Query_ExcludesHistoryLinkedNonUrgent_AndIncludesUrgentAndUnlinked()
+    {
+        var historyId = Guid.NewGuid();
+        var scheduledAt = DateTimeOffset.UtcNow.AddHours(1);
+
+        var historyLinkedNonUrgent = NewUsenetFile("history-linked-non-urgent.mkv", historyId, scheduledAt);
+        var historyLinkedUrgent = NewUsenetFile("history-linked-urgent.mkv", historyId, DateTimeOffset.UnixEpoch);
+        var unlinkedUrgent = NewUsenetFile("unlinked-urgent.mkv", null, DateTimeOffset.UnixEpoch);
+        var unlinkedScheduled = NewUsenetFile("unlinked-scheduled.mkv", null, scheduledAt);
+
+        _context.Items.AddRange(
+            historyLinkedNonUrgent,
+            historyLinkedUrgent,
+            unlinkedUrgent,
+            unlinkedScheduled);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var ids = await HealthCheckService.GetHealthCheckQueueItemsQuery(_dbClient)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        Assert.DoesNotContain(historyLinkedNonUrgent.Id, ids);
+        Assert.Contains(historyLinkedUrgent.Id, ids);
+        Assert.Contains(unlinkedUrgent.Id, ids);
+        Assert.Contains(unlinkedScheduled.Id, ids);
+    }
+
+    [Fact]
+    public async Task OrderedQuery_PlacesUrgentHistoryLinkedItemAheadOfScheduledItem()
+    {
+        var historyId = Guid.NewGuid();
+        var scheduledAt = DateTimeOffset.UtcNow.AddHours(2);
+
+        var historyLinkedUrgent = NewUsenetFile("urgent-first.mkv", historyId, DateTimeOffset.UnixEpoch);
+        var unlinkedScheduled = NewUsenetFile("scheduled-second.mkv", null, scheduledAt);
+
+        _context.Items.AddRange(historyLinkedUrgent, unlinkedScheduled);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var orderedIds = await HealthCheckService.GetHealthCheckQueueItems(_dbClient)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        Assert.Equal(
+            [historyLinkedUrgent.Id, unlinkedScheduled.Id],
+            orderedIds);
+    }
+
+    private static DavItem NewUsenetFile(string name, Guid? historyItemId, DateTimeOffset nextHealthCheck)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            name,
+            fileSize: 100,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+            lastHealthCheck: null,
+            historyItemId,
+            fileBlobId: null);
+        item.NextHealthCheck = nextHealthCheck;
+        return item;
+    }
+}


### PR DESCRIPTION
## Summary
- Admit `NextHealthCheck == UnixEpoch` items through the SAB-history exclusion in `GetHealthCheckQueueItemsQuery`, so streaming-triggered urgent repairs run while a file is still linked to history.
- Add SQLite regression coverage for include/exclude filtering and urgent sort order.

Closes #568

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter HealthCheckQueueItemsQuery`
- [x] Full backend suite: 872 passed; 1 unrelated local failure (`rapidyenc` native lib missing for `MultiSegmentStreamPrefetchBudgetTests`)
- [ ] CI green on PR