### PR TITLE
fix(queue): stop a queue worker pinning a CPU core when a new download is added mid-import

### DIFF
--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -215,21 +215,8 @@ public class QueueManager : IDisposable
                 // Wait for any worker to finish, an awaken signal, or a short
                 // poll so worker-count increases can fill new slots promptly.
                 var workerTasks = _inProgress.Values.Select(x => x.CompletionSignal.Task).ToArray();
-                using var wakeWait = CancellationTokenSource.CreateLinkedTokenSource(
-                    ct, _sleepingQueueToken.Token);
-                try
-                {
-                    var wakeDelay = Task.Delay(TimeSpan.FromSeconds(1), wakeWait.Token);
-                    await Task.WhenAny(Task.WhenAny(workerTasks), wakeDelay).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (_sleepingQueueToken.IsCancellationRequested)
-                {
-                    ResetSleepingQueueToken();
-                }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
-                {
+                if (!await WaitForWorkerOrAwakenAsync(workerTasks, ct).ConfigureAwait(false))
                     break;
-                }
             }
             catch (Exception e) when (!e.IsCancellationException(ct))
             {
@@ -510,6 +497,32 @@ public class QueueManager : IDisposable
         }
     }
 
+    // Wait for any worker to finish, an awaken signal, or a short poll. Returns
+    // false when shutdown is requested. Task.WhenAny completes without observing
+    // wakeDelay's cancellation, so the awaken signal is consumed here explicitly
+    // rather than in a catch clause that never runs.
+    internal async Task<bool> WaitForWorkerOrAwakenAsync(Task[] workerTasks, CancellationToken ct)
+    {
+        using var wakeWait = CancellationTokenSource.CreateLinkedTokenSource(
+            ct, _sleepingQueueToken.Token);
+        var wakeDelay = Task.Delay(TimeSpan.FromSeconds(1), wakeWait.Token);
+
+        // The poll always joins the wait set, so the wait stays bounded when no
+        // workers are in flight and Task.WhenAny never sees an empty array.
+        await Task.WhenAny([.. workerTasks, wakeDelay]).ConfigureAwait(false);
+
+        if (ct.IsCancellationRequested)
+            return false;
+
+        if (_sleepingQueueToken.IsCancellationRequested)
+            ResetSleepingQueueToken();
+
+        return true;
+    }
+
+    // Resetting discards a CancelAfter scheduled by a paused add. The pause is
+    // still honored because ComputeIdleDelayAsync re-derives the next wake from
+    // the database once the queue goes idle.
     private void ResetSleepingQueueToken()
     {
         lock (_sleepingQueueLock)

--- a/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
@@ -229,6 +229,60 @@ public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ProcessQueueAsync_DoesNotSpinAfterAwakenWhileWorkerRuns()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var item = CreateQueueItem("spin.nzb", "movies", "SpinJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        // One claimable item, so once it is in flight every later poll returns
+        // null and each poll marks one pass of the coordinator loop.
+        var polls = 0;
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            Interlocked.Increment(ref polls);
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, new GateStream(gate));
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && !_queueManager.HasActiveQueueItems)
+            await Task.Delay(20);
+        Assert.True(_queueManager.HasActiveQueueItems, "Expected a worker to be in flight");
+
+        // An addfile lands while that worker is still running. The signal must be
+        // consumed once; latching it spins the loop as fast as the CPU allows.
+        var before = Volatile.Read(ref polls);
+        _queueManager.AwakenQueue();
+        await Task.Delay(500);
+        var passes = Volatile.Read(ref polls) - before;
+
+        Assert.True(passes <= 15,
+            $"Coordinator ran {passes} passes in 500ms, expected a bounded poll rather than a spin");
+
+        gate.Set();
+        deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && _queueManager.HasActiveQueueItems)
+            await Task.Delay(20);
+
+        await cts.CancelAsync();
+        try { await loop; }
+        catch (OperationCanceledException) { }
+    }
+
+    [Fact]
     public async Task GetTopQueueItem_ExcludesInFlightIds()
     {
         var a = CreateQueueItem("a.nzb", "movies", "A");

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -128,6 +128,70 @@ public class QueueManagerLoopTests
         await loop;
     }
 
