### PR TITLE
fix(health): delay Arr replacements until repeated streaming failures

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1261,8 +1261,8 @@ public class ConfigManager
     }
 
     /// <summary>
-    /// Number of streaming failures before auto-removing a broken file during urgent repair.
-    /// 0 (default) disables auto-remove and preserves today's immediate-repair behavior.
+    /// Number of streaming failures before urgent repair starts.
+    /// 0 (default) preserves immediate-repair behavior.
     /// </summary>
     public int GetAutoRemoveAfterFailures()
     {
@@ -1272,9 +1272,8 @@ public class ConfigManager
     }
 
     /// <summary>
-    /// When true (default), auto-remove only deletes unlinked/orphaned files; library-linked
-    /// items still go through *Arr remove-and-search. When false, linked items are force-deleted
-    /// after the failure threshold as well.
+    /// When true (default), library-linked items use *Arr remove-and-search at the failure
+    /// threshold. When false, linked items are force-deleted after the threshold as well.
     /// </summary>
     public bool IsAutoRemoveUnlinkedOnly()
     {

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -258,10 +258,18 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         if (!configManager.IsRepairJobEnabled())
             return;
 
-        // Track every distinct streaming failure (not deduped by RepairDedupeWindow below) so the
-        // optional repair.auto-remove-after-failures policy in HealthCheckService can see how many
-        // times playback has actually failed against this item.
-        failureTracker.RecordFailure(davItemId);
+        // Count every distinct streaming failure before applying either threshold or deduplication.
+        // Repeated failures must still advance the repair threshold while duplicate DB scheduling
+        // writes remain suppressed below.
+        var failureCount = failureTracker.RecordFailure(davItemId);
+        var threshold = configManager.GetAutoRemoveAfterFailures();
+        if (!ShouldScheduleUrgentRepair(threshold, failureCount))
+        {
+            Log.Information(
+                "Deferring dynamic repair for DavItem {DavItemId} until streaming failure {FailureCount}/{FailureThreshold}",
+                davItemId, failureCount, threshold);
+            return;
+        }
 
         var now = DateTime.UtcNow;
         var isDuplicate = false;
@@ -305,6 +313,11 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                 Log.Warning(ex, "Failed to schedule dynamic repair for DavItem {DavItemId}", davItemId);
             }
         });
+    }
+
+    internal static bool ShouldScheduleUrgentRepair(int threshold, int failureCount)
+    {
+        return threshold <= 0 || failureCount >= threshold;
     }
 
     private static void LogWithDedup(

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -502,7 +502,7 @@ public class HealthCheckService : BackgroundService
     }
 
     /// <summary>
-    /// How an urgent (streaming-triggered) repair should proceed given auto-remove settings.
+    /// How an urgent (streaming-triggered) repair should proceed given the streaming-failure threshold.
     /// </summary>
     public enum UrgentRepairDisposition
     {
@@ -516,7 +516,8 @@ public class HealthCheckService : BackgroundService
 
     /// <summary>
     /// Decides urgent-repair disposition from failure count and auto-remove config.
-    /// Threshold 0 disables the feature (identical to today's immediate Repair).
+    /// Threshold 0 preserves immediate repair; otherwise all streaming-triggered actions wait
+    /// until the configured number of consecutive failures.
     /// </summary>
     public static UrgentRepairDisposition GetUrgentRepairDisposition(
         int threshold,
@@ -528,13 +529,7 @@ public class HealthCheckService : BackgroundService
             return UrgentRepairDisposition.RepairNormally;
 
         if (failureCount < threshold)
-        {
-            // Library-linked + unlinked-only: prefer Arr remove-and-search immediately.
-            // Unlinked (and aggressive linked) wait until the threshold before deleting.
-            if (hasLibraryLink && autoRemoveUnlinkedOnly)
-                return UrgentRepairDisposition.RepairNormally;
             return UrgentRepairDisposition.Defer;
-        }
 
         if (hasLibraryLink && autoRemoveUnlinkedOnly)
             return UrgentRepairDisposition.RepairNormally;
@@ -651,7 +646,7 @@ public class HealthCheckService : BackgroundService
                 string.Join(" ", [
                     "File failed during streaming.",
                     $"Streaming failure count: {failureCount}/{threshold}.",
-                    "Auto-remove deferred until the failure threshold is reached."
+                    "Repair and replacement deferred until the failure threshold is reached."
                 ]), ct).ConfigureAwait(false);
             return;
         }

