### PR TITLE
fix(ui): stop dumping BackendUnavailableError stacks when the API is unreachable

### DIFF
--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -173,20 +173,27 @@ public class DownloadingNntpClient : WrappingNntpClient
         return (semaphore, priority);
     }
 
-    private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(CancellationToken cancellationToken)
+    private async Task WaitForSemaphoreAsync(
+        PrioritizedSemaphore semaphore,
+        SemaphorePriority priority,
+        CancellationToken cancellationToken)
     {
-        var (semaphore, priority) = SelectSemaphore(cancellationToken);
         var queueContext = cancellationToken.GetContext<QueueDownloadContext>();
         if (queueContext is null)
         {
             await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+            return;
         }
-        else
-        {
-            var waitTimer = Stopwatch.StartNew();
-            await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
-            queueContext.RecordSemaphoreWait(waitTimer.ElapsedMilliseconds);
-        }
+
+        var waitTimer = Stopwatch.StartNew();
+        await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+        queueContext.RecordSemaphoreWait(waitTimer.ElapsedMilliseconds);
+    }
+
+    private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(CancellationToken cancellationToken)
+    {
+        var (semaphore, priority) = SelectSemaphore(cancellationToken);
+        await WaitForSemaphoreAsync(semaphore, priority, cancellationToken).ConfigureAwait(false);
         return semaphore;
     }
 
@@ -244,7 +251,7 @@ public class DownloadingNntpClient : WrappingNntpClient
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var (semaphore, priority) = SelectSemaphore(cancellationToken);
-        await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+        await WaitForSemaphoreAsync(semaphore, priority, cancellationToken).ConfigureAwait(false);
         try
         {
             await foreach (var result in base.StatsPipelinedAsync(segmentIds, depth, cancellationToken)
@@ -262,7 +269,7 @@ public class DownloadingNntpClient : WrappingNntpClient
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var (semaphore, priority) = SelectSemaphore(cancellationToken);
-        await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+        await WaitForSemaphoreAsync(semaphore, priority, cancellationToken).ConfigureAwait(false);
         try
         {
             await foreach (var result in base.DecodedBodiesPipelinedAsync(segmentIds, depth, cancellationToken)
@@ -280,7 +287,7 @@ public class DownloadingNntpClient : WrappingNntpClient
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var (semaphore, priority) = SelectSemaphore(cancellationToken);
-        await semaphore.WaitAsync(priority, cancellationToken).ConfigureAwait(false);
+        await WaitForSemaphoreAsync(semaphore, priority, cancellationToken).ConfigureAwait(false);
         try
         {
             await foreach (var result in base.DecodedArticlesPipelinedAsync(segmentIds, depth, cancellationToken)

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -219,9 +219,38 @@ describe("BackendClient", () => {
     await expect(backendClient.isOnboarding()).rejects.toBeInstanceOf(BackendUnavailableError);
   });
 
+  it("preserves the undici cause code on BackendUnavailableError", async () => {
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:5000"), {
+      code: "ECONNREFUSED",
+    });
+    fetchMock.mockRejectedValueOnce(Object.assign(new TypeError("fetch failed"), { cause }));
+
+    const error = await backendClient.isOnboarding().then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(BackendUnavailableError);
+    expect(error).toMatchObject({
+      name: "BackendUnavailableError",
+      code: "ECONNREFUSED",
+      message: "Failed to fetch onboarding status: fetch failed (ECONNREFUSED)",
+    });
+  });
+
   it("throws BackendUnavailableError on 503 migrating responses", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ status: "migrating" }, 503));
 
-    await expect(backendClient.isOnboarding()).rejects.toBeInstanceOf(BackendUnavailableError);
+    const error = await backendClient.isOnboarding().then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(BackendUnavailableError);
+    expect(error).toMatchObject({
+      name: "BackendUnavailableError",
+      code: "MIGRATING",
+      message: "Failed to fetch onboarding status: backend is starting or migrating",
+    });
   });
 });

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -7,10 +7,37 @@ export class WebdavDirectoryNotFoundError extends Error {
 
 /** Thrown when the backend is unreachable or still in the migration handoff. */
 export class BackendUnavailableError extends Error {
-    public constructor(message = "Backend temporarily unavailable") {
-        super(message);
+    public constructor(
+        message = "Backend temporarily unavailable",
+        public readonly code?: string,
+        options?: ErrorOptions,
+    ) {
+        super(message, options);
         this.name = "BackendUnavailableError";
     }
+}
+
+/** Walks cause/AggregateError chains for undici / Node network failure codes. */
+function extractNetworkErrorCode(error: unknown): string | undefined {
+    const candidates: unknown[] = [error];
+    if (error && typeof error === "object") {
+        const withCause = error as { cause?: unknown; errors?: unknown[] };
+        if (withCause.cause) candidates.push(withCause.cause);
+        if (Array.isArray(withCause.errors)) candidates.push(...withCause.errors);
+        // One more level: TypeError("fetch failed") → AggregateError → ECONNREFUSED
+        if (withCause.cause && typeof withCause.cause === "object") {
+            const nested = withCause.cause as { cause?: unknown; errors?: unknown[] };
+            if (nested.cause) candidates.push(nested.cause);
+            if (Array.isArray(nested.errors)) candidates.push(...nested.errors);
+        }
+    }
+
+    for (const candidate of candidates) {
+        if (!candidate || typeof candidate !== "object") continue;
+        const code = (candidate as { code?: string }).code;
+        if (typeof code === "string" && code.length > 0) return code;
+    }
+    return undefined;
 }
 
 /** Builds a FormData body from a list of [name, value] entries. */
@@ -40,7 +67,12 @@ async function call(path: string, errorPrefix: string, init?: RequestInit): Prom
         });
     } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
