### PR TITLE
fix(utils): library scans no longer break on quoted paths or newline filenames

### DIFF
--- a/backend/Utils/SymlinkAndStrmUtil.cs
+++ b/backend/Utils/SymlinkAndStrmUtil.cs
@@ -8,6 +8,8 @@ public static class SymlinkAndStrmUtil
 {
     private static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
     private const int MaxStderrChars = 4096;
+    internal const int MaxStrmTargetBytes = 8 * 1024;
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     public static IEnumerable<ISymlinkOrStrmInfo> GetAllSymlinksAndStrms(string directoryPath)
     {
@@ -18,35 +20,11 @@ public static class SymlinkAndStrmUtil
 
     private static IEnumerable<ISymlinkOrStrmInfo> GetAllSymlinksAndStrmsLinux(string directoryPath)
     {
-        // find -exec (instead of piping to xargs) keeps traversal errors (permission
-        // denied, etc.) in find's own exit code without `set -o pipefail`, which
-        // Ubuntu's dash (/bin/sh) does not support.
-        const string command =
-            """
-            find . \( -type l -o -name '*.strm' \) -exec sh -c '
-              for path in \"$@\"; do
-                echo \"$path\"
-                if [ \"${path##*.}\" = \"strm\" ]; then
-                  echo \"$(cat \"$path\")\"
-                else
-                  echo \"$(readlink \"$path\")\"
-                fi
-              done
-            ' sh {} +
-            """;
-
-        var escapedDirectory = directoryPath.Replace("'", "'\"'\"'");
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "sh",
-            Arguments = $"-c \"cd '{escapedDirectory}' && {command}\"",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        using var process = Process.Start(startInfo)!;
+        // find -print0 (no shell) keeps traversal errors in find's own exit code and avoids
+        // argv quoting / newline framing hazards. Targets are read in managed code.
+        var startInfo = CreateLinuxFindStartInfo(directoryPath);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Library symlink scan failed to start find.");
 
         // Drain stderr asynchronously. Leaving it unread can fill the OS pipe buffer and
         // deadlock find when a library tree produces many permission errors.
@@ -66,32 +44,48 @@ public static class SymlinkAndStrmUtil
         };
         process.BeginErrorReadLine();
 
-        while (process.StandardOutput.EndOfStream == false)
+        var completed = false;
+        try
         {
-            var filePath = process.StandardOutput.ReadLine();
-            if (filePath == null) break;
-            var target = process.StandardOutput.ReadLine();
-            if (target == null) break;
+            while (true)
+            {
+                var filePath = ReadNullTerminated(process.StandardOutput);
+                if (filePath is null)
+                    break;
 
-            if (filePath.ToLower().EndsWith(".strm"))
-            {
-                yield return new StrmInfo()
-                {
-                    StrmPath = Path.GetFullPath(filePath, directoryPath),
-                    TargetUrl = target
-                };
+                var info = ReadLinuxFindEntry(filePath);
+                if (info is not null)
+                    yield return info;
             }
-            else
+
+            completed = true;
+        }
+        finally
+        {
+            try
             {
-                yield return new SymlinkInfo()
+                // Only force-kill on early dispose / mid-scan failure. After a clean EOF,
+                // find is exiting normally and Kill would turn a success into a false failure.
+                if (!completed && !process.HasExited)
                 {
-                    SymlinkPath = Path.GetFullPath(filePath, directoryPath),
-                    TargetPath = target
-                };
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch
+                    {
+                        // Best-effort cleanup when the consumer disposes early or a read fails.
+                    }
+                }
+
+                process.WaitForExit();
+            }
+            catch
+            {
+                // Ignore cleanup failures; the primary error (if any) is already propagating.
             }
         }
 
-        process.WaitForExit();
         if (process.ExitCode != 0)
         {
             string stderr;
@@ -102,6 +96,99 @@ public static class SymlinkAndStrmUtil
                 $"Library symlink scan failed with exit code {process.ExitCode}" +
                 (string.IsNullOrWhiteSpace(stderr) ? "." : $": {stderr}"));
         }
+    }
+
+    /// <summary>
+    /// Builds the Linux traversal process without a command shell. Every value,
+    /// including the user-selected root, is passed as a distinct argv entry.
+    /// </summary>
+    internal static ProcessStartInfo CreateLinuxFindStartInfo(string directoryPath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "find",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        // -H preserves the old `cd root && find .` behavior when the selected
+        // root itself is a symlink, without following symlinks found below it.
+        startInfo.ArgumentList.Add("-H");
+        // An absolute starting point cannot be interpreted as a find option even
+        // when a caller supplies a relative directory beginning with '-'.
+        startInfo.ArgumentList.Add(Path.GetFullPath(directoryPath));
+        startInfo.ArgumentList.Add("(");
+        startInfo.ArgumentList.Add("-type");
+        startInfo.ArgumentList.Add("l");
+        startInfo.ArgumentList.Add("-o");
+        startInfo.ArgumentList.Add("-name");
+        startInfo.ArgumentList.Add("*.strm");
+        startInfo.ArgumentList.Add(")");
+        startInfo.ArgumentList.Add("-print0");
+        return startInfo;
+    }
+
+    /// <summary>
+    /// Reads one NUL-terminated record. Clean EOF with no pending bytes returns null;
+    /// EOF with a partial record is a protocol failure.
+    /// </summary>
+    internal static string? ReadNullTerminated(TextReader reader)
+    {
+        var value = new StringBuilder();
+        while (true)
+        {
+            var next = reader.Read();
+            if (next < 0)
+            {
+                if (value.Length == 0)
+                    return null;
+
+                throw new InvalidOperationException(
+                    "Library symlink scan received a truncated NUL-terminated path.");
+            }
+
+            if (next == '\0')
+                return value.ToString();
+
+            value.Append((char)next);
+        }
+    }
+
+    /// <summary>
+    /// Resolves one path emitted by find into a symlink or strm record.
+    /// </summary>
+    internal static ISymlinkOrStrmInfo? ReadLinuxFindEntry(string filePath)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+        if (Path.GetExtension(fullPath).Equals(".strm", StringComparison.OrdinalIgnoreCase))
+        {
+            var targetUrl = ReadStrmTargetUrl(fullPath);
+            if (targetUrl is null)
+                return null;
+
+            return new StrmInfo
+            {
+                StrmPath = fullPath,
+                TargetUrl = targetUrl
+            };
+        }
+
+        // Do not require Exists: broken library symlinks are still links and must be reported.
+        var fileInfo = new FileInfo(fullPath);
+        var target = fileInfo.LinkTarget;
+        if (target is null)
+        {
+            throw new InvalidOperationException(
+                $"Library symlink scan could not read the symlink target for '{fullPath}'.");
+        }
+
+        return new SymlinkInfo
+        {
+            SymlinkPath = fullPath,
+            TargetPath = target
+        };
     }
 
     private static IEnumerable<ISymlinkOrStrmInfo> GetAllSymlinksAndStrmsWindows(string directoryPath)