--- a/backend/Services/StreamingFailureTracker.cs
+++ b/backend/Services/StreamingFailureTracker.cs
@@ -5,9 +5,9 @@ namespace NzbWebDAV.Services;
 /// <summary>
 /// In-memory counter of consecutive permanent streaming failures (missing usenet articles
 /// or structurally corrupt archives) per
-/// <c>DavItem</c>. Incremented by <c>ExceptionMiddleware</c> whenever it schedules an urgent
-/// repair for an item; consulted (and cleared) by <c>HealthCheckService</c> to power the
-/// opt-in "auto-remove after N failures" repair policy (see <c>repair.auto-remove-after-failures</c>).
+/// <c>DavItem</c>. Incremented by <c>ExceptionMiddleware</c> whenever it observes a qualifying
+/// failure; consulted by urgent-repair scheduling and cleared after a successful full read,
+/// health check, repair, or deletion.
 ///
 /// Deliberately in-memory rather than persisted: failures recur naturally on replay, so a
 /// process restart simply resets the count, which is an acceptable trade-off for avoiding a
@@ -29,7 +29,7 @@ public class StreamingFailureTracker
         return _failureCounts.GetValueOrDefault(davItemId);
     }
 
-    /// <summary>Clears the counter, e.g. after a successful health check or once the item is repaired/removed.</summary>
+    /// <summary>Clears the counter after a successful full read, health check, repair, or deletion.</summary>
     public void ClearFailure(Guid davItemId)
     {
         _failureCounts.TryRemove(davItemId, out _);

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -7,6 +7,7 @@ using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.StreamTrace;
@@ -30,17 +31,20 @@ public class GetAndHeadHandlerPatch : IRequestHandler
     private readonly ProviderUsageTracker _providerUsageTracker;
     private readonly ActiveReadRegistry _activeReadRegistry;
     private readonly StreamTraceBuffer _streamTrace;
+    private readonly StreamingFailureTracker _failureTracker;
 
     public GetAndHeadHandlerPatch(
         IStore store,
         ProviderUsageTracker providerUsageTracker,
         ActiveReadRegistry activeReadRegistry,
-        StreamTraceBuffer streamTrace)
+        StreamTraceBuffer streamTrace,
+        StreamingFailureTracker failureTracker)
     {
         _store = store;
         _providerUsageTracker = providerUsageTracker;
         _activeReadRegistry = activeReadRegistry;
         _streamTrace = streamTrace;
+        _failureTracker = failureTracker;
     }
 
     /// <summary>
@@ -217,6 +221,14 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
                             httpContext.RequestAborted).ConfigureAwait(false);
                         FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+                        ClearStreamingFailureAfterCompletedRead(
+                            _failureTracker,
+                            httpContext.Items["DavItem"],
+                            isHeadRequest,
+                            true,
+                            copyStart,
+                            copyEnd,
+                            stream.CanSeek ? stream.Length : null);
                     }
                     catch (OperationCanceledException) when (httpContext.RequestAborted.IsCancellationRequested)
                     {
@@ -236,6 +248,28 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                 response.SetStatus(DavStatusCode.NoContent);
             }
         }
