### PR TITLE
fix(queue): prevent concurrent imports waiting indefinitely

### DIFF
--- a/backend/Clients/Usenet/Contexts/QueueDownloadContext.cs
+++ b/backend/Clients/Usenet/Contexts/QueueDownloadContext.cs
@@ -8,6 +8,8 @@ namespace NzbWebDAV.Clients.Usenet.Contexts;
 /// </summary>
 public sealed class QueueDownloadContext
 {
+    private long _semaphoreWaitMilliseconds;
+
     /// <summary>
     /// True while this worker is the preferred (first) active queue item.
     /// Mutated in place when a secondary is promoted after the previous primary finishes.
@@ -19,4 +21,12 @@ public sealed class QueueDownloadContext
     /// promoted secondary immediately gets the primary budget.
     /// </summary>
     public required Func<int> GetFanOutConcurrency { get; init; }
+
+    public long SemaphoreWaitMilliseconds => Interlocked.Read(ref _semaphoreWaitMilliseconds);
+
+    public void RecordSemaphoreWait(long elapsedMilliseconds)
+    {
+        if (elapsedMilliseconds > 0)
+            Interlocked.Add(ref _semaphoreWaitMilliseconds, elapsedMilliseconds);
+    }
 }

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -1,4 +1,5 @@
-﻿using NzbWebDAV.Clients.Usenet.Concurrency;
+﻿using System.Diagnostics;
+using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
@@ -26,7 +27,10 @@ public class DownloadingNntpClient : WrappingNntpClient
         var streamingPriority = configManager.GetStreamingPriority();
         _configManager = configManager;
         _streamingSemaphore = new PrioritizedSemaphore(maxDownloadConnections, maxDownloadConnections, streamingPriority);
-        _queueSemaphore = new PrioritizedSemaphore(maxQueueConnections, maxQueueConnections);
+        _queueSemaphore = new PrioritizedSemaphore(
+            maxQueueConnections,
+            maxQueueConnections,
+            new SemaphorePriorityOdds { HighPriorityOdds = 80 });
         configManager.OnConfigChanged += OnConfigChanged;
     }
 
@@ -172,7 +176,17 @@ public class DownloadingNntpClient : WrappingNntpClient
     private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(CancellationToken cancellationToken)
     {
         var (semaphore, priority) = SelectSemaphore(cancellationToken);
-        await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+        var queueContext = cancellationToken.GetContext<QueueDownloadContext>();
+        if (queueContext is null)
+        {
+            await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var waitTimer = Stopwatch.StartNew();
+            await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+            queueContext.RecordSemaphoreWait(waitTimer.ElapsedMilliseconds);
+        }
         return semaphore;
     }
 

--- a/backend/Queue/QueueFanOut.cs
+++ b/backend/Queue/QueueFanOut.cs
@@ -23,7 +23,9 @@ public static class QueueFanOut
     /// </summary>
     public static int PrimaryFanOutWhenSharing(int maxQueueConnections, int activeSecondaryCount)
     {
-        var reserve = Math.Max(1, activeSecondaryCount);
+        var reserve = Math.Max(
+            Math.Max(1, activeSecondaryCount),
+            Math.Max(1, maxQueueConnections / 8));
         return Math.Max(1, maxQueueConnections - reserve);
     }
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Api.SabControllers.GetHistory;
 using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -69,6 +70,7 @@ public class QueueItemProcessor(
     }
 
     private const int MaxProviderRetryAttempts = 20;
+    private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(15);
 
     private static TimeSpan GetProviderRetryBackoff(int attempt)
     {
@@ -165,6 +167,57 @@ public class QueueItemProcessor(
         }
     }
 
