### PR TITLE
fix(webdav): fail stuck Usenet reads quickly instead of wedging rclone

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -155,9 +155,9 @@ public class GetWebdavItemController(
             using var scope = providerUsageTracker.BeginScope(sessionId);
             using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
 
-            // Bound the entire backend wait (NNTP admission + segment delivery) for this
-            // read so a stuck provider fails the HTTP request instead of blocking until
-            // the client disconnects. See GetAndHeadHandlerPatch for the WebDAV parity path.
+            // Bound the initial backend wait (store lookup + stream open). Cleared once
+            // body copy starts — mid-stream stalls use per-segment timeouts. See
+            // GetAndHeadHandlerPatch for the WebDAV parity path.
             using var readCts = CancellationTokenSource.CreateLinkedTokenSource(HttpContext.RequestAborted);
             readCts.CancelAfter(configManager.GetStreamingReadTimeout());
             var ct = readCts.Token;
@@ -180,6 +180,9 @@ public class GetWebdavItemController(
                     HttpContext.Connection.RemoteIpAddress?.ToString());
                 try
                 {
+                    // Body transfer can run for minutes; drop the admission/open
+                    // deadline and rely on per-segment mid-stream timeouts.
+                    readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                     await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, ct);
                     FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
                 }
@@ -194,12 +197,14 @@ public class GetWebdavItemController(
                     throw;
                 }
             }
-            catch (OperationCanceledException) when (!HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException oce) when (!HttpContext.RequestAborted.IsCancellationRequested)
             {
+                FinishRange(sessionId, ReadSession.EndReasonCode.Error, "streaming-read-timeout");
                 throw new StreamingReadTimeoutException(
                     "WebDAV /view read exceeded the " +
                     $"{configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
-                    "while waiting for the Usenet backend.");
+                    "while waiting for the Usenet backend.",
+                    oce);
             }
         }
         catch (UnauthorizedAccessException)
@@ -300,12 +305,13 @@ public class GetWebdavItemController(
                 await using var response = await GetWebdavItem(request, ct).ConfigureAwait(false);
                 // HEAD: headers already set, body omitted
             }
-            catch (OperationCanceledException) when (!HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException oce) when (!HttpContext.RequestAborted.IsCancellationRequested)
             {
                 throw new StreamingReadTimeoutException(
                     "WebDAV /view HEAD exceeded the " +
                     $"{configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
-                    "while waiting for the Usenet backend.");
+                    "while waiting for the Usenet backend.",
+                    oce);
             }
         }
         catch (UnauthorizedAccessException)

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Par2Recovery;
 using NzbWebDAV.Services;