+    [Fact]
+    public async Task WaitForWorkerOrAwaken_ConsumesAwakenSignalInsteadOfSpinning()
+    {
+        using var manager = CreateManager();
+
+        // Stand in for an in-progress worker that never finishes.
+        var runningWorker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // An addfile (e.g. a new grab) awakens the queue while a worker runs.
+        manager.AwakenQueue();
+
+        using var cts = new CancellationTokenSource();
+        var firstWait = manager.WaitForWorkerOrAwakenAsync([runningWorker.Task], cts.Token);
+        Assert.True(await firstWait.WaitAsync(TimeSpan.FromSeconds(1)));
+
+        // With the signal consumed, the next wait must block on the poll/worker
+        // instead of returning instantly. Before the fix the token stayed latched
+        // and this returned immediately every iteration, spinning a core.
+        var secondWait = manager.WaitForWorkerOrAwakenAsync([runningWorker.Task], cts.Token);
+        var winner = await Task.WhenAny(secondWait, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        Assert.NotSame(secondWait, winner);
+
+        runningWorker.SetResult();
+        await cts.CancelAsync();
+        await secondWait;
+    }
+
+    [Fact]
+    public async Task WaitForWorkerOrAwaken_ReturnsFalseOnShutdown()
+    {
+        using var manager = CreateManager();
+        var runningWorker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var cts = new CancellationTokenSource();
+        var wait = manager.WaitForWorkerOrAwakenAsync([runningWorker.Task], cts.Token);
+
+        // Shutdown while a worker is still running must break the coordinator loop.
+        await cts.CancelAsync();
+        Assert.False(await wait.WaitAsync(TimeSpan.FromSeconds(1)));
+
+        runningWorker.SetResult();
+    }
+
+    [Fact]
+    public async Task WaitForWorkerOrAwaken_TimedAwakenDoesNotSpin()
+    {
+        using var manager = CreateManager();
+        var runningWorker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // A future pause schedules a timed wake. Until it fires the token is not
+        // cancelled, so the wait must block on the poll rather than resetting and
+        // returning instantly the way a fired awaken does.
+        manager.AwakenQueue(DateTime.Now.AddSeconds(5));
+
+        using var cts = new CancellationTokenSource();
+        var wait = manager.WaitForWorkerOrAwakenAsync([runningWorker.Task], cts.Token);
+        var winner = await Task.WhenAny(wait, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        Assert.NotSame(wait, winner);
+
+        runningWorker.SetResult();
+        await cts.CancelAsync();
+        await wait;
+    }
+
     private static QueueManager CreateManager()
     {
         var config = new ConfigManager();


### PR DESCRIPTION
Kind of a tricky issue, only happens on the latest main branch. Noticed one core pinned at 100% whenever a new grab arrived while an import was already running, and it stayed there until the queue drained. The coordinator's wait in ProcessQueueAsync uses Task.WhenAny, which completes without surfacing the cancelled wakeDelay, so the catch that resets the sleeping-queue token never runs and every awaken after the first spins the loop. Moved the wait into a helper that consumes the signal with an explicit post-await check. The reset can consume an awaken that lands while a worker is finishing, but no wake is lost, AddFileController commits the queue row before calling AwakenQueue, so FillWorkerSlotsAsync on the next loop iteration always sees it, and the busy path re-polls every second regardless. Added QueueManagerLoopTests cases that latch an awaken behind a never-completing worker and assert the next wait blocks instead of returning instantly.
When a worker slot is free, because worker count is above one or the remaining items conflict on mount key, each pass also takes the state lock and queries SQLite, so it contends with queue removal and UI state reads rather than only burning CPU. A test that drives the whole loop now covers that case, and with the reset removed it records 1219 passes in 500ms against a bound of 15.