### PR TITLE
feat(queue): process multiple NZB downloads at once

### DIFF
--- a/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
+++ b/backend/Api/Controllers/BenchmarkUsenetConnection/BenchmarkUsenetConnectionController.cs
@@ -52,7 +52,7 @@ public class BenchmarkUsenetConnectionController(
             // Activity we can't pause — a download already mid-flight or live
             // streams — still uses connections; capture it so we can flag it.
             var streamsBefore = activeReads.Count;
-            var (inProgressBefore, _) = queueManager.GetInProgressQueueItem();
+            var inProgressBefore = queueManager.HasActiveQueueItems;
 
             var result = await benchmarkService.RunAsync(
                 request.ToConnectionDetails(),
@@ -65,13 +65,13 @@ public class BenchmarkUsenetConnectionController(
             ).ConfigureAwait(false);
 
             var streamsAfter = activeReads.Count;
-            var (inProgressAfter, _) = queueManager.GetInProgressQueueItem();
+            var inProgressAfter = queueManager.HasActiveQueueItems;
             AddContentionWarnings(
                 result,
                 streamsBefore,
                 streamsAfter,
-                inProgressBefore != null,
-                inProgressAfter != null);
+                inProgressBefore,
+                inProgressAfter);
 
             return new BenchmarkUsenetConnectionResponse { Status = true, Result = result };
         }

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -995,8 +995,9 @@ public class ProfilePlayController(
 
             if (stallFailover)
             {
-                var (inProg, inProgPct) = queueManager.GetInProgressQueueItem();
-                var isMine = inProg?.Id == nzoId;
+                var inProg = queueManager.FindInProgressQueueItem(nzoId);
+                var isMine = inProg is not null;
+                var inProgPct = inProg?.ProgressPercentage;
                 var now = DateTimeOffset.UtcNow;
                 if (!isMine)
                     lastProgressAt = now;

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -176,8 +176,7 @@ public class AddFileController(
             .ConfigureAwait(false);
         if (existingId is null) return;
 
-        var (inProgress, _) = queueManager.GetInProgressQueueItem();
-        var wasInProgress = inProgress?.Id == existingId.Value;
+        var wasInProgress = queueManager.FindInProgressQueueItem(existingId.Value) is not null;
         Log.Warning(
             "Replacing existing queue item {QueueItemId} ({FileName} in {Category}) on re-add{InProgressSuffix}",
             existingId.Value,
@@ -204,8 +203,7 @@ public class AddFileController(
             .ConfigureAwait(false);
         if (conflictingId is null) return;
 
-        var (inProgress, _) = queueManager.GetInProgressQueueItem();
-        var wasInProgress = inProgress?.Id == conflictingId.Value;
+        var wasInProgress = queueManager.FindInProgressQueueItem(conflictingId.Value) is not null;
         Log.Warning(
             "Replacing existing queue item {QueueItemId} ({FileName} in {Category}) after UNIQUE conflict on re-add{InProgressSuffix}",
             conflictingId.Value,

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
-using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
@@ -18,21 +19,37 @@ public class GetQueueController(
 {
     private async Task<GetQueueResponse> GetQueueAsync(GetQueueRequest request)
     {
-        // get in progress item
-        var (inProgressQueueItem, progressPercentage) = queueManager.GetInProgressQueueItem();
+        // Snapshot every in-progress item (primary first).
+        var inProgress = queueManager.GetInProgressQueueItems();
+        if (!string.IsNullOrEmpty(request.Category))
+        {
+            inProgress = inProgress
+                .Where(x => x.QueueItem.Category == request.Category)
+                .ToList();
+        }
+
+        var inProgressIds = inProgress.Select(x => x.QueueItem.Id).ToHashSet();
+        var inProgressById = inProgress.ToDictionary(x => x.QueueItem.Id);
 
         // get total count
         var ct = request.CancellationToken;
         var totalCount = await dbClient.GetQueueItemsCount(request.Category, ct).ConfigureAwait(false);
 
-        // get queued items
-        var getQueueItemsTask = dbClient.GetQueueItems(request.Category, request.Start, request.Limit, ct);
-        var queueItems = (await getQueueItemsTask.ConfigureAwait(false))
-            .Where(x => x.Id != inProgressQueueItem?.Id)
+        // get queued items, then merge active items ahead for the requested page
+        var getQueueItemsTask = dbClient.GetQueueItems(request.Category, 0, request.Start + request.Limit, ct);
+        var queuedItems = (await getQueueItemsTask.ConfigureAwait(false))
+            .Where(x => !inProgressIds.Contains(x.Id))
             .ToArray();
 
+        var merged = inProgress
+            .Select(x => x.QueueItem)
+            .Concat(queuedItems)
+            .Skip(request.Start)
+            .Take(request.Limit)
+            .ToList();
+
         // Metrics keys of every configured Usenet provider — used to show idle providers
-        // alongside active ones for the in-progress download.
+        // alongside active ones for in-progress downloads.
         var configuredProviders = configManager.GetUsenetProviderConfig().Providers;
         var configuredKeys = configuredProviders
             .Where(p => p.ProviderId != Guid.Empty)
@@ -42,24 +59,23 @@ public class GetQueueController(
         var displayByMetricsKey = ProviderUsageHelper.BuildDisplayByMetricsKey(configuredProviders);
 
         // get slots
-        var slots = queueItems
-            .Prepend(request is { Start: 0, Limit: > 0 } ? inProgressQueueItem : null)
-            .Where(queueItem => queueItem != null)
+        var slots = merged
             .Select((queueItem, index) =>
             {
-                var isInProgress = queueItem == inProgressQueueItem;
-                var percentage = (isInProgress ? progressPercentage : 0)!.Value;
+                var isInProgress = inProgressById.TryGetValue(queueItem.Id, out var active);
+                var percentage = isInProgress ? active.ProgressPercentage : 0;
                 var status = isInProgress ? "Downloading" : "Queued";
                 IReadOnlyDictionary<string, long> providerUsage =
-                    GetProviderUsageForSlot(isInProgress, queueItem!.Id, providerUsageTracker);
+                    GetProviderUsageForSlot(isInProgress, queueItem.Id, providerUsageTracker);
                 if (isInProgress && configuredKeys.Count > 0)
                 {
-                    var merged = new Dictionary<string, long>();
-                    foreach (var key in configuredKeys) merged[key] = 0;
-                    foreach (var kv in providerUsage) merged[kv.Key] = kv.Value;
-                    providerUsage = merged;
+                    var mergedUsage = new Dictionary<string, long>();
+                    foreach (var key in configuredKeys) mergedUsage[key] = 0;
+                    foreach (var kv in providerUsage) mergedUsage[kv.Key] = kv.Value;
+                    providerUsage = mergedUsage;
                 }
-                return GetQueueResponse.QueueSlot.FromQueueItem(queueItem!, index, percentage, status, providerUsage, displayByMetricsKey);
+                return GetQueueResponse.QueueSlot.FromQueueItem(
+                    queueItem, index, percentage, status, providerUsage, displayByMetricsKey);
             })
             .ToList();
 
@@ -77,7 +93,7 @@ public class GetQueueController(
 
     /// <summary>
     /// Queued slots do not display live provider metrics; only snapshot the
-    /// in-progress item to keep large queues responsive.
+    /// in-progress items to keep large queues responsive.
     /// </summary>
     internal static IReadOnlyDictionary<string, long> GetProviderUsageForSlot(
         bool isInProgress,

--- a/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
+++ b/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
@@ -22,6 +22,7 @@ public class ContextualCancellationTokenSource : IDisposable
         var contextualCts = new ContextualCancellationTokenSource(cts);
         contextualCts.SetContext(linkedToken.GetContext<DownloadPriorityContext>());
         contextualCts.SetContext(linkedToken.GetContext<StreamingTimeoutContext>());
+        contextualCts.SetContext(linkedToken.GetContext<QueueDownloadContext>());
         return contextualCts;
     }
 
@@ -37,6 +38,8 @@ public class ContextualCancellationTokenSource : IDisposable
         contextualCts.SetContext(linkedToken2.GetContext<DownloadPriorityContext>());
         contextualCts.SetContext(linkedToken1.GetContext<StreamingTimeoutContext>());
         contextualCts.SetContext(linkedToken2.GetContext<StreamingTimeoutContext>());
+        contextualCts.SetContext(linkedToken1.GetContext<QueueDownloadContext>());
+        contextualCts.SetContext(linkedToken2.GetContext<QueueDownloadContext>());
         return contextualCts;
     }
 

--- a/backend/Clients/Usenet/Contexts/QueueDownloadContext.cs
+++ b/backend/Clients/Usenet/Contexts/QueueDownloadContext.cs
@@ -1,0 +1,22 @@
+namespace NzbWebDAV.Clients.Usenet.Contexts;
+
+/// <summary>
+/// Marks an NNTP cancellation token as belonging to a queue import worker.
+/// Primary workers get preferred admission on the queue soft semaphore; secondary
+/// workers use the Low lane and share spare capacity. Does not change physical
+/// pool priority — queue BODY requests remain Low at the provider pool.
+/// </summary>
+public sealed class QueueDownloadContext
+{
+    /// <summary>
+    /// True while this worker is the preferred (first) active queue item.
+    /// Mutated in place when a secondary is promoted after the previous primary finishes.
+    /// </summary>
+    public bool IsPrimary { get; set; }
+
+    /// <summary>
+    /// Per-phase task fan-out for this worker. Re-evaluated each phase so a
+    /// promoted secondary immediately gets the primary budget.
+    /// </summary>
+    public required Func<int> GetFanOutConcurrency { get; init; }
+}

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -146,12 +146,21 @@ public class DownloadingNntpClient : WrappingNntpClient
     }
 
     // Picks the semaphore (and its priority) a download should acquire from.
-    // High-priority streaming reads use the per-stream semaphore carried on the
-    // DownloadPriorityContext when "per stream" mode is enabled, otherwise the
-    // shared global streaming semaphore. Low-priority queue reads always use the
-    // queue semaphore.
+    // QueueDownloadContext always uses the shared queue semaphore: primary workers
+    // take the High lane (preferred admission), secondaries take Low. Streaming
+    // (DownloadPriorityContext High) uses the streaming semaphore. Default /
+    // background health STAT work uses the queue semaphore Low lane.
     private (PrioritizedSemaphore Semaphore, SemaphorePriority Priority) SelectSemaphore(CancellationToken cancellationToken)
     {
+        var queueContext = cancellationToken.GetContext<QueueDownloadContext>();
+        if (queueContext is not null)
+        {
+            var queuePriority = queueContext.IsPrimary
+                ? SemaphorePriority.High
+                : SemaphorePriority.Low;
+            return (_queueSemaphore, queuePriority);
+        }
+
         var context = cancellationToken.GetContext<DownloadPriorityContext>();
         var priority = context?.Priority ?? SemaphorePriority.Low;
         var semaphore = priority == SemaphorePriority.High

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -39,6 +39,7 @@ public static class ConfigKeys
     public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";
     public const string UsenetMaxQueueConnections = "usenet.max-queue-connections";
+    public const string QueueWorkerCount = "queue.worker-count";
     public const string UsenetPipelinedBodyRequests = "usenet.pipelined-body-requests";
     public const string UsenetPipeliningDepth = "usenet.pipelining.depth";
     public const string UsenetPipeliningEnabled = "usenet.pipelining.enabled";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -231,6 +231,7 @@ public class ConfigManager
             {
                 case ConfigKeys.UsenetMaxDownloadConnections:
                 case ConfigKeys.UsenetMaxQueueConnections:
+                case ConfigKeys.QueueWorkerCount:
                 case ConfigKeys.UsenetPipeliningDepth:
                 case ConfigKeys.UsenetArticleBufferSize:
                 case ConfigKeys.UsenetIdleConnectionTimeoutSeconds:
@@ -552,6 +553,18 @@ public class ConfigManager
         if (configured is null || !int.TryParse(configured, out var value))
             return pool;
         return Math.Clamp(value, 1, pool);
+    }
+
+    /// <summary>
+    /// How many NZB queue items may process concurrently. Default 1 preserves
+    /// historical single-item behavior. Workers share <see cref="GetMaxQueueConnections"/>.
+    /// </summary>
+    public int GetQueueWorkerCount()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueueWorkerCount));
+        if (configured is null || !int.TryParse(configured, out var value))
+            return 1;
+        return Math.Clamp(value, 1, 8);
     }
 
     public bool IsPipeliningEnabled()

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -557,14 +557,15 @@ public class ConfigManager
 
     /// <summary>
     /// How many NZB queue items may process concurrently. Default 1 preserves
-    /// historical single-item behavior. Workers share <see cref="GetMaxQueueConnections"/>.
+    /// historical single-item behavior. Clamped to 1–4 while the feature is new.
+    /// Workers share <see cref="GetMaxQueueConnections"/>.
     /// </summary>
     public int GetQueueWorkerCount()
     {
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueueWorkerCount));
         if (configured is null || !int.TryParse(configured, out var value))
             return 1;
-        return Math.Clamp(value, 1, 8);
+        return Math.Clamp(value, 1, 4);
     }
 
     public bool IsPipeliningEnabled()

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -161,14 +161,29 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         CancellationToken ct = default
     )
     {
+        return await GetTopQueueItem(excludeIds: null, ct).ConfigureAwait(false);
+    }
+
+    public async Task<(QueueItem? queueItem, Stream? queueNzbStream)> GetTopQueueItem
+    (
+        IReadOnlyCollection<Guid>? excludeIds,
+        CancellationToken ct = default
+    )
+    {
         // read queue item from database
         var nowTime = DateTime.Now;
-        var queueItem = await Ctx.QueueItems
+        var query = Ctx.QueueItems
             .OrderByDescending(q => q.Priority)
             .ThenBy(q => q.CreatedAt)
-            .Where(q => q.PauseUntil == null || nowTime >= q.PauseUntil)
-            .Skip(0)
-            .Take(1)
+            .Where(q => q.PauseUntil == null || nowTime >= q.PauseUntil);
+
+        if (excludeIds is { Count: > 0 })
+        {
+            var excluded = excludeIds as HashSet<Guid> ?? excludeIds.ToHashSet();
+            query = query.Where(q => !excluded.Contains(q.Id));
+        }
+
+        var queueItem = await query
             .FirstOrDefaultAsync(ct).ConfigureAwait(false);
 
         // attempt to read nzb contents from blob-store.

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -1,6 +1,7 @@
 // ReSharper disable InconsistentNaming
 
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Exceptions;
@@ -44,7 +45,8 @@ public static class FetchFirstSegmentsStep
         IProgress<int>? progress
     )
     {
-        using var abortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        // Preserve QueueDownloadContext so primary preference / fan-out survive abort linking.
+        using var abortCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var results = new List<NzbFileWithFirstSegment>(files.Count);
         var completed = 0;
 
@@ -63,7 +65,7 @@ public static class FetchFirstSegmentsStep
             {
                 Log.Warning("First segment for `{FileName}` missing across all providers",
                     result.NzbFile.GetSubjectFileName());
-                AbortRemainingFirstSegmentChecks(result.NzbFile, abortCts);
+                AbortRemainingFirstSegmentChecks(result.NzbFile, abortCts.Cancel);
             }
         }
 
@@ -93,7 +95,7 @@ public static class FetchFirstSegmentsStep
         }
         var completed = 0;
         NzbFile? abortFile = null;
-        using var abortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var abortCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         try
         {
@@ -155,12 +157,12 @@ public static class FetchFirstSegmentsStep
         }
 
         if (abortFile is not null)
-            AbortRemainingFirstSegmentChecks(abortFile, abortCts: null);
+            AbortRemainingFirstSegmentChecks(abortFile, cancel: null);
 
         var pending = Enumerable.Range(0, files.Count).Where(i => results[i] is null).ToList();
         if (pending.Count > 0)
         {
-            using var rescueAbortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var rescueAbortCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             await foreach (var (i, result) in pending
                                .Select(i => RescueFirstSegment(i, files[i], usenetClient, rescueAbortCts.Token))
                                .WithConcurrencyAsync(
@@ -173,7 +175,7 @@ public static class FetchFirstSegmentsStep
                 progress?.Report(++completed);
 
                 if (result.MissingFirstSegment && DeadNzbFailFast.IsImportantNzbFile(result.NzbFile))
-                    AbortRemainingFirstSegmentChecks(result.NzbFile, rescueAbortCts);
+                    AbortRemainingFirstSegmentChecks(result.NzbFile, rescueAbortCts.Cancel);
             }
         }
 
@@ -182,12 +184,12 @@ public static class FetchFirstSegmentsStep
 
     private static void AbortRemainingFirstSegmentChecks(
         NzbFile nzbFile,
-        CancellationTokenSource? abortCts)
+        Action? cancel)
     {
         Log.Warning(
             "Aborting remaining first-segment checks after missing important file `{FileName}`",
             nzbFile.GetSubjectFileName());
-        abortCts?.Cancel();
+        cancel?.Invoke();
         DeadNzbFailFast.FailMissingImportantFile(nzbFile);
     }
 

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
 using Serilog;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -50,7 +51,7 @@ public static class FetchFirstSegmentsStep
         await foreach (var result in files
                            .Select(x => FetchFirstSegment(x, usenetClient, abortCts.Token))
                            .WithConcurrencyAsync(
-                               Math.Min(configManager.GetMaxQueueConnections() + 5, 50),
+                               QueueFanOut.GetConcurrency(abortCts.Token, configManager),
                                abortCts.Token)
                            .WithCancellation(abortCts.Token)
                            .ConfigureAwait(false))
@@ -163,7 +164,7 @@ public static class FetchFirstSegmentsStep
             await foreach (var (i, result) in pending
                                .Select(i => RescueFirstSegment(i, files[i], usenetClient, rescueAbortCts.Token))
                                .WithConcurrencyAsync(
-                                   Math.Min(configManager.GetMaxQueueConnections() + 5, 50),
+                                   QueueFanOut.GetConcurrency(rescueAbortCts.Token, configManager),
                                    rescueAbortCts.Token)
                                .WithCancellation(rescueAbortCts.Token)
                                .ConfigureAwait(false))

--- a/backend/Queue/FileProcessors/SevenZipProcessor.cs
+++ b/backend/Queue/FileProcessors/SevenZipProcessor.cs
@@ -126,7 +126,7 @@ public class SevenZipProcessor : BaseProcessor
         var progressPercentage = progress.ToPercentage(missingFileSizes.Count);
         var populatedFileSizes = await missingFileSizes
             .Select(PopulateMissingFileSize)
-            .WithConcurrencyAsync(_configManager.GetMaxQueueConnections())
+            .WithConcurrencyAsync(NzbWebDAV.Queue.QueueFanOut.GetExactQueueConcurrency(_ct, _configManager))
             .GetAllAsync(_ct, progressPercentage)
             .ConfigureAwait(false);
         progress.Report(100);

--- a/backend/Queue/QueueFanOut.cs
+++ b/backend/Queue/QueueFanOut.cs
@@ -10,15 +10,26 @@ namespace NzbWebDAV.Queue;
 public static class QueueFanOut
 {
     /// <summary>
-    /// Fan-out used by a lone / primary queue item today:
+    /// Fan-out used by a lone primary queue item:
     /// <c>min(maxQueueConnections + 5, 50)</c>.
     /// </summary>
     public static int PrimaryFanOut(int maxQueueConnections) =>
         Math.Min(maxQueueConnections + 5, 50);
 
     /// <summary>
-    /// Secondary workers collectively borrow the full queue budget when the
-    /// primary has no demand: <c>max(1, ceil(maxQueue / secondaryCount))</c>.
+    /// When secondaries are active, leave at least one soft-budget slot per
+    /// secondary so High-lane primary waiters cannot occupy the entire queue
+    /// semaphore. Without this, 100% High odds starve Low-lane secondaries.
+    /// </summary>
+    public static int PrimaryFanOutWhenSharing(int maxQueueConnections, int activeSecondaryCount)
+    {
+        var reserve = Math.Max(1, activeSecondaryCount);
+        return Math.Max(1, maxQueueConnections - reserve);
+    }
+
+    /// <summary>
+    /// Secondary workers share the queue budget:
+    /// <c>max(1, ceil(maxQueue / secondaryCount))</c>.
     /// </summary>
     public static int SecondaryFanOut(int maxQueueConnections, int activeSecondaryCount) =>
         Math.Max(1, (int)Math.Ceiling(maxQueueConnections / (double)Math.Max(1, activeSecondaryCount)));
@@ -36,13 +47,17 @@ public static class QueueFanOut
     }
 
     /// <summary>
-    /// Fan-out for SevenZip size population (historically uncapped +5).
+    /// Fan-out for SevenZip size population — never applies the primary +5 overshoot.
     /// </summary>
     public static int GetExactQueueConcurrency(CancellationToken ct, ConfigManager configManager)
     {
+        var maxQueue = Math.Max(1, configManager.GetMaxQueueConnections());
         var ctx = ct.GetContext<QueueDownloadContext>();
-        if (ctx is not null)
-            return Math.Max(1, ctx.GetFanOutConcurrency());
-        return Math.Max(1, configManager.GetMaxQueueConnections());
+        if (ctx is null)
+            return maxQueue;
+
+        // Clamp live fan-out to maxQueue so solo-primary BODY overshoot (+5) is not
+        // reused for exact-budget work like SevenZip size population.
+        return Math.Min(Math.Max(1, ctx.GetFanOutConcurrency()), maxQueue);
     }
 }

--- a/backend/Queue/QueueFanOut.cs
+++ b/backend/Queue/QueueFanOut.cs
@@ -1,0 +1,48 @@
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Queue;
+
+/// <summary>
+/// Resolves per-phase NNTP task fan-out for queue processing.
+/// </summary>
+public static class QueueFanOut
+{
+    /// <summary>
+    /// Fan-out used by a lone / primary queue item today:
+    /// <c>min(maxQueueConnections + 5, 50)</c>.
+    /// </summary>
+    public static int PrimaryFanOut(int maxQueueConnections) =>
+        Math.Min(maxQueueConnections + 5, 50);
+
+    /// <summary>
+    /// Secondary workers collectively borrow the full queue budget when the
+    /// primary has no demand: <c>max(1, ceil(maxQueue / secondaryCount))</c>.
+    /// </summary>
+    public static int SecondaryFanOut(int maxQueueConnections, int activeSecondaryCount) =>
+        Math.Max(1, (int)Math.Ceiling(maxQueueConnections / (double)Math.Max(1, activeSecondaryCount)));
+
+    /// <summary>
+    /// Reads <see cref="QueueDownloadContext"/> from <paramref name="ct"/> when present;
+    /// otherwise falls back to primary fan-out (single-item / test paths).
+    /// </summary>
+    public static int GetConcurrency(CancellationToken ct, ConfigManager configManager)
+    {
+        var ctx = ct.GetContext<QueueDownloadContext>();
+        if (ctx is not null)
+            return Math.Max(1, ctx.GetFanOutConcurrency());
+        return PrimaryFanOut(configManager.GetMaxQueueConnections());
+    }
+
+    /// <summary>
+    /// Fan-out for SevenZip size population (historically uncapped +5).
+    /// </summary>
+    public static int GetExactQueueConcurrency(CancellationToken ct, ConfigManager configManager)
+    {
+        var ctx = ct.GetContext<QueueDownloadContext>();
+        if (ctx is not null)
+            return Math.Max(1, ctx.GetFanOutConcurrency());
+        return Math.Max(1, configManager.GetMaxQueueConnections());
+    }
+}

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -135,7 +135,7 @@ public class QueueItemProcessor(
                 queueItem.PauseUntil = DateTime.Now + backoff;
                 dbClient.Ctx.QueueItems.Attach(queueItem);
                 dbClient.Ctx.Entry(queueItem).Property(x => x.PauseUntil).IsModified = true;
-                await WithFinalizeLockAsync(() => dbClient.Ctx.SaveChangesAsync())
+                await WithFinalizeLockAsync(() => dbClient.Ctx.SaveChangesAsync(ct))
                     .ConfigureAwait(false);
                 _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{queueItem.Id}|Queued");
             }

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -38,6 +38,7 @@ public class QueueItemProcessor(
     QueueItemSourceTracker sourceTracker,
     IProgress<int> progress,
     ConcurrentDictionary<Guid, int> retryAttempts,
+    SemaphoreSlim? finalizeLock,
     CancellationToken ct
 )
 {
@@ -62,6 +63,7 @@ public class QueueItemProcessor(
             new QueueItemSourceTracker(),
             progress,
             new ConcurrentDictionary<Guid, int>(),
+            finalizeLock: null,
             ct)
     {
     }
@@ -133,7 +135,8 @@ public class QueueItemProcessor(
                 queueItem.PauseUntil = DateTime.Now + backoff;
                 dbClient.Ctx.QueueItems.Attach(queueItem);
                 dbClient.Ctx.Entry(queueItem).Property(x => x.PauseUntil).IsModified = true;
-                await dbClient.Ctx.SaveChangesAsync().ConfigureAwait(false);
+                await WithFinalizeLockAsync(() => dbClient.Ctx.SaveChangesAsync())
+                    .ConfigureAwait(false);
                 _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{queueItem.Id}|Queued");
             }
             catch (Exception ex)
@@ -276,7 +279,7 @@ public class QueueItemProcessor(
             .ToMultiProgress(fileProcessors.Count);
         var fileProcessingResultsAll = await fileProcessors
             .Select(x => x!.ProcessAsync(part2Progress.SubProgress))
-            .WithConcurrencyAsync(Math.Min(configManager.GetMaxQueueConnections() + 5, 50))
+            .WithConcurrencyAsync(QueueFanOut.GetConcurrency(ct, configManager))
             .GetAllAsync(ct).ConfigureAwait(false);
         var fileProcessingResults = fileProcessingResultsAll
             .Where(x => x is not null)
@@ -300,7 +303,9 @@ public class QueueItemProcessor(
             var part3Progress = progress
                 .Offset(100)
                 .ToPercentage(articlesToCheck.Count);
-            var healthCheckConcurrency = configManager.GetHealthCheckConcurrency();
+            var healthCheckConcurrency = Math.Min(
+                configManager.GetHealthCheckConcurrency(),
+                QueueFanOut.GetConcurrency(ct, configManager));
             await ArticleExistenceChecker
                 .CheckAsync(usenetClient, articlesToCheck, healthCheckConcurrency, part3Progress, ct)
                 .ConfigureAwait(false);
@@ -501,19 +506,29 @@ public class QueueItemProcessor(
         Func<Task<DavItem?>>? databaseOperations = null
     )
     {
-        dbClient.Ctx.ClearChangeTracker();
-        var mountFolder = databaseOperations != null ? await databaseOperations.Invoke().ConfigureAwait(false) : null;
-        var historyItem = CreateHistoryItem(mountFolder, startTime, error);
-        var providerUsage = providerUsageTracker.Snapshot(queueItem.Id);
-        var displayByMetricsKey = ProviderUsageHelper
-            .BuildDisplayByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
-        var historySlot = GetHistoryResponse.HistorySlot.FromHistoryItem(
-            historyItem, mountFolder, configManager, providerUsage, displayByMetricsKey);
-        dbClient.Ctx.QueueItems.Remove(queueItem);
-        dbClient.Ctx.HistoryItems.Add(historyItem);
-        await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        HistoryItem? historyItem = null;
+        GetHistoryResponse.HistorySlot? historySlot = null;
+        IReadOnlyDictionary<string, long>? providerUsage = null;
+
+        await WithFinalizeLockAsync(async () =>
+        {
+            dbClient.Ctx.ClearChangeTracker();
+            var mountFolder = databaseOperations != null
+                ? await databaseOperations.Invoke().ConfigureAwait(false)
+                : null;
+            historyItem = CreateHistoryItem(mountFolder, startTime, error);
+            providerUsage = providerUsageTracker.Snapshot(queueItem.Id);
+            var displayByMetricsKey = ProviderUsageHelper
+                .BuildDisplayByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
+            historySlot = GetHistoryResponse.HistorySlot.FromHistoryItem(
+                historyItem, mountFolder, configManager, providerUsage, displayByMetricsKey);
+            dbClient.Ctx.QueueItems.Remove(queueItem);
+            dbClient.Ctx.HistoryItems.Add(historyItem);
+            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
-        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historySlot.ToJson());
+        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historySlot!.ToJson());
         _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
         _ = RefreshMonitoredDownloads();
         if (error is null)
@@ -522,7 +537,7 @@ public class QueueItemProcessor(
                 "Completed queue item {JobName} ({QueueItemId}) in {ElapsedSeconds} seconds",
                 queueItem.JobName,
                 queueItem.Id,
-                historyItem.DownloadTimeSeconds);
+                historyItem!.DownloadTimeSeconds);
         }
         else
         {
@@ -530,12 +545,31 @@ public class QueueItemProcessor(
                 "Failed queue item {JobName} ({QueueItemId}) after {ElapsedSeconds} seconds: {Reason}",
                 queueItem.JobName,
                 queueItem.Id,
-                historyItem.DownloadTimeSeconds,
+                historyItem!.DownloadTimeSeconds,
                 error);
         }
 
-        RecordWatchdogAttemptIfExternal(startTime, error, providerUsage);
+        RecordWatchdogAttemptIfExternal(startTime, error, providerUsage!);
         retryAttempts.TryRemove(queueItem.Id, out _);
+    }
+
+    private async Task WithFinalizeLockAsync(Func<Task> action)
+    {
+        if (finalizeLock is null)
+        {
+            await action().ConfigureAwait(false);
+            return;
+        }
+
+        await finalizeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        finally
+        {
+            finalizeLock.Release();
+        }
     }
 
     // Emits a Watchdog attempt entry for queue items that didn't come through

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -14,13 +15,13 @@ namespace NzbWebDAV.Queue;
 
 public class QueueManager : IDisposable
 {
-    private InProgressQueueItem? _inProgressQueueItem;
-
+    private readonly ConcurrentDictionary<Guid, InProgressQueueItem> _inProgress = new();
     private readonly ConcurrentDictionary<Guid, int> _retryAttempts = new();
 
     private readonly UsenetStreamingClient _usenetClient;
     private readonly CancellationTokenSource? _cancellationTokenSource;
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private readonly SemaphoreSlim _stateLock = new(1, 1);
+    private readonly SemaphoreSlim _finalizeLock = new(1, 1);
     private readonly ConfigManager _configManager;
     private readonly WebsocketManager _websocketManager;
     private readonly ProviderUsageTracker _providerUsageTracker;
@@ -31,15 +32,21 @@ public class QueueManager : IDisposable
     private CancellationTokenSource _sleepingQueueToken = new();
     private readonly Lock _sleepingQueueLock = new();
     private int _loopStarted;
+    private Task? _coordinatorTask;
+    private Guid? _primaryId;
 
     // Overridable in tests so persistent-failure / idle-sleep behaviour can be
     // exercised without a real database.
     internal TimeSpan ErrorBackoffDelay { get; set; } = TimeSpan.FromSeconds(5);
     internal TimeSpan IdleDelay { get; set; } = TimeSpan.FromMinutes(1);
-    internal Func<CancellationToken, Task<(QueueItem? queueItem, Stream? queueNzbStream)>>?
+    internal Func<IReadOnlyCollection<Guid>, CancellationToken, Task<(QueueItem? queueItem, Stream? queueNzbStream)>>?
         GetTopQueueItemOverride
     { get; set; }
     internal Func<CancellationToken, Task<DateTime?>>? GetNextPauseUntilOverride { get; set; }
+    internal Func<DavDatabaseContext>? CreateDbContextOverride { get; set; }
+
+    private DavDatabaseContext CreateDbContext() =>
+        CreateDbContextOverride?.Invoke() ?? new DavDatabaseContext();
 
     public QueueManager(
         UsenetStreamingClient usenetClient,
@@ -87,12 +94,46 @@ public class QueueManager : IDisposable
     public void StartProcessing()
     {
         if (Interlocked.Exchange(ref _loopStarted, 1) == 1) return;
-        _ = ProcessQueueAsync(_cancellationTokenSource!.Token);
+        _coordinatorTask = ProcessQueueAsync(_cancellationTokenSource!.Token);
     }
 
+    /// <summary>True while any NZB queue item is actively processing.</summary>
+    public bool HasActiveQueueItems => !_inProgress.IsEmpty;
+
+    /// <summary>
+    /// Immutable snapshot of every in-flight queue item and its progress.
+    /// Primary (preferred) item is listed first when present.
+    /// </summary>
+    public IReadOnlyList<InProgressQueueItemSnapshot> GetInProgressQueueItems()
+    {
+        var items = _inProgress.Values
+            .Select(x => new InProgressQueueItemSnapshot(x.QueueItem, x.ProgressPercentage, x.IsPrimary))
+            .ToList();
+
+        items.Sort((a, b) =>
+        {
+            if (a.IsPrimary != b.IsPrimary) return a.IsPrimary ? -1 : 1;
+            return a.QueueItem.CreatedAt.CompareTo(b.QueueItem.CreatedAt);
+        });
+        return items;
+    }
+
+    /// <summary>
+    /// Compatibility helper: returns the primary in-progress item, or the oldest
+    /// active item when no primary is designated yet.
+    /// </summary>
     public (QueueItem? queueItem, int? progress) GetInProgressQueueItem()
     {
-        return (_inProgressQueueItem?.QueueItem, _inProgressQueueItem?.ProgressPercentage);
+        var items = GetInProgressQueueItems();
+        if (items.Count == 0) return (null, null);
+        return (items[0].QueueItem, items[0].ProgressPercentage);
+    }
+
+    public InProgressQueueItemSnapshot? FindInProgressQueueItem(Guid queueItemId)
+    {
+        return _inProgress.TryGetValue(queueItemId, out var item)
+            ? new InProgressQueueItemSnapshot(item.QueueItem, item.ProgressPercentage, item.IsPrimary)
+            : null;
     }
 
     public void AwakenQueue(DateTime? dateTime = null)
@@ -114,16 +155,31 @@ public class QueueManager : IDisposable
         CancellationToken ct = default
     )
     {
+        List<InProgressQueueItem> toCancel = [];
+        await LockAsync(() =>
+        {
+            toCancel = _inProgress.Values
+                .Where(x => queueItemIds.Contains(x.QueueItem.Id))
+                .ToList();
+            foreach (var item in toCancel)
+                item.CancellationTokenSource.Cancel();
+        }).ConfigureAwait(false);
+
+        foreach (var item in toCancel)
+        {
+            try
+            {
+                await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+                await item.ProcessingTask.ConfigureAwait(false);
+            }
+            catch (Exception e) when (!e.IsCancellationException())
+            {
+                Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
+            }
+        }
+
         await LockAsync(async () =>
         {
-            var inProgressId = _inProgressQueueItem?.QueueItem?.Id;
-            if (inProgressId is not null && queueItemIds.Contains(inProgressId.Value))
-            {
-                await _inProgressQueueItem!.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
-                await _inProgressQueueItem.ProcessingTask.ConfigureAwait(false);
-                _inProgressQueueItem = null;
-            }
-
             await dbClient.RemoveQueueItemsAsync(queueItemIds, ct).ConfigureAwait(false);
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
             foreach (var id in queueItemIds) _retryAttempts.TryRemove(id, out _);
@@ -147,96 +203,304 @@ public class QueueManager : IDisposable
 
             try
             {
-                // get the next queue-item from the database (or test override)
-                (QueueItem? queueItem, Stream? queueNzbStream) topItem;
-                DavDatabaseClient? dbClient = null;
-                DavDatabaseContext? dbContext = null;
+                await FillWorkerSlotsAsync(ct).ConfigureAwait(false);
+
+                if (_inProgress.IsEmpty)
+                {
+                    await IdleSleepAsync(ct).ConfigureAwait(false);
+                    continue;
+                }
+
+                // Wait for any worker to finish, an awaken signal, or a short
+                // poll so worker-count increases can fill new slots promptly.
+                var workerTasks = _inProgress.Values.Select(x => x.CompletionSignal.Task).ToArray();
+                using var wakeWait = CancellationTokenSource.CreateLinkedTokenSource(
+                    ct, _sleepingQueueToken.Token);
                 try
                 {
-                    if (GetTopQueueItemOverride is not null)
-                    {
-                        topItem = await GetTopQueueItemOverride(ct).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        dbContext = new DavDatabaseContext();
-                        dbClient = new DavDatabaseClient(dbContext);
-                        topItem = await LockAsync(() => dbClient.GetTopQueueItem(ct)).ConfigureAwait(false);
-                    }
-
-                    if (topItem.queueItem is null)
-                    {
-                        try
-                        {
-                            // if we're done with the queue, wait until the next retry pause
-                            // expires (or IdleDelay, whichever is sooner). Also wake early
-                            // on cancellation of _sleepingQueueToken / process shutdown (ct).
-                            var idleDelay = await ComputeIdleDelayAsync(dbClient, ct)
-                                .ConfigureAwait(false);
-                            using var idleWait = CancellationTokenSource.CreateLinkedTokenSource(
-                                ct, _sleepingQueueToken.Token);
-                            await Task.Delay(idleDelay, idleWait.Token).ConfigureAwait(false);
-                        }
-                        catch when (_sleepingQueueToken.IsCancellationRequested)
-                        {
-                            lock (_sleepingQueueLock)
-                            {
-                                if (!_sleepingQueueToken.TryReset())
-                                {
-                                    _sleepingQueueToken.Dispose();
-                                    _sleepingQueueToken = new CancellationTokenSource();
-                                }
-                            }
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            // ct fired: fall through; the while condition exits the loop
-                        }
-
-                        continue;
-                    }
-
-                    // create an article-caching nntp-client.
-                    // the cache will be scoped only to this single queue-item.
-                    using var cachingUsenetClient = new ArticleCachingNntpClient(_usenetClient);
-
-                    // process the queue-item
-                    try
-                    {
-                        using var queueItemCancellationTokenSource =
-                            CancellationTokenSource.CreateLinkedTokenSource(ct);
-                        await LockAsync(() =>
-                        {
-                            // ReSharper disable twice AccessToDisposedClosure
-                            _inProgressQueueItem = BeginProcessingQueueItem(
-                                dbClient!, cachingUsenetClient,
-                                topItem.queueItem, topItem.queueNzbStream,
-                                queueItemCancellationTokenSource);
-                        }).ConfigureAwait(false);
-                        await (_inProgressQueueItem?.ProcessingTask ?? Task.CompletedTask)
-                            .ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        if (topItem.queueNzbStream is not null)
-                            await topItem.queueNzbStream!.DisposeAsync();
-                    }
+                    var wakeDelay = Task.Delay(TimeSpan.FromSeconds(1), wakeWait.Token);
+                    await Task.WhenAny(Task.WhenAny(workerTasks), wakeDelay).ConfigureAwait(false);
                 }
-                finally
+                catch (OperationCanceledException) when (_sleepingQueueToken.IsCancellationRequested)
                 {
-                    if (dbContext is not null)
-                        await dbContext.DisposeAsync().ConfigureAwait(false);
+                    ResetSleepingQueueToken();
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                await ReapCompletedWorkersAsync().ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCancellationException(ct))
             {
                 Log.Error(e, "An unexpected error occurred while processing the queue");
                 try { await Task.Delay(ErrorBackoffDelay, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { /* shutting down */ }
             }
+        }
+
+        // Shutdown: cancel remaining workers and observe their tasks.
+        foreach (var item in _inProgress.Values)
+            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
+        var remaining = _inProgress.Values.Select(x => x.ProcessingTask).ToArray();
+        if (remaining.Length > 0)
+        {
+            try { await Task.WhenAll(remaining).ConfigureAwait(false); }
+            catch (Exception e) when (!e.IsCancellationException())
+            {
+                Log.Debug(e, "Queue workers finished with errors during shutdown");
+            }
+        }
+
+        await ReapCompletedWorkersAsync().ConfigureAwait(false);
+    }
+
+    private async Task FillWorkerSlotsAsync(CancellationToken ct)
+    {
+        while (!_benchmarkGate.IsPaused && !ct.IsCancellationRequested)
+        {
+            var workerCount = _configManager.GetQueueWorkerCount();
+            if (_inProgress.Count >= workerCount)
+                return;
+
+            var started = await TryStartNextWorkerAsync(ct).ConfigureAwait(false);
+            if (!started)
+                return;
+        }
+    }
+
+    private async Task<bool> TryStartNextWorkerAsync(CancellationToken ct)
+    {
+        DavDatabaseContext? dbContext = null;
+        DavDatabaseClient? dbClient = null;
+        QueueItem? queueItem = null;
+        Stream? queueNzbStream = null;
+        InProgressQueueItem? inProgress = null;
+        CancellationTokenContext? queueContextRegistration = null;
+
+        try
+        {
+            await _stateLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var workerCount = _configManager.GetQueueWorkerCount();
+                if (_inProgress.Count >= workerCount)
+                    return false;
+
+                var excludeIds = _inProgress.Keys.ToHashSet();
+                var reservedMountKeys = _inProgress.Values
+                    .Select(x => (x.QueueItem.Category, x.QueueItem.JobName))
+                    .ToHashSet();
+
+                // Skip mount-key conflicts by excluding them from subsequent queries.
+                while (true)
+                {
+                    (QueueItem? item, Stream? stream) claimed;
+                    if (GetTopQueueItemOverride is not null)
+                    {
+                        claimed = await GetTopQueueItemOverride(excludeIds, ct).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        dbContext ??= CreateDbContext();
+                        dbClient ??= new DavDatabaseClient(dbContext);
+                        claimed = await dbClient.GetTopQueueItem(excludeIds, ct).ConfigureAwait(false);
+                    }
+
+                    if (claimed.item is null)
+                    {
+                        if (claimed.stream is not null)
+                            await claimed.stream.DisposeAsync().ConfigureAwait(false);
+                        return false;
+                    }
+
+                    if (reservedMountKeys.Contains((claimed.item.Category, claimed.item.JobName)))
+                    {
+                        excludeIds.Add(claimed.item.Id);
+                        if (claimed.stream is not null)
+                            await claimed.stream.DisposeAsync().ConfigureAwait(false);
+                        continue;
+                    }
+
+                    queueItem = claimed.item;
+                    queueNzbStream = claimed.stream;
+                    break;
+                }
+
+                // Own a dedicated DB context for this worker (may already be
+                // created above when claiming from the database).
+                if (dbContext is null)
+                {
+                    dbContext = CreateDbContext();
+                    dbClient = new DavDatabaseClient(dbContext);
+                }
+
+                var isPrimary = _primaryId is null || !_inProgress.ContainsKey(_primaryId.Value);
+                var queueDownloadContext = new QueueDownloadContext
+                {
+                    IsPrimary = isPrimary,
+                    GetFanOutConcurrency = () => ComputeFanOutConcurrency(queueItem.Id),
+                };
+
+                var workerCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                queueContextRegistration = workerCts.Token.SetContext(queueDownloadContext);
+
+                inProgress = BeginProcessingQueueItem(
+                    dbClient!,
+                    queueItem,
+                    queueNzbStream,
+                    workerCts,
+                    queueDownloadContext,
+                    queueContextRegistration,
+                    dbContext);
+
+                _inProgress[queueItem.Id] = inProgress;
+                if (isPrimary)
+                    _primaryId = queueItem.Id;
+                else
+                    EnsurePrimaryDesignation();
+
+                // Ownership transferred to InProgressQueueItem / worker task.
+                dbContext = null;
+                dbClient = null;
+                queueNzbStream = null;
+                queueContextRegistration = null;
+                inProgress = null;
+                return true;
+            }
             finally
             {
-                await LockAsync(() => { _inProgressQueueItem = null; }).ConfigureAwait(false);
+                _stateLock.Release();
+            }
+        }
+        catch
+        {
+            if (queueNzbStream is not null)
+                await queueNzbStream.DisposeAsync().ConfigureAwait(false);
+            if (dbContext is not null)
+                await dbContext.DisposeAsync().ConfigureAwait(false);
+            queueContextRegistration?.Dispose();
+            inProgress?.CancellationTokenSource.Dispose();
+            throw;
+        }
+    }
+
+    private int ComputeFanOutConcurrency(Guid queueItemId)
+    {
+        var maxQueue = _configManager.GetMaxQueueConnections();
+        if (_primaryId == queueItemId ||
+            (_inProgress.TryGetValue(queueItemId, out var item) && item.QueueDownloadContext.IsPrimary))
+        {
+            return QueueFanOut.PrimaryFanOut(maxQueue);
+        }
+
+        var secondaryCount = _inProgress.Values.Count(x => !x.QueueDownloadContext.IsPrimary);
+        return QueueFanOut.SecondaryFanOut(maxQueue, secondaryCount);
+    }
+
+    private void EnsurePrimaryDesignation()
+    {
+        if (_primaryId is not null && _inProgress.ContainsKey(_primaryId.Value))
+        {
+            foreach (var item in _inProgress.Values)
+                item.QueueDownloadContext.IsPrimary = item.QueueItem.Id == _primaryId.Value;
+            return;
+        }
+
+        // Promote the oldest active secondary before claiming a new primary.
+        var oldest = _inProgress.Values
+            .OrderBy(x => x.StartedAt)
+            .ThenBy(x => x.QueueItem.CreatedAt)
+            .FirstOrDefault();
+
+        if (oldest is null)
+        {
+            _primaryId = null;
+            return;
+        }
+
+        _primaryId = oldest.QueueItem.Id;
+        foreach (var item in _inProgress.Values)
+            item.QueueDownloadContext.IsPrimary = item.QueueItem.Id == _primaryId.Value;
+    }
+
+    private async Task ReapCompletedWorkersAsync()
+    {
+        List<InProgressQueueItem> completed = [];
+        await LockAsync(() =>
+        {
+            completed = _inProgress.Values
+                .Where(x => x.ProcessingTask.IsCompleted)
+                .ToList();
+
+            foreach (var item in completed)
+            {
+                _inProgress.TryRemove(item.QueueItem.Id, out _);
+                if (_primaryId == item.QueueItem.Id)
+                    _primaryId = null;
+            }
+
+            if (completed.Count > 0)
+                EnsurePrimaryDesignation();
+        }).ConfigureAwait(false);
+
+        foreach (var item in completed)
+        {
+            try
+            {
+                await item.ProcessingTask.ConfigureAwait(false);
+            }
+            catch (Exception e) when (!e.IsCancellationException())
+            {
+                Log.Error(e, "Queue worker for {QueueItemId} faulted", item.QueueItem.Id);
+            }
+
+            await item.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task IdleSleepAsync(CancellationToken ct)
+    {
+        DavDatabaseContext? dbContext = null;
+        try
+        {
+            DavDatabaseClient? dbClient = null;
+            if (GetNextPauseUntilOverride is null && GetTopQueueItemOverride is null)
+            {
+                dbContext = CreateDbContext();
+                dbClient = new DavDatabaseClient(dbContext);
+            }
+
+            var idleDelay = await ComputeIdleDelayAsync(dbClient, ct).ConfigureAwait(false);
+            using var idleWait = CancellationTokenSource.CreateLinkedTokenSource(
+                ct, _sleepingQueueToken.Token);
+            await Task.Delay(idleDelay, idleWait.Token).ConfigureAwait(false);
+        }
+        catch when (_sleepingQueueToken.IsCancellationRequested)
+        {
+            ResetSleepingQueueToken();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // shutting down
+        }
+        finally
+        {
+            if (dbContext is not null)
+                await dbContext.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void ResetSleepingQueueToken()
+    {
+        lock (_sleepingQueueLock)
+        {
+            if (!_sleepingQueueToken.TryReset())
+            {
+                _sleepingQueueToken.Dispose();
+                _sleepingQueueToken = new CancellationTokenSource();
             }
         }
     }
@@ -244,25 +508,53 @@ public class QueueManager : IDisposable
     private InProgressQueueItem BeginProcessingQueueItem
     (
         DavDatabaseClient dbClient,
-        INntpClient usenetClient,
         QueueItem queueItem,
         Stream? queueNzbStream,
-        CancellationTokenSource cts
+        CancellationTokenSource cts,
+        QueueDownloadContext queueDownloadContext,
+        CancellationTokenContext queueContextRegistration,
+        DavDatabaseContext dbContext
     )
     {
+        // Per-item article cache; disposed with the worker.
+        var cachingUsenetClient = new ArticleCachingNntpClient(_usenetClient);
         var progressHook = new Progress<int>();
+        var completionSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
         var task = new QueueItemProcessor(
-            queueItem, queueNzbStream, dbClient, usenetClient,
+            queueItem, queueNzbStream, dbClient, cachingUsenetClient,
             _configManager, _websocketManager, _providerUsageTracker,
-            _watchdogLog, _sourceTracker, progressHook, _retryAttempts, cts.Token
+            _watchdogLog, _sourceTracker, progressHook, _retryAttempts,
+            _finalizeLock, cts.Token
         ).ProcessAsync();
-        var inProgressQueueItem = new InProgressQueueItem()
+
+        _ = task.ContinueWith(
+            t =>
+            {
+                if (t.IsFaulted)
+                    Log.Error(t.Exception!.GetBaseException(),
+                        "Unhandled queue processor fault for {QueueItemId}", queueItem.Id);
+                completionSignal.TrySetResult();
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        var inProgressQueueItem = new InProgressQueueItem
         {
             QueueItem = queueItem,
             ProcessingTask = task,
+            CompletionSignal = completionSignal,
             ProgressPercentage = 0,
-            CancellationTokenSource = cts
+            CancellationTokenSource = cts,
+            QueueDownloadContext = queueDownloadContext,
+            QueueContextRegistration = queueContextRegistration,
+            DbContext = dbContext,
+            QueueNzbStream = queueNzbStream,
+            CachingUsenetClient = cachingUsenetClient,
+            StartedAt = DateTime.UtcNow,
         };
+
         var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
         var providersDebounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(500));
         var progressLock = new object();
@@ -333,27 +625,27 @@ public class QueueManager : IDisposable
 
     private async Task LockAsync(Func<Task> actionAsync)
     {
-        await _semaphore.WaitAsync().ConfigureAwait(false);
+        await _stateLock.WaitAsync().ConfigureAwait(false);
         try
         {
             await actionAsync().ConfigureAwait(false);
         }
         finally
         {
-            _semaphore.Release();
+            _stateLock.Release();
         }
     }
 
-    private async Task<T> LockAsync<T>(Func<Task<T>> actionAsync)
+    private async Task LockAsync(Action action)
     {
-        await _semaphore.WaitAsync().ConfigureAwait(false);
+        await _stateLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            return await actionAsync().ConfigureAwait(false);
+            action();
         }
         finally
         {
-            _semaphore.Release();
+            _stateLock.Release();
         }
     }
 
@@ -385,30 +677,52 @@ public class QueueManager : IDisposable
         }
     }
 
-    private async Task LockAsync(Action action)
-    {
-        await _semaphore.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            action();
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
-    }
-
     public void Dispose()
     {
         _cancellationTokenSource?.Cancel();
+        try
+        {
+            _coordinatorTask?.GetAwaiter().GetResult();
+        }
+        catch (Exception e) when (!e.IsCancellationException())
+        {
+            Log.Debug(e, "Queue coordinator exited with error during dispose");
+        }
+
         _cancellationTokenSource?.Dispose();
+        _stateLock.Dispose();
+        _finalizeLock.Dispose();
+        _sleepingQueueToken.Dispose();
     }
 
-    private class InProgressQueueItem
+    public readonly record struct InProgressQueueItemSnapshot(
+        QueueItem QueueItem,
+        int ProgressPercentage,
+        bool IsPrimary);
+
+    private sealed class InProgressQueueItem
     {
         public QueueItem QueueItem { get; init; } = null!;
         public int ProgressPercentage { get; set; }
         public Task ProcessingTask { get; init; } = null!;
+        public TaskCompletionSource CompletionSignal { get; init; } = null!;
         public CancellationTokenSource CancellationTokenSource { get; init; } = null!;
+        public QueueDownloadContext QueueDownloadContext { get; init; } = null!;
+        public CancellationTokenContext QueueContextRegistration { get; init; } = null!;
+        public DavDatabaseContext DbContext { get; init; } = null!;
+        public Stream? QueueNzbStream { get; init; }
+        public ArticleCachingNntpClient CachingUsenetClient { get; init; } = null!;
+        public DateTime StartedAt { get; init; }
+        public bool IsPrimary => QueueDownloadContext.IsPrimary;
+
+        public async ValueTask DisposeAsync()
+        {
+            QueueContextRegistration.Dispose();
+            CancellationTokenSource.Dispose();
+            CachingUsenetClient.Dispose();
+            if (QueueNzbStream is not null)
+                await QueueNzbStream.DisposeAsync().ConfigureAwait(false);
+            await DbContext.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -161,8 +161,6 @@ public class QueueManager : IDisposable
             toCancel = _inProgress.Values
                 .Where(x => queueItemIds.Contains(x.QueueItem.Id))
                 .ToList();
-            foreach (var item in toCancel)
-                item.CancellationTokenSource.Cancel();
         }).ConfigureAwait(false);
 
         foreach (var item in toCancel)
@@ -203,6 +201,9 @@ public class QueueManager : IDisposable
 
             try
             {
+                // Reap before fill so completed primaries do not occupy slots or
+                // block secondary promotion while new workers are claimed.
+                await ReapCompletedWorkersAsync().ConfigureAwait(false);
                 await FillWorkerSlotsAsync(ct).ConfigureAwait(false);
 
                 if (_inProgress.IsEmpty)
@@ -229,8 +230,6 @@ public class QueueManager : IDisposable
                 {
                     break;
                 }
-
-                await ReapCompletedWorkersAsync().ConfigureAwait(false);
             }
             catch (Exception e) when (!e.IsCancellationException(ct))
             {
@@ -337,7 +336,11 @@ public class QueueManager : IDisposable
                     dbClient = new DavDatabaseClient(dbContext);
                 }
 
-                var isPrimary = _primaryId is null || !_inProgress.ContainsKey(_primaryId.Value);
+                // Treat a completed-but-not-yet-reaped primary as vacant so Fill
+                // can claim a new preferred worker without waiting for the next loop.
+                var isPrimary = _primaryId is null ||
+                    !_inProgress.TryGetValue(_primaryId.Value, out var primaryItem) ||
+                    primaryItem.ProcessingTask.IsCompleted;
                 var queueDownloadContext = new QueueDownloadContext
                 {
                     IsPrimary = isPrimary,
@@ -390,27 +393,39 @@ public class QueueManager : IDisposable
     private int ComputeFanOutConcurrency(Guid queueItemId)
     {
         var maxQueue = _configManager.GetMaxQueueConnections();
-        if (_primaryId == queueItemId ||
-            (_inProgress.TryGetValue(queueItemId, out var item) && item.QueueDownloadContext.IsPrimary))
+        var secondaryCount = _inProgress.Values.Count(x => !x.QueueDownloadContext.IsPrimary);
+        var isPrimary = _primaryId == queueItemId ||
+            (_inProgress.TryGetValue(queueItemId, out var item) && item.QueueDownloadContext.IsPrimary);
+
+        if (isPrimary)
         {
-            return QueueFanOut.PrimaryFanOut(maxQueue);
+            return secondaryCount > 0
+                ? QueueFanOut.PrimaryFanOutWhenSharing(maxQueue, secondaryCount)
+                : QueueFanOut.PrimaryFanOut(maxQueue);
         }
 
-        var secondaryCount = _inProgress.Values.Count(x => !x.QueueDownloadContext.IsPrimary);
         return QueueFanOut.SecondaryFanOut(maxQueue, secondaryCount);
     }
 
     private void EnsurePrimaryDesignation()
     {
-        if (_primaryId is not null && _inProgress.ContainsKey(_primaryId.Value))
+        // Ignore completed workers still awaiting reap so a finished primary
+        // cannot block promotion or keep IsPrimary while Fill starts new work.
+        var live = _inProgress.Values
+            .Where(x => !x.ProcessingTask.IsCompleted)
+            .ToList();
+
+        if (_primaryId is not null &&
+            _inProgress.TryGetValue(_primaryId.Value, out var current) &&
+            !current.ProcessingTask.IsCompleted)
         {
             foreach (var item in _inProgress.Values)
                 item.QueueDownloadContext.IsPrimary = item.QueueItem.Id == _primaryId.Value;
             return;
         }
 
-        // Promote the oldest active secondary before claiming a new primary.
-        var oldest = _inProgress.Values
+        // Promote the oldest live secondary before claiming a new primary.
+        var oldest = live
             .OrderBy(x => x.StartedAt)
             .ThenBy(x => x.QueueItem.CreatedAt)
             .FirstOrDefault();
@@ -418,6 +433,8 @@ public class QueueManager : IDisposable
         if (oldest is null)
         {
             _primaryId = null;
+            foreach (var item in _inProgress.Values)
+                item.QueueDownloadContext.IsPrimary = false;
             return;
         }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.PostProcessors;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
@@ -34,6 +35,7 @@ public class HealthCheckService : BackgroundService
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
     private readonly StreamingFailureTracker _failureTracker;
+    private readonly QueueManager _queueManager;
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
@@ -44,7 +46,8 @@ public class HealthCheckService : BackgroundService
         UsenetStreamingClient usenetClient,
         WebsocketManager websocketManager,
         BenchmarkGate benchmarkGate,
-        StreamingFailureTracker failureTracker
+        StreamingFailureTracker failureTracker,
+        QueueManager queueManager
     )
     {
         _configManager = configManager;
@@ -52,6 +55,7 @@ public class HealthCheckService : BackgroundService
         _websocketManager = websocketManager;
         _benchmarkGate = benchmarkGate;
         _failureTracker = failureTracker;
+        _queueManager = queueManager;
 
         _configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -80,6 +84,15 @@ public class HealthCheckService : BackgroundService
 
                 // if the repair-job is disabled, then don't do anything
                 if (!_configManager.IsRepairJobEnabled())
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                // Defer new background library health checks while the NZB queue
+                // is actively processing. An already-running check finishes normally;
+                // queue-item article validation inside QueueItemProcessor is separate.
+                if (_queueManager.HasActiveQueueItems)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
                     continue;

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -13,6 +13,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | WebDAV User | `webdav.user` | `admin` / `WEBDAV_USER` | Alphanumeric + `_` `-` |
 | WebDAV Password | `webdav.pass` | env `WEBDAV_PASSWORD` | Required for rclone/clients |
 | Queue Download Connections | `usenet.max-queue-connections` | blank = all | Cap queue NNTP use |
+| Concurrent Queue Downloads [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Concurrent NZB imports (1–8); share the queue connection budget |
 | Enable Segment Cache | `usenet.segment-cache.enabled` | off | Disk cache; **restart required** |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | |
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | |

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -13,7 +13,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | WebDAV User | `webdav.user` | `admin` / `WEBDAV_USER` | Alphanumeric + `_` `-` |
 | WebDAV Password | `webdav.pass` | env `WEBDAV_PASSWORD` | Required for rclone/clients |
 | Queue Download Connections | `usenet.max-queue-connections` | blank = all | Cap queue NNTP use |
-| Concurrent Queue Downloads [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Concurrent NZB imports (1–8); share the queue connection budget |
+| Concurrent Queue Downloads [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Concurrent NZB imports (1–4); share the queue connection budget |
 | Enable Segment Cache | `usenet.segment-cache.enabled` | off | Disk cache; **restart required** |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | |
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | |

--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -66,7 +66,7 @@ export function useQueueEvents(
             }
             if (moved.length === 0) return slots;
 
-            // Keep an in-progress download pinned at the front (matches GetQueueController).
+            // Keep every in-progress download pinned at the front (matches GetQueueController).
             const insertAt = remaining.findIndex(s => s.status !== "Downloading");
             const index = insertAt < 0 ? remaining.length : insertAt;
             return [

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -45,6 +45,7 @@ const defaultConfig = {
     "usenet.max-download-connections-per-stream": "false",
     "usenet.max-download-connections-per-stream-preset": "high",
     "usenet.max-queue-connections": "",
+    "queue.worker-count": "1",
     "usenet.streaming-priority": "80",
     "usenet.streaming-segment-timeout-seconds": "8",
     "usenet.streaming-segment-retries": "3",

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -49,17 +49,20 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
             <hr />
             <ManagedSetting configKey="queue.worker-count">
             <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="queue-worker-count-input">Concurrent Queue Downloads</label>
-                <Input
-                    {...className(['w-full', !isValidQueueWorkerCount(config["queue.worker-count"]) && 'input-error'])}
-                    type="text"
-                    id="queue-worker-count-input"
+                <label className="block text-sm font-medium text-base-content" htmlFor="queue-worker-count-select">Concurrent Queue Downloads</label>
+                <Select
+                    className="w-full"
+                    id="queue-worker-count-select"
                     aria-describedby="queue-worker-count-help"
-                    placeholder="1"
-                    value={config["queue.worker-count"] ?? "1"}
-                    onChange={e => setNewConfig({ ...config, "queue.worker-count": e.target.value })} />
+                    value={config["queue.worker-count"] || "1"}
+                    onChange={e => setNewConfig({ ...config, "queue.worker-count": e.target.value })}>
+                    <option value="1">1 — one at a time (default)</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                </Select>
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-worker-count-help">
-                    How many NZB queue items may process at once (1–8, default 1). The first active item
+                    How many NZB queue items may process at once. The first active item
                     gets preferred access to Queue Download Connections; additional items use spare capacity.
                     Raising this does not increase the connection budget.
                 </p>
@@ -427,7 +430,7 @@ function isValidMaxQueueConnections(value: string): boolean {
 function isValidQueueWorkerCount(value: string | undefined): boolean {
     if (value == null || value.trim() === "") return true;
     const num = Number(value);
-    return Number.isInteger(num) && num >= 1 && num <= 8;
+    return Number.isInteger(num) && num >= 1 && num <= 4;
 }
 
 function isValidStreamingPriority(value: string): boolean {

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -42,6 +42,26 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     onChange={e => setNewConfig({ ...config, "usenet.max-queue-connections": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="max-queue-connections-help">
                     Connections available to queue imports. Leave blank to use all provider connections.
+                    Shared across concurrent queue workers and background health checks.
+                </p>
+            </div>
+            </ManagedSetting>
+            <hr />
+            <ManagedSetting configKey="queue.worker-count">
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="queue-worker-count-input">Concurrent Queue Downloads</label>
+                <Input
+                    {...className(['w-full', !isValidQueueWorkerCount(config["queue.worker-count"]) && 'input-error'])}
+                    type="text"
+                    id="queue-worker-count-input"
+                    aria-describedby="queue-worker-count-help"
+                    placeholder="1"
+                    value={config["queue.worker-count"] ?? "1"}
+                    onChange={e => setNewConfig({ ...config, "queue.worker-count": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-worker-count-help">
+                    How many NZB queue items may process at once (1–8, default 1). The first active item
+                    gets preferred access to Queue Download Connections; additional items use spare capacity.
+                    Raising this does not increase the connection budget.
                 </p>
             </div>
             </ManagedSetting>
@@ -351,6 +371,7 @@ export function isWebdavSettingsUpdated(config: Record<string, string>, newConfi
         || config["usenet.max-download-connections-per-stream"] !== newConfig["usenet.max-download-connections-per-stream"]
         || config["usenet.max-download-connections-per-stream-preset"] !== newConfig["usenet.max-download-connections-per-stream-preset"]
         || config["usenet.max-queue-connections"] !== newConfig["usenet.max-queue-connections"]
+        || config["queue.worker-count"] !== newConfig["queue.worker-count"]
         || config["usenet.streaming-priority"] !== newConfig["usenet.streaming-priority"]
         || config["usenet.streaming-segment-timeout-seconds"] !== newConfig["usenet.streaming-segment-timeout-seconds"]
         || config["usenet.streaming-segment-retries"] !== newConfig["usenet.streaming-segment-retries"]
@@ -373,6 +394,7 @@ export function isWebdavSettingsValid(newConfig: Record<string, string>) {
     return isValidUser(newConfig["webdav.user"])
         && isValidMaxDownloadConnections(newConfig["usenet.max-download-connections"])
         && isValidMaxQueueConnections(newConfig["usenet.max-queue-connections"])
+        && isValidQueueWorkerCount(newConfig["queue.worker-count"])
         && isValidStreamingPriority(newConfig["usenet.streaming-priority"])
         && isValidStreamingSegmentTimeout(newConfig["usenet.streaming-segment-timeout-seconds"])
         && isValidStreamingSegmentRetries(newConfig["usenet.streaming-segment-retries"])
@@ -400,6 +422,12 @@ function isValidMaxDownloadConnections(value: string | undefined): boolean {
 
 function isValidMaxQueueConnections(value: string): boolean {
     return value.trim() === "" || isPositiveInteger(value);
+}
+
+function isValidQueueWorkerCount(value: string | undefined): boolean {
+    if (value == null || value.trim() === "") return true;
+    const num = Number(value);
+    return Number.isInteger(num) && num >= 1 && num <= 8;
 }
 
 function isValidStreamingPriority(value: string): boolean {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -1,7 +1,10 @@
+using System.Collections.Concurrent;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -89,13 +92,97 @@ public class DownloadingNntpClientStatGateTests
         Assert.True(maxInFlight <= 2);
     }
 
+    [Fact]
+    public async Task StatAsync_PrimaryQueueContext_AdmittedBeforeSecondaryWaiters()
+    {
+        var holdSecondary = new ManualResetEventSlim(false);
+        var holdPrimary = new ManualResetEventSlim(false);
+        var entered = new ConcurrentQueue<string>();
+        var fake = new SelectiveBlockingStatNntpClient(
+            segmentId =>
+            {
+                entered.Enqueue(segmentId);
+                return segmentId switch
+                {
+                    "secondary-held" => holdSecondary,
+                    "primary-waiting" => holdPrimary,
+                    _ => null,
+                };
+            });
+
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10, poolConnections: 20);
+        using var client = new DownloadingNntpClient(fake, config);
+
+        var secondaryCtx = new QueueDownloadContext
+        {
+            IsPrimary = false,
+            GetFanOutConcurrency = () => 1,
+        };
+        var primaryCtx = new QueueDownloadContext
+        {
+            IsPrimary = true,
+            GetFanOutConcurrency = () => 1,
+        };
+
+        using var secondaryHeldCts = new CancellationTokenSource();
+        using var secondaryHeldReg = secondaryHeldCts.Token.SetContext(secondaryCtx);
+        var heldSecondary = client.StatAsync(new SegmentId("secondary-held"), secondaryHeldCts.Token);
+        await WaitUntilAsync(() => entered.Contains("secondary-held"), TimeSpan.FromSeconds(2));
+
+        using var primaryCts = new CancellationTokenSource();
+        using var primaryReg = primaryCts.Token.SetContext(primaryCtx);
+        var primary = client.StatAsync(new SegmentId("primary-waiting"), primaryCts.Token);
+
+        using var secondaryWaitingCts = new CancellationTokenSource();
+        using var secondaryWaitingReg = secondaryWaitingCts.Token.SetContext(secondaryCtx);
+        var waitingSecondary = client.StatAsync(new SegmentId("secondary-waiting"), secondaryWaitingCts.Token);
+
+        await Task.Delay(80);
+        Assert.DoesNotContain("primary-waiting", entered);
+        Assert.DoesNotContain("secondary-waiting", entered);
+
+        // Free the held secondary; the waiting primary (High lane) should run next
+        // and remain in-flight while we assert the Low-lane secondary is still waiting.
+        holdSecondary.Set();
+        await WaitUntilAsync(() => entered.Contains("primary-waiting"), TimeSpan.FromSeconds(2));
+        await Task.Delay(50);
+        Assert.DoesNotContain("secondary-waiting", entered);
+
+        holdPrimary.Set();
+        await Task.WhenAll(primary, heldSecondary, waitingSecondary);
+
+        var order = entered.ToArray();
+        Assert.Equal(
+            new[] { "secondary-held", "primary-waiting", "secondary-waiting" },
+            order);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(10);
+        }
+
+        Assert.Fail($"Condition not met within {timeout.TotalSeconds:0.#}s");
+    }
+
     private static ConfigManager CreateConfig(
         int maxQueueConnections,
-        int maxDownloadConnections)
+        int maxDownloadConnections,
+        int poolConnections = 50)
     {
         var config = new ConfigManager();
         config.UpdateValues(
         [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue =
+                    $$"""{"providers":[{"host":"nntp.example","port":563,"useSsl":true,"user":"u","pass":"p","maxConnections":{{poolConnections}},"type":1}]}""",
+            },
             new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = maxQueueConnections.ToString() },
             new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = maxDownloadConnections.ToString() },
         ]);
@@ -180,6 +267,36 @@ public class DownloadingNntpClientStatGateTests
 
         public override void Dispose()
         {
+        }
+    }
+
+    private sealed class SelectiveBlockingStatNntpClient(Func<string, ManualResetEventSlim?> gateFor)
+        : MinimalNntpClient
+    {
+        public override async Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            var gate = gateFor(segmentId.ToString());
+            if (gate is not null)
+            {
+                while (!gate.IsSet)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return await base.StatAsync(segmentId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class RecordingStatNntpClient(INntpClient inner, ConcurrentQueue<string> entered) : MinimalNntpClient
+    {
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            entered.Enqueue(segmentId.ToString());
+            return inner.StatAsync(segmentId, cancellationToken);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
@@ -1,0 +1,264 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Queue;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-qworkers-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private ConfigManager _configManager = null!;
+    private QueueManager _queueManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+
+        await using (var ctx = new DavDatabaseContext(_options))
+            await ctx.Database.MigrateAsync();
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            ProviderId = Guid.NewGuid(),
+                            Type = NzbWebDAV.Models.ProviderType.Pooled,
+                            Host = "nntp.example",
+                            Port = 563,
+                            UseSsl = true,
+                            User = "u",
+                            Pass = "p",
+                            MaxConnections = 20,
+                        },
+                    ],
+                }),
+            },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = "10" },
+            new ConfigItem { ConfigName = ConfigKeys.QueueWorkerCount, ConfigValue = "2" },
+        ]);
+
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false)
+        {
+            CreateDbContextOverride = () => new DavDatabaseContext(_options),
+        };
+    }
+
+    public Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try
+        {
+            if (Directory.Exists(_configRoot))
+                Directory.Delete(_configRoot, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ProcessQueueAsync_WithWorkerCountTwo_RunsTwoItemsConcurrently()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var item1 = CreateQueueItem("a.nzb", "movies", "JobA");
+        var item2 = CreateQueueItem("b.nzb", "movies", "JobB");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.AddRange(item1, item2);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Fresh streams per claim so each worker blocks independently.
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (item, _) = await client.GetTopQueueItem(exclude, ct);
+            if (item is null) return (null, null);
+            // Detach so the worker context owns the entity instance.
+            ctx.ChangeTracker.Clear();
+            return (item, new GateStream(gate));
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        var maxActive = 0;
+        while (DateTime.UtcNow < deadline)
+        {
+            maxActive = Math.Max(maxActive, _queueManager.GetInProgressQueueItems().Count);
+            if (maxActive >= 2) break;
+            await Task.Delay(20);
+        }
+
+        Assert.True(maxActive >= 2, $"Expected 2 concurrent workers, saw max {maxActive}");
+        Assert.True(_queueManager.HasActiveQueueItems);
+        Assert.NotNull(_queueManager.FindInProgressQueueItem(item1.Id)
+            ?? _queueManager.FindInProgressQueueItem(item2.Id));
+
+        gate.Set();
+
+        deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && _queueManager.HasActiveQueueItems)
+            await Task.Delay(20);
+
+        await cts.CancelAsync();
+        try { await loop; }
+        catch (OperationCanceledException) { }
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            Assert.Empty(await ctx.QueueItems.AsNoTracking().ToListAsync());
+            Assert.True(await ctx.HistoryItems.CountAsync() >= 2);
+        }
+    }
+
+    [Fact]
+    public async Task ProcessQueueAsync_SkipsSameMountKeyWhileSiblingIsActive()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var first = CreateQueueItem("dup1.nzb", "tv", "SameJob");
+        var sibling = CreateQueueItem("dup2.nzb", "tv", "SameJob");
+        var other = CreateQueueItem("other.nzb", "tv", "OtherJob");
+        first.CreatedAt = DateTime.Now.AddMinutes(-3);
+        sibling.CreatedAt = DateTime.Now.AddMinutes(-2);
+        other.CreatedAt = DateTime.Now.AddMinutes(-1);
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.AddRange(first, sibling, other);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (item, _) = await client.GetTopQueueItem(exclude, ct);
+            if (item is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (item, new GateStream(gate));
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var sawConflictPair = false;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var active = _queueManager.GetInProgressQueueItems();
+            var names = active.Select(x => x.QueueItem.JobName).ToHashSet();
+            if (names.Contains("SameJob") && names.Contains("OtherJob"))
+                sawConflictPair = true;
+            if (active.Count(x => x.QueueItem.JobName == "SameJob") > 1)
+                Assert.Fail("Two SameJob items were processing concurrently");
+            if (sawConflictPair && active.Count >= 2) break;
+            await Task.Delay(20);
+        }
+
+        Assert.True(sawConflictPair,
+            "Expected SameJob and OtherJob to overlap while the duplicate SameJob waited");
+        Assert.Null(_queueManager.FindInProgressQueueItem(sibling.Id));
+
+        gate.Set();
+        deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && _queueManager.HasActiveQueueItems)
+            await Task.Delay(20);
+
+        await cts.CancelAsync();
+        try { await loop; }
+        catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task GetTopQueueItem_ExcludesInFlightIds()
+    {
+        var a = CreateQueueItem("a.nzb", "movies", "A");
+        var b = CreateQueueItem("b.nzb", "movies", "B");
+        a.CreatedAt = DateTime.Now.AddMinutes(-2);
+        b.CreatedAt = DateTime.Now.AddMinutes(-1);
+
+        await using var ctx = new DavDatabaseContext(_options);
+        var client = new DavDatabaseClient(ctx);
+        ctx.QueueItems.AddRange(a, b);
+        await ctx.SaveChangesAsync();
+
+        var (top, _) = await client.GetTopQueueItem([a.Id]);
+        Assert.NotNull(top);
+        Assert.Equal(b.Id, top.Id);
+    }
+
+    private static QueueItem CreateQueueItem(string fileName, string category, string jobName)
+    {
+        return new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.Now,
+            FileName = fileName,
+            JobName = jobName,
+            NzbFileSize = 100,
+            TotalSegmentBytes = 200,
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/GateStream.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GateStream.cs
@@ -1,0 +1,53 @@
+namespace NzbWebDAV.Tests.Queue;
+
+/// <summary>
+/// Stream whose first read waits on a gate so queue workers can be held in-flight.
+/// After the gate opens it yields a tiny NZB payload once, then EOF.
+/// </summary>
+internal sealed class GateStream(ManualResetEventSlim gate) : Stream
+{
+    private static readonly byte[] Payload = "<nzb></nzb>"u8.ToArray();
+    private int _phase; // 0 = waiting, 1 = yield payload, 2 = eof
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => 0;
+        set => throw new NotSupportedException();
+    }
+
+    public override async Task<int> ReadAsync(
+        byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _phase) == 0)
+        {
+            while (!gate.IsSet)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+            }
+
+            Interlocked.CompareExchange(ref _phase, 1, 0);
+        }
+
+        if (Interlocked.CompareExchange(ref _phase, 2, 1) == 1)
+        {
+            var n = Math.Min(count, Payload.Length);
+            Buffer.BlockCopy(Payload, 0, buffer, offset, n);
+            return n;
+        }
+
+        return 0;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Queue;
 
 namespace NzbWebDAV.Tests.Queue;
@@ -16,6 +18,18 @@ public class QueueFanOutTests
     }
 
     [Theory]
+    [InlineData(10, 1, 9)]
+    [InlineData(10, 2, 8)]
+    [InlineData(10, 3, 7)]
+    [InlineData(1, 1, 1)]
+    [InlineData(2, 4, 1)]
+    public void PrimaryFanOutWhenSharing_LeavesSpareSoftSlots(
+        int maxQueue, int secondaryCount, int expected)
+    {
+        Assert.Equal(expected, QueueFanOut.PrimaryFanOutWhenSharing(maxQueue, secondaryCount));
+    }
+
+    [Theory]
     [InlineData(10, 1, 10)]
     [InlineData(10, 2, 5)]
     [InlineData(10, 3, 4)]
@@ -28,6 +42,54 @@ public class QueueFanOutTests
 
     [Fact]
     public void GetConcurrency_WithoutContext_UsesPrimaryFanOut()
+    {
+        var config = CreateConfig(maxQueueConnections: 8);
+        Assert.Equal(13, QueueFanOut.GetConcurrency(CancellationToken.None, config));
+    }
+
+    [Fact]
+    public void GetExactQueueConcurrency_WithoutContext_UsesMaxQueue()
+    {
+        var config = CreateConfig(maxQueueConnections: 8);
+        Assert.Equal(8, QueueFanOut.GetExactQueueConcurrency(CancellationToken.None, config));
+    }
+
+    [Fact]
+    public void GetExactQueueConcurrency_ClampsSoloPrimaryOvershootToMaxQueue()
+    {
+        var config = CreateConfig(maxQueueConnections: 10);
+        using var cts = new CancellationTokenSource();
+        using var ctx = cts.Token.SetContext(new QueueDownloadContext
+        {
+            IsPrimary = true,
+            GetFanOutConcurrency = () => QueueFanOut.PrimaryFanOut(10),
+        });
+
+        Assert.Equal(15, QueueFanOut.GetConcurrency(cts.Token, config));
+        Assert.Equal(10, QueueFanOut.GetExactQueueConcurrency(cts.Token, config));
+    }
+
+    [Fact]
+    public void LinkedCancellationToken_PreservesQueueDownloadContextFanOut()
+    {
+        var config = CreateConfig(maxQueueConnections: 10);
+        using var parentCts = new CancellationTokenSource();
+        using var parentCtx = parentCts.Token.SetContext(new QueueDownloadContext
+        {
+            IsPrimary = true,
+            GetFanOutConcurrency = () => 7,
+        });
+
+        using var linked = ContextualCancellationTokenSource.CreateLinkedTokenSource(parentCts.Token);
+
+        Assert.Equal(7, QueueFanOut.GetConcurrency(linked.Token, config));
+        Assert.Equal(7, QueueFanOut.GetExactQueueConcurrency(linked.Token, config));
+        Assert.Same(
+            parentCts.Token.GetContext<QueueDownloadContext>(),
+            linked.Token.GetContext<QueueDownloadContext>());
+    }
+
+    private static ConfigManager CreateConfig(int maxQueueConnections)
     {
         var config = new ConfigManager();
         config.UpdateValues(
@@ -53,10 +115,13 @@ public class QueueFanOutTests
                     ],
                 }),
             },
-            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = "8" },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetMaxQueueConnections,
+                ConfigValue = maxQueueConnections.ToString(),
+            },
         ]);
-
-        Assert.Equal(13, QueueFanOut.GetConcurrency(CancellationToken.None, config));
+        return config;
     }
 }
 

--- a/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class QueueFanOutTests
+{
+    [Fact]
+    public void PrimaryFanOut_MatchesHistoricalSingleItemBudget()
+    {
+        Assert.Equal(15, QueueFanOut.PrimaryFanOut(10));
+        Assert.Equal(50, QueueFanOut.PrimaryFanOut(100));
+        Assert.Equal(6, QueueFanOut.PrimaryFanOut(1));
+    }
+
+    [Theory]
+    [InlineData(10, 1, 10)]
+    [InlineData(10, 2, 5)]
+    [InlineData(10, 3, 4)]
+    [InlineData(1, 4, 1)]
+    public void SecondaryFanOut_DividesBudgetAcrossSecondaries(
+        int maxQueue, int secondaryCount, int expected)
+    {
+        Assert.Equal(expected, QueueFanOut.SecondaryFanOut(maxQueue, secondaryCount));
+    }
+
+    [Fact]
+    public void GetConcurrency_WithoutContext_UsesPrimaryFanOut()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            ProviderId = Guid.NewGuid(),
+                            Type = NzbWebDAV.Models.ProviderType.Pooled,
+                            Host = "nntp.example",
+                            Port = 563,
+                            UseSsl = true,
+                            User = "u",
+                            Pass = "p",
+                            MaxConnections = 20,
+                        },
+                    ],
+                }),
+            },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = "8" },
+        ]);
+
+        Assert.Equal(13, QueueFanOut.GetConcurrency(CancellationToken.None, config));
+    }
+}
+
+public class QueueWorkerCountConfigTests
+{
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData("", 1)]
+    [InlineData("1", 1)]
+    [InlineData("4", 4)]
+    [InlineData("8", 8)]
+    [InlineData("0", 1)]
+    [InlineData("99", 8)]
+    [InlineData("abc", 1)]
+    public void GetQueueWorkerCount_ClampsToOneThroughEight(string? configured, int expected)
+    {
+        var config = new ConfigManager();
+        if (configured is not null)
+        {
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.QueueWorkerCount, ConfigValue = configured },
+            ]);
+        }
+
+        Assert.Equal(expected, config.GetQueueWorkerCount());
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
@@ -67,11 +67,11 @@ public class QueueWorkerCountConfigTests
     [InlineData("", 1)]
     [InlineData("1", 1)]
     [InlineData("4", 4)]
