### PR TITLE
fix(ui): keep live updates connected during bursty activity

### DIFF
--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.WebSockets;
+﻿using System.Diagnostics;
+using System.Net.WebSockets;
 using System.Text;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Http;
@@ -71,12 +72,7 @@ public class WebsocketManager
 
         var bytes = SerializeMessage(topic, message);
         foreach (var session in sessions)
-        {
-            if (session.TryEnqueue(topic, bytes)) continue;
-
-            Log.Warning("Disconnecting websocket client because its outbound event queue is full");
-            AbortSocket(session);
-        }
+            session.TryEnqueue(topic, bytes);
 
         return Task.CompletedTask;
     }
@@ -167,6 +163,13 @@ public class WebsocketManager
                     var stateMessages = session.TakePendingState();
                     var eventMessages = session.TakePendingEvents();
                     if (stateMessages.Count == 0 && eventMessages.Count == 0) break;
+
+                    if (session.TryTakeDroppedEventMessageCount(out var droppedEventMessageCount))
+                    {
+                        Log.Warning(
+                            "Websocket client is consuming events too slowly; dropped {Count} event messages",
+                            droppedEventMessageCount);
+                    }
 
                     foreach (var message in stateMessages)
                         await SendToSocket(session, message).ConfigureAwait(false);
@@ -279,13 +282,7 @@ public class WebsocketManager
     {
         private readonly object _stateLock = new();
         private readonly Dictionary<WebsocketTopic, ArraySegment<byte>> _pendingState = new();
-        private readonly Channel<ArraySegment<byte>> _eventMessages =
-            Channel.CreateBounded<ArraySegment<byte>>(new BoundedChannelOptions(EventQueueCapacity)
-            {
-                FullMode = BoundedChannelFullMode.Wait,
-                SingleReader = true,
-                SingleWriter = false
-            });
+        private readonly Channel<ArraySegment<byte>> _eventMessages;
         private readonly Channel<bool> _workSignal =
             Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
             {
@@ -295,11 +292,21 @@ public class WebsocketManager
             });
         private readonly CancellationTokenSource _cancellation =
             CancellationTokenSource.CreateLinkedTokenSource(SigtermUtil.GetCancellationToken());
+        private long _droppedEventMessageCount;
+        private long _lastDroppedEventWarningTimestamp;
         private int _stopped;
 
         public SocketSession(WebSocket socket)
         {
             Socket = socket;
+            _eventMessages = Channel.CreateBounded<ArraySegment<byte>>(
+                new BoundedChannelOptions(EventQueueCapacity)
+                {
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = false
+                },
+                _ => Interlocked.Increment(ref _droppedEventMessageCount));
         }
 
         public WebSocket Socket { get; }
@@ -349,6 +356,24 @@ public class WebsocketManager
             while (messages.Count < EventQueueCapacity && _eventMessages.Reader.TryRead(out var message))
                 messages.Add(message);
             return messages;
+        }
+
+        public bool TryTakeDroppedEventMessageCount(out long count)
+        {
+            count = 0;
+            if (Volatile.Read(ref _droppedEventMessageCount) == 0) return false;
+
+            var now = Stopwatch.GetTimestamp();
+            var lastWarning = Volatile.Read(ref _lastDroppedEventWarningTimestamp);
+            if (lastWarning != 0 &&
+                Stopwatch.GetElapsedTime(lastWarning, now) < TimeSpan.FromMinutes(1))
+                return false;
+
+            if (Interlocked.CompareExchange(ref _lastDroppedEventWarningTimestamp, now, lastWarning) != lastWarning)
+                return false;
+
+            count = Interlocked.Exchange(ref _droppedEventMessageCount, 0);
+            return count > 0;
         }
 
         public bool Stop()

--- a/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
@@ -69,7 +69,7 @@ public class WebsocketManagerTests
     }
 
     [Fact]
-    public async Task EventQueueOverflow_AbortsAndRemovesSlowSocket()
+    public async Task EventQueueOverflow_DropsOldestEventsAndKeepsSocketConnected()
     {
         var manager = new WebsocketManager();
         using var socket = new TestWebSocket(blockSends: true);
@@ -83,8 +83,16 @@ public class WebsocketManagerTests
             for (var i = 0; i <= 64; i++)
                 await manager.SendMessage(WebsocketTopic.QueueItemAdded, $"event-{i}");
 
-            await WaitUntil(() => socket.Aborted);
-            Assert.Equal(0, manager.GetAuthenticatedSocketCount());
+            socket.ReleaseSends();
+            await WaitUntil(() => socket.Messages.Count == 65);
+
+            Assert.False(socket.Aborted);
+            Assert.Equal(1, manager.GetAuthenticatedSocketCount());
+            var messages = socket.Messages.Select(Parse).ToList();
+            Assert.Equal("blocked", messages[0].Message);
+            Assert.Equal(
+                Enumerable.Range(1, 64).Select(i => $"event-{i}"),
+                messages.Skip(1).Select(x => x.Message));
         }
         finally
         {


### PR DESCRIPTION
## Summary
- retain the frontend websocket relay when event bursts fill its outbound buffer
- discard only the oldest queued event and provide a throttled operator warning
- cover queue overflow delivery with a websocket manager test

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~WebsocketManagerTests\"`
- [ ] Full backend suite is blocked locally by a missing macOS `rapidyenc` native library in `MultiSegmentStreamPrefetchBudgetTests`