### PR TITLE
fix(ui): recover failed uploads and preserve encoded Explore paths

### DIFF
--- a/frontend/app/routes/explore/breadcrumbs/breadcrumbs.tsx
+++ b/frontend/app/routes/explore/breadcrumbs/breadcrumbs.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 import { useCallback } from "react"
 import { useNavigate } from "react-router"
 import { Icon } from "~/components/ui"
+import { getExploreBreadcrumbHref } from "~/utils/path"
 
 export type BreadcrumbProps = {
     parentDirectories: string[]
@@ -10,8 +11,7 @@ export type BreadcrumbProps = {
 export function Breadcrumbs({ parentDirectories }: BreadcrumbProps): ReactNode {
     const navigate = useNavigate();
     const onClick = useCallback((index: number) => {
-        if (index === -1) return navigate("/explore");
-        navigate(`/explore/${parentDirectories.slice(0, index + 1).join('/')}`)
+        navigate(getExploreBreadcrumbHref(parentDirectories, index));
     }, [parentDirectories, navigate]);
 
     return (

--- a/frontend/app/routes/queue/controllers/nzb-upload-controller.test.ts
+++ b/frontend/app/routes/queue/controllers/nzb-upload-controller.test.ts
@@ -1,0 +1,162 @@
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UploadingFile } from "../route";
+import {
+    buildAddFileUploadUrl,
+    getXhrErrorMessage,
+    processUploadQueue,
+} from "./nzb-upload-controller";
+
+type XhrScenario = (xhr: FakeXmlHttpRequest) => void;
+
+class FakeXmlHttpRequest {
+    static scenarios: XhrScenario[] = [];
+    static urls: string[] = [];
+
+    status = 0;
+    statusText = "";
+    response: unknown = null;
+    responseText = "";
+    responseType = "";
+    timeout = 0;
+    upload = {
+        addEventListener: (_name: string, _listener: () => void) => undefined,
+    };
+    private listeners = new Map<string, (() => void)[]>();
+
+    addEventListener(name: string, listener: () => void) {
+        this.listeners.set(name, [...(this.listeners.get(name) ?? []), listener]);
+    }
+
+    open(_method: string, url: string) {
+        FakeXmlHttpRequest.urls.push(url);
+    }
+
+    send(_body: FormData) {
+        const scenario = FakeXmlHttpRequest.scenarios.shift();
+        if (!scenario) throw new Error("Missing fake XHR scenario");
+        scenario(this);
+    }
+
+    dispatch(name: string) {
+        for (const listener of this.listeners.get(name) ?? []) listener();
+    }
+}
+
+function createUploadingFile(id: string): UploadingFile {
+    return {
+        file: new File(["nzb"], `${id}.nzb`),
+        queueSlot: {
+            nzo_id: id,
+            priority: "0",
+            filename: `${id}.nzb`,
+            cat: "uncategorized",
+            percentage: "0",
+            true_percentage: "0",
+            status: "queued",
+            mb: "0",
+            mbleft: "0",
+        },
+    };
+}
+
+function createState(files: UploadingFile[]) {
+    let currentFiles = files;
+    const setUploadingFiles = (update: React.SetStateAction<UploadingFile[]>) => {
+        currentFiles = typeof update === "function" ? update(currentFiles) : update;
+    };
+
+    return {
+        get files() {
+            return currentFiles;
+        },
+        setUploadingFiles,
+    };
+}
+
+function successfulResponse(xhr: FakeXmlHttpRequest) {
+    xhr.status = 200;
+    xhr.response = { status: true };
+    xhr.dispatch("load");
+}
+
+describe("buildAddFileUploadUrl", () => {
+    it("serializes manual categories as individual query parameters", () => {
+        const url = new URL(buildAddFileUploadUrl("tv & movies=a#100% C++ 日本語"), "https://nzbdav.test");
+
+        expect(url.pathname).toBe("/api");
+        expect(Object.fromEntries(url.searchParams)).toEqual({
+            mode: "addfile",
+            cat: "tv & movies=a#100% C++ 日本語",
+            priority: "0",
+            pp: "0",
+        });
+    });
+});
+
+describe("getXhrErrorMessage", () => {
+    it("uses a structured JSON error when present", () => {
+        expect(getXhrErrorMessage({
+            response: { error: "Invalid NZB" },
+            responseText: "",
+            status: 400,
+            statusText: "Bad Request",
+        })).toBe("Invalid NZB");
+    });
+
+    it("falls back to a text proxy response", () => {
+        expect(getXhrErrorMessage({
+            response: null,
+            responseText: "Bad Gateway",
+            status: 502,
+            statusText: "",
+        })).toBe("Bad Gateway");
+    });
+
+    it("falls back to the HTTP status for an empty response", () => {
+        expect(getXhrErrorMessage({
+            response: null,
+            responseText: "",
+            status: 500,
+            statusText: "",
+        })).toBe("Upload failed with status 500");
+    });
+});
+
+describe("processUploadQueue", () => {
+    afterEach(() => {
+        FakeXmlHttpRequest.scenarios = [];
+        FakeXmlHttpRequest.urls = [];
+        vi.unstubAllGlobals();
+    });
+
+    it.each([
+        ["a plain-text HTTP failure", (xhr: FakeXmlHttpRequest) => {
+            xhr.status = 502;
+            xhr.responseText = "Bad Gateway";
+            xhr.dispatch("load");
+        }, "Bad Gateway"],
+        ["a network error", (xhr: FakeXmlHttpRequest) => xhr.dispatch("error"), "Upload failed"],
+        ["an aborted upload", (xhr: FakeXmlHttpRequest) => xhr.dispatch("abort"), "Upload aborted"],
+        ["a timed out upload", (xhr: FakeXmlHttpRequest) => xhr.dispatch("timeout"), "Upload timed out"],
+    ])("continues after %s", async (_description, failedResponse, errorMessage) => {
+        vi.stubGlobal("XMLHttpRequest", FakeXmlHttpRequest);
+        FakeXmlHttpRequest.scenarios = [failedResponse, successfulResponse];
+
+        const first = createUploadingFile("first");
+        const second = createUploadingFile("second");
+        const state = createState([first, second]);
+        const queueRef = { current: [first, second] } as React.RefObject<UploadingFile[]>;
+        const isUploadingRef = { current: false } as React.RefObject<boolean>;
+
+        await processUploadQueue(isUploadingRef, queueRef, state.setUploadingFiles);
+
+        expect(state.files[0].queueSlot).toMatchObject({
+            status: "upload failed",
+            error: errorMessage,
+        });
+        expect(FakeXmlHttpRequest.urls).toHaveLength(2);
+        expect(queueRef.current).toEqual([]);
+        expect(isUploadingRef.current).toBe(false);
+    });
+});

--- a/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
+++ b/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
@@ -1,6 +1,16 @@
 import { useEffect } from "react";
 import type { UploadingFile } from "../route";
 
+const UPLOAD_TIMEOUT_MS = 120_000;
+const MAX_RESPONSE_TEXT_LENGTH = 500;
+
+type UploadResponse = {
+    status?: unknown;
+    error?: unknown;
+};
+
+type XhrErrorResponse = Pick<XMLHttpRequest, "response" | "responseText" | "status" | "statusText">;
+
 export function initializeUploadController(
     isUploadingRef: React.RefObject<boolean>,
     uploadQueueRef: React.RefObject<UploadingFile[]>,
@@ -12,83 +22,137 @@ export function initializeUploadController(
     }, [uploadingFiles]);
 }
 
-async function processUploadQueue(
+export function buildAddFileUploadUrl(category: string): string {
+    const params = new URLSearchParams({
+        mode: "addfile",
+        cat: category,
+        priority: "0",
+        pp: "0",
+    });
+    return `/api?${params.toString()}`;
+}
+
+export function getXhrErrorMessage(xhr: XhrErrorResponse): string {
+    if (
+        typeof xhr.response === "object" &&
+        xhr.response !== null &&
+        "error" in xhr.response &&
+        typeof xhr.response.error === "string" &&
+        xhr.response.error.trim() !== ""
+    ) {
+        return xhr.response.error;
+    }
+
+    if (xhr.statusText.trim() !== "") return xhr.statusText;
+
+    const responseText = xhr.responseText.trim();
+    if (responseText !== "") return responseText.slice(0, MAX_RESPONSE_TEXT_LENGTH);
+
+    return `Upload failed with status ${xhr.status}`;
+}
+
+function getUploadResponseError(response: unknown): string | undefined {
+    if (
+        typeof response !== "object" ||
+        response === null ||
+        !("status" in response) ||
+        response.status !== false
+    ) {
+        return undefined;
+    }
+
+    const error = "error" in response ? response.error : undefined;
+    return typeof error === "string" && error.trim() !== ""
+        ? error
+        : "Upload failed";
+}
+
+function uploadNzbFile(fileToUpload: UploadingFile, setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void): Promise<UploadResponse> {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        const formData = new FormData();
+        let settled = false;
+
+        const settle = (callback: () => void) => {
+            if (settled) return;
+            settled = true;
+            callback();
+        };
+
+        formData.append("nzbFile", fileToUpload.file, fileToUpload.file.name);
+        xhr.responseType = "json";
+        xhr.timeout = UPLOAD_TIMEOUT_MS;
+        xhr.upload.addEventListener("progress", (e) => {
+            if (!e.lengthComputable) return;
+
+            const progress = Math.round((e.loaded / e.total) * 100);
+            setUploadingFiles(files => files.map(f =>
+                f.queueSlot.nzo_id === fileToUpload.queueSlot.nzo_id
+                    ? {
+                        ...f,
+                        queueSlot: {
+                            ...f.queueSlot,
+                            percentage: progress.toString(),
+                            true_percentage: progress.toString(),
+                        },
+                    }
+                    : f
+            ));
+        });
+
+        xhr.addEventListener("load", () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                settle(() => resolve(xhr.response as UploadResponse));
+            } else {
+                settle(() => reject(new Error(getXhrErrorMessage(xhr))));
+            }
+        });
+        xhr.addEventListener("error", () => settle(() => reject(new Error("Upload failed"))));
+        xhr.addEventListener("abort", () => settle(() => reject(new Error("Upload aborted"))));
+        xhr.addEventListener("timeout", () => settle(() => reject(new Error("Upload timed out"))));
+
+        xhr.open("POST", buildAddFileUploadUrl(fileToUpload.queueSlot.cat));
+        xhr.send(formData);
+    });
+}
+
+export async function processUploadQueue(
     isUploadingRef: React.RefObject<boolean>,
     uploadQueueRef: React.RefObject<UploadingFile[]>,
-    setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void
+    setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void,
 ) {
     if (isUploadingRef.current || uploadQueueRef.current.length === 0) return;
 
     isUploadingRef.current = true;
-    const fileToUpload = uploadQueueRef.current[0];
-
-    setUploadingFiles(files => files.map(f =>
-        f.queueSlot.nzo_id === fileToUpload.queueSlot.nzo_id
-            ? { ...f, queueSlot: { ...f.queueSlot, status: 'uploading' } }
-            : f
-    ));
-
     try {
-        const xhr = new XMLHttpRequest();
-        const formData = new FormData();
-        formData.append('nzbFile', fileToUpload.file, fileToUpload.file.name);
+        while (uploadQueueRef.current.length > 0) {
+            const fileToUpload = uploadQueueRef.current[0];
+            setUploadingFiles(files => files.map(f =>
+                f.queueSlot.nzo_id === fileToUpload.queueSlot.nzo_id
+                    ? { ...f, queueSlot: { ...f.queueSlot, status: "uploading" } }
+                    : f
+            ));
 
-        xhr.responseType = 'json';
-        xhr.upload.addEventListener('progress', (e) => {
-            if (e.lengthComputable) {
-                const progress = Math.round((e.loaded / e.total) * 100);
+            try {
+                const response = await uploadNzbFile(fileToUpload, setUploadingFiles);
+                const responseError = getUploadResponseError(response);
+                if (responseError) throw new Error(responseError);
+            } catch (error) {
                 setUploadingFiles(files => files.map(f =>
-                    f.queueSlot.nzo_id === fileToUpload.queueSlot.nzo_id
-                        ? {
-                            ...f,
-                            queueSlot: {
-                                ...f.queueSlot,
-                                percentage: progress.toString(),
-                                true_percentage: progress.toString()
-                            }
-                        }
-                        : f
+                    f.queueSlot.nzo_id === fileToUpload.queueSlot.nzo_id ? {
+                        ...f,
+                        queueSlot: {
+                            ...f.queueSlot,
+                            status: "upload failed",
+                            error: error instanceof Error ? error.message : "Upload failed",
+                        },
+                    } : f
                 ));
+            } finally {
+                uploadQueueRef.current = uploadQueueRef.current.filter(x => x !== fileToUpload);
             }
-        });
-
-        const response: any = await new Promise<void>((resolve, reject) => {
-            xhr.addEventListener('load', () => {
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr.response);
-                } else {
-                    const errorMessage = xhr.response.error || `Upload failed with status ${xhr.status}`;
-                    reject(new Error(errorMessage));
-                }
-            });
-            xhr.addEventListener('error', () => reject(new Error('Upload failed')));
-            xhr.addEventListener('abort', () => reject(new Error('Upload aborted')));
-
-            xhr.open('POST', `/api?mode=addfile&cat=${fileToUpload.queueSlot.cat}&priority=0&pp=0`);
-            xhr.send(formData);
-        });
-
-        if (response.status == false) {
-            throw new Error(response.error);
         }
-
-    } catch (error) {
-        setUploadingFiles(files => files.map(f =>
-            f.queueSlot.nzo_id === fileToUpload.queueSlot.nzo_id ? {
-                ...f,
-                queueSlot: {
-                    ...f.queueSlot,
-                    status: 'upload failed',
-                    error: error instanceof Error ? error.message : 'Upload failed'
-                }
-            } : f
-        ));
-    }
-
-    uploadQueueRef.current = uploadQueueRef.current.filter(x => x !== fileToUpload);
-    isUploadingRef.current = false;
-
-    if (uploadQueueRef.current.length > 0) {
-        processUploadQueue(isUploadingRef, uploadQueueRef, setUploadingFiles);
+    } finally {
+        isUploadingRef.current = false;
     }
 }

