### PR TITLE
chore(ci): label pre-release images with dev run numbers

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     with:
       tags: "ghcr.io/${{ github.repository }}:dev"
-      nzbdav_version: pre-${{ github.run_number }}
+      nzbdav_version: dev-${{ github.run_number }}
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,14 +8,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      short_sha: ${{ steps.sha.outputs.short_sha }}
+    steps:
+      - id: sha
+        run: echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: resolve
     uses: ./.github/workflows/docker-build-push.yml
     permissions:
       contents: read
       packages: write
     with:
       tags: "ghcr.io/${{ github.repository }}:dev"
-      nzbdav_version: dev-${{ github.run_number }}
+      nzbdav_version: dev-${{ needs.resolve.outputs.short_sha }}
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/frontend/app/utils/update-check.server.test.ts
+++ b/frontend/app/utils/update-check.server.test.ts
@@ -66,7 +66,7 @@ describe("isComparableVersion", () => {
     ["0.0.0", false],
     ["pre-123", false],
     ["PRE-1", false],
-    ["dev-123", false],
+    ["dev-e0eef52", false],
     ["0.7.5", true],
     ["v0.7.5", true],
   ])("treats %s as comparable=%s", (version, expected) => {
@@ -311,7 +311,7 @@ describe("checkForUpdate (dev builds)", () => {
       }),
     );
 
-    await expect(checkForUpdate("dev-42")).resolves.toEqual({
+    await expect(checkForUpdate("dev-e0eef52")).resolves.toEqual({
       kind: "dev",
       commitsBehind: 3,
       compareUrl: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,

--- a/frontend/app/utils/update-check.server.test.ts
+++ b/frontend/app/utils/update-check.server.test.ts
@@ -66,6 +66,7 @@ describe("isComparableVersion", () => {
     ["0.0.0", false],
     ["pre-123", false],
     ["PRE-1", false],
+    ["dev-123", false],
     ["0.7.5", true],
     ["v0.7.5", true],
   ])("treats %s as comparable=%s", (version, expected) => {
@@ -301,7 +302,7 @@ describe("checkForUpdate (dev builds)", () => {
     });
   });
 
-  it("returns commits behind when main is ahead", async () => {
+  it("returns commits behind for dev builds when main is ahead", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         status: "ahead",
@@ -310,7 +311,7 @@ describe("checkForUpdate (dev builds)", () => {
       }),
     );
 
-    await expect(checkForUpdate("pre-42")).resolves.toEqual({
+    await expect(checkForUpdate("dev-42")).resolves.toEqual({
       kind: "dev",
       commitsBehind: 3,
       compareUrl: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,


### PR DESCRIPTION
## Summary
- show `dev-<run number>` in pre-release image headers
- retain commit-based update checks for pre-release images

## Test plan
- [x] `cd frontend && npm test -- app/utils/update-check.server.test.ts`