-    [InlineData("8", 8)]
+    [InlineData("8", 4)]
     [InlineData("0", 1)]
-    [InlineData("99", 8)]
+    [InlineData("99", 4)]
     [InlineData("abc", 1)]
-    public void GetQueueWorkerCount_ClampsToOneThroughEight(string? configured, int expected)
+    public void GetQueueWorkerCount_ClampsToOneThroughFour(string? configured, int expected)
     {
         var config = new ConfigManager();
         if (configured is not null)

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -18,7 +18,7 @@ public class QueueManagerLoopTests
         using var manager = CreateManager();
         var iterations = 0;
         manager.ErrorBackoffDelay = TimeSpan.FromSeconds(5);
-        manager.GetTopQueueItemOverride = _ =>
+        manager.GetTopQueueItemOverride = (_, _) =>
         {
             Interlocked.Increment(ref iterations);
             throw new InvalidOperationException("persistent db failure");
@@ -39,7 +39,7 @@ public class QueueManagerLoopTests
 
         var pollTimes = new List<DateTime>();
         var pauseCalls = 0;
-        manager.GetTopQueueItemOverride = _ =>
+        manager.GetTopQueueItemOverride = (_, _) =>
         {
             lock (pollTimes) pollTimes.Add(DateTime.UtcNow);
             return Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
@@ -87,7 +87,7 @@ public class QueueManagerLoopTests
     {
         using var manager = CreateManager();
         manager.IdleDelay = TimeSpan.FromMinutes(1);
-        manager.GetTopQueueItemOverride = _ =>
+        manager.GetTopQueueItemOverride = (_, _) =>
             Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
 
         using var cts = new CancellationTokenSource();


### PR DESCRIPTION
## Summary
- Adds `queue.worker-count` (1–4, default 1) so the queue can process multiple NZBs concurrently while still sharing `usenet.max-queue-connections`.
- The first active item is preferred on the queue soft semaphore; secondary workers use spare capacity. Streaming stays High priority at the physical pool.
- Serializes queue completion DB writes, defers new background health checks while queue work is active, and updates SAB/API/UI for multiple in-progress downloads.

Closes #112

## Test plan
- [x] Backend focused tests: QueueFanOut, QueueManagerLoop, ConcurrentQueueManager, DownloadingNntpClient primary admission
- [x] Frontend `npm run typecheck`
- [x] Full backend test suite (prior run: 917 passed; 1 known rapidyenc native skip/fail unrelated to this change)
- [x] Sol review fixes: context propagation, primary share reserve, reap-before-fill, exact fan-out clamp
- [ ] Manual: set Concurrent Queue Downloads to 2, enqueue two NZBs, confirm both show Downloading and progress
- [ ] Manual: verify playback still gets priority while two queue items run
- [ ] Manual: confirm health checks pause while the queue is busy and resume when idle