+    private async Task<T> RunStageAsync<T>(string stage, Func<Task<T>> action)
+    {
+        using var stageCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var stageTimer = Stopwatch.StartNew();
+        var monitorTask = MonitorLongRunningStageAsync(stage, stageTimer, stageCts.Token);
+        try
+        {
+            return await action().ConfigureAwait(false);
+        }
+        finally
+        {
+            await stageCts.CancelAsync().ConfigureAwait(false);
+            await monitorTask.ConfigureAwait(false);
+        }
+    }
+
+    private Task RunStageAsync(string stage, Func<Task> action)
+    {
+        return RunStageAsync<object?>(stage, async () =>
+        {
+            await action().ConfigureAwait(false);
+            return null;
+        });
+    }
+
+    private async Task MonitorLongRunningStageAsync(string stage, Stopwatch stageTimer, CancellationToken stageCt)
+    {
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(StageWarningInterval, stageCt).ConfigureAwait(false);
+                var queueContext = ct.GetContext<QueueDownloadContext>();
+                Log.Warning(
+                    "Queue item {JobName} ({QueueItemId}) remains in {Stage} after {ElapsedSeconds:0}s; " +
+                    "primary={IsPrimary} fanOut={FanOut} semaphoreWait={SemaphoreWait}ms",
+                    queueItem.JobName,
+                    queueItem.Id,
+                    stage,
+                    stageTimer.Elapsed.TotalSeconds,
+                    queueContext?.IsPrimary ?? false,
+                    queueContext?.GetFanOutConcurrency() ?? 1,
+                    queueContext?.SemaphoreWaitMilliseconds ?? 0);
+            }
+        }
+        catch (OperationCanceledException) when (stageCt.IsCancellationRequested)
+        {
+            // The stage completed or the worker was cancelled.
+        }
+    }
+
     private async Task ProcessQueueItemAsync(DateTime startTime)
     {
         // if the `/blobs` folder is tampered with outside the nzbdav process,
@@ -208,12 +261,16 @@ public class QueueItemProcessor(
         var part1Progress = progress
             .Scale(50, 100)
             .ToPercentage(nzbFiles.Count);
-        var segments = await FetchFirstSegmentsStep.FetchFirstSegments(
-            nzbFiles, usenetClient, configManager, ct, part1Progress).ConfigureAwait(false);
+        var segments = await RunStageAsync(
+            "first-segment",
+            () => FetchFirstSegmentsStep.FetchFirstSegments(
+                nzbFiles, usenetClient, configManager, ct, part1Progress)).ConfigureAwait(false);
         var msFirstSeg = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
-        var par2FileDescriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(
-            segments, usenetClient, ct).ConfigureAwait(false);
+        var par2FileDescriptors = await RunStageAsync(
+            "par2",
+            () => GetPar2FileDescriptorsStep.GetPar2FileDescriptors(
+                segments, usenetClient, ct)).ConfigureAwait(false);
         var msPar2 = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
         var fileInfos = GetFileInfosStep.GetFileInfos(
@@ -258,7 +315,8 @@ public class QueueItemProcessor(
         if (configManager.IsLazyRarParsingEnabled() && rarFiles.Count > 0)
         {
             var lazyProc = new LazyRarProcessor(rarFiles, usenetClient, archivePassword, ct);
-            lazyRarResult = await lazyProc.ProcessAsync().ConfigureAwait(false) as LazyRarProcessor.Result;
+            lazyRarResult = await RunStageAsync("lazy-rar", lazyProc.ProcessAsync)
+                .ConfigureAwait(false) as LazyRarProcessor.Result;
             // Nested archives need the full eager pass + NestedRarExpansionStep.
             if (lazyRarResult is not null &&
                 FilenameUtil.IsRarFile(Path.GetFileName(lazyRarResult.PathInArchive)))
@@ -277,17 +335,20 @@ public class QueueItemProcessor(
             .Offset(50)
             .Scale(50, 100)
             .ToMultiProgress(fileProcessors.Count);
-        var fileProcessingResultsAll = await fileProcessors
-            .Select(x => x!.ProcessAsync(part2Progress.SubProgress))
-            .WithConcurrencyAsync(QueueFanOut.GetConcurrency(ct, configManager))
-            .GetAllAsync(ct).ConfigureAwait(false);
-        var fileProcessingResults = fileProcessingResultsAll
-            .Where(x => x is not null)
-            .Select(x => x!)
-            .ToList();
-        if (lazyRarResult is not null) fileProcessingResults.Add(lazyRarResult);
-        fileProcessingResults = await NestedRarExpansionStep.ExpandAsync(
-            fileProcessingResults, usenetClient, archivePassword, ct).ConfigureAwait(false);
+        var fileProcessingResults = await RunStageAsync("processors", async () =>
+        {
+            var fileProcessingResultsAll = await fileProcessors
+                .Select(x => x!.ProcessAsync(part2Progress.SubProgress))
+                .WithConcurrencyAsync(QueueFanOut.GetConcurrency(ct, configManager))
+                .GetAllAsync(ct).ConfigureAwait(false);
+            var results = fileProcessingResultsAll
+                .Where(x => x is not null)
+                .Select(x => x!)
+                .ToList();
+            if (lazyRarResult is not null) results.Add(lazyRarResult);
+            return await NestedRarExpansionStep.ExpandAsync(
+                results, usenetClient, archivePassword, ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
         var msProcessors = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
 
@@ -306,8 +367,10 @@ public class QueueItemProcessor(
             var healthCheckConcurrency = Math.Min(
                 configManager.GetHealthCheckConcurrency(),
                 QueueFanOut.GetConcurrency(ct, configManager));
-            await ArticleExistenceChecker
-                .CheckAsync(usenetClient, articlesToCheck, healthCheckConcurrency, part3Progress, ct)
+            await RunStageAsync(
+                    "health",
+                    () => ArticleExistenceChecker
+                        .CheckAsync(usenetClient, articlesToCheck, healthCheckConcurrency, part3Progress, ct))
                 .ConfigureAwait(false);
             checkedFullHealth = true;
         }
@@ -316,8 +379,9 @@ public class QueueItemProcessor(
 
         Log.Information(
             "play-timing nzo={NzoId} files={Files} firstSeg={FirstSeg}ms par2={Par2}ms rar={Rar}ms " +
-            "processors={Processors}ms health={Health}ms",
-            queueItem.Id, nzbFiles.Count, msFirstSeg, msPar2, msRar, msProcessors, msHealth);
+            "processors={Processors}ms health={Health}ms semWait={SemaphoreWait}ms",
+            queueItem.Id, nzbFiles.Count, msFirstSeg, msPar2, msRar, msProcessors, msHealth,
+            ct.GetContext<QueueDownloadContext>()?.SemaphoreWaitMilliseconds ?? 0);
 
         // update the database
         await MarkQueueItemCompleted(startTime, error: null, async () =>

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -13,7 +13,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | WebDAV User | `webdav.user` | `admin` / `WEBDAV_USER` | Alphanumeric + `_` `-` |
 | WebDAV Password | `webdav.pass` | env `WEBDAV_PASSWORD` | Required for rclone/clients |
 | Queue Download Connections | `usenet.max-queue-connections` | blank = all | Cap queue NNTP use |
-| Concurrent Queue Downloads [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Concurrent NZB imports (1–4); share the queue connection budget |
+| Concurrent Queue Downloads [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Concurrent NZB imports (1–4); the oldest item is preferred while other workers share the connection budget |
 | Enable Segment Cache | `usenet.segment-cache.enabled` | off | Disk cache; **restart required** |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | |
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | |

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
@@ -353,6 +353,35 @@ public class ConcurrencyTests
     }
 
     [Fact]
+    public async Task PrioritizedSemaphore_80PercentHighPriority_AllowsLowWaiterEveryFifthContestedRelease()
+    {
+        using var semaphore = new PrioritizedSemaphore(
+            initialAllowed: 1,
+            maxAllowed: 1,
+            new SemaphorePriorityOdds { HighPriorityOdds = 80 });
+        await semaphore.WaitAsync(SemaphorePriority.Low);
+        var lowWaiter = semaphore.WaitAsync(SemaphorePriority.Low);
+
+        for (var handoff = 1; handoff <= 4; handoff++)
+        {
+            var highWaiter = semaphore.WaitAsync(SemaphorePriority.High);
+            semaphore.Release();
+
+            await highWaiter.WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.False(lowWaiter.IsCompleted);
+        }
+
+        var fifthHighWaiter = semaphore.WaitAsync(SemaphorePriority.High);
+        semaphore.Release();
+
+        await lowWaiter.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(fifthHighWaiter.IsCompleted);
+        semaphore.Release();
+        await fifthHighWaiter.WaitAsync(TimeSpan.FromSeconds(1));
+        semaphore.Release();
+    }
+
+    [Fact]
     public async Task PrioritizedSemaphore_RemovesCanceledWaiter()
     {
         using var semaphore = new PrioritizedSemaphore(initialAllowed: 0, maxAllowed: 1);

--- a/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
@@ -23,6 +23,7 @@ public class QueueFanOutTests
     [InlineData(10, 3, 7)]
     [InlineData(1, 1, 1)]
     [InlineData(2, 4, 1)]
+    [InlineData(160, 3, 140)]
     public void PrimaryFanOutWhenSharing_LeavesSpareSoftSlots(
         int maxQueue, int secondaryCount, int expected)
     {
@@ -87,6 +88,22 @@ public class QueueFanOutTests
         Assert.Same(
             parentCts.Token.GetContext<QueueDownloadContext>(),
             linked.Token.GetContext<QueueDownloadContext>());
+    }
+
+    [Fact]
+    public void QueueDownloadContext_AccumulatesSemaphoreWait()
+    {
+        var context = new QueueDownloadContext
+        {
+            IsPrimary = false,
+            GetFanOutConcurrency = () => 1,
+        };
+
+        context.RecordSemaphoreWait(12);
+        context.RecordSemaphoreWait(8);
+        context.RecordSemaphoreWait(0);
+
+        Assert.Equal(20, context.SemaphoreWaitMilliseconds);
     }
 
     private static ConfigManager CreateConfig(int maxQueueConnections)


### PR DESCRIPTION
## Summary
- Bound preferred queue-worker admission and reserve a proportional share of the queue connection budget for secondary workers.
- Record queue semaphore wait time in completion timing and warn while queue stages remain active for 15-minute intervals.
- Document queue-worker sharing and cover priority fairness and wait accounting.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~QueueFanOutTests|FullyQualifiedName~ConcurrencyTests\"`
- [x] `zensical build --clean --strict`
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (932 passed, 11 skipped; one existing macOS ARM `rapidyenc` native-library failure)