### PR TITLE
ux(ui): clarify WebDAV settings with grouped layout cards

### DIFF
--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -1,6 +1,7 @@
-import { ManagedSetting, SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select, Toggle } from "~/components/ui/form";
-import { type Dispatch, type SetStateAction } from "react";
+import { Icon } from "~/components/ui/icon";
+import { type Dispatch, type ReactNode, type SetStateAction } from "react";
 import { className } from "~/utils/styling";
 import { isPositiveInteger } from "../usenet/usenet";
 
@@ -9,360 +10,422 @@ type SabnzbdSettingsProps = {
     setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
 };
 
+function SettingsCard({
+    icon,
+    title,
+    description,
+    children,
+}: {
+    icon: string
+    title: string
+    description: string
+    children: ReactNode
+}) {
+    return (
+        <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+            <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+                <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                    <Icon name={icon} className="!text-[20px]" />
+                </span>
+                <div>
+                    <h2 className="text-sm font-semibold text-base-content">{title}</h2>
+                    <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">
+                        {description}
+                    </p>
+                </div>
+            </div>
+            <div className="space-y-4 p-4">
+                {children}
+            </div>
+        </section>
+    );
+}
+
 export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
     return (
         <SettingsPage>
-            <ManagedSetting configKey="webdav.user">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="webdav-user-input">WebDAV User</label>
-                <Input
-                    {...className(['w-full', !isValidUser(config["webdav.user"]) && 'input-error'])}
-                    type="text"
-                    id="webdav-user-input"
-                    aria-describedby="webdav-user-help"
-                    placeholder="admin"
-                    value={config["webdav.user"]}
-                    onChange={e => setNewConfig({ ...config, "webdav.user": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="webdav-user-help">
-                    Use this user to connect to the webdav. Only letters, numbers, dashes, and underscores allowed.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.max-queue-connections">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="max-queue-connections-input">Queue Download Connections</label>
-                <Input
-                    {...className(['w-full', !isValidMaxQueueConnections(config["usenet.max-queue-connections"]) && 'input-error'])}
-                    type="text"
-                    id="max-queue-connections-input"
-                    aria-describedby="max-queue-connections-help"
-                    placeholder="Auto (all connections)"
-                    value={config["usenet.max-queue-connections"]}
-                    onChange={e => setNewConfig({ ...config, "usenet.max-queue-connections": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="max-queue-connections-help">
-                    Connections available to queue imports. Leave blank to use all provider connections.
-                    Shared across concurrent queue workers and background health checks.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="queue.worker-count">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="queue-worker-count-select">Concurrent Queue Downloads</label>
-                <Select
-                    className="w-full"
-                    id="queue-worker-count-select"
-                    aria-describedby="queue-worker-count-help"
-                    value={config["queue.worker-count"] || "1"}
-                    onChange={e => setNewConfig({ ...config, "queue.worker-count": e.target.value })}>
-                    <option value="1">1 — one at a time (default)</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                    <option value="4">4</option>
-                </Select>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-worker-count-help">
-                    How many NZB queue items may process at once. The first active item
-                    gets preferred access to Queue Download Connections; additional items use spare capacity.
-                    Raising this does not increase the connection budget.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="webdav.pass">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="webdav-pass-input">WebDAV Password</label>
-                <Input
-                    className={'w-full'}
-                    type="password"
-                    id="webdav-pass-input"
-                    aria-describedby="webdav-pass-help"
-                    value={config["webdav.pass"]}
-                    onChange={e => setNewConfig({ ...config, "webdav.pass": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="webdav-pass-help">
-                    Use this password to connect to the webdav.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKeys={["usenet.segment-cache.enabled", "usenet.segment-cache.path", "usenet.segment-cache.max-gb"]}>
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                        id="segment-cache-enabled-checkbox"
-                        aria-describedby="segment-cache-enabled-help"
-                        checked={config["usenet.segment-cache.enabled"] === "true"}
-                        onChange={e => setNewConfig({ ...config, "usenet.segment-cache.enabled": String(e.target.checked) })} />
-                    <span>Enable Segment Cache</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="segment-cache-enabled-help">
-                    Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.
-                </p>
-                {config["usenet.segment-cache.enabled"] === "true" && (
-                    <div className="grid gap-4 border-l border-base-content/10 pl-4 sm:grid-cols-2">
-                        <label className="space-y-2 text-sm text-base-content/80">
-                            <span>Cache path</span>
+            <SettingsIntro>
+                Configure WebDAV credentials and how playback shares NNTP connections with queue imports.
+                Queue connection budgets live here because they compete with streaming for the same provider pool.
+            </SettingsIntro>
+
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <SettingsCard
+                    icon="lock"
+                    title="Access"
+                    description="Credentials used by rclone, Plex, and other WebDAV clients."
+                >
+                    <ManagedSetting configKey="webdav.user">
+                        <div className="space-y-2">
+                            <label className="block text-sm font-medium text-base-content" htmlFor="webdav-user-input">WebDAV User</label>
                             <Input
-                                className={`w-full ${!isValidSegmentCachePath(config["usenet.segment-cache.path"]) ? "input-error" : ""}`}
-                                value={config["usenet.segment-cache.path"]}
-                                placeholder="/config/segment-cache"
-                                onChange={e => setNewConfig({ ...config, "usenet.segment-cache.path": e.target.value })} />
-                        </label>
-                        <label className="space-y-2 text-sm text-base-content/80">
-                            <span>Maximum size (GB)</span>
+                                {...className(['w-full', !isValidUser(config["webdav.user"]) && 'input-error'])}
+                                type="text"
+                                id="webdav-user-input"
+                                aria-describedby="webdav-user-help"
+                                placeholder="admin"
+                                value={config["webdav.user"]}
+                                onChange={e => setNewConfig({ ...config, "webdav.user": e.target.value })} />
+                            <p className="text-[11px] leading-relaxed text-base-content/45" id="webdav-user-help">
+                                Use this user to connect to the webdav. Only letters, numbers, dashes, and underscores allowed.
+                            </p>
+                        </div>
+                    </ManagedSetting>
+
+                    <ManagedSetting configKey="webdav.pass">
+                        <div className="space-y-2">
+                            <label className="block text-sm font-medium text-base-content" htmlFor="webdav-pass-input">WebDAV Password</label>
                             <Input
-                                className={`w-full ${!isPositiveInteger(config["usenet.segment-cache.max-gb"]) ? "input-error" : ""}`}
-                                inputMode="numeric"
-                                value={config["usenet.segment-cache.max-gb"]}
-                                onChange={e => setNewConfig({ ...config, "usenet.segment-cache.max-gb": e.target.value })} />
-                        </label>
-                    </div>
-                )}
+                                className={'w-full'}
+                                type="password"
+                                id="webdav-pass-input"
+                                aria-describedby="webdav-pass-help"
+                                value={config["webdav.pass"]}
+                                onChange={e => setNewConfig({ ...config, "webdav.pass": e.target.value })} />
+                            <p className="text-[11px] leading-relaxed text-base-content/45" id="webdav-pass-help">
+                                Use this password to connect to the webdav.
+                            </p>
+                        </div>
+                    </ManagedSetting>
+                </SettingsCard>
+
+                <SettingsCard
+                    icon="folder_shared"
+                    title="Filesystem & Explorer"
+                    description="How content appears to WebDAV clients and the Dav Explorer."
+                >
+                    <ManagedSetting configKey="webdav.enforce-readonly">
+                        <div className="space-y-2">
+                            <label className="flex items-center gap-2 text-sm text-base-content/80">
+                                <Checkbox
+                                    id="readonly-checkbox"
+                                    aria-describedby="readonly-help"
+                                    checked={config["webdav.enforce-readonly"] === "true"}
+                                    onChange={e => setNewConfig({ ...config, "webdav.enforce-readonly": "" + e.target.checked })} />
+                                <span>{`Enforce Read-Only`}</span>
+                            </label>
+                            <p className="text-[11px] leading-relaxed text-base-content/45" id="readonly-help">
+                                The WebDAV `/content` folder will be readonly when checked. WebDAV clients will not be able to delete files within this directory.
+                            </p>
+                        </div>
+                    </ManagedSetting>
+
+                    <ManagedSetting configKey="webdav.windows-safe-paths">
+                        <div className="space-y-2">
+                            <label className="flex items-center gap-2 text-sm text-base-content/80">
+                                <Checkbox
+                                    id="windows-safe-paths-checkbox"
+                                    aria-describedby="windows-safe-paths-help"
+                                    checked={config["webdav.windows-safe-paths"] !== "false"}
+                                    onChange={e => setNewConfig({ ...config, "webdav.windows-safe-paths": String(e.target.checked) })} />
+                                <span>Sanitize paths for Windows</span>
+                            </label>
+                            <p className="text-[11px] leading-relaxed text-base-content/45" id="windows-safe-paths-help">
+                                Replace characters that are invalid on Windows (<code>{`<>:"/\\|?*`}</code>), trim trailing
+                                dots/spaces, and prefix reserved device names. Recommended when using Windows WebDAV
+                                clients or rclone on Windows. Applies to newly mounted content only.
+                            </p>
+                        </div>
+                    </ManagedSetting>
+
+                    <ManagedSetting configKey="webdav.show-hidden-files">
+                        <div className="space-y-2">
+                            <label className="flex items-center gap-2 text-sm text-base-content/80">
+                                <Checkbox
+                                    id="show-hidden-files-checkbox"
+                                    aria-describedby="show-hidden-files-help"
+                                    checked={config["webdav.show-hidden-files"] === "true"}
+                                    onChange={e => setNewConfig({ ...config, "webdav.show-hidden-files": "" + e.target.checked })} />
+                                <span>{`Show hidden files on Dav Explorer`}</span>
+                            </label>
+                            <p className="text-[11px] leading-relaxed text-base-content/45" id="show-hidden-files-help">
+                                Hidden files or directories are those whose names are prefixed by a period.
+                            </p>
+                        </div>
+                    </ManagedSetting>
+
+                    <ManagedSetting configKey="webdav.preview-par2-files">
+                        <div className="space-y-2">
+                            <label className="flex items-center gap-2 text-sm text-base-content/80">
+                                <Checkbox
+                                    id="preview-par2-files-checkbox"
+                                    aria-describedby="preview-par2-files-help"
+                                    checked={config["webdav.preview-par2-files"] === "true"}
+                                    onChange={e => setNewConfig({ ...config, "webdav.preview-par2-files": "" + e.target.checked })} />
+                                <span>{`Preview par2 files on Dav Explorer`}</span>
+                            </label>
+                            <p className="text-[11px] leading-relaxed text-base-content/45" id="preview-par2-files-help">
+                                When enabled, par2 files will be rendered as text files on the Dav Explorer page, displaying all File-Descriptor entries.
+                            </p>
+                        </div>
+                    </ManagedSetting>
+                </SettingsCard>
             </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.max-download-connections">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-auto-checkbox">Max Download Connections</label>
-                <Toggle
-                    id="max-download-connections-auto-checkbox"
-                    aria-describedby="max-download-connections-help"
-                    label="Auto — use all Pool provider connections"
-                    checked={isAutoMaxDownloadConnections(config["usenet.max-download-connections"])}
-                    onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.checked ? "0" : "15" })} />
-                {!isAutoMaxDownloadConnections(config["usenet.max-download-connections"]) && (
-                    <Input
-                        {...className(['w-full', !isValidMaxDownloadConnections(config["usenet.max-download-connections"]) && 'input-error'])}
-                        type="text"
-                        id="max-download-connections-input"
-                        aria-describedby="max-download-connections-help"
-                        placeholder="15"
-                        value={config["usenet.max-download-connections"]}
-                        onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.value })} />
-                )}
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-help">
-                    The total connections used for <strong>webdav streaming</strong> (playback). Leave on
-                    <strong> Auto</strong> to use the combined connection limit of your Pool providers — it
-                    tracks changes as you add or remove providers — or turn Auto off to set a fixed number.
-                    Queue imports use their own budget — see Queue Download Connections above.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKeys={["usenet.max-download-connections-per-stream", "usenet.max-download-connections-per-stream-preset"]}>
-            <div className="space-y-2">
-                <Toggle
-                    id="max-download-connections-per-stream-checkbox"
-                    aria-describedby="max-download-connections-per-stream-help"
-                    label="Apply limit per stream"
-                    checked={config["usenet.max-download-connections-per-stream"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "usenet.max-download-connections-per-stream": String(e.target.checked) })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-per-stream-help">
-                    By default the budget above is a <strong>shared total</strong> across all active playback
-                    streams. Enable this to give each concurrent stream <strong>its own budget</strong> instead,
-                    sized by the performance preset below. Your provider's connection limit still applies as a
-                    hard ceiling on the total connections actually opened.
-                </p>
-                {config["usenet.max-download-connections-per-stream"] === "true" && (
-                    <div className="space-y-2 border-l border-base-content/10 pl-4">
-                        <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-per-stream-preset-select">Per-stream performance</label>
-                        <Select
-                            className="w-full"
-                            id="max-download-connections-per-stream-preset-select"
-                            aria-describedby="max-download-connections-per-stream-preset-help"
-                            value={config["usenet.max-download-connections-per-stream-preset"] || "high"}
-                            onChange={e => setNewConfig({ ...config, "usenet.max-download-connections-per-stream-preset": e.target.value })}>
-                            <option value="low">Low — 25% of the budget per stream</option>
-                            <option value="medium">Medium — 50% of the budget per stream</option>
-                            <option value="high">High — 75% of the budget per stream</option>
-                            <option value="max">Max — 100% (full budget per stream)</option>
-                        </Select>
-                        <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-per-stream-preset-help">
-                            How aggressively each stream may use the budget above. Higher fills and seeks faster
-                            per stream; lower keeps more connections free for other simultaneous streams.
+
+            <SettingsCard
+                icon="tune"
+                title="Queue & connection allocation"
+                description="Split provider connections between queue imports and WebDAV playback."
+            >
+                <ManagedSetting configKey="usenet.max-queue-connections">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="max-queue-connections-input">Queue Download Connections</label>
+                        <Input
+                            {...className(['w-full', !isValidMaxQueueConnections(config["usenet.max-queue-connections"]) && 'input-error'])}
+                            type="text"
+                            id="max-queue-connections-input"
+                            aria-describedby="max-queue-connections-help"
+                            placeholder="Auto (all connections)"
+                            value={config["usenet.max-queue-connections"]}
+                            onChange={e => setNewConfig({ ...config, "usenet.max-queue-connections": e.target.value })} />
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="max-queue-connections-help">
+                            Connections available to queue imports. Leave blank to use all provider connections.
+                            Shared across concurrent queue workers and background health checks.
                         </p>
                     </div>
-                )}
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.streaming-priority">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="streaming-priority-input">Streaming Priority (vs Queue)</label>
-                <div className="flex w-full">
-                    <Input
-                        className={!isValidStreamingPriority(config["usenet.streaming-priority"]) ? 'input-error' : undefined}
-                        type="text"
-                        id="streaming-priority-input"
-                        aria-describedby="streaming-priority-help"
-                        placeholder="80"
-                        value={config["usenet.streaming-priority"]}
-                        onChange={e => setNewConfig({ ...config, "usenet.streaming-priority": e.target.value })} />
-                    <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">%</span>
-                </div>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-priority-help">
-                    When streaming from the webdav while the queue is also active, how much bandwidth should be dedicated to streaming?
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.streaming-segment-timeout-seconds">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-timeout-input">Streaming Segment Timeout</label>
-                <div className="flex w-full">
-                    <Input
-                        className={!isValidStreamingSegmentTimeout(config["usenet.streaming-segment-timeout-seconds"]) ? 'input-error' : undefined}
-                        type="text"
-                        id="streaming-segment-timeout-input"
-                        aria-describedby="streaming-segment-timeout-help"
-                        placeholder="8"
-                        value={config["usenet.streaming-segment-timeout-seconds"]}
-                        onChange={e => setNewConfig({ ...config, "usenet.streaming-segment-timeout-seconds": e.target.value })} />
-                    <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">sec</span>
-                </div>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-segment-timeout-help">
-                    Per-segment deadline for WebDAV playback (2–40s). Stalled connections are replaced and retried before waiting for the provider&apos;s ~40s read timeout.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.streaming-segment-retries">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-retries-input">Streaming Segment Retries</label>
-                <Input
-                    className={!isValidStreamingSegmentRetries(config["usenet.streaming-segment-retries"]) ? 'input-error' : undefined}
-                    type="text"
-                    id="streaming-segment-retries-input"
-                    aria-describedby="streaming-segment-retries-help"
-                    placeholder="3"
-                    value={config["usenet.streaming-segment-retries"]}
-                    onChange={e => setNewConfig({ ...config, "usenet.streaming-segment-retries": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-segment-retries-help">
-                    Extra attempts on a fresh connection after a streaming segment timeout (0–5). Queue and health checks are unaffected.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.article-buffer-size">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="article-buffer-size-input">Article Buffer Size</label>
-                <Input
-                    {...className(['w-full', !isValidArticleBufferSize(config["usenet.article-buffer-size"]) && 'input-error'])}
-                    type="text"
-                    id="article-buffer-size-input"
-                    aria-describedby="article-buffer-size-help"
-                    placeholder="40"
-                    value={config["usenet.article-buffer-size"]}
-                    onChange={e => setNewConfig({ ...config, "usenet.article-buffer-size": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="article-buffer-size-help">
-                    The number of articles to buffer ahead, per stream, when reading from the webdav.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.idle-connection-timeout-seconds">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="idle-connection-timeout-input">Idle connection timeout (seconds)</label>
-                <Input
-                    {...className(['w-full', !isValidIdleConnectionTimeout(config["usenet.idle-connection-timeout-seconds"]) && 'input-error'])}
-                    type="text"
-                    id="idle-connection-timeout-input"
-                    aria-describedby="idle-connection-timeout-help"
-                    placeholder="60"
-                    value={config["usenet.idle-connection-timeout-seconds"] ?? "60"}
-                    onChange={e => setNewConfig({ ...config, "usenet.idle-connection-timeout-seconds": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="idle-connection-timeout-help">
-                    How long unused NNTP connections stay in the pool before being closed (15–300, default 60).
-                    Raising this can reduce reconnect stalls during playback gaps, but values above your
-                    provider&apos;s server-side idle timeout are counterproductive. Takes effect on the next
-                    connection-pool rebuild (provider config change or restart).
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="usenet.pipelined-body-requests">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                    id="pipelined-body-requests-checkbox"
-                    aria-describedby="pipelined-body-requests-help"
-                    checked={config["usenet.pipelined-body-requests"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "usenet.pipelined-body-requests": "" + e.target.checked })} />
-                    <span>Pipelined article downloads</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="pipelined-body-requests-help">
-                    Fetch articles in small NNTP batches for smoother WebDAV streaming. Queue imports use the
-                    separate <strong>Enable NNTP pipelining</strong> toggle under Usenet settings. Disable this
-                    to use the legacy one-at-a-time API while retaining the configured article buffer.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="webdav.enforce-readonly">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                    id="readonly-checkbox"
-                    aria-describedby="readonly-help"
-                    checked={config["webdav.enforce-readonly"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "webdav.enforce-readonly": "" + e.target.checked })}  />
-                    <span>{`Enforce Read-Only`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="readonly-help">
-                    The WebDAV `/content` folder will be readonly when checked. WebDAV clients will not be able to delete files within this directory.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="webdav.show-hidden-files">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                    id="show-hidden-files-checkbox"
-                    aria-describedby="show-hidden-files-help"
-                    checked={config["webdav.show-hidden-files"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "webdav.show-hidden-files": "" + e.target.checked })}  />
-                    <span>{`Show hidden files on Dav Explorer`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="show-hidden-files-help">
-                    Hidden files or directories are those whose names are prefixed by a period.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="webdav.preview-par2-files">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                    id="preview-par2-files-checkbox"
-                    aria-describedby="preview-par2-files-help"
-                    checked={config["webdav.preview-par2-files"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "webdav.preview-par2-files": "" + e.target.checked })}  />
-                    <span>{`Preview par2 files on Dav Explorer`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="preview-par2-files-help">
-                    When enabled, par2 files will be rendered as text files on the Dav Explorer page, displaying all File-Descriptor entries.
-                </p>
-            </div>
-            </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="webdav.windows-safe-paths">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                        id="windows-safe-paths-checkbox"
-                        aria-describedby="windows-safe-paths-help"
-                        checked={config["webdav.windows-safe-paths"] !== "false"}
-                        onChange={e => setNewConfig({ ...config, "webdav.windows-safe-paths": String(e.target.checked) })} />
-                    <span>Sanitize paths for Windows</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="windows-safe-paths-help">
-                    Replace characters that are invalid on Windows (<code>{`<>:"/\\|?*`}</code>), trim trailing
-                    dots/spaces, and prefix reserved device names. Recommended when using Windows WebDAV
-                    clients or rclone on Windows. Applies to newly mounted content only.
-                </p>
-            </div>
-            </ManagedSetting>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="queue.worker-count">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="queue-worker-count-select">Concurrent Queue Downloads</label>
+                        <Select
+                            className="w-full"
+                            id="queue-worker-count-select"
+                            aria-describedby="queue-worker-count-help"
+                            value={config["queue.worker-count"] || "1"}
+                            onChange={e => setNewConfig({ ...config, "queue.worker-count": e.target.value })}>
+                            <option value="1">1 — one at a time (default)</option>
+                            <option value="2">2</option>
+                            <option value="3">3</option>
+                            <option value="4">4</option>
+                        </Select>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-worker-count-help">
+                            How many NZB queue items may process at once. The first active item
+                            gets preferred access to Queue Download Connections; additional items use spare capacity.
+                            Raising this does not increase the connection budget.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.max-download-connections">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-auto-checkbox">Max Download Connections</label>
+                        <Toggle
+                            id="max-download-connections-auto-checkbox"
+                            aria-describedby="max-download-connections-help"
+                            label="Auto — use all Pool provider connections"
+                            checked={isAutoMaxDownloadConnections(config["usenet.max-download-connections"])}
+                            onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.checked ? "0" : "15" })} />
+                        {!isAutoMaxDownloadConnections(config["usenet.max-download-connections"]) && (
+                            <Input
+                                {...className(['w-full', !isValidMaxDownloadConnections(config["usenet.max-download-connections"]) && 'input-error'])}
+                                type="text"
+                                id="max-download-connections-input"
+                                aria-describedby="max-download-connections-help"
+                                placeholder="15"
+                                value={config["usenet.max-download-connections"]}
+                                onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.value })} />
+                        )}
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-help">
+                            The total connections used for <strong>webdav streaming</strong> (playback). Leave on
+                            <strong> Auto</strong> to use the combined connection limit of your Pool providers — it
+                            tracks changes as you add or remove providers — or turn Auto off to set a fixed number.
+                            Queue imports use their own budget — see Queue Download Connections above.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKeys={["usenet.max-download-connections-per-stream", "usenet.max-download-connections-per-stream-preset"]}>
+                    <div className="space-y-2">
+                        <Toggle
+                            id="max-download-connections-per-stream-checkbox"
+                            aria-describedby="max-download-connections-per-stream-help"
+                            label="Apply limit per stream"
+                            checked={config["usenet.max-download-connections-per-stream"] === "true"}
+                            onChange={e => setNewConfig({ ...config, "usenet.max-download-connections-per-stream": String(e.target.checked) })} />
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-per-stream-help">
+                            By default the budget above is a <strong>shared total</strong> across all active playback
+                            streams. Enable this to give each concurrent stream <strong>its own budget</strong> instead,
+                            sized by the performance preset below. Your provider&apos;s connection limit still applies as a
+                            hard ceiling on the total connections actually opened.
+                        </p>
+                        {config["usenet.max-download-connections-per-stream"] === "true" && (
+                            <div className="space-y-2 border-l border-base-content/10 pl-4">
+                                <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-per-stream-preset-select">Per-stream performance</label>
+                                <Select
+                                    className="w-full"
+                                    id="max-download-connections-per-stream-preset-select"
+                                    aria-describedby="max-download-connections-per-stream-preset-help"
+                                    value={config["usenet.max-download-connections-per-stream-preset"] || "high"}
+                                    onChange={e => setNewConfig({ ...config, "usenet.max-download-connections-per-stream-preset": e.target.value })}>
+                                    <option value="low">Low — 25% of the budget per stream</option>
+                                    <option value="medium">Medium — 50% of the budget per stream</option>
+                                    <option value="high">High — 75% of the budget per stream</option>
+                                    <option value="max">Max — 100% (full budget per stream)</option>
+                                </Select>
+                                <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-per-stream-preset-help">
+                                    How aggressively each stream may use the budget above. Higher fills and seeks faster
+                                    per stream; lower keeps more connections free for other simultaneous streams.
+                                </p>
+                            </div>
+                        )}
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.streaming-priority">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="streaming-priority-input">Streaming Priority (vs Queue)</label>
+                        <div className="flex w-full">
+                            <Input
+                                className={!isValidStreamingPriority(config["usenet.streaming-priority"]) ? 'input-error' : undefined}
+                                type="text"
+                                id="streaming-priority-input"
+                                aria-describedby="streaming-priority-help"
+                                placeholder="80"
+                                value={config["usenet.streaming-priority"]}
+                                onChange={e => setNewConfig({ ...config, "usenet.streaming-priority": e.target.value })} />
+                            <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">%</span>
+                        </div>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-priority-help">
+                            When streaming from the webdav while the queue is also active, how much bandwidth should be dedicated to streaming?
+                        </p>
+                    </div>
+                </ManagedSetting>
+            </SettingsCard>
+
+            <SettingsCard
+                icon="speed"
+                title="Streaming performance"
+                description="Buffering, caching, and timeout behavior for WebDAV playback."
+            >
+                <ManagedSetting configKeys={["usenet.segment-cache.enabled", "usenet.segment-cache.path", "usenet.segment-cache.max-gb"]}>
+                    <div className="space-y-2">
+                        <label className="flex items-center gap-2 text-sm text-base-content/80">
+                            <Checkbox
+                                id="segment-cache-enabled-checkbox"
+                                aria-describedby="segment-cache-enabled-help"
+                                checked={config["usenet.segment-cache.enabled"] === "true"}
+                                onChange={e => setNewConfig({ ...config, "usenet.segment-cache.enabled": String(e.target.checked) })} />
+                            <span>Enable Segment Cache</span>
+                        </label>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="segment-cache-enabled-help">
+                            Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.
+                        </p>
+                        {config["usenet.segment-cache.enabled"] === "true" && (
+                            <div className="grid gap-4 border-l border-base-content/10 pl-4 sm:grid-cols-2">
+                                <label className="space-y-2 text-sm text-base-content/80">
+                                    <span>Cache path</span>
+                                    <Input
+                                        className={`w-full ${!isValidSegmentCachePath(config["usenet.segment-cache.path"]) ? "input-error" : ""}`}
+                                        value={config["usenet.segment-cache.path"]}
+                                        placeholder="/config/segment-cache"
+                                        onChange={e => setNewConfig({ ...config, "usenet.segment-cache.path": e.target.value })} />
+                                </label>
+                                <label className="space-y-2 text-sm text-base-content/80">
+                                    <span>Maximum size (GB)</span>
+                                    <Input
+                                        className={`w-full ${!isPositiveInteger(config["usenet.segment-cache.max-gb"]) ? "input-error" : ""}`}
+                                        inputMode="numeric"
+                                        value={config["usenet.segment-cache.max-gb"]}
+                                        onChange={e => setNewConfig({ ...config, "usenet.segment-cache.max-gb": e.target.value })} />
+                                </label>
+                            </div>
+                        )}
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.streaming-segment-timeout-seconds">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-timeout-input">Streaming Segment Timeout</label>
+                        <div className="flex w-full">
+                            <Input
+                                className={!isValidStreamingSegmentTimeout(config["usenet.streaming-segment-timeout-seconds"]) ? 'input-error' : undefined}
+                                type="text"
+                                id="streaming-segment-timeout-input"
+                                aria-describedby="streaming-segment-timeout-help"
+                                placeholder="8"
+                                value={config["usenet.streaming-segment-timeout-seconds"]}
+                                onChange={e => setNewConfig({ ...config, "usenet.streaming-segment-timeout-seconds": e.target.value })} />
+                            <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">sec</span>
+                        </div>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-segment-timeout-help">
+                            Per-segment deadline for WebDAV playback (2–40s). Stalled connections are replaced and retried before waiting for the provider&apos;s ~40s read timeout.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.streaming-segment-retries">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-retries-input">Streaming Segment Retries</label>
+                        <Input
+                            className={!isValidStreamingSegmentRetries(config["usenet.streaming-segment-retries"]) ? 'input-error' : undefined}
+                            type="text"
+                            id="streaming-segment-retries-input"
+                            aria-describedby="streaming-segment-retries-help"
+                            placeholder="3"
+                            value={config["usenet.streaming-segment-retries"]}
+                            onChange={e => setNewConfig({ ...config, "usenet.streaming-segment-retries": e.target.value })} />
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-segment-retries-help">
+                            Extra attempts on a fresh connection after a streaming segment timeout (0–5). Queue and health checks are unaffected.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.article-buffer-size">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="article-buffer-size-input">Article Buffer Size</label>
+                        <Input
+                            {...className(['w-full', !isValidArticleBufferSize(config["usenet.article-buffer-size"]) && 'input-error'])}
+                            type="text"
+                            id="article-buffer-size-input"
+                            aria-describedby="article-buffer-size-help"
+                            placeholder="40"
+                            value={config["usenet.article-buffer-size"]}
+                            onChange={e => setNewConfig({ ...config, "usenet.article-buffer-size": e.target.value })} />
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="article-buffer-size-help">
+                            The number of articles to buffer ahead, per stream, when reading from the webdav.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.idle-connection-timeout-seconds">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="idle-connection-timeout-input">Idle connection timeout (seconds)</label>
+                        <Input
+                            {...className(['w-full', !isValidIdleConnectionTimeout(config["usenet.idle-connection-timeout-seconds"]) && 'input-error'])}
+                            type="text"
+                            id="idle-connection-timeout-input"
+                            aria-describedby="idle-connection-timeout-help"
+                            placeholder="60"
+                            value={config["usenet.idle-connection-timeout-seconds"] ?? "60"}
+                            onChange={e => setNewConfig({ ...config, "usenet.idle-connection-timeout-seconds": e.target.value })} />
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="idle-connection-timeout-help">
+                            How long unused NNTP connections stay in the pool before being closed (15–300, default 60).
+                            Raising this can reduce reconnect stalls during playback gaps, but values above your
+                            provider&apos;s server-side idle timeout are counterproductive. Takes effect on the next
+                            connection-pool rebuild (provider config change or restart).
+                        </p>
+                    </div>
+                </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.pipelined-body-requests">
+                    <div className="space-y-2">
+                        <label className="flex items-center gap-2 text-sm text-base-content/80">
+                            <Checkbox
+                                id="pipelined-body-requests-checkbox"
+                                aria-describedby="pipelined-body-requests-help"
+                                checked={config["usenet.pipelined-body-requests"] === "true"}
+                                onChange={e => setNewConfig({ ...config, "usenet.pipelined-body-requests": "" + e.target.checked })} />
+                            <span>Pipelined article downloads</span>
+                        </label>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="pipelined-body-requests-help">
+                            Fetch articles in small NNTP batches for smoother WebDAV streaming. Queue imports use the
+                            separate <strong>Enable NNTP pipelining</strong> toggle under Usenet settings. Disable this
+                            to use the legacy one-at-a-time API while retaining the configured article buffer.
+                        </p>
+                    </div>
+                </ManagedSetting>
+            </SettingsCard>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -24,7 +24,7 @@ function SettingsCard({
     return (
         <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
             <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
-                <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
                     <Icon name={icon} className="!text-[20px]" />
                 </span>
                 <div>


### PR DESCRIPTION
## Summary
- Reorganize Settings → WebDAV into four labeled cards (Access, Queue & connection allocation, Streaming performance, Filesystem & Explorer)
- Add a short intro explaining why queue connection budgets live on this page
- Presentation-only: config keys, validation, IDs, and save behavior are unchanged

## Test plan
- [x] `npm run typecheck && npm run lint && npm test && npm run build` in `frontend/`
- [ ] Open Settings → WebDAV and confirm Access / Filesystem sit side-by-side on desktop and stack on mobile
- [ ] Toggle per-stream limit and segment cache; confirm conditional fields still appear
- [ ] Change a queue/streaming value and save; confirm it persists
- [ ] Confirm ENV-managed fields still show the lock badge when set