### PR TITLE
fix(arr): health-check repair no longer fails when Sonarr no longer has a cached episode file

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -9,6 +9,7 @@ namespace NzbWebDAV.Clients.RadarrSonarr;
 public class ArrClient(string host, string apiKey)
 {
     protected static readonly HttpClient HttpClient = new();
+    protected virtual HttpClient Client => HttpClient;
 
     public string Host { get; } = host;
     private string ApiKey { get; } = apiKey;
@@ -55,10 +56,23 @@ public class ArrClient(string host, string apiKey)
     protected Task<T> Get<T>(string path, CancellationToken ct = default) =>
         GetRoot<T>($"{BasePath}{path}", ct);
 
+    protected Task<T?> GetOrNull<T>(string path, CancellationToken ct = default) where T : class =>
+        GetRootOrNull<T>($"{BasePath}{path}", ct);
+
     protected async Task<T> GetRoot<T>(string rootPath, CancellationToken ct = default)
     {
         var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
         using var response = await SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
+    }
+
+    private async Task<T?> GetRootOrNull<T>(string rootPath, CancellationToken ct) where T : class
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
+        using var response = await SendAsync(request, ct);
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(ct);
         return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
@@ -95,6 +109,6 @@ public class ArrClient(string host, string apiKey)
     private Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
     {
         request.Headers.Add("X-Api-Key", ApiKey);
-        return HttpClient.SendAsync(request, ct);
+        return Client.SendAsync(request, ct);
     }
 }

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -11,6 +11,9 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public Task<RadarrMovie> GetMovieAsync(int id) =>
         Get<RadarrMovie>($"/movie/{id}");
 
+    private Task<RadarrMovie?> GetMovieOrNullAsync(int id) =>
+        GetOrNull<RadarrMovie>($"/movie/{id}");
+
     public Task<List<RadarrMovie>> GetMoviesAsync() =>
         Get<List<RadarrMovie>>($"/movie");
 
@@ -42,9 +45,11 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         // then let's use it to find and return the corresponding movie-file-id
         if (SymlinkOrStrmToMovieIdCache.TryGetValue(symlinkOrStrmPath, out var movieId))
         {
-            var movie = await GetMovieAsync(movieId);
-            if (movie.MovieFile?.Path == symlinkOrStrmPath)
-                return (movie.MovieFile.Id!, movieId);
+            var movie = await GetMovieOrNullAsync(movieId);
+            var movieFile = movie?.MovieFile;
+            if (movieFile?.Path == symlinkOrStrmPath)
+                return (movieFile.Id!, movieId);
+            SymlinkOrStrmToMovieIdCache.Remove(symlinkOrStrmPath);
         }
 
         // otherwise, let's fetch all movies, cache all movie files

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -19,8 +19,14 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public Task<SonarrSeries> GetSeries(int seriesId) =>
         Get<SonarrSeries>($"/series/{seriesId}");
 
+    private Task<SonarrSeries?> GetSeriesOrNull(int seriesId) =>
+        GetOrNull<SonarrSeries>($"/series/{seriesId}");
+
     public Task<SonarrEpisodeFile> GetEpisodeFile(int episodeFileId) =>
         Get<SonarrEpisodeFile>($"/episodefile/{episodeFileId}");
+
+    private Task<SonarrEpisodeFile?> GetEpisodeFileOrNull(int episodeFileId) =>
+        GetOrNull<SonarrEpisodeFile>($"/episodefile/{episodeFileId}");
 
     public Task<List<SonarrEpisodeFile>> GetAllEpisodeFiles(int seriesId) =>
         Get<List<SonarrEpisodeFile>>($"/episodefile?seriesId={seriesId}");
@@ -69,8 +75,9 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         // if episode-file-id is found in the cache, verify it and return it
         if (SymlinkOrStrmToEpisodeFileIdCache.TryGetValue(symlinkOrStrmPath, out var episodeFileId))
         {
-            var episodeFile = await GetEpisodeFile(episodeFileId);
-            if (episodeFile.Path == symlinkOrStrmPath) return episodeFileId;
+            var episodeFile = await GetEpisodeFileOrNull(episodeFileId);
+            if (episodeFile?.Path == symlinkOrStrmPath) return episodeFileId;
+            SymlinkOrStrmToEpisodeFileIdCache.Remove(symlinkOrStrmPath);
         }
 
         // otherwise, find the series-id
