### PR TITLE
chore(ci): fail CI on high and critical dependency advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Audit production dependencies
         working-directory: frontend
-        continue-on-error: true
         run: npm audit --omit=dev --audit-level=high
 
       - name: Lint
@@ -110,9 +109,18 @@ jobs:
       - name: Restore backend
         run: dotnet restore backend/NzbWebDAV.csproj && dotnet restore tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
 
-      - name: List vulnerable packages
-        continue-on-error: true
-        run: dotnet list backend/NzbWebDAV.csproj package --vulnerable --include-transitive
+      - name: Verify NuGet vulnerability gate fixtures
+        run: bash scripts/test-nuget-vulnerability-gate.sh
+
+      - name: Audit NuGet production dependencies
+        run: |
+          report="$(mktemp)"
+          trap 'rm -f "$report"' EXIT
+          dotnet list backend/NzbWebDAV.csproj package --vulnerable --include-transitive --format json --output-version 1 > "$report"
+          python3 scripts/check-nuget-vulnerabilities.py \
+            "$report" \
+            --allowlist scripts/nuget-vulnerability-allowlist.json \
+            --summary "${GITHUB_STEP_SUMMARY}"
 
       - name: Build backend
         working-directory: backend

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -5,7 +5,9 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <WarningsAsErrors>Nullable;NU1903</WarningsAsErrors>
+        <WarningsAsErrors>Nullable;NU1903;NU1904</WarningsAsErrors>
+        <!-- Explicit: net10 defaults to all; keep transitive restore audits gated. -->
+        <NuGetAuditMode>all</NuGetAuditMode>
         <ServerGarbageCollection>true</ServerGarbageCollection>
     </PropertyGroup>
 

--- a/scripts/check-nuget-vulnerabilities.py
+++ b/scripts/check-nuget-vulnerabilities.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Fail CI when high/critical NuGet advisories are present.
+
+Reads `dotnet list package --vulnerable --include-transitive --format json`
+output and exits nonzero for High/Critical findings that are not covered by a
+non-expired allowlist entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlsplit, urlunsplit
+
+
+FAIL_SEVERITIES = frozenset({"high", "critical"})
+
+
+@dataclass(frozen=True)
+class Finding:
+    project: str
+    package_id: str
+    resolved_version: str
+    severity: str
+    advisory_url: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    package_id: str
+    advisory_url: str
+    reason: str
+    expires_on: date
+
+
+def normalize_advisory_url(url: str) -> str:
+    parts = urlsplit((url or "").strip())
+    path = parts.path.rstrip("/")
+    return urlunsplit((parts.scheme.lower(), parts.netloc.lower(), path, "", ""))
+
+
+def parse_allowlist(path: Path | None, today: date) -> list[AllowlistEntry]:
+    if path is None:
+        return []
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    entries: list[AllowlistEntry] = []
+    for raw in data.get("exceptions", []):
+        expires_on = date.fromisoformat(str(raw["expiresOn"]))
+        if expires_on < today:
+            continue
+        entries.append(
+            AllowlistEntry(
+                package_id=str(raw["packageId"]).strip(),
+                advisory_url=normalize_advisory_url(str(raw["advisoryUrl"])),
+                reason=str(raw.get("reason", "")).strip(),
+                expires_on=expires_on,
+            )
+        )
+    return entries
+
+
+def is_allowed(finding: Finding, allowlist: Iterable[AllowlistEntry]) -> AllowlistEntry | None:
+    advisory = normalize_advisory_url(finding.advisory_url)
+    for entry in allowlist:
+        if (
+            entry.package_id.lower() == finding.package_id.lower()
+            and entry.advisory_url == advisory
+        ):
+            return entry
+    return None
+
+
+def iter_packages(framework: dict[str, Any]) -> Iterable[tuple[str, dict[str, Any]]]:
+    for scope, key in (
+        ("top-level", "topLevelPackages"),
+        ("transitive", "transitivePackages"),
+    ):
+        for package in framework.get(key) or []:
+            yield scope, package
+
+
+def collect_findings(report: dict[str, Any]) -> list[Finding]:
+    findings: list[Finding] = []
+    for project in report.get("projects") or []:
+        project_path = str(project.get("path") or "")
+        for framework in project.get("frameworks") or []:
+            for scope, package in iter_packages(framework):
+                package_id = str(package.get("id") or "")
+                resolved = str(
+                    package.get("resolvedVersion")
+                    or package.get("resolvedversion")
+                    or ""
+                )
+                for vuln in package.get("vulnerabilities") or []:
+                    severity = str(vuln.get("severity") or "").strip()
+                    advisory_url = str(
+                        vuln.get("advisoryurl")
+                        or vuln.get("advisoryUrl")
+                        or ""
+                    ).strip()
+                    findings.append(
+                        Finding(
+                            project=project_path,
+                            package_id=package_id,
+                            resolved_version=resolved,
+                            severity=severity,
+                            advisory_url=advisory_url,
+                            scope=scope,
+                        )
+                    )
+    return findings
+
+
+def write_summary(
+    path: Path | None,
+    *,
+    failing: list[Finding],
+    allowed: list[tuple[Finding, AllowlistEntry]],
+    visible: list[Finding],
+) -> None:
+    if path is None:
+        return
+
+    lines = [
+        "## NuGet vulnerability gate",
+        "",
+        f"- High/critical failing: **{len(failing)}**",
+        f"- High/critical allowlisted: **{len(allowed)}**",
+        f"- Low/moderate visible: **{len(visible)}**",
+        "",
+    ]
+
+    def table(title: str, rows: list[Finding], extra: str | None = None) -> None:
+        lines.append(f"### {title}")
+        lines.append("")
+        if not rows:
+            lines.append("_None_")
+            lines.append("")
+            return
+        headers = "| Package | Version | Severity | Scope | Advisory |"
+        sep = "| --- | --- | --- | --- | --- |"
+        if extra:
+            headers = "| Package | Version | Severity | Scope | Advisory | Notes |"
+            sep = "| --- | --- | --- | --- | --- | --- |"
+        lines.extend([headers, sep])
+        for finding in rows:
+            advisory = finding.advisory_url or "(missing)"
+            base = (
+                f"| `{finding.package_id}` | `{finding.resolved_version}` | "
+                f"{finding.severity} | {finding.scope} | {advisory}"
+            )
+            if extra is None:
+                lines.append(base + " |")
+            else:
+                lines.append(base + f" | {extra} |")
+        lines.append("")
+
+    table("Failing (high/critical)", failing)
+    if allowed:
+        lines.append("### Allowlisted (high/critical)")
+        lines.append("")
+        lines.append(
+            "| Package | Version | Severity | Scope | Advisory | Reason | Expires |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+        for finding, entry in allowed:
+            lines.append(
+                f"| `{finding.package_id}` | `{finding.resolved_version}` | "
+                f"{finding.severity} | {finding.scope} | {finding.advisory_url} | "
+                f"{entry.reason or '_n/a_'} | {entry.expires_on.isoformat()} |"
+            )
+        lines.append("")
+    table("Other severities", visible)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        if not lines[-1].endswith("\n"):
+            handle.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "report",
+        type=Path,
+        help="JSON report from `dotnet list package --vulnerable --format json`",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="Optional JSON allowlist of temporary exceptions",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=None,
+        help="Append a Markdown summary (typically $GITHUB_STEP_SUMMARY)",
+    )
+    parser.add_argument(
+        "--today",
+        type=str,
+        default=None,
+        help="Override today (YYYY-MM-DD) for allowlist expiry checks",
+    )
+    args = parser.parse_args(argv)
+
+    today = (
+        date.fromisoformat(args.today)
+        if args.today
+        else datetime.now(timezone.utc).date()
+    )
+    report = json.loads(args.report.read_text(encoding="utf-8"))
+    allowlist = parse_allowlist(args.allowlist, today)
+    findings = collect_findings(report)
+
+    failing: list[Finding] = []
+    allowed: list[tuple[Finding, AllowlistEntry]] = []
+    visible: list[Finding] = []
+
+    for finding in findings:
+        severity = finding.severity.lower()
+        if severity not in FAIL_SEVERITIES:
+            visible.append(finding)
+            continue
+        entry = is_allowed(finding, allowlist)
+        if entry is not None:
+            allowed.append((finding, entry))
+        else:
+            failing.append(finding)
+
+    write_summary(args.summary, failing=failing, allowed=allowed, visible=visible)
+
+    if not findings:
+        print("No NuGet vulnerabilities reported.")
+        return 0
+
+    for finding in visible:
+        print(
+            f"info: {finding.severity} {finding.package_id} "
+            f"{finding.resolved_version} ({finding.scope}) {finding.advisory_url}"
+        )
+    for finding, entry in allowed:
+        print(
+            f"allowlisted: {finding.severity} {finding.package_id} "
+            f"{finding.resolved_version} until {entry.expires_on.isoformat()} "
+            f"({entry.reason}) {finding.advisory_url}"
+        )
+    for finding in failing:
+        print(
+            f"error: {finding.severity} {finding.package_id} "
+            f"{finding.resolved_version} ({finding.scope}) {finding.advisory_url}",
+            file=sys.stderr,
+        )
+
+    if failing:
+        print(
+            f"NuGet vulnerability gate failed: {len(failing)} high/critical "
+            "finding(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"NuGet vulnerability gate passed "
+        f"({len(allowed)} allowlisted high/critical, {len(visible)} lower severity)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/nuget-vuln-allowlist.json
+++ b/scripts/fixtures/nuget-vuln-allowlist.json
@@ -1,0 +1,10 @@
+{
+  "exceptions": [
+    {
+      "packageId": "Example.Vulnerable",
+      "advisoryUrl": "https://github.com/advisories/GHSA-test-high-0001",
+      "reason": "Fixture exception used by scripts/test-nuget-vulnerability-gate.sh",
+      "expiresOn": "2099-01-01"
+    }
+  ]
+}

--- a/scripts/fixtures/nuget-vuln-clean.json
+++ b/scripts/fixtures/nuget-vuln-clean.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "parameters": "--vulnerable --include-transitive",
+  "sources": [
+    "https://api.nuget.org/v3/index.json"
+  ],
+  "projects": [
+    {
+      "path": "/tmp/NzbWebDAV.csproj"
+    }
+  ]
+}

--- a/scripts/fixtures/nuget-vuln-high.json
+++ b/scripts/fixtures/nuget-vuln-high.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "parameters": "--vulnerable --include-transitive",
+  "sources": [
+    "https://api.nuget.org/v3/index.json"
+  ],
+  "projects": [
+    {
+      "path": "/tmp/NzbWebDAV.csproj",
+      "frameworks": [
+        {
+          "framework": "net10.0",
+          "topLevelPackages": [
+            {
+              "id": "Example.Vulnerable",
+              "requestedVersion": "1.0.0",
+              "resolvedVersion": "1.0.0",
+              "vulnerabilities": [
+                {
+                  "severity": "High",
+                  "advisoryurl": "https://github.com/advisories/GHSA-test-high-0001"
+                }
+              ]
+            }
+          ],
+          "transitivePackages": [
+            {
+              "id": "Example.TransitiveModerate",
+              "resolvedVersion": "2.0.0",
+              "vulnerabilities": [
+                {
+                  "severity": "Moderate",
+                  "advisoryurl": "https://github.com/advisories/GHSA-test-mod-0002"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/nuget-vulnerability-allowlist.json
+++ b/scripts/nuget-vulnerability-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "$schema_comment": "Temporary NuGet advisory exceptions for CI. Each entry must name packageId, advisoryUrl, reason, and expiresOn (YYYY-MM-DD). Expired entries are ignored and the finding fails CI.",
+  "exceptions": []
+}

--- a/scripts/test-nuget-vulnerability-gate.sh
+++ b/scripts/test-nuget-vulnerability-gate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fixture checks for scripts/check-nuget-vulnerabilities.py
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="${ROOT}/scripts/check-nuget-vulnerabilities.py"
+FIXTURES="${ROOT}/scripts/fixtures"
+
+python3 "${GATE}" "${FIXTURES}/nuget-vuln-clean.json"
+
+if python3 "${GATE}" "${FIXTURES}/nuget-vuln-high.json"; then
+  echo "expected high fixture to fail" >&2
+  exit 1
+fi
+
+python3 "${GATE}" \
+  "${FIXTURES}/nuget-vuln-high.json" \
+  --allowlist "${FIXTURES}/nuget-vuln-allowlist.json"
+
+if python3 "${GATE}" \
+  "${FIXTURES}/nuget-vuln-high.json" \
+  --allowlist "${FIXTURES}/nuget-vuln-allowlist.json" \
+  --today 2099-01-02; then
+  echo "expected expired allowlist entry to fail" >&2
+  exit 1
+fi
+
+echo "NuGet vulnerability gate fixtures passed."


### PR DESCRIPTION
## Summary
- Enforce frontend `npm audit --omit=dev --audit-level=high` (no more `continue-on-error`)
- Treat NuGet `NU1903`/`NU1904` as errors with explicit transitive audit (`NuGetAuditMode=all`)
- Gate backend CI on structured `dotnet list package --vulnerable --format json` output via an allowlist-aware parser, fixture checks, and a GitHub step summary

Fixes #588

## Test plan
- [x] `bash scripts/test-nuget-vulnerability-gate.sh` (clean pass, high fail, allowlist pass, expired allowlist fail)
- [x] Live `dotnet list ... --vulnerable --format json` currently reports no findings and gate passes
- [x] `npm audit --omit=dev --audit-level=high` reports 0 vulnerabilities
- [ ] CI frontend + backend jobs green on this PR