### PR TITLE
fix(warden): keep the previous dead-release source if a refresh is interrupted

### DIFF
--- a/backend/Api/Controllers/Warden/WardenImportController.cs
+++ b/backend/Api/Controllers/Warden/WardenImportController.cs
@@ -27,6 +27,8 @@ public class WardenImportController(WardenStore warden) : BaseApiController
 
         var target = form["target"].ToString();
         var file = form.Files[0];
+        if (file.Length > 256L * 1024 * 1024)
+            throw new BadHttpRequestException("Warden upload exceeds the 256 MiB size limit.", StatusCodes.Status413PayloadTooLarge);
 
         await using var buffered = await BufferAndDecompressAsync(file, ct);
 
@@ -60,13 +62,27 @@ public class WardenImportController(WardenStore warden) : BaseApiController
             {
                 var decompressed = new MemoryStream();
                 await using (var gz = new GZipStream(ms, CompressionMode.Decompress, leaveOpen: true))
-                    await gz.CopyToAsync(decompressed, ct);
+                    await CopyWithLimitAsync(gz, decompressed, WardenInputLimits.MaxDecompressedBytes, ct);
                 decompressed.Position = 0;
                 return decompressed;
             }
         }
         ms.Position = 0;
         return ms;
+    }
+
+    private static async Task CopyWithLimitAsync(Stream input, Stream output, long limit, CancellationToken ct)
+    {
+        var buffer = new byte[64 * 1024];
+        var copied = 0L;
+        int read;
+        while ((read = await input.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        {
+            if (copied > limit - read)
+                throw new BadHttpRequestException("Warden source exceeds the decompressed size limit.", StatusCodes.Status413PayloadTooLarge);
+            await output.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+            copied += read;
+        }
     }
 }
 

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -155,7 +155,8 @@ public partial class WardenBackupService : BackgroundService
             await using var raw = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             using var buffer = await BufferAsync(raw, ct).ConfigureAwait(false);
             Stream body = LooksGzip(buffer) ? new GZipStream(buffer, CompressionMode.Decompress) : buffer;
-            var count = await _store.ReplaceSourceAsync(WardenStore.LocalSourceId, body, ct).ConfigureAwait(false);
+            using var limitedBody = new LimitedReadStream(body, WardenInputLimits.MaxDecompressedBytes);
+            var count = await _store.ReplaceSourceAsync(WardenStore.LocalSourceId, limitedBody, ct).ConfigureAwait(false);
             Log.Information("Warden backup: restored {Count} fingerprints from {Repo}", count, s.Repo);
             return $"Restored {count:N0} fingerprints into your list.";
         }

--- a/backend/Services/WardenInputLimits.cs
+++ b/backend/Services/WardenInputLimits.cs
@@ -1,0 +1,36 @@
+namespace NzbWebDAV.Services;
+
+internal static class WardenInputLimits
+{
+    internal const long MaxDecompressedBytes = 512L * 1024 * 1024;
+    internal const int MaxRecordCharacters = 64 * 1024;
+    internal const int MaxRecords = 4_000_000;
+}
+
+internal sealed class LimitedReadStream(Stream inner, long maximumBytes) : Stream
+{
+    private long _read;
+
+    public override bool CanRead => inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => _read; set => throw new NotSupportedException(); }
+    public override void Flush() => throw new NotSupportedException();
+    public override int Read(byte[] buffer, int offset, int count) => Count(inner.Read(buffer, offset, count));
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => ReadAndCountAsync(buffer, ct);
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    private int Count(int read)
+    {
+        if (read > 0 && _read > maximumBytes - read)
+            throw new InvalidOperationException($"Warden source exceeds the {maximumBytes:N0}-byte decompressed limit.");
+        _read += read;
+        return read;
+    }
+
+    private async ValueTask<int> ReadAndCountAsync(Memory<byte> buffer, CancellationToken ct) =>
+        Count(await inner.ReadAsync(buffer, ct).ConfigureAwait(false));
+}

--- a/backend/Services/WardenRemoteSourceService.cs
+++ b/backend/Services/WardenRemoteSourceService.cs
@@ -79,7 +79,8 @@ public class WardenRemoteSourceService : BackgroundService
             Stream body = buffer;
             if (LooksGzip(buffer)) body = new GZipStream(buffer, CompressionMode.Decompress);
 
-            var count = await _store.ReplaceSourceAsync(source.Id, body, ct).ConfigureAwait(false);
+            using var limitedBody = new LimitedReadStream(body, WardenInputLimits.MaxDecompressedBytes);
+            var count = await _store.ReplaceSourceAsync(source.Id, limitedBody, ct).ConfigureAwait(false);
             _store.SetSourceStatus(source.Id, newEtag, now, now, $"ok ({count})");
             Log.Information("Warden: refreshed remote list {Name} ({Count} fingerprints)", source.Name, count);
             return $"ok ({count})";

--- a/backend/Services/WardenStore.cs
+++ b/backend/Services/WardenStore.cs
@@ -388,10 +388,15 @@ public partial class WardenStore
         cmd.Transaction = tx;
 
         var processed = 0;
+        var recordsRead = 0;
         var inBatch = 0;
         string? line;
         while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
         {
+            if (++recordsRead > WardenInputLimits.MaxRecords)
+                throw new InvalidOperationException($"Source exceeds the {WardenInputLimits.MaxRecords:N0}-record processing limit.");
+            if (line.Length > WardenInputLimits.MaxRecordCharacters)
+                throw new InvalidOperationException($"Source contains a record longer than the {WardenInputLimits.MaxRecordCharacters:N0}-character limit.");
             if (line.Length == 0) continue;
             if (line.StartsWith("{\"warden\"", StringComparison.Ordinal)) continue;
 

--- a/backend/Services/WardenStore.cs
+++ b/backend/Services/WardenStore.cs
@@ -422,7 +422,9 @@ public partial class WardenStore
             cmd.ExecuteNonQuery();
             processed++;
 
-            if (++inBatch >= 5000)
+            // Replacements must remain invisible until the complete source has
+            // passed validation; merge imports may still commit in batches.
+            if (!replace && ++inBatch >= 5000)
             {
                 await tx.CommitAsync(ct).ConfigureAwait(false);
                 await tx.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- retain source replacement changes in one transaction until input validation completes
- preserve batch commits for additive local merges

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~Warden`

Closes #576
Depends on #617