### PR TITLE
chore(ui): organize Repairs, Preflight, and Rclone settings

### DIFF
--- a/frontend/app/components/ui/index.ts
+++ b/frontend/app/components/ui/index.ts
@@ -4,5 +4,6 @@ export * from "./form";
 export * from "./icon";
 export * from "./managed-setting";
 export * from "./modal";
+export * from "./settings-card";
 export * from "./settings-nav";
 export * from "./tabs";

--- a/frontend/app/components/ui/settings-card.tsx
+++ b/frontend/app/components/ui/settings-card.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { Icon } from "./icon";
+
+type SettingsCardProps = {
+  icon: string;
+  title: string;
+  description: ReactNode;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+};
+
+/** A labeled settings group with a fixed-size Material Symbol header icon. */
+export function SettingsCard({
+  icon,
+  title,
+  description,
+  children,
+  className = "",
+  contentClassName = "space-y-4",
+}: SettingsCardProps) {
+  return (
+    <section className={`overflow-hidden rounded-lg border border-base-content/10 bg-base-100 ${className}`}>
+      <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
+        <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon name={icon} className="!text-[20px]" />
+        </span>
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-base-content">{title}</h2>
+          <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">{description}</p>
+        </div>
+      </div>
+      <div className={`p-4 ${contentClassName}`}>{children}</div>
+    </section>
+  );
+}