@@ -93,18 +100,18 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     private async Task<int?> GetSeriesId(string symlinkOrStrmPath)
     {
         // get series-id from cache
-        var cachedSeriesId = PathUtil.GetAllParentDirectories(symlinkOrStrmPath)
+        var cachedSeriesPath = PathUtil.GetAllParentDirectories(symlinkOrStrmPath)
             .Where(x => SeriesPathToSeriesIdCache.ContainsKey(x))
-            .Select(x => SeriesPathToSeriesIdCache[x])
-            .Select(x => (int?)x)
             .FirstOrDefault();
 
         // if found, verify and return it
-        if (cachedSeriesId != null)
+        if (cachedSeriesPath != null)
         {
-            var series = await GetSeries(cachedSeriesId.Value);
-            if (symlinkOrStrmPath.StartsWith(series.Path!))
+            var cachedSeriesId = SeriesPathToSeriesIdCache[cachedSeriesPath];
+            var series = await GetSeriesOrNull(cachedSeriesId);
+            if (series?.Path != null && symlinkOrStrmPath.StartsWith(series.Path))
                 return cachedSeriesId;
+            SeriesPathToSeriesIdCache.Remove(cachedSeriesPath);
         }
 
         // otherwise, fetch all series and repopulate the cache

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -582,8 +582,10 @@ public class HealthCheckService : BackgroundService
             catch (Exception e)
             {
                 anInstanceFailed = true;
-                Log.Warning(e, "Health-check repair: could not query root folders from {Host}",
-                            arrClient.Host);
+                LogArrRepairFailure(
+                    e,
+                    "Health-check repair: could not query root folders from {Host}",
+                    arrClient.Host);
                 continue;
             }
 
@@ -605,8 +607,10 @@ public class HealthCheckService : BackgroundService
             catch (Exception e)
             {
                 anInstanceFailed = true;
-                Log.Warning(e, "Health-check repair: remove-and-search failed on {Host}",
-                            arrClient.Host);
+                LogArrRepairFailure(
+                    e,
+                    "Health-check repair: remove-and-search failed on {Host}",
+                    arrClient.Host);
                 continue;
             }
 
@@ -624,6 +628,29 @@ public class HealthCheckService : BackgroundService
             return ArrLinkedRepairDecision.DeferUnreachable;
 
         return ArrLinkedRepairDecision.DeleteConfirmedOrphan;
+    }
+
+    private static void LogArrRepairFailure(Exception exception, string messageTemplate, string host)
+    {
+        if (exception.TryGetCausingException<HttpRequestException>(out var httpException) &&
+            httpException is not null)
+        {
+            var reason = httpException.StatusCode is { } statusCode
+                ? $"HTTP {(int)statusCode} ({statusCode})"
+                : httpException.Message;
+            Log.Warning(messageTemplate + ". Reason: {Reason}", host, reason);
+            Log.Debug(exception, "Health-check repair Arr HTTP failure stack");
+            return;
+        }
+
+        if (exception.TryGetKnownErrorMessage(out var knownReason))
+        {
+            Log.Warning(messageTemplate + ". Reason: {Reason}", host, knownReason);
+            Log.Debug(exception, "Health-check repair Arr known failure stack");
+            return;
+        }
+
+        Log.Warning(exception, messageTemplate, host);
     }
 
     private async Task HandleUrgentRepair(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Text;
+using NzbWebDAV.Clients.RadarrSonarr;
+
+namespace NzbWebDAV.Tests.Clients;
+
+public class RadarrSonarrClientTests
+{
+    [Fact]
+    public async Task SonarrStaleCachedEpisodeAndSeries_ReturnsFalseAfter404()
+    {
+        const string seriesPath = "/library/tv/Stale Show";
+        const string filePath = seriesPath + "/Stale Show S01E01.mkv";
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse("""[{"id":101,"path":"/library/tv/Stale Show"}]""")),
+            ("GET /api/v3/episodefile?seriesId=101", JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
+            ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
+            ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"id":1}""", Encoding.UTF8, "application/json"),
+            }),
+            ("GET /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/series/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/series", JsonResponse("[]"))));
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.True(await client.RemoveAndSearch(filePath));
+        Assert.False(await client.RemoveAndSearch(filePath));
+    }
+
+    [Fact]
+    public async Task RadarrStaleCachedMovie_ReturnsFalseAfter404()
+    {
+        const string filePath = "/library/movies/Stale Movie/Stale Movie.mkv";
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie", JsonResponse($"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
+            ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"id":1}""", Encoding.UTF8, "application/json"),
+            }),
+            ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/movie", JsonResponse("[]"))));
+        var client = new TestRadarrClient(httpClient);
+
+        Assert.True(await client.RemoveAndSearch(filePath));
+        Assert.False(await client.RemoveAndSearch(filePath));
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static ResponseQueueHandler CreateHandler(
+        params (string request, HttpResponseMessage response)[] responses) =>
+        new(responses
+            .GroupBy(x => x.request)
+            .ToDictionary(
+                x => x.Key,
+                x => new Queue<HttpResponseMessage>(x.Select(y => y.response))));
+
+    private sealed class TestSonarrClient(HttpClient client) : SonarrClient("http://arr.test", "test-key")
+    {
+        protected override HttpClient Client => client;
+    }
+
+    private sealed class TestRadarrClient(HttpClient client) : RadarrClient("http://arr.test", "test-key")
+    {
+        protected override HttpClient Client => client;
+    }
+
+    private sealed class ResponseQueueHandler(
+        Dictionary<string, Queue<HttpResponseMessage>> responses) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var key = $"{request.Method} {request.RequestUri!.PathAndQuery}";
+            if (!responses.TryGetValue(key, out var queuedResponses) || !queuedResponses.TryDequeue(out var response))
+                throw new InvalidOperationException($"Unexpected request: {key}");
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Treat Sonarr/Radarr cache-validation 404s as cache misses so remove-and-search can rescan and correctly confirm orphans instead of deferring repair.
- Log Arr root-folder and remove-and-search failures as a single Warning with `{Reason}` (HTTP status when available); keep stacks at Debug.
- Add focused Sonarr/Radarr HTTP mock tests for the stale-cache path.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~RadarrSonarrClientTests|FullyQualifiedName~ArrLinkedRepairDecisionTests"`
- [ ] Trigger health-check repair against a library path whose Sonarr episode-file ID is stale; confirm Warning has Reason and no stack at Warning/Info
- [ ] Confirm a still-present file after stale-cache miss still remove-and-searches successfully