### PR TITLE
feat(config): configure all Settings via authoritative NZBDAV_CONFIG environment variables

### DIFF
--- a/backend/Api/Controllers/GetConfig/ConfigItemDto.cs
+++ b/backend/Api/Controllers/GetConfig/ConfigItemDto.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Api.Controllers.GetConfig;
+
+public class ConfigItemDto
+{
+    public string ConfigName { get; init; } = null!;
+    public string ConfigValue { get; init; } = null!;
+
+    /// <summary>
+    /// When set, this setting is managed by an authoritative
+    /// <c>NZBDAV_CONFIG__...</c> environment variable and is read-only in the UI.
+    /// </summary>
+    public string? EnvironmentVariableName { get; init; }
+}

--- a/backend/Api/Controllers/GetConfig/GetConfigController.cs
+++ b/backend/Api/Controllers/GetConfig/GetConfigController.cs
@@ -2,14 +2,13 @@
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
-using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.Controllers.GetConfig;
 
 [ApiController]
 [Route("api/get-config")]
-public class GetConfigController(DavDatabaseClient dbClient) : BaseApiController
+public class GetConfigController(DavDatabaseClient dbClient, ConfigManager configManager) : BaseApiController
 {
     private async Task<GetConfigResponse> GetConfig(GetConfigRequest request)
     {
@@ -17,17 +16,29 @@ public class GetConfigController(DavDatabaseClient dbClient) : BaseApiController
             .AsNoTracking()
             .Where(x => request.ConfigKeys.Contains(x.ConfigName))
             .ToListAsync(HttpContext.RequestAborted).ConfigureAwait(false);
+        var storedByName = storedConfigItems.ToDictionary(x => x.ConfigName);
 
         var secretMasker = new ConfigSecretMasker(
             EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
-        var configItems = storedConfigItems.Select(item => new ConfigItem
-        {
-            ConfigName = item.ConfigName,
-            ConfigValue = secretMasker.MaskForResponse(item.ConfigName, item.ConfigValue)
-        }).ToList();
 
-        var response = new GetConfigResponse { ConfigItems = configItems };
-        return response;
+        var configItems = new List<ConfigItemDto>();
+        foreach (var key in request.ConfigKeys)
+        {
+            // Prefer the effective (ENV overlay) value so the Settings UI matches
+            // what the process is running. Fall back to the stored SQLite row.
+            var effectiveValue = configManager.GetEffectiveConfigValue(key)
+                                 ?? storedByName.GetValueOrDefault(key)?.ConfigValue;
+            if (effectiveValue is null) continue;
+
+            configItems.Add(new ConfigItemDto
+            {
+                ConfigName = key,
+                ConfigValue = secretMasker.MaskForResponse(key, effectiveValue),
+                EnvironmentVariableName = configManager.GetEnvironmentVariableName(key),
+            });
+        }
+
+        return new GetConfigResponse { ConfigItems = configItems };
     }
 
     protected override async Task<IActionResult> HandleRequest()

--- a/backend/Api/Controllers/GetConfig/GetConfigResponse.cs
+++ b/backend/Api/Controllers/GetConfig/GetConfigResponse.cs
@@ -1,8 +1,6 @@
-﻿using NzbWebDAV.Database.Models;
-
-namespace NzbWebDAV.Api.Controllers.GetConfig;
+﻿namespace NzbWebDAV.Api.Controllers.GetConfig;
 
 public class GetConfigResponse : BaseApiResponse
 {
-    public List<ConfigItem> ConfigItems { get; init; } = new();
+    public List<ConfigItemDto> ConfigItems { get; init; } = new();
 }

--- a/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
+++ b/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
@@ -18,6 +19,24 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
         // clear message instead of throwing later deep inside a request or background task.
         // Run before webdav.pass hashing so validation sees the raw submitted value.
         ConfigManager.ValidateConfigItems(request.ConfigItems);
+
+        var managed = request.ConfigItems
+            .Where(item => configManager.IsEnvironmentManaged(item.ConfigName))
+            .Select(item => item.ConfigName)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+        if (managed.Count > 0)
+        {
+            var details = string.Join(", ", managed.Select(name =>
+            {
+                var envName = configManager.GetEnvironmentVariableName(name) ?? name;
+                return $"`{name}` (managed by `{envName}`)";
+            }));
+            throw new BadHttpRequestException(
+                $"Cannot update environment-managed setting(s): {details}. " +
+                "Change the container environment and restart instead.");
+        }
 
         var configNames = request.ConfigItems.Select(x => x.ConfigName).ToHashSet();
         var existingItems = await dbClient.Ctx.ConfigItems

--- a/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
+++ b/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
@@ -15,11 +15,8 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
 {
     private async Task<UpdateConfigResponse> UpdateConfig(UpdateConfigRequest request)
     {
-        // Validate incoming values up-front so a malformed value is rejected here with a
-        // clear message instead of throwing later deep inside a request or background task.
-        // Run before webdav.pass hashing so validation sees the raw submitted value.
-        ConfigManager.ValidateConfigItems(request.ConfigItems);
-
+        // Reject ENV-managed keys before validation so malformed managed payloads
+        // cannot leak submitted values through ValidateConfigItems error text.
         var managed = request.ConfigItems
             .Where(item => configManager.IsEnvironmentManaged(item.ConfigName))
             .Select(item => item.ConfigName)
@@ -37,6 +34,12 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
                 $"Cannot update environment-managed setting(s): {details}. " +
                 "Change the container environment and restart instead.");
         }
+
+        // Validate SQLite-owned values up-front so a malformed value is rejected here
+        // with a clear message instead of throwing later deep inside a request or
+        // background task. Run before webdav.pass hashing so validation sees the raw
+        // submitted value.
+        ConfigManager.ValidateConfigItems(request.ConfigItems);
 
         var configNames = request.ConfigItems.Select(x => x.ConfigName).ToHashSet();
         var existingItems = await dbClient.Ctx.ConfigItems

--- a/backend/Config/ConfigEnvMapping.cs
+++ b/backend/Config/ConfigEnvMapping.cs
@@ -1,0 +1,94 @@
+using System.Collections.Frozen;
+using System.Reflection;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Deterministic mapping between <see cref="ConfigKeys"/> values and the
+/// <c>NZBDAV_CONFIG__...</c> environment-variable namespace used for headless
+/// / infrastructure-as-code configuration.
+/// </summary>
+public static class ConfigEnvMapping
+{
+    public const string EnvPrefix = "NZBDAV_CONFIG__";
+
+    /// <summary>
+    /// Keys that must never be supplied via the ENV overlay: runtime-managed
+    /// cache state and non-persisted prefix constants.
+    /// </summary>
+    public static readonly FrozenSet<string> ExcludedConfigKeys = new HashSet<string>(StringComparer.Ordinal)
+    {
+        ConfigKeys.SearchExcludePrefix,
+        ConfigKeys.SearchExcludeSyncCache,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly Lazy<IReadOnlyDictionary<string, string>> ConfigKeyToEnvVar =
+        new(BuildConfigKeyToEnvVarMap);
+
+    private static readonly Lazy<IReadOnlyDictionary<string, string>> EnvVarToConfigKey =
+        new(BuildEnvVarToConfigKeyMap);
+
+    /// <summary>Every user-owned <c>ConfigItems</c> key eligible for ENV overlay.</summary>
+    public static IReadOnlyCollection<string> PublicConfigKeys =>
+        (IReadOnlyCollection<string>)ConfigKeyToEnvVar.Value.Keys;
+
+    /// <summary>
+    /// Maps a config key (<c>api.categories</c>) to its ENV name
+    /// (<c>NZBDAV_CONFIG__API__CATEGORIES</c>). Returns null for excluded keys.
+    /// </summary>
+    public static string? ToEnvironmentVariableName(string configKey)
+    {
+        return ConfigKeyToEnvVar.Value.TryGetValue(configKey, out var envVar) ? envVar : null;
+    }
+
+    /// <summary>
+    /// Maps an ENV name back to a config key. Matching is case-insensitive for
+    /// the ENV name (process environments are case-insensitive on Windows).
+    /// </summary>
+    public static bool TryGetConfigKey(string environmentVariableName, out string configKey)
+    {
+        return EnvVarToConfigKey.Value.TryGetValue(environmentVariableName, out configKey!);
+    }
+
+    /// <summary>
+    /// Pure transform used by tests and docs: dots → <c>__</c>, hyphens → <c>_</c>,
+    /// uppercased, then prefixed with <see cref="EnvPrefix"/>.
+    /// </summary>
+    public static string FormatEnvironmentVariableName(string configKey)
+    {
+        var body = configKey
+            .Replace('-', '_')
+            .Replace(".", "__", StringComparison.Ordinal)
+            .ToUpperInvariant();
+        return EnvPrefix + body;
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildConfigKeyToEnvVarMap()
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var field in typeof(ConfigKeys).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.FieldType != typeof(string) || !field.IsLiteral) continue;
+            var configKey = (string)field.GetRawConstantValue()!;
+            if (ExcludedConfigKeys.Contains(configKey)) continue;
+            map[configKey] = FormatEnvironmentVariableName(configKey);
+        }
+
+        return map;
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildEnvVarToConfigKeyMap()
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (configKey, envVar) in ConfigKeyToEnvVar.Value)
+        {
+            if (!map.TryAdd(envVar, configKey))
+            {
+                throw new InvalidOperationException(
+                    $"ENV mapping collision for `{envVar}` between `{map[envVar]}` and `{configKey}`.");
+            }
+        }
+
+        return map;
+    }
+}

--- a/backend/Config/ConfigEnvironmentOverlay.cs
+++ b/backend/Config/ConfigEnvironmentOverlay.cs
@@ -1,0 +1,155 @@
+using System.Collections;
+using System.Text.Json;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Snapshot of authoritative <c>NZBDAV_CONFIG__...</c> values loaded at startup.
+/// Values are kept out of SQLite; they overlay persisted <c>ConfigItems</c> at
+/// read time and make matching Settings controls read-only.
+/// </summary>
+public sealed class ConfigEnvironmentOverlay
+{
+    public static ConfigEnvironmentOverlay Empty { get; } = new(new Dictionary<string, string>(StringComparer.Ordinal));
+
+    private readonly Dictionary<string, string> _values;
+
+    private ConfigEnvironmentOverlay(Dictionary<string, string> values)
+    {
+        _values = values;
+    }
+
+    public int Count => _values.Count;
+
+    public bool IsEmpty => _values.Count == 0;
+
+    public bool TryGetValue(string configKey, out string value) =>
+        _values.TryGetValue(configKey, out value!);
+
+    public bool IsManaged(string configKey) => _values.ContainsKey(configKey);
+
+    public string? GetEnvironmentVariableName(string configKey) =>
+        IsManaged(configKey) ? ConfigEnvMapping.ToEnvironmentVariableName(configKey) : null;
+
+    public IReadOnlyDictionary<string, string> Values => _values;
+
+    /// <summary>
+    /// Loads, validates, and normalizes every <c>NZBDAV_CONFIG__...</c> variable
+    /// from the process environment. Unknown / colliding / invalid values throw
+    /// <see cref="ConfigEnvironmentException"/> without including secret values.
+    /// </summary>
+    public static ConfigEnvironmentOverlay LoadFromEnvironment(
+        IDictionary? environment = null,
+        string? existingUsenetProvidersJson = null)
+    {
+        environment ??= Environment.GetEnvironmentVariables();
+        var supplied = new Dictionary<string, string>(StringComparer.Ordinal);
+        var seenEnvVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (DictionaryEntry entry in environment)
+        {
+            var envName = entry.Key?.ToString();
+            if (envName is null ||
+                !envName.StartsWith(ConfigEnvMapping.EnvPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!ConfigEnvMapping.TryGetConfigKey(envName, out var configKey))
+            {
+                throw new ConfigEnvironmentException(
+                    $"Unknown configuration environment variable `{envName}`.");
+            }
+
+            if (seenEnvVars.TryGetValue(envName, out var previousConfigKey) &&
+                !string.Equals(previousConfigKey, configKey, StringComparison.Ordinal))
+            {
+                throw new ConfigEnvironmentException(
+                    $"Environment variable `{envName}` maps to multiple config keys.");
+            }
+
+            seenEnvVars[envName] = configKey;
+            // Last-writer wins for case variants of the same ENV name on
+            // case-sensitive platforms; the canonical key is unique.
+            supplied[configKey] = entry.Value?.ToString() ?? "";
+        }
+
+        if (supplied.Count == 0)
+            return Empty;
+
+        // Empty ENV values are treated as unset (same as ValidateConfigItems).
+        var items = supplied
+            .Where(pair => StringUtil.EmptyToNull(pair.Value) != null)
+            .Select(pair => new ConfigItem { ConfigName = pair.Key, ConfigValue = pair.Value })
+            .ToList();
+
+        if (items.Count == 0)
+            return Empty;
+
+        // Validate one key at a time so failures name the ENV variable without
+        // echoing the submitted value (ValidateConfigItems includes values).
+        foreach (var item in items)
+        {
+            try
+            {
+                ConfigManager.ValidateConfigItems([item]);
+            }
+            catch (ArgumentException)
+            {
+                var envName = ConfigEnvMapping.ToEnvironmentVariableName(item.ConfigName)
+                              ?? item.ConfigName;
+                throw new ConfigEnvironmentException(
+                    $"Invalid configuration environment variable `{envName}`.");
+            }
+        }
+
+        var normalized = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            var value = item.ConfigValue;
+            if (item.ConfigName == ConfigKeys.WebdavPass)
+                value = PasswordUtil.Hash(value);
+            else if (item.ConfigName == ConfigKeys.UsenetProviders)
+                value = NormalizeUsenetProviderIds(value, existingUsenetProvidersJson);
+
+            normalized[item.ConfigName] = value;
+        }
+
+        Log.Information(
+            "Loaded {Count} authoritative configuration environment variable(s): {Keys}",
+            normalized.Count,
+            string.Join(", ", normalized.Keys.OrderBy(x => x, StringComparer.Ordinal)));
+
+        return new ConfigEnvironmentOverlay(normalized);
+    }
+
+    private static string NormalizeUsenetProviderIds(string incomingJson, string? existingJson)
+    {
+        var incoming = JsonSerializer.Deserialize<UsenetProviderConfig>(incomingJson)
+                       ?? new UsenetProviderConfig();
+        UsenetProviderConfig? existing = null;
+        if (!string.IsNullOrWhiteSpace(existingJson))
+        {
+            try
+            {
+                existing = JsonSerializer.Deserialize<UsenetProviderConfig>(existingJson);
+            }
+            catch (JsonException)
+            {
+                existing = null;
+            }
+        }
+
+        UsenetProviderIdentity.NormalizeProviderIdsOnSave(incoming, existing);
+        return JsonSerializer.Serialize(incoming);
+    }
+}
+
+/// <summary>
+/// Fatal startup error for malformed or unknown <c>NZBDAV_CONFIG__...</c> values.
+/// Message must never include secret values.
+/// </summary>
+public sealed class ConfigEnvironmentException(string message) : Exception(message);

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -25,6 +25,7 @@ public class ConfigManager
     // contend on _config.
     private readonly object _excludeLock = new();
     private IReadOnlyList<Regex>? _compiledExcludeCache;
