### PR TITLE
fix(arr): stop hung Radarr or Sonarr hosts from blocking shutdown and monitoring

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -20,7 +20,10 @@ public class ArrClient(string host, string apiKey)
     public virtual Task<bool> RemoveAndSearch(string symlinkOrStrmPath) =>
         throw new InvalidOperationException();
 
-    public virtual Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct = default) =>
+    public virtual Task<List<ArrRootFolder>> GetRootFolders() =>
+        GetRootFolders(CancellationToken.None);
+
+    public virtual Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct) =>
         Get<List<ArrRootFolder>>($"/rootfolder", ct);
 
     public Task<List<ArrDownloadClient>> GetDownloadClientsAsync(CancellationToken ct = default) =>

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -14,26 +14,26 @@ public class ArrClient(string host, string apiKey)
     private string ApiKey { get; } = apiKey;
     private const string BasePath = "/api/v3";
 
-    public Task<ArrApiInfoResponse> GetApiInfo() =>
-        GetRoot<ArrApiInfoResponse>($"/api");
+    public Task<ArrApiInfoResponse> GetApiInfo(CancellationToken ct = default) =>
+        GetRoot<ArrApiInfoResponse>($"/api", ct);
 
     public virtual Task<bool> RemoveAndSearch(string symlinkOrStrmPath) =>
         throw new InvalidOperationException();
 
-    public virtual Task<List<ArrRootFolder>> GetRootFolders() =>
-        Get<List<ArrRootFolder>>($"/rootfolder");
+    public virtual Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct = default) =>
+        Get<List<ArrRootFolder>>($"/rootfolder", ct);
 
-    public Task<List<ArrDownloadClient>> GetDownloadClientsAsync() =>
-        Get<List<ArrDownloadClient>>($"/downloadClient");
+    public Task<List<ArrDownloadClient>> GetDownloadClientsAsync(CancellationToken ct = default) =>
+        Get<List<ArrDownloadClient>>($"/downloadClient", ct);
 
-    public Task<ArrCommand> RefreshMonitoredDownloads() =>
-        CommandAsync(new { name = "RefreshMonitoredDownloads" });
+    public Task<ArrCommand> RefreshMonitoredDownloads(CancellationToken ct = default) =>
+        CommandAsync(new { name = "RefreshMonitoredDownloads" }, ct);
 
-    public Task<ArrQueueStatus> GetQueueStatusAsync() =>
-        Get<ArrQueueStatus>($"/queue/status");
+    public Task<ArrQueueStatus> GetQueueStatusAsync(CancellationToken ct = default) =>
+        Get<ArrQueueStatus>($"/queue/status", ct);
 
-    public Task<ArrQueue<ArrQueueRecord>> GetQueueAsync() =>
-        Get<ArrQueue<ArrQueueRecord>>($"/queue?protocol=usenet&pageSize=5000");
+    public Task<ArrQueue<ArrQueueRecord>> GetQueueAsync(CancellationToken ct = default) =>
+        Get<ArrQueue<ArrQueueRecord>>($"/queue?protocol=usenet&pageSize=5000", ct);
 
     public async Task<int> GetQueueCountAsync() =>
         (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1")).TotalRecords;
@@ -46,34 +46,36 @@ public class ArrClient(string host, string apiKey)
             ? Delete($"/queue/{id}", new DeleteQueueRecordRequest(request).GetQueryParams())
             : Task.FromResult(HttpStatusCode.OK);
 
-    public Task<ArrCommand> CommandAsync(object command) =>
-        Post<ArrCommand>($"/command", command);
+    public Task<ArrCommand> CommandAsync(object command, CancellationToken ct = default) =>
+        Post<ArrCommand>($"/command", command, ct);
 
-    protected Task<T> Get<T>(string path) =>
-        GetRoot<T>($"{BasePath}{path}");
+    protected Task<T> Get<T>(string path, CancellationToken ct = default) =>
+        GetRoot<T>($"{BasePath}{path}", ct);
 
-    protected async Task<T> GetRoot<T>(string rootPath)
+    protected async Task<T> GetRoot<T>(string rootPath, CancellationToken ct = default)
     {
         var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
-        using var response = await SendAsync(request);
-        await using var stream = await response.Content.ReadAsStreamAsync();
-        return await JsonSerializer.DeserializeAsync<T>(stream) ?? throw new NullReferenceException();
+        using var response = await SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
     }
 
-    protected async Task<T> Post<T>(string path, object body)
+    protected async Task<T> Post<T>(string path, object body, CancellationToken ct = default)
     {
         var request = new HttpRequestMessage(HttpMethod.Post, GetRequestUri(path));
         var jsonBody = JsonSerializer.Serialize(body);
         request.Content = new StringContent(jsonBody, new MediaTypeHeaderValue("application/json"));
-        using var response = await SendAsync(request);
-        await using var stream = await response.Content.ReadAsStreamAsync();
-        return await JsonSerializer.DeserializeAsync<T>(stream) ?? throw new NullReferenceException();
+        using var response = await SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
     }
 
-    protected async Task<HttpStatusCode> Delete(string path, Dictionary<string, string>? queryParams = null)
+    protected async Task<HttpStatusCode> Delete(string path, Dictionary<string, string>? queryParams = null, CancellationToken ct = default)
     {
         var request = new HttpRequestMessage(HttpMethod.Delete, GetRequestUri(path, queryParams));
-        using var response = await SendAsync(request);
+        using var response = await SendAsync(request, ct);
         return response.StatusCode;
     }
 
@@ -87,9 +89,9 @@ public class ArrClient(string host, string apiKey)
         return resource;
     }
 
