### PR TITLE
fix(db): stop restore SQL from attaching or rewriting live databases

### DIFF
--- a/backend/Database/Backup/SqliteSqlImporter.cs
+++ b/backend/Database/Backup/SqliteSqlImporter.cs
@@ -12,6 +12,7 @@ namespace NzbWebDAV.Database.Backup;
 public static class SqliteSqlImporter
 {
     private static int _batteriesInitialized;
+    private static readonly strdelegate_authorizer RestoreAuthorizer = AuthorizeRestoreStatement;
 
     public static async Task ImportAsync(
         string sqlFilePath,
@@ -47,6 +48,7 @@ public static class SqliteSqlImporter
 
             await using var connection = new SqliteConnection(connectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            raw.sqlite3_set_authorizer(connection.Handle, RestoreAuthorizer, null);
 
             progress?.Invoke("Importing SQL dump");
             await ExecuteStatementsAsync(sqlFilePath, connection, progress, cancellationToken).ConfigureAwait(false);
@@ -77,6 +79,32 @@ public static class SqliteSqlImporter
             TryDeleteDatabaseFiles(targetDatabaseFilePath);
             throw;
         }
+    }
+
+    private static int AuthorizeRestoreStatement(
+        object? _,
+        int actionCode,
+        string? parameter1,
+        string? parameter2,
+        string? _databaseName,
+        string? _triggerOrView)
+    {
+        if (actionCode is raw.SQLITE_ATTACH or raw.SQLITE_DETACH)
+            return raw.SQLITE_DENY;
+
+        if (actionCode == raw.SQLITE_FUNCTION &&
+            string.Equals(parameter2, "load_extension", StringComparison.OrdinalIgnoreCase))
+        {
+            return raw.SQLITE_DENY;
+        }
+
+        if (actionCode == raw.SQLITE_PRAGMA &&
+            string.Equals(parameter1, "writable_schema", StringComparison.OrdinalIgnoreCase))
+        {
+            return raw.SQLITE_DENY;
+        }
+
+        return raw.SQLITE_OK;
     }
 
     private static async Task ExecuteStatementsAsync(

--- a/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
@@ -141,6 +141,48 @@ public sealed class SqliteDumpImportTests
     }
 
     [Fact]
+    public async Task Importer_RejectsAttachedDatabaseAndLeavesItUnchanged()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-import-authorizer-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var sqlPath = Path.Combine(root, "malicious.sql");
+            var stagedPath = Path.Combine(root, "staged.sqlite");
+            var livePath = Path.Combine(root, "live.sqlite");
+            await File.WriteAllTextAsync(sqlPath, $"""
+                CREATE TABLE Safe(Value TEXT);
+                aTtAcH DATABASE '{livePath.Replace("'", "''", StringComparison.Ordinal)}' AS live;
+                DELETE FROM live.Marker;
+                """);
+
+            await using (var live = Open(livePath, create: true))
+            {
+                await live.OpenAsync();
+                await using var create = live.CreateCommand();
+                create.CommandText = "CREATE TABLE Marker(Value TEXT); INSERT INTO Marker VALUES ('live');";
+                await create.ExecuteNonQueryAsync();
+            }
+
+            var error = await Assert.ThrowsAsync<SqliteException>(
+                () => SqliteSqlImporter.ImportAsync(sqlPath, stagedPath));
+
+            Assert.Contains("not authorized", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(stagedPath));
+
+            await using var check = Open(livePath);
+            await check.OpenAsync();
+            await using var marker = check.CreateCommand();
+            marker.CommandText = "SELECT Value FROM Marker;";
+            Assert.Equal("live", await marker.ExecuteScalarAsync());
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public async Task DumpAndImport_RoundTripsRealDavSchema()
     {
         var root = Path.Combine(Path.GetTempPath(), $"nzbdav-schema-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary
- deny database attach, detach, extension loading, and writable-schema changes during SQL restore imports
- retain dump compatibility and clean failed staging databases
- cover a crafted attached-database restore attempt

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~SqliteDumpImportTests`

Closes #574