+    private ConfigEnvironmentOverlay _environmentOverlay = ConfigEnvironmentOverlay.Empty;
     public event EventHandler<ConfigEventArgs>? OnConfigChanged;
 
     public async Task LoadConfig()
@@ -44,10 +45,60 @@ public class ConfigManager
         SyncPathSanitizer();
     }
 
+    /// <summary>
+    /// Applies an authoritative <c>NZBDAV_CONFIG__...</c> overlay. Must run after
+    /// <see cref="LoadConfig"/> so provider-ID normalization can see persisted JSON.
+    /// ENV values stay out of SQLite and win over persisted rows at read time.
+    /// </summary>
+    public void ApplyEnvironmentOverlay(ConfigEnvironmentOverlay overlay)
+    {
+        ArgumentNullException.ThrowIfNull(overlay);
+        lock (_config)
+        {
+            _environmentOverlay = overlay;
+            _deserializedConfig.Clear();
+        }
+        lock (_excludeLock) { _compiledExcludeCache = null; }
+        SyncPathSanitizer();
+    }
+
+    public bool IsEnvironmentManaged(string configName)
+    {
+        lock (_config)
+        {
+            return _environmentOverlay.IsManaged(configName);
+        }
+    }
+
+    public string? GetEnvironmentVariableName(string configName)
+    {
+        lock (_config)
+        {
+            return _environmentOverlay.GetEnvironmentVariableName(configName);
+        }
+    }
+
+    /// <summary>
+    /// Effective value for a key: ENV overlay wins, then SQLite. Used by the
+    /// Settings API so the UI shows what the process is actually running.
+    /// </summary>
+    public string? GetEffectiveConfigValue(string configName) => GetConfigValue(configName);
+
+    /// <summary>Persisted SQLite value only (ignores ENV overlay). Used when normalizing provider IDs.</summary>
+    public string? GetPersistedConfigValue(string configName)
+    {
+        lock (_config)
+        {
+            return _config.TryGetValue(configName, out string? value) ? value : null;
+        }
+    }
+
     private string? GetConfigValue(string configName)
     {
         lock (_config)
         {
+            if (_environmentOverlay.TryGetValue(configName, out var envValue))
+                return envValue;
             return _config.TryGetValue(configName, out string? value) ? value : null;
         }
     }
@@ -59,7 +110,13 @@ public class ConfigManager
 
         lock (_config)
         {
-            if (!_config.TryGetValue(configName, out var storedValue)) return default;
+            string? storedValue = null;
+            if (_environmentOverlay.TryGetValue(configName, out var envValue))
+                storedValue = envValue;
+            else if (_config.TryGetValue(configName, out var dbValue))
+                storedValue = dbValue;
+
+            if (storedValue is null) return default;
             rawValue = StringUtil.EmptyToNull(storedValue);
             if (rawValue == null) return default;
 
@@ -76,8 +133,13 @@ public class ConfigManager
             if (_deserializedConfig.TryGetValue(cacheKey, out var cachedValue))
                 return cachedValue is null ? default : (T)cachedValue;
 
-            if (_config.TryGetValue(configName, out var storedValue) &&
-                StringUtil.EmptyToNull(storedValue) == rawValue)
+            string? currentStored = null;
+            if (_environmentOverlay.TryGetValue(configName, out var envValue))
+                currentStored = envValue;
+            else if (_config.TryGetValue(configName, out var dbValue))
+                currentStored = dbValue;
+
+            if (StringUtil.EmptyToNull(currentStored) == rawValue)
             {
                 _deserializedConfig[cacheKey] = value;
             }
@@ -112,10 +174,14 @@ public class ConfigManager
 
     public void UpdateValues(List<ConfigItem> configItems)
     {
+        Dictionary<string, string> changedConfig;
         lock (_config)
         {
             foreach (var configItem in configItems)
             {
+                // Always update the SQLite-backed map so removing an ENV overlay
+                // on the next restart restores the last persisted value. ENV-managed
+                // keys still resolve from the overlay at read time.
                 _config[configItem.ConfigName] = configItem.ConfigValue;
                 foreach (var cacheKey in _deserializedConfig.Keys
                              .Where(key => key.Name == configItem.ConfigName)
@@ -124,6 +190,12 @@ public class ConfigManager
                     _deserializedConfig.Remove(cacheKey);
                 }
             }
+
+            // Only emit OnConfigChanged for keys whose *effective* value changed.
+            // Writes to ENV-managed keys leave the running value unchanged.
+            changedConfig = configItems
+                .Where(item => !_environmentOverlay.IsManaged(item.ConfigName))
+                .ToDictionary(x => x.ConfigName, x => x.ConfigValue);
         }
 
         if (configItems.Any(x => x.ConfigName.StartsWith(ConfigKeys.SearchExcludePrefix, StringComparison.Ordinal)
@@ -132,7 +204,8 @@ public class ConfigManager
             lock (_excludeLock) { _compiledExcludeCache = null; }
         }
 
-        var changedConfig = configItems.ToDictionary(x => x.ConfigName, x => x.ConfigValue);
+        if (changedConfig.Count == 0) return;
+
         if (changedConfig.ContainsKey(ConfigKeys.WebdavWindowsSafePaths))
             SyncPathSanitizer();
         OnConfigChanged?.Invoke(this, new ConfigEventArgs { ChangedConfig = changedConfig });

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -30,6 +30,7 @@ public static class UsenetProviderIdentity
     public static async Task EnsureAsync(ConfigManager configManager, CancellationToken ct = default)
     {
         var providerConfig = configManager.GetUsenetProviderConfig();
+        var assignedCount = CountMissingProviderIds(providerConfig);
         var assigned = EnsureProviderIds(providerConfig);
         if (!assigned) return;
 
@@ -40,7 +41,7 @@ public static class UsenetProviderIdentity
         {
             Log.Information(
                 "Assigned ProviderId for {Count} ENV-managed usenet provider(s) in memory only.",
-                providerConfig.Providers.Count);
+                assignedCount);
             return;
         }
 
@@ -48,7 +49,7 @@ public static class UsenetProviderIdentity
         {
             await SaveProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);
             Log.Information("Assigned and persisted ProviderId for {Count} usenet provider(s).",
-                providerConfig.Providers.Count);
+                assignedCount);
         }
         catch (Exception ex)
         {
@@ -57,6 +58,9 @@ public static class UsenetProviderIdentity
                 "Metrics keys may not be stable across restarts until a save succeeds.");
         }
     }
+
+    private static int CountMissingProviderIds(UsenetProviderConfig config) =>
+        config.Providers.Count(provider => provider.ProviderId == Guid.Empty);
 
     /// <summary>
     /// Assigns a Guid to every provider missing one. Returns true when any id was created.

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -33,6 +33,17 @@ public static class UsenetProviderIdentity
         var assigned = EnsureProviderIds(providerConfig);
         if (!assigned) return;
 
+        // ENV-managed provider JSON is authoritative and must stay out of SQLite.
+        // IDs are normalized when the overlay loads; any remaining in-memory
+        // assignments above are kept until restart without persisting.
+        if (configManager.IsEnvironmentManaged(ConfigKeys.UsenetProviders))
+        {
+            Log.Information(
+                "Assigned ProviderId for {Count} ENV-managed usenet provider(s) in memory only.",
+                providerConfig.Providers.Count);
+            return;
+        }
+
         try
         {
             await SaveProvidersAsync(configManager, providerConfig, ct).ConfigureAwait(false);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -137,8 +137,11 @@ class Program
             }
             catch (ConfigEnvironmentException ex)
             {
+                // Operator-facing validation failure — log a single line and exit
+                // without the outer catch / runtime printing a stack dump.
                 Log.Fatal("Invalid headless configuration: {Message}", ex.Message);
-                throw;
+                Environment.ExitCode = 1;
+                return;
             }
 
             RunYencNativeSelfTest();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -125,6 +125,22 @@ class Program
             var configManager = new ConfigManager();
             await configManager.LoadConfig().ConfigureAwait(false);
 
+            // Authoritative NZBDAV_CONFIG__... overlay (opt-in). Loaded after
+            // SQLite so provider-ID normalization can reuse persisted IDs; values
+            // stay out of the database and win over ConfigItems at read time.
+            try
+            {
+                var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(
+                    existingUsenetProvidersJson: configManager.GetPersistedConfigValue(
+                        ConfigKeys.UsenetProviders));
+                configManager.ApplyEnvironmentOverlay(overlay);
+            }
+            catch (ConfigEnvironmentException ex)
+            {
+                Log.Fatal("Invalid headless configuration: {Message}", ex.Message);
+                throw;
+            }
+
             RunYencNativeSelfTest();
 
             // Assign stable ProviderIds (persisting if needed) before the streaming

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -1,6 +1,7 @@
 # Radarr / Sonarr
 
-*Arr instance credentials and automatic stuck-queue handling. Config key: `arr.instances`.
+*Arr instance credentials and automatic stuck-queue handling. Config key: `arr.instances`
+(`NZBDAV_CONFIG__ARR__INSTANCES` — see [headless](headless.md)).
 
 | Control | Effect |
 |---------|--------|

--- a/docs/configuration/backup.md
+++ b/docs/configuration/backup.md
@@ -2,10 +2,17 @@
 
 Logical SQL dumps of databases, schedule/retention, upload/download/restore.
 
+!!! tip "Headless ENV"
+
+    Map schedule/retention keys to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`backup.schedule-time` → `NZBDAV_CONFIG__BACKUP__SCHEDULE_TIME`, minutes from midnight).
+    Create / upload / restore **actions** remain out of the ENV overlay.
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | Enable daily backup | `backup.schedule-enabled` | off | `.sql` under config volume |
-| Daily run time | `backup.schedule-time` | midnight | Uses `TZ` |
+| Daily run time | `backup.schedule-time` | midnight (`0`) | Minutes from midnight; uses `TZ` |
 | Keep newest backups | `backup.retention-count` | `5` | Prune non-preserved; `0` = no prune |
 
 Actions: Create / Upload / Download / Preserve / Restore / Delete.

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -1,8 +1,12 @@
 # Environment variables
 
-Advanced reference for **headless / container** configuration. Most day-to-day tunables live in the Settings UI (SQLite). Env vars wire the process, supply secrets at bootstrap, and act as fallbacks when a UI value is empty.
+Advanced reference for **process / container** wiring and **legacy Settings fallbacks**. Most day-to-day tunables live in the Settings UI (SQLite).
 
-Precedence for fallbacks: **saved Settings value wins** over env, which wins over built-in default (unless noted).
+!!! tip "Authoritative headless Settings [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }"
+
+    To drive every Settings (`ConfigItems`) value from the environment — with read-only UI locks and values kept out of SQLite — use the **`NZBDAV_CONFIG__...`** overlay documented in **[Headless environment configuration](headless.md)**. That page includes a fully hydrated Compose example.
+
+    Precedence when both are present: **`NZBDAV_CONFIG__...` > SQLite/UI > legacy fallbacks on this page > defaults**.
 
 ## Container / entrypoint
 
@@ -58,6 +62,9 @@ for bridge networking, host networking, healthcheck, and DUMB examples.
 
 ## Settings fallbacks (when UI empty)
 
+These apply only when the matching Settings value is empty **and** no
+[`NZBDAV_CONFIG__...`](headless.md) overlay supplies that key.
+
 | Variable | Related setting | Default if both empty |
 |----------|-----------------|------------------------|
 | `FRONTEND_BACKEND_API_KEY` | API Key | required |
@@ -74,6 +81,9 @@ for bridge networking, host networking, healthcheck, and DUMB examples.
 | `DATABASE_MAINTENANCE_INTERVAL_HOURS` | Retention sweep cadence | `6` |
 
 ## Example Compose snippet