-    private Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+    private Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
     {
         request.Headers.Add("X-Api-Key", ApiKey);
-        return HttpClient.SendAsync(request);
+        return HttpClient.SendAsync(request, ct);
     }
 }

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -38,7 +38,7 @@ public class ArrMonitoringService : BackgroundService
 
                 // otherwise, handle stuck queue items according to the config
                 foreach (var arrClient in arrConfig.GetArrClients())
-                    await HandleStuckQueueItems(arrConfig, arrClient).ConfigureAwait(false);
+                    await HandleStuckQueueItems(arrConfig, arrClient, stoppingToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -51,18 +51,21 @@ public class ArrMonitoringService : BackgroundService
         }
     }
 
-    private async Task HandleStuckQueueItems(ArrConfig arrConfig, ArrClient client)
+    private async Task HandleStuckQueueItems(ArrConfig arrConfig, ArrClient client, CancellationToken ct)
     {
         try
         {
-            var queueStatus = await client.GetQueueStatusAsync().ConfigureAwait(false);
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(TimeSpan.FromSeconds(20));
+            var queueStatus = await client.GetQueueStatusAsync(timeout.Token).ConfigureAwait(false);
             if (queueStatus is { Warnings: false, UnknownWarnings: false }) return;
-            var queue = await client.GetQueueAsync().ConfigureAwait(false);
+            var queue = await client.GetQueueAsync(timeout.Token).ConfigureAwait(false);
             var actionableStatuses = arrConfig.QueueRules.Select(x => x.Message);
             var stuckRecords = queue.Records.Where(x => actionableStatuses.Any(x.HasStatusMessage));
             foreach (var record in stuckRecords)
-                await HandleStuckQueueItem(record, arrConfig, client).ConfigureAwait(false);
+                await HandleStuckQueueItem(record, arrConfig, client, timeout.Token).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
         catch (Exception e) when (e is HttpRequestException { InnerException: System.Net.Sockets.SocketException })
         {
             Log.Debug(e, "Could not reach Arr instance {Host} for queue monitoring", client.Host);
@@ -73,7 +76,7 @@ public class ArrMonitoringService : BackgroundService
         }
     }
 
-    private async Task HandleStuckQueueItem(ArrQueueRecord item, ArrConfig arrConfig, ArrClient client)
+    private async Task HandleStuckQueueItem(ArrQueueRecord item, ArrConfig arrConfig, ArrClient client, CancellationToken ct)
     {
         // since there may be multiple status messages, multiple actions may apply.
         // in such case, always perform the strongest action.


### PR DESCRIPTION
## Summary
- pass cancellation tokens into Arr HTTP reads and JSON parsing
- use a 20-second linked timeout for queue monitoring
- avoid error logging during host shutdown cancellation

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`

Closes #578