--- a/frontend/app/utils/path.ts
+++ b/frontend/app/utils/path.ts
@@ -28,6 +28,12 @@ export function getExploreContentLink(storage: string | null | undefined, catego
     return `/explore/content/${encodeURIComponent(category.trim())}/${encodeURIComponent(downloadFolder)}`;
 }
 
+/** Explore link for a selected decoded breadcrumb directory, including the WebDAV root. */
+export function getExploreBreadcrumbHref(parentDirectories: string[], index: number): string {
+    if (index === -1) return "/explore";
+    return `/explore/${parentDirectories.slice(0, index + 1).map(encodeURIComponent).join("/")}`;
+}
+
 export type ParsedExploreWebdavPath =
     | { ok: true; path: string }
     | { ok: false };

--- a/frontend/app/utils/utils.test.ts
+++ b/frontend/app/utils/utils.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { clientIdentityTooltip, clientLabelFromUserAgent } from "./client-label";
 import { isMaskedSecret } from "./config-mask";
 import { formatFileSize } from "./file-size";
-import { getExploreContentLink, getLeafDirectoryName, parseExploreWebdavPath } from "./path";
+import {
+  getExploreBreadcrumbHref,
+  getExploreContentLink,
+  getLeafDirectoryName,
+  parseExploreWebdavPath,
+} from "./path";
 import { className, classNames } from "./styling";
 import { receiveMessage } from "./websocket-util";
 