+
+Operational wiring only — for a full Settings-via-ENV stack see the
+[headless Compose example](headless.md#fully-hydrated-compose-example).
 
 ```yaml
 environment:

--- a/docs/configuration/headless.md
+++ b/docs/configuration/headless.md
@@ -1,0 +1,188 @@
+# Headless environment configuration [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
+
+Authoritative, opt-in configuration of every user-owned Settings (`ConfigItems`) value via `NZBDAV_CONFIG__...` environment variables. Designed for infrastructure-as-code / Docker Compose deployments where the Settings UI should not own those values.
+
+!!! tip "Operational vs headless"
+
+    Process wiring (`CONFIG_PATH`, `PORT`, `LOG_LEVEL`, cookies, …) and legacy Settings *fallbacks* (`WEBDAV_USER`, `MOUNT_DIR`, …) stay on the [Environment variables](environment-variables.md) page. This page covers only the new authoritative `ConfigItems` overlay.
+
+## What is in scope
+
+- Every public key in Settings that persists as a `ConfigItems` row (scalars and JSON blobs such as `usenet.providers`, `arr.instances`, `indexers.instances`, `profiles.instances`).
+- Read-only Settings UI for ENV-managed keys, with the exact variable name shown.
+- Startup validation that fails fast on unknown / invalid prefixed variables.
+
+## What is out of scope (v0.9)
+
+These remain separate persistence / operational domains — they are **not** driven by `NZBDAV_CONFIG__...`:
+
+- Frontend **admin account** bootstrap (first-run username/password)
+- **Warden** source lists and GitHub backup state (`warden.db`)
+- Database restore / one-off maintenance task actions
+- Process variables such as `CONFIG_PATH`, `PORT`, `LOG_LEVEL`, `FRONTEND_BACKEND_API_KEY` (unless also mirrored as a Settings key like `api.key`)
+
+## Naming algorithm
+
+Take the Settings config key (documented on each [configuration](index.md) page), then:
+
+1. Replace every `.` with `__`
+2. Replace every `-` with `_`
+3. Uppercase
+4. Prefix with `NZBDAV_CONFIG__`
+
+Examples:
+
+| Config key | Environment variable |
+|------------|----------------------|
+| `api.categories` | `NZBDAV_CONFIG__API__CATEGORIES` |
+| `usenet.segment-cache.enabled` | `NZBDAV_CONFIG__USENET__SEGMENT_CACHE__ENABLED` |
+| `api.addurl-trusted-hosts` | `NZBDAV_CONFIG__API__ADDURL_TRUSTED_HOSTS` |
+| `usenet.providers` | `NZBDAV_CONFIG__USENET__PROVIDERS` |
+
+Structured settings use the same JSON shapes as the Settings API / UI. Per-feature pages list the config keys; apply the mapping rule above for the ENV name.
+
+Internal runtime keys are **excluded** and rejected if supplied:
+
+- `search.exclude` (prefix constant)
+- `search.exclude-sync-cache`
+
+## Precedence
+
+```
+NZBDAV_CONFIG__...  >  SQLite / Settings UI  >  legacy fallbacks (WEBDAV_*, MOUNT_DIR, …)  >  built-in defaults
+```
+
+- ENV values are **not** written into SQLite.
+- Removing an ENV variable and restarting restores the prior SQLite value (if any) and re-enables editing in the UI.
+- With **no** `NZBDAV_CONFIG__...` variables set, behavior is identical to previous releases.
+
+## Settings UI
+
+When a key is ENV-managed:
+
+- The control is shown **read-only** (disabled fieldset) with a lock badge naming the variable
+- Save payloads omit managed keys (backend still rejects writes as the authority)
+- A page banner notes that managed settings require changing container configuration and restarting
+
+## Validation and restart
+
+- Unknown `NZBDAV_CONFIG__...` names, or invalid values for a known key, abort startup with a **single-line** error that names the variable and **never** prints its value
+- Changing ENV configuration requires a **container restart** to take effect
+- Logs list managed **key names** only (not secret values)
+
+## Secrets
+
+!!! danger "Runtime visibility"
+
+    Even when Compose uses `${WEBDAV_PASS:?missing}` placeholders, resolved secrets are visible to the container runtime and inspection tools (`docker inspect`, orchestrator secret mounts that materialize as env, etc.). Prefer an uncommitted `.env` file or orchestrator secret injection. **Never** commit real credentials or paste resolved values into docs, issues, or logs.
+
+`NZBDAV_CONFIG__WEBDAV__PASS` accepts plaintext; NzbDAV hashes it at overlay load (same as the Settings UI). Other secrets in JSON (Usenet `Pass`, indexer / *Arr API keys) remain in the ENV JSON as supplied.
+
+## Fully hydrated Compose example
+
+Copy-ready skeleton. Secrets use `${VAR:?message}` so Compose fails closed if they are missing — put real values in an uncommitted `.env` (or your orchestrator's secret store), not in git.
+
+```yaml
+services:
+  nzbdav:
+    image: ghcr.io/nzbdav/nzbdav:latest
+    container_name: nzbdav
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsSL http://localhost:3000/healthz > /dev/null || exit 1"]
+      interval: 30s
+      retries: 3
+      start_period: 60s
+      timeout: 5s
+    ports:
+      - "3000:3000"
+    environment:
+      # --- Process / operational (unchanged; see environment-variables.md) ---
+      PUID: "1000"
+      PGID: "1000"
+      TZ: America/New_York
+      TRUST_PROXY: "1"
+      SECURE_COOKIES: "true"
+      FRONTEND_BACKEND_API_KEY: ${FRONTEND_BACKEND_API_KEY:?set FRONTEND_BACKEND_API_KEY}
+
+      # --- Authoritative ConfigItems overlay (NZBDAV_CONFIG__...) ---
+      NZBDAV_CONFIG__API__KEY: ${FRONTEND_BACKEND_API_KEY:?set FRONTEND_BACKEND_API_KEY}
+      NZBDAV_CONFIG__API__CATEGORIES: "tv,movies"
+      NZBDAV_CONFIG__API__MANUAL_CATEGORY: "uncategorized"
+      NZBDAV_CONFIG__API__IMPORT_STRATEGY: "symlinks"
+      NZBDAV_CONFIG__API__ENSURE_IMPORTABLE_VIDEO: "true"
+      NZBDAV_CONFIG__API__IGNORE_HISTORY_LIMIT: "true"
+
+      NZBDAV_CONFIG__WEBDAV__USER: "webdav"
+      NZBDAV_CONFIG__WEBDAV__PASS: ${WEBDAV_PASS:?set WEBDAV_PASS}
+      NZBDAV_CONFIG__WEBDAV__ENFORCE_READONLY: "true"
+
+      NZBDAV_CONFIG__RCLONE__MOUNT_DIR: "/mnt/remote/nzbdav"
+
+      NZBDAV_CONFIG__USENET__MAX_DOWNLOAD_CONNECTIONS: "0"
+      NZBDAV_CONFIG__USENET__STREAMING_PRIORITY: "80"
+      NZBDAV_CONFIG__USENET__PIPELINING__ENABLED: "false"
+      NZBDAV_CONFIG__USENET__CASCADE__ENABLED: "true"
+      NZBDAV_CONFIG__USENET__PROVIDERS: >-
+        {"Providers":[{"Type":1,"Host":"news.example.com","Port":563,"UseSsl":true,"User":"${USENET_USER:?set USENET_USER}","Pass":"${USENET_PASS:?set USENET_PASS}","MaxConnections":20,"Nickname":"primary"}]}
+
+      NZBDAV_CONFIG__ARR__INSTANCES: >-
+        {"RadarrInstances":[{"Host":"http://radarr:7878","ApiKey":"${RADARR_API_KEY:?set RADARR_API_KEY}"}],"SonarrInstances":[{"Host":"http://sonarr:8989","ApiKey":"${SONARR_API_KEY:?set SONARR_API_KEY}"}],"QueueRules":[]}
+
+      NZBDAV_CONFIG__INDEXERS__INSTANCES: >-
+        {"Indexers":[{"Name":"Example","Url":"https://indexer.example/api","ApiKey":"${INDEXER_API_KEY:?set INDEXER_API_KEY}","Enabled":true}]}
+
+      NZBDAV_CONFIG__PROFILES__INSTANCES: >-
+        {"Profiles":[{"Name":"Default","Token":"default"}]}
+
+      NZBDAV_CONFIG__REPAIR__ENABLE: "true"
+      NZBDAV_CONFIG__REPAIR__HEALTHCHECK_CONCURRENCY: "50"
+      NZBDAV_CONFIG__REPAIR__HEALTHCHECK_DEPTH: "standard"
+
+      NZBDAV_CONFIG__MAINTENANCE__REMOVE_ORPHANED_SCHEDULE_ENABLED: "true"
+      NZBDAV_CONFIG__MAINTENANCE__REMOVE_ORPHANED_SCHEDULE_TIME: "180"
+
+      NZBDAV_CONFIG__BACKUP__SCHEDULE_ENABLED: "true"
+      NZBDAV_CONFIG__BACKUP__SCHEDULE_TIME: "120"
+      NZBDAV_CONFIG__BACKUP__RETENTION_COUNT: "7"
+
+      NZBDAV_CONFIG__PREFLIGHT__MODE: "off"
+      NZBDAV_CONFIG__PLAY__WATCHDOG_ENABLED: "true"
+    volumes:
+      - ./config:/config
+      - /mnt:/mnt
+```
+
+!!! note "JSON and Compose escaping"
+
+    Multi-line `>-` YAML folds to a single line. Nested `${...}` inside JSON strings are expanded by Compose before the container starts. `ProviderType` for **Pool Connections** is `1` (`0` = Disabled, `2` = BackupAndStats, `3` = BackupOnly — see [Usenet](usenet.md)). Omit `ProviderId` in ENV JSON — NzbDAV preserves matching SQLite ids by host/port/user, or assigns new ones.
+
+### After start
+
+1. Open **Settings**. ENV-managed controls show a lock badge such as `Managed by NZBDAV_CONFIG__WEBDAV__USER`.
+2. Attempting to save a managed key is rejected by the API.
+3. To hand a key back to SQLite/UI: remove that `NZBDAV_CONFIG__...` line, recreate the container, and the prior SQLite value (if any) becomes editable again.
+
+### Minimal `.env` (do not commit)
+
+```bash
+FRONTEND_BACKEND_API_KEY=generate-a-long-random-string
+WEBDAV_PASS=
+USENET_USER=
+USENET_PASS=
+RADARR_API_KEY=
+SONARR_API_KEY=
+INDEXER_API_KEY=
+```
+
+## Legacy compatibility
+
+- Existing `WEBDAV_USER` / `WEBDAV_PASSWORD` / `MOUNT_DIR` / `CATEGORIES` / … fallbacks are unchanged and still apply only when neither ENV overlay nor SQLite supplies a value.
+- Prefer `NZBDAV_CONFIG__...` for new headless deployments so Settings shows the authoritative source and rejects conflicting UI edits.
+
+## Related pages
+
+- [Environment variables](environment-variables.md) — process + legacy fallbacks
+- [Docker](../getting-started/docker.md) — Compose basics
+- [First run](../getting-started/first-run.md) — admin account (still UI / out of ENV scope)
+- Feature Settings references: [Usenet](usenet.md) · [SABnzbd](sabnzbd.md) · [WebDAV](webdav.md) · [Radarr/Sonarr](arrs.md) · [Indexers](indexers.md) · [Profiles](profiles.md) · [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md)

--- a/docs/configuration/headless.md
+++ b/docs/configuration/headless.md
@@ -41,10 +41,12 @@ Examples:
 
 Structured settings use the same JSON shapes as the Settings API / UI. Per-feature pages list the config keys; apply the mapping rule above for the ENV name.
 
-Internal runtime keys are **excluded** and rejected if supplied:
+Internal runtime keys are **excluded** from the public map. Supplying their mapped names
+(e.g. `NZBDAV_CONFIG__SEARCH__EXCLUDE_SYNC_CACHE`) fails startup as an **unknown**
+configuration variable:
 
-- `search.exclude` (prefix constant)
-- `search.exclude-sync-cache`
+- `search.exclude` (prefix constant — not a persisted setting)
+- `search.exclude-sync-cache` (runtime cache state)
 
 ## Precedence
 

--- a/docs/configuration/headless.md
+++ b/docs/configuration/headless.md
@@ -25,8 +25,8 @@ These remain separate persistence / operational domains — they are **not** dri
 
 Take the Settings config key (documented on each [configuration](index.md) page), then:
 
-1. Replace every `.` with `__`
-2. Replace every `-` with `_`
+1. Replace every `-` with `_`
+2. Replace every `.` with `__`
 3. Uppercase
 4. Prefix with `NZBDAV_CONFIG__`
 
@@ -39,7 +39,7 @@ Examples:
 | `api.addurl-trusted-hosts` | `NZBDAV_CONFIG__API__ADDURL_TRUSTED_HOSTS` |
 | `usenet.providers` | `NZBDAV_CONFIG__USENET__PROVIDERS` |
 
-Structured settings use the same JSON shapes as the Settings API / UI. Per-feature pages list the config keys; apply the mapping rule above for the ENV name.
+Structured settings use the same JSON shapes as the Settings API / UI (**PascalCase** property names — see [JSON and Compose notes](#fully-hydrated-compose-example) below). Per-feature pages list the config keys; apply the mapping rule above for the ENV name.
 
 Internal runtime keys are **excluded** from the public map. Supplying their mapped names
 (e.g. `NZBDAV_CONFIG__SEARCH__EXCLUDE_SYNC_CACHE`) fails startup as an **unknown**
@@ -47,6 +47,8 @@ configuration variable:
 
 - `search.exclude` (prefix constant — not a persisted setting)
 - `search.exclude-sync-cache` (runtime cache state)
+
+Persisted exclude settings such as `search.exclude-patterns` → `NZBDAV_CONFIG__SEARCH__EXCLUDE_PATTERNS` **are** supported.
 
 ## Precedence
 
@@ -68,8 +70,10 @@ When a key is ENV-managed:
 
 ## Validation and restart
 
-- Unknown `NZBDAV_CONFIG__...` names, or invalid values for a known key, abort startup with a **single-line** error that names the variable and **never** prints its value
-- Changing ENV configuration requires a **container restart** to take effect
+- Unknown `NZBDAV_CONFIG__...` names, or invalid values for keys with schema validation (booleans, integers, enums such as `repair.healthcheck-depth`, and JSON blobs), abort startup with a **single-line** error that names the variable and **never** prints its value
+- Free-form string keys (categories, paths, import strategy labels, some mode strings) are not fully schema-checked at ENV load — use the allowed values from the matching [Settings reference](index.md) page
+- Empty ENV values are ignored (same as omitting the variable); they do **not** clear a SQLite value
+- Changing ENV configuration requires a **container restart or recreate** (including after `.env` changes)
 - Logs list managed **key names** only (not secret values)
 
 ## Secrets
@@ -78,7 +82,9 @@ When a key is ENV-managed:
 
     Even when Compose uses `${WEBDAV_PASS:?missing}` placeholders, resolved secrets are visible to the container runtime and inspection tools (`docker inspect`, orchestrator secret mounts that materialize as env, etc.). Prefer an uncommitted `.env` file or orchestrator secret injection. **Never** commit real credentials or paste resolved values into docs, issues, or logs.
 
-`NZBDAV_CONFIG__WEBDAV__PASS` accepts plaintext; NzbDAV hashes it at overlay load (same as the Settings UI). Other secrets in JSON (Usenet `Pass`, indexer / *Arr API keys) remain in the ENV JSON as supplied.
+Headless stacks must still set **`FRONTEND_BACKEND_API_KEY`** for frontend↔backend proxy authentication. Mirror the same value into **`NZBDAV_CONFIG__API__KEY`** so *Arr/SAB and the Settings UI agree on the download-client API key.
+
+`NZBDAV_CONFIG__WEBDAV__PASS` accepts plaintext; NzbDAV hashes it at overlay load (same as the Settings UI). The example uses a Compose-only placeholder name `WEBDAV_PASS` — the legacy fallback variable remains **`WEBDAV_PASSWORD`** ([environment variables](environment-variables.md)). Other secrets in JSON (Usenet `Pass`, indexer / *Arr API keys, profile tokens) remain in the ENV JSON as supplied.
 
 ## Fully hydrated Compose example
 
@@ -108,18 +114,22 @@ services:
       FRONTEND_BACKEND_API_KEY: ${FRONTEND_BACKEND_API_KEY:?set FRONTEND_BACKEND_API_KEY}
 
       # --- Authoritative ConfigItems overlay (NZBDAV_CONFIG__...) ---
+      # Mirror FRONTEND_BACKEND_API_KEY so proxy auth and *Arr/SAB share one key.
       NZBDAV_CONFIG__API__KEY: ${FRONTEND_BACKEND_API_KEY:?set FRONTEND_BACKEND_API_KEY}
       NZBDAV_CONFIG__API__CATEGORIES: "tv,movies"
       NZBDAV_CONFIG__API__MANUAL_CATEGORY: "uncategorized"
       NZBDAV_CONFIG__API__IMPORT_STRATEGY: "symlinks"
       NZBDAV_CONFIG__API__ENSURE_IMPORTABLE_VIDEO: "true"
       NZBDAV_CONFIG__API__IGNORE_HISTORY_LIMIT: "true"
+      # NZBDAV_CONFIG__API__ADDURL_TRUSTED_HOSTS: "prowlarr,indexer"
+      # NZBDAV_CONFIG__GENERAL__BASE_URL: "https://nzbdav.example.com"
 
       NZBDAV_CONFIG__WEBDAV__USER: "webdav"
       NZBDAV_CONFIG__WEBDAV__PASS: ${WEBDAV_PASS:?set WEBDAV_PASS}
       NZBDAV_CONFIG__WEBDAV__ENFORCE_READONLY: "true"
 
       NZBDAV_CONFIG__RCLONE__MOUNT_DIR: "/mnt/remote/nzbdav"
+      NZBDAV_CONFIG__MEDIA__LIBRARY_DIR: "/mnt/media"
 
       NZBDAV_CONFIG__USENET__MAX_DOWNLOAD_CONNECTIONS: "0"
       NZBDAV_CONFIG__USENET__STREAMING_PRIORITY: "80"
@@ -135,16 +145,18 @@ services:
         {"Indexers":[{"Name":"Example","Url":"https://indexer.example/api","ApiKey":"${INDEXER_API_KEY:?set INDEXER_API_KEY}","Enabled":true}]}
 
       NZBDAV_CONFIG__PROFILES__INSTANCES: >-
-        {"Profiles":[{"Name":"Default","Token":"default"}]}
+        {"Profiles":[{"Name":"Default","Token":"${PROFILE_TOKEN:?set PROFILE_TOKEN}"}]}
 
       NZBDAV_CONFIG__REPAIR__ENABLE: "true"
       NZBDAV_CONFIG__REPAIR__HEALTHCHECK_CONCURRENCY: "50"
       NZBDAV_CONFIG__REPAIR__HEALTHCHECK_DEPTH: "standard"
 
       NZBDAV_CONFIG__MAINTENANCE__REMOVE_ORPHANED_SCHEDULE_ENABLED: "true"
+      # Minutes from midnight in TZ (180 = 03:00)
       NZBDAV_CONFIG__MAINTENANCE__REMOVE_ORPHANED_SCHEDULE_TIME: "180"
 
       NZBDAV_CONFIG__BACKUP__SCHEDULE_ENABLED: "true"
+      # Minutes from midnight in TZ (120 = 02:00)
       NZBDAV_CONFIG__BACKUP__SCHEDULE_TIME: "120"
       NZBDAV_CONFIG__BACKUP__RETENTION_COUNT: "7"
 
@@ -157,13 +169,19 @@ services:
 
 !!! note "JSON and Compose escaping"
 
-    Multi-line `>-` YAML folds to a single line. Nested `${...}` inside JSON strings are expanded by Compose before the container starts. `ProviderType` for **Pool Connections** is `1` (`0` = Disabled, `2` = BackupAndStats, `3` = BackupOnly — see [Usenet](usenet.md)). Omit `ProviderId` in ENV JSON — NzbDAV preserves matching SQLite ids by host/port/user, or assigns new ones.
+    Multi-line `>-` YAML folds to a single line. Nested `${...}` inside JSON strings are expanded by Compose before the container starts.
+
+    Use **PascalCase** property names exactly as the Settings UI persists them (`Providers`, `Type`, `Host`, `RadarrInstances`, `Indexers`, `Profiles`, …). camelCase keys are ignored by deserialization and can produce empty or wrong configuration without a startup error.
+
+    Provider `Type` for **Pool Connections** is `1` (`0` = Disabled, `2` = BackupAndStats, `3` = BackupOnly — see [Usenet](usenet.md)). Omit `ProviderId` in ENV JSON — NzbDAV preserves matching SQLite ids by host/port/user, or assigns new ones. Pure ENV-only first installs (no matching SQLite row) get new IDs each restart until a SQLite match exists, so metrics keys may drift.
+
+    Passwords containing `"`, `\`, or `$` can break JSON after Compose substitution; prefer `.env` values without those characters or inject secrets outside inline JSON.
 
 ### After start
 
 1. Open **Settings**. ENV-managed controls show a lock badge such as `Managed by NZBDAV_CONFIG__WEBDAV__USER`.
 2. Attempting to save a managed key is rejected by the API.
-3. To hand a key back to SQLite/UI: remove that `NZBDAV_CONFIG__...` line, recreate the container, and the prior SQLite value (if any) becomes editable again.
+3. To hand a key back to SQLite/UI: remove that `NZBDAV_CONFIG__...` line, restart or recreate the container, and the prior SQLite value (if any) becomes editable again.
 
 ### Minimal `.env` (do not commit)
 
@@ -175,6 +193,7 @@ USENET_PASS=
 RADARR_API_KEY=
 SONARR_API_KEY=
 INDEXER_API_KEY=
+PROFILE_TOKEN=
 ```
 
 ## Legacy compatibility
@@ -187,4 +206,4 @@ INDEXER_API_KEY=
 - [Environment variables](environment-variables.md) — process + legacy fallbacks
 - [Docker](../getting-started/docker.md) — Compose basics
 - [First run](../getting-started/first-run.md) — admin account (still UI / out of ENV scope)
-- Feature Settings references: [Usenet](usenet.md) · [SABnzbd](sabnzbd.md) · [WebDAV](webdav.md) · [Radarr/Sonarr](arrs.md) · [Indexers](indexers.md) · [Profiles](profiles.md) · [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md)
+- Feature Settings references: [Usenet](usenet.md) · [SABnzbd](sabnzbd.md) · [WebDAV](webdav.md) · [Radarr/Sonarr](arrs.md) · [Indexers](indexers.md) · [Profiles](profiles.md) · [Rclone](rclone.md) · [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md) · [Preflight](preflight.md) · [Watchdog](watchdog.md) · [Watchtower](watchtower.md) · [Warden](warden.md)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2,7 +2,7 @@
 
 Day-to-day settings live in the admin UI (**Settings**) and persist in SQLite under `/config`. Use this section as a walkthrough of every Settings tab.
 
-For headless / container bootstrap, see **[Environment variables](environment-variables.md)** — the schema of env vars that configure NzbDAV without the UI (or as fallbacks when a UI value is empty).
+For **authoritative headless** configuration of those same Settings keys via `NZBDAV_CONFIG__...`, see **[Headless environment configuration](headless.md)** [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }. Process wiring and legacy fallbacks remain on **[Environment variables](environment-variables.md)**.
 
 !!! note "Docs track latest"
 
@@ -16,9 +16,10 @@ For headless / container bootstrap, see **[Environment variables](environment-va
 -   **Playback & automation** — [Watchdog](watchdog.md) · [Preflight](preflight.md) · [Watchtower](watchtower.md) · [Warden](warden.md)
 -   **Integrations** — [SABnzbd](sabnzbd.md) · [WebDAV](webdav.md) · [Radarr/Sonarr](arrs.md) · [Rclone](rclone.md)
 -   **System** — [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md)
+-   **Headless / ops** — [Headless ENV config](headless.md) · [Environment variables](environment-variables.md)
 
 </div>
 
 !!! tip "Config vs env"
 
-    Most tunables are UI/`ConfigItems` keys. Env vars cover process wiring (`CONFIG_PATH`, ports, auth cookies), secrets bootstrap, and a handful of fallbacks documented on the [environment variables](environment-variables.md) page.
+    Most tunables are UI/`ConfigItems` keys. Map any documented config key to `NZBDAV_CONFIG__...` with the [naming rule](headless.md#naming-algorithm) for authoritative headless setup. Separate domains (frontend admin account, Warden `warden.db`, restore actions) are not part of that overlay — see [headless out of scope](headless.md#what-is-out-of-scope-v09). Process variables (`CONFIG_PATH`, ports, auth cookies) and legacy Settings *fallbacks* stay on [environment variables](environment-variables.md).

--- a/docs/configuration/indexers.md
+++ b/docs/configuration/indexers.md
@@ -2,6 +2,12 @@
 
 Newznab indexers/aggregators, global request defaults, and title exclude patterns.
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`indexers.instances` → `NZBDAV_CONFIG__INDEXERS__INSTANCES`).
+
 ## Global defaults
 
 | Control | Config key | Default | Effect |

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -2,6 +2,13 @@
 
 Database housekeeping, scheduled orphan cleanup, and one-off tools.
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm).
+    Schedule times are **minutes from midnight** in container `TZ`
+    (`180` = 03:00). One-off maintenance **tasks** remain out of the ENV overlay.
+
 ## Settings
 
 | Control | Config key | Default | Effect |
@@ -10,7 +17,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | SAB history retention (days) | `database.history-retention-days` | `90` | Does not delete WebDAV; `0` = keep all |
 | Health-check retention (days) | `database.healthcheck-retention-days` | `30` | `0` = keep all |
 | Enable daily orphan cleanup | `maintenance.remove-orphaned-schedule-enabled` | off | Remove Orphaned Files schedule |
-| Daily run time | `maintenance.remove-orphaned-schedule-time` | midnight | Uses container `TZ` |
+| Daily run time | `maintenance.remove-orphaned-schedule-time` | midnight (`0`) | Minutes from midnight; uses container `TZ` |
 
 ## Tasks (actions)
 

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -2,6 +2,12 @@
 
 Background warm-up of top search results before the user clicks.
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`preflight.mode` → `NZBDAV_CONFIG__PREFLIGHT__MODE`).
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | Mode | `preflight.mode` | `off` | off / light / standard / full |

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -1,6 +1,7 @@
 # Search profiles
 
-Named profiles select which indexers to query and which output adapters to expose. Stored as `profiles.instances`.
+Named profiles select which indexers to query and which output adapters to expose. Stored as `profiles.instances`
+(`NZBDAV_CONFIG__PROFILES__INSTANCES` — see [headless](headless.md)).
 
 | Control | Effect | Default |
 |---------|--------|---------|

--- a/docs/configuration/rclone.md
+++ b/docs/configuration/rclone.md
@@ -2,6 +2,12 @@
 
 Notify rclone RC when WebDAV files change (useful with high `dir-cache-time`).
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`rclone.host` → `NZBDAV_CONFIG__RCLONE__HOST`).
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | Enable Rclone RC notifications | `rclone.rc-enabled` | off | Auto `vfs/forget` on add/remove |

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -2,6 +2,13 @@
 
 Background health monitoring and replacement of unhealthy library items.
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`repair.enable` → `NZBDAV_CONFIG__REPAIR__ENABLE`). Enabling repairs via ENV
+    also needs `media.library-dir` and *Arr instances.
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | Enable Background Repairs | `repair.enable` | off | Needs library dir + *Arr |

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -2,6 +2,12 @@
 
 SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API compatibility](../features/sab-api.md).
 
+!!! tip "Headless ENV"
+
+    Map any config key in the table to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`api.categories` → `NZBDAV_CONFIG__API__CATEGORIES`).
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | API Key | `api.key` | from `FRONTEND_BACKEND_API_KEY` if unset | *Arr download client auth |

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -2,6 +2,12 @@
 
 Configure NNTP providers, cascade vs pooled routing, and queue-side NNTP pipelining.
 
+!!! tip "Headless ENV"
+
+    Each config key below maps to `NZBDAV_CONFIG__...` via the
+    [naming algorithm](headless.md#naming-algorithm) (for example
+    `usenet.providers` → `NZBDAV_CONFIG__USENET__PROVIDERS`).
+
 ## Providers
 
 Add one or more accounts. Each provider supports:

--- a/docs/configuration/warden.md
+++ b/docs/configuration/warden.md
@@ -2,6 +2,12 @@
 
 Portable dead-release fingerprint list: filter search results, sync remote sources, optional GitHub backup.
 
+!!! note "Headless ENV scope"
+
+    Scalar Settings below (`warden.hide-dead`, `warden.quorum`, `warden.backbone-scope`) can use
+    [`NZBDAV_CONFIG__...`](headless.md). Warden **sources**, GitHub backup state, and `warden.db`
+    remain a separate domain and are **not** driven by the ENV overlay.
+
 ## Persisted settings
 
 | Control | Config key | Default | Effect |

--- a/docs/configuration/watchdog.md
+++ b/docs/configuration/watchdog.md
@@ -2,6 +2,12 @@
 
 Playback failover, stall failover, and size-variant retention when a release cannot be served.
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`play.watchdog-enabled` → `NZBDAV_CONFIG__PLAY__WATCHDOG_ENABLED`).
+
 ## Failover
 
 | Control | Config key | Default | Effect |

--- a/docs/configuration/watchtower.md
+++ b/docs/configuration/watchtower.md
@@ -2,6 +2,12 @@
 
 Pre-resolve list titles to healthy releases. Feature overview: [Watchtower](../features/watchtower.md).
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`watchtower.enabled` → `NZBDAV_CONFIG__WATCHTOWER__ENABLED`).
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | Enable Watchtower | `watchtower.enabled` | off | Master switch |

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -2,6 +2,12 @@
 
 WebDAV authentication and streaming/connection behavior for playback mounts.
 
+!!! tip "Headless ENV"
+
+    Map config keys below to `NZBDAV_CONFIG__...` with the
+    [naming algorithm](headless.md#naming-algorithm)
+    (`webdav.pass` → `NZBDAV_CONFIG__WEBDAV__PASS`).
+
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
 | WebDAV User | `webdav.user` | `admin` / `WEBDAV_USER` | Alphanumeric + `_` `-` |

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -41,6 +41,13 @@ docker compose up -d
 
 Set `PUID`/`PGID` from `id` on the host. Map `/mnt` (or your media paths) so completed downloads and library folders share paths with *Arr and media servers.
 
+!!! tip "Headless Settings [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }"
+
+    Prefer infrastructure-as-code for Usenet, WebDAV, *Arr, and other Settings? Use authoritative
+    [`NZBDAV_CONFIG__...`](../configuration/headless.md) variables — see the
+    [fully hydrated Compose example](../configuration/headless.md#fully-hydrated-compose-example).
+    Process variables on this page (`PUID`, `TZ`, …) stay separate.
+
 ## Change the published port
 
 Compose port mappings use `HOST_PORT:CONTAINER_PORT`. To open NzbDAV on port

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -2,6 +2,14 @@
 
 Open `http://your-server:3000` after the container is healthy.
 
+!!! tip "Headless ConfigItems vs first-run account"
+
+    You can pre-seed Usenet, WebDAV, *Arr, and other **Settings** values with
+    [`NZBDAV_CONFIG__...`](../configuration/headless.md) before the first UI visit.
+    The **admin username/password** for the web UI is still created here (or via your
+    existing account) — that bootstrap is **not** part of the ENV overlay. Warden
+    sources and database restore actions are also separate domains.
+
 ## 1. Create the admin account
 
 Set username and password for the web UI. Session cookies can be hardened later with `SECURE_COOKIES=true` behind HTTPS.
@@ -17,7 +25,7 @@ Set username and password for the web UI. Session cookies can be hardened later 
 | Use SSL | On for remote providers |
 | Storage group | Optional — same label for resellers that share upstream storage |
 
-Click **Test** / **Auto-tune** when available. See [Usenet settings](../configuration/usenet.md).
+Click **Test** / **Auto-tune** when available. See [Usenet settings](../configuration/usenet.md). Skip this step when providers are already supplied via [headless ENV](../configuration/headless.md).
 
 ## 3. WebDAV (`Settings` → `WebDAV`)
 
@@ -53,3 +61,4 @@ Copy the **API Key** from this page — *Arr download clients need it.
 - [Connect Radarr/Sonarr](connect-arr.md)
 - [Import strategies](../guides/import-strategies.md)
 - [Configuration reference](../configuration/index.md)
+- [Headless environment configuration](../configuration/headless.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -167,7 +167,7 @@ Then open `http://localhost:3000` (self-hosted) or your DUMB service URL, create
 
     ---
 
-    What every Settings control does, plus the headless environment-variable schema.
+    What every Settings control does, plus the [headless `NZBDAV_CONFIG__...` schema](configuration/headless.md).
 
     [:octicons-arrow-right-24: Settings reference](configuration/index.md)
 

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -75,7 +75,13 @@ describe("BackendClient", () => {
   });
 
   it("gets, updates, and defaults config items", async () => {
-    const configItems = [{ configName: "one", configValue: "value" }];
+    const configItems = [
+      {
+        configName: "one",
+        configValue: "value",
+        environmentVariableName: "NZBDAV_CONFIG__ONE",
+      },
+    ];
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ configItems }))
       .mockResolvedValueOnce(jsonResponse({}))

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -376,6 +376,8 @@ export type DirectoryItem = {
 export type ConfigItem = {
     configName: string,
     configValue: string,
+    /** Present when the setting is owned by an NZBDAV_CONFIG__... environment variable. */
+    environmentVariableName?: string | null,
 }
 
 export type ExcludeSyncUrlStatus = {

--- a/frontend/app/components/ui/index.ts
+++ b/frontend/app/components/ui/index.ts
@@ -2,6 +2,7 @@ export * from "./button";
 export * from "./feedback";
 export * from "./form";
 export * from "./icon";
+export * from "./managed-setting";
 export * from "./modal";
 export * from "./settings-nav";
 export * from "./tabs";

--- a/frontend/app/components/ui/managed-setting.test.ts
+++ b/frontend/app/components/ui/managed-setting.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  omitManagedConfigKeys,
+  pinManagedConfigKeys,
+  type ManagedEnvMap,
+} from "./managed-setting";
+
+describe("omitManagedConfigKeys", () => {
+  it("returns the payload unchanged when nothing is managed", () => {
+    const changed = { "api.categories": "tv", "webdav.user": "admin" };
+    expect(omitManagedConfigKeys(changed, {})).toEqual(changed);
+  });
+
+  it("drops only ENV-managed keys from the save payload", () => {
+    const managed: ManagedEnvMap = {
+      "api.categories": "NZBDAV_CONFIG__API__CATEGORIES",
+    };
+    expect(
+      omitManagedConfigKeys(
+        {
+          "api.categories": "movies",
+          "webdav.user": "admin",
+          "webdav.show-hidden-files": "true",
+        },
+        managed,
+      ),
+    ).toEqual({
+      "webdav.user": "admin",
+      "webdav.show-hidden-files": "true",
+    });
+  });
+});
+
+describe("pinManagedConfigKeys", () => {
+  it("returns next unchanged when nothing is managed", () => {
+    const next = { "api.categories": "movies" };
+    expect(pinManagedConfigKeys(next, { "api.categories": "tv" }, {})).toEqual(next);
+  });
+
+  it("re-pins managed keys to the loaded baseline", () => {
+    const managed: ManagedEnvMap = {
+      "api.categories": "NZBDAV_CONFIG__API__CATEGORIES",
+      "webdav.user": "NZBDAV_CONFIG__WEBDAV__USER",
+    };
+    const baseline = {
+      "api.categories": "env-cats",
+      "webdav.user": "env-user",
+      "webdav.show-hidden-files": "false",
+    };
+    const next = {
+      "api.categories": "mutated",
+      "webdav.user": "also-mutated",
+      "webdav.show-hidden-files": "true",
+    };
+
+    expect(pinManagedConfigKeys(next, baseline, managed)).toEqual({
+      "api.categories": "env-cats",
+      "webdav.user": "env-user",
+      "webdav.show-hidden-files": "true",
+    });
+  });
+});

--- a/frontend/app/components/ui/managed-setting.tsx
+++ b/frontend/app/components/ui/managed-setting.tsx
@@ -1,0 +1,122 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { Icon } from "~/components/ui/icon";
+
+/** configName → NZBDAV_CONFIG__... environment variable name */
+export type ManagedEnvMap = Record<string, string>;
+
+const ManagedEnvContext = createContext<ManagedEnvMap>({});
+
+export function ManagedEnvProvider({
+  value,
+  children,
+}: {
+  value: ManagedEnvMap;
+  children: ReactNode;
+}) {
+  return <ManagedEnvContext.Provider value={value}>{children}</ManagedEnvContext.Provider>;
+}
+
+export function useManagedEnvMap(): ManagedEnvMap {
+  return useContext(ManagedEnvContext);
+}
+
+export function useManagedEnv(configKey: string): string | undefined {
+  return useContext(ManagedEnvContext)[configKey];
+}
+
+export function useIsAnyManaged(configKeys: string[]): boolean {
+  const map = useContext(ManagedEnvContext);
+  return configKeys.some((key) => key in map);
+}
+
+/**
+ * Accessible read-only wrapper for settings managed by an authoritative
+ * NZBDAV_CONFIG__... environment variable. Disables nested controls via
+ * fieldset[disabled] and names the exact ENV var operators must change.
+ */
+export function ManagedSetting({
+  configKey,
+  configKeys,
+  children,
+  className = "",
+}: {
+  configKey?: string;
+  configKeys?: string[];
+  children: ReactNode;
+  className?: string;
+}) {
+  const map = useManagedEnvMap();
+  const keys = configKeys ?? (configKey ? [configKey] : []);
+  const managed = keys
+    .map((key) => ({ key, env: map[key] }))
+    .filter((entry): entry is { key: string; env: string } => Boolean(entry.env));
+
+  if (managed.length === 0) {
+    return <div className={className}>{children}</div>;
+  }
+
+  const envNames = [...new Set(managed.map((entry) => entry.env))];
+  const label =
+    envNames.length === 1
+      ? `Managed by ${envNames[0]}`
+      : `Managed by environment (${envNames.length} variables)`;
+
+  return (
+    <fieldset
+      disabled
+      className={`relative m-0 min-w-0 rounded-lg border border-warning/30 bg-warning/5 p-3 ${className}`}
+      aria-label={label}
+    >
+      <legend className="float-right mb-2 flex max-w-full items-center gap-1.5 rounded-md border border-warning/40 bg-base-100 px-2 py-1 text-[11px] font-medium text-warning">
+        <Icon name="lock" className="!text-[14px] shrink-0" />
+        <span className="min-w-0 truncate" title={envNames.join(", ")}>
+          {envNames.length === 1 ? (
+            <>
+              Managed by <code className="font-mono text-[10px]">{envNames[0]}</code>
+            </>
+          ) : (
+            <>Managed by environment</>
+          )}
+        </span>
+      </legend>
+      <div className="clear-both opacity-80">{children}</div>
+      {envNames.length > 1 && (
+        <p className="mt-2 text-[11px] leading-relaxed text-base-content/55">
+          Variables:{" "}
+          {envNames.map((name, index) => (
+            <span key={name}>
+              {index > 0 ? ", " : ""}
+              <code className="font-mono text-[10px]">{name}</code>
+            </span>
+          ))}
+        </p>
+      )}
+    </fieldset>
+  );
+}
+
+/** Drop ENV-managed keys from a settings save payload. */
+export function omitManagedConfigKeys(
+  changed: Record<string, string>,
+  managed: ManagedEnvMap,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(changed)) {
+    if (!(key in managed)) next[key] = value;
+  }
+  return next;
+}
+
+/** Keep ENV-managed keys pinned to their effective (loaded) values. */
+export function pinManagedConfigKeys(
+  next: Record<string, string>,
+  baseline: Record<string, string>,
+  managed: ManagedEnvMap,
+): Record<string, string> {
+  if (Object.keys(managed).length === 0) return next;
+  const pinned = { ...next };
+  for (const key of Object.keys(managed)) {
+    if (key in baseline) pinned[key] = baseline[key];
+  }
+  return pinned;
+}

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
 import { Spinner } from "~/components/ui/feedback";
-import { SettingsPage } from "~/components/ui";
+import { SettingsPage, ManagedSetting } from "~/components/ui";
 import { Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
@@ -195,6 +195,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
 
     return (
         <SettingsPage>
+            <ManagedSetting configKey="arr.instances">
             <div className={'space-y-4'}>
                 <div className={'flex items-center justify-between text-lg font-semibold text-base-content'}>
                     <div>Radarr Instances</div>
@@ -277,6 +278,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                     })}
                 </ul>
             </div>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -10,7 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Alert, Badge, Spinner } from "~/components/ui/feedback";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
