### PR TITLE
fix(config): fail startup on a mistyped NZBDAV_CONFIG property instead of dropping it silently

### DIFF
--- a/backend/Config/ConfigEnvironmentOverlay.cs
+++ b/backend/Config/ConfigEnvironmentOverlay.cs
@@ -91,11 +91,21 @@ public sealed class ConfigEnvironmentOverlay
 
         // Validate one key at a time so failures name the ENV variable without
         // echoing the submitted value (ValidateConfigItems includes values).
+        // Structured values reject unknown properties here because a declarative
+        // config has nobody watching a Settings page to notice a dropped key.
         foreach (var item in items)
         {
             try
             {
-                ConfigManager.ValidateConfigItems([item]);
+                ConfigManager.ValidateConfigItems([item], rejectUnknownJsonProperties: true);
+            }
+            catch (ConfigUnmappedPropertyException e)
+            {
+                var envName = ConfigEnvMapping.ToEnvironmentVariableName(item.ConfigName)
+                              ?? item.ConfigName;
+                throw new ConfigEnvironmentException(
+                    $"Invalid configuration environment variable `{envName}`. " +
+                    $"Unknown or miscased property at `{e.JsonPath}`.");
             }
             catch (ArgumentException)
             {

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet.Concurrency;
@@ -243,14 +244,29 @@ public class ConfigManager
     private void SyncPathSanitizer() =>
         PathSanitizer.SetWindowsSafePathsEnabled(IsWindowsSafePathsEnabled());
 
+    // Get-only computed properties are serialized by default and count as mapped,
+    // so JsonSerializer.Serialize output for these types round-trips unchanged.
+    private static readonly JsonSerializerOptions RejectUnknownPropertiesJsonOptions = new()
+    {
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    };
+
+    private static readonly JsonSerializerOptions CaseInsensitiveJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
     /// <summary>
     /// Validates incoming config values, failing fast for anything that would otherwise throw
     /// deep inside a request/background task at read time (non-numeric ints, non-boolean flags,
     /// malformed JSON). Empty values are treated as "unset" and always allowed, matching the
-    /// getters' fallback-to-default behavior.
+    /// getters' fallback-to-default behavior. With <paramref name="rejectUnknownJsonProperties"/>
+    /// set, structured JSON values also reject unknown or miscased properties instead of silently
+    /// dropping them.
     /// </summary>
-    public static void ValidateConfigItems(IEnumerable<ConfigItem> configItems)
+    public static void ValidateConfigItems(IEnumerable<ConfigItem> configItems, bool rejectUnknownJsonProperties = false)
     {
+        var jsonOptions = rejectUnknownJsonProperties ? RejectUnknownPropertiesJsonOptions : null;
         foreach (var item in configItems)
         {
             var value = StringUtil.EmptyToNull(item.ConfigValue);
@@ -355,19 +371,19 @@ public class ConfigManager
                     break;
 
                 case ConfigKeys.UsenetProviders:
-                    RequireValidUsenetProviders(item.ConfigName, value);
+                    RequireValidUsenetProviders(item.ConfigName, value, jsonOptions);
                     break;
 
                 case ConfigKeys.ArrInstances:
-                    RequireJson<ArrConfig>(item.ConfigName, value);
+                    RequireJson<ArrConfig>(item.ConfigName, value, jsonOptions);
                     break;
 
                 case ConfigKeys.IndexersInstances:
-                    RequireJson<IndexerConfig>(item.ConfigName, value);
+                    RequireJson<IndexerConfig>(item.ConfigName, value, jsonOptions);
                     break;
 
                 case ConfigKeys.ProfilesInstances:
-                    RequireJson<ProfileConfig>(item.ConfigName, value);
+                    RequireJson<ProfileConfig>(item.ConfigName, value, jsonOptions);
                     break;
             }
         }
@@ -393,28 +409,61 @@ public class ConfigManager
                     $"Config value for '{key}' must be one of '{string.Join("', '", allowed)}', but was '{value}'.");
         }
 
-        static void RequireJson<T>(string key, string value)
+        static void RequireJson<T>(string key, string value, JsonSerializerOptions? options)
         {
             try
             {
-                JsonSerializer.Deserialize<T>(value);
+                JsonSerializer.Deserialize<T>(value, options);
             }
             catch (JsonException e)
             {
-                throw new ArgumentException($"Config value for '{key}' is not valid JSON: {e.Message}");
+                throw DescribeJsonFailure<T>(key, value, options, e);
             }
         }
 