+        return true;
+    }
+
+    internal static bool ClearStreamingFailureAfterCompletedRead(
+        StreamingFailureTracker failureTracker,
+        object? requestDavItem,
+        bool isHeadRequest,
+        bool copySucceeded,
+        long copyStart,
+        long? copyEnd,
+        long? streamLength)
+    {
+        if (!copySucceeded ||
+            isHeadRequest ||
+            copyStart != 0 ||
+            requestDavItem is not DavItem davItem ||
+            (copyEnd.HasValue && (streamLength is null || copyEnd.Value != streamLength.Value - 1)))
+        {
+            return false;
+        }
+
+        failureTracker.ClearFailure(davItem.Id);
         return true;
     }
 

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -15,8 +15,18 @@ Background health monitoring and replacement of unhealthy library items.
 | Health Check Concurrency | `repair.healthcheck-concurrency` | `50` | STAT connections; capped by pool |
 | Health Check Depth | `repair.healthcheck-depth` | `standard` | standard / enhanced / deep / complete |
 | Check older releases less thoroughly [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | `repair.healthcheck-aging` | off | Aging taper |
-| Auto-Remove After Streaming Failures | `repair.auto-remove-after-failures` | `0` | `0` = disabled |
-| Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | Linked → *Arr remove-and-search |
+| Repair After Streaming Failures | `repair.auto-remove-after-failures` | `0` | Consecutive streaming failures before urgent repair; `0` = immediate repair |
+| Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items use *Arr remove-and-search instead of force-delete |
 | Library Directory | `media.library-dir` | empty | Organized media path in container |
+
+`repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
+articles and corrupt archives. With a value greater than `0`, NzbDAV waits for that many
+consecutive failures before it starts an urgent repair. At the threshold, linked library items
+trigger *Arr remove-and-search when **Auto-remove unlinked files only** is enabled; unlinked files
+are removed. Disable that option to force-delete linked items at the threshold.
+
+Successful full-file playback and a successful background health check reset the in-memory failure
+count. The count resets when NzbDAV restarts, so it is intentionally not a durable replacement for
+health checks.
 
 [Health and repairs](../operations/health-repairs.md)

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -10,7 +10,12 @@ Requires:
 - At least one configured Radarr/Sonarr instance
 - **Enable Background Repairs**
 
-Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }, and auto-remove thresholds — [Repairs settings](../configuration/repairs.md).
+Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }, and streaming-failure thresholds — [Repairs settings](../configuration/repairs.md).
+
+For streaming-triggered failures, **Repair After Streaming Failures** can require consecutive
+failures before NzbDAV starts a repair or asks *Arr to find a replacement. A successful full-file
+playback or background health check resets that count. The counter is in memory, so it also resets
+when NzbDAV restarts.
 
 ## Health-check retention
 

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -145,13 +145,13 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
 
             <SettingsCard
                 icon="delete_sweep"
-                title="Automatic cleanup"
-                description="Choose when repeated playback failures should remove broken files."
+                title="Streaming failure handling"
+                description="Choose when repeated playback failures should trigger repair or removal."
                 contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
             >
             <ManagedSetting configKey="repair.auto-remove-after-failures">
             <div className="space-y-2">
-                <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Auto-Remove After Streaming Failures</label>
+                <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Repair After Streaming Failures</label>
                 <Input
                     className={`w-full ${!isNonNegativeInteger(autoRemoveAfter || "0") ? "input-error" : ""}`}
                     type="text"
@@ -161,9 +161,9 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     value={autoRemoveAfter}
                     onChange={e => setNewConfig({ ...config, "repair.auto-remove-after-failures": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-after-failures-help">
-                    After this many streaming playback failures (missing articles or corrupt archives), urgent repair will
-                    auto-remove the broken file. Set to 0 to disable (default). Example: 3 removes an
-                    unlinked file on the third failure.
+                    Wait for this many consecutive streaming playback failures before urgent repair starts. Linked library
+                    items then use Radarr/Sonarr remove-and-search; unlinked items are removed. Set to 0 for immediate
+                    repair (default).
                 </p>
             </div>
             </ManagedSetting>

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -83,6 +83,19 @@ public class ExceptionMiddlewareTests
         Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
     }
 
+    [Theory]
+    [InlineData(0, 1, true)]
+    [InlineData(3, 2, false)]
+    [InlineData(3, 3, true)]
+    [InlineData(3, 4, true)]
+    public void ShouldScheduleUrgentRepair_RequiresConfiguredFailureThreshold(
+        int threshold,
+        int failureCount,
+        bool expected)
+    {
+        Assert.Equal(expected, ExceptionMiddleware.ShouldScheduleUrgentRepair(threshold, failureCount));
+    }
+
     private static ExceptionMiddleware CreateMiddleware(
         RequestDelegate next,
         ConfigManager? configManager = null,

--- a/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
@@ -37,10 +37,10 @@ public class UrgentRepairDispositionTests
     }
 
     [Fact]
-    public void Linked_UnlinkedOnly_UsesArrPathEvenAtThreshold()
+    public void Linked_UnlinkedOnly_DefersUntilThresholdThenUsesArrPath()
     {
         Assert.Equal(
-            HealthCheckService.UrgentRepairDisposition.RepairNormally,
+            HealthCheckService.UrgentRepairDisposition.Defer,
             HealthCheckService.GetUrgentRepairDisposition(3, 1, hasLibraryLink: true, autoRemoveUnlinkedOnly: true));
         Assert.Equal(
             HealthCheckService.UrgentRepairDisposition.RepairNormally,

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -1,3 +1,5 @@
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
 using NzbWebDAV.WebDav.Base;
 
 namespace NzbWebDAV.Tests.WebDav;
@@ -41,5 +43,61 @@ public class GetAndHeadHandlerRangeTests
     public void TryResolveRange_IgnoresRangeOnHead(string header)
     {
         Assert.Null(GetAndHeadHandlerPatch.TryResolveRange(isHeadRequest: true, header));
+    }
+
+    [Fact]
+    public void CompletedFullRead_ClearsStreamingFailures()
+    {
+        var tracker = new StreamingFailureTracker();
+        var item = NewDavItem();
+        tracker.RecordFailure(item.Id);
+
+        var cleared = GetAndHeadHandlerPatch.ClearStreamingFailureAfterCompletedRead(
+            tracker, item, isHeadRequest: false, copySucceeded: true, copyStart: 0, copyEnd: null, streamLength: 100);
+
+        Assert.True(cleared);
+        Assert.Equal(0, tracker.GetFailureCount(item.Id));
+    }
+
+    [Fact]
+    public void CompletedExplicitFullRange_ClearsStreamingFailures()
+    {
+        var tracker = new StreamingFailureTracker();
+        var item = NewDavItem();
+        tracker.RecordFailure(item.Id);
+
+        var cleared = GetAndHeadHandlerPatch.ClearStreamingFailureAfterCompletedRead(
+            tracker, item, isHeadRequest: false, copySucceeded: true, copyStart: 0, copyEnd: 99, streamLength: 100);
+
+        Assert.True(cleared);
+        Assert.Equal(0, tracker.GetFailureCount(item.Id));
+    }
+
+    [Theory]
+    [InlineData(true, false, 0, 99, 100)]
+    [InlineData(false, false, 1, 99, 100)]
+    [InlineData(false, false, 0, 98, 100)]
+    [InlineData(false, true, 0, 99, 100)]
+    public void IncompleteOrUnsuccessfulRead_DoesNotClearStreamingFailures(
+        bool isHeadRequest,
+        bool copyFailed,
+        long copyStart,
+        long copyEnd,
+        long streamLength)
+    {
+        var tracker = new StreamingFailureTracker();
+        var item = NewDavItem();
+        tracker.RecordFailure(item.Id);
+
+        var cleared = GetAndHeadHandlerPatch.ClearStreamingFailureAfterCompletedRead(
+            tracker, item, isHeadRequest, !copyFailed, copyStart, copyEnd, streamLength);
+
+        Assert.False(cleared);
+        Assert.Equal(1, tracker.GetFailureCount(item.Id));
+    }
+
+    private static DavItem NewDavItem()
+    {
+        return new DavItem { Id = Guid.NewGuid() };
     }
 }


### PR DESCRIPTION
## Summary
- delay urgent repair and Arr remove-and-search until the configured streaming-failure threshold is reached
- reset streaming failure counts only after successful full reads or existing successful health/repair paths
- clarify the existing Repairs setting and document its in-memory lifecycle

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~ExceptionMiddlewareTests|FullyQualifiedName~UrgentRepairDispositionTests|FullyQualifiedName~GetAndHeadHandlerRangeTests|FullyQualifiedName~StreamingFailureTrackerTests'`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `cd frontend && npm run typecheck && npm run build && npm test -- --run`
- [x] `zensical build --clean --strict`