-import { SettingsIntro, SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 type BackupSettingsProps = {
@@ -352,6 +352,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
             )}
 
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <ManagedSetting configKeys={["backup.schedule-enabled", "backup.schedule-time"]}>
                 <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
                     <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
                         <span className="rounded-lg bg-primary/10 p-2 text-primary">
@@ -476,7 +477,9 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                         </div>
                     </div>
                 </section>
+                </ManagedSetting>
 
+                <ManagedSetting configKeys={["backup.retention-count"]}>
                 <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
                     <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
                         <span className="rounded-lg bg-primary/10 p-2 text-primary">
@@ -525,6 +528,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                         </div>
                     </div>
                 </section>
+                </ManagedSetting>
             </div>
 
             <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -13,6 +13,7 @@ import {
     Select,
     Spinner,
     Textarea,
+    useIsAnyManaged,
 } from "~/components/ui";
 import { isMaskedSecret } from "~/utils/config-mask";
 
@@ -297,7 +298,12 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         const timer = setTimeout(() => { void loadSyncStatus(); }, 2000);
         return () => clearTimeout(timer);
     }, [savedSyncUrls, loadSyncStatus]);
+    const excludeSyncManaged = useIsAnyManaged([
+        "search.exclude-sync-urls",
+        "search.exclude-sync-refresh-minutes",
+    ]);
     const handleSyncNow = useCallback(async () => {
+        if (excludeSyncManaged) return;
         setIsSyncing(true);
         try {
             const res = await fetch("/settings/exclude-sync", { method: "POST" });
@@ -307,7 +313,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         } finally {
             setIsSyncing(false);
         }
-    }, []);
+    }, [excludeSyncManaged]);
 
     const defaultSearchUserAgent = config["api.search-user-agent"] ?? "";
     const handleSearchUserAgentChange = useCallback((value: string) => {
@@ -491,7 +497,15 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                                 value={excludeSyncRefresh}
                                 onChange={e => handleSyncRefreshChange(e.target.value)} />
                             <span className="text-[11px] text-base-content/45">minutes</span>
-                            <Button variant="primary" size="small" onClick={handleSyncNow} disabled={isSyncing}>
+                            <Button
+                                variant="primary"
+                                size="small"
+                                onClick={handleSyncNow}
+                                disabled={isSyncing || excludeSyncManaged}
+                                title={excludeSyncManaged
+                                    ? "Synced exclude URLs are managed by NZBDAV_CONFIG__... — change the container environment and restart"
+                                    : undefined}
+                            >
                                 <Icon name={isSyncing ? "progress_activity" : "sync"} className={`!text-[18px] ${isSyncing ? "animate-spin" : ""}`} />
                                 {isSyncing ? "Syncing…" : "Sync now"}
                             </Button>

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -8,6 +8,7 @@ import {
     Icon,
     Input,
     Label,
+    ManagedSetting,
     Modal,
     Select,
     Spinner,
@@ -328,6 +329,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         : "";
 
     return (
+        <ManagedSetting configKeys={["indexers.instances", "api.user-agent", "api.search-user-agent"]}>
         <div className="mb-6 flex w-full flex-col gap-6">
             <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between gap-3">
@@ -535,6 +537,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                 onSave={handleSave}
             />
         </div>
+        </ManagedSetting>
     );
 }
 
@@ -1423,7 +1426,6 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
         </Modal>
     );
 }
