### PR TITLE
chore(ui): organize Indexer and Radarr/Sonarr settings

### DIFF
--- a/frontend/app/components/ui/settings-card.tsx
+++ b/frontend/app/components/ui/settings-card.tsx
@@ -6,6 +6,7 @@ type SettingsCardProps = {
   title: string;
   description: ReactNode;
   children: ReactNode;
+  action?: ReactNode;
   className?: string;
   contentClassName?: string;
 };
@@ -16,6 +17,7 @@ export function SettingsCard({
   title,
   description,
   children,
+  action,
   className = "",
   contentClassName = "space-y-4",
 }: SettingsCardProps) {
@@ -25,10 +27,11 @@ export function SettingsCard({
         <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
           <Icon name={icon} className="!text-[20px]" />
         </span>
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h2 className="text-sm font-semibold text-base-content">{title}</h2>
           <p className="mt-0.5 text-xs leading-relaxed text-base-content/50">{description}</p>
         </div>
+        {action && <div className="shrink-0">{action}</div>}
       </div>
       <div className={`p-4 ${contentClassName}`}>{children}</div>
     </section>

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
 import { Spinner } from "~/components/ui/feedback";
-import { SettingsPage, ManagedSetting } from "~/components/ui";
+import { SettingsCard, SettingsIntro, SettingsPage, ManagedSetting } from "~/components/ui";
 import { Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
@@ -195,15 +195,25 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
 
     return (
         <SettingsPage>
+            <SettingsIntro>
+                Connect Radarr and Sonarr instances for automated replacement searches, then choose how
+                NzbDAV handles downloads stuck in their queues.
+            </SettingsIntro>
+
             <ManagedSetting configKey="arr.instances">
-            <div className={'space-y-4'}>
-                <div className={'flex items-center justify-between text-lg font-semibold text-base-content'}>
-                    <div>Radarr Instances</div>
+            <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <SettingsCard
+                icon="movie"
+                title="Radarr instances"
+                description="Movie managers that can search for replacement releases."
+                action={
                     <Button variant="primary" size="small" onClick={addRadarrInstance}>
                         <Icon name="add" className="!text-[18px]" />
                         Add
                     </Button>
-                </div>
+                }
+            >
                 {arrConfig.RadarrInstances.length === 0 ? (
                     <div role="alert" className="alert alert-info alert-soft text-sm">No Radarr instances configured. Click on the "Add" button to get started.</div>
                 ) : (
@@ -218,16 +228,19 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                         />
                     )
                 )}
-            </div>
-            <hr />
-            <div className={'space-y-4'}>
-                <div className={'flex items-center justify-between text-lg font-semibold text-base-content'}>
-                    <div>Sonarr Instances</div>
+            </SettingsCard>
+
+            <SettingsCard
+                icon="live_tv"
+                title="Sonarr instances"
+                description="Series managers that can search for replacement releases."
+                action={
                     <Button variant="primary" size="small" onClick={addSonarrInstance}>
                         <Icon name="add" className="!text-[18px]" />
                         Add
                     </Button>
-                </div>
+                }
+            >
                 {arrConfig.SonarrInstances.length === 0 ? (
                     <div role="alert" className="alert alert-info alert-soft text-sm">No Sonarr instances configured. Click on the "Add" button to get started.</div>
                 ) : (
@@ -242,10 +255,14 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                         />
                     )
                 )}
+            </SettingsCard>
             </div>
-            <hr />
-            <div className="space-y-4">
-                <div className="text-lg font-semibold">Automatic Queue Management</div>
+
+            <SettingsCard
+                icon="rule"
+                title="Automatic queue management"
+                description="Choose how matching Radarr and Sonarr queue warnings should be handled."
+            >
                 <div role="alert" className="alert alert-info alert-soft text-sm">
                     Configure what to do for items stuck in Radarr / Sonarr queues.
                     Different actions can be configured for different status messages.
@@ -277,6 +294,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                         );
                     })}
                 </ul>
