### PR TITLE
fix(queue): honor cancellation and reject unsafe WebDAV requests

### DIFF
--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -161,7 +161,7 @@ public class QueueManager : IDisposable
             toCancel = _inProgress.Values
                 .Where(x => queueItemIds.Contains(x.QueueItem.Id))
                 .ToList();
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
 
         foreach (var item in toCancel)
         {
@@ -181,7 +181,7 @@ public class QueueManager : IDisposable
             await dbClient.RemoveQueueItemsAsync(queueItemIds, ct).ConfigureAwait(false);
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
             foreach (var id in queueItemIds) _retryAttempts.TryRemove(id, out _);
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
     }
 
     internal async Task ProcessQueueAsync(CancellationToken ct)
@@ -203,7 +203,7 @@ public class QueueManager : IDisposable
             {
                 // Reap before fill so completed primaries do not occupy slots or
                 // block secondary promotion while new workers are claimed.
-                await ReapCompletedWorkersAsync().ConfigureAwait(false);
+                await ReapCompletedWorkersAsync(ct).ConfigureAwait(false);
                 await FillWorkerSlotsAsync(ct).ConfigureAwait(false);
 
                 if (_inProgress.IsEmpty)
@@ -253,7 +253,7 @@ public class QueueManager : IDisposable
             }
         }
 
-        await ReapCompletedWorkersAsync().ConfigureAwait(false);
+        await ReapCompletedWorkersAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
     private async Task FillWorkerSlotsAsync(CancellationToken ct)
@@ -443,7 +443,7 @@ public class QueueManager : IDisposable
             item.QueueDownloadContext.IsPrimary = item.QueueItem.Id == _primaryId.Value;
     }
 