-
 export function isIndexersSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["indexers.instances"] !== newConfig["indexers.instances"]
         || (config["api.user-agent"] ?? "") !== (newConfig["api.user-agent"] ?? "")

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -329,7 +329,6 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         : "";
 
     return (
-        <ManagedSetting configKeys={["indexers.instances", "api.user-agent", "api.search-user-agent"]}>
         <div className="mb-6 flex w-full flex-col gap-6">
             <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between gap-3">
@@ -341,7 +340,8 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                     </div>
                 </div>
                 <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    <ManagedSetting configKey="indexers.instances" className="sm:col-span-2">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-default-proxy">HTTP(S) Proxy URL</Label>
                         <Input
                             type="text"
@@ -352,7 +352,9 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             onChange={e => handleProxyChange(e.target.value)}
                         />
                     </div>
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    </ManagedSetting>
+                    <ManagedSetting configKey="api.search-user-agent" className="sm:col-span-2">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-default-search-user-agent">
                             Default Search User-Agent <span className="text-[11px] font-normal text-base-content/45">(sent when searching indexers; per-indexer override below)</span>
                         </Label>
@@ -368,7 +370,9 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             Sent on indexer search and caps queries. Leave blank to use the default.
                         </HelpText>
                     </div>
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    </ManagedSetting>
+                    <ManagedSetting configKey="api.user-agent" className="sm:col-span-2">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-default-retrieve-user-agent">
                             Default Retrieve User-Agent <span className="text-[11px] font-normal text-base-content/45">(sent when retrieving the .nzb; per-indexer override below)</span>
                         </Label>
@@ -384,7 +388,9 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             Sent when retrieving the .nzb file. Leave blank to use the default.
                         </HelpText>
                     </div>
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    </ManagedSetting>
+                    <ManagedSetting configKey="indexers.instances" className="sm:col-span-2 space-y-3.5">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-default-timeout">
                             Request timeout (seconds) <span className="text-[11px] font-normal text-base-content/45">(leave blank for {DEFAULT_TIMEOUT_SECONDS}s default)</span>
                         </Label>
@@ -397,7 +403,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             onChange={e => handleTimeoutChange(e.target.value)}
                         />
                     </div>
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-default-search-limit">
                             Search results per indexer <span className="text-[11px] font-normal text-base-content/45">(blank = {DEFAULT_SEARCH_RESULT_LIMIT}; higher pages the indexer for more results, using more API calls)</span>
                         </Label>
@@ -410,8 +416,10 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             onChange={e => handleSearchLimitChange(e.target.value)}
                         />
                     </div>
+                    </ManagedSetting>
 
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    <ManagedSetting configKey="search.exclude-patterns" className="sm:col-span-2">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-exclude-patterns">
                             Exclude result patterns <span className="text-[11px] font-normal text-base-content/45">(applies to every indexer)</span>
                         </Label>
@@ -441,8 +449,13 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             releases your setup can't handle, whatever the reason.
                         </HelpText>
                     </div>
+                    </ManagedSetting>
 
-                    <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    <ManagedSetting configKeys={[
+                        "search.exclude-sync-urls",
+                        "search.exclude-sync-refresh-minutes",
+                    ]} className="sm:col-span-2">
+                    <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-exclude-sync-urls">
                             Synced exclude URLs <span className="text-[11px] font-normal text-base-content/45">(auto-updating; one URL per line)</span>
                         </Label>
@@ -502,9 +515,11 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             reached, the last good copy keeps working. Save your changes first, then use <strong>Sync now</strong>.
                         </HelpText>
                     </div>
+                    </ManagedSetting>
                 </div>
             </div>
 
+            <ManagedSetting configKey="indexers.instances">
             <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between gap-3">
                     <div className="text-base font-semibold text-base-content">Indexers</div>
@@ -536,8 +551,8 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                 onClose={handleCloseModal}
                 onSave={handleSave}
             />
+            </ManagedSetting>
         </div>
-        </ManagedSetting>
     );
 }
 

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,4 +1,4 @@
-import { SettingsIntro, SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
@@ -28,6 +28,11 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
             </SettingsIntro>
 
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <ManagedSetting configKeys={[
+                    "db.is-startup-vacuum-enabled",
+                    "database.history-retention-days",
+                    "database.healthcheck-retention-days",
+                ]}>
                 <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
                     <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
                         <span className="rounded-lg bg-primary/10 p-2 text-primary">
@@ -121,7 +126,12 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                         </div>
                     </div>
                 </section>
+                </ManagedSetting>
 
+                <ManagedSetting configKeys={[
+                    "maintenance.remove-orphaned-schedule-enabled",
+                    "maintenance.remove-orphaned-schedule-time",
+                ]}>
                 <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
                     <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
                         <span className="rounded-lg bg-primary/10 p-2 text-primary">
@@ -235,6 +245,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                         </div>
                     </div>
                 </section>
+                </ManagedSetting>
             </div>
 
             <section className="space-y-3">

--- a/frontend/app/routes/settings/preflight/preflight.tsx
+++ b/frontend/app/routes/settings/preflight/preflight.tsx
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction } from "react";
-import { Field, Input, Label, Select, SettingsIntro, SettingsPage } from "~/components/ui";
+import { Field, Input, Label, ManagedSetting, Select, SettingsIntro, SettingsPage } from "~/components/ui";
 
 type PreflightSettingsProps = {
     config: Record<string, string>
@@ -20,6 +20,7 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                 more it does.
             </SettingsIntro>
 
+            <ManagedSetting configKey="preflight.mode">
             <Field>
                 <Label htmlFor="preflight-mode">Mode</Label>
                 <Select
@@ -41,7 +42,9 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                     that maps to a previously completed item — useful when re-opening something.
                 </p>
             </Field>
+            </ManagedSetting>
 
+            <ManagedSetting configKey="preflight.max-attempts">
             <Field>
                 <Label htmlFor="preflight-max-attempts">Max candidates to try</Label>
                 <Input
@@ -60,7 +63,9 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                     background. Default 20.
                 </p>
             </Field>
+            </ManagedSetting>
 
+            <ManagedSetting configKey="preflight.ttl-seconds">
             <Field>
                 <Label htmlFor="preflight-ttl">Keep preflight state for (seconds)</Label>
                 <Input
@@ -78,7 +83,9 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                     Default 120.
                 </p>
             </Field>
+            </ManagedSetting>
 
+            <ManagedSetting configKey="preflight.indexer-max-wait-seconds">
             <Field>
                 <Label htmlFor="preflight-max-wait">Skip if indexer wait exceeds (seconds)</Label>
                 <Input
@@ -97,6 +104,7 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                     Default 5.
                 </p>
             </Field>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/profiles/profiles.tsx
+++ b/frontend/app/routes/settings/profiles/profiles.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch, type ReactNode, type SetStateAction, useCallback, useMemo, useState } from "react";
 import { MultiCheckboxInput } from "~/components/multi-checkbox-input/multi-checkbox-input";