+            </SettingsCard>
             </div>
             </ManagedSetting>
         </SettingsPage>

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -11,6 +11,9 @@ import {
     ManagedSetting,
     Modal,
     Select,
+    SettingsCard,
+    SettingsIntro,
+    SettingsPage,
     Spinner,
     Textarea,
     useIsAnyManaged,
@@ -335,17 +338,18 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         : "";
 
     return (
-        <div className="mb-6 flex w-full flex-col gap-6">
-            <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between gap-3">
-                    <div>
-                        <div className="text-base font-semibold text-base-content">Defaults</div>
-                        <HelpText className="mt-1 text-xs">
-                            Global settings used by indexers when no per-indexer override is set.
-                        </HelpText>
-                    </div>
-                </div>
-                <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+        <SettingsPage className="mb-6">
+            <SettingsIntro>
+                Configure shared search behavior, filter unwanted results, and manage the Newznab-compatible
+                indexers NzbDAV queries.
+            </SettingsIntro>
+
+            <SettingsCard
+                icon="tune"
+                title="Connection defaults"
+                description="Fallback connection and request settings used when an indexer has no override."
+                contentClassName="grid grid-cols-1 gap-3.5 sm:grid-cols-2"
+            >
                     <ManagedSetting configKey="indexers.instances" className="sm:col-span-2">
                     <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-default-proxy">HTTP(S) Proxy URL</Label>
@@ -423,7 +427,13 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                         />
                     </div>
                     </ManagedSetting>
+            </SettingsCard>
 
+            <SettingsCard
+                icon="filter_alt"
+                title="Result exclusions"
+                description="Drop matching releases with local patterns or synchronized external lists."
+            >
                     <ManagedSetting configKey="search.exclude-patterns" className="sm:col-span-2">
                     <div className="flex flex-col gap-1.5">
                         <Label htmlFor="indexers-exclude-patterns">
@@ -530,16 +540,17 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                         </HelpText>
                     </div>
                     </ManagedSetting>
-                </div>
-            </div>
+            </SettingsCard>
 
             <ManagedSetting configKey="indexers.instances">
-            <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between gap-3">
-                    <div className="text-base font-semibold text-base-content">Indexers</div>
+            <SettingsCard
+                icon="travel_explore"
+                title="Configured indexers"
+                description="Add, enable, and tune the services used to discover NZB releases."
+                action={
                     <Button size="xsmall" onClick={handleAdd}>Add</Button>
-                </div>
-
+                }
+            >
                 {indexerConfig.Indexers.length === 0 ? (
                     <p className="rounded border border-base-content/10 bg-base-200/40 px-5 py-5 text-sm italic text-base-content/60">
                         No indexers configured. Add a Newznab-compatible indexer (or aggregator) to enable search.
@@ -557,7 +568,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                         ))}
                     </div>
                 )}
-            </div>
+            </SettingsCard>
 
             <IndexerModal
                 show={showModal}
@@ -566,7 +577,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                 onSave={handleSave}
             />
             </ManagedSetting>
-        </div>
+        </SettingsPage>
     );
 }
 


### PR DESCRIPTION
## Summary
- add header actions to the shared settings card for contextual Add buttons
- group Indexers into Connection defaults, Result exclusions, and Configured indexers
- place Radarr and Sonarr instances in matching responsive cards
- group automatic Arr queue rules into their own card
- preserve config serialization, validation, connection testing, modals, and managed-environment behavior

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (existing warnings only, no errors)
- [x] `npm test` (224 tests)
- [x] `npm run build`
- [ ] Verify Indexers and Radarr/Sonarr settings at desktop and narrow widths
- [ ] Add/edit/test an indexer and confirm its modal behavior is unchanged
- [ ] Add/test/remove Radarr and Sonarr instances and change a queue rule