### PR TITLE
chore(ui): fail CI on hook-rule violations and freeze the lint warning budget

### DIFF
--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -103,7 +103,7 @@ export function useQueueEvents(
         setQueueSlots(slots => slots.map(x => x.nzo_id === nzo_id ? { ...x, providers } : x));
     }, [setQueueSlots]);
 
-    return memoize({
+    return useStableEventHandlers({
         onAddQueueSlot,
         onSelectQueueSlots,
         onRemovingQueueSlots,
@@ -135,7 +135,7 @@ export function useHistoryEvents(
         setHistorySlots(slots => slots.filter(x => !ids.has(x.nzo_id)));
     }, [setHistorySlots]);
 
-    return memoize({
+    return useStableEventHandlers({
         onAddHistorySlot,
         onSelectHistorySlots,
         onRemovingHistorySlots,
@@ -143,7 +143,7 @@ export function useHistoryEvents(
     });
 }
 
-function memoize<T extends Record<string, unknown>>(object: T): T {
+function useStableEventHandlers<T extends Record<string, unknown>>(object: T): T {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return useMemo(() => object, Object.values(object));
 }

--- a/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
+++ b/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
@@ -11,7 +11,7 @@ type UploadResponse = {
 
 type XhrErrorResponse = Pick<XMLHttpRequest, "response" | "responseText" | "status" | "statusText">;
 
-export function initializeUploadController(
+export function useUploadController(
     isUploadingRef: React.RefObject<boolean>,
     uploadQueueRef: React.RefObject<UploadingFile[]>,
     uploadingFiles: UploadingFile[],

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -24,7 +24,7 @@ const topicSubscriptions = {
     [topicNames.historyItemRemoved]: 'event',
 } as const;
 
-export function initializeQueueHistoryWebsocket(
+export function useQueueHistoryWebsocket(
     queueEvents: QueueEvents,
     historyEvents: HistoryEvents,
     isQueueLive: boolean,

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -5,8 +5,8 @@ import { HistoryTable } from "./components/history-table/history-table";
 import { QueueTable } from "./components/queue-table/queue-table";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useHistoryEvents, useQueueEvents } from "./controllers/events-controller";
-import { initializeQueueHistoryWebsocket } from "./controllers/websocket-controller";
-import { initializeUploadController } from "./controllers/nzb-upload-controller";
+import { useQueueHistoryWebsocket } from "./controllers/websocket-controller";
+import { useUploadController } from "./controllers/nzb-upload-controller";
 import { useQueueDropzone } from "./controllers/dropzone-controller";
 import { Alert } from "~/components/ui";
 
@@ -114,11 +114,11 @@ export default function Queue(props: Route.ComponentProps) {
     const historyEvents = useHistoryEvents(setHistorySlots, historyPageSize);
 
     // websocket
-    initializeQueueHistoryWebsocket(queueEvents, historyEvents, isQueueLive, isHistoryLive);
+    useQueueHistoryWebsocket(queueEvents, historyEvents, isQueueLive, isHistoryLive);
 
     // uploads
     const dropzone = useQueueDropzone(setUploadingFiles, uploadQueueRef, manualCategoryRef);
-    initializeUploadController(isUploadingRef, uploadQueueRef, uploadingFiles, setUploadingFiles);
+    useUploadController(isUploadingRef, uploadQueueRef, uploadingFiles, setUploadingFiles);
 
     // view
     return (

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -62,10 +62,11 @@ export default tseslint.config(
 
       // Plugin registered so existing eslint-disable comments resolve.
       // Full react-hooks recommended (incl. React Compiler rules) is a follow-up ratchet.
-      "react-hooks/rules-of-hooks": "warn",
+      "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
 
-      // Existing backlog — ratchet to error in a follow-up.
+      // Existing backlog — the npm lint script locks its 163-warning baseline;
+      // follow-ups must reduce it before the budget can be lowered.
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": [
         "warn",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "predev": "bash ../scripts/sync-dev-env.sh",
     "dev": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --import tsx server.ts",
     "start": "node dist-node/server.js",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 163",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "react-router typegen && tsc -b"


### PR DESCRIPTION
## Summary
- name queue hook helpers according to React hook conventions
- promote rules-of-hooks to an error
- prevent the remaining 163 lint warnings from increasing

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`

Closes #586