-import { Button, Field, Icon, Input, Label, Select, SettingsPage, Toggle } from "~/components/ui";
+import { Button, Field, Icon, Input, Label, ManagedSetting, Select, SettingsPage, Toggle } from "~/components/ui";
 
 type ProfilesSettingsProps = {
     config: Record<string, string>
@@ -117,6 +117,7 @@ export function ProfilesSettings({ config, setNewConfig }: ProfilesSettingsProps
 
     return (
         <SettingsPage>
+            <ManagedSetting configKey="profiles.instances">
             <div className="flex flex-col gap-2">
                 <div className="mb-[18px] flex items-center justify-between">
                     <div>Search Profiles</div>
@@ -142,6 +143,7 @@ export function ProfilesSettings({ config, setNewConfig }: ProfilesSettingsProps
                     ))
                 )}
             </div>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -67,7 +67,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
             </div>
             </ManagedSetting>
             <hr />
-            <ManagedSetting configKeys={["rclone.host", "rclone.pass"]}>
+            <ManagedSetting configKey="rclone.host">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-host-input">Rclone Server Host</label>
                 <div className="flex w-full">
@@ -122,6 +122,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
             </div>
             </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="rclone.pass">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-pass-input">Rclone Server Password</label>
                 <Input
@@ -135,6 +136,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                     The password for authenticating to the rclone RC API. This field is optional.
                 </p>
             </div>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
 import { Spinner } from "~/components/ui/feedback";
-import { SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsPage } from "~/components/ui";
 import { Checkbox, Input } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
