### PR TITLE
fix(ui): hide explore delete controls when WebDAV is read-only

### DIFF
--- a/frontend/app/routes/explore/route.test.ts
+++ b/frontend/app/routes/explore/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getConfigMock, listWebdavDirectoryMock } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+  listWebdavDirectoryMock: vi.fn(),
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    getConfig: getConfigMock,
+    listWebdavDirectory: listWebdavDirectoryMock,
+  },
+  WebdavDirectoryNotFoundError: class WebdavDirectoryNotFoundError extends Error {},
+}));
+
+import { isDeletable, loader } from "./route";
+import type { ExplorePageData } from "./route";
+
+function loaderArgs(wildcard: string) {
+  return {
+    request: new Request(`http://localhost/explore/${wildcard}`),
+    params: { "*": wildcard },
+  } as unknown as Parameters<typeof loader>[0];
+}
+
+describe("isDeletable", () => {
+  it("is not deletable above two directories deep", () => {
+    expect(isDeletable([], false)).toBe(false);
+    expect(isDeletable(["content"], false)).toBe(false);
+  });
+
+  it("is deletable two or more directories deep when writable", () => {
+    expect(isDeletable(["content", "movie"], false)).toBe(true);
+    expect(isDeletable(["content", "show", "season"], false)).toBe(true);
+  });
+
+  it("is never deletable while WebDAV is read-only", () => {
+    expect(isDeletable(["content", "movie"], true)).toBe(false);
+  });
+});
+
+describe("explore loader read-only state", () => {
+  beforeEach(() => {
+    getConfigMock.mockReset();
+    listWebdavDirectoryMock.mockReset();
+    listWebdavDirectoryMock.mockResolvedValue([]);
+  });
+
+  it("requests the enforce-readonly setting and reports it enabled", async () => {
+    getConfigMock.mockResolvedValue([
+      { configName: "webdav.enforce-readonly", configValue: "true" },
+    ]);
+
+    const data = (await loader(loaderArgs("content/movie"))) as ExplorePageData;
+
+    expect(getConfigMock).toHaveBeenCalledWith(["webdav.enforce-readonly"]);
+    expect(data.enforceReadonly).toBe(true);
+  });
+
+  it("reports read-write when the setting is off", async () => {
+    getConfigMock.mockResolvedValue([
+      { configName: "webdav.enforce-readonly", configValue: "false" },
+    ]);
+
+    const data = (await loader(loaderArgs("content/movie"))) as ExplorePageData;
+
+    expect(data.enforceReadonly).toBe(false);
+  });
+
+  it("defaults to read-only when the setting is unset or empty, matching the backend", async () => {
+    getConfigMock.mockResolvedValueOnce([]);
+    expect(((await loader(loaderArgs("content/movie"))) as ExplorePageData).enforceReadonly).toBe(true);
+
+    getConfigMock.mockResolvedValueOnce([
+      { configName: "webdav.enforce-readonly", configValue: "" },
+    ]);
+    expect(((await loader(loaderArgs("content/movie"))) as ExplorePageData).enforceReadonly).toBe(true);
+  });
+});

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -25,6 +25,7 @@ export type ExplorePageData = {
     parentDirectories: string[],
     items: (DirectoryItem | ExploreFile)[],
     error: "not-found" | null,
+    enforceReadonly: boolean,
 }
 
 export type ExploreFile = DirectoryItem & {
@@ -46,14 +47,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             parentDirectories: [],
             items: [],
             error: "not-found" as const,
+            enforceReadonly: true,
         };
     }
     const path = parsed.path;
     try {
+        const [entries, config] = await Promise.all([
+            backendClient.listWebdavDirectory(path),
+            backendClient.getConfig(["webdav.enforce-readonly"]),
+        ]);
+        // WebDAV is read-only by default in the backend, so an unset or empty value counts as enforced.
+        const enforceReadonlyValue = config.find(x => x.configName === "webdav.enforce-readonly")?.configValue;
+        const enforceReadonly = !enforceReadonlyValue || enforceReadonlyValue.toLowerCase() === "true";
         return {
             parentDirectories: getParentDirectories(path),
             error: null,
-            items: (await backendClient.listWebdavDirectory(path)).map(x => {
+            enforceReadonly,
+            items: entries.map(x => {
                 if (x.isDirectory) return x;
                 return {
                     ...x,
@@ -68,6 +78,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             parentDirectories: getParentDirectories(path),
             items: [],
             error: "not-found" as const,
+            enforceReadonly: true,
         };
     }
 }
@@ -88,7 +99,7 @@ function Body(props: ExplorePageData) {
     const parentDirectories = isNavigating
         ? getParentDirectories(getWebdavPathDecoded(navigation.location!.pathname))
         : props.parentDirectories;
-    const canDelete = isDeletable(parentDirectories);
+    const canDelete = isDeletable(parentDirectories, props.enforceReadonly);
 
     const [query, setQuery] = useState("");
     const [sortKey, setSortKey] = useState<SortKey>("name");
@@ -657,8 +668,8 @@ function getParentDirectories(webdavPath: string): string[] {
     return webdavPath == "" ? [] : webdavPath.split('/');
 }
 
-function isDeletable(parentDirectories: string[]): boolean {
-    return parentDirectories.length >= 2;
+export function isDeletable(parentDirectories: string[], enforceReadonly: boolean): boolean {
+    return parentDirectories.length >= 2 && !enforceReadonly;
 }
 
 function getClassName(item: DirectoryItem | ExploreFile, isSelected: boolean) {


### PR DESCRIPTION
The remove button throws an error if you try to use it while the WebDAV is in read only mode, so hide it.