### PR TITLE
fix(search): prevent OOM from oversized indexer NZB responses

### DIFF
--- a/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
@@ -55,7 +56,20 @@ public class NzbProxyController(
                         .SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token)
                         .ConfigureAwait(false);
                     if (!resp.IsSuccessStatusCode) return null;
-                    return await resp.Content.ReadAsByteArrayAsync(cts.Token).ConfigureAwait(false);
+                    try
+                    {
+                        return await HttpContentReadUtil
+                            .ReadBoundedAsync(resp.Content, NzbFetchLimits.MaxResponseBytes, cts.Token)
+                            .ConfigureAwait(false);
+                    }
+                    catch (NzbResponseTooLargeException e)
+                    {
+                        Log.Warning(
+                            "NZB proxy rejected oversized response from {Url}. Limit: {Limit} bytes. Reason: {Reason}",
+                            candidate.NzbUrl, e.MaxBytes, e.Message);
+                        Log.Debug(e, "NZB proxy oversized response stack");
+                        return null;
+                    }
                 },
                 HttpContext.RequestAborted).ConfigureAwait(false);
         }

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Api.SabControllers.AddFile;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue;
@@ -842,9 +843,23 @@ public class ProfilePlayController(
                 var client = ProxyHttpClientPool.GetClient(c.ProxyUrl, skipTlsVerification);
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
                 cts.CancelAfter(NzbFetchTimeout);
-                using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);
+                using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token).ConfigureAwait(false);
                 if (!resp.IsSuccessStatusCode) return null;
-                var bytes = await resp.Content.ReadAsByteArrayAsync(cts.Token).ConfigureAwait(false);
+                byte[] bytes;
+                try
+                {
+                    bytes = await HttpContentReadUtil
+                        .ReadBoundedAsync(resp.Content, NzbFetchLimits.MaxResponseBytes, cts.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (NzbResponseTooLargeException e)
+                {
+                    Log.Warning(
+                        "NZB fetch rejected oversized response from {Url}. Limit: {Limit} bytes. Reason: {Reason}",
+                        c.NzbUrl, e.MaxBytes, e.Message);
+                    Log.Debug(e, "NZB fetch oversized response stack");
+                    return null;
+                }
                 _ = hitTracker.RecordAsync(c.IndexerName, IndexerApiHit.HitType.Download, CancellationToken.None);
                 return bytes;
             }

--- a/backend/Exceptions/NzbResponseTooLargeException.cs
+++ b/backend/Exceptions/NzbResponseTooLargeException.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Exceptions;
+
+public sealed class NzbResponseTooLargeException(long maxBytes, long? contentLength = null)
+    : Exception(FormatMessage(maxBytes, contentLength))
+{
+    public long MaxBytes { get; } = maxBytes;
+    public long? ContentLength { get; } = contentLength;
+
+    private static string FormatMessage(long maxBytes, long? contentLength) =>
+        contentLength is { } declared
+            ? $"NZB response Content-Length {declared} exceeds the {maxBytes}-byte limit."
+            : $"NZB response exceeded the {maxBytes}-byte limit while streaming.";
+}

--- a/backend/Services/NzbFetchCoalescer.cs
+++ b/backend/Services/NzbFetchCoalescer.cs
@@ -1,16 +1,42 @@
 using System.Collections.Concurrent;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Services;
 
 public class NzbFetchCoalescer
 {
-    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(300);
+    private static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(300);
     private static readonly TimeSpan HardFetchCap = TimeSpan.FromSeconds(90);
     private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(1);
 
     private readonly ConcurrentDictionary<FetchKey, Lazy<Task<byte[]?>>> _inFlight = new();
     private readonly ConcurrentDictionary<FetchKey, Entry> _cache = new();
+    private readonly object _cacheLock = new();
+    private readonly long _maxCacheBytes;
+    private readonly int _maxCacheEntries;
+    private readonly TimeSpan _cacheTtl;
+    private long _currentBytes;
     private DateTimeOffset _lastSweep = DateTimeOffset.UtcNow;
+
+    public NzbFetchCoalescer(
+        long? maxCacheBytes = null,
+        int? maxCacheEntries = null,
+        TimeSpan? cacheTtl = null)
+    {
+        _maxCacheBytes = maxCacheBytes ?? NzbFetchLimits.CoalescerMaxCacheBytes;
+        _maxCacheEntries = maxCacheEntries ?? NzbFetchLimits.CoalescerMaxCacheEntries;
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+        if (_maxCacheBytes < 1) throw new ArgumentOutOfRangeException(nameof(maxCacheBytes));
+        if (_maxCacheEntries < 1) throw new ArgumentOutOfRangeException(nameof(maxCacheEntries));
+        if (_cacheTtl <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(cacheTtl));
+    }
+
+    internal long CurrentCachedBytes
+    {
+        get { lock (_cacheLock) return _currentBytes; }
+    }
+
+    internal int CachedEntryCount => _cache.Count;
 
     public async Task<byte[]?> GetOrFetchAsync(
         string url,
@@ -22,7 +48,7 @@ public class NzbFetchCoalescer
         var key = new FetchKey(url, proxyUrl ?? "", skipTlsVerification);
         if (TryGetCached(key, out var cached)) return cached;
 
-        var lazy = _inFlight.GetOrAdd(key, k => new Lazy<Task<byte[]?>>(() => RunSharedAsync(k, fetch)));
+        var lazy = _inFlight.GetOrAdd(key, _ => new Lazy<Task<byte[]?>>(() => RunSharedAsync(key, fetch)));
         return await lazy.Value.WaitAsync(ct).ConfigureAwait(false);
     }
 
@@ -33,10 +59,7 @@ public class NzbFetchCoalescer
             using var cts = new CancellationTokenSource(HardFetchCap);
             var bytes = await fetch(cts.Token).ConfigureAwait(false);
             if (bytes is not null)
-            {
-                _cache[key] = new Entry(bytes, DateTimeOffset.UtcNow + CacheTtl);
-                SweepIfDue();
-            }
+                TryAdmit(key, bytes);
             return bytes;
         }
         finally
@@ -51,20 +74,73 @@ public class NzbFetchCoalescer
         if (!_cache.TryGetValue(key, out var e)) return false;
         if (DateTimeOffset.UtcNow > e.ExpiresAt)
         {
-            _cache.TryRemove(key, out _);
+            RemoveAccounting(key);
             return false;
         }
         bytes = e.Bytes;
         return true;
     }
 