-    private async Task ReapCompletedWorkersAsync()
+    private async Task ReapCompletedWorkersAsync(CancellationToken ct)
     {
         List<InProgressQueueItem> completed = [];
         await LockAsync(() =>
@@ -461,7 +461,7 @@ public class QueueManager : IDisposable
 
             if (completed.Count > 0)
                 EnsurePrimaryDesignation();
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
 
         foreach (var item in completed)
         {
@@ -640,9 +640,9 @@ public class QueueManager : IDisposable
         return $"{queueItemId}|{payload}";
     }
 
-    private async Task LockAsync(Func<Task> actionAsync)
+    private async Task LockAsync(Func<Task> actionAsync, CancellationToken ct = default)
     {
-        await _stateLock.WaitAsync().ConfigureAwait(false);
+        await _stateLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             await actionAsync().ConfigureAwait(false);
@@ -653,9 +653,9 @@ public class QueueManager : IDisposable
         }
     }
 
-    private async Task LockAsync(Action action)
+    private async Task LockAsync(Action action, CancellationToken ct = default)
     {
-        await _stateLock.WaitAsync().ConfigureAwait(false);
+        await _stateLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             action();

--- a/backend/WebDav/Base/BaseStoreCollection.cs
+++ b/backend/WebDav/Base/BaseStoreCollection.cs
@@ -23,6 +23,8 @@ public abstract class BaseStoreCollection : IStoreCollection
     protected abstract Task<StoreItemResult> MoveItemAsync(MoveItemRequest request);
     protected abstract Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request);
 
+    protected virtual bool SupportsEmptyFileStaging => false;
+
     // private members
     private BaseStoreEmptyFileManager EmptyFileManager => BaseStoreEmptyFileManager.GetEmptyFileManager(UniqueKey);
 
@@ -31,9 +33,9 @@ public abstract class BaseStoreCollection : IStoreCollection
 
     // Depth > 1 PROPFIND would recurse into child collections while the parent's
     // streamed EF query is still open, starting a second operation on the same scoped
-    // DbContext. It also materializes the entire subtree in memory. Clamp to depth 1;
-    // WebDAV clients (rclone included) traverse one directory per request anyway.
-    public InfiniteDepthMode InfiniteDepthMode => InfiniteDepthMode.Assume1;
+    // DbContext. It also materializes the entire subtree in memory. Reject it rather
+    // than silently returning an incomplete depth-1 response.
+    public InfiniteDepthMode InfiniteDepthMode => InfiniteDepthMode.Rejected;
 
     public Task<StoreItemResult> CopyAsync
     (
@@ -94,7 +96,8 @@ public abstract class BaseStoreCollection : IStoreCollection
         if (existingItem is null)
         {
             // This handles step #1 in the note above.
-            if (await probingStream.IsEmptyAsync().ConfigureAwait(false))
+            if (SupportsEmptyFileStaging &&
+                await probingStream.IsEmptyAsync().ConfigureAwait(false))
             {
                 var emptyFile = new BaseStoreEmptyFile(name);
                 EmptyFileManager.Add(emptyFile);

--- a/backend/WebDav/DatabaseStoreCategoryWatchFolder.cs
+++ b/backend/WebDav/DatabaseStoreCategoryWatchFolder.cs
@@ -25,6 +25,7 @@ public class DatabaseStoreCategoryWatchFolder(
     public override string Name => category;
     public override string UniqueKey => $"nzbs_category_{category}";
     public override DateTime CreatedAt => DateTime.Now;
+    protected override bool SupportsEmptyFileStaging => true;
 
     protected override async Task<IStoreItem?> GetItemAsync(GetItemRequest request)
     {

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -100,6 +100,34 @@ public class QueueManagerLoopTests
         await loop; // observe completion / no fault
     }
 
+    [Fact]
+    public async Task RemoveQueueItemsAsync_CancellationInterruptsContendedStateLock()
+    {
+        using var manager = CreateManager();
+        var lockEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        manager.GetTopQueueItemOverride = async (_, _) =>
+        {
+            lockEntered.TrySetResult();
+            await releaseLock.Task;
+            return (null, null);
+        };
+
+        using var loopCancellation = new CancellationTokenSource();
+        var loop = manager.ProcessQueueAsync(loopCancellation.Token);
+        await lockEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        using var requestCancellation = new CancellationTokenSource();
+        var remove = manager.RemoveQueueItemsAsync([], null!, requestCancellation.Token);
+        await requestCancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await remove);
+
+        releaseLock.TrySetResult();
+        await loopCancellation.CancelAsync();
+        await loop;
+    }
+
     private static QueueManager CreateManager()
     {
         var config = new ConfigManager();

--- a/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
@@ -1,0 +1,70 @@
+using NWebDav.Server;
+using NWebDav.Server.Stores;
+using NzbWebDAV.WebDav.Base;
+using NzbWebDAV.WebDav.Requests;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+public sealed class BaseStoreCollectionTests
+{
+    [Fact]
+    public async Task ReadonlyCollection_RejectsEmptyPutWithoutAddingPhantomFile()
+    {
+        var collection = new ReadonlyCollection();
+
+        var result = await collection.CreateItemAsync(
+            "phantom.txt", Stream.Null, overwrite: false, CancellationToken.None);
+
+        Assert.Equal(DavStatusCode.Forbidden, result.Result);
+        Assert.Null(await collection.GetItemAsync("phantom.txt", CancellationToken.None));
+
+        var items = new List<IStoreItem>();
+        await foreach (var item in collection.GetItemsAsync(CancellationToken.None))
+            items.Add(item);
+        Assert.Empty(items);
+    }
+
+    [Fact]
+    public async Task ReadonlyCollection_RejectsNonEmptyPut()
+    {
+        var collection = new ReadonlyCollection();
+        await using var stream = new MemoryStream([1]);
+
+        var result = await collection.CreateItemAsync(
+            "file.txt", stream, overwrite: false, CancellationToken.None);
+
+        Assert.Equal(DavStatusCode.Forbidden, result.Result);
+    }
+
+    [Fact]
+    public void Collection_RejectsInfiniteDepth()
+    {
+        var collection = new ReadonlyCollection();
+
+        Assert.Equal(InfiniteDepthMode.Rejected, collection.InfiniteDepthMode);
+    }
+
+    private sealed class ReadonlyCollection : BaseStoreReadonlyCollection
+    {
+        public override string Name => "root";
+        public override string UniqueKey => "base-store-collection-tests";
+        public override DateTime CreatedAt => DateTime.UnixEpoch;
+
+        protected override Task<StoreItemResult> CopyAsync(CopyRequest request)
+            => Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
+
+        protected override Task<IStoreItem?> GetItemAsync(GetItemRequest request)
+            => Task.FromResult<IStoreItem?>(null);
+
+        protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        protected override Task<StoreCollectionResult> CreateCollectionAsync(
+            CreateCollectionRequest request)
+            => Task.FromResult(new StoreCollectionResult(DavStatusCode.Forbidden));
+    }
+}


### PR DESCRIPTION
## Summary
- Make queue state-lock waits honor request and processing cancellation without leaking semaphore permits.
- Reject phantom empty PUTs on read-only collections while preserving explicit watch-folder staging.
- Reject infinite-depth PROPFIND requests instead of silently truncating results.

## Test plan
- [x] Focused queue and WebDAV tests
- [x] Backend build
- [x] Full backend test suite (one existing macOS native `rapidyenc` failure: `MultiSegmentStreamPrefetchBudgetTests.ReadBudget_CapsPrefetchBelowArticleBufferSize`)
- [x] Linter diagnostics and whitespace checks

Fixes #579
Fixes #580
Fixes #581