@@ -29,7 +30,7 @@ public class GetWebdavItemController(
     StreamTraceBuffer streamTrace
 ) : ControllerBase
 {
-    private async Task<Stream> GetWebdavItem(GetWebdavItemRequest request)
+    private async Task<Stream> GetWebdavItem(GetWebdavItemRequest request, CancellationToken ct)
     {
         // /view streams outside NWebDav; attach the same streaming timeout context
         // BaseStoreStreamFile sets for WebDAV so segment fetches fail fast.
@@ -40,14 +41,14 @@ public class GetWebdavItemController(
             PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
             MaxRetries = configManager.GetStreamingSegmentRetries(),
         };
-        var scopedStreamingTimeoutContext = HttpContext.RequestAborted.SetContext(streamingTimeoutContext);
+        var scopedStreamingTimeoutContext = ct.SetContext(streamingTimeoutContext);
         HttpContext.Response.OnCompleted(() =>
         {
             scopedStreamingTimeoutContext.Dispose();
             return Task.CompletedTask;
         });
 
-        var item = await store.GetItemAsync(request.Item, HttpContext.RequestAborted).ConfigureAwait(false);
+        var item = await store.GetItemAsync(request.Item, ct).ConfigureAwait(false);
         if (item is null) throw new BadHttpRequestException("The file does not exist.");
         if (item is IStoreCollection) throw new BadHttpRequestException("The file does not exist.");
 
@@ -56,14 +57,14 @@ public class GetWebdavItemController(
 
         // handle par2 preview
         if (Path.GetExtension(item.Name).ToLower() == ".par2" && configManager.IsPreviewPar2FilesEnabled())
-            return await GetPar2PreviewStream(item).ConfigureAwait(false);
+            return await GetPar2PreviewStream(item, ct).ConfigureAwait(false);
 
         // Provisional budget for fully-specified ranges before stream creation.
         if (request.RangeStart is { } provisionalStart && request.RangeEnd is { } provisionalEnd)
             RangeContext.SetReadBudget(provisionalEnd - provisionalStart + 1);
 
         // get the file stream and set the file-size in header
-        var stream = await item.GetReadableStreamAsync(HttpContext.RequestAborted).ConfigureAwait(false);
+        var stream = await item.GetReadableStreamAsync(ct).ConfigureAwait(false);
         var fileSize = stream.Length;
 
         var idFile = item as DatabaseStoreIdFile;
@@ -153,34 +154,52 @@ public class GetWebdavItemController(
             HttpContext.Items["readSessionId"] = sessionId;
             using var scope = providerUsageTracker.BeginScope(sessionId);
             using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
-            await using var response = await GetWebdavItem(request);
-            if (response == Stream.Null)
-                return;
-            var effectiveStart = (long)(HttpContext.Items["effectiveRangeStart"] ?? 0L);
-            var rangeEnd = HttpContext.Items["effectiveRangeEnd"] as long?;
-            streamTrace.RangeOpen(
-                sessionId,
-                request.Item,
-                "GET",
-                effectiveStart,
-                rangeEnd,
-                response.CanSeek ? response.Length : null,
-                Request.Headers.UserAgent.ToString(),
-                HttpContext.Connection.RemoteIpAddress?.ToString());
+
+            // Bound the entire backend wait (NNTP admission + segment delivery) for this
+            // read so a stuck provider fails the HTTP request instead of blocking until
+            // the client disconnects. See GetAndHeadHandlerPatch for the WebDAV parity path.
+            using var readCts = CancellationTokenSource.CreateLinkedTokenSource(HttpContext.RequestAborted);
+            readCts.CancelAfter(configManager.GetStreamingReadTimeout());
+            var ct = readCts.Token;
+
             try
             {
-                await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, HttpContext.RequestAborted);
-                FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+                await using var response = await GetWebdavItem(request, ct);
+                if (response == Stream.Null)
+                    return;
+                var effectiveStart = (long)(HttpContext.Items["effectiveRangeStart"] ?? 0L);
+                var rangeEnd = HttpContext.Items["effectiveRangeEnd"] as long?;
+                streamTrace.RangeOpen(
+                    sessionId,
+                    request.Item,
+                    "GET",
+                    effectiveStart,
+                    rangeEnd,
+                    response.CanSeek ? response.Length : null,
+                    Request.Headers.UserAgent.ToString(),
+                    HttpContext.Connection.RemoteIpAddress?.ToString());
+                try
+                {
+                    await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, ct);
+                    FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+                }
+                catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+                {
+                    FinishRange(sessionId, ReadSession.EndReasonCode.Aborted);
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    FinishRange(sessionId, ReadSession.EndReasonCode.Error, ex.Message);
+                    throw;
+                }
             }
-            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException) when (!HttpContext.RequestAborted.IsCancellationRequested)
             {
-                FinishRange(sessionId, ReadSession.EndReasonCode.Aborted);
-                throw;
-            }
-            catch (Exception ex)
-            {
-                FinishRange(sessionId, ReadSession.EndReasonCode.Error, ex.Message);
-                throw;
+                throw new StreamingReadTimeoutException(
+                    "WebDAV /view read exceeded the " +
+                    $"{configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
+                    "while waiting for the Usenet backend.");
             }
         }
         catch (UnauthorizedAccessException)