-        throw new BackendUnavailableError(`${errorPrefix}: ${detail}`);
+        const code = extractNetworkErrorCode(error);
+        throw new BackendUnavailableError(
+            `${errorPrefix}: ${detail}${code ? ` (${code})` : ""}`,
+            code,
+            { cause: error },
+        );
     }
 
     if (!response.ok) {
@@ -50,6 +82,7 @@ async function call(path: string, errorPrefix: string, init?: RequestInit): Prom
         if (response.status === 503 || body?.status === "migrating") {
             throw new BackendUnavailableError(
                 `${errorPrefix}: backend is starting or migrating`,
+                "MIGRATING",
             );
         }
 

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -7,15 +7,19 @@ import { isbot } from "isbot";
 import type { RenderToPipeableStreamOptions } from "react-dom/server";
 import { renderToPipeableStream } from "react-dom/server";
 import {
+  formatBackendUnavailableReason,
   isExpectedBackendUnavailableError,
   isWithinBackendStartupGrace,
+  shouldEmitThrottledBackendUnavailableLog,
 } from "../server/startup-grace";
+import { logger } from "../server/logger";
 
 export const streamTimeout = 5_000;
 
 /**
  * Quiet expected BackendUnavailableError stacks during frontend-first Docker
- * startup. Outside the grace window (or for any other error), keep default logging.
+ * startup. Outside the grace window, emit a throttled single-line warn (no stack).
+ * Unexpected errors keep default stack logging.
  */
 export const handleError: HandleErrorFunction = (error, { request }) => {
   if (request.signal.aborted) return;
@@ -25,7 +29,13 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
     ? (error as { error?: unknown }).error
     : undefined;
   const unwrapped = routeError ?? error;
-  if (isWithinBackendStartupGrace() && isExpectedBackendUnavailableError(unwrapped)) {
+  if (isExpectedBackendUnavailableError(unwrapped)) {
+    if (isWithinBackendStartupGrace()) return;
+    if (shouldEmitThrottledBackendUnavailableLog()) {
+      logger.warn(
+        `Backend unreachable during SSR. Reason: ${formatBackendUnavailableReason(unwrapped)}`,
+      );
+    }
     return;
   }
   console.error(unwrapped);

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -29,12 +29,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     const historyPage = parsePage(url.searchParams.get("hp"));
     const queuePageSize = parsePageSize(url.searchParams.get("qps"));
     const historyPageSize = parsePageSize(url.searchParams.get("hps"));
-    const queuePromise = backendClient.getQueue(queuePageSize, (queuePage - 1) * queuePageSize);
-    const historyPromise = backendClient.getHistory(historyPageSize, (historyPage - 1) * historyPageSize);
-    const configPromise = backendClient.getConfig(["api.categories", "api.manual-category"])
-    const queue = await queuePromise;
-    const history = await historyPromise;
-    const config = await configPromise;
+    const [queue, history, config] = await Promise.all([
+        backendClient.getQueue(queuePageSize, (queuePage - 1) * queuePageSize),
+        backendClient.getHistory(historyPageSize, (historyPage - 1) * historyPageSize),
+        backendClient.getConfig(["api.categories", "api.manual-category"]),
+    ]);
     const categoriesValue = config
         .find(x => x.configName === "api.categories")
         ?.configValue ?? "uncategorized,audio,software,tv,movies";

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -6,8 +6,10 @@ import { shouldCompressResponse } from "./server/compression-filter.js";
 import { logger, requestLogger } from "./server/logger.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
 import {
+  formatBackendUnavailableReason,
   isExpectedBackendUnavailableError,
   isWithinBackendStartupGrace,
+  shouldEmitThrottledBackendUnavailableLog,
 } from "./server/startup-grace.js";
 
 // Short-circuit the type-checking of the built output.
@@ -25,10 +27,13 @@ const PORT = Number.parseInt(process.env.PORT || "3000");
 // Deliberately do not hook uncaughtException: that fires for fatal errors
 // where restarting the process is the right answer.
 process.on("unhandledRejection", (reason) => {
-  if (
-    isWithinBackendStartupGrace()
-    && isExpectedBackendUnavailableError(reason)
-  ) {
+  if (isExpectedBackendUnavailableError(reason)) {
+    if (isWithinBackendStartupGrace()) return;
+    if (shouldEmitThrottledBackendUnavailableLog()) {
+      logger.warn(
+        `Backend unreachable during SSR. Reason: ${formatBackendUnavailableReason(reason)}`,
+      );
+    }
     return;
   }
   logger.error("Unhandled promise rejection:", reason);

--- a/frontend/server/startup-grace.test.ts
+++ b/frontend/server/startup-grace.test.ts
@@ -1,12 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
+  BACKEND_FAILURE_LOG_THROTTLE_MS,
+  BACKEND_MIGRATING_CODE,
   BACKEND_STARTUP_GRACE_MS,
+  formatBackendUnavailableReason,
   isExpectedBackendConnectionError,
   isExpectedBackendUnavailableError,
   isWithinBackendStartupGrace,
+  resetBackendUnavailableLogThrottleForTests,
+  shouldEmitThrottledBackendUnavailableLog,
 } from "./startup-grace";
 
 describe("startup-grace helpers", () => {
+  beforeEach(() => {
+    resetBackendUnavailableLogThrottleForTests();
+  });
+
   it("recognizes ECONNREFUSED AggregateErrors", () => {
     const error = Object.assign(new Error("proxy failed"), {
       code: undefined,
@@ -20,22 +29,87 @@ describe("startup-grace helpers", () => {
     expect(isExpectedBackendConnectionError(new Error("boom"))).toBe(false);
   });
 
+  it("recognizes undici timeout codes", () => {
+    const error = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("headers timeout"), {
+        code: "UND_ERR_HEADERS_TIMEOUT",
+      }),
+    });
+
+    expect(isExpectedBackendConnectionError(error)).toBe(true);
+    expect(isExpectedBackendUnavailableError(error)).toBe(true);
+  });
+
   it("reports within the startup grace window for a fresh process", () => {
     expect(isWithinBackendStartupGrace()).toBe(true);
     expect(isWithinBackendStartupGrace(0)).toBe(true);
     expect(isWithinBackendStartupGrace(BACKEND_STARTUP_GRACE_MS)).toBe(false);
   });
 
-  it("recognizes BackendUnavailableError by name", () => {
-    const error = new Error("Failed to fetch onboarding status: fetch failed");
-    error.name = "BackendUnavailableError";
+  it("treats BackendUnavailableError with a network code as expected", () => {
+    const error = Object.assign(
+      new Error("Failed to get history: fetch failed (ECONNREFUSED)"),
+      { name: "BackendUnavailableError", code: "ECONNREFUSED" },
+    );
 
     expect(isExpectedBackendUnavailableError(error)).toBe(true);
-    expect(isExpectedBackendUnavailableError(new Error("boom"))).toBe(false);
   });
 
-  it("treats connection errors as expected backend unavailability", () => {
+  it("treats BackendUnavailableError with MIGRATING code as expected", () => {
+    const error = Object.assign(
+      new Error("Failed to get config items: backend is starting or migrating"),
+      { name: "BackendUnavailableError", code: BACKEND_MIGRATING_CODE },
+    );
+
+    expect(isExpectedBackendUnavailableError(error)).toBe(true);
+  });
+
+  it("does not treat BackendUnavailableError without a network code as expected", () => {
+    const error = Object.assign(
+      new Error("Failed to get config items: Invalid URL"),
+      { name: "BackendUnavailableError" },
+    );
+
+    expect(isExpectedBackendUnavailableError(error)).toBe(false);
+  });
+
+  it("treats BackendUnavailableError with a network cause chain as expected", () => {
+    const error = Object.assign(
+      new Error("Failed to get history: fetch failed"),
+      {
+        name: "BackendUnavailableError",
+        cause: Object.assign(new Error("connect failed"), { code: "ECONNRESET" }),
+      },
+    );
+
+    expect(isExpectedBackendUnavailableError(error)).toBe(true);
+  });
+
+  it("treats raw connection errors as expected backend unavailability", () => {
     const error = Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
     expect(isExpectedBackendUnavailableError(error)).toBe(true);
+  });
+
+  it("formats BackendUnavailableError messages for warn lines", () => {
+    const error = Object.assign(
+      new Error("Failed to get history: fetch failed (UND_ERR_HEADERS_TIMEOUT)"),
+      { name: "BackendUnavailableError", code: "UND_ERR_HEADERS_TIMEOUT" },
+    );
+    expect(formatBackendUnavailableReason(error)).toBe(
+      "Failed to get history: fetch failed (UND_ERR_HEADERS_TIMEOUT)",
+    );
+    expect(formatBackendUnavailableReason("plain")).toBe("plain");
+  });
+
+  it("throttles repeated expected-backend-unavailable log emission", () => {
+    const t0 = 1_000_000;
+    expect(shouldEmitThrottledBackendUnavailableLog(t0)).toBe(true);
+    expect(shouldEmitThrottledBackendUnavailableLog(t0 + 1)).toBe(false);
+    expect(
+      shouldEmitThrottledBackendUnavailableLog(t0 + BACKEND_FAILURE_LOG_THROTTLE_MS - 1),
+    ).toBe(false);
+    expect(
+      shouldEmitThrottledBackendUnavailableLog(t0 + BACKEND_FAILURE_LOG_THROTTLE_MS),
+    ).toBe(true);
   });
 });

--- a/frontend/server/startup-grace.test.ts
+++ b/frontend/server/startup-grace.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BACKEND_FAILURE_LOG_THROTTLE_MS,
   BACKEND_MIGRATING_CODE,
@@ -111,5 +111,15 @@ describe("startup-grace helpers", () => {
     expect(
       shouldEmitThrottledBackendUnavailableLog(t0 + BACKEND_FAILURE_LOG_THROTTLE_MS),
     ).toBe(true);
+  });
+
+  it("shares throttle state across separately loaded server bundles", async () => {
+    const t0 = 1_000_000;
+    expect(shouldEmitThrottledBackendUnavailableLog(t0)).toBe(true);
+
+    vi.resetModules();
+    const separatelyLoaded = await import("./startup-grace");
+
+    expect(separatelyLoaded.shouldEmitThrottledBackendUnavailableLog(t0 + 1)).toBe(false);
   });
 });

--- a/frontend/server/startup-grace.ts
+++ b/frontend/server/startup-grace.ts
@@ -15,10 +15,17 @@ const EXPECTED_NETWORK_CODES = new Set([
   "UND_ERR_HEADERS_TIMEOUT",
   "UND_ERR_BODY_TIMEOUT",
   "UND_ERR_SOCKET",
-  BACKEND_MIGRATING_CODE,
 ]);
 
-let lastExpectedBackendUnavailableLogAt = 0;
+const backendUnavailableLogState = process as typeof process & {
+  __nzbdavBackendUnavailableLogState?: { lastLogAt: number };
+};
+
+function getBackendUnavailableLogState(): { lastLogAt: number } {
+  return backendUnavailableLogState.__nzbdavBackendUnavailableLogState ??= {
+    lastLogAt: 0,
+  };
+}
 
 /** Uses process uptime so Express and SSR bundles agree even if this module is duplicated. */
 export function isWithinBackendStartupGrace(uptimeMs = process.uptime() * 1000): boolean {
@@ -62,8 +69,8 @@ export function isExpectedBackendConnectionError(error: unknown): boolean {
 export function isExpectedBackendUnavailableError(error: unknown): boolean {
   if (error instanceof Error && error.name === "BackendUnavailableError") {
     const code = (error as { code?: string }).code;
+    if (code === BACKEND_MIGRATING_CODE) return true;
     if (isExpectedNetworkCode(code)) return true;
-    if (error.message.includes("backend is starting or migrating")) return true;
     return isExpectedBackendConnectionError(error);
   }
   return isExpectedBackendConnectionError(error);
@@ -79,14 +86,15 @@ export function formatBackendUnavailableReason(error: unknown): string {
  * backend-unavailable failure. Shared by unhandledRejection and SSR handleError.
  */
 export function shouldEmitThrottledBackendUnavailableLog(now = Date.now()): boolean {
-  if (now - lastExpectedBackendUnavailableLogAt < BACKEND_FAILURE_LOG_THROTTLE_MS) {
+  const state = getBackendUnavailableLogState();
+  if (now - state.lastLogAt < BACKEND_FAILURE_LOG_THROTTLE_MS) {
     return false;
   }
-  lastExpectedBackendUnavailableLogAt = now;
+  state.lastLogAt = now;
   return true;
 }
 
 /** Test-only: reset throttle state between cases. */
 export function resetBackendUnavailableLogThrottleForTests(): void {
-  lastExpectedBackendUnavailableLogAt = 0;
+  getBackendUnavailableLogState().lastLogAt = 0;
 }

--- a/frontend/server/startup-grace.ts
+++ b/frontend/server/startup-grace.ts
@@ -2,30 +2,91 @@
 export const BACKEND_STARTUP_GRACE_MS = 30_000;
 export const BACKEND_FAILURE_LOG_THROTTLE_MS = 60_000;
 
+/** Synthetic code for HTTP 503 / migration handoff from the backend client. */
+export const BACKEND_MIGRATING_CODE = "MIGRATING";
+
+const EXPECTED_NETWORK_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EPIPE",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_SOCKET",
+  BACKEND_MIGRATING_CODE,
+]);
+
+let lastExpectedBackendUnavailableLogAt = 0;
+
 /** Uses process uptime so Express and SSR bundles agree even if this module is duplicated. */
 export function isWithinBackendStartupGrace(uptimeMs = process.uptime() * 1000): boolean {
   return uptimeMs < BACKEND_STARTUP_GRACE_MS;
 }
 
-export function isExpectedBackendConnectionError(error: unknown): boolean {
+function collectErrorCandidates(error: unknown): unknown[] {
   const candidates: unknown[] = [error];
-  if (error && typeof error === "object") {
-    const withCause = error as { cause?: unknown; errors?: unknown[] };
-    if (withCause.cause) candidates.push(withCause.cause);
-    if (Array.isArray(withCause.errors)) candidates.push(...withCause.errors);
-  }
+  if (!error || typeof error !== "object") return candidates;
 
-  return candidates.some((candidate) => {
+  const withCause = error as { cause?: unknown; errors?: unknown[] };
+  if (withCause.cause) {
+    candidates.push(withCause.cause);
+    if (typeof withCause.cause === "object") {
+      const nested = withCause.cause as { cause?: unknown; errors?: unknown[] };
+      if (nested.cause) candidates.push(nested.cause);
+      if (Array.isArray(nested.errors)) candidates.push(...nested.errors);
+    }
+  }
+  if (Array.isArray(withCause.errors)) candidates.push(...withCause.errors);
+  return candidates;
+}
+
+export function isExpectedNetworkCode(code: string | undefined): boolean {
+  return typeof code === "string" && EXPECTED_NETWORK_CODES.has(code);
+}
+
+export function isExpectedBackendConnectionError(error: unknown): boolean {
+  return collectErrorCandidates(error).some((candidate) => {
     if (!candidate || typeof candidate !== "object") return false;
-    const code = (candidate as { code?: string }).code;
-    return code === "ECONNREFUSED" || code === "ECONNRESET" || code === "EPIPE";
+    return isExpectedNetworkCode((candidate as { code?: string }).code);
   });
 }
 
-/** Match by name so callers need not import BackendUnavailableError across bundle boundaries. */
+/**
+ * Expected backend-unreachable failures: network connection/timeout codes on a
+ * BackendUnavailableError (or raw connection error), or the migration/503 handoff.
+ * A BackendUnavailableError with no network code (e.g. wrapped TypeError from a
+ * bad BACKEND_URL) stays unexpected so it keeps ERR + stack.
+ */
 export function isExpectedBackendUnavailableError(error: unknown): boolean {
   if (error instanceof Error && error.name === "BackendUnavailableError") {
-    return true;
+    const code = (error as { code?: string }).code;
+    if (isExpectedNetworkCode(code)) return true;
+    if (error.message.includes("backend is starting or migrating")) return true;
+    return isExpectedBackendConnectionError(error);
   }
   return isExpectedBackendConnectionError(error);
+}
+
+export function formatBackendUnavailableReason(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/**
+ * Returns true when the caller should emit a throttled warn for an expected
+ * backend-unavailable failure. Shared by unhandledRejection and SSR handleError.
+ */
+export function shouldEmitThrottledBackendUnavailableLog(now = Date.now()): boolean {
+  if (now - lastExpectedBackendUnavailableLogAt < BACKEND_FAILURE_LOG_THROTTLE_MS) {
+    return false;
+  }
+  lastExpectedBackendUnavailableLogAt = now;
+  return true;
+}
+
+/** Test-only: reset throttle state between cases. */
+export function resetBackendUnavailableLogThrottleForTests(): void {
+  lastExpectedBackendUnavailableLogAt = 0;
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -157,6 +157,63 @@ public class DownloadingNntpClientStatGateTests
             order);
     }
 
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_RecordsSemaphoreWait_UnderQueueContention()
+    {
+        var holdFirst = new ManualResetEventSlim(false);
+        var entered = new ConcurrentQueue<string>();
+        var fake = new BlockingPipelinedBodyNntpClient(holdFirst, entered);
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(fake, config);
+
+        var heldCtx = new QueueDownloadContext
+        {
+            IsPrimary = true,
+            GetFanOutConcurrency = () => 1,
+        };
+        var waitingCtx = new QueueDownloadContext
+        {
+            IsPrimary = false,
+            GetFanOutConcurrency = () => 1,
+        };
+
+        using var heldCts = new CancellationTokenSource();
+        using var heldReg = heldCts.Token.SetContext(heldCtx);
+        var heldTask = CollectPipelinedBodiesAsync(client, ["held"], heldCts.Token);
+        await WaitUntilAsync(() => entered.Contains("held"), TimeSpan.FromSeconds(2));
+
+        using var waitingCts = new CancellationTokenSource();
+        using var waitingReg = waitingCts.Token.SetContext(waitingCtx);
+        var waitingTask = CollectPipelinedBodiesAsync(client, ["waiting"], waitingCts.Token);
+
+        await Task.Delay(80);
+        Assert.DoesNotContain("waiting", entered);
+        Assert.Equal(0, waitingCtx.SemaphoreWaitMilliseconds);
+
+        holdFirst.Set();
+        await Task.WhenAll(heldTask, waitingTask);
+
+        Assert.Contains("waiting", entered);
+        Assert.True(
+            waitingCtx.SemaphoreWaitMilliseconds > 0,
+            $"Expected pipelined wait to record semaphore contention, got {waitingCtx.SemaphoreWaitMilliseconds}ms");
+    }
+
+    private static async Task<List<PipelinedBodyResult>> CollectPipelinedBodiesAsync(
+        DownloadingNntpClient client,
+        IReadOnlyList<string> segmentIds,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<PipelinedBodyResult>();
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           segmentIds, depth: 1, cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(result);
+        }
+
+        return results;
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -348,6 +405,33 @@ public class DownloadingNntpClientStatGateTests
             finally
             {
                 onExit?.Invoke();
+            }
+        }
+    }
+
+    private sealed class BlockingPipelinedBodyNntpClient(
+        ManualResetEventSlim gate,
+        ConcurrentQueue<string> entered) : MinimalNntpClient
+    {
+        public override async IAsyncEnumerable<PipelinedBodyResult> DecodedBodiesPipelinedAsync(
+            IReadOnlyList<string> segmentIds,
+            int depth,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var segmentId in segmentIds)
+            {
+                entered.Enqueue(segmentId);
+                while (!gate.IsSet)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                }
+
+                yield return new PipelinedBodyResult
+                {
+                    SegmentId = segmentId,
+                    Found = true,
+                };
             }
         }
     }


### PR DESCRIPTION
## Summary
- Queue page SSR no longer leaves sibling `getHistory` / `getConfig` promises unhandled when the backend is down; they fail together via `Promise.all`.
- After the 30s startup grace, expected backend-unreachable errors log as a throttled single-line warning (with undici cause code) instead of ERR + full stack. Misconfigurations without a network cause stay loud.
- The warning throttle is process-global so the Node entrypoint and bundled SSR graph cannot emit duplicate lines for the same outage.
- Pipelined NNTP queue fetches now record semaphore wait time, so the first-segment `semaphoreWait=` warning is accurate when pipelining is enabled.

## Test plan
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test` (255 passed)
- [x] `cd frontend && npm run build && npm run build:server`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1069 passed, 14 platform skips)
- [ ] Manual: stop backend after >30s uptime, load `/queue` — expect at most one throttled WRN per minute with a cause code, no unhandled-rejection stacks, backend-unavailable boundary still shown