### PR TITLE
fix(rclone): stop dumping stacks when rclone RC requests time out

### DIFF
--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -213,12 +213,15 @@ public class RcloneClient
         }
         catch (HttpRequestException ex)
         {
-            Log.Warning(ex, "Rclone RC request to {Endpoint} failed", endpoint);
+            Log.Warning("Rclone RC request to {Endpoint} failed. Reason: {Reason}", endpoint, ex.Message);
             return new T { Success = false, Error = ex.Message };
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException)
         {
-            Log.Warning(ex, "Rclone RC request to {Endpoint} timed out", endpoint);
+            Log.Warning(
+                "Rclone RC request to {Endpoint} timed out after {TimeoutSeconds}s",
+                endpoint,
+                (int)HttpClient.Timeout.TotalSeconds);
             return new T { Success = false, Error = "Request timed out" };
         }
     }


### PR DESCRIPTION
## Summary
- Log rclone RC timeouts and `HttpRequestException` failures as single-line Warnings without exception objects.
- Keep returning `Success = false` so callers behave the same; this only removes operator-facing stack noise.

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (929 passed; 1 pre-existing local failure from missing `rapidyenc` native dylib, unrelated to this change)
- [ ] Confirm a timed-out `vfs/forget` produces one Warning line and no stack dump in container logs