@@ -271,8 +290,23 @@ public class GetWebdavItemController(
         {
             HttpContext.Items["configManager"] = configManager;
             var request = new GetWebdavItemRequest(HttpContext);
-            await using var response = await GetWebdavItem(request).ConfigureAwait(false);
-            // HEAD: headers already set, body omitted
+
+            using var readCts = CancellationTokenSource.CreateLinkedTokenSource(HttpContext.RequestAborted);
+            readCts.CancelAfter(configManager.GetStreamingReadTimeout());
+            var ct = readCts.Token;
+
+            try
+            {
+                await using var response = await GetWebdavItem(request, ct).ConfigureAwait(false);
+                // HEAD: headers already set, body omitted
+            }
+            catch (OperationCanceledException) when (!HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                throw new StreamingReadTimeoutException(
+                    "WebDAV /view HEAD exceeded the " +
+                    $"{configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
+                    "while waiting for the Usenet backend.");
+            }
         }
         catch (UnauthorizedAccessException)
         {
@@ -317,11 +351,11 @@ public class GetWebdavItemController(
         return $"{type}; filename=\"{ascii}\"; filename*=UTF-8''{utf8}";
     }
 
-    private async Task<Stream> GetPar2PreviewStream(IStoreItem item)
+    private async Task<Stream> GetPar2PreviewStream(IStoreItem item, CancellationToken ct)
     {
         Response.Headers.ContentType = "text/plain";
-        await using var stream = await item.GetReadableStreamAsync(HttpContext.RequestAborted).ConfigureAwait(false);
-        var fileDescriptors = await Par2.ReadFileDescriptions(stream, HttpContext.RequestAborted).GetAllAsync()
+        await using var stream = await item.GetReadableStreamAsync(ct).ConfigureAwait(false);
+        var fileDescriptors = await Par2.ReadFileDescriptions(stream, ct).GetAllAsync()
             .ConfigureAwait(false);
         return new MemoryStream(Encoding.UTF8.GetBytes(fileDescriptors.ToIndentedJson()));
     }

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -50,6 +50,7 @@ public static class ConfigKeys
     public const string UsenetStreamingPriority = "usenet.streaming-priority";
     public const string UsenetStreamingSegmentTimeoutSeconds = "usenet.streaming-segment-timeout-seconds";
     public const string UsenetStreamingSegmentRetries = "usenet.streaming-segment-retries";
+    public const string UsenetStreamingReadTimeoutSeconds = "usenet.streaming-read-timeout-seconds";
 
     // webdav
     public const string WebdavEnforceReadonly = "webdav.enforce-readonly";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -284,6 +284,7 @@ public class ConfigManager
                 case ConfigKeys.UsenetStreamingPriority:
                 case ConfigKeys.UsenetStreamingSegmentTimeoutSeconds:
                 case ConfigKeys.UsenetStreamingSegmentRetries:
+                case ConfigKeys.UsenetStreamingReadTimeoutSeconds:
                 case ConfigKeys.WardenQuorum:
                 case ConfigKeys.WardenMaxSourceEntries:
                 case ConfigKeys.PlayTotalBudgetSeconds:
@@ -737,6 +738,20 @@ public class ConfigManager
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingSegmentRetries));
         return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 5) : 3;
+    }
+
+    /// <summary>
+    /// Total backend-wait budget for a single WebDAV/`/view` GET or range read —
+    /// covers download-semaphore admission, the connection-pool gate, and segment
+    /// delivery together. Distinct from (and larger than) the per-segment timeout:
+    /// this bounds the whole read so a stuck provider fails the HTTP request
+    /// instead of blocking until the client disconnects.
+    /// </summary>
+    public TimeSpan GetStreamingReadTimeout()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingReadTimeoutSeconds));
+        var seconds = int.TryParse(v, out var n) ? Math.Clamp(n, 5, 120) : 30;
+        return TimeSpan.FromSeconds(seconds);
     }
 
     public bool IsEnforceReadonlyWebdavEnabled()

--- a/backend/Exceptions/StreamingReadTimeoutException.cs
+++ b/backend/Exceptions/StreamingReadTimeoutException.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Thrown when a WebDAV/`/view` GET or range read exceeds the configured
+/// streaming-read-timeout while waiting on NNTP admission (download semaphore,
+/// connection-pool gate) or segment delivery. Distinct from a client-initiated
+/// disconnect (<see cref="OperationCanceledException"/> with <c>RequestAborted</c>
+/// cancelled) — this represents the backend failing to deliver within budget.
+/// </summary>
+public class StreamingReadTimeoutException(string message, Exception? innerException = null)
+    : Exception(message, innerException)
+{
+}

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -102,6 +102,7 @@ public static class ExceptionExtensions
         return exception is TimeoutException
             or SocketException
             or IOException
+            or StreamingReadTimeoutException
             || exception.IsRetryableDownloadException()
             || exception.IsNonRetryableDownloadException();
     }

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -154,6 +154,10 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                 context.Response.Clear();
                 context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
                 context.Response.Headers.RetryAfter = "5";
