### PR TITLE
fix(webdav): reject infinite-depth PROPFIND per RFC 4918 instead of answering shallow

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -317,6 +318,31 @@ class Program
             app.Map("/ws", websocketManager.HandleRoute);
             app.MapControllers();
             app.UseWebdavBasicAuthentication();
+            // RFC 4918 §9.1: a server that does not support infinite-depth
+            // PROPFIND must reject it with 403 + <propfind-finite-depth/>.
+            // NWebDav instead answers 207 with only depth-1 results, which
+            // silently lies to clients: the `webdav` npm library's deep mode
+            // (used by AIOStreams and friends) trusts the "successful" shallow
+            // listing, sees no files for releases whose video sits in a nested
+            // folder, and reports the download as empty instead of falling
+            // back to manual traversal. Returning the RFC error makes those
+            // clients throw and recover via their own recursive walk.
+            // Requests WITHOUT a Depth header keep NWebDav's existing
+            // behavior — some clients omit it while expecting a shallow
+            // answer, and rejecting them would regress working setups.
+            app.Use(async (context, next) =>
+            {
+                if (string.Equals(context.Request.Method, "PROPFIND", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(context.Request.Headers["Depth"], "infinity", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.StatusCode = 403;
+                    context.Response.ContentType = "application/xml; charset=utf-8";
+                    await context.Response.WriteAsync(
+                        "<?xml version=\"1.0\" encoding=\"utf-8\"?><D:error xmlns:D=\"DAV:\"><D:propfind-finite-depth/></D:error>");
+                    return;
+                }
+                await next();
+            });
             app.UseNWebDav();
             app.Lifetime.ApplicationStopping.Register(SigtermUtil.Cancel);
             // Remap legacy host-keyed metrics rows onto ProviderIds after the app is


### PR DESCRIPTION
### The bug
NWebDav answers a `Depth: infinity` PROPFIND with **207 and only depth-1 results**. RFC 4918 §9.1 says a server that doesn't support infinite depth must reject with 403 and a `<propfind-finite-depth/>` error body — succeeding shallowly actively lies to clients.

The practical consequence: the `webdav` npm library's `deep: true` mode (used by AIOStreams and other integrations that resolve streams against NzbDAV's WebDAV tree) trusts the successful response. For releases whose video sits inside a nested folder (the common `Release.Name/Release.Name/video.mkv` + `Subs/` scene layout — which NzbDAV itself now produces more often thanks to nested-RAR extraction), the deep listing contains only directories, and the client concludes the download is empty (`No files found in NZB download`) even though the file is one level down. Flat releases work; nested-layout releases fail on every attempt. Verified live against v0.8.0.

### The fix
A small middleware ahead of NWebDav returns the RFC-compliant rejection (403 + `propfind-finite-depth` XML body) for PROPFIND requests that explicitly ask for `Depth: infinity`. Clients then throw and engage their own documented fallback (manual recursive traversal) — with this change alone, the AIOStreams scenario above heals end-to-end.

Requests **without** a Depth header keep NWebDav's existing behavior: RFC-strictly they also mean infinity, but some clients omit the header while expecting a shallow answer, and rejecting them would regress working setups (rclone et al. send explicit `Depth: 1`).

(We're also submitting the complementary client-side guard to AIOStreams — Viren070/AIOStreams#1134 — but the server answering per-RFC protects every deep-listing client, not just that one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)