### PR TITLE
feat(health): download redacted support packs from Settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -86,8 +86,14 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant logs or screenshots
-      description: Paste redacted logs (wrap them in ```text fences if helpful) or attach screenshots. Remove credentials, API keys, paths that identify you, and NZB contents.
+      label: Technical support pack, relevant logs, or screenshots
+      description: |
+        For the most useful diagnostics, open **Settings → Support** in NzbDav and select
+        **Generate & download**. Review the downloaded ZIP, then drag it into this field to upload it.
+        The pack automatically redacts credentials, API keys, tokens, URL credentials, sensitive URL
+        parameters, and IP addresses; it can still contain file names, paths, account usernames, and DNS
+        names. Do not attach NZB contents or other private data. You can also paste redacted logs (inside
+        ```text fences) or attach screenshots.
 
   - type: textarea
     id: environment

--- a/backend/Api/Controllers/DownloadSupportPack/DownloadSupportPackController.cs
+++ b/backend/Api/Controllers/DownloadSupportPack/DownloadSupportPackController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services.SupportPack;
+
+namespace NzbWebDAV.Api.Controllers.DownloadSupportPack;
+
+[ApiController]
+[Route("api/download-support-pack")]
+public sealed class DownloadSupportPackController(SupportPackService supportPack) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+        Response.ContentType = "application/zip";
+        Response.Headers.ContentDisposition = $"attachment; filename=\"nzbdav-support-{timestamp}.zip\"";
+        Response.Headers.CacheControl = "no-store";
+
+        // ZipArchive performs synchronous finalization writes. BodyWriter's stream
+        // supports those writes whereas Kestrel's Response.Body does not.
+        await supportPack.WriteAsync(Response.BodyWriter.AsStream(), HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+        return new EmptyResult();
+    }
+}

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -93,6 +93,35 @@ public class ConfigManager
         }
     }
 
+    /// <summary>
+    /// Takes a consistent snapshot of the public Settings inputs for diagnostics
+    /// exports. Callers must still redact values before exposing the snapshot.
+    /// </summary>
+    internal IReadOnlyList<ConfigDiagnosticSnapshot> GetDiagnosticSnapshot()
+    {
+        lock (_config)
+        {
+            return ConfigEnvMapping.PublicConfigKeys
+                .OrderBy(key => key, StringComparer.Ordinal)
+                .Select(key =>
+                {
+                    if (_environmentOverlay.TryGetValue(key, out var environmentValue))
+                    {
+                        return new ConfigDiagnosticSnapshot(
+                            key,
+                            environmentValue,
+                            "NZBDAV_CONFIG",
+                            _environmentOverlay.GetEnvironmentVariableName(key));
+                    }
+
+                    return _config.TryGetValue(key, out var persistedValue)
+                        ? new ConfigDiagnosticSnapshot(key, persistedValue, "SQLite", null)
+                        : new ConfigDiagnosticSnapshot(key, null, "default-or-unset", null);
+                })
+                .ToList();
+        }
+    }
+
     private string? GetConfigValue(string configName)
     {
         lock (_config)
@@ -1467,3 +1496,9 @@ public class ConfigManager
         public required Dictionary<string, string> ChangedConfig { get; init; }
     }
 }
+
+internal sealed record ConfigDiagnosticSnapshot(
+    string Key,
+    string? Value,
+    string Source,
+    string? EnvironmentVariableName);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -19,6 +19,7 @@ using NzbWebDAV.Middlewares;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.SupportPack;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
@@ -188,6 +189,7 @@ class Program
                 .AddSingleton(websocketManager)
                 .AddSingleton(logBufferSink)
                 .AddSingleton(streamTraceBuffer)
+                .AddSingleton<SupportPackService>()
                 .AddSingleton<BenchmarkGate>()
                 .AddSingleton<NzbWebDAV.Services.Benchmark.BenchmarkRunControl>()
                 .AddHostedService<LogBroadcaster>()