--- a/frontend/app/routes/settings/preflight/preflight.tsx
+++ b/frontend/app/routes/settings/preflight/preflight.tsx
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction } from "react";
-import { Field, Input, Label, ManagedSetting, Select, SettingsIntro, SettingsPage } from "~/components/ui";
+import { Field, Input, Label, ManagedSetting, Select, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
 
 type PreflightSettingsProps = {
     config: Record<string, string>
@@ -20,6 +20,12 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                 more it does.
             </SettingsIntro>
 
+            <SettingsCard
+                icon="fact_check"
+                title="Preflight behavior"
+                description="Choose how much speculative work runs and how long its warm state is reused."
+                contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
+            >
             <ManagedSetting configKey="preflight.mode">
             <Field>
                 <Label htmlFor="preflight-mode">Mode</Label>
@@ -105,6 +111,7 @@ export function PreflightSettings({ config, setNewConfig }: PreflightSettingsPro
                 </p>
             </Field>
             </ManagedSetting>
+            </SettingsCard>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
 import { Spinner } from "~/components/ui/feedback";
-import { ManagedSetting, SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Checkbox, Input } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
@@ -51,6 +51,17 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
 
     return (
         <SettingsPage>
+            <SettingsIntro>
+                Connect NzbDAV to an rclone Remote Control server so mounted directory caches can be
+                refreshed automatically when files change.
+            </SettingsIntro>
+
+            <div className="flex flex-col gap-4">
+            <SettingsCard
+                icon="notifications_active"
+                title="RC notifications"
+                description="Notify the rclone mount whenever WebDAV content is added or removed."
+            >
             <ManagedSetting configKey="rclone.rc-enabled">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
@@ -66,8 +77,15 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="rclone.host">
+            </SettingsCard>
+
+            <SettingsCard
+                icon="dns"
+                title="Server connection"
+                description="Configure and test access to the rclone Remote Control API."
+                contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
+            >
+            <ManagedSetting configKey="rclone.host" className="lg:col-span-2">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-host-input">Rclone Server Host</label>
                 <div className="flex w-full">
@@ -105,7 +123,6 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
             <ManagedSetting configKey="rclone.user">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-user-input">Rclone Server User</label>
@@ -121,7 +138,6 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
             <ManagedSetting configKey="rclone.pass">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="rclone-pass-input">Rclone Server Password</label>
@@ -137,6 +153,8 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 </p>
             </div>
             </ManagedSetting>
+            </SettingsCard>
+            </div>
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -1,4 +1,4 @@
-import { ManagedSetting, SettingsPage } from "~/components/ui";
+import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Checkbox, Input, Select } from "~/components/ui/form";
 import { type Dispatch, type SetStateAction } from "react";
 import { isPositiveInteger } from "../usenet/usenet";
@@ -28,6 +28,18 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
 
     return (
         <SettingsPage>
+            <SettingsIntro>
+                Monitor mounted media for missing articles, tune health-check coverage, and control how
+                broken files are removed or replaced.
+            </SettingsIntro>
+
+            <div className="flex flex-col gap-4">
+            <SettingsCard
+                icon="build"
+                title="Background repairs"
+                description="Connect repair monitoring to the organized media library."
+                contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
+            >
             <ManagedSetting configKey="repair.enable">
             <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm text-base-content/80">
@@ -44,7 +56,30 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
+
+            <ManagedSetting configKey="media.library-dir">
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="library-dir-input">Library Directory</label>
+                <Input
+                    className={'w-full'}
+                    type="text"
+                    id="library-dir-input"
+                    aria-describedby="library-dir-help"
+                    value={config["media.library-dir"]}
+                    onChange={e => setNewConfig({ ...config, "media.library-dir": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="library-dir-help">
+                    The path to your organized media library that contains all your imported symlinks or *.strm files.
+                    Make sure this path is visible to your NzbDAV container.
+                </p>
+            </div>
+            </ManagedSetting>
+            </SettingsCard>
+
+            <SettingsCard
+                icon="monitor_heart"
+                title="Health checks"
+                description="Balance verification coverage against provider connection pressure."
+            >
             <ManagedSetting configKey="repair.healthcheck-concurrency">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="healthcheck-concurrency-input">Health Check Concurrency</label>
@@ -63,8 +98,10 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
-            <ManagedSetting configKeys={["repair.healthcheck-depth", "repair.healthcheck-aging"]}>
+            <ManagedSetting
+                configKeys={["repair.healthcheck-depth", "repair.healthcheck-aging"]}
+                className="grid grid-cols-1 gap-4 lg:grid-cols-2"
+            >
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="healthcheck-depth-input">Health Check Depth</label>
                 <Select
@@ -104,7 +141,14 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
+            </SettingsCard>
+
+            <SettingsCard
+                icon="delete_sweep"
+                title="Automatic cleanup"
+                description="Choose when repeated playback failures should remove broken files."
+                contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
+            >
             <ManagedSetting configKey="repair.auto-remove-after-failures">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Auto-Remove After Streaming Failures</label>
@@ -141,23 +185,8 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </p>
             </div>
             </ManagedSetting>
-            <hr />
-            <ManagedSetting configKey="media.library-dir">
-            <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="library-dir-input">Library Directory</label>
-                <Input
-                    className={'w-full'}
-                    type="text"
-                    id="library-dir-input"
-                    aria-describedby="library-dir-help"
-                    value={config["media.library-dir"]}
-                    onChange={e => setNewConfig({ ...config, "media.library-dir": e.target.value })} />
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="library-dir-help">
-                    The path to your organized media library that contains all your imported symlinks or *.strm files.
-                    Make sure this path is visible to your NzbDAV container.
-                </p>
+            </SettingsCard>
             </div>
-            </ManagedSetting>
         </SettingsPage>
     );
 }


### PR DESCRIPTION
## Summary
- add a reusable settings card with a fixed-size icon badge and responsive content layout
- group Repairs into Background repairs, Health checks, and Automatic cleanup
- place Preflight controls in a clear responsive behavior card
- separate Rclone RC notifications from server connection credentials and testing
- preserve config keys, defaults, validation, disabled states, managed-environment behavior, and update detection

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (existing warnings only, no errors)
- [x] `npm test` (224 tests)
- [x] `npm run build`
- [ ] Verify Repairs, Preflight, and Rclone Server at desktop and narrow widths
- [ ] Confirm dependent controls enable and disable as before
- [ ] Confirm the Rclone connection test button retains its loading/success/error states
- [ ] Confirm ENV-managed controls retain their lock treatment