### PR TITLE
fix(ui): keep queue category labels on one line

### DIFF
--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -148,7 +148,14 @@ function isSameDate(a: Date, b: Date): boolean {
 
 export function CategoryBadge({ category }: { category: string }) {
     const categoryLower = category?.toLowerCase();
-    return <Badge className="badge-outline badge-sm w-[88px] lowercase">{categoryLower}</Badge>;
+    return (
+        <Badge
+            className="badge-outline badge-sm min-w-[88px] max-w-[120px] shrink-0 justify-center whitespace-nowrap lowercase"
+            title={`Category: ${categoryLower}`}
+        >
+            <span className="min-w-0 truncate">{categoryLower}</span>
+        </Badge>
+    );
 }
 
 export function IndexerBadge({ indexer }: { indexer: string }) {


### PR DESCRIPTION
## Summary
- prevent queue and history category badges from wrapping onto two lines
- allow common category names to expand from 88px up to 120px
- truncate unusually long categories while preserving the full value in a title tooltip

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (existing warnings only, no errors)
- [x] `npm test` (224 tests)
- [x] `npm run build`
- [ ] Verify categories such as `sonarr-nzbdav` stay on one line in Queue and History
- [ ] Verify unusually long categories truncate without widening the table excessively