-        static void RequireValidUsenetProviders(string key, string value)
+        // Parsing case-insensitively proves the payload is well formed and satisfies
+        // the type, so a strict failure can only be property naming and the path is
+        // safe to surface. One that fails both is malformed, and that message can
+        // quote part of the value.
+        static ArgumentException DescribeJsonFailure<T>(
+            string key, string value, JsonSerializerOptions? options, JsonException e)
+        {
+            if (options is null || !ParsesIgnoringCase<T>(value))
+                return new ArgumentException($"Config value for '{key}' is not valid JSON: {e.Message}");
+
+            return new ConfigUnmappedPropertyException(key, TruncatePath(e.Path));
+        }
+
+        static bool ParsesIgnoringCase<T>(string value)
+        {
+            try
+            {
+                JsonSerializer.Deserialize<T>(value, CaseInsensitiveJsonOptions);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        // A property name is operator-supplied text, so bound what reaches the log.
+        static string TruncatePath(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return "$";
+            return path.Length <= 120 ? path : path[..120] + "...";
+        }
+
+        static void RequireValidUsenetProviders(string key, string value, JsonSerializerOptions? options)
         {
             UsenetProviderConfig? config;
             try
             {
-                config = JsonSerializer.Deserialize<UsenetProviderConfig>(value);
+                config = JsonSerializer.Deserialize<UsenetProviderConfig>(value, options);
             }
             catch (JsonException e)
             {
-                throw new ArgumentException($"Config value for '{key}' is not valid JSON: {e.Message}");
+                throw DescribeJsonFailure<UsenetProviderConfig>(key, value, options, e);
             }
 
             if (config?.Providers is null) return;
@@ -1501,3 +1550,15 @@ internal sealed record ConfigDiagnosticSnapshot(
     string? Value,
     string Source,
     string? EnvironmentVariableName);
+
+/// <summary>
+/// A structured config value carried a property that maps to nothing on the target
+/// type. <see cref="JsonPath"/> holds property names and array indices only, never a
+/// value. It derives from <see cref="ArgumentException"/>, so widening strict
+/// validation beyond the environment overlay would put the path in API responses.
+/// </summary>
+public sealed class ConfigUnmappedPropertyException(string configName, string jsonPath)
+    : ArgumentException($"Config value for '{configName}' has an unknown or miscased property at '{jsonPath}'.")
+{
+    public string JsonPath { get; } = jsonPath;
+}

--- a/docs/configuration/headless.md
+++ b/docs/configuration/headless.md
@@ -71,6 +71,8 @@ When a key is ENV-managed:
 ## Validation and restart
 
 - Unknown `NZBDAV_CONFIG__...` names, or invalid values for keys with schema validation (booleans, integers, enums such as `repair.healthcheck-depth`, and JSON blobs), abort startup with a **single-line** error that names the variable and **never** prints its value
+- Unknown or miscased properties **inside** a structured JSON value (`usenet.providers`, `arr.instances`, `indexers.instances`, `profiles.instances`) also abort startup, reporting the JSON path of the offending property (**property names only**, never values) so a typo is not silently dropped
+- Structured values are therefore **not forward compatible**: a Compose file cannot carry a property intended for a newer image, and rolling back to an image that predates a property fails startup rather than ignoring it
 - Free-form string keys (categories, paths, import strategy labels, some mode strings) are not fully schema-checked at ENV load — use the allowed values from the matching [Settings reference](index.md) page
 - Empty ENV values are ignored (same as omitting the variable); they do **not** clear a SQLite value
 - Changing ENV configuration requires a **container restart or recreate** (including after `.env` changes)
@@ -171,7 +173,7 @@ services:
 
     Multi-line `>-` YAML folds to a single line. Nested `${...}` inside JSON strings are expanded by Compose before the container starts.
 
-    Use **PascalCase** property names exactly as the Settings UI persists them (`Providers`, `Type`, `Host`, `RadarrInstances`, `Indexers`, `Profiles`, …). camelCase keys are ignored by deserialization and can produce empty or wrong configuration without a startup error.
+    Use **PascalCase** property names exactly as the Settings UI persists them (`Providers`, `Type`, `Host`, `RadarrInstances`, `Indexers`, `Profiles`, …). camelCase or misspelled keys abort startup with an error naming the JSON path of the offending property, so a typo cannot leave you with empty or partial configuration.
 
     Provider `Type` for **Pool Connections** is `1` (`0` = Disabled, `2` = BackupAndStats, `3` = BackupOnly — see [Usenet](usenet.md)). Omit `ProviderId` in ENV JSON — NzbDAV preserves matching SQLite ids by host/port/user, or assigns new ones. Pure ENV-only first installs (no matching SQLite row) get new IDs each restart until a SQLite match exists, so metrics keys may drift.
 

--- a/tests/NzbWebDAV.Tests/Config/ConfigEnvironmentOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigEnvironmentOverlayTests.cs
@@ -162,4 +162,152 @@ public class ConfigEnvironmentOverlayTests
         var parsed = JsonSerializer.Deserialize<UsenetProviderConfig>(normalized)!;
         Assert.NotEqual(Guid.Empty, parsed.Providers[0].ProviderId);
     }
+
+    [Fact]
+    public void LoadFromEnvironment_RejectsMiscasedUsenetProviderJson()
+    {
+        var secret = "env-secret-pass";
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                // camelCase "providers" used to deserialize to zero providers
+                // and boot clean.
+                ["NZBDAV_CONFIG__USENET__PROVIDERS"] =
+                    "{\"providers\":[{\"Type\":1,\"Host\":\"news.example\",\"Port\":563," +
+                    $"\"UseSsl\":true,\"User\":\"u\",\"Pass\":\"{secret}\",\"MaxConnections\":10}}]}}",
+            }));
+
+        Assert.Contains("NZBDAV_CONFIG__USENET__PROVIDERS", ex.Message);
+        Assert.Contains("$.providers", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, ex.Message);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_RejectsUnknownArrInstanceProperty()
+    {
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                ["NZBDAV_CONFIG__ARR__INSTANCES"] =
+                    "{\"radarrInstances\":[{\"host\":\"http://radarr:7878\",\"apiKey\":\"k\"}]}",
+            }));
+
+        Assert.Contains("NZBDAV_CONFIG__ARR__INSTANCES", ex.Message);
+        Assert.Contains("$.radarrInstances", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_NamesNestedUnknownProperty()
+    {
+        var apiKey = "nested-secret-key";
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                // A stale property inside an instance, left behind by a rename or
+                // by config copied from a newer image.
+                ["NZBDAV_CONFIG__ARR__INSTANCES"] =
+                    $"{{\"RadarrInstances\":[{{\"Host\":\"http://radarr:7878\",\"ApiKey\":\"{apiKey}\",\"Timeout\":30}}]}}",
+            }));
+
+        // The path locates the offending property inside the array element.
+        Assert.Contains("$.RadarrInstances[0].Timeout", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(apiKey, ex.Message);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_MalformedJsonDoesNotEchoValue()
+    {
+        var secret = "supersecretpassword";
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                ["NZBDAV_CONFIG__ARR__INSTANCES"] = $"{{\"RadarrInstances\": {secret}}}",
+            }));
+
+        // Malformed input keeps the bare message, since its parser detail can
+        // quote the value.
+        Assert.Equal(
+            "Invalid configuration environment variable `NZBDAV_CONFIG__ARR__INSTANCES`.",
+            ex.Message);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_AcceptsPascalCaseArrInstances()
+    {
+        var arr = JsonSerializer.Serialize(new ArrConfig
+        {
+            RadarrInstances =
+            [
+                new ArrConfig.ConnectionDetails { Host = "http://radarr:7878", ApiKey = "k" },
+            ],
+        });
+
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__ARR__INSTANCES"] = arr,
+        });
+
+        Assert.True(overlay.TryGetValue(ConfigKeys.ArrInstances, out var stored));
+        var parsed = JsonSerializer.Deserialize<ArrConfig>(stored)!;
+        Assert.Equal("http://radarr:7878", Assert.Single(parsed.RadarrInstances).Host);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_NamesMiscasedMemberInsideProvider()
+    {
+        var secret = "provider-pass";
+        var ex = Assert.Throws<ConfigEnvironmentException>(() =>
+            ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+            {
+                // Container key correct, members camelCased. Every member is skipped,
+                // so the required ones read as missing and only a case-insensitive
+                // parse proves this is a naming problem rather than a malformed one.
+                ["NZBDAV_CONFIG__USENET__PROVIDERS"] =
+                    "{\"Providers\":[{\"type\":1,\"host\":\"news.example\",\"port\":563," +
+                    $"\"useSsl\":true,\"user\":\"u\",\"pass\":\"{secret}\",\"maxConnections\":10}}]}}",
+            }));
+
+        Assert.Contains("$.Providers[0].type", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, ex.Message);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_AcceptsSerializedProfilesInstances()
+    {
+        var profiles = JsonSerializer.Serialize(new ProfileConfig
+        {
+            Profiles = [new ProfileConfig.Profile { Token = "t", Name = "n" }],
+        });
+
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__PROFILES__INSTANCES"] = profiles,
+        });
+
+        Assert.True(overlay.TryGetValue(ConfigKeys.ProfilesInstances, out var stored));
+        Assert.Equal("n", Assert.Single(JsonSerializer.Deserialize<ProfileConfig>(stored)!.Profiles).Name);
+    }
+
+    [Fact]
+    public void LoadFromEnvironment_AcceptsSerializedIndexersInstances()
+    {
+        var indexers = JsonSerializer.Serialize(new IndexerConfig
+        {
+            Indexers =
+            [
+                new IndexerConfig.ConnectionDetails
+                {
+                    Name = "example", Url = "https://indexer.example/api", ApiKey = "k",
+                },
+            ],
+        });
+
+        var overlay = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__INDEXERS__INSTANCES"] = indexers,
+        });
+
+        Assert.True(overlay.TryGetValue(ConfigKeys.IndexersInstances, out var stored));
+        Assert.Equal("example", Assert.Single(JsonSerializer.Deserialize<IndexerConfig>(stored)!.Indexers).Name);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Config/UsenetProvidersValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/UsenetProvidersValidationTests.cs
@@ -111,6 +111,38 @@ public class UsenetProvidersValidationTests
         ];
     }
 