--- a/backend/Services/SupportPack/SupportPackRedactor.cs
+++ b/backend/Services/SupportPack/SupportPackRedactor.cs
@@ -1,0 +1,204 @@
+using System.Buffers;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Services.SupportPack;
+
+/// <summary>
+/// Export-only privacy filter. It is intentionally separate from Settings'
+/// reversible masking tokens: support archives must not carry opaque tokens
+/// that can be replayed to recover a secret.
+/// </summary>
+internal sealed partial class SupportPackRedactor
+{
+    private static readonly HashSet<string> ScalarSecretKeys =
+    [
+        ConfigKeys.ApiKey,
+        ConfigKeys.ApiStrmKey,
+        ConfigKeys.RclonePass,
+        ConfigKeys.WebdavPass,
+        ConfigKeys.WatchtowerProfileToken,
+    ];
+
+    private static readonly HashSet<string> SecretPropertyNames =
+    [
+        "apikey", "api_key", "authorization", "cookie", "pass", "password",
+        "secret", "strmkey", "token", "downloadkey",
+    ];
+
+    private readonly List<string> _literalSecrets;
+    private readonly Dictionary<string, string> _ipAliases = new(StringComparer.Ordinal);
+
+    public SupportPackRedactor(IEnumerable<string?> literalSecrets)
+    {
+        _literalSecrets = literalSecrets
+            .Where(value => !string.IsNullOrWhiteSpace(value) && value!.Length >= 4)
+            .Select(value => value!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(value => value.Length)
+            .ToList();
+    }
+
+    public int SecretsRedacted { get; private set; }
+    public int AddressesPseudonymized { get; private set; }
+
+    public string RedactConfigurationValue(string key, string? value)
+    {
+        if (value is null)
+            return "";
+        if (ScalarSecretKeys.Contains(key))
+        {
+            SecretsRedacted++;
+            return "[REDACTED]";
+        }
+
+        if (key is ConfigKeys.UsenetProviders or ConfigKeys.ArrInstances
+            or ConfigKeys.IndexersInstances or ConfigKeys.ProfilesInstances)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(value);
+                var buffer = new ArrayBufferWriter<byte>();
+                using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true }))
+                    WriteRedactedJson(writer, document.RootElement);
+                return Encoding.UTF8.GetString(buffer.WrittenSpan);
+            }
+            catch (JsonException)
+            {
+                SecretsRedacted++;
+                return "[REDACTED_MALFORMED_STRUCTURED_VALUE]";
+            }
+        }
+
+        return RedactText(value);
+    }
+
+    public string RedactText(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value ?? "";
+
+        var redacted = value;
+        foreach (var secret in _literalSecrets)
+        {
+            redacted = Replace(redacted, secret, "[REDACTED]");
+            var encoded = Uri.EscapeDataString(secret);
+            if (!string.Equals(encoded, secret, StringComparison.Ordinal))
+                redacted = Replace(redacted, encoded, "[REDACTED]");
+        }
+
+        redacted = SensitiveQueryRegex().Replace(redacted, match =>
+        {
+            SecretsRedacted++;
+            return $"{match.Groups[1].Value}{match.Groups[2].Value}=[REDACTED]";
+        });
+        redacted = AuthorizationRegex().Replace(redacted, match =>
+        {
+            SecretsRedacted++;
+            return $"{match.Groups[1].Value}[REDACTED]";
+        });
+        redacted = MaskTokenRegex().Replace(redacted, _ =>
+        {
+            SecretsRedacted++;
+            return "[REDACTED_MASK_TOKEN]";
+        });
+        redacted = UrlUserInfoRegex().Replace(redacted, match =>
+        {
+            SecretsRedacted++;
+            return $"{match.Groups[1].Value}[REDACTED]@";
+        });
+        redacted = Ipv4Regex().Replace(redacted, PseudonymizeIp);
+        return Ipv6Regex().Replace(redacted, PseudonymizeIp);
+    }
+
+    private string Replace(string value, string secret, string replacement)
+    {
+        var count = 0;
+        var result = value.Replace(secret, replacement, StringComparison.Ordinal);
+        for (var index = 0; index <= value.Length - secret.Length; index++)
+        {
+            if (value.AsSpan(index, secret.Length).Equals(secret, StringComparison.Ordinal))
+                count++;
+        }
+        SecretsRedacted += count;
+        return result;
+    }
+
+    private string PseudonymizeIp(Match match)
+    {
+        var candidate = match.Value.Trim('[', ']');
+        if (!IPAddress.TryParse(candidate, out _))
+            return match.Value;
+
+        if (!_ipAliases.TryGetValue(candidate, out var alias))
+        {
+            alias = $"[IP-{_ipAliases.Count + 1}]";
+            _ipAliases[candidate] = alias;
+            AddressesPseudonymized++;
+        }
+        return alias;
+    }
+
+    private void WriteRedactedJson(Utf8JsonWriter writer, JsonElement element, string? propertyName = null)
+    {
+        if (propertyName is not null && SecretPropertyNames.Contains(Normalize(propertyName)))
+        {
+            SecretsRedacted++;
+            writer.WriteStringValue("[REDACTED]");
+            return;
+        }
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                foreach (var property in element.EnumerateObject())
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteRedactedJson(writer, property.Value, property.Name);
+                }
+                writer.WriteEndObject();
+                break;
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                    WriteRedactedJson(writer, item);
+                writer.WriteEndArray();
+                break;
+            case JsonValueKind.String:
+                writer.WriteStringValue(RedactText(element.GetString()));
+                break;
+            default:
+                element.WriteTo(writer);
+                break;
+        }
+    }
+
+    private static string Normalize(string value) =>
+        value.Replace("-", "", StringComparison.Ordinal)
+            .Replace("_", "", StringComparison.Ordinal)
+            .ToLowerInvariant();
+
+    [GeneratedRegex(@"([?&])(apikey|api_key|token|pass|password|auth|downloadkey)=([^&\s""']+)", RegexOptions.IgnoreCase)]
+    private static partial Regex SensitiveQueryRegex();
+
+    [GeneratedRegex(@"(Authorization:\s*(?:Bearer|Basic)\s+)\S+", RegexOptions.IgnoreCase)]
+    private static partial Regex AuthorizationRegex();
+
+    [GeneratedRegex(@"__NZBDAV_SECRET_MASK_V1__:[A-Za-z0-9_.-]+")]
+    private static partial Regex MaskTokenRegex();
+
+    [GeneratedRegex(@"((?:https?|socks5?)://)[^/\s@]+@", RegexOptions.IgnoreCase)]
+    private static partial Regex UrlUserInfoRegex();
+
+    [GeneratedRegex(@"(?<![\d.])\d{1,3}(?:\.\d{1,3}){3}(?![\d.])")]
+    private static partial Regex Ipv4Regex();
+
+    // Avoid treating timestamps, version numbers, and counters as IPv6. Full
+    // numeric IPv6 addresses are still recognized when they use compression.
+    [GeneratedRegex(@"(?<![A-Za-z0-9])(?:\[[0-9A-Fa-f:.]*[A-Fa-f][0-9A-Fa-f:.]*\]|[0-9A-Fa-f]*::[0-9A-Fa-f:]*|[0-9A-Fa-f]*[A-Fa-f][0-9A-Fa-f]*(?::[0-9A-Fa-f]+)+)(?![A-Za-z0-9])")]
+    private static partial Regex Ipv6Regex();
+}

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -176,14 +176,25 @@ public sealed class SupportPackService(
             .Where(row => row.Minute >= since24Hours)
             .Select(row => new
             {
-                row.Minute, row.Articles, row.Misses, row.Errors, row.BytesFetched, row.BytesServed,
+                row.Minute,
+                row.Articles,
+                row.Misses,
+                row.Errors,
+                row.BytesFetched,
+                row.BytesServed,
             })
             .ToListAsync(cancellationToken).ConfigureAwait(false);
         var providerHours = await db.ProviderHourly
             .Where(row => row.Hour >= since7Days)
             .Select(row => new
             {
-                row.Hour, row.Provider, row.Articles, row.Misses, row.Errors, row.Retries, row.BytesFetched,
+                row.Hour,
+                row.Provider,
+                row.Articles,
+                row.Misses,
+                row.Errors,
+                row.Retries,
+                row.BytesFetched,
                 row.FailoverSaves,
             })
             .ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -1,0 +1,449 @@
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Logging;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Services.SupportPack;
+
+public sealed class SupportPackService(
+    LogBufferSink logBuffer,
+    ConfigManager configManager,
+    MetricsWriter metricsWriter,
+    ProviderBytesTracker bytesTracker,
+    UsenetStreamingClient usenetStreamingClient)
+{
+    private const long MinuteMs = 60_000;
+    private const long HourMs = 60 * MinuteMs;
+    private const long DayMs = 24 * HourMs;
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private readonly DateTimeOffset _startedAt = DateTimeOffset.UtcNow;
+
+    internal async Task WriteAsync(Stream output, CancellationToken cancellationToken)
+    {
+        var generatedAt = DateTimeOffset.UtcNow;
+        var config = configManager.GetDiagnosticSnapshot();
+        var redactor = new SupportPackRedactor(CollectSecrets(config));
+        var logSnapshot = logBuffer.Snapshot(logBuffer.Capacity, null, null, null, null);
+        var sectionStatus = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["logs"] = "included",
+            ["configuration"] = "included",
+            ["environment"] = "included",
+        };
+
+        using var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true);
+        await WriteTextAsync(archive, "README.txt", BuildReadme(), cancellationToken).ConfigureAwait(false);
+        await WriteTextAsync(
+            archive,
+            "logs/backend.log",
+            redactor.RedactText(FormatLogs(logSnapshot.Entries)),
+            cancellationToken).ConfigureAwait(false);
+        await WriteJsonAsync(
+            archive,
+            "configuration.json",
+            BuildConfiguration(config, redactor),
+            redactor,
+            cancellationToken).ConfigureAwait(false);
+        await WriteJsonAsync(
+            archive,
+            "environment.json",
+            BuildEnvironment(generatedAt),
+            redactor,
+            cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var metrics = await BuildMetricsAsync(generatedAt, cancellationToken).ConfigureAwait(false);
+            await WriteJsonAsync(archive, "metrics/recent.json", metrics, redactor, cancellationToken)
+                .ConfigureAwait(false);
+            sectionStatus["metrics"] = "included";
+        }
+        catch
+        {
+            sectionStatus["metrics"] = "unavailable";
+        }
+
+        await WriteJsonAsync(
+            archive,
+            "manifest.json",
+            await BuildManifestAsync(generatedAt, logSnapshot, sectionStatus, redactor, cancellationToken)
+                .ConfigureAwait(false),
+            redactor,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static string BuildReadme() =>
+        """
+        NzbDAV technical support pack
+
+        This archive contains the current backend in-memory log buffer, a redacted
+        active Settings snapshot, runtime information, and aggregate metrics.
+        Backend logs are cleared when NzbDAV restarts. Frontend and container logs
+        are not included.
+
+        The archive deliberately excludes database files, backups, blobs/NZBs,
+        environment files, session/API key files, crash dumps, stream traces, and
+        segment-cache data. Credentials, API keys, tokens, URL credentials and
+        sensitive URL query values are redacted. IP addresses are pseudonymized.
+
+        File names, filesystem paths, account usernames, DNS hostnames, and
+        non-secret URL paths can remain for troubleshooting. Share this archive only
+        with trusted NzbDAV support.
+        """;
+
+    private static object BuildConfiguration(
+        IReadOnlyList<ConfigDiagnosticSnapshot> config,
+        SupportPackRedactor redactor) =>
+        new
+        {
+            settings = config.Select(item => new
+            {
+                key = item.Key,
+                value = redactor.RedactConfigurationValue(item.Key, item.Value),
+                source = item.Source,
+                environmentVariable = item.EnvironmentVariableName,
+            }),
+        };
+
+    private object BuildEnvironment(DateTimeOffset generatedAt)
+    {
+        ThreadPool.GetMinThreads(out var minWorkerThreads, out var minIoThreads);
+        ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxIoThreads);
+        var configPath = DavDatabaseContext.ConfigPath;
+        var root = Path.GetPathRoot(Path.GetFullPath(configPath)) ?? configPath;
+        var drive = new DriveInfo(root);
+
+        return new
+        {
+            generatedAtUtc = generatedAt,
+            appVersion = ConfigManager.AppVersion,
+            commit = Environment.GetEnvironmentVariable("NZBDAV_COMMIT_SHA"),
+            uptimeSeconds = (long)(generatedAt - _startedAt).TotalSeconds,
+            runtime = new
+            {
+                framework = RuntimeInformation.FrameworkDescription,
+                os = RuntimeInformation.OSDescription,
+                osArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+                processArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                processorCount = Environment.ProcessorCount,
+                workingSetBytes = Environment.WorkingSet,
+                gcTotalMemoryBytes = GC.GetTotalMemory(forceFullCollection: false),
+                timeZone = TimeZoneInfo.Local.Id,
+            },
+            threadPool = new { minWorkerThreads, minIoThreads, maxWorkerThreads, maxIoThreads },
+            storage = new
+            {
+                configPath,
+                configDatabaseBytes = FileSize(DavDatabaseContext.DatabaseFilePath),
+                metricsDatabaseBytes = FileSize(MetricsDbContext.DatabaseFilePath),
+                availableFreeSpaceBytes = drive.IsReady ? drive.AvailableFreeSpace : (long?)null,
+            },
+            environment = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["LOG_LEVEL"] = Environment.GetEnvironmentVariable("LOG_LEVEL"),
+                ["LOG_BUFFER_SIZE"] = Environment.GetEnvironmentVariable("LOG_BUFFER_SIZE"),
+                ["STREAM_TRACE_EVENTS"] = Environment.GetEnvironmentVariable("STREAM_TRACE_EVENTS"),
+                ["TZ"] = Environment.GetEnvironmentVariable("TZ"),
+                ["PUID"] = Environment.GetEnvironmentVariable("PUID"),
+                ["PGID"] = Environment.GetEnvironmentVariable("PGID"),
+                ["MAX_REQUEST_BODY_SIZE"] = Environment.GetEnvironmentVariable("MAX_REQUEST_BODY_SIZE"),
+            },
+        };
+    }
+
+    private async Task<object> BuildMetricsAsync(DateTimeOffset generatedAt, CancellationToken cancellationToken)
+    {
+        var now = generatedAt.ToUnixTimeMilliseconds();
+        var since24Hours = now - DayMs;
+        var since7Days = now - 7 * DayMs;
+        var providers = configManager.GetUsenetProviderConfig().Providers;
+        var nicknames = providers
+            .Where(provider => provider.ProviderId != Guid.Empty)
+            .ToDictionary(
+                UsenetProviderIdentity.MetricsKey,
+                provider => string.IsNullOrWhiteSpace(provider.Nickname) ? null : provider.Nickname,
+                StringComparer.Ordinal);
+
+        await using var db = new MetricsDbContext();
+        var minuteRows = await db.ThroughputMinutes
+            .Where(row => row.Minute >= since24Hours)
+            .Select(row => new
+            {
+                row.Minute, row.Articles, row.Misses, row.Errors, row.BytesFetched, row.BytesServed,
+            })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var providerHours = await db.ProviderHourly
+            .Where(row => row.Hour >= since7Days)
+            .Select(row => new
+            {
+                row.Hour, row.Provider, row.Articles, row.Misses, row.Errors, row.Retries, row.BytesFetched,
+                row.FailoverSaves,
+            })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var circuitTransitions = await db.MetricEvents
+            .Where(row => row.Kind == "circuit" && row.At >= since7Days)
+            .Select(row => new { row.At, row.Tag1, row.Tag2, row.Num })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var failover = await db.FailoverHourly
+            .Where(row => row.Hour >= since7Days)
+            .GroupBy(row => row.Reason)
+            .Select(group => new { reason = group.Key.ToString(), count = group.Sum(row => row.Count) })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var usageHours = await ProviderUsageHelper.ReadRecentHoursAsync(
+            providers.Where(provider => provider.ProviderId != Guid.Empty).Select(UsenetProviderIdentity.MetricsKey))
+            .ConfigureAwait(false);
+        var usage = providers
+            .Where(provider => provider.ProviderId != Guid.Empty)
+            .Select(provider =>
+            {
+                var key = UsenetProviderIdentity.MetricsKey(provider);
+                usageHours.TryGetValue(key, out var hours);
+                var bytesUsed = ProviderUsageHelper.ComputeUsage(bytesTracker, provider);
+                var (bytesPerDay, daysRemaining) = ProviderUsageHelper.ComputeBurnRate(provider, bytesUsed, hours);
+                return new
+                {
+                    providerKey = key,
+                    nickname = nicknames.GetValueOrDefault(key),
+                    bytesUsed,
+                    byteLimit = provider.ByteLimit,
+                    overLimit = ProviderUsageHelper.IsOverLimit(bytesTracker, provider),
+                    bytesPerDay,
+                    daysRemaining,
+                };
+            })
+            .ToList();
+
+        var circuitStates = usenetStreamingClient.GetProviderCircuitSnapshots()
+            .Select(snapshot => new
+            {
+                providerKey = snapshot.MetricsKey,
+                nickname = nicknames.GetValueOrDefault(snapshot.MetricsKey),
+                state = snapshot.Breaker.State.ToString(),
+                snapshot.Breaker.CooldownRemainingSeconds,
+                snapshot.Breaker.LastFailureReason,
+                snapshot.Breaker.TripCount,
+                snapshot.Breaker.FailureCount,
+                snapshot.Breaker.ArticleMissCount,
+            })
+            .ToList();
+        var stats = metricsWriter.Stats;
+        return new
+        {
+            generatedAtUtc = generatedAt,
+            outage24Hours = new
+            {
+                bucketSizeMs = 5 * MinuteMs,
+                throughput = minuteRows
+                    .GroupBy(row => row.Minute - row.Minute % (5 * MinuteMs))
+                    .OrderBy(group => group.Key)
+                    .Select(group => new
+                    {
+                        bucket = group.Key,
+                        articles = group.Sum(row => row.Articles),
+                        misses = group.Sum(row => row.Misses),
+                        errors = group.Sum(row => row.Errors),
+                        bytesFetched = group.Sum(row => row.BytesFetched),
+                        bytesServed = group.Sum(row => row.BytesServed),
+                    }),
+            },
+            consumption7Days = new
+            {
+                providerHours = providerHours
+                    .OrderBy(row => row.Hour)
+                    .Select(row => new
+                    {
+                        row.Hour,
+                        providerKey = row.Provider,
+                        nickname = nicknames.GetValueOrDefault(row.Provider),
+                        row.Articles,
+                        row.Misses,
+                        row.Errors,
+                        row.Retries,
+                        row.BytesFetched,
+                        row.FailoverSaves,
+                    }),
+                providerUsage = usage,
+            },
+            circuits = new
+            {
+                current = circuitStates,
+                transitions = circuitTransitions
+                    .Where(row => row.Tag1 is not null && row.Tag2 is not null)
+                    .Select(row => new
+                    {
+                        at = row.At,
+                        providerKey = row.Tag1,
+                        nickname = nicknames.GetValueOrDefault(row.Tag1!),
+                        state = row.Tag2,
+                        cooldownMs = row.Num,
+                    }),
+            },
+            failoverReasons = failover,
+            metricsHealth = new
+            {
+                queued = stats.QueuedFetches + stats.QueuedEvents + stats.QueuedSessions + stats.QueuedFailoverMisses,
+                dropped = stats.DroppedFetches + stats.DroppedEvents + stats.DroppedSessions + stats.DroppedFailoverMisses,
+                stats.LastSuccessfulFlushAtMs,
+                stats.LastFlushError,
+            },
+        };
+    }
+
+    private async Task<object> BuildManifestAsync(
+        DateTimeOffset generatedAt,
+        LogSnapshot logs,
+        IReadOnlyDictionary<string, string> sectionStatus,
+        SupportPackRedactor redactor,
+        CancellationToken cancellationToken)
+    {
+        var (mainMigration, metricsMigration) = await ReadMigrationsAsync(cancellationToken).ConfigureAwait(false);
+        return new
+        {
+            schemaVersion = 1,
+            generatedAtUtc = generatedAt,
+            appVersion = ConfigManager.AppVersion,
+            commit = Environment.GetEnvironmentVariable("NZBDAV_COMMIT_SHA"),
+            migrations = new { main = mainMigration, metrics = metricsMigration },
+            logs = new { count = logs.Entries.Count, logs.OldestSequence, logs.NewestSequence, capacity = logBuffer.Capacity },
+            sections = sectionStatus,
+            redaction = new { secrets = redactor.SecretsRedacted, ipAddresses = redactor.AddressesPseudonymized },
+        };
+    }
+
+    private static async Task<(string? Main, string? Metrics)> ReadMigrationsAsync(CancellationToken cancellationToken)
+    {
+        async Task<string?> ReadAsync(DbContext db)
+        {
+            try
+            {
+                return (await db.Database.GetAppliedMigrationsAsync(cancellationToken).ConfigureAwait(false))
+                    .LastOrDefault();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        await using var main = new DavDatabaseContext();
+        await using var metrics = new MetricsDbContext();
+        return (await ReadAsync(main).ConfigureAwait(false), await ReadAsync(metrics).ConfigureAwait(false));
+    }
+
+    private static IEnumerable<string?> CollectSecrets(IEnumerable<ConfigDiagnosticSnapshot> config)
+    {
+        foreach (var item in config)
+        {
+            if (item.Value is null)
+                continue;
+            if (item.Key is ConfigKeys.ApiKey or ConfigKeys.ApiStrmKey or ConfigKeys.RclonePass
+                or ConfigKeys.WebdavPass or ConfigKeys.WatchtowerProfileToken)
+            {
+                yield return item.Value;
+                continue;
+            }
+
+            if (item.Key is not (ConfigKeys.UsenetProviders or ConfigKeys.ArrInstances
+                or ConfigKeys.IndexersInstances or ConfigKeys.ProfilesInstances))
+                continue;
+
+            List<string>? structuredSecrets = null;
+            try
+            {
+                using var document = JsonDocument.Parse(item.Value);
+                structuredSecrets = CollectJsonSecrets(document.RootElement).ToList();
+            }
+            catch (JsonException)
+            {
+                // The structured value will be omitted by the redactor.
+            }
+
+            if (structuredSecrets is not null)
+                foreach (var secret in structuredSecrets)
+                    yield return secret;
+        }
+
+        yield return Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        yield return Environment.GetEnvironmentVariable("WEBDAV_PASSWORD");
+        yield return Environment.GetEnvironmentVariable("SESSION_KEY");
+    }
+
+    private static IEnumerable<string> CollectJsonSecrets(JsonElement element, string? propertyName = null)
+    {
+        var normalized = propertyName?.Replace("-", "", StringComparison.Ordinal)
+            .Replace("_", "", StringComparison.Ordinal)
+            .ToLowerInvariant();
+        if (normalized is "apikey" or "pass" or "password" or "token")
+        {
+            if (element.ValueKind == JsonValueKind.String)
+                yield return element.GetString()!;
+            yield break;
+        }
+
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+                foreach (var secret in CollectJsonSecrets(property.Value, property.Name))
+                    yield return secret;
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+                foreach (var secret in CollectJsonSecrets(item))
+                    yield return secret;
+        }
+    }
+
+    private static async Task WriteJsonAsync(
+        ZipArchive archive,
+        string name,
+        object value,
+        SupportPackRedactor redactor,
+        CancellationToken cancellationToken) =>
+        await WriteTextAsync(
+            archive,
+            name,
+            redactor.RedactText(JsonSerializer.Serialize(value, JsonOptions)),
+            cancellationToken).ConfigureAwait(false);
+
+    private static async Task WriteTextAsync(
+        ZipArchive archive,
+        string name,
+        string content,
+        CancellationToken cancellationToken)
+    {
+        var entry = archive.CreateEntry(name, CompressionLevel.Fastest);
+        await using var stream = entry.Open();
+        var bytes = Encoding.UTF8.GetBytes(content);
+        await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static long? FileSize(string path) =>
+        File.Exists(path) ? new FileInfo(path).Length : null;
+
+    private static string FormatLogs(IEnumerable<LogEntry> entries)
+    {
+        var builder = new StringBuilder();
+        foreach (var entry in entries)
+        {
+            builder.Append('[')
+                .Append(DateTimeOffset.FromUnixTimeMilliseconds(entry.TimestampUnixMs)
+                    .ToString("yyyy-MM-dd HH:mm:ss.fff"))
+                .Append("] [").Append(entry.Level).Append(']');
+            if (entry.Source is not null)
+                builder.Append(" [").Append(entry.Source).Append(']');
+            builder.Append(' ').AppendLine(entry.Message);
+            if (entry.Exception is not null)
+                builder.AppendLine(entry.Exception);
+        }
+        return builder.ToString();
+    }
+}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -15,7 +15,7 @@ For **authoritative headless** configuration of those same Settings keys via `NZ
 -   **Connections** — [Usenet](usenet.md) · [Indexers](indexers.md) · [Search profiles](profiles.md)
 -   **Playback & automation** — [Watchdog](watchdog.md) · [Preflight](preflight.md) · [Watchtower](watchtower.md) · [Warden](warden.md)
 -   **Integrations** — [SABnzbd](sabnzbd.md) · [WebDAV](webdav.md) · [Radarr/Sonarr](arrs.md) · [Rclone](rclone.md)
--   **System** — [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md)
+-   **System** — [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md) · [Support](support.md)
 -   **Headless / ops** — [Headless ENV config](headless.md) · [Environment variables](environment-variables.md)
 
 </div>

--- a/docs/configuration/support.md
+++ b/docs/configuration/support.md
@@ -1,0 +1,25 @@
+# Technical support pack [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
+
+**Settings → Support** generates a ZIP you can provide to trusted NzbDAV support
+when troubleshooting an issue. The archive is streamed to your browser and is
+not retained by NzbDAV.
+
+## Included
+
+- Recent backend logs from the in-memory log buffer
+- Redacted active Settings and runtime/build information
+- Aggregate provider throughput, outage, failover, and consumption metrics
+
+Backend logs are memory-only and are cleared when NzbDAV restarts. Frontend and
+container logs are not included.
+
+## Privacy
+
+The pack redacts passwords, API keys, tokens, URL credentials, sensitive URL
+parameters, authorization values, and IP addresses. It does **not** anonymize
+file names, filesystem paths, account usernames, DNS names, or non-secret URL
+paths. Review the ZIP before sharing it.
+
+The pack never includes databases, database backups, NZBs, blobs, environment
+files, session or API-key files, crash dumps, stream traces, or segment-cache
+data.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -36,4 +36,6 @@ See [Deletion audit](../operations/deletion-audit.md) — history retention ≠ 
 
 ## Still stuck
 
-[Open an issue](https://github.com/nzbdav/nzbdav/issues) with logs (redact credentials). For local stream debugging, see [Contributing](../community/contributing.md).
+Generate a [technical support pack](../configuration/support.md) from **Settings → Support**,
+review it for personal paths and names, then [open an issue](https://github.com/nzbdav/nzbdav/issues).
+For local stream debugging, see [Contributing](../community/contributing.md).

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -17,6 +17,7 @@ import { isPreflightSettingsUpdated, PreflightSettings } from "./preflight/prefl
 import { isWatchtowerSettingsUpdated, WatchtowerSettings } from "./watchtower/watchtower";
 import { isWardenSettingsUpdated, WardenSettings } from "./warden/warden";
 import { isRcloneSettingsUpdated, RcloneSettings } from "./rclone/rclone";
+import { SupportSettings } from "./support/support";
 import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from "react";
 import { useBlocker, useSearchParams } from "react-router";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
@@ -303,6 +304,7 @@ function Body(props: BodyProps) {
                 {activeTab === "rclone" && <RcloneSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "maintenance" && <Maintenance savedConfig={config} config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "backup" && <BackupSettings config={newConfig} setNewConfig={setNewConfig} />}
+                {activeTab === "support" && <SupportSettings />}
             </SettingsPanel>
 
             {saveError && (
@@ -310,7 +312,7 @@ function Body(props: BodyProps) {
                     {saveError}
                 </Alert>
             )}
-            <div className="sticky bottom-0 z-10 -mx-4 flex flex-wrap justify-end gap-2 border-t border-base-content/10 bg-base-300/95 px-4 py-3 backdrop-blur md:-mx-8 md:px-8">
+            {(activeTab !== "support" || isUpdated) && <div className="sticky bottom-0 z-10 -mx-4 flex flex-wrap justify-end gap-2 border-t border-base-content/10 bg-base-300/95 px-4 py-3 backdrop-blur md:-mx-8 md:px-8">
                 {isUpdated && <Button
                     className="min-w-28"
                     variant="outline"
@@ -327,7 +329,7 @@ function Body(props: BodyProps) {
                     <Icon name={isSaving ? "progress_activity" : saveButtonLabel === "Saved" ? "check" : "save"} className={`!text-[18px] ${isSaving ? "animate-spin" : ""}`} />
                     {saveButtonLabel}
                 </Button>
-            </div>
+            </div>}
             <ConfirmModal
                 show={navigationBlocker.showConfirmation}
                 title="Unsaved Changes"

--- a/frontend/app/routes/settings/settings-tabs.ts
+++ b/frontend/app/routes/settings/settings-tabs.ts
@@ -12,7 +12,8 @@ export type SettingsTab =
     | "repairs"
     | "rclone"
     | "maintenance"
-    | "backup";
+    | "backup"
+    | "support";
 
 export type SettingsTabItem = {
     id: SettingsTab;
@@ -58,6 +59,7 @@ export const SETTINGS_TAB_GROUPS: SettingsTabGroup[] = [
             { id: "repairs", label: "Repairs", icon: "build" },
             { id: "maintenance", label: "Maintenance", icon: "settings_suggest" },
             { id: "backup", label: "Backup & Restore", icon: "settings_backup_restore" },
+            { id: "support", label: "Support", icon: "support_agent" },
         ],
     },
 ];

--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useState } from "react";
+import { Alert, Button, Icon, SettingsCard, SettingsIntro, SettingsPage, Spinner } from "~/components/ui";
+
+type Message = { text: string; variant: "success" | "danger" } | null;
+
+function downloadName(response: Response): string {
+    const header = response.headers.get("content-disposition");
+    const match = header?.match(/filename="?([^";]+)"?/i);
+    return match?.[1] ?? "nzbdav-support-pack.zip";
+}
+
+export function SupportSettings() {
+    const [busy, setBusy] = useState(false);
+    const [message, setMessage] = useState<Message>(null);
+
+    const download = useCallback(async () => {
+        setBusy(true);
+        setMessage(null);
+        try {
+            const response = await fetch("/api/download-support-pack", { cache: "no-store" });
+            if (!response.ok) {
+                const body = await response.json().catch(() => null);
+                throw new Error(body?.error || `Support pack failed (${response.status})`);
+            }
+
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            const anchor = document.createElement("a");
+            anchor.href = url;
+            anchor.download = downloadName(response);
+            document.body.append(anchor);
+            anchor.click();
+            anchor.remove();
+            URL.revokeObjectURL(url);
+            setMessage({ text: "Support pack downloaded. Share it only with trusted NzbDAV support.", variant: "success" });
+        } catch (error) {
+            setMessage({
+                text: error instanceof Error ? error.message : "Could not generate the support pack.",
+                variant: "danger",
+            });
+        } finally {
+            setBusy(false);
+        }
+    }, []);
+
+    return (
+        <SettingsPage>
+            <SettingsIntro>
+                Generate a technical support pack to help diagnose an NzbDAV problem.
+                It is generated in memory and is not saved on the server.
+            </SettingsIntro>
+
+            <Alert variant="warning" className="items-start text-sm">
+                <Icon name="privacy_tip" className="mt-0.5 !text-[20px]" />
+                <span>
+                    Passwords, API keys, tokens, URL credentials, sensitive URL parameters, and IP addresses
+                    are automatically redacted. File names, paths, account usernames, DNS names, and non-secret
+                    URL paths can remain. Review the archive before sharing it.
+                </span>
+            </Alert>
+
+            <SettingsCard
+                icon="support_agent"
+                title="Technical support pack"
+                description="A ZIP with recent backend diagnostics for troubleshooting.">
+                <ul className="list-inside list-disc space-y-1 text-sm text-base-content/70">
+                    <li>Current backend logs from the in-memory buffer</li>
+                    <li>Redacted active settings and runtime information</li>
+                    <li>Recent provider outage, failover, and consumption metrics</li>
+                </ul>
+                <p className="text-xs text-base-content/50">
+                    It excludes frontend and container logs, databases, backups, NZBs, blobs, environment files,
+                    crash dumps, stream traces, and segment-cache data.
+                </p>
+                <div className="flex flex-wrap items-center gap-3 pt-1">
+                    <Button variant="primary" disabled={busy} onClick={() => void download()}>
+                        {busy ? <Spinner size="sm" /> : <Icon name="download" className="!text-[18px]" />}
+                        {busy ? "Generating…" : "Generate & download"}
+                    </Button>
+                    <span className="text-xs text-base-content/50" aria-live="polite">
+                        {busy ? "Collecting and redacting diagnostics…" : ""}
+                    </span>
+                </div>
+                {message && <Alert variant={message.variant}>{message.text}</Alert>}
+            </SettingsCard>
+        </SettingsPage>
+    );
+}

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackRedactorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackRedactorTests.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services.SupportPack;
+
+namespace NzbWebDAV.Tests.Services.SupportPack;
+
+public class SupportPackRedactorTests
+{
+    [Fact]
+    public void RedactText_RedactsLiteralEncodedUrlSecretsAndPseudonymizesAddresses()
+    {
+        var redactor = new SupportPackRedactor(["top secret", "api-secret"]);
+
+        var result = redactor.RedactText(
+            "GET https://user:pass@example.test/nzb?apikey=api-secret&token=abc " +
+            "from 192.0.2.10 and [2001:db8::1]; repeated 192.0.2.10; encoded top%20secret");
+
+        Assert.DoesNotContain("api-secret", result);
+        Assert.DoesNotContain("top%20secret", result);
+        Assert.DoesNotContain("user:pass@", result);
+        Assert.DoesNotContain("192.0.2.10", result);
+        Assert.DoesNotContain("2001:db8::1", result);
+        Assert.Contains("apikey=[REDACTED]", result);
+        Assert.Contains("token=[REDACTED]", result);
+        Assert.Equal(2, redactor.AddressesPseudonymized);
+    }
+
+    [Fact]
+    public void RedactConfigurationValue_RedactsKnownStructuredSecrets()
+    {
+        var redactor = new SupportPackRedactor([]);
+        var result = redactor.RedactConfigurationValue(
+            ConfigKeys.UsenetProviders,
+            """{"Providers":[{"Host":"news.example","User":"alice","Pass":"provider-secret"}]}""");
+
+        using var document = JsonDocument.Parse(result);
+        var provider = document.RootElement.GetProperty("Providers")[0];
+        Assert.Equal("news.example", provider.GetProperty("Host").GetString());
+        Assert.Equal("alice", provider.GetProperty("User").GetString());
+        Assert.Equal("[REDACTED]", provider.GetProperty("Pass").GetString());
+    }
+
+    [Fact]
+    public void RedactConfigurationValue_FailsClosedForMalformedStructuredConfig()
+    {
+        var redactor = new SupportPackRedactor([]);
+
+        var result = redactor.RedactConfigurationValue(ConfigKeys.IndexersInstances, "{not-json");
+
+        Assert.Equal("[REDACTED_MALFORMED_STRUCTURED_VALUE]", result);
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
     { "Repairs" = "configuration/repairs.md" },
     { "Maintenance" = "configuration/maintenance.md" },
     { "Backup and restore" = "configuration/backup.md" },
+    { "Support" = "configuration/support.md" },
     { "Environment variables" = "configuration/environment-variables.md" },
   ]},
   { "Use cases" = [


### PR DESCRIPTION
## Summary
- add an authenticated Settings → Support download for a streamed, privacy-redacted diagnostics ZIP
- include current backend logs, active configuration sources, runtime details, and aggregate reliability/consumption metrics
- document the workflow and prompt bug reporters to upload a reviewed support pack

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~SupportPackRedactorTests`
- [x] `npm run lint && npm test && npm run build`
- [x] `zensical build --clean --strict`
- [x] Generated and verified the archive through the local Settings → Support GUI
- [ ] Full backend suite (blocked locally by the missing macOS arm64 `rapidyenc` native library)