### PR TITLE
fix(test): run prefetch budget tests without native decoder

### DIFF
--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -18,7 +18,7 @@ public class MultiSegmentStreamPrefetchBudgetTests
             .ToDictionary(
                 i => $"seg-{i}",
                 i => Enumerable.Repeat((byte)(i % 256), segmentSize).ToArray());
-        var client = new FakeNntpClient(segments);
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true);
         var segmentIds = segments.Keys.ToArray().AsMemory();
 
         await using var stream = MultiSegmentStream.Create(
@@ -57,7 +57,7 @@ public class MultiSegmentStreamPrefetchBudgetTests
             .ToDictionary(
                 i => $"seg-{i}",
                 _ => Enumerable.Repeat((byte)1, segmentSize).ToArray());
-        var client = new FakeNntpClient(segments);
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true);
 
         await using var stream = MultiSegmentStream.Create(
             segments.Keys.ToArray().AsMemory(),


### PR DESCRIPTION
## Summary
- Configure both prefetch-budget tests to use FakeNntpClient's cached yEnc streams.
- Remove the native rapidyenc dependency from tests that measure prefetch accounting.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~MultiSegmentStreamPrefetchBudgetTests --no-restore`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`

Resolves #585.