### PR TITLE
fix(db): prevent oversized backups from exhausting disk or memory during restore

### DIFF
--- a/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
+++ b/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
@@ -13,6 +13,11 @@ namespace NzbWebDAV.Api.Controllers.DbBackupUpload;
 [RequestFormLimits(MultipartBodyLengthLimit = 4L * 1024 * 1024 * 1024)]
 public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiController
 {
+    private const long MaxRestoreBytes = 4L * 1024 * 1024 * 1024;
+    private const int MaxRecognizedZipEntries = 4;
+    private const int HeaderSampleCharacters = 4 * 1024;
+    private const long MaxCompressionRatio = 200;
+
     protected override async Task<IActionResult> HandleRequest()
     {
         // Allow large backup uploads regardless of the global Kestrel body limit.
@@ -38,10 +43,13 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
             }
             else if (fileName.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
             {
+                if (file.Length > MaxRestoreBytes)
+                    throw PayloadTooLarge("SQL dump exceeds the restore size limit.");
+
                 var target = Path.Combine(stagingPath, DatabaseBackupStore.DbSqlName);
                 await using var stream = file.OpenReadStream();
                 await using var output = System.IO.File.Create(target);
-                await stream.CopyToAsync(output, HttpContext.RequestAborted).ConfigureAwait(false);
+                await CopyWithLimitAsync(stream, output, MaxRestoreBytes, HttpContext.RequestAborted).ConfigureAwait(false);
             }
             else
             {
@@ -72,6 +80,9 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
     {
         await using var upload = file.OpenReadStream();
         using var archive = new ZipArchive(upload, ZipArchiveMode.Read, leaveOpen: false);
+        var extractedBytes = 0L;
+        var recognizedEntries = 0;
+        var extractedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var entry in archive.Entries)
         {
             if (string.IsNullOrEmpty(entry.Name))
@@ -88,11 +99,44 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
                 or DatabaseBackupStore.ManifestFileName))
                 continue;
 
+            if (!extractedNames.Add(fileName))
+                throw new BadHttpRequestException($"Zip contains duplicate {fileName} entries.");
+
+            if (++recognizedEntries > MaxRecognizedZipEntries)
+                throw PayloadTooLarge("Zip contains too many recognized backup entries.");
+
+            if (entry.Length > MaxRestoreBytes || extractedBytes > MaxRestoreBytes - entry.Length)
+                throw PayloadTooLarge("Zip extraction exceeds the restore size limit.");
+
+            if (entry.CompressedLength > 0 && entry.Length / entry.CompressedLength > MaxCompressionRatio)
+                throw PayloadTooLarge("Zip entry compression ratio exceeds the restore safety limit.");
+
             var dest = Path.Combine(stagingPath, fileName);
             await using var entryStream = entry.Open();
             await using var output = System.IO.File.Create(dest);
-            await entryStream.CopyToAsync(output, ct).ConfigureAwait(false);
+            extractedBytes += await CopyWithLimitAsync(
+                entryStream,
+                output,
+                MaxRestoreBytes - extractedBytes,
+                ct).ConfigureAwait(false);
         }
+    }
+
+    private static async Task<long> CopyWithLimitAsync(Stream input, Stream output, long remainingBytes, CancellationToken ct)
+    {
+        var buffer = new byte[64 * 1024];
+        var copied = 0L;
+        int read;
+        while ((read = await input.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        {
+            if (copied > remainingBytes - read)
+                throw PayloadTooLarge("Backup data exceeds the restore size limit.");
+
+            await output.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+            copied += read;
+        }
+
+        return copied;
     }
 
     private static void ValidateSqlFiles(string stagingPath)
@@ -112,15 +156,13 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
                 continue;
             found = true;
             using var reader = new StreamReader(path);
-            var header = reader.ReadLine() ?? "";
-            if (!header.Contains("PRAGMA foreign_keys", StringComparison.OrdinalIgnoreCase)
-                && !header.Contains("BEGIN", StringComparison.OrdinalIgnoreCase)
-                && !header.Contains("CREATE", StringComparison.OrdinalIgnoreCase))
+            var sampleBuffer = new char[HeaderSampleCharacters];
+            var sampleLength = reader.ReadBlock(sampleBuffer, 0, sampleBuffer.Length);
+            var sample = new string(sampleBuffer, 0, sampleLength);
+            if (!sample.Contains("PRAGMA foreign_keys", StringComparison.OrdinalIgnoreCase)
+                && !sample.Contains("BEGIN", StringComparison.OrdinalIgnoreCase)
+                && !sample.Contains("CREATE", StringComparison.OrdinalIgnoreCase))
             {
-                // Soft check — dumps may start with blank lines; read a bit more.
-                var sample = header + "\n" + reader.ReadToEnd();
-                if (sample.Length > 4096)
-                    sample = sample[..4096];
                 if (!sample.Contains("CREATE TABLE", StringComparison.OrdinalIgnoreCase)
                     && !sample.Contains("BEGIN", StringComparison.OrdinalIgnoreCase))
                     throw new BadHttpRequestException($"{name} does not look like a SQLite SQL dump.");
@@ -130,4 +172,7 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
         if (!found)
             throw new BadHttpRequestException("Upload did not contain any recognized .sql dump files.");
     }
+
+    private static BadHttpRequestException PayloadTooLarge(string message) =>
+        new(message, StatusCodes.Status413PayloadTooLarge);
 }

--- a/backend/Database/Backup/SqliteSqlImporter.cs
+++ b/backend/Database/Backup/SqliteSqlImporter.cs
@@ -12,6 +12,7 @@ namespace NzbWebDAV.Database.Backup;
 public static class SqliteSqlImporter
 {
     private static int _batteriesInitialized;
+    private static readonly strdelegate_authorizer RestoreAuthorizer = AuthorizeRestoreStatement;
 
     public static async Task ImportAsync(
         string sqlFilePath,
@@ -47,6 +48,7 @@ public static class SqliteSqlImporter
 
             await using var connection = new SqliteConnection(connectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            raw.sqlite3_set_authorizer(connection.Handle, RestoreAuthorizer, null);
 
             progress?.Invoke("Importing SQL dump");
             await ExecuteStatementsAsync(sqlFilePath, connection, progress, cancellationToken).ConfigureAwait(false);
@@ -77,6 +79,32 @@ public static class SqliteSqlImporter
             TryDeleteDatabaseFiles(targetDatabaseFilePath);
             throw;
         }
+    }
+
+    private static int AuthorizeRestoreStatement(
+        object? _,
+        int actionCode,
+        string? parameter1,
+        string? parameter2,
+        string? _databaseName,
+        string? _triggerOrView)
+    {
+        if (actionCode is raw.SQLITE_ATTACH or raw.SQLITE_DETACH)
+            return raw.SQLITE_DENY;
+
+        if (actionCode == raw.SQLITE_FUNCTION &&
+            string.Equals(parameter2, "load_extension", StringComparison.OrdinalIgnoreCase))
+        {
+            return raw.SQLITE_DENY;
+        }
+
+        if (actionCode == raw.SQLITE_PRAGMA &&
+            string.Equals(parameter1, "writable_schema", StringComparison.OrdinalIgnoreCase))
+        {
+            return raw.SQLITE_DENY;
+        }
+
+        return raw.SQLITE_OK;
     }
 
     private static async Task ExecuteStatementsAsync(

--- a/backend/Database/Backup/SqliteSqlImporter.cs
+++ b/backend/Database/Backup/SqliteSqlImporter.cs
@@ -11,6 +11,7 @@ namespace NzbWebDAV.Database.Backup;
 /// </summary>
 public static class SqliteSqlImporter
 {
+    internal const int MaxStatementCharacters = 64 * 1024 * 1024;
     private static int _batteriesInitialized;
     private static readonly strdelegate_authorizer RestoreAuthorizer = AuthorizeRestoreStatement;
 
@@ -125,6 +126,10 @@ public static class SqliteSqlImporter
         while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            var separatorLength = buffer.Length > 0 ? 1 : 0;
+            if (line.Length > MaxStatementCharacters - buffer.Length - separatorLength)
+                throw new InvalidOperationException($"SQL statement exceeds the {MaxStatementCharacters:N0}-character restore limit.");
 
             if (buffer.Length > 0)
                 buffer.Append('\n');

--- a/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
@@ -141,6 +141,48 @@ public sealed class SqliteDumpImportTests
     }
 
     [Fact]
+    public async Task Importer_RejectsAttachedDatabaseAndLeavesItUnchanged()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-import-authorizer-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var sqlPath = Path.Combine(root, "malicious.sql");
+            var stagedPath = Path.Combine(root, "staged.sqlite");
+            var livePath = Path.Combine(root, "live.sqlite");
+            await File.WriteAllTextAsync(sqlPath, $"""
+                CREATE TABLE Safe(Value TEXT);
+                aTtAcH DATABASE '{livePath.Replace("'", "''", StringComparison.Ordinal)}' AS live;
+                DELETE FROM live.Marker;
+                """);
+
+            await using (var live = Open(livePath, create: true))
+            {
+                await live.OpenAsync();
+                await using var create = live.CreateCommand();
+                create.CommandText = "CREATE TABLE Marker(Value TEXT); INSERT INTO Marker VALUES ('live');";
+                await create.ExecuteNonQueryAsync();
+            }
+
+            var error = await Assert.ThrowsAsync<SqliteException>(
+                () => SqliteSqlImporter.ImportAsync(sqlPath, stagedPath));
+
+            Assert.Contains("not authorized", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(stagedPath));
+
+            await using var check = Open(livePath);
+            await check.OpenAsync();
+            await using var marker = check.CreateCommand();
+            marker.CommandText = "SELECT Value FROM Marker;";
+            Assert.Equal("live", await marker.ExecuteScalarAsync());
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public async Task DumpAndImport_RoundTripsRealDavSchema()
     {
         var root = Path.Combine(Path.GetTempPath(), $"nzbdav-schema-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary
- enforce ZIP entry, aggregate extraction, duplicate-name, and compression-ratio limits
- bound raw SQL uploads and SQL statement accumulation
- validate only a fixed SQL header sample

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~SqliteDumpImportTests`

Closes #575
Depends on #615