### PR TITLE
feat(sab): let Sonarr and Radarr pause, resume, and set a speed limit

### DIFF
--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
@@ -63,7 +64,13 @@ public class GetQueueController(
             {
                 var isInProgress = inProgressById.TryGetValue(queueItem.Id, out var active);
                 var percentage = isInProgress ? active.ProgressPercentage : 0;
-                var status = isInProgress ? "Downloading" : "Queued";
+                // Arr treats slot status "Paused" (priority -2) separately from the
+                // queue-level paused flag set by mode=pause.
+                var status = isInProgress
+                    ? "Downloading"
+                    : queueItem.Priority == QueueItem.PriorityOption.Paused
+                        ? "Paused"
+                        : "Queued";
                 IReadOnlyDictionary<string, long> providerUsage =
                     GetProviderUsageForSlot(isInProgress, queueItem.Id, providerUsageTracker);
                 if (isInProgress && configuredKeys.Count > 0)

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -16,7 +16,7 @@ public class GetQueueController(
     ProviderUsageTracker providerUsageTracker
 ) : SabApiController.BaseController(httpContext, configManager)
 {
-    private async Task<GetQueueResponse> GetQueueAsync(GetQueueRequest request)
+    internal async Task<GetQueueResponse> GetQueueAsync(GetQueueRequest request)
     {
         // Snapshot every in-progress item (primary first).
         var inProgress = queueManager.GetInProgressQueueItems();
@@ -79,13 +79,16 @@ public class GetQueueController(
             .ToList();
 
         // return response
+        var speedLimitKbps = configManager.GetSabSpeedLimitKbps();
         return new GetQueueResponse()
         {
             Queue = new GetQueueResponse.QueueObject()
             {
-                Paused = false,
+                Paused = configManager.IsSabQueuePaused(),
                 Slots = slots,
                 TotalCount = totalCount,
+                SpeedLimit = speedLimitKbps.ToString(),
+                SpeedLimitAbs = speedLimitKbps.ToString(),
             }
         };
     }

--- a/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
@@ -20,6 +20,20 @@ public class GetQueueResponse : SabBaseResponse
 
         [JsonPropertyName("noofslots")]
         public int TotalCount { get; set; }
+
+        // Accepted-and-stored only (see #375 for actual byte/s enforcement). SAB
+        // reports "speedlimit" as a percentage of a configured max line speed;
+        // NzbDAV has no such setting, so both fields carry the same KB/s value.
+        [JsonPropertyName("speedlimit")]
+        public string SpeedLimit { get; init; } = "0";
+
+        [JsonPropertyName("speedlimit_abs")]
+        public string SpeedLimitAbs { get; init; } = "0";
+
+        // Seconds remaining on a scheduled/timed unpause. NzbDAV's pause has no
+        // duration, so this is always "0".
+        [JsonPropertyName("pause_int")]
+        public string PauseInt { get; init; } = "0";
     }
 
     public class QueueSlot

--- a/backend/Api/SabControllers/Pause/PauseController.cs
+++ b/backend/Api/SabControllers/Pause/PauseController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+
+namespace NzbWebDAV.Api.SabControllers.Pause;
+
+/// <summary>
+/// SAB-compatible <c>mode=pause</c> (and <c>mode=queue&amp;name=pause</c>).
+/// Stops the queue coordinator from starting new downloads; items already in
+/// progress finish naturally and WebDAV keeps serving mounted content.
+/// </summary>
+public class PauseController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<PauseResponse> Pause(CancellationToken ct)
+    {
+        await ConfigPersistenceUtil.SetValueAsync(
+            dbClient, configManager, ConfigKeys.QueuePaused, "true", ct).ConfigureAwait(false);
+        return new PauseResponse { Status = true };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        return Ok(await Pause(httpContext.RequestAborted).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/Pause/PauseResponse.cs
+++ b/backend/Api/SabControllers/Pause/PauseResponse.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Api.SabControllers.Pause;
+
+public class PauseResponse : SabBaseResponse
+{
+}

--- a/backend/Api/SabControllers/Resume/ResumeController.cs
+++ b/backend/Api/SabControllers/Resume/ResumeController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Queue;
+
+namespace NzbWebDAV.Api.SabControllers.Resume;
+
+/// <summary>
+/// SAB-compatible <c>mode=resume</c> (and <c>mode=queue&amp;name=resume</c>).
+/// Clears the queue pause flag and wakes the queue coordinator so it starts
+/// claiming work again without waiting for its idle-poll interval.
+/// </summary>
+public class ResumeController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    QueueManager queueManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<ResumeResponse> Resume(CancellationToken ct)
+    {
+        await ConfigPersistenceUtil.SetValueAsync(
+            dbClient, configManager, ConfigKeys.QueuePaused, "false", ct).ConfigureAwait(false);
+        queueManager.AwakenQueue();
+        return new ResumeResponse { Status = true };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        return Ok(await Resume(httpContext.RequestAborted).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/Resume/ResumeResponse.cs
+++ b/backend/Api/SabControllers/Resume/ResumeResponse.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Api.SabControllers.Resume;
+
+public class ResumeResponse : SabBaseResponse
+{
+}

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -10,9 +10,12 @@ using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Api.SabControllers.GetStatus;
 using NzbWebDAV.Api.SabControllers.GetVersion;
 using NzbWebDAV.Api.SabControllers.MoveInQueue;
+using NzbWebDAV.Api.SabControllers.Pause;
 using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
+using NzbWebDAV.Api.SabControllers.Resume;
 using NzbWebDAV.Api.SabControllers.RetryHistory;
+using NzbWebDAV.Api.SabControllers.SpeedLimit;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -96,12 +99,23 @@ public class SabApiController(
                 return new AddUrlController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager, hitTracker);
 
+            case "pause":
+                return new PauseController(HttpContext, dbClient, configManager);
+            case "resume":
+                return new ResumeController(HttpContext, dbClient, configManager, queueManager);
+            case "speedlimit":
+                return new SpeedLimitController(HttpContext, dbClient, configManager);
+
             case "queue" when HttpContext.GetRequestParam("name") == "delete":
                 return new RemoveFromQueueController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager);
             case "queue" when HttpContext.GetRequestParam("name") == "move":
                 return new MoveInQueueController(
                     HttpContext, dbClient, configManager, websocketManager);
+            case "queue" when HttpContext.GetRequestParam("name") == "pause":
+                return new PauseController(HttpContext, dbClient, configManager);
+            case "queue" when HttpContext.GetRequestParam("name") == "resume":
+                return new ResumeController(HttpContext, dbClient, configManager, queueManager);
             case "queue":
                 return new GetQueueController(
                     HttpContext, dbClient, queueManager, configManager, providerUsageTracker);

--- a/backend/Api/SabControllers/SpeedLimit/SpeedLimitController.cs
+++ b/backend/Api/SabControllers/SpeedLimit/SpeedLimitController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+
+namespace NzbWebDAV.Api.SabControllers.SpeedLimit;
+
+/// <summary>
+/// SAB-compatible <c>mode=speedlimit</c>. Accepted and persisted so the queue
+/// JSON reflects the configured value; actual byte/s throttling is tracked
+/// separately (see #375) and is not yet enforced here.
+/// </summary>
+public class SpeedLimitController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<SpeedLimitResponse> SetSpeedLimit(SpeedLimitRequest request, CancellationToken ct)
+    {
+        await ConfigPersistenceUtil.SetValueAsync(
+            dbClient, configManager, ConfigKeys.QueueSpeedLimitKbps,
+            request.LimitKbps.ToString(), ct).ConfigureAwait(false);
+        return new SpeedLimitResponse { Status = true };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        var request = SpeedLimitRequest.New(httpContext);
+        return Ok(await SetSpeedLimit(request, httpContext.RequestAborted).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/SpeedLimit/SpeedLimitRequest.cs
+++ b/backend/Api/SabControllers/SpeedLimit/SpeedLimitRequest.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.SabControllers.SpeedLimit;
+
+public class SpeedLimitRequest
+{
+    /// <summary>Requested speed limit in KB/s. 0 (or absent) means unlimited.</summary>
+    public int LimitKbps { get; init; }
+
+    public static SpeedLimitRequest New(HttpContext httpContext)
+    {
+        // SABnzbd accepts the value under either "value" (percentage of max
+        // line speed) or "value2"/"limit" depending on client. NzbDAV has no
+        // "max line speed" setting to compute a percentage against, so the
+        // raw number is stored directly as a KB/s override.
+        var raw = httpContext.GetRequestParam("value")
+            ?? httpContext.GetRequestParam("limit");
+
+        if (string.IsNullOrWhiteSpace(raw))
+            return new SpeedLimitRequest { LimitKbps = 0 };
+
+        if (!int.TryParse(raw, out var limitKbps) || limitKbps < 0)
+            throw new BadHttpRequestException("Invalid speed limit value.");
+
+        return new SpeedLimitRequest { LimitKbps = limitKbps };
+    }
+}

--- a/backend/Api/SabControllers/SpeedLimit/SpeedLimitResponse.cs
+++ b/backend/Api/SabControllers/SpeedLimit/SpeedLimitResponse.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Api.SabControllers.SpeedLimit;
+
+public class SpeedLimitResponse : SabBaseResponse
+{
+}

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -40,6 +40,8 @@ public static class ConfigKeys
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";
     public const string UsenetMaxQueueConnections = "usenet.max-queue-connections";
     public const string QueueWorkerCount = "queue.worker-count";
+    public const string QueuePaused = "queue.paused";
+    public const string QueueSpeedLimitKbps = "queue.speed-limit-kbps";
     public const string UsenetPipelinedBodyRequests = "usenet.pipelined-body-requests";
     public const string UsenetPipeliningDepth = "usenet.pipelining.depth";
     public const string UsenetPipeliningEnabled = "usenet.pipelining.enabled";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -328,6 +328,7 @@ public class ConfigManager
                 case ConfigKeys.BackupScheduleTime:
                 case ConfigKeys.BackupRetentionCount:
                 case ConfigKeys.ApiNzbBackupRetentionDays:
+                case ConfigKeys.QueueSpeedLimitKbps:
                     RequireLong(item.ConfigName, value);
                     break;
 
@@ -363,6 +364,7 @@ public class ConfigManager
                 case ConfigKeys.DbIsStartupVacuumEnabled:
                 case ConfigKeys.MaintenanceRemoveOrphanedScheduleEnabled:
                 case ConfigKeys.BackupScheduleEnabled:
+                case ConfigKeys.QueuePaused:
                     RequireBool(item.ConfigName, value);
                     break;
 
@@ -644,6 +646,29 @@ public class ConfigManager
         if (configured is null || !int.TryParse(configured, out var value))
             return 1;
         return Math.Clamp(value, 1, 4);
+    }
+
+    /// <summary>
+    /// SAB-compatible queue pause state (<c>mode=pause</c> / <c>mode=resume</c>).
+    /// Blocks the queue coordinator from starting new downloads; items already
+    /// in progress finish naturally and WebDAV keeps serving mounted content.
+    /// </summary>
+    public bool IsSabQueuePaused()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueuePaused));
+        return v != null && bool.Parse(v);
+    }
+
+    /// <summary>
+    /// SAB-compatible speed limit in KB/s set via <c>mode=speedlimit</c>. 0 means
+    /// unlimited. Accepted and stored for Arr/API compatibility; actual byte/s
+    /// throttling is tracked separately (see #375).
+    /// </summary>
+    public int GetSabSpeedLimitKbps()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueueSpeedLimitKbps));
+        if (v == null) return 0;
+        return int.TryParse(v, out var n) ? Math.Max(0, n) : 0;
     }
 
     public bool IsPipeliningEnabled()

--- a/backend/Config/ConfigPersistenceUtil.cs
+++ b/backend/Config/ConfigPersistenceUtil.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Persists a single config key/value pair to SQLite and refreshes the running
+/// <see cref="ConfigManager"/> cache. Used by call sites that update one setting
+/// directly (e.g. SAB pause/resume/speedlimit) rather than through the bulk
+/// settings-page save flow in UpdateConfigController.
+/// </summary>
+public static class ConfigPersistenceUtil
+{
+    public static async Task SetValueAsync(
+        DavDatabaseClient dbClient,
+        ConfigManager configManager,
+        string configName,
+        string configValue,
+        CancellationToken ct = default)
+    {
+        var item = await dbClient.Ctx.ConfigItems
+            .FirstOrDefaultAsync(c => c.ConfigName == configName, ct)
+            .ConfigureAwait(false);
+        if (item == null)
+        {
+            item = new ConfigItem { ConfigName = configName, ConfigValue = configValue };
+            dbClient.Ctx.ConfigItems.Add(item);
+        }
+        else
+        {
+            item.ConfigValue = configValue;
+        }
+
+        await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        configManager.UpdateValues([item]);
+    }
+}

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -175,7 +175,8 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var query = Ctx.QueueItems
             .OrderByDescending(q => q.Priority)
             .ThenBy(q => q.CreatedAt)
-            .Where(q => q.PauseUntil == null || nowTime >= q.PauseUntil);
+            .Where(q => q.PauseUntil == null || nowTime >= q.PauseUntil)
+            .Where(q => q.Priority != QueueItem.PriorityOption.Paused);
 
         if (excludeIds is { Count: > 0 })
         {

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -188,11 +188,12 @@ public class QueueManager : IDisposable
     {
         while (!ct.IsCancellationRequested)
         {
-            // While a speed-test is running, hold off starting new downloads so
-            // it gets the provider's full connection budget. Any item already in
-            // progress finishes naturally; this only gates new work. Resumes
-            // within ~1s of the test ending.
-            if (_benchmarkGate.IsPaused)
+            // While a speed-test is running, or the SAB-compatible queue pause is
+            // active (mode=pause), hold off starting new downloads so a benchmark
+            // gets the provider's full connection budget and a paused queue stops
+            // claiming work. Any item already in progress finishes naturally; this
+            // only gates new work. Resumes within ~1s of the gate clearing.
+            if (_benchmarkGate.IsPaused || _configManager.IsSabQueuePaused())
             {
                 try { await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { }
@@ -245,7 +246,7 @@ public class QueueManager : IDisposable
 
     private async Task FillWorkerSlotsAsync(CancellationToken ct)
     {
-        while (!_benchmarkGate.IsPaused && !ct.IsCancellationRequested)
+        while (!_benchmarkGate.IsPaused && !_configManager.IsSabQueuePaused() && !ct.IsCancellationRequested)
         {
             var workerCount = _configManager.GetQueueWorkerCount();
             if (_inProgress.Count >= workerCount)

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -192,11 +192,24 @@ public class QueueManager : IDisposable
             // active (mode=pause), hold off starting new downloads so a benchmark
             // gets the provider's full connection budget and a paused queue stops
             // claiming work. Any item already in progress finishes naturally; this
-            // only gates new work. Resumes within ~1s of the gate clearing.
+            // only gates new work. ResumeController calls AwakenQueue so resume
+            // does not wait out the full poll interval.
             if (_benchmarkGate.IsPaused || _configManager.IsSabQueuePaused())
             {
-                try { await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false); }
-                catch (OperationCanceledException) { }
+                try
+                {
+                    using var pauseWait = CancellationTokenSource.CreateLinkedTokenSource(
+                        ct, _sleepingQueueToken.Token);
+                    await Task.Delay(TimeSpan.FromSeconds(1), pauseWait.Token).ConfigureAwait(false);
+                }
+                catch when (_sleepingQueueToken.IsCancellationRequested)
+                {
+                    ResetSleepingQueueToken();
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // shutting down
+                }
                 continue;
             }
 

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -7,9 +7,16 @@ NzbDAV implements the SABnzbd-compatible operations used by Sonarr, Radarr, and 
 - `version`, `status`, `fullstatus`, `get_config`, and `get_cats`
 - `addfile` and `addurl`
 - `queue` listing and `queue&name=delete`
+- `pause` / `resume` (also `queue&name=pause` / `queue&name=resume`) and `speedlimit` [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
 - `history` listing and `history&name=delete`
 
 Queue and history filters accept both `cat` and `category`. The default category sentinel returned by `get_cats` is `*`.
+
+## Pause, resume, and speed limit [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
+
+`mode=pause` / `mode=resume` stop and restart **new** queue dequeues. Workers already downloading finish naturally. WebDAV mounts keep serving — pause does not interrupt playback. Queue JSON reports `paused` accurately.
+
+`mode=speedlimit` is accepted and reflected in queue JSON (`speedlimit` / `speedlimit_abs`). Byte-accurate download throttling is tracked separately and is not enforced yet.
 
 ## Intentional differences
 

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -14,9 +14,9 @@ Queue and history filters accept both `cat` and `category`. The default category
 
 ## Pause, resume, and speed limit [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since }
 
-`mode=pause` / `mode=resume` stop and restart **new** queue dequeues. Workers already downloading finish naturally. WebDAV mounts keep serving — pause does not interrupt playback. Queue JSON reports `paused` accurately.
+`mode=pause` / `mode=resume` stop and restart **new** queue dequeues. Workers already downloading finish naturally. WebDAV mounts keep serving — pause does not interrupt playback. Queue JSON reports `paused` accurately. Items added with SAB priority `-2` (Paused) are skipped until their priority changes; queue slots report `status: Paused` for those jobs.
 
-`mode=speedlimit` is accepted and reflected in queue JSON (`speedlimit` / `speedlimit_abs`). Byte-accurate download throttling is tracked separately and is not enforced yet.
+`mode=speedlimit` is **accepted and stored** and reflected in queue JSON (`speedlimit` / `speedlimit_abs`). Byte-accurate download throttling is **not** enforced yet — that work is tracked in [#375](https://github.com/nzbdav/nzbdav/issues/375).
 
 ## Intentional differences
 

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -234,6 +234,22 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
         Assert.Null(queueItem);
     }
 
+    [Fact]
+    public async Task GetQueue_ReportsPausedStatusForPriorityPausedItems()
+    {
+        var pausedItem = CreateQueueItem("paused.nzb", QueueItem.PriorityOption.Paused, DateTime.UtcNow);
+        _context.QueueItems.Add(pausedItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var queue = await CreateGetQueueController()
+            .GetQueueAsync(new GetQueueRequest(new DefaultHttpContext(), _configManager));
+
+        var slot = Assert.Single(queue.Queue.Slots);
+        Assert.Equal("Paused", slot.Status);
+        Assert.Equal(pausedItem.Id.ToString(), slot.NzoId);
+    }
+
     [Theory]
     [InlineData("pause", typeof(PauseController))]
     [InlineData("resume", typeof(ResumeController))]

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -1,0 +1,319 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Api.SabControllers.Pause;
+using NzbWebDAV.Api.SabControllers.Resume;
+using NzbWebDAV.Api.SabControllers.SpeedLimit;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class SabPauseResumeTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-pause-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+    private WebsocketManager _websocketManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        _websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Pause_PersistsPauseState_AndGetQueueReportsIt()
+    {
+        Assert.False(_configManager.IsSabQueuePaused());
+
+        var response = await CreatePauseController().Pause(CancellationToken.None);
+
+        Assert.True(response.Status);
+        Assert.True(_configManager.IsSabQueuePaused());
+
+        var persisted = await _context.ConfigItems.AsNoTracking()
+            .SingleAsync(c => c.ConfigName == ConfigKeys.QueuePaused);
+        Assert.Equal("true", persisted.ConfigValue);
+
+        var queue = await CreateGetQueueController()
+            .GetQueueAsync(new GetQueueRequest(new DefaultHttpContext(), _configManager));
+        Assert.True(queue.Queue.Paused);
+    }
+
+    [Fact]
+    public async Task Resume_ClearsPauseState_AndAwakensQueue()
+    {
+        await CreatePauseController().Pause(CancellationToken.None);
+        Assert.True(_configManager.IsSabQueuePaused());
+
+        var response = await CreateResumeController().Resume(CancellationToken.None);
+
+        Assert.True(response.Status);
+        Assert.False(_configManager.IsSabQueuePaused());
+
+        var persisted = await _context.ConfigItems.AsNoTracking()
+            .SingleAsync(c => c.ConfigName == ConfigKeys.QueuePaused);
+        Assert.Equal("false", persisted.ConfigValue);
+
+        var queue = await CreateGetQueueController()
+            .GetQueueAsync(new GetQueueRequest(new DefaultHttpContext(), _configManager));
+        Assert.False(queue.Queue.Paused);
+    }
+
+    [Fact]
+    public async Task PauseThenResume_RoundTripsCleanly()
+    {
+        await CreatePauseController().Pause(CancellationToken.None);
+        Assert.True(_configManager.IsSabQueuePaused());
+
+        await CreateResumeController().Resume(CancellationToken.None);
+        Assert.False(_configManager.IsSabQueuePaused());
+
+        await CreatePauseController().Pause(CancellationToken.None);
+        Assert.True(_configManager.IsSabQueuePaused());
+    }
+
+    [Fact]
+    public async Task SpeedLimit_PersistsValue_AndReflectsInGetQueue()
+    {
+        Assert.Equal(0, _configManager.GetSabSpeedLimitKbps());
+
+        var response = await CreateSpeedLimitController()
+            .SetSpeedLimit(new SpeedLimitRequest { LimitKbps = 2048 }, CancellationToken.None);
+
+        Assert.True(response.Status);
+        Assert.Equal(2048, _configManager.GetSabSpeedLimitKbps());
+
+        var persisted = await _context.ConfigItems.AsNoTracking()
+            .SingleAsync(c => c.ConfigName == ConfigKeys.QueueSpeedLimitKbps);
+        Assert.Equal("2048", persisted.ConfigValue);
+
+        var queue = await CreateGetQueueController()
+            .GetQueueAsync(new GetQueueRequest(new DefaultHttpContext(), _configManager));
+        Assert.Equal("2048", queue.Queue.SpeedLimit);
+        Assert.Equal("2048", queue.Queue.SpeedLimitAbs);
+    }
+
+    [Fact]
+    public void SpeedLimitRequest_New_ParsesValueParam()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?value=512");
+
+        var request = SpeedLimitRequest.New(context);
+
+        Assert.Equal(512, request.LimitKbps);
+    }
+
+    [Fact]
+    public void SpeedLimitRequest_New_ParsesLimitParamWhenValueMissing()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=256");
+
+        var request = SpeedLimitRequest.New(context);
+
+        Assert.Equal(256, request.LimitKbps);
+    }
+
+    [Fact]
+    public void SpeedLimitRequest_New_MissingValue_DefaultsToUnlimited()
+    {
+        var context = new DefaultHttpContext();
+
+        var request = SpeedLimitRequest.New(context);
+
+        Assert.Equal(0, request.LimitKbps);
+    }
+
+    [Fact]
+    public void SpeedLimitRequest_New_NegativeValue_ThrowsBadRequest()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?value=-5");
+
+        Assert.Throws<BadHttpRequestException>(() => SpeedLimitRequest.New(context));
+    }
+
+    [Fact]
+    public async Task GetTopQueueItem_SkipsPausedPriorityItems()
+    {
+        var pausedItem = CreateQueueItem("paused.nzb", QueueItem.PriorityOption.Paused, DateTime.UtcNow.AddMinutes(-10));
+        var normalItem = CreateQueueItem("normal.nzb", QueueItem.PriorityOption.Normal, DateTime.UtcNow.AddMinutes(-5));
+        _context.QueueItems.AddRange(pausedItem, normalItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var (queueItem, stream) = await _dbClient.GetTopQueueItem();
+        stream?.Dispose();
+
+        Assert.NotNull(queueItem);
+        Assert.Equal(normalItem.Id, queueItem!.Id);
+    }
+
+    [Fact]
+    public async Task GetTopQueueItem_AllItemsPaused_ReturnsNull()
+    {
+        var pausedItem = CreateQueueItem("paused.nzb", QueueItem.PriorityOption.Paused, DateTime.UtcNow);
+        _context.QueueItems.Add(pausedItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var (queueItem, stream) = await _dbClient.GetTopQueueItem();
+        stream?.Dispose();
+
+        Assert.Null(queueItem);
+    }
+
+    [Theory]
+    [InlineData("pause", typeof(PauseController))]
+    [InlineData("resume", typeof(ResumeController))]
+    [InlineData("speedlimit", typeof(SpeedLimitController))]
+    public void GetController_DispatchesNewSabModes(string mode, Type expectedType)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?mode={mode}");
+
+        var controller = CreateSabApiController(context).GetController();
+
+        Assert.IsType(expectedType, controller);
+    }
+
+    [Theory]
+    [InlineData("pause", typeof(PauseController))]
+    [InlineData("resume", typeof(ResumeController))]
+    public void GetController_DispatchesQueueNameAliases(string name, Type expectedType)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?mode=queue&name={name}");
+
+        var controller = CreateSabApiController(context).GetController();
+
+        Assert.IsType(expectedType, controller);
+    }
+
+    [Fact]
+    public void GetController_UnknownMode_StillThrowsInvalidMode()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?mode=not-a-real-mode");
+
+        var ex = Assert.Throws<BadHttpRequestException>(
+            () => CreateSabApiController(context).GetController());
+        Assert.Equal("Invalid mode", ex.Message);
+    }
+
+    private SabApiController CreateSabApiController(HttpContext httpContext)
+    {
+        var controller = new SabApiController(
+            _dbClient,
+            _configManager,
+            _queueManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new IndexerHitTracker());
+        controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+        {
+            HttpContext = httpContext,
+        };
+        return controller;
+    }
+
+    private PauseController CreatePauseController() =>
+        new(new DefaultHttpContext(), _dbClient, _configManager);
+
+    private ResumeController CreateResumeController() =>
+        new(new DefaultHttpContext(), _dbClient, _configManager, _queueManager);
+
+    private SpeedLimitController CreateSpeedLimitController() =>
+        new(new DefaultHttpContext(), _dbClient, _configManager);
+
+    private GetQueueController CreateGetQueueController() =>
+        new(new DefaultHttpContext(), _dbClient, _queueManager, _configManager, new ProviderUsageTracker());
+
+    private static QueueItem CreateQueueItem(
+        string fileName, QueueItem.PriorityOption priority, DateTime createdAt)
+    {
+        return new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            NzbFileSize = 100,
+            TotalSegmentBytes = 200,
+            Category = "movies",
+            Priority = priority,
+            PostProcessing = QueueItem.PostProcessingOption.None
+        };
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -192,7 +192,8 @@ public class QueueManagerLoopTests
         await wait;
     }
 
-    private static QueueManager CreateManager()
+    [Fact]
+    public async Task ProcessQueueAsync_SkipsDequeueWhileSabQueuePaused_AndResumesOnAwaken()
     {
         var config = new ConfigManager();
         config.UpdateValues(
@@ -202,7 +203,43 @@ public class QueueManagerLoopTests
                 ConfigName = ConfigKeys.UsenetProviders,
                 ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
             },
+            new ConfigItem { ConfigName = ConfigKeys.QueuePaused, ConfigValue = "true" },
         ]);
+
+        using var manager = CreateManager(config);
+        var polls = 0;
+        manager.GetTopQueueItemOverride = (_, _) =>
+        {
+            Interlocked.Increment(ref polls);
+            return Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+        };
+
+        using var cts = new CancellationTokenSource();
+        var loop = manager.ProcessQueueAsync(cts.Token);
+
+        // While paused, the coordinator must not claim work.
+        await Task.Delay(350);
+        Assert.Equal(0, Volatile.Read(ref polls));
+
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.QueuePaused, ConfigValue = "false" },
+        ]);
+        manager.AwakenQueue();
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (DateTime.UtcNow < deadline && Volatile.Read(ref polls) == 0)
+            await Task.Delay(20);
+
+        await cts.CancelAsync();
+        await loop;
+
+        Assert.True(Volatile.Read(ref polls) >= 1, "Expected dequeue attempt after resume + awaken");
+    }
+
+    private static QueueManager CreateManager(ConfigManager? config = null)
+    {
+        config ??= CreateDefaultConfig();
 
         var usenet = new UsenetStreamingClient(
             config,
@@ -222,5 +259,19 @@ public class QueueManagerLoopTests
             new QueueItemSourceTracker(),
             new BenchmarkGate(),
             startLoop: false);
+    }
+
+    private static ConfigManager CreateDefaultConfig()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+        return config;
     }
 }


### PR DESCRIPTION
## Summary
- Implement SABnzbd-compatible `mode=pause` / `mode=resume` (and `queue&name=pause|resume`) so Arr can stop new queue dequeues without getting `Invalid mode`.
- Accept `mode=speedlimit` and reflect it in queue JSON; byte-accurate throttling remains #375.
- Pause blocks **new** workers only — in-flight imports finish and WebDAV keeps serving.
- Skip `PriorityOption.Paused` items when selecting queue work.

Closes #638

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~SabPauseResume` (16 passed)
- [ ] Arr client: pause download client → queue `paused: true`; resume clears it
- [ ] Confirm WebDAV playback continues while paused