+                context.Response.ContentType = "text/plain; charset=utf-8";
+                await context.Response.WriteAsync(
+                    "Usenet backend did not deliver within the streaming-read-timeout. Retry shortly.",
+                    context.RequestAborted).ConfigureAwait(false);
                 LogWithDedup(RecentStreamingReadTimeouts, filePath, suppressed =>
                 {
                     if (suppressed > 0)

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -20,6 +20,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentConnectionLimitErrors = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentSeekErrors = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentReadErrors = new();
+    private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentStreamingReadTimeouts = new();
     private static readonly ConcurrentDictionary<Guid, DateTime> RecentRepairTriggers = new();
     private static readonly TimeSpan DedupeWindow = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan RepairDedupeWindow = TimeSpan.FromMinutes(5);
@@ -141,6 +142,52 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             var filePath = GetRequestFilePath(context);
             Log.Error("File {FilePath} could not connect to usenet provider: {ErrorMessage}", filePath, e.Message);
             AbortStartedResponse(context);
+        }
+        catch (Exception e) when (e.TryGetCausingException(out StreamingReadTimeoutException? _))
+        {
+            // Backend-wait deadline (not client disconnect). Fail fast before headers so
+            // rclone/FUSE can surface an HTTP error instead of wedging in D-state; after
+            // headers we can only abort the truncated body.
+            var filePath = GetRequestFilePath(context);
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                context.Response.Headers.RetryAfter = "5";
+                LogWithDedup(RecentStreamingReadTimeouts, filePath, suppressed =>
+                {
+                    if (suppressed > 0)
+                        Log.Warning(
+                            "WebDAV read failed fast. Path={Path} Reason: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
+                            filePath,
+                            "streaming-read-timeout",
+                            suppressed);
+                    else
+                        Log.Warning(
+                            "WebDAV read failed fast. Path={Path} Reason: {Reason}",
+                            filePath,
+                            "streaming-read-timeout");
+                });
+                Log.Debug(e, "WebDAV streaming-read-timeout stack");
+                return;
+            }
+
+            AbortStartedResponse(context);
+            LogWithDedup(RecentStreamingReadTimeouts, filePath + "|after-headers", suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "WebDAV read aborted after headers due to backend deadline. Path={Path} Reason: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        "streaming-read-timeout-after-headers",
+                        suppressed);
+                else
+                    Log.Warning(
+                        "WebDAV read aborted after headers due to backend deadline. Path={Path} Reason: {Reason}",
+                        filePath,
+                        "streaming-read-timeout-after-headers");
+            });
+            Log.Debug(e, "WebDAV streaming-read-timeout after-headers stack");
         }
         catch (Exception e) when (
             IsDavItemRequest(context) &&
@@ -389,6 +436,11 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         {
             if (kvp.Value.LastLogged < cutoff)
                 RecentReadErrors.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in RecentStreamingReadTimeouts)
+        {
+            if (kvp.Value.LastLogged < cutoff)
+                RecentStreamingReadTimeouts.TryRemove(kvp.Key, out _);
         }
         foreach (var kvp in RecentRepairTriggers)
         {

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -7,8 +7,10 @@ using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.WebDav.Requests;
@@ -28,6 +30,7 @@ namespace NzbWebDAV.WebDav.Base;
 public class GetAndHeadHandlerPatch : IRequestHandler
 {
     private readonly IStore _store;
+    private readonly ConfigManager _configManager;
     private readonly ProviderUsageTracker _providerUsageTracker;
     private readonly ActiveReadRegistry _activeReadRegistry;
     private readonly StreamTraceBuffer _streamTrace;
@@ -35,12 +38,14 @@ public class GetAndHeadHandlerPatch : IRequestHandler
 
     public GetAndHeadHandlerPatch(
         IStore store,
+        ConfigManager configManager,
         ProviderUsageTracker providerUsageTracker,
         ActiveReadRegistry activeReadRegistry,
         StreamTraceBuffer streamTrace,
         StreamingFailureTracker failureTracker)
     {
         _store = store;
+        _configManager = configManager;
         _providerUsageTracker = providerUsageTracker;
         _activeReadRegistry = activeReadRegistry;
         _streamTrace = streamTrace;
@@ -77,8 +82,41 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         if (range is { Start: not null, End: not null })
             RangeContext.SetReadBudget(range.End.Value - range.Start.Value + 1);
 
+        // Bound the entire backend wait (NNTP admission + segment delivery) for this
+        // read so a stuck provider fails the HTTP request instead of blocking until
+        // the client disconnects. Every downstream await below must observe `ct`
+        // (not httpContext.RequestAborted directly) — StreamingTimeoutContext /
+        // CancellationTokenContext key by the exact token instance passed in.
+        using var readCts = CancellationTokenSource.CreateLinkedTokenSource(httpContext.RequestAborted);
+        readCts.CancelAfter(_configManager.GetStreamingReadTimeout());
+        var ct = readCts.Token;
+
+        try
+        {
+            return await HandleRequestCoreAsync(httpContext, request, response, isHeadRequest, range, copyStart, copyEnd, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!httpContext.RequestAborted.IsCancellationRequested)
+        {
+            throw new StreamingReadTimeoutException(
+                "WebDAV read exceeded the " +
+                $"{_configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
+                "while waiting for the Usenet backend.");
+        }
+    }
+
+    private async Task<bool> HandleRequestCoreAsync(
+        HttpContext httpContext,
+        HttpRequest request,
+        HttpResponse response,
+        bool isHeadRequest,
+        NWebDav.Server.Helpers.Range? range,
+        long copyStart,
+        long? copyEnd,
+        CancellationToken ct)
+    {
         // Obtain the WebDAV collection
-        var entry = await _store.GetItemAsync(request.GetUri(), httpContext.RequestAborted).ConfigureAwait(false);
+        var entry = await _store.GetItemAsync(request.GetUri(), ct).ConfigureAwait(false);
         if (entry == null)
         {
             // Set status to not found
@@ -94,28 +132,28 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         if (propertyManager != null)
         {
             // Add Last-Modified header
-            var lastModifiedUtc = (string?)await propertyManager.GetPropertyAsync(entry, DavGetLastModified<IStoreItem>.PropertyName, true, httpContext.RequestAborted).ConfigureAwait(false);
+            var lastModifiedUtc = (string?)await propertyManager.GetPropertyAsync(entry, DavGetLastModified<IStoreItem>.PropertyName, true, ct).ConfigureAwait(false);
             if (lastModifiedUtc != null)
                 response.Headers.LastModified = lastModifiedUtc;
 
             // Add ETag
-            etag = (string?)await propertyManager.GetPropertyAsync(entry, DavGetEtag<IStoreItem>.PropertyName, true, httpContext.RequestAborted).ConfigureAwait(false);
+            etag = (string?)await propertyManager.GetPropertyAsync(entry, DavGetEtag<IStoreItem>.PropertyName, true, ct).ConfigureAwait(false);
             if (etag != null)
                 response.Headers.ETag = etag;
 
             // Add type
-            var contentType = (string?)await propertyManager.GetPropertyAsync(entry, DavGetContentType<IStoreItem>.PropertyName, true, httpContext.RequestAborted).ConfigureAwait(false);
+            var contentType = (string?)await propertyManager.GetPropertyAsync(entry, DavGetContentType<IStoreItem>.PropertyName, true, ct).ConfigureAwait(false);
             if (contentType != null)
                 response.ContentType = contentType;
 
             // Add language
-            var contentLanguage = (string?)await propertyManager.GetPropertyAsync(entry, DavGetContentLanguage<IStoreItem>.PropertyName, true, httpContext.RequestAborted).ConfigureAwait(false);
+            var contentLanguage = (string?)await propertyManager.GetPropertyAsync(entry, DavGetContentLanguage<IStoreItem>.PropertyName, true, ct).ConfigureAwait(false);
             if (contentLanguage != null)
                 response.Headers.ContentLanguage = contentLanguage;
         }
 
         // Stream the actual entry
-        var stream = await entry.GetReadableStreamAsync(httpContext.RequestAborted).ConfigureAwait(false);
+        var stream = await entry.GetReadableStreamAsync(ct).ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))
         {
             if (stream != Stream.Null)
@@ -219,7 +257,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                     {
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                            httpContext.RequestAborted).ConfigureAwait(false);
+                            ct).ConfigureAwait(false);
                         FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
                         ClearStreamingFailureAfterCompletedRead(
                             _failureTracker,

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -82,26 +82,30 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         if (range is { Start: not null, End: not null })
             RangeContext.SetReadBudget(range.End.Value - range.Start.Value + 1);
 
-        // Bound the entire backend wait (NNTP admission + segment delivery) for this
-        // read so a stuck provider fails the HTTP request instead of blocking until
-        // the client disconnects. Every downstream await below must observe `ct`
-        // (not httpContext.RequestAborted directly) — StreamingTimeoutContext /
-        // CancellationTokenContext key by the exact token instance passed in.
+        // Bound the initial backend wait (store lookup + stream open / first segment)
+        // so a stuck provider fails the HTTP request instead of blocking until the
+        // client disconnects. Cleared once body copy starts — mid-stream stalls use
+        // the per-segment StreamingTimeoutContext, not this wall clock. Every
+        // downstream await below must observe `ct` (not httpContext.RequestAborted
+        // directly) — StreamingTimeoutContext / CancellationTokenContext key by the
+        // exact token instance passed in.
         using var readCts = CancellationTokenSource.CreateLinkedTokenSource(httpContext.RequestAborted);
         readCts.CancelAfter(_configManager.GetStreamingReadTimeout());
         var ct = readCts.Token;
 
         try
         {
-            return await HandleRequestCoreAsync(httpContext, request, response, isHeadRequest, range, copyStart, copyEnd, ct)
+            return await HandleRequestCoreAsync(
+                    httpContext, request, response, isHeadRequest, range, copyStart, copyEnd, readCts, ct)
                 .ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (!httpContext.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException oce) when (!httpContext.RequestAborted.IsCancellationRequested)
         {
             throw new StreamingReadTimeoutException(
                 "WebDAV read exceeded the " +
                 $"{_configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
-                "while waiting for the Usenet backend.");
+                "while waiting for the Usenet backend.",
+                oce);
         }
     }
 
@@ -113,6 +117,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         NWebDav.Server.Helpers.Range? range,
         long copyStart,
         long? copyEnd,
+        CancellationTokenSource readCts,
         CancellationToken ct)
     {
         // Obtain the WebDAV collection
@@ -255,6 +260,9 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                     using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
                     try
                     {
+                        // Body transfer can run for minutes; drop the admission/open
+                        // deadline and rely on per-segment mid-stream timeouts.
+                        readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
                             ct).ConfigureAwait(false);

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -22,6 +22,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | Per-stream performance | `usenet.max-download-connections-per-stream-preset` | `high` | low/medium/high/max |
 | Streaming Priority (vs Queue) | `usenet.streaming-priority` | `80` | % bandwidth to streaming |
 | Streaming Segment Timeout | `usenet.streaming-segment-timeout-seconds` | `8` | 2–40s |
+| Streaming Read Timeout [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.streaming-read-timeout-seconds` | `30` | 5–120s total backend wait for one GET/range (semaphore + pool + segments). Unstarted responses return **503** with `Retry-After`; the server fails the HTTP read promptly — rclone/FUSE may still show client-side errors |
 | Streaming Segment Retries | `usenet.streaming-segment-retries` | `3` | 0–5 |
 | Article Buffer Size | `usenet.article-buffer-size` | `40` | Articles buffered ahead/stream |
 | Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | 15–300; pool rebuild/restart |

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -22,7 +22,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | Per-stream performance | `usenet.max-download-connections-per-stream-preset` | `high` | low/medium/high/max |
 | Streaming Priority (vs Queue) | `usenet.streaming-priority` | `80` | % bandwidth to streaming |
 | Streaming Segment Timeout | `usenet.streaming-segment-timeout-seconds` | `8` | 2–40s |
-| Streaming Read Timeout [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.streaming-read-timeout-seconds` | `30` | 5–120s total backend wait for one GET/range (semaphore + pool + segments). Unstarted responses return **503** with `Retry-After`; the server fails the HTTP read promptly — rclone/FUSE may still show client-side errors |
+| Streaming Read Timeout [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.streaming-read-timeout-seconds` | `30` | 5–120s initial backend wait to open a GET/range (semaphore + pool + first segment). Cleared once body bytes flow; mid-stream stalls use the per-segment timeout. Unstarted responses return **503** with `Retry-After` — rclone/FUSE may still show client-side errors |
 | Streaming Segment Retries | `usenet.streaming-segment-retries` | `3` | 0–5 |
 | Article Buffer Size | `usenet.article-buffer-size` | `40` | Articles buffered ahead/stream |
 | Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | 15–300; pool rebuild/restart |

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -49,6 +49,7 @@ const defaultConfig = {
     "queue.worker-count": "1",
     "usenet.streaming-priority": "80",
     "usenet.streaming-segment-timeout-seconds": "8",
+    "usenet.streaming-read-timeout-seconds": "30",
     "usenet.streaming-segment-retries": "3",
     "usenet.article-buffer-size": "40",
     "usenet.idle-connection-timeout-seconds": "60",

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -354,6 +354,26 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     </div>
                 </ManagedSetting>
 
+                <ManagedSetting configKey="usenet.streaming-read-timeout-seconds">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="streaming-read-timeout-input">Streaming Read Timeout</label>
+                        <div className="flex w-full">
+                            <Input
+                                className={!isValidStreamingReadTimeout(config["usenet.streaming-read-timeout-seconds"]) ? 'input-error' : undefined}
+                                type="text"
+                                id="streaming-read-timeout-input"
+                                aria-describedby="streaming-read-timeout-help"
+                                placeholder="30"
+                                value={config["usenet.streaming-read-timeout-seconds"]}
+                                onChange={e => setNewConfig({ ...config, "usenet.streaming-read-timeout-seconds": e.target.value })} />
+                            <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">sec</span>
+                        </div>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-read-timeout-help">
+                            Total backend wait budget for one WebDAV or /view GET/range (5–120s, default 30). Covers download-semaphore admission, connection-pool wait, and segment delivery together. Distinct from the per-segment timeout above — this fails the whole read promptly when the Usenet backend cannot deliver, instead of blocking until the client disconnects.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
                 <ManagedSetting configKey="usenet.streaming-segment-retries">
                     <div className="space-y-2">
                         <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-retries-input">Streaming Segment Retries</label>
@@ -440,6 +460,7 @@ export function isWebdavSettingsUpdated(config: Record<string, string>, newConfi
         || config["queue.worker-count"] !== newConfig["queue.worker-count"]
         || config["usenet.streaming-priority"] !== newConfig["usenet.streaming-priority"]
         || config["usenet.streaming-segment-timeout-seconds"] !== newConfig["usenet.streaming-segment-timeout-seconds"]
+        || config["usenet.streaming-read-timeout-seconds"] !== newConfig["usenet.streaming-read-timeout-seconds"]
         || config["usenet.streaming-segment-retries"] !== newConfig["usenet.streaming-segment-retries"]
         || config["usenet.article-buffer-size"] !== newConfig["usenet.article-buffer-size"]
         || config["usenet.idle-connection-timeout-seconds"] !== newConfig["usenet.idle-connection-timeout-seconds"]
@@ -463,6 +484,7 @@ export function isWebdavSettingsValid(newConfig: Record<string, string>) {
         && isValidQueueWorkerCount(newConfig["queue.worker-count"])
         && isValidStreamingPriority(newConfig["usenet.streaming-priority"])
         && isValidStreamingSegmentTimeout(newConfig["usenet.streaming-segment-timeout-seconds"])
+        && isValidStreamingReadTimeout(newConfig["usenet.streaming-read-timeout-seconds"])
         && isValidStreamingSegmentRetries(newConfig["usenet.streaming-segment-retries"])
         && isValidArticleBufferSize(newConfig["usenet.article-buffer-size"])
         && isValidIdleConnectionTimeout(newConfig["usenet.idle-connection-timeout-seconds"])
@@ -506,6 +528,12 @@ function isValidStreamingSegmentTimeout(value: string): boolean {
     if (value.trim() === "") return false;
     const num = Number(value);
     return Number.isInteger(num) && num >= 2 && num <= 40;
+}
+
+function isValidStreamingReadTimeout(value: string): boolean {
+    if (value.trim() === "") return false;
+    const num = Number(value);
+    return Number.isInteger(num) && num >= 5 && num <= 120;
 }
 
 function isValidStreamingSegmentRetries(value: string): boolean {

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -369,7 +369,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                             <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">sec</span>
                         </div>
                         <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-read-timeout-help">
-                            Total backend wait budget for one WebDAV or /view GET/range (5–120s, default 30). Covers download-semaphore admission, connection-pool wait, and segment delivery together. Distinct from the per-segment timeout above — this fails the whole read promptly when the Usenet backend cannot deliver, instead of blocking until the client disconnects.
+                            Initial backend wait budget to open a WebDAV or /view GET/range (5–120s, default 30): store lookup, download-semaphore admission, connection-pool wait, and first segment. Cleared once body bytes start flowing — mid-stream stalls use the per-segment timeout above. Fails the HTTP read promptly when the Usenet backend never starts delivering, instead of blocking until the client disconnects.
                         </p>
                     </div>
                 </ManagedSetting>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
@@ -404,6 +405,55 @@ public class StreamingTimeoutTests
 
         Assert.False(breaker.IsTripped);
         Assert.Equal(0, breaker.GetSnapshot().FailureCount);
+    }
+
+    [Fact]
+    public async Task DownloadSemaphoreWait_CancelsWithinStreamingReadDeadline()
+    {
+        // Mirrors WebDAV linking RequestAborted + CancelAfter(streaming-read-timeout)
+        // into AcquireExclusiveConnectionAsync's WaitAsync — a held permit must not hang forever.
+        using var semaphore = new PrioritizedSemaphore(initialAllowed: 1, maxAllowed: 1);
+        await semaphore.WaitAsync(SemaphorePriority.High);
+
+        using var readCts = new CancellationTokenSource();
+        readCts.CancelAfter(TimeSpan.FromMilliseconds(200));
+        var sw = Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => semaphore.WaitAsync(SemaphorePriority.High, readCts.Token));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"Expected deadline cancel within ~200ms, took {sw.Elapsed}");
+        // Holding the original permit — release must still succeed (no leak from cancelled waiter).
+        semaphore.Release();
+        await semaphore.WaitAsync(SemaphorePriority.High).WaitAsync(TimeSpan.FromSeconds(1));
+        semaphore.Release();
+    }
+
+    [Fact]
+    public async Task ConnectionPoolGate_CancelsWithinStreamingReadDeadline()
+    {
+        var created = 0;
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref created);
+                return ValueTask.FromResult<INntpClient>(new HangingNntpClient());
+            });
+
+        using var held = await pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None);
+
+        using var readCts = new CancellationTokenSource();
+        readCts.CancelAfter(TimeSpan.FromMilliseconds(200));
+        var sw = Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, readCts.Token));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"Expected pool-gate cancel within ~200ms, took {sw.Elapsed}");
+        Assert.Equal(1, created);
     }
 
     /// <summary>

--- a/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
@@ -31,6 +31,31 @@ public class StreamingPriorityConfigTests
     }
 
     [Theory]
+    [InlineData("abc", 30)]
+    [InlineData("", 30)]
+    [InlineData(null, 30)]
+    [InlineData("4", 5)]
+    [InlineData("200", 120)]
+    [InlineData("45", 45)]
+    public void GetStreamingReadTimeout_ClampsAndFallsBack(string? value, int expectedSeconds)
+    {
+        var config = new ConfigManager();
+        if (value is not null)
+        {
+            config.UpdateValues(
+            [
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.UsenetStreamingReadTimeoutSeconds,
+                    ConfigValue = value,
+                },
+            ]);
+        }
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), config.GetStreamingReadTimeout());
+    }
+
+    [Theory]
     [InlineData("abc", 10L * 1024 * 1024 * 1024)]
     [InlineData("0", 1L * 1024 * 1024 * 1024)]
     [InlineData("2", 2L * 1024 * 1024 * 1024)]

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -206,6 +206,49 @@ public class ExceptionMiddlewareTests
         Assert.Null(logged.Exception);
     }
 
+    [Fact]
+    public async Task StreamingReadTimeout_BeforeResponseStarted_Returns503WithRetryAfter()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new StreamingReadTimeoutException(
+                "WebDAV read exceeded the 5s streaming-read-timeout while waiting for the Usenet backend."));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+        Assert.Equal("5", context.Response.Headers.RetryAfter.ToString());
+        Assert.False(lifetimeFeature.Aborted);
+
+        var logged = Assert.Single(
+            events,
+            e => e.RenderMessage().Contains("streaming-read-timeout", StringComparison.Ordinal)
+                 && e.Level == LogEventLevel.Warning
+                 && e.Exception is null);
+        Assert.Contains("failed fast", logged.RenderMessage(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task StreamingReadTimeout_AfterResponseStarted_AbortsWithoutErrorStack()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new StreamingReadTimeoutException(
+                "WebDAV read exceeded the 5s streaming-read-timeout while waiting for the Usenet backend."));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        Assert.True(lifetimeFeature.Aborted);
+        var logged = Assert.Single(
+            events,
+            e => e.RenderMessage().Contains("streaming-read-timeout-after-headers", StringComparison.Ordinal)
+                 && e.Level == LogEventLevel.Warning
+                 && e.Exception is null);
+        Assert.Contains("aborted after headers", logged.RenderMessage(), StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData(0, 1, true)]
     [InlineData(3, 2, false)]

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -211,6 +211,7 @@ public class ExceptionMiddlewareTests
     {
         var lifetimeFeature = new TestHttpRequestLifetimeFeature();
         var context = CreateContext(hasStarted: false, lifetimeFeature);
+        context.Response.Body = new MemoryStream();
         var middleware = CreateMiddleware(
             _ => throw new StreamingReadTimeoutException(
                 "WebDAV read exceeded the 5s streaming-read-timeout while waiting for the Usenet backend."));
@@ -220,6 +221,10 @@ public class ExceptionMiddlewareTests
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
         Assert.Equal("5", context.Response.Headers.RetryAfter.ToString());
         Assert.False(lifetimeFeature.Aborted);
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body);
+        var body = await reader.ReadToEndAsync();
+        Assert.Contains("streaming-read-timeout", body, StringComparison.OrdinalIgnoreCase);
 
         var logged = Assert.Single(
             events,


### PR DESCRIPTION
## Summary
- Add `usenet.streaming-read-timeout-seconds` (default 30s, clamp 5–120) as the total backend wait budget for one WebDAV/`/view` GET or range.
- Link that deadline into the request CTS (not only `RequestAborted`) so download-semaphore and connection-pool waits cancel promptly.
- Before response headers: return **503** + `Retry-After`; after headers: abort the truncated body. Known timeouts log Warning + `{Reason}`, not Error + stack.

Closes #635

## Test plan
- [x] Focused tests: StreamingTimeout / ExceptionMiddleware / GetAndHead
- [ ] Saturate connections, hit a WebDAV range, confirm fail-fast vs hang
- [ ] Confirm settings UI + docs for the new timeout