+    [Fact]
+    public void ValidateConfigItems_RejectsUnknownJsonPropertiesOnlyWhenStrict()
+    {
+        var miscased = new ConfigItem
+        {
+            ConfigName = ConfigKeys.ArrInstances,
+            ConfigValue = "{\"radarrInstances\":[]}",
+        };
+
+        // The default UI and API save path is unchanged and tolerates miscased JSON.
+        ConfigManager.ValidateConfigItems([miscased]);
+
+        var ex = Assert.Throws<ConfigUnmappedPropertyException>(() =>
+            ConfigManager.ValidateConfigItems([miscased], rejectUnknownJsonProperties: true));
+        Assert.Equal("$.radarrInstances", ex.JsonPath);
+    }
+
+    [Fact]
+    public void ValidateConfigItems_StrictStillReportsMalformedJsonAsInvalid()
+    {
+        var malformed = new ConfigItem
+        {
+            ConfigName = ConfigKeys.ArrInstances,
+            ConfigValue = "{\"RadarrInstances\": [",
+        };
+
+        // Malformed input is not a mapping problem, so it keeps the generic error.
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([malformed], rejectUnknownJsonProperties: true));
+        Assert.IsNotType<ConfigUnmappedPropertyException>(ex);
+    }
+
     private static UsenetProviderConfig.ConnectionDetails MakeProvider(
         string host = "nntp.example",
         int port = 563,


### PR DESCRIPTION
I use Ansible to manage my media server, so I was happy to see IaC support in nzbdav. However I fat-fingered one of the config keys and the container came up clean with zero providers and no error, and it took me a while to realize nothing had actually been configured. The structured NZBDAV_CONFIG values (the provider list and the arr, indexer, and profile instances) deserialize with default options, so a miscased or unknown property is silently skipped instead of rejected. The docs do warn about this in headless.md, but a declarative config has no one watching a Settings page, so a dropped key should fail startup rather than boot half-configured. 
This validates those structured values with UnmappedMemberHandling.Disallow, so an unknown or miscased property throws the same fatal startup error an unknown env var already does. I scoped it to the env overlay only, since the UI and API save path has a human who notices an empty list right away, but it could be expanded.