@@ -87,6 +92,23 @@ describe("getExploreContentLink", () => {
     expect(getExploreContentLink("   ", "movies")).toBeNull();
     expect(getExploreContentLink("/completed/movies/Alien", "   ")).toBeNull();
     expect(getExploreContentLink("/completed/movies/Alien", "")).toBeNull();
+  });
+});
+
+describe("getExploreBreadcrumbHref", () => {
+  it("returns the Explore root for the home breadcrumb", () => {
+    expect(getExploreBreadcrumbHref(["content"], -1)).toBe("/explore");
+  });
+
+  it("encodes each selected directory independently", () => {
+    const directories = ["content", "My#1 Hits", "100%", "A?B", "tv shows", "日本語"];
+    const href = getExploreBreadcrumbHref(directories, directories.length - 1);
+
+    expect(href).toBe("/explore/content/My%231%20Hits/100%25/A%3FB/tv%20shows/%E6%97%A5%E6%9C%AC%E8%AA%9E");
+    expect(parseExploreWebdavPath(href.slice("/explore/".length))).toEqual({
+      ok: true,
+      path: directories.join("/"),
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- prevent drag-and-drop NZB upload failures from permanently blocking later uploads
- serialize manual upload categories safely and add failure-recovery coverage
- encode every Explore breadcrumb segment before navigation

Closes #582
Closes #583
Closes #584

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint` (existing warnings only)
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run build`