### PR TITLE
fix(webdav): stop cancelled directory scans from flooding logs

### DIFF
--- a/backend/Logging/NWebDavLogFilter.cs
+++ b/backend/Logging/NWebDavLogFilter.cs
@@ -1,0 +1,18 @@
+using Serilog.Events;
+
+namespace NzbWebDAV.Logging;
+
+internal static class NWebDavLogFilter
+{
+    private const string PropFindHandlerSource = "NWebDav.Server.Handlers.PropFindHandler";
+    private const string PropertyErrorPrefix = "Property ";
+
+    internal static bool IsCancelledPropFindPropertyError(LogEvent logEvent)
+    {
+        return logEvent.Exception is OperationCanceledException
+               && logEvent.Properties.TryGetValue("SourceContext", out var sourceContext)
+               && sourceContext is ScalarValue { Value: string source }
+               && string.Equals(source, PropFindHandlerSource, StringComparison.Ordinal)
+               && logEvent.MessageTemplate.Text.StartsWith(PropertyErrorPrefix, StringComparison.Ordinal);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -64,6 +64,18 @@ class Program
             .MinimumLevel.Override("Microsoft.AspNetCore.Routing", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Server.Kestrel", AtLeast(level, LogEventLevel.Error))
             .MinimumLevel.Override("Microsoft.AspNetCore.DataProtection", AtLeast(level, LogEventLevel.Error))
+            // Suppress NWebDav's per-property "raised an exception" Errors when
+            // the cause is client cancellation. When a WebDAV client disconnects
+            // mid-PROPFIND, PropFindHandler keeps iterating its property list
+            // and every remaining property's getter throws
+            // OperationCanceledException against the now-cancelled token. Each
+            // one logs an Error with a full stack trace — ~10 lines for a
+            // single cancelled PROPFIND, and clients like Plex/Jellyfin/rclone
+            // cancel slow PROPFINDs routinely. Client cancellation is normal
+            // behaviour, not an error worth alerting on.
+            .Filter.ByExcluding(e =>
+                e.Exception is OperationCanceledException
+                && e.MessageTemplate.Text.StartsWith("Property "))
             .WriteTo.Console(new ExpressionTemplate(
                 "[{@t:HH:mm:ss} {@l:u3}] " +
                 "{#if SourceContext is not null}" +

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -64,18 +64,9 @@ class Program
             .MinimumLevel.Override("Microsoft.AspNetCore.Routing", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Server.Kestrel", AtLeast(level, LogEventLevel.Error))
             .MinimumLevel.Override("Microsoft.AspNetCore.DataProtection", AtLeast(level, LogEventLevel.Error))
-            // Suppress NWebDav's per-property "raised an exception" Errors when
-            // the cause is client cancellation. When a WebDAV client disconnects
-            // mid-PROPFIND, PropFindHandler keeps iterating its property list
-            // and every remaining property's getter throws
-            // OperationCanceledException against the now-cancelled token. Each
-            // one logs an Error with a full stack trace — ~10 lines for a
-            // single cancelled PROPFIND, and clients like Plex/Jellyfin/rclone
-            // cancel slow PROPFINDs routinely. Client cancellation is normal
-            // behaviour, not an error worth alerting on.
-            .Filter.ByExcluding(e =>
-                e.Exception is OperationCanceledException
-                && e.MessageTemplate.Text.StartsWith("Property "))
+            // NWebDav logs every remaining property as an Error after a
+            // PROPFIND client disconnects. Suppress only that known event.
+            .Filter.ByExcluding(NWebDavLogFilter.IsCancelledPropFindPropertyError)
             .WriteTo.Console(new ExpressionTemplate(
                 "[{@t:HH:mm:ss} {@l:u3}] " +
                 "{#if SourceContext is not null}" +

--- a/tests/NzbWebDAV.Tests/NWebDavLogFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/NWebDavLogFilterTests.cs
@@ -1,0 +1,80 @@
+using NzbWebDAV.Logging;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Logging;
+
+public class NWebDavLogFilterTests
+{
+    private const string PropFindHandlerSource = "NWebDav.Server.Handlers.PropFindHandler";
+
+    [Fact]
+    public void CancelledPropFindPropertyError_IsExcluded()
+    {
+        var events = CaptureFilteredLogs(logger =>
+            WritePropertyError(logger, PropFindHandlerSource, new OperationCanceledException()));
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void NonCancellationPropertyError_IsRetained()
+    {
+        var events = CaptureFilteredLogs(logger =>
+            WritePropertyError(logger, PropFindHandlerSource, new InvalidOperationException()));
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void CancelledPropertyErrorFromAnotherSource_IsRetained()
+    {
+        var events = CaptureFilteredLogs(logger =>
+            WritePropertyError(logger, "NzbWebDAV.SomeComponent", new OperationCanceledException()));
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void OtherCancelledPropFindError_IsRetained()
+    {
+        var events = CaptureFilteredLogs(logger =>
+            logger
+                .ForContext("SourceContext", PropFindHandlerSource)
+                .Error(new OperationCanceledException(), "PROPFIND response failed"));
+
+        Assert.Single(events);
+    }
+
+    private static void WritePropertyError(ILogger logger, string source, Exception exception)
+    {
+        logger
+            .ForContext("SourceContext", source)
+            .Error(
+                exception,
+                "Property {PropertyName} on item {ItemName} raised an exception.",
+                "{DAV:}displayname",
+                "item");
+    }
+
+    private static IReadOnlyList<LogEvent> CaptureFilteredLogs(Action<ILogger> write)
+    {
+        var sink = new CollectingSink();
+        using var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .Filter.ByExcluding(NWebDavLogFilter.IsCancelledPropFindPropertyError)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        write(logger);
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+}


### PR DESCRIPTION
## Summary
- suppress NWebDav's repeated per-property cancellation errors after a PROPFIND client disconnects
- scope suppression to the exact NWebDav PROPFIND handler so unrelated cancellation errors remain visible
- cover the excluded event and neighboring retained events with regression tests

Supersedes #550 because GitHub rejected maintainer pushes to its organization-owned fork despite `maintainerCanModify` being enabled. The original contributor commit and attribution are preserved in this branch.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~NWebDavLogFilterTests`
- [ ] CI backend suite (the local full suite requires the macOS `rapidyenc` native library)