@@ -115,9 +202,90 @@ public static class SymlinkAndStrmUtil
 
     public static ISymlinkOrStrmInfo? GetSymlinkOrStrmInfo(FileInfo x)
     {
-        return IsStrm(x) ? new StrmInfo() { StrmPath = x.FullName, TargetUrl = File.ReadAllText(x.FullName) }
-            : IsSymLink(x) ? new SymlinkInfo() { SymlinkPath = x.FullName, TargetPath = x.LinkTarget! }
+        if (IsStrm(x))
+        {
+            var targetUrl = ReadStrmTargetUrl(x.FullName);
+            return targetUrl is null
+                ? null
+                : new StrmInfo { StrmPath = x.FullName, TargetUrl = targetUrl };
+        }
+
+        return IsSymLink(x)
+            ? new SymlinkInfo { SymlinkPath = x.FullName, TargetPath = x.LinkTarget! }
             : null;
+    }
+
+    /// <summary>
+    /// Returns the first non-empty STRM target line, inspecting at most
+    /// <see cref="MaxStrmTargetBytes"/>. Empty files yield null; an oversized first
+    /// non-empty line throws rather than truncating into a wrong mapping.
+    /// </summary>
+    internal static string? ReadStrmTargetUrl(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        var buffer = new byte[MaxStrmTargetBytes];
+        var bytesRead = stream.Read(buffer, 0, buffer.Length);
+        if (bytesRead == 0)
+            return null;
+
+        var span = buffer.AsSpan(0, bytesRead);
+        if (span.Length >= 3 && span[0] == 0xEF && span[1] == 0xBB && span[2] == 0xBF)
+            span = span[3..];
+
+        var offset = 0;
+        while (offset <= span.Length)
+        {
+            var remaining = span[offset..];
+            var newline = remaining.IndexOf((byte)'\n');
+            ReadOnlySpan<byte> lineBytes;
+            bool lineComplete;
+            if (newline >= 0)
+            {
+                lineBytes = remaining[..newline];
+                lineComplete = true;
+                offset += newline + 1;
+            }
+            else
+            {
+                lineBytes = remaining;
+                // The first non-empty line is complete only when the inspected window
+                // reached EOF. A full buffer with no newline means the line may continue.
+                lineComplete = bytesRead < MaxStrmTargetBytes;
+                offset = span.Length + 1; // no further lines in this window
+            }
+
+            if (lineBytes.Length > 0 && lineBytes[^1] == (byte)'\r')
+                lineBytes = lineBytes[..^1];
+
+            if (lineBytes.IsEmpty)
+            {
+                if (!lineComplete)
+                {
+                    throw new InvalidOperationException(
+                        $"Library strm target in '{path}' exceeds {MaxStrmTargetBytes} bytes.");
+                }
+
+                continue;
+            }
+
+            if (!lineComplete)
+            {
+                throw new InvalidOperationException(
+                    $"Library strm target in '{path}' exceeds {MaxStrmTargetBytes} bytes.");
+            }
+
+            try
+            {
+                return StrictUtf8.GetString(lineBytes);
+            }
+            catch (DecoderFallbackException e)
+            {
+                throw new InvalidOperationException(
+                    $"Library strm target in '{path}' is not valid UTF-8.", e);
+            }
+        }
+
+        return null;
     }
 
     private static bool IsStrm(FileInfo x) =>

