### PR TITLE
fix(ui): history failed status tooltips no longer hide behind table rows

### DIFF
--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -44,13 +44,15 @@ export function Tooltip({
   content,
   children,
   placement = "top",
+  className = "",
 }: {
   content: string;
   children: ReactNode;
   placement?: TooltipPlacement;
+  className?: string;
 }) {
   return (
-    <span className={`tooltip ${tooltipPlacementClass[placement]}`} data-tip={content}>
+    <span className={`tooltip ${tooltipPlacementClass[placement]} ${className}`.trim()} data-tip={content}>
       {children}
     </span>
   );

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -9,6 +9,7 @@ import { Badge } from "~/components/ui";
 
 const desktopHeaderClass = "hidden min-[900px]:table-cell w-[120px] text-center text-xs font-semibold uppercase tracking-wide";
 const desktopCellClass = "hidden min-[900px]:table-cell max-w-[200px] min-w-0 overflow-hidden whitespace-nowrap px-1 py-3 text-center align-middle";
+const statusCellClass = "hidden min-[900px]:table-cell max-w-[200px] min-w-0 overflow-visible whitespace-nowrap px-1 py-3 text-center align-middle";
 const providerCellClass = "hidden min-[900px]:table-cell max-w-[200px] min-w-0 overflow-hidden px-1 py-3 text-center align-middle";
 
 export type PageTableProps = {
@@ -105,7 +106,7 @@ export function PageRow(props: PageRowProps) {
                     ? <ProvidersBadge providers={props.providers} />
                     : <span className="text-base-content/30 text-xs">—</span>}
             </td>
-            <td className={desktopCellClass}>
+            <td className={statusCellClass}>
                 <StatusBadge status={props.status} percentage={props.percentage} error={props.error} />
             </td>
             <td className="hidden min-[900px]:table-cell max-w-[200px] whitespace-nowrap px-1 py-3 text-center align-middle font-mono text-xs">

--- a/frontend/app/routes/queue/components/status-badge/status-badge.tsx
+++ b/frontend/app/routes/queue/components/status-badge/status-badge.tsx
@@ -21,7 +21,7 @@ export function StatusBadge({ className, status, percentage, error }: StatusBadg
             error = "Missing articles";
 
         return (
-            <Tooltip content={error || "Upload failed"}>
+            <Tooltip content={error || "Upload failed"} className="z-50">
                 <StatusShell className="badge-error cursor-help">
                     {statusLower === "upload failed" && <Icon name="upload" className="!text-[12px]" />}
                     failed


### PR DESCRIPTION
## Summary
- Status column cells use `overflow-visible` so daisyUI failed-status tooltips are not clipped
- Failed/upload-failed badges raise tooltip stacking (`z-50`) so tips paint above zebra rows
- Shared `Tooltip` accepts an optional `className` for callers that need stacking control

## Test plan
- [ ] Open Queue → History with at least one **failed** item (desktop width ≥900px)
- [ ] Hover the red **failed** badge and confirm the fail message tip appears fully above neighboring rows
- [ ] Confirm Category/Indexer cells still truncate long text
- [ ] Spot-check mobile layout: failed badge in the name cell still shows the tip on hover/focus