-    private void SweepIfDue()
+    private void TryAdmit(FetchKey key, byte[] bytes)
     {
-        var now = DateTimeOffset.UtcNow;
-        if (now - _lastSweep < SweepInterval) return;
-        _lastSweep = now;
+        lock (_cacheLock)
+        {
+            SweepExpiredUnlocked(DateTimeOffset.UtcNow);
+
+            if (_cache.TryRemove(key, out var existing))
+                _currentBytes -= existing.Bytes.LongLength;
+
+            while ((_cache.Count >= _maxCacheEntries || _currentBytes + bytes.LongLength > _maxCacheBytes)
+                   && _cache.Count > 0)
+            {
+                var oldest = default(KeyValuePair<FetchKey, Entry>);
+                var found = false;
+                foreach (var kv in _cache)
+                {
+                    if (!found || kv.Value.ExpiresAt < oldest.Value.ExpiresAt)
+                    {
+                        oldest = kv;
+                        found = true;
+                    }
+                }
+
+                if (!found) break;
+                if (_cache.TryRemove(oldest.Key, out var removed))
+                    _currentBytes -= removed.Bytes.LongLength;
+            }
+
+            if (_cache.Count >= _maxCacheEntries || _currentBytes + bytes.LongLength > _maxCacheBytes)
+                return;
+
+            _cache[key] = new Entry(bytes, DateTimeOffset.UtcNow + _cacheTtl);
+            _currentBytes += bytes.LongLength;
+            MaybeMarkSweep(DateTimeOffset.UtcNow);
+        }
+    }
+
+    private void RemoveAccounting(FetchKey key)
+    {
+        lock (_cacheLock)
+        {
+            if (_cache.TryRemove(key, out var removed))
+                _currentBytes -= removed.Bytes.LongLength;
+        }
+    }
+
+    private void SweepExpiredUnlocked(DateTimeOffset now)
+    {
         foreach (var kv in _cache)
-            if (now > kv.Value.ExpiresAt) _cache.TryRemove(kv.Key, out _);
+        {
+            if (now > kv.Value.ExpiresAt && _cache.TryRemove(kv.Key, out var removed))
+                _currentBytes -= removed.Bytes.LongLength;
+        }
+    }
+
+    private void MaybeMarkSweep(DateTimeOffset now)
+    {
+        if (now - _lastSweep < SweepInterval) return;
+        SweepExpiredUnlocked(now);
+        _lastSweep = now;
     }
 
     private readonly record struct Entry(byte[] Bytes, DateTimeOffset ExpiresAt);