--- a/tests/NzbWebDAV.Tests/Utils/SymlinkAndStrmUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/SymlinkAndStrmUtilTests.cs
@@ -1,0 +1,284 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public sealed class SymlinkAndStrmUtilTests
+{
+    [Fact]
+    public void LinuxFindStartInfo_PassesHostileRootAsOneOpaqueArgument()
+    {
+        var hostileRoot = Path.Combine(
+            Path.GetTempPath(),
+            "-library-\"-'-$()-; touch injected-line1\nline2-ユニコード");
+
+        var startInfo = SymlinkAndStrmUtil.CreateLinuxFindStartInfo(hostileRoot);
+
+        Assert.Equal("find", startInfo.FileName);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.Empty(startInfo.Arguments);
+        Assert.Equal(Path.GetFullPath(hostileRoot), startInfo.ArgumentList[1]);
+        Assert.Equal(
+            ["-H", Path.GetFullPath(hostileRoot), "(", "-type", "l", "-o", "-name", "*.strm", ")", "-print0"],
+            startInfo.ArgumentList.ToArray());
+    }
+
+    [Fact]
+    public void ReadNullTerminated_PreservesNewlinesAndRejectsTruncatedRecords()
+    {
+        using var reader = new StringReader("path/with\nnewline\0next\0");
+        Assert.Equal("path/with\nnewline", SymlinkAndStrmUtil.ReadNullTerminated(reader));
+        Assert.Equal("next", SymlinkAndStrmUtil.ReadNullTerminated(reader));
+        Assert.Null(SymlinkAndStrmUtil.ReadNullTerminated(reader));
+
+        using var truncated = new StringReader("partial-without-nul");
+        var error = Assert.Throws<InvalidOperationException>(
+            () => SymlinkAndStrmUtil.ReadNullTerminated(truncated));
+        Assert.Contains("truncated NUL-terminated path", error.Message);
+    }
+
+    [Fact]
+    public void ReadStrmTargetUrl_SelectsFirstNonEmptyLineAndBoundsInspection()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var multiLine = Path.Combine(root, "multi.strm");
+            File.WriteAllText(multiLine, "\n\r\nhttp://localhost/view/.ids/a.mkv?extension=mkv\nsecond-line\n");
+
+            var withBom = Path.Combine(root, "bom.strm");
+            File.WriteAllBytes(
+                withBom,
+                new byte[] { 0xEF, 0xBB, 0xBF }
+                    .Concat(Encoding.UTF8.GetBytes("http://localhost/view/.ids/b.mkv\r\n"))
+                    .ToArray());
+
+            var empty = Path.Combine(root, "empty.strm");
+            File.WriteAllText(empty, "");
+
+            var oversized = Path.Combine(root, "oversized.strm");
+            File.WriteAllText(oversized, new string('a', SymlinkAndStrmUtil.MaxStrmTargetBytes + 1));
+
+            var hugeLaterLine = Path.Combine(root, "huge-later.strm");
+            File.WriteAllText(
+                hugeLaterLine,
+                "http://localhost/view/.ids/c.mkv\n" + new string('b', SymlinkAndStrmUtil.MaxStrmTargetBytes * 4));
+
+            Assert.Equal(
+                "http://localhost/view/.ids/a.mkv?extension=mkv",
+                SymlinkAndStrmUtil.ReadStrmTargetUrl(multiLine));
+            Assert.Equal(
+                "http://localhost/view/.ids/b.mkv",
+                SymlinkAndStrmUtil.ReadStrmTargetUrl(withBom));
+            Assert.Null(SymlinkAndStrmUtil.ReadStrmTargetUrl(empty));
+            Assert.Equal(
+                "http://localhost/view/.ids/c.mkv",
+                SymlinkAndStrmUtil.ReadStrmTargetUrl(hugeLaterLine));
+
+            var oversizedError = Assert.Throws<InvalidOperationException>(
+                () => SymlinkAndStrmUtil.ReadStrmTargetUrl(oversized));
+            Assert.Contains("exceeds", oversizedError.Message);
+
+            Assert.Null(SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(new FileInfo(empty)));
+            var strmInfo = Assert.IsType<SymlinkAndStrmUtil.StrmInfo>(
+                SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(new FileInfo(multiLine)));
+            Assert.Equal("http://localhost/view/.ids/a.mkv?extension=mkv", strmInfo.TargetUrl);
+        }
+        finally
+        {
+            DeleteQuietly(root);
+        }
+    }
+
+    [Fact]
+    public void ReadLinuxFindEntry_FailsClosedWhenSymlinkTargetDisappears()
+    {
+        var root = CreateTempDirectory();
+        var path = Path.Combine(root, "victim.mkv");
+        try
+        {
+            File.CreateSymbolicLink(path, "original-target.mkv");
+            File.Delete(path);
+            File.WriteAllText(path, "not-a-symlink-anymore");
+
+            var error = Assert.Throws<InvalidOperationException>(
+                () => SymlinkAndStrmUtil.ReadLinuxFindEntry(path));
+            Assert.Contains("could not read the symlink target", error.Message);
+        }
+        finally
+        {
+            DeleteQuietly(root);
+        }
+    }
+
+    [SkippableFact]
+    public void LinuxEnumeration_HandlesHostileNamesNewlinesAndExactSymlinkTargets()
+    {
+        Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
+
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            $"-library-\"-'-$()-; touch injected-line1\nline2-ユニコード-{Guid.NewGuid():N}");
+        var newlineName = "file\nwith\nnewlines.mkv";
+        var symlinkPath = Path.Combine(root, newlineName);
+        var strmPath = Path.Combine(root, "movie.strm");
+        var trailingSymlinkPath = Path.Combine(root, "trailing.mkv");
+        const string targetUrl = "http://localhost:8080/view/.ids/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.mkv?extension=mkv";
+        const string linkTarget = "missing-target\nwith\nnewlines.mkv";
+        const string trailingTarget = "next-target.mkv";
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            File.WriteAllText(strmPath, targetUrl + "\nignored-second-line\n");
+            File.CreateSymbolicLink(symlinkPath, linkTarget);
+            File.CreateSymbolicLink(trailingSymlinkPath, trailingTarget);
+
+            var results = SymlinkAndStrmUtil.GetAllSymlinksAndStrms(root).ToList();
+
+            var strm = Assert.Single(results.OfType<SymlinkAndStrmUtil.StrmInfo>());
+            Assert.Equal(strmPath, strm.StrmPath);
+            Assert.Equal(targetUrl, strm.TargetUrl);
+
+            var links = results.OfType<SymlinkAndStrmUtil.SymlinkInfo>()
+                .OrderBy(x => x.SymlinkPath, StringComparer.Ordinal)
+                .ToList();
+            Assert.Equal(2, links.Count);
+
+            var newlineLink = Assert.Single(links, x => x.SymlinkPath == symlinkPath);
+            Assert.Equal(linkTarget, newlineLink.TargetPath);
+
+            var trailing = Assert.Single(links, x => x.SymlinkPath == trailingSymlinkPath);
+            Assert.Equal(trailingTarget, trailing.TargetPath);
+        }
+        finally
+        {
+            DeleteQuietly(root);
+        }
+    }
+
+    [SkippableFact]
+    public void LinuxEnumeration_FollowsSymlinkedRootButNotNestedDirectorySymlinks()
+    {
+        Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
+
+        var parent = CreateTempDirectory();
+        var realRoot = Path.Combine(parent, "real-root");
+        var linkRoot = Path.Combine(parent, "link-root");
+        var nestedReal = Path.Combine(parent, "nested-real");
+        var nestedLink = Path.Combine(realRoot, "nested-link");
+
+        try
+        {
+            Directory.CreateDirectory(realRoot);
+            Directory.CreateDirectory(nestedReal);
+            File.CreateSymbolicLink(linkRoot, realRoot);
+            Directory.CreateSymbolicLink(nestedLink, nestedReal);
+
+            File.WriteAllText(Path.Combine(realRoot, "root.strm"), "http://localhost/view/.ids/root.mkv");
+            File.WriteAllText(Path.Combine(nestedReal, "nested.strm"), "http://localhost/view/.ids/nested.mkv");
+
+            var results = SymlinkAndStrmUtil.GetAllSymlinksAndStrms(linkRoot).ToList();
+            var strmPaths = results.OfType<SymlinkAndStrmUtil.StrmInfo>()
+                .Select(x => x.StrmPath)
+                .ToHashSet(StringComparer.Ordinal);
+
+            // find -H may report the strm under the symlink root path or the real path.
+            Assert.True(
+                strmPaths.Contains(Path.Combine(realRoot, "root.strm")) ||
+                strmPaths.Contains(Path.Combine(linkRoot, "root.strm")),
+                $"Expected root.strm under the followed symlink root. Found: {string.Join(", ", strmPaths)}");
+            Assert.DoesNotContain(Path.Combine(nestedReal, "nested.strm"), strmPaths);
+            Assert.DoesNotContain(Path.Combine(nestedLink, "nested.strm"), strmPaths);
+
+            // The nested directory symlink itself is still a -type l match.
+            Assert.Contains(
+                results.OfType<SymlinkAndStrmUtil.SymlinkInfo>(),
+                x =>
+                    (x.SymlinkPath == nestedLink ||
+                     x.SymlinkPath == Path.Combine(linkRoot, "nested-link")) &&
+                    (x.TargetPath == nestedReal ||
+                     Path.GetFullPath(x.TargetPath, Path.GetDirectoryName(x.SymlinkPath)!) == nestedReal));
+        }
+        finally
+        {
+            DeleteQuietly(parent);
+        }
+    }
+
+    [SkippableFact]
+    public void LinuxEnumeration_FailsClosedOnPermissionDeniedWithBoundedStderr()
+    {
+        Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
+        Skip.If(geteuid() == 0, "Permission-denied traversal cannot be validated as root.");
+
+        var root = CreateTempDirectory();
+        var deniedDirs = new List<string>();
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "ok.strm"), "http://localhost/view/.ids/ok.mkv");
+
+            // Enough denied subtrees to exceed MaxStderrChars when find reports each one.
+            for (var i = 0; i < 80; i++)
+            {
+                var denied = Path.Combine(root, $"denied-{i:D3}");
+                Directory.CreateDirectory(denied);
+                File.WriteAllText(Path.Combine(denied, $"hidden-{i}.strm"), "http://localhost/view/.ids/hidden.mkv");
+                chmod(denied, 0);
+                deniedDirs.Add(denied);
+            }
+
+            var error = Assert.Throws<InvalidOperationException>(
+                () => SymlinkAndStrmUtil.GetAllSymlinksAndStrms(root).ToList());
+            Assert.Contains("Library symlink scan failed with exit code", error.Message);
+            Assert.True(
+                error.Message.Length <= 512 + 4096,
+                $"Expected bounded stderr in the failure message, got length {error.Message.Length}.");
+        }
+        finally
+        {
+            foreach (var denied in deniedDirs)
+            {
+                try
+                {
+                    chmod(denied, 0x1FF); // 0777
+                }
+                catch
+                {
+                    // Best-effort restore before recursive delete.
+                }
+            }
+
+            DeleteQuietly(root);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nzbdav-symlink-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteQuietly(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+            else if (File.Exists(path) || new FileInfo(path).LinkTarget is not null)
+                File.Delete(path);
+        }
+        catch
+        {
+            // Best-effort cleanup for tests.
+        }
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int chmod(string path, int mode);
+
+    [DllImport("libc")]
+    private static extern uint geteuid();
+}


### PR DESCRIPTION
## Summary
- Fixes [#589](https://github.com/nzbdav/nzbdav/issues/589) by removing the nested `sh -c` library scanner and invoking `find` directly with `ProcessStartInfo.ArgumentList`.
- Path records are NUL-delimited; symlink/STRM targets are read in managed code with fail-closed races, bounded first-line STRM targets, and preserved permission-error diagnostics.
- Adds Linux/Alpine-covered tests for hostile roots, newline filenames, symlink-root semantics, oversized STRMs, and permission-denied stderr bounds.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~SymlinkAndStrmUtil`
- [x] Same filter on Alpine BusyBox (`mcr.microsoft.com/dotnet/sdk:10.0-alpine`, non-root): 7 passed
- [ ] CI backend job on `ubuntu-latest` (Linux integration cases)
- [ ] Optional: run Remove Orphaned Files dry-run against a library root containing spaces/quotes