@@ -51,6 +51,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
 
     return (
         <SettingsPage>
+            <ManagedSetting configKey="rclone.rc-enabled">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -64,7 +65,9 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                     When enabled, NzbDAV will automatically notify your rclone mount via the RC API whenever files are added or removed on the webdav. This allows setting a high dir-cache-time setting on Rclone.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKeys={["rclone.host", "rclone.pass"]}>
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-host-input">Rclone Server Host</label>
                 <div className="flex w-full">
@@ -101,7 +104,9 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                     The host address of the rclone RC API.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="rclone.user">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-user-input">Rclone Server User</label>
                 <Input
@@ -115,6 +120,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                     The username for authenticating to the rclone RC API. This field is optional.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-pass-input">Rclone Server Password</label>

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -1,4 +1,4 @@
-import { SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { type Dispatch, type SetStateAction } from "react";
 import { isPositiveInteger } from "../usenet/usenet";
@@ -28,6 +28,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
 
     return (
         <SettingsPage>
+            <ManagedSetting configKey="repair.enable">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -42,7 +43,9 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     {helpText}
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="repair.healthcheck-concurrency">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="healthcheck-concurrency-input">Health Check Concurrency</label>
                 <Input
@@ -59,7 +62,9 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     Capped at your total provider pool size.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKeys={["repair.healthcheck-depth", "repair.healthcheck-aging"]}>
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="healthcheck-depth-input">Health Check Depth</label>
                 <Select
@@ -98,7 +103,9 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     is long-since posted and rechecking it in full costs more than it finds.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="repair.auto-remove-unlinked-only">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Auto-Remove After Streaming Failures</label>
                 <Input
@@ -131,6 +138,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     force-deletes linked files after the failure threshold.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="library-dir-input">Library Directory</label>

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -105,7 +105,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             </ManagedSetting>
             <hr />
-            <ManagedSetting configKey="repair.auto-remove-unlinked-only">
+            <ManagedSetting configKey="repair.auto-remove-after-failures">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Auto-Remove After Streaming Failures</label>
                 <Input
@@ -122,6 +122,8 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     unlinked file on the third failure.
                 </p>
             </div>
+            </ManagedSetting>
+            <ManagedSetting configKey="repair.auto-remove-unlinked-only">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -140,6 +142,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="media.library-dir">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="library-dir-input">Library Directory</label>
                 <Input
@@ -154,6 +157,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     Make sure this path is visible to your NzbDAV container.
                 </p>
             </div>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -238,14 +238,20 @@ function Body(props: BodyProps) {
         setIsSaved(false);
         setSaveError(null);
         try {
+            const changedConfig = omitManagedConfigKeys(
+                getChangedConfig(config, newConfig),
+                managedEnv,
+            );
+            if (Object.keys(changedConfig).length === 0) {
+                // Managed keys are pinned client-side; nothing left to persist.
+                setConfig(newConfig);
+                setIsSaved(true);
+                return;
+            }
             const response = await fetch("/settings/update", {
                 method: "POST",
                 body: (() => {
                     const form = new FormData();
-                    const changedConfig = omitManagedConfigKeys(
-                        getChangedConfig(config, newConfig),
-                        managedEnv,
-                    );
                     form.append("config", JSON.stringify(changedConfig));
                     return form;
                 })()

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
-import { SettingsPanel } from "~/components/ui/settings-nav";
+import { SettingsPanel, ManagedEnvProvider, omitManagedConfigKeys, pinManagedConfigKeys, type ManagedEnvMap } from "~/components/ui";
 import type { Route } from "./+types/route";
 import { backendClient } from "~/clients/backend-client.server";
 import { isUsenetSettingsUpdated, UsenetSettings } from "./usenet/usenet";
@@ -17,7 +17,7 @@ import { isPreflightSettingsUpdated, PreflightSettings } from "./preflight/prefl
 import { isWatchtowerSettingsUpdated, WatchtowerSettings } from "./watchtower/watchtower";
 import { isWardenSettingsUpdated, WardenSettings } from "./warden/warden";
 import { isRcloneSettingsUpdated, RcloneSettings } from "./rclone/rclone";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from "react";
 import { useBlocker, useSearchParams } from "react-router";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { getAppVersion } from "~/utils/version.server";
@@ -150,13 +150,18 @@ const defaultConfig = {
 export async function loader({ request }: Route.LoaderArgs) {
     const configItems = await backendClient.getConfig(Object.keys(defaultConfig));
 
-    const config: Record<string, string> = defaultConfig;
+    const config: Record<string, string> = { ...defaultConfig };
+    const managedEnv: ManagedEnvMap = {};
     for (const item of configItems) {
         config[item.configName] = item.configValue;
+        if (item.environmentVariableName) {
+            managedEnv[item.configName] = item.environmentVariableName;
+        }
     }
 
     return {
         config: config,
+        managedEnv,
         appVersion: (await getAppVersion()) ?? "unknown",
     }
 }
@@ -169,6 +174,7 @@ export default function Settings(props: Route.ComponentProps) {
 
 type BodyProps = {
     config: Record<string, string>,
+    managedEnv: ManagedEnvMap,
     appVersion: string,
 };
 
@@ -177,10 +183,18 @@ function Body(props: BodyProps) {
     const activeTab = parseSettingsTab(searchParams.get("tab"));
     const activeTabItem = getSettingsTabItem(activeTab);
     const [config, setConfig] = useState(props.config);
-    const [newConfig, setNewConfig] = useState(config);
+    const [newConfig, setNewConfigState] = useState(config);
+    const managedEnv = props.managedEnv;
+    const setNewConfig: Dispatch<SetStateAction<Record<string, string>>> = useCallback((updater) => {
+        setNewConfigState((prev) => {
+            const next = typeof updater === "function" ? updater(prev) : updater;
+            return pinManagedConfigKeys(next, config, managedEnv);
+        });
+    }, [config, managedEnv]);
     const [isSaving, setIsSaving] = useState(false);
     const [isSaved, setIsSaved] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
+    const managedCount = useMemo(() => Object.keys(managedEnv).length, [managedEnv]);
 
     const iseUsenetUpdated = isUsenetSettingsUpdated(config, newConfig);
     const isSabnzbdUpdated = isSabnzbdSettingsUpdated(config, newConfig);
@@ -214,10 +228,10 @@ function Body(props: BodyProps) {
     const isSaveButtonDisabled = saveButtonLabel !== "Save";
 
     const onClear = useCallback(() => {
-        setNewConfig(config);
+        setNewConfigState(config);
         setIsSaved(false);
         setSaveError(null);
-    }, [config, setNewConfig]);
+    }, [config]);
 
     const onSave = useCallback(async () => {
         setIsSaving(true);
@@ -228,7 +242,10 @@ function Body(props: BodyProps) {
                 method: "POST",
                 body: (() => {
                     const form = new FormData();
-                    const changedConfig = getChangedConfig(config, newConfig);
+                    const changedConfig = omitManagedConfigKeys(
+                        getChangedConfig(config, newConfig),
+                        managedEnv,
+                    );
                     form.append("config", JSON.stringify(changedConfig));
                     return form;
                 })()
@@ -243,9 +260,10 @@ function Body(props: BodyProps) {
         } finally {
             setIsSaving(false);
         }
-    }, [config, newConfig, setIsSaving, setIsSaved, setConfig]);
+    }, [config, newConfig, managedEnv]);
 
     return (
+        <ManagedEnvProvider value={managedEnv}>
         <div className="flex min-h-full flex-col gap-6 px-4 py-4 md:px-8">
             <SettingsPanel>
                 <header className="mb-6 flex items-center gap-3 border-b border-base-content/10 pb-4">
@@ -254,6 +272,16 @@ function Body(props: BodyProps) {
                         {activeTabItem.label}
                     </h1>
                 </header>
+                {managedCount > 0 && (
+                    <Alert variant="warning" className="mb-6 text-sm">
+                        <span>
+                            {managedCount === 1 ? "1 setting is" : `${managedCount} settings are`}{" "}
+                            managed by <code className="font-mono text-xs">NZBDAV_CONFIG__...</code>{" "}
+                            environment variables and shown read-only. Change the container environment
+                            and restart to update them.
+                        </span>
+                    </Alert>
+                )}
                 {activeTab === "usenet" && <UsenetSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "indexers" && <IndexersSettings config={newConfig} setNewConfig={setNewConfig} savedConfig={config} />}
                 {activeTab === "profiles" && <ProfilesSettings config={newConfig} setNewConfig={setNewConfig} />}
@@ -303,6 +331,7 @@ function Body(props: BodyProps) {
                 onConfirm={navigationBlocker.onConfirmNavigation}
             />
         </div>
+        </ManagedEnvProvider>
     );
 }
 

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -1,5 +1,5 @@
 import { Button } from "~/components/ui/button";
-import { SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from "react";
@@ -24,6 +24,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
 
     return (
         <SettingsPage>
+            <ManagedSetting configKey="api.key">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="api-key-input">API Key</label>
                 <div className="flex w-full">
@@ -42,7 +43,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     Use this API key when configuring your download client in Radarr or Sonarr.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.categories">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="categories-input">Categories</label>
                 <TagInput
@@ -56,7 +59,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     The complete list of categories for organizing imported nzbs. Only letters, numbers, and dashes are allowed.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.manual-category">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="manual-category-input">Manual Upload Category</label>
                 <Input
@@ -71,7 +76,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     The category to use for manual uploads through the Queue page on the UI.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.import-strategy">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="import-strategy-input">Import Strategy</label>
                 <Select
@@ -86,6 +93,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     If you need to be able to stream from Plex, you will need to configure rclone and should select the `Symlinks` option here. If you only need to stream through Emby or Jellyfin, then you can skip rclone altogether and select the `STRM Files` option.
                 </p>
             </div>
+            </ManagedSetting>
             {/* <hr /> */}
             {config["api.import-strategy"] === 'symlinks' &&
                 <div className={'ml-4 space-y-2 border-l border-base-content/10 pl-4'}>
@@ -134,6 +142,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                 </div>
             </>}
             <hr />
+            <ManagedSetting configKey="api.download-file-blocklist">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="ignored-files-input">Ignored Files</label>
                 <TagInput
@@ -147,7 +156,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     Files that match these patterns will be ignored and not mounted onto the webdav when processing an nzb. Wildcards (*) are supported.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.duplicate-nzb-behavior">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="duplicate-nzb-behavior-input">Behavior for Duplicate NZBs</label>
                 <Select
@@ -163,7 +174,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     When an NZB is added, a new folder is created on the webdav. What should be done when the download folder for an NZB already exists?
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.user-agent">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="user-agent-input">User Agent</label>
                 <ExpandingTextInput
@@ -179,7 +192,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     for fetching nzb files.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.addurl-trusted-hosts">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="addurl-trusted-hosts-input">Trusted local hosts</label>
                 <ExpandingTextInput
@@ -197,7 +212,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     <code>*</code> to trust every non-public address. Only list hosts you control.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.ensure-importable-video">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -211,7 +228,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     Whether to mark downloads as `failed` when no single video file is found inside the nzb. This will force Radarr / Sonarr to automatically look for a new nzb.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.skip-non-video-on-missing-articles">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -229,7 +248,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     Enable this to fail the download instead so *Arr can grab an alternate release.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.ensure-article-existence-categories">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -249,7 +270,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     onChange={value => setNewConfig({ ...config, "api.ensure-article-existence-categories": value })}
                 />
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="api.ignore-history-limit">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -264,6 +287,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     <a href="https://github.com/Sonarr/Sonarr/issues/5452">See here</a>.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -96,6 +96,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
             </ManagedSetting>
             {/* <hr /> */}
             {config["api.import-strategy"] === 'symlinks' &&
+                <ManagedSetting configKey="rclone.mount-dir">
                 <div className={'ml-4 space-y-2 border-l border-base-content/10 pl-4'}>
                     <label className="block text-sm font-medium text-base-content" htmlFor="mount-dir-input">Rclone Mount Directory</label>
                     <Input
@@ -110,8 +111,10 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                         The location at which you've mounted (or will mount) the webdav root, through Rclone. This is used to tell Radarr / Sonarr where to look for completed "downloads."
                     </p>
                 </div>
+                </ManagedSetting>
             }
             {config["api.import-strategy"] === 'strm' && <>
+                <ManagedSetting configKey="api.completed-downloads-dir">
                 <div className={'ml-4 space-y-2 border-l border-base-content/10 pl-4'}>
                     <label className="block text-sm font-medium text-base-content" htmlFor="completed-downloads-dir-input">Completed Downloads Dir</label>
                     <Input
@@ -126,6 +129,8 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                         This is used to tell Radarr / Sonarr where to look for completed "downloads." Make sure this path is also visible to your Radarr / Sonarr containers. The "downloads" placed in this folder will all be *.strm files that point to nzbdav for streaming.
                     </p>
                 </div>
+                </ManagedSetting>
+                <ManagedSetting configKey="general.base-url">
                 <div className={'ml-4 space-y-2 border-l border-base-content/10 pl-4'}>
                     <label className="block text-sm font-medium text-base-content" htmlFor="base-url-input">Base URL</label>
                     <Input
@@ -140,6 +145,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                         What is the base URL at which you access nzbdav? Make sure that Emby/Jellyfin can access this url. This is the URL they will connect to for streaming. All *.strm files will point to this URL.
                     </p>
                 </div>
+                </ManagedSetting>
             </>}
             <hr />
             <ManagedSetting configKey="api.download-file-blocklist">
@@ -289,6 +295,11 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
             </div>
             </ManagedSetting>
             <hr />
+            <ManagedSetting configKeys={[
+                "api.nzb-backup-enabled",
+                "api.nzb-backup-location",
+                "api.nzb-backup-retention-days",
+            ]}>
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -328,6 +339,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     Aged <code>*.nzb</code> files under the backup directory are pruned hourly. Use <code>0</code> to keep backups forever. Default is 30 days.
                 </p>
             </div>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, type ReactNode, type CSSProperties, useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { Alert, Badge, Button, HelpText, Icon, Input, Label, Modal, Select, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
+import { Alert, Badge, Button, HelpText, Icon, Input, Label, ManagedSetting, Modal, Select, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
 import { Checkbox } from "~/components/ui/form";
 import { subscribeWebsocketTopics, useWebsocketTopic } from "~/utils/shared-websocket";
 import { isMaskedSecret } from "~/utils/config-mask";
@@ -423,6 +423,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                 pipelining for faster queue first-segment fetches.
             </SettingsIntro>
 
+            <ManagedSetting configKey="usenet.providers">
             <section className="space-y-3">
                 <div className="flex items-end justify-between gap-4">
                     <div>
@@ -612,7 +613,9 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                     </DndContext>
                 )}
             </section>
+            </ManagedSetting>
 
+            <ManagedSetting configKeys={["usenet.cascade.enabled", "usenet.pipelining.enabled", "usenet.pipelining.depth"]}>
             <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
                 <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
                     <span className="rounded-lg bg-primary/10 p-2 text-primary">
@@ -709,6 +712,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                     </div>
                 </div>
             </section>
+            </ManagedSetting>
 
             <ProviderModal
                 show={showModal}

--- a/frontend/app/routes/settings/warden/warden.tsx
+++ b/frontend/app/routes/settings/warden/warden.tsx
@@ -1,6 +1,6 @@
 import { type ChangeEvent, type DragEvent, type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
-import { Alert, Button, Icon, Modal, NativeForm as Form, SettingsIntro, SettingsPage, Spinner, Textarea } from "~/components/ui";
+import { Alert, Button, Icon, ManagedSetting, Modal, NativeForm as Form, SettingsIntro, SettingsPage, Spinner, Textarea } from "~/components/ui";
 
 type WardenSettingsProps = {
     config: Record<string, string>;
@@ -400,6 +400,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 indexer, or server, and free of credentials.
             </SettingsIntro>
 
+            <ManagedSetting configKey="warden.hide-dead">
             <Form.Group className={"flex flex-col gap-2"}>
                 <Form.Check
                     type="switch"
@@ -413,7 +414,9 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                     as a last resort.
                 </p>
             </Form.Group>
+            </ManagedSetting>
 
+            <ManagedSetting configKey="warden.quorum">
             <Form.Group className={"flex flex-col gap-2"}>
                 <Form.Label>Agreement needed for shared lists</Form.Label>
                 <Form.Control className={"w-full max-w-md"} type="number" min={1} max={20}
@@ -425,7 +428,9 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                     on their own.
                 </p>
             </Form.Group>
+            </ManagedSetting>
 
+            <ManagedSetting configKey="warden.backbone-scope">
             <Form.Group className={"flex flex-col gap-2"}>
                 <Form.Check
                     type="switch"
@@ -438,6 +443,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                     of yours. Your own list always filters.
                 </p>
             </Form.Group>
+            </ManagedSetting>
 
             <div className={`${"flex flex-col gap-2"} ${"w-full"}`}>
                 <div className={"flex items-start justify-between gap-3 mb-1"}>

--- a/frontend/app/routes/settings/watchdog/watchdog.tsx
+++ b/frontend/app/routes/settings/watchdog/watchdog.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import type { Dispatch, SetStateAction } from "react";
-import { NativeForm as Form, SettingsPage } from "~/components/ui";
+import { NativeForm as Form, ManagedSetting, SettingsPage } from "~/components/ui";
 
 type WatchdogSettingsProps = {
     config: Record<string, string>
@@ -20,6 +20,16 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
 
     return (
         <SettingsPage>
+            <ManagedSetting configKeys={[
+                "play.watchdog-enabled", "play.total-budget-seconds", "play.hedge-delay-seconds",
+                "play.max-candidates", "play.max-attempts", "play.verify-mode",
+                "play.candidate-negative-cache-minutes", "play.resolution-cache-ttl-hours",
+                "play.prefer-subtitles", "grab.stall-failover-enabled",
+                "grab.stall-failover-window-seconds", "grab.stall-failover-ceiling-seconds",
+                "variants.mode", "variants.tolerance-pct", "variants.max-per-group",
+                "variants.replay-strategy", "variants.fallback-on-failure",
+                "variants.eviction-strategy", "variants.eviction-active-grace-seconds",
+            ]}>
             <div className="flex flex-col gap-2">
                 <div className="text-[0.95rem] font-semibold text-base-content">Failover</div>
                 <div className="text-[0.8125rem] leading-relaxed text-base-content/55">
@@ -357,6 +367,7 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
                     never remove an item that's still being accessed. Default 60.
                 </p>
             </Form.Group>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/watchtower/watchtower.tsx
+++ b/frontend/app/routes/settings/watchtower/watchtower.tsx
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction } from "react";
-import { NativeForm as Form, SettingsIntro, SettingsPage } from "~/components/ui";
+import { NativeForm as Form, ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
 
 const GB = 1024 * 1024 * 1024;
 
@@ -45,6 +45,35 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
                 indexer caps. Manage your lists on the <b>Watchtower</b> page; tune the engine here.
             </SettingsIntro>
 
+            <ManagedSetting configKeys={[
+                "watchtower.enabled",
+                "watchtower.profile-token",
+                "watchtower.ranking",
+                "watchtower.size-floor-bytes",
+                "watchtower.size-ceiling-bytes",
+                "watchtower.shortlist-depth",
+                "watchtower.grab-cap-per-resolve",
+                "watchtower.active-set-cap",
+                "watchtower.daily-resolve-budget",
+                "watchtower.auto-throughput",
+                "watchtower.sync-interval-seconds",
+                "watchtower.series-scope",
+                "watchtower.season-bundles",
+                "watchtower.series-max-episodes",
+                "watchtower.series-cap-keep",
+                "watchtower.series-recent-count",
+                "watchtower.season-bundle-fallback",
+                "watchtower.season-bundle-fallback-scope",
+                "watchtower.season-bundle-fallback-recent-count",
+                "watchtower.season-bundle-fallback-max-episodes",
+                "watchtower.min-grabs",
+                "watchtower.verify-sample-count",
+                "watchtower.verify-timeout-seconds",
+                "watchtower.keepfresh-base-seconds",
+                "watchtower.keepfresh-max-seconds",
+                "watchtower.unavailable-retry-seconds",
+                "watchtower.verbose-logging",
+            ]}>
             <Form.Group className="flex flex-col gap-2">
                 <Form.Check
                     type="switch"
@@ -443,6 +472,7 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
                     Watchtower is enabled. Leave off for normal use — it's chatty.
                 </p>
             </Form.Group>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -1,4 +1,4 @@
-import { SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select, Toggle } from "~/components/ui/form";
 import { type Dispatch, type SetStateAction } from "react";
 import { className } from "~/utils/styling";
@@ -12,6 +12,7 @@ type SabnzbdSettingsProps = {
 export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
     return (
         <SettingsPage>
+            <ManagedSetting configKey="webdav.user">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="webdav-user-input">WebDAV User</label>
                 <Input
@@ -26,7 +27,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Use this user to connect to the webdav. Only letters, numbers, dashes, and underscores allowed.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.max-queue-connections">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="max-queue-connections-input">Queue Download Connections</label>
                 <Input
@@ -41,7 +44,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Connections available to queue imports. Leave blank to use all provider connections.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="webdav.pass">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="webdav-pass-input">WebDAV Password</label>
                 <Input
@@ -55,7 +60,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Use this password to connect to the webdav.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKeys={["usenet.segment-cache.enabled", "usenet.segment-cache.path", "usenet.segment-cache.max-gb"]}>
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -89,7 +96,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     </div>
                 )}
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.max-download-connections">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-auto-checkbox">Max Download Connections</label>
                 <Toggle
@@ -115,7 +124,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Queue imports use their own budget — see Queue Download Connections above.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKeys={["usenet.max-download-connections-per-stream", "usenet.max-download-connections-per-stream-preset"]}>
             <div className="space-y-2">
                 <Toggle
                     id="max-download-connections-per-stream-checkbox"
@@ -150,7 +161,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     </div>
                 )}
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.streaming-priority">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="streaming-priority-input">Streaming Priority (vs Queue)</label>
                 <div className="flex w-full">
@@ -168,7 +181,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     When streaming from the webdav while the queue is also active, how much bandwidth should be dedicated to streaming?
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.streaming-segment-timeout-seconds">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-timeout-input">Streaming Segment Timeout</label>
                 <div className="flex w-full">
@@ -186,7 +201,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Per-segment deadline for WebDAV playback (2–40s). Stalled connections are replaced and retried before waiting for the provider&apos;s ~40s read timeout.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.streaming-segment-retries">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-retries-input">Streaming Segment Retries</label>
                 <Input
@@ -201,7 +218,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Extra attempts on a fresh connection after a streaming segment timeout (0–5). Queue and health checks are unaffected.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.article-buffer-size">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="article-buffer-size-input">Article Buffer Size</label>
                 <Input
@@ -216,7 +235,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     The number of articles to buffer ahead, per stream, when reading from the webdav.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.idle-connection-timeout-seconds">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="idle-connection-timeout-input">Idle connection timeout (seconds)</label>
                 <Input
@@ -234,7 +255,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     connection-pool rebuild (provider config change or restart).
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="usenet.pipelined-body-requests">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -250,7 +273,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     to use the legacy one-at-a-time API while retaining the configured article buffer.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="webdav.enforce-readonly">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -264,7 +289,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     The WebDAV `/content` folder will be readonly when checked. WebDAV clients will not be able to delete files within this directory.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="webdav.show-hidden-files">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -278,7 +305,9 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Hidden files or directories are those whose names are prefixed by a period.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="webdav.preview-par2-files">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -292,6 +321,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     When enabled, par2 files will be rendered as text files on the Dav Explorer page, displaying all File-Descriptor entries.
                 </p>
             </div>
+            </ManagedSetting>
             <hr />
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -323,6 +323,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
             </div>
             </ManagedSetting>
             <hr />
+            <ManagedSetting configKey="webdav.windows-safe-paths">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
                     <Checkbox
@@ -338,6 +339,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     clients or rclone on Windows. Applies to newly mounted content only.
                 </p>
             </div>
+            </ManagedSetting>
         </SettingsPage>
     );
 }

--- a/tests/NzbWebDAV.Tests/Api/EnvironmentManagedConfigApiTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/EnvironmentManagedConfigApiTests.cs
@@ -75,4 +75,38 @@ public class EnvironmentManagedConfigApiTests
         Assert.DoesNotContain("attempted", ex.Message);
         Assert.DoesNotContain("movies", ex.Message);
     }
+
+    [Fact]
+    public void UpdateConfigContract_RejectsManagedKeysBeforeValidationCanLeakValues()
+    {
+        var config = new ConfigManager();
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__REPAIR__HEALTHCHECK_CONCURRENCY"] = "50",
+        }));
+
+        const string leakedValue = "not-a-number-secret";
+        var requestItems = new List<ConfigItem>
+        {
+            new()
+            {
+                ConfigName = ConfigKeys.RepairHealthcheckConcurrency,
+                ConfigValue = leakedValue,
+            },
+        };
+
+        Assert.True(config.IsEnvironmentManaged(ConfigKeys.RepairHealthcheckConcurrency));
+
+        // Mimic UpdateConfigController ordering: managed rejection first.
+        var managed = requestItems
+            .Where(item => config.IsEnvironmentManaged(item.ConfigName))
+            .Select(item => item.ConfigName)
+            .ToList();
+        Assert.NotEmpty(managed);
+
+        // Validation must not run for managed keys — its messages embed values.
+        var validationWouldLeak = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems(requestItems));
+        Assert.Contains(leakedValue, validationWouldLeak.Message);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Api/EnvironmentManagedConfigApiTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/EnvironmentManagedConfigApiTests.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+/// <summary>
+/// Covers the GetConfig / UpdateConfig ENV-managed contract without spinning up
+/// the full ASP.NET host: effective source metadata for reads, and the rejection
+/// predicate used before any SQLite write.
+/// </summary>
+public class EnvironmentManagedConfigApiTests
+{
+    [Fact]
+    public void GetConfigContract_ExposesEnvironmentVariableNameForManagedKeys()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiCategories, ConfigValue = "sqlite-cats" },
+        ]);
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__API__CATEGORIES"] = "env-cats",
+        }));
+
+        Assert.Equal("env-cats", config.GetEffectiveConfigValue(ConfigKeys.ApiCategories));
+        Assert.Equal(
+            "NZBDAV_CONFIG__API__CATEGORIES",
+            config.GetEnvironmentVariableName(ConfigKeys.ApiCategories));
+        Assert.Null(config.GetEnvironmentVariableName(ConfigKeys.WebdavUser));
+    }
+
+    [Fact]
+    public void UpdateConfigContract_RejectsManagedKeysWithBadHttpRequestExceptionShape()
+    {
+        var config = new ConfigManager();
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__WEBDAV__USER"] = "env-user",
+            ["NZBDAV_CONFIG__API__CATEGORIES"] = "tv",
+        }));
+
+        var requestItems = new List<ConfigItem>
+        {
+            new() { ConfigName = ConfigKeys.WebdavUser, ConfigValue = "attempted" },
+            new() { ConfigName = ConfigKeys.ApiCategories, ConfigValue = "movies" },
+            new() { ConfigName = ConfigKeys.WebdavShowHiddenFiles, ConfigValue = "true" },
+        };
+
+        var managed = requestItems
+            .Where(item => config.IsEnvironmentManaged(item.ConfigName))
+            .Select(item => item.ConfigName)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(
+            [ConfigKeys.ApiCategories, ConfigKeys.WebdavUser],
+            managed);
+
+        var details = string.Join(", ", managed.Select(name =>
+        {
+            var envName = config.GetEnvironmentVariableName(name) ?? name;
+            return $"`{name}` (managed by `{envName}`)";
+        }));
+        var message =
+            $"Cannot update environment-managed setting(s): {details}. " +
+            "Change the container environment and restart instead.";
+
+        var ex = new BadHttpRequestException(message);
+        Assert.Contains("NZBDAV_CONFIG__API__CATEGORIES", ex.Message);
+        Assert.Contains("NZBDAV_CONFIG__WEBDAV__USER", ex.Message);
+        Assert.DoesNotContain("attempted", ex.Message);
+        Assert.DoesNotContain("movies", ex.Message);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ConfigEnvMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigEnvMappingTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ConfigEnvMappingTests
+{
+    [Theory]
+    [InlineData("api.categories", "NZBDAV_CONFIG__API__CATEGORIES")]
+    [InlineData("usenet.segment-cache.enabled", "NZBDAV_CONFIG__USENET__SEGMENT_CACHE__ENABLED")]
+    [InlineData("api.addurl-trusted-hosts", "NZBDAV_CONFIG__API__ADDURL_TRUSTED_HOSTS")]
+    [InlineData("maintenance.remove-orphaned-schedule-time", "NZBDAV_CONFIG__MAINTENANCE__REMOVE_ORPHANED_SCHEDULE_TIME")]
+    public void FormatEnvironmentVariableName_UsesDeterministicRules(string configKey, string expected)
+    {
+        Assert.Equal(expected, ConfigEnvMapping.FormatEnvironmentVariableName(configKey));
+    }
+
+    [Fact]
+    public void PublicConfigKeys_CoverAllNonExcludedConfigKeysLiterals()
+    {
+        var literals = typeof(ConfigKeys)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(string) && field.IsLiteral)
+            .Select(field => (string)field.GetRawConstantValue()!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var excluded in ConfigEnvMapping.ExcludedConfigKeys)
+            Assert.Contains(excluded, literals);
+
+        var expected = literals
+            .Except(ConfigEnvMapping.ExcludedConfigKeys, StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+        var actual = ConfigEnvMapping.PublicConfigKeys
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void PublicConfigKeys_MapToUniqueEnvironmentVariableNames()
+    {
+        var envNames = ConfigEnvMapping.PublicConfigKeys
+            .Select(ConfigEnvMapping.ToEnvironmentVariableName)
+            .ToList();
+
+        Assert.All(envNames, name => Assert.False(string.IsNullOrWhiteSpace(name)));
+        Assert.Equal(envNames.Count, envNames.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void ExcludedKeys_AreNotMapped()
+    {
+        Assert.Null(ConfigEnvMapping.ToEnvironmentVariableName(ConfigKeys.SearchExcludePrefix));
+        Assert.Null(ConfigEnvMapping.ToEnvironmentVariableName(ConfigKeys.SearchExcludeSyncCache));
+        Assert.False(ConfigEnvMapping.TryGetConfigKey(
+            ConfigEnvMapping.FormatEnvironmentVariableName(ConfigKeys.SearchExcludeSyncCache),
+            out _));
+    }
+
+    [Fact]
+    public void TryGetConfigKey_IsCaseInsensitiveForEnvNames()
+    {
+        Assert.True(ConfigEnvMapping.TryGetConfigKey(
+            "nzbdav_config__api__categories",
+            out var configKey));
+        Assert.Equal(ConfigKeys.ApiCategories, configKey);
+    }
+
+    [Fact]
+    public void RoundTrip_EveryPublicKey()
+    {
+        foreach (var configKey in ConfigEnvMapping.PublicConfigKeys)
+        {
+            var envName = ConfigEnvMapping.ToEnvironmentVariableName(configKey);
+            Assert.NotNull(envName);
+            Assert.True(ConfigEnvMapping.TryGetConfigKey(envName!, out var roundTrip));
+            Assert.Equal(configKey, roundTrip);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ConfigEnvironmentOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigEnvironmentOverlayTests.cs
@@ -1,0 +1,165 @@
+using System.Collections;
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ConfigEnvironmentOverlayTests
+{
+    [Fact]
+    public void LoadFromEnvironment_WithNoPrefixedVars_ReturnsEmpty()
+    {
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["CONFIG_PATH"] = "/tmp",
+            ["WEBDAV_USER"] = "legacy",
+        });
+
+        Assert.True(overlay.IsEmpty);
+        Assert.Equal(0, overlay.Count);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_TreatsEmptyValuesAsUnset()
+    {
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__WEBDAV__USER"] = "",
+            ["NZBDAV_CONFIG__API__CATEGORIES"] = "tv,movies",
+        });
+
+        Assert.False(overlay.IsManaged(ConfigKeys.WebdavUser));
+        Assert.True(overlay.TryGetValue(ConfigKeys.ApiCategories, out var categories));
+        Assert.Equal("tv,movies", categories);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_RejectsUnknownPrefixedVariable()
+    {
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                ["NZBDAV_CONFIG__NOT__A__REAL__KEY"] = "x",
+            }));
+
+        Assert.Contains("NZBDAV_CONFIG__NOT__A__REAL__KEY", ex.Message);
+        Assert.DoesNotContain("x", ex.Message);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_RejectsInvalidValuesWithoutLeakingSecrets()
+    {
+        var secret = "super-secret-password-value";
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                ["NZBDAV_CONFIG__REPAIR__HEALTHCHECK_CONCURRENCY"] = secret,
+            }));
+
+        Assert.Equal(
+            "Invalid configuration environment variable `NZBDAV_CONFIG__REPAIR__HEALTHCHECK_CONCURRENCY`.",
+            ex.Message);
+        Assert.DoesNotContain(secret, ex.Message);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_HashesWebdavPassword()
+    {
+        var plaintext = "plain-webdav-pass";
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__WEBDAV__PASS"] = plaintext,
+        });
+
+        Assert.True(overlay.TryGetValue(ConfigKeys.WebdavPass, out var hashed));
+        Assert.NotEqual(plaintext, hashed);
+        Assert.True(PasswordUtil.Verify(hashed, plaintext));
+        Assert.Equal(
+            "NZBDAV_CONFIG__WEBDAV__PASS",
+            overlay.GetEnvironmentVariableName(ConfigKeys.WebdavPass));
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_PreservesExistingUsenetProviderIds()
+    {
+        var existingId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var existing = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    ProviderId = existingId,
+                    Type = ProviderType.Pooled,
+                    Host = "news.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "alice",
+                    Pass = "stored",
+                    MaxConnections = 10,
+                },
+            ],
+        });
+
+        var incoming = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    Type = ProviderType.Pooled,
+                    Host = "news.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "alice",
+                    Pass = "env-secret",
+                    MaxConnections = 20,
+                },
+            ],
+        });
+
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(
+            new Hashtable { ["NZBDAV_CONFIG__USENET__PROVIDERS"] = incoming },
+            existingUsenetProvidersJson: existing);
+
+        Assert.True(overlay.TryGetValue(ConfigKeys.UsenetProviders, out var normalized));
+        var parsed = JsonSerializer.Deserialize<UsenetProviderConfig>(normalized)!;
+        Assert.Single(parsed.Providers);
+        Assert.Equal(existingId, parsed.Providers[0].ProviderId);
+        Assert.Equal(20, parsed.Providers[0].MaxConnections);
+        Assert.Equal("env-secret", parsed.Providers[0].Pass);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_AssignsProviderIdsWhenMissingEverywhere()
+    {
+        var incoming = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    Type = ProviderType.Pooled,
+                    Host = "news.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "alice",
+                    Pass = "env-secret",
+                    MaxConnections = 5,
+                },
+            ],
+        });
+
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__USENET__PROVIDERS"] = incoming,
+        });
+
+        Assert.True(overlay.TryGetValue(ConfigKeys.UsenetProviders, out var normalized));
+        var parsed = JsonSerializer.Deserialize<UsenetProviderConfig>(normalized)!;
+        Assert.NotEqual(Guid.Empty, parsed.Providers[0].ProviderId);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ConfigManagerEnvironmentOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigManagerEnvironmentOverlayTests.cs
@@ -1,0 +1,176 @@
+using System.Collections;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ConfigManagerEnvironmentOverlayTests
+{
+    [Fact]
+    public void WithoutOverlay_BehaviorMatchesSqliteAndLegacyFallbacks()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.WebdavUser, ConfigValue = "sqlite-user" },
+        ]);
+
+        Assert.Equal("sqlite-user", config.GetWebdavUser());
+        Assert.False(config.IsEnvironmentManaged(ConfigKeys.WebdavUser));
+        Assert.Null(config.GetEnvironmentVariableName(ConfigKeys.WebdavUser));
+        Assert.Equal("sqlite-user", config.GetPersistedConfigValue(ConfigKeys.WebdavUser));
+    }
+
+    [Fact]
+    public void WithoutOverlay_LegacyEnvFallbackStillAppliesWhenSqliteEmpty()
+    {
+        var previous = Environment.GetEnvironmentVariable("WEBDAV_USER");
+        try
+        {
+            Environment.SetEnvironmentVariable("WEBDAV_USER", "legacy-user");
+            var config = new ConfigManager();
+            Assert.Equal("legacy-user", config.GetWebdavUser());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("WEBDAV_USER", previous);
+        }
+    }
+
+    [Fact]
+    public void EnvOverlay_WinsOverSqliteAndLegacyFallbacks()
+    {
+        var previous = Environment.GetEnvironmentVariable("WEBDAV_USER");
+        try
+        {
+            Environment.SetEnvironmentVariable("WEBDAV_USER", "legacy-user");
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.WebdavUser, ConfigValue = "sqlite-user" },
+            ]);
+            config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                ["NZBDAV_CONFIG__WEBDAV__USER"] = "env-user",
+            }));
+
+            Assert.Equal("env-user", config.GetWebdavUser());
+            Assert.Equal("env-user", config.GetEffectiveConfigValue(ConfigKeys.WebdavUser));
+            Assert.Equal("sqlite-user", config.GetPersistedConfigValue(ConfigKeys.WebdavUser));
+            Assert.True(config.IsEnvironmentManaged(ConfigKeys.WebdavUser));
+            Assert.Equal(
+                "NZBDAV_CONFIG__WEBDAV__USER",
+                config.GetEnvironmentVariableName(ConfigKeys.WebdavUser));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("WEBDAV_USER", previous);
+        }
+    }
+
+    [Fact]
+    public void UpdateValues_DoesNotEmitChangeEventForEnvManagedKeys()
+    {
+        var config = new ConfigManager();
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__API__CATEGORIES"] = "tv",
+            ["NZBDAV_CONFIG__WEBDAV__USER"] = "env-user",
+        }));
+
+        var changedKeys = new List<string>();
+        config.OnConfigChanged += (_, args) =>
+            changedKeys.AddRange(args.ChangedConfig.Keys);
+
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiCategories, ConfigValue = "movies" },
+            new ConfigItem { ConfigName = ConfigKeys.WebdavShowHiddenFiles, ConfigValue = "true" },
+        ]);
+
+        Assert.Equal(["webdav.show-hidden-files"], changedKeys);
+        Assert.Equal("tv", config.GetEffectiveConfigValue(ConfigKeys.ApiCategories));
+        Assert.Equal("movies", config.GetPersistedConfigValue(ConfigKeys.ApiCategories));
+        Assert.Equal("true", config.GetEffectiveConfigValue(ConfigKeys.WebdavShowHiddenFiles));
+    }
+
+    [Fact]
+    public void UpdateValues_OnlyEnvManaged_DoesNotRaiseEvent()
+    {
+        var config = new ConfigManager();
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__API__CATEGORIES"] = "tv",
+        }));
+
+        var raised = false;
+        config.OnConfigChanged += (_, _) => raised = true;
+
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiCategories, ConfigValue = "movies" },
+        ]);
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void EmptyOverlay_LeavesRuntimeUnchanged()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiCategories, ConfigValue = "audio" },
+        ]);
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.Empty);
+
+        Assert.Equal("audio", config.GetEffectiveConfigValue(ConfigKeys.ApiCategories));
+        Assert.False(config.IsEnvironmentManaged(ConfigKeys.ApiCategories));
+    }
+
+    [Fact]
+    public void EffectiveWebdavPasswordHash_UsesHashedEnvValue()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WebdavPass,
+                ConfigValue = PasswordUtil.Hash("sqlite-pass"),
+            },
+        ]);
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__WEBDAV__PASS"] = "env-pass",
+        }));
+
+        var hash = config.GetWebdavPasswordHash();
+        Assert.NotNull(hash);
+        Assert.True(PasswordUtil.Verify(hash!, "env-pass"));
+        Assert.False(PasswordUtil.Verify(hash!, "sqlite-pass"));
+    }
+
+    [Fact]
+    public void SecretMasker_MasksEffectiveEnvManagedIndexerSecrets()
+    {
+        const string envJson =
+            """{"Indexers":[{"Name":"One","Url":"https://indexer.example","ApiKey":"env-indexer-secret"}]}""";
+        var config = new ConfigManager();
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__INDEXERS__INSTANCES"] = envJson,
+        }));
+
+        var effective = config.GetEffectiveConfigValue(ConfigKeys.IndexersInstances)!;
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var masked = masker.MaskForResponse(ConfigKeys.IndexersInstances, effective);
+
+        Assert.DoesNotContain("env-indexer-secret", masked);
+        Assert.Contains(ConfigSecretMasker.MaskPrefix, masked);
+        Assert.Equal(
+            "NZBDAV_CONFIG__INDEXERS__INSTANCES",
+            config.GetEnvironmentVariableName(ConfigKeys.IndexersInstances));
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -43,6 +43,7 @@ nav = [
   ]},
   { "Configuration" = [
     { "Overview" = "configuration/index.md" },
+    { "Headless environment config" = "configuration/headless.md" },
     { "Usenet" = "configuration/usenet.md" },
     { "Indexers" = "configuration/indexers.md" },
     { "Search profiles" = "configuration/profiles.md" },


### PR DESCRIPTION
## Summary
- Adds an opt-in `NZBDAV_CONFIG__...` overlay so every user-owned Settings (`ConfigItems`) value can be set from the container environment for headless / Compose deployments.
- ENV values stay out of SQLite, win over UI/legacy fallbacks, are validated at startup without leaking secrets, and appear as read-only locked controls in Settings.
- Documents the naming rule, precedence, out-of-scope domains (admin account, Warden DB, restore actions), and a fully hydrated Compose example (`since 0.9.0`).

Closes #147

## Test plan
- [x] Focused backend tests for mapping, overlay validation, precedence, provider IDs, and managed-write rejection contract
- [x] Frontend unit tests for pin/omit helpers + config client `environmentVariableName`
- [x] Frontend `typecheck`, `build`, and `vitest`
- [x] Strict docs build (`zensical build --clean --strict`)
- [ ] Manually confirm Settings locks scalar + structured controls when ENV is set, and that removing one ENV var + restart restores SQLite editability