### PR TITLE
fix(ui): restore frontend startup after compression-filter ESM import failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,20 @@ jobs:
         run: npm run build && npm run build:server
 
       # Node ESM requires explicit .js extensions in emitted dist-node imports.
+      # Import every helper under dist-node/server/ (not server.js, which listens).
       - name: Smoke-import dist-node server modules
         working-directory: frontend
-        run: node --input-type=module -e "import('./dist-node/server/security-headers.js')"
+        run: |
+          node --input-type=module <<'EOF'
+          import { readdir } from "node:fs/promises";
+
+          const directory = "./dist-node/server";
+          for (const file of await readdir(directory)) {
+            if (file.endsWith(".js")) {
+              await import(`${directory}/${file}`);
+            }
+          }
+          EOF
 
       # The production launcher (server.ts) requires these exports; a build that
       # falls back to the virtual SSR entry ships a server that crashes on start.

--- a/frontend/server/compression-filter.ts
+++ b/frontend/server/compression-filter.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import compression from "compression";
-import { shouldSkipCompression } from "./proxy-path";
+import { shouldSkipCompression } from "./proxy-path.js";
 
 // React Router streams document and `.data` responses and calls res.flush()
 // after every chunk. Express `compression` maps that to zlib flush, which


### PR DESCRIPTION
## Summary
- Fix production frontend crash (`ERR_MODULE_NOT_FOUND` for `proxy-path`) by adding the required `.js` extension on the compression-filter import.
- Broaden CI to smoke-import every emitted `dist-node/server/*.js` helper so this class of Node ESM resolution failure cannot ship again.

Affects `:dev` / post-#598 source builds; stable `v0.8.1` is unaffected. After merge, dispatch **Pre-release** to refresh the `:dev` image.

## Test plan
- [x] Reproduced failure with smoke-import before the fix
- [x] `npm run typecheck && npm run lint && npm run build && npm run build:server`
- [x] Smoke-import of every `dist-node/server/*.js` helper succeeds
- [x] `npm test` (231 tests passed)