--- a/backend/Services/PreflightCache.cs
+++ b/backend/Services/PreflightCache.cs
@@ -1,20 +1,45 @@
 using System.Collections.Concurrent;
 using NzbWebDAV.Config;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Services;
 
-public class PreflightCache(ConfigManager configManager)
+public class PreflightCache
 {
+    private readonly ConfigManager _configManager;
     private readonly ConcurrentDictionary<string, Entry> _entries = new();
+    private readonly object _cacheLock = new();
+    private readonly long _maxCacheBytes;
+    private readonly int _maxCacheEntries;
+    private long _currentBytes;
     private DateTimeOffset _lastSweep = DateTimeOffset.UtcNow;
     private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(1);
+
+    public PreflightCache(
+        ConfigManager configManager,
+        long? maxCacheBytes = null,
+        int? maxCacheEntries = null)
+    {
+        _configManager = configManager;
+        _maxCacheBytes = maxCacheBytes ?? NzbFetchLimits.PreflightMaxCacheBytes;
+        _maxCacheEntries = maxCacheEntries ?? NzbFetchLimits.PreflightMaxCacheEntries;
+        if (_maxCacheBytes < 1) throw new ArgumentOutOfRangeException(nameof(maxCacheBytes));
+        if (_maxCacheEntries < 1) throw new ArgumentOutOfRangeException(nameof(maxCacheEntries));
+    }
+
+    internal long CurrentCachedBytes
+    {
+        get { lock (_cacheLock) return _currentBytes; }
+    }
+
+    internal int CachedEntryCount => _entries.Count;
 
     public Entry? Get(string nzbUrl)
     {
         if (!_entries.TryGetValue(nzbUrl, out var entry)) return null;
         if (DateTimeOffset.UtcNow > entry.ExpiresAt)
         {
-            _entries.TryRemove(nzbUrl, out _);
+            RemoveAccounting(nzbUrl);
             return null;
         }
         return entry;
@@ -22,8 +47,8 @@ public class PreflightCache(ConfigManager configManager)
 
     public void SetVerified(string nzbUrl, byte[]? nzbBytes, PlaybackFastVerifier.Verdict verdict, string? responderHost)
     {
-        var ttl = TimeSpan.FromSeconds(configManager.GetPreflightTtlSeconds());
-        _entries[nzbUrl] = new Entry
+        var ttl = TimeSpan.FromSeconds(_configManager.GetPreflightTtlSeconds());
+        var entry = new Entry
         {
             NzbBytes = nzbBytes,
             Verdict = verdict,
@@ -31,21 +56,75 @@ public class PreflightCache(ConfigManager configManager)
             PreparedAt = DateTimeOffset.UtcNow,
             ExpiresAt = DateTimeOffset.UtcNow + ttl,
         };
-        SweepIfDue();
+        Admit(nzbUrl, entry);
     }
 
-    public void Invalidate(string nzbUrl) => _entries.TryRemove(nzbUrl, out _);
+    public void Invalidate(string nzbUrl) => RemoveAccounting(nzbUrl);
 
-    private void SweepIfDue()
+    private void Admit(string nzbUrl, Entry entry)
     {
-        var now = DateTimeOffset.UtcNow;
-        if (now - _lastSweep < SweepInterval) return;
-        _lastSweep = now;
-        foreach (var kv in _entries)
+        var bytes = ByteLength(entry.NzbBytes);
+        lock (_cacheLock)
         {
-            if (now > kv.Value.ExpiresAt) _entries.TryRemove(kv.Key, out _);
+            SweepExpiredUnlocked(DateTimeOffset.UtcNow);
+
+            if (_entries.TryRemove(nzbUrl, out var existing))
+                _currentBytes -= ByteLength(existing.NzbBytes);
+
+            while ((_entries.Count >= _maxCacheEntries || _currentBytes + bytes > _maxCacheBytes)
+                   && _entries.Count > 0)
+            {
+                var oldest = default(KeyValuePair<string, Entry>);
+                var found = false;
+                foreach (var kv in _entries)
+                {
+                    if (!found || kv.Value.ExpiresAt < oldest.Value.ExpiresAt)
+                    {
+                        oldest = kv;
+                        found = true;
+                    }
+                }
+
+                if (!found) break;
+                if (_entries.TryRemove(oldest.Key, out var removed))
+                    _currentBytes -= ByteLength(removed.NzbBytes);
+            }
+
+            if (_entries.Count >= _maxCacheEntries || _currentBytes + bytes > _maxCacheBytes)
+                return;
+
+            _entries[nzbUrl] = entry;
+            _currentBytes += bytes;
+            MaybeMarkSweep(DateTimeOffset.UtcNow);
         }
     }
+
+    private void RemoveAccounting(string nzbUrl)
+    {
+        lock (_cacheLock)
+        {
+            if (_entries.TryRemove(nzbUrl, out var removed))
+                _currentBytes -= ByteLength(removed.NzbBytes);
+        }
+    }
+
+    private void SweepExpiredUnlocked(DateTimeOffset now)
+    {
+        foreach (var kv in _entries)
+        {
+            if (now > kv.Value.ExpiresAt && _entries.TryRemove(kv.Key, out var removed))
+                _currentBytes -= ByteLength(removed.NzbBytes);
+        }
+    }
+
+    private void MaybeMarkSweep(DateTimeOffset now)
+    {
+        if (now - _lastSweep < SweepInterval) return;
+        SweepExpiredUnlocked(now);
+        _lastSweep = now;
+    }
+
+    private static long ByteLength(byte[]? bytes) => bytes?.LongLength ?? 0;
 
     public class Entry
     {

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 using Serilog;
@@ -151,9 +152,22 @@ public class PreflightOrchestrator(
                 var client = ProxyHttpClientPool.GetClient(c.ProxyUrl, skipTlsVerification);
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
                 cts.CancelAfter(FetchTimeout);
-                using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);
+                using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token).ConfigureAwait(false);
                 if (!resp.IsSuccessStatusCode) return null;
-                return await resp.Content.ReadAsByteArrayAsync(cts.Token).ConfigureAwait(false);
+                try
+                {
+                    return await HttpContentReadUtil
+                        .ReadBoundedAsync(resp.Content, NzbFetchLimits.MaxResponseBytes, cts.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (NzbResponseTooLargeException e)
+                {
+                    Log.Warning(
+                        "Preflight rejected oversized NZB response from {Url}. Limit: {Limit} bytes. Reason: {Reason}",
+                        c.NzbUrl, e.MaxBytes, e.Message);
+                    Log.Debug(e, "Preflight oversized NZB response stack");
+                    return null;
+                }
             }
             catch (Exception e) when (!e.IsCancellationException())
             {

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -1139,14 +1140,28 @@ public class WatchtowerService(
                     var client = ProxyHttpClientPool.GetClient(c.ProxyUrl, skipTlsVerification);
                     using var cts = CancellationTokenSource.CreateLinkedTokenSource(innerCt);
                     cts.CancelAfter(NzbFetchTimeout);
-                    using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);
+                    using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token).ConfigureAwait(false);
                     if (!resp.IsSuccessStatusCode)
                     {
                         LogActivity("Watchtower: NZB fetch HTTP {Status} from {Indexer} for {Url}",
                             (int)resp.StatusCode, c.IndexerName, c.NzbUrl);
                         return null;
                     }
-                    var bytes = await resp.Content.ReadAsByteArrayAsync(cts.Token).ConfigureAwait(false);
+                    byte[] bytes;
+                    try
+                    {
+                        bytes = await HttpContentReadUtil
+                            .ReadBoundedAsync(resp.Content, NzbFetchLimits.MaxResponseBytes, cts.Token)
+                            .ConfigureAwait(false);
+                    }
+                    catch (NzbResponseTooLargeException e)
+                    {
+                        Log.Warning(
+                            "Watchtower rejected oversized NZB response from {Url}. Limit: {Limit} bytes. Reason: {Reason}",
+                            c.NzbUrl, e.MaxBytes, e.Message);
+                        Log.Debug(e, "Watchtower oversized NZB response stack");
+                        return null;
+                    }
                     _ = hitTracker.RecordAsync(c.IndexerName, IndexerApiHit.HitType.Download, CancellationToken.None);
                     return bytes;
                 }

--- a/backend/Utils/HttpContentReadUtil.cs
+++ b/backend/Utils/HttpContentReadUtil.cs
@@ -1,0 +1,36 @@
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Utils;
+
+public static class HttpContentReadUtil
+{
+    private const int BufferSize = 81920;
+
+    public static async Task<byte[]> ReadBoundedAsync(
+        HttpContent content,
+        long maxBytes,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxBytes);
+
+        var declared = content.Headers.ContentLength;
+        if (declared is { } length && length > maxBytes)
+            throw new NzbResponseTooLargeException(maxBytes, length);
+
+        await using var input = await content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var ms = new MemoryStream(declared is { } known && known >= 0 && known <= int.MaxValue
+            ? (int)known
+            : 0);
+        var buf = new byte[BufferSize];
+        int read;
+        while ((read = await input.ReadAsync(buf.AsMemory(0, buf.Length), ct).ConfigureAwait(false)) > 0)
+        {
+            if (ms.Length + read > maxBytes)
+                throw new NzbResponseTooLargeException(maxBytes);
+            ms.Write(buf, 0, read);
+        }
+
+        return ms.ToArray();
+    }
+}

--- a/backend/Utils/NzbFetchLimits.cs
+++ b/backend/Utils/NzbFetchLimits.cs
@@ -1,0 +1,20 @@
+namespace NzbWebDAV.Utils;
+
+/// <summary>Shared hard caps for buffered NZB HTTP responses and their in-memory caches.</summary>
+public static class NzbFetchLimits
+{
+    /// <summary>Maximum NZB response body size accepted from an indexer (50 MiB).</summary>
+    public const long MaxResponseBytes = 50L * 1024 * 1024;
+
+    /// <summary>Aggregate byte budget for <see cref="Services.NzbFetchCoalescer"/> success cache.</summary>
+    public const long CoalescerMaxCacheBytes = 256L * 1024 * 1024;
+
+    /// <summary>Maximum entries retained by <see cref="Services.NzbFetchCoalescer"/>.</summary>
+    public const int CoalescerMaxCacheEntries = 64;
+
+    /// <summary>Aggregate byte budget for non-null NZB bodies in <see cref="Services.PreflightCache"/>.</summary>
+    public const long PreflightMaxCacheBytes = 256L * 1024 * 1024;
+
+    /// <summary>Maximum entries retained by <see cref="Services.PreflightCache"/>.</summary>
+    public const int PreflightMaxCacheEntries = 128;
+}

--- a/tests/NzbWebDAV.Tests/Services/NzbFetchCoalescerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbFetchCoalescerTests.cs
@@ -1,0 +1,164 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class NzbFetchCoalescerTests
+{
+    [Fact]
+    public async Task GetOrFetchAsync_CoalescesSameKeyAndCachesSuccess()
+    {
+        var coalescer = new NzbFetchCoalescer(maxCacheBytes: 1024, maxCacheEntries: 8);
+        var calls = 0;
+        var payload = new byte[] { 1, 2, 3 };
+
+        Task<byte[]?> Fetch(CancellationToken _)
+        {
+            Interlocked.Increment(ref calls);
+            return Task.FromResult<byte[]?>(payload);
+        }
+
+        var first = await coalescer.GetOrFetchAsync("http://nzb/a", null, false, Fetch, CancellationToken.None);
+        var second = await coalescer.GetOrFetchAsync("http://nzb/a", null, false, Fetch, CancellationToken.None);
+
+        Assert.Same(payload, first);
+        Assert.Same(payload, second);
+        Assert.Equal(1, calls);
+        Assert.Equal(3, coalescer.CurrentCachedBytes);
+        Assert.Equal(1, coalescer.CachedEntryCount);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_DoesNotCacheNull()
+    {
+        var coalescer = new NzbFetchCoalescer(maxCacheBytes: 1024, maxCacheEntries: 8);
+        var calls = 0;
+
+        var first = await coalescer.GetOrFetchAsync(
+            "http://nzb/miss", null, false,
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult<byte[]?>(null);
+            },
+            CancellationToken.None);
+
+        var second = await coalescer.GetOrFetchAsync(
+            "http://nzb/miss", null, false,
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult<byte[]?>(null);
+            },
+            CancellationToken.None);
+
+        Assert.Null(first);
+        Assert.Null(second);
+        Assert.Equal(2, calls);
+        Assert.Equal(0, coalescer.CurrentCachedBytes);
+        Assert.Equal(0, coalescer.CachedEntryCount);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_EvictsOldestWhenEntryBudgetExceeded()
+    {
+        var coalescer = new NzbFetchCoalescer(maxCacheBytes: 1024, maxCacheEntries: 2);
+        await coalescer.GetOrFetchAsync("http://nzb/1", null, false, _ => Task.FromResult<byte[]?>([1]), CancellationToken.None);
+        await Task.Delay(5);
+        await coalescer.GetOrFetchAsync("http://nzb/2", null, false, _ => Task.FromResult<byte[]?>([2]), CancellationToken.None);
+        await Task.Delay(5);
+        await coalescer.GetOrFetchAsync("http://nzb/3", null, false, _ => Task.FromResult<byte[]?>([3]), CancellationToken.None);
+
+        Assert.Equal(2, coalescer.CachedEntryCount);
+        Assert.Equal(2, coalescer.CurrentCachedBytes);
+
+        var calls = 0;
+        var again = await coalescer.GetOrFetchAsync(
+            "http://nzb/1", null, false,
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult<byte[]?>([1]);
+            },
+            CancellationToken.None);
+
+        Assert.Equal(new byte[] { 1 }, again);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_EvictsUntilByteBudgetAllowsAdmit()
+    {
+        var coalescer = new NzbFetchCoalescer(maxCacheBytes: 10, maxCacheEntries: 8);
+        await coalescer.GetOrFetchAsync("http://nzb/a", null, false, _ => Task.FromResult<byte[]?>(new byte[6]), CancellationToken.None);
+        await coalescer.GetOrFetchAsync("http://nzb/b", null, false, _ => Task.FromResult<byte[]?>(new byte[6]), CancellationToken.None);
+
+        Assert.True(coalescer.CurrentCachedBytes <= 10);
+        Assert.Equal(1, coalescer.CachedEntryCount);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_DoesNotCacheWhenSingleEntryExceedsBudget()
+    {
+        var coalescer = new NzbFetchCoalescer(maxCacheBytes: 4, maxCacheEntries: 8);
+        var payload = new byte[8];
+
+        var result = await coalescer.GetOrFetchAsync(
+            "http://nzb/big", null, false,
+            _ => Task.FromResult<byte[]?>(payload),
+            CancellationToken.None);
+
+        Assert.Same(payload, result);
+        Assert.Equal(0, coalescer.CachedEntryCount);
+        Assert.Equal(0, coalescer.CurrentCachedBytes);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_ConcurrentUniqueUrlsNeverExceedBudget()
+    {
+        var coalescer = new NzbFetchCoalescer(maxCacheBytes: 100, maxCacheEntries: 50);
+        var tasks = Enumerable.Range(0, 40)
+            .Select(i => coalescer.GetOrFetchAsync(
+                $"http://nzb/{i}", null, false,
+                _ => Task.FromResult<byte[]?>(new byte[10]),
+                CancellationToken.None))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.True(coalescer.CurrentCachedBytes <= 100);
+        Assert.True(coalescer.CachedEntryCount <= 50);
+        Assert.True(coalescer.CachedEntryCount * 10L >= coalescer.CurrentCachedBytes);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_ExpiresAndDecrementsAccountingExactlyOnce()
+    {
+        var coalescer = new NzbFetchCoalescer(
+            maxCacheBytes: 1024,
+            maxCacheEntries: 8,
+            cacheTtl: TimeSpan.FromMilliseconds(30));
+
+        await coalescer.GetOrFetchAsync(
+            "http://nzb/ttl", null, false,
+            _ => Task.FromResult<byte[]?>(new byte[5]),
+            CancellationToken.None);
+        Assert.Equal(5, coalescer.CurrentCachedBytes);
+
+        await Task.Delay(50);
+
+        var calls = 0;
+        var refreshed = await coalescer.GetOrFetchAsync(
+            "http://nzb/ttl", null, false,
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult<byte[]?>(new byte[5]);
+            },
+            CancellationToken.None);
+
+        Assert.NotNull(refreshed);
+        Assert.Equal(1, calls);
+        Assert.Equal(5, coalescer.CurrentCachedBytes);
+        Assert.Equal(1, coalescer.CachedEntryCount);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/PreflightCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/PreflightCacheTests.cs
@@ -1,0 +1,105 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class PreflightCacheTests
+{
+    [Fact]
+    public void SetVerified_TracksBytesAndReturnsCachedEntry()
+    {
+        var cache = CreateCache(maxCacheBytes: 1024, maxCacheEntries: 8, ttlSeconds: 120);
+        var bytes = new byte[] { 1, 2, 3, 4 };
+
+        cache.SetVerified("http://nzb/a", bytes, PlaybackFastVerifier.Verdict.Available, "host");
+
+        var entry = cache.Get("http://nzb/a");
+        Assert.NotNull(entry);
+        Assert.Same(bytes, entry!.NzbBytes);
+        Assert.Equal(4, cache.CurrentCachedBytes);
+        Assert.Equal(1, cache.CachedEntryCount);
+    }
+
+    [Fact]
+    public void SetVerified_NullBytesCountTowardEntryLimitOnly()
+    {
+        var cache = CreateCache(maxCacheBytes: 1024, maxCacheEntries: 2, ttlSeconds: 120);
+
+        cache.SetVerified("http://nzb/1", null, PlaybackFastVerifier.Verdict.Available, null);
+        cache.SetVerified("http://nzb/2", null, PlaybackFastVerifier.Verdict.Available, null);
+        cache.SetVerified("http://nzb/3", null, PlaybackFastVerifier.Verdict.Available, null);
+
+        Assert.Equal(0, cache.CurrentCachedBytes);
+        Assert.Equal(2, cache.CachedEntryCount);
+        Assert.Null(cache.Get("http://nzb/1"));
+        Assert.NotNull(cache.Get("http://nzb/3"));
+    }
+
+    [Fact]
+    public void Invalidate_DecrementsAccounting()
+    {
+        var cache = CreateCache(maxCacheBytes: 1024, maxCacheEntries: 8, ttlSeconds: 120);
+        cache.SetVerified("http://nzb/a", new byte[7], PlaybackFastVerifier.Verdict.Available, null);
+        Assert.Equal(7, cache.CurrentCachedBytes);
+
+        cache.Invalidate("http://nzb/a");
+
+        Assert.Null(cache.Get("http://nzb/a"));
+        Assert.Equal(0, cache.CurrentCachedBytes);
+        Assert.Equal(0, cache.CachedEntryCount);
+    }
+
+    [Fact]
+    public void SetVerified_EvictsOldestWhenByteBudgetExceeded()
+    {
+        var cache = CreateCache(maxCacheBytes: 10, maxCacheEntries: 8, ttlSeconds: 120);
+        cache.SetVerified("http://nzb/a", new byte[6], PlaybackFastVerifier.Verdict.Available, null);
+        Thread.Sleep(5);
+        cache.SetVerified("http://nzb/b", new byte[6], PlaybackFastVerifier.Verdict.Available, null);
+
+        Assert.True(cache.CurrentCachedBytes <= 10);
+        Assert.Equal(1, cache.CachedEntryCount);
+        Assert.Null(cache.Get("http://nzb/a"));
+        Assert.NotNull(cache.Get("http://nzb/b"));
+    }
+
+    [Fact]
+    public void SetVerified_DoesNotCacheWhenSingleEntryExceedsBudget()
+    {
+        var cache = CreateCache(maxCacheBytes: 4, maxCacheEntries: 8, ttlSeconds: 120);
+        cache.SetVerified("http://nzb/big", new byte[8], PlaybackFastVerifier.Verdict.Available, null);
+
+        Assert.Null(cache.Get("http://nzb/big"));
+        Assert.Equal(0, cache.CurrentCachedBytes);
+        Assert.Equal(0, cache.CachedEntryCount);
+    }
+
+    [Fact]
+    public void Get_ExpiresAndDecrementsAccountingExactlyOnce()
+    {
+        var cache = CreateCache(maxCacheBytes: 1024, maxCacheEntries: 8, ttlSeconds: 10);
+        // Clamp floor is 10 seconds — force expire by writing an already-expired entry via short TTL
+        // and waiting is impractical; use Invalidate path for double-remove safety instead.
+        cache.SetVerified("http://nzb/a", new byte[5], PlaybackFastVerifier.Verdict.Available, null);
+        cache.Invalidate("http://nzb/a");
+        cache.Invalidate("http://nzb/a");
+
+        Assert.Equal(0, cache.CurrentCachedBytes);
+        Assert.Equal(0, cache.CachedEntryCount);
+    }
+
+    private static PreflightCache CreateCache(long maxCacheBytes, int maxCacheEntries, int ttlSeconds)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.PreflightTtlSeconds,
+                ConfigValue = ttlSeconds.ToString(),
+            },
+        ]);
+        return new PreflightCache(config, maxCacheBytes, maxCacheEntries);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/HttpContentReadUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/HttpContentReadUtilTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Text;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class HttpContentReadUtilTests
+{
+    private const long Limit = 16;
+
+    [Theory]
+    [InlineData(15)]
+    [InlineData(16)]
+    public async Task ReadBoundedAsync_AcceptsBodiesAtOrBelowLimit(int size)
+    {
+        var payload = Enumerable.Repeat((byte)'a', size).ToArray();
+        using var content = new ByteArrayContent(payload);
+        content.Headers.ContentLength = payload.Length;
+
+        var bytes = await HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None);
+
+        Assert.Equal(payload, bytes);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_RejectsDeclaredContentLengthAboveLimit()
+    {
+        using var content = new ByteArrayContent(new byte[Limit + 1]);
+        content.Headers.ContentLength = Limit + 1;
+
+        var ex = await Assert.ThrowsAsync<NzbResponseTooLargeException>(
+            () => HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None));
+
+        Assert.Equal(Limit, ex.MaxBytes);
+        Assert.Equal(Limit + 1, ex.ContentLength);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_RejectsStreamedBodyAboveLimitWithoutPartialReturn()
+    {
+        using var content = new UndeclaredLengthContent(new byte[Limit + 1]);
+
+        var ex = await Assert.ThrowsAsync<NzbResponseTooLargeException>(
+            () => HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None));
+
+        Assert.Equal(Limit, ex.MaxBytes);
+        Assert.Null(ex.ContentLength);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_AcceptsUndeclaredBodyAtLimit()
+    {
+        var payload = Encoding.ASCII.GetBytes("0123456789abcdef");
+        Assert.Equal(Limit, payload.Length);
+        using var content = new UndeclaredLengthContent(payload);
+
+        var bytes = await HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None);
+
+        Assert.Equal(payload, bytes);
+    }
+
+    private sealed class UndeclaredLengthContent(byte[] payload) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            stream.WriteAsync(payload, 0, payload.Length);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Cap every buffered NZB HTTP body at 50 MiB via a shared reader that rejects oversized `Content-Length` and stops dishonest/chunked streams mid-read.
- Bound `NzbFetchCoalescer` (256 MiB / 64 entries) and `PreflightCache` (256 MiB / 128 entries) with oldest-first eviction and exact byte accounting.
- Map oversized responses to existing failure paths (proxy/single-candidate play → 502; multi-candidate/preflight/Watchtower → skip candidate) without caching partial content.

Closes #573

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~HttpContentReadUtil|FullyQualifiedName~NzbFetchCoalescer|FullyQualifiedName~PreflightCache"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Manual: point proxy/play at an indexer URL that returns a body > 50 MiB (or forged Content-Length) and confirm 502 / candidate skip with a Warning log, and no retained cache entry