### PR TITLE
ux(ui): use green toggles with tooltips for boolean settings

### DIFF
--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -7,8 +7,8 @@ import {
     type MigrationStatus,
 } from "~/components/migration-progress";
 import { Button } from "~/components/ui/button";
-import { Alert, Badge, Spinner } from "~/components/ui/feedback";
-import { Checkbox, Input, Select } from "~/components/ui/form";
+import { Alert, Badge, Spinner, Tooltip } from "~/components/ui/feedback";
+import { Checkbox, Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
@@ -367,13 +367,10 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                     </div>
 
                     <div className="space-y-4 p-4">
-                        <label
-                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
-                            htmlFor="backup-schedule-enabled"
-                        >
-                            <Checkbox
-                                className="checkbox-primary mt-0.5 shrink-0"
+                        <Tooltip content="Writes a logical .sql dump of all databases under the config volume once per day.">
+                            <Toggle
                                 id="backup-schedule-enabled"
+                                className="cursor-pointer gap-2 rounded-lg bg-base-200/40 p-3"
                                 checked={scheduleEnabled}
                                 onChange={(e) =>
                                     setNewConfig({
@@ -381,15 +378,9 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                                         "backup.schedule-enabled": String(e.target.checked),
                                     })
                                 }
+                                label={<span className="text-sm font-medium text-base-content">Enable daily backup</span>}
                             />
-                            <span>
-                                <span className="block text-sm font-medium text-base-content">Enable daily backup</span>
-                                <span className="mt-0.5 block text-xs leading-relaxed text-base-content/50">
-                                    Writes a logical <code className="font-mono">.sql</code> dump of all databases under
-                                    the config volume.
-                                </span>
-                            </span>
-                        </label>
+                        </Tooltip>
 
                         <fieldset className="space-y-2" disabled={!scheduleEnabled}>
                             <legend className="text-xs font-medium uppercase tracking-wide text-base-content/50">

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     Badge,
     Button,
-    Checkbox,
     HelpText,
     Icon,
     Input,
@@ -16,6 +15,8 @@ import {
     SettingsPage,
     Spinner,
     Textarea,
+    Toggle,
+    Tooltip,
     useIsAnyManaged,
 } from "~/components/ui";
 import { isMaskedSecret } from "~/utils/config-mask";
@@ -1097,14 +1098,15 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                         </div>
                         {isHttpsUrl && (
                             <div className="flex flex-col gap-1.5 sm:col-span-2">
-                                <label htmlFor="indexer-skip-tls-verification" className="flex items-center gap-2">
-                                    <Checkbox
+                                <Tooltip content="TLS stays encrypted, but accepts an untrusted or mismatched certificate. Only enable for an indexer you trust.">
+                                    <Toggle
                                         id="indexer-skip-tls-verification"
+                                        className="cursor-pointer gap-2 p-0"
                                         checked={skipTlsVerification}
                                         onChange={e => setSkipTlsVerification(e.target.checked)}
+                                        label={<span className="text-sm text-base-content">Skip TLS certificate verification</span>}
                                     />
-                                    <span className="text-sm text-base-content/80">Skip TLS certificate verification</span>
-                                </label>
+                                </Tooltip>
                                 {skipTlsVerification && (
                                     <Alert variant="warning" className="text-xs">
                                         TLS remains encrypted, but this accepts an untrusted or mismatched certificate.
@@ -1252,31 +1254,27 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                         </div>
 
                         <div className="flex flex-col gap-1.5 sm:col-span-2">
-                            <div className="flex items-center gap-2">
-                                <Checkbox
-                                                                        id="indexer-enabled"
-                                    className="checkbox"
+                            <Tooltip content="Include this indexer in search and grab requests.">
+                                <Toggle
+                                    id="indexer-enabled"
+                                    className="cursor-pointer gap-2 p-0"
                                     checked={enabled}
                                     onChange={e => setEnabled(e.target.checked)}
+                                    label={<span className="text-sm text-base-content">Enabled</span>}
                                 />
-                                <Label htmlFor="indexer-enabled" className="text-sm font-normal text-base-content/80">
-                                    Enabled
-                                </Label>
-                            </div>
+                            </Tooltip>
                         </div>
 
                         <div className="flex flex-col gap-1.5 sm:col-span-2">
-                            <div className="flex items-center gap-2">
-                                <Checkbox
-                                                                        id="indexer-strict"
-                                    className="checkbox"
+                            <Tooltip content="Drop results whose title doesn't match the request.">
+                                <Toggle
+                                    id="indexer-strict"
+                                    className="cursor-pointer gap-2 p-0"
                                     checked={strict}
                                     onChange={e => setStrict(e.target.checked)}
+                                    label={<span className="text-sm text-base-content">Strict matching</span>}
                                 />
-                                <Label htmlFor="indexer-strict" className="text-sm font-normal text-base-content/80">
-                                    Strict matching <span className="text-[11px] font-normal text-base-content/45">(drop results whose title doesn't match the request)</span>
-                                </Label>
-                            </div>
+                            </Tooltip>
                         </div>
 
                         <div className="flex flex-col gap-1.5">
@@ -1310,31 +1308,27 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                         </div>
 
                         <div className="flex flex-col gap-1.5 sm:col-span-2">
-                            <div className="flex items-center gap-2">
-                                <Checkbox
-                                                                        id="indexer-ignore-category-filter"
-                                    className="checkbox"
+                            <Tooltip content="Send no cat= param — escape hatch for indexers with fully custom category schemas.">
+                                <Toggle
+                                    id="indexer-ignore-category-filter"
+                                    className="cursor-pointer gap-2 p-0"
                                     checked={ignoreCategoryFilter}
                                     onChange={e => setIgnoreCategoryFilter(e.target.checked)}
+                                    label={<span className="text-sm text-base-content">Ignore category filter</span>}
                                 />
-                                <Label htmlFor="indexer-ignore-category-filter" className="text-sm font-normal text-base-content/80">
-                                    Ignore category filter <span className="text-[11px] font-normal text-base-content/45">(send no <code>cat=</code> param at all — escape hatch for indexers with fully custom category schemas)</span>
-                                </Label>
-                            </div>
+                            </Tooltip>
                         </div>
 
                         <div className="flex flex-col gap-1.5 sm:col-span-2">
-                            <div className="flex items-center gap-2">
-                                <Checkbox
-                                                                        id="indexer-filter-enabled"
-                                    className="checkbox"
+                            <Tooltip content="Use indexer-supplied metadata to filter and rank this indexer's results. Recommended defaults apply when enabled.">
+                                <Toggle
+                                    id="indexer-filter-enabled"
+                                    className="cursor-pointer gap-2 p-0"
                                     checked={filterEnabled}
                                     onChange={e => setFilterEnabled(e.target.checked)}
+                                    label={<span className="text-sm text-base-content">Result filtering</span>}
                                 />
-                                <Label htmlFor="indexer-filter-enabled" className="text-sm font-normal text-base-content/80">
-                                    Result filtering <span className="text-[11px] font-normal text-base-content/45">(uses indexer-supplied metadata to filter and rank this indexer's results; recommended defaults applied when enabled)</span>
-                                </Label>
-                            </div>
+                            </Tooltip>
                         </div>
 
                         {filterEnabled && (
@@ -1361,17 +1355,15 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                         {filterEnabled && filterAdvancedOpen && (
                             <>
                                 <div className="flex flex-col gap-1.5 sm:col-span-2">
-                                    <div className="flex items-center gap-2">
-                                        <Checkbox
-                                                                                        id="indexer-filter-pw"
-                                            className="checkbox"
+                                    <Tooltip content="Skip items the indexer flags as containing a passworded archive.">
+                                        <Toggle
+                                            id="indexer-filter-pw"
+                                            className="cursor-pointer gap-2 p-0"
                                             checked={filterSkipPassworded}
                                             onChange={e => setFilterSkipPassworded(e.target.checked)}
+                                            label={<span className="text-sm text-base-content">Skip password-protected releases</span>}
                                         />
-                                        <Label htmlFor="indexer-filter-pw" className="text-sm font-normal text-base-content/80">
-                                            Skip password-protected releases <span className="text-[11px] font-normal text-base-content/45">(items the indexer flags as containing a passworded archive)</span>
-                                        </Label>
-                                    </div>
+                                    </Tooltip>
                                 </div>
 
                                 <div className="flex flex-col gap-1.5">
@@ -1417,17 +1409,15 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                                 </div>
 
                                 <div className="flex flex-col gap-1.5 sm:col-span-2">
-                                    <div className="flex items-center gap-2">
-                                        <Checkbox
-                                                                                        id="indexer-filter-prefer"
-                                            className="checkbox"
+                                    <Tooltip content="Sort results by download count descending. Items without a count sort below those with one.">
+                                        <Toggle
+                                            id="indexer-filter-prefer"
+                                            className="cursor-pointer gap-2 p-0"
                                             checked={filterPreferDownloaded}
                                             onChange={e => setFilterPreferDownloaded(e.target.checked)}
+                                            label={<span className="text-sm text-base-content">Rank by download count</span>}
                                         />
-                                        <Label htmlFor="indexer-filter-prefer" className="text-sm font-normal text-base-content/80">
-                                            Rank by download count <span className="text-[11px] font-normal text-base-content/45">(sort results by number of downloads, descending; items without a download count sort below those with one)</span>
-                                        </Label>
-                                    </div>
+                                    </Tooltip>
                                 </div>
 
                                 <div className="flex flex-col gap-1.5 sm:col-span-2">

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,5 +1,5 @@
-import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
-import { Checkbox, Input, Select } from "~/components/ui/form";
+import { ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
+import { Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
@@ -47,30 +47,18 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                     </div>
 
                     <div className="space-y-4 p-4">
-                        <label
-                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
-                            htmlFor="db-startup-vacuum-enabled-checkbox"
-                        >
-                            <Checkbox
-                                className="checkbox-primary mt-0.5 shrink-0"
+                        <Tooltip content="Reclaim unused SQLite space. Large databases may take longer to start.">
+                            <Toggle
                                 id="db-startup-vacuum-enabled-checkbox"
-                                aria-describedby="db-startup-vacuum-enabled-help"
+                                className="cursor-pointer gap-2 rounded-lg bg-base-200/40 p-3"
                                 checked={config["db.is-startup-vacuum-enabled"] === "true"}
                                 onChange={e => setNewConfig({
                                     ...config,
                                     "db.is-startup-vacuum-enabled": String(e.target.checked),
                                 })}
+                                label={<span className="text-sm font-medium text-base-content">Vacuum on startup</span>}
                             />
-                            <span>
-                                <span className="block text-sm font-medium text-base-content">Vacuum on startup</span>
-                                <span
-                                    className="mt-0.5 block text-xs leading-relaxed text-base-content/50"
-                                    id="db-startup-vacuum-enabled-help"
-                                >
-                                    Reclaim unused SQLite space. Large databases may take longer to start.
-                                </span>
-                            </span>
-                        </label>
+                        </Tooltip>
 
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                             <div className="space-y-2">
@@ -146,30 +134,18 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                     </div>
 
                     <div className="space-y-4 p-4">
-                        <label
-                            className="flex cursor-pointer items-start gap-3 rounded-lg bg-base-200/40 p-3"
-                            htmlFor="remove-orphaned-schedule-enabled-checkbox"
-                        >
-                            <Checkbox
-                                className="checkbox-primary mt-0.5 shrink-0"
+                        <Tooltip content="Runs the same protected Remove Orphaned Files cleanup available in the task panel below.">
+                            <Toggle
                                 id="remove-orphaned-schedule-enabled-checkbox"
-                                aria-describedby="remove-orphaned-schedule-help"
+                                className="cursor-pointer gap-2 rounded-lg bg-base-200/40 p-3"
                                 checked={orphanScheduleEnabled}
                                 onChange={e => setNewConfig({
                                     ...config,
                                     "maintenance.remove-orphaned-schedule-enabled": String(e.target.checked),
                                 })}
+                                label={<span className="text-sm font-medium text-base-content">Enable daily cleanup</span>}
                             />
-                            <span>
-                                <span className="block text-sm font-medium text-base-content">Enable daily cleanup</span>
-                                <span
-                                    className="mt-0.5 block text-xs leading-relaxed text-base-content/50"
-                                    id="remove-orphaned-schedule-help"
-                                >
-                                    Runs the same protected cleanup available in the task panel below.
-                                </span>
-                            </span>
-                        </label>
+                        </Tooltip>
 
                         <fieldset className="space-y-2" disabled={!orphanScheduleEnabled}>
                             <legend className="text-xs font-medium uppercase tracking-wide text-base-content/50">

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
-import { Alert } from "~/components/ui/feedback";
-import { Checkbox } from "~/components/ui/form";
+import { Alert, Tooltip } from "~/components/ui/feedback";
+import { Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
@@ -102,15 +102,16 @@ export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
                 </p>
 
                 <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
-                    <label className="flex items-center gap-2 text-sm text-base-content/75">
-                        <Checkbox
+                    <Tooltip content="Rewrite every existing STRM sidecar and bump modification times, not only missing or stale ones.">
+                        <Toggle
                             id="recreate-strm-rewrite-all"
+                            className="cursor-pointer gap-2 p-0"
                             checked={rewriteAll}
                             onChange={e => setRewriteAll(e.target.checked)}
                             disabled={isRunning}
+                            label={<span className="text-sm text-base-content">Rewrite every STRM file and update modification times</span>}
                         />
-                        <span>Rewrite every STRM file and update modification times</span>
-                    </label>
+                    </Tooltip>
                     <div className="mt-3 flex flex-col gap-3 border-t border-base-content/10 pt-3 sm:flex-row sm:items-center sm:justify-between">
                         <Button
                             className="shrink-0"

--- a/frontend/app/routes/settings/profiles/profiles.tsx
+++ b/frontend/app/routes/settings/profiles/profiles.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch, type ReactNode, type SetStateAction, useCallback, useMemo, useState } from "react";
 import { MultiCheckboxInput } from "~/components/multi-checkbox-input/multi-checkbox-input";
-import { Button, Field, Icon, Input, Label, ManagedSetting, Select, SettingsPage, Toggle } from "~/components/ui";
+import { Button, Field, Icon, Input, Label, ManagedSetting, Select, SettingsPage, Toggle, Tooltip } from "~/components/ui";
 
 type ProfilesSettingsProps = {
     config: Record<string, string>
@@ -367,12 +367,14 @@ function AdapterRow({ token, origin, adapter, enabled, onToggle }: AdapterRowPro
                     <span className="text-sm font-medium text-base-content">{adapter.name}</span>
                     <span className="text-xs text-base-content/60">{adapter.description}</span>
                 </div>
-                <Toggle
-                    id={`adapter-${token}-${adapter.key}`}
-                    label={`Enable ${adapter.name}`}
-                    className="[&>span:last-child]:sr-only"
-                    checked={enabled}
-                    onChange={e => onToggle(e.target.checked)} />
+                <Tooltip content={adapter.description}>
+                    <Toggle
+                        id={`adapter-${token}-${adapter.key}`}
+                        label={`Enable ${adapter.name}`}
+                        className="cursor-pointer gap-2 p-0 [&>span:last-child]:sr-only"
+                        checked={enabled}
+                        onChange={e => onToggle(e.target.checked)} />
+                </Tooltip>
             </div>
             {enabled && (
                 <div className="mt-2 flex items-center gap-2">

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -1,7 +1,7 @@
 import { Button } from "~/components/ui/button";
-import { Spinner } from "~/components/ui/feedback";
+import { Spinner, Tooltip } from "~/components/ui/feedback";
 import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
-import { Checkbox, Input } from "~/components/ui/form";
+import { Input, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
 import { isMaskedSecret } from "~/utils/config-mask";
@@ -63,19 +63,15 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 description="Notify the rclone mount whenever WebDAV content is added or removed."
             >
             <ManagedSetting configKey="rclone.rc-enabled">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
+            <Tooltip content="Notify your rclone mount via the RC API when files are added or removed on the WebDAV, so you can use a high dir-cache-time.">
+                <Toggle
                     id="rclone-rc-enabled-checkbox"
-                    aria-describedby="rclone-rc-enabled-help"
+                    className="cursor-pointer gap-2 p-0"
                     checked={config["rclone.rc-enabled"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "rclone.rc-enabled": "" + e.target.checked })}  />
-                    <span>{`Enable Rclone RC Server Notifications`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="rclone-rc-enabled-help">
-                    When enabled, NzbDAV will automatically notify your rclone mount via the RC API whenever files are added or removed on the webdav. This allows setting a high dir-cache-time setting on Rclone.
-                </p>
-            </div>
+                    onChange={e => setNewConfig({ ...config, "rclone.rc-enabled": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Enable Rclone RC Server Notifications</span>}
+                />
+            </Tooltip>
             </ManagedSetting>
             </SettingsCard>
 

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -1,5 +1,5 @@
-import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
-import { Checkbox, Input, Select } from "~/components/ui/form";
+import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
+import { Input, Select, Toggle } from "~/components/ui/form";
 import { type Dispatch, type SetStateAction } from "react";
 import { isPositiveInteger } from "../usenet/usenet";
 
@@ -41,20 +41,16 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
             >
             <ManagedSetting configKey="repair.enable">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
+            <Tooltip content={helpText}>
+                <Toggle
                     id="enable-repairs-checkbox"
-                    aria-describedby="enable-repairs-help"
+                    className="cursor-pointer gap-2 p-0"
                     checked={canEnableRepairs && config["repair.enable"] === "true"}
                     disabled={!canEnableRepairs}
-                    onChange={e => setNewConfig({ ...config, "repair.enable": "" + e.target.checked })}  />
-                    <span>{`Enable Background Repairs`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="enable-repairs-help">
-                    {helpText}
-                </p>
-            </div>
+                    onChange={e => setNewConfig({ ...config, "repair.enable": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Enable Background Repairs</span>}
+                />
+            </Tooltip>
             </ManagedSetting>
 
             <ManagedSetting configKey="media.library-dir">
@@ -125,20 +121,15 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </p>
             </div>
             <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                    id="healthcheck-aging-checkbox"
-                    aria-describedby="healthcheck-aging-help"
-                    checked={(config["repair.healthcheck-aging"] ?? "false") === "true"}
-                    onChange={e => setNewConfig({ ...config, "repair.healthcheck-aging": "" + e.target.checked })}  />
-                    <span>Check older releases less thoroughly</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-aging-help">
-                    Off by default. When enabled, coverage tapers for releases past their first year, on
-                    the basis that a post which has already survived that long is less likely to break.
-                    The taper stops at ten years. Useful for large libraries where most of the catalogue
-                    is long-since posted and rechecking it in full costs more than it finds.
-                </p>
+                <Tooltip content="Off by default. When enabled, coverage tapers for releases past their first year (stops at ten years), useful for large libraries of long-posted content.">
+                    <Toggle
+                        id="healthcheck-aging-checkbox"
+                        className="cursor-pointer gap-2 p-0"
+                        checked={(config["repair.healthcheck-aging"] ?? "false") === "true"}
+                        onChange={e => setNewConfig({ ...config, "repair.healthcheck-aging": "" + e.target.checked })}
+                        label={<span className="text-sm text-base-content">Check older releases less thoroughly</span>}
+                    />
+                </Tooltip>
             </div>
             </ManagedSetting>
             </SettingsCard>
@@ -168,22 +159,16 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             </ManagedSetting>
             <ManagedSetting configKey="repair.auto-remove-unlinked-only">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
+            <Tooltip content="When enabled (default), library-linked files still use Radarr/Sonarr remove-and-search. Disable to force-delete linked files after the failure threshold.">
+                <Toggle
                     id="auto-remove-unlinked-only-checkbox"
-                    aria-describedby="auto-remove-unlinked-only-help"
+                    className="cursor-pointer gap-2 p-0"
                     checked={(config["repair.auto-remove-unlinked-only"] ?? "true") === "true"}
                     disabled={!autoRemoveEnabled}
-                    onChange={e => setNewConfig({ ...config, "repair.auto-remove-unlinked-only": "" + e.target.checked })}  />
-                    <span>Auto-remove unlinked files only</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-unlinked-only-help">
-                    When enabled (default), library-linked files still go through Radarr/Sonarr
-                    remove-and-search instead of silent delete. Disable for aggressive mode that
-                    force-deletes linked files after the failure threshold.
-                </p>
-            </div>
+                    onChange={e => setNewConfig({ ...config, "repair.auto-remove-unlinked-only": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Auto-remove unlinked files only</span>}
+                />
+            </Tooltip>
             </ManagedSetting>
             </SettingsCard>
             </div>

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/components/ui/button";
-import { ManagedSetting, SettingsPage } from "~/components/ui";
-import { Checkbox, Input, Select } from "~/components/ui/form";
+import { ManagedSetting, SettingsPage, Tooltip } from "~/components/ui";
+import { Checkbox, Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from "react";
 import { TagInput } from "~/components/tag-input/tag-input";
@@ -221,39 +221,30 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
             </ManagedSetting>
             <hr />
             <ManagedSetting configKey="api.ensure-importable-video">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
+            <Tooltip content="Mark downloads as failed when no video file is found, so Radarr/Sonarr can grab another NZB.">
+                <Toggle
                     id="ensure-importable-video-checkbox"
-                    aria-describedby="ensure-importable-video-help"
+                    className="cursor-pointer gap-2 p-0"
                     checked={config["api.ensure-importable-video"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "api.ensure-importable-video": "" + e.target.checked })}  />
-                    <span>{`Fail downloads for nzbs without video content`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="ensure-importable-video-help">
-                    Whether to mark downloads as `failed` when no single video file is found inside the nzb. This will force Radarr / Sonarr to automatically look for a new nzb.
-                </p>
-            </div>
+                    onChange={e => setNewConfig({ ...config, "api.ensure-importable-video": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Fail downloads for nzbs without video content</span>}
+                />
+            </Tooltip>
             </ManagedSetting>
             <hr />
             <ManagedSetting configKey="api.skip-non-video-on-missing-articles">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
+            <Tooltip content="By default, missing articles in PAR2/NFO/subtitles are skipped. Enable to fail the download so *Arr can grab an alternate.">
+                <Toggle
                     id="fail-missing-non-video-checkbox"
-                    aria-describedby="fail-missing-non-video-help"
+                    className="cursor-pointer gap-2 p-0"
                     checked={config["api.skip-non-video-on-missing-articles"] === "false"}
                     onChange={e => setNewConfig({
                         ...config,
                         "api.skip-non-video-on-missing-articles": String(!e.target.checked)
-                    })} />
-                    <span>Fail downloads when non-video files have missing articles</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="fail-missing-non-video-help">
-                    By default, missing articles in PAR2/NFO/subtitle files are skipped and the job still completes.
-                    Enable this to fail the download instead so *Arr can grab an alternate release.
-                </p>
-            </div>
+                    })}
+                    label={<span className="text-sm text-base-content">Fail downloads when non-video files have missing articles</span>}
+                />
+            </Tooltip>
             </ManagedSetting>
             <hr />
             <ManagedSetting configKey="api.ensure-article-existence-categories">
@@ -279,20 +270,15 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
             </ManagedSetting>
             <hr />
             <ManagedSetting configKey="api.ignore-history-limit">
-            <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
+            <Tooltip content="Ignore the History limit from Radarr/Sonarr and always reply with all History items (workaround for Sonarr issue #5452).">
+                <Toggle
                     id="ignore-history-limit-checkbox"
-                    aria-describedby="ignore-history-limit-help"
+                    className="cursor-pointer gap-2 p-0"
                     checked={config["api.ignore-history-limit"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "api.ignore-history-limit": "" + e.target.checked })}  />
-                    <span>{`Always send full History to Radarr/Sonarr`}</span>
-                </label>
-                <p className="text-[11px] leading-relaxed text-base-content/45" id="ignore-history-limit-help">
-                    When enabled, this will ignore the History limit sent by radarr/sonarr and always reply with all History items.&nbsp;
-                    <a href="https://github.com/Sonarr/Sonarr/issues/5452">See here</a>.
-                </p>
-            </div>
+                    onChange={e => setNewConfig({ ...config, "api.ignore-history-limit": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Always send full History to Radarr/Sonarr</span>}
+                />
+            </Tooltip>
             </ManagedSetting>
             <hr />
             <ManagedSetting configKeys={[
@@ -301,14 +287,15 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                 "api.nzb-backup-retention-days",
             ]}>
             <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-base-content/80">
-                    <Checkbox
-                    id="nzb-backup-enabled-checkbox"
-                    aria-describedby="nzb-backup-location-help"
-                    checked={config["api.nzb-backup-enabled"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "api.nzb-backup-enabled": "" + e.target.checked })}  />
-                    <span>{`Save backup copies of incoming NZBs`}</span>
-                </label>
+                <Tooltip content="Save a copy of each incoming NZB to the directory below, organized by category. The directory is created if missing.">
+                    <Toggle
+                        id="nzb-backup-enabled-checkbox"
+                        className="cursor-pointer gap-2 p-0"
+                        checked={config["api.nzb-backup-enabled"] === "true"}
+                        onChange={e => setNewConfig({ ...config, "api.nzb-backup-enabled": "" + e.target.checked })}
+                        label={<span className="text-sm text-base-content">Save backup copies of incoming NZBs</span>}
+                    />
+                </Tooltip>
                 <Input
                     className="mt-4 w-full"
                     type="text"
@@ -320,8 +307,7 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     aria-invalid={!isValidNzbBackupLocation(config)}
                     onChange={e => setNewConfig({ ...config, "api.nzb-backup-location": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="nzb-backup-location-help">
-                    When enabled, a copy of each incoming NZB will be saved to this directory, organized by category.
-                    The directory will be created if it doesn't already exist.
+                    Directory for NZB backups, organized by category.
                 </p>
                 <label className="mt-4 flex items-center gap-2 text-sm text-base-content/80" htmlFor="nzb-backup-retention-days-input">
                     <span>Keep NZB backups for (days)</span>

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1,6 +1,5 @@
 import { type Dispatch, type SetStateAction, type ReactNode, type CSSProperties, useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { Alert, Badge, Button, HelpText, Icon, Input, Label, ManagedSetting, Modal, Select, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
-import { Checkbox, Toggle } from "~/components/ui/form";
+import { Alert, Badge, Button, HelpText, Icon, Input, Label, ManagedSetting, Modal, Select, SettingsIntro, SettingsPage, Tooltip, Toggle } from "~/components/ui";
 import { subscribeWebsocketTopics, useWebsocketTopic } from "~/utils/shared-websocket";
 import { isMaskedSecret } from "~/utils/config-mask";
 import { shouldWarnCleartextCredentials } from "./cleartext-credentials";
@@ -1328,17 +1327,18 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                 </div>
 
                 <div className="flex flex-col gap-1.5 sm:col-span-2">
-                    <label htmlFor="provider-ssl" className="flex items-center gap-2">
-                        <Checkbox
+                    <Tooltip content="Encrypt the NNTP connection. Prefer port 563 with SSL enabled; without SSL credentials are sent in cleartext.">
+                        <Toggle
                             id="provider-ssl"
+                            className="cursor-pointer gap-2 p-0"
                             checked={useSsl}
                             onChange={(e) => {
                                 setUseSsl(e.target.checked);
                                 setConnectionTested(false);
                             }}
+                            label={<span className="text-sm text-base-content">Use SSL</span>}
                         />
-                        <span className="text-sm text-base-content/80">Use SSL</span>
-                    </label>
+                    </Tooltip>
                     {shouldWarnCleartextCredentials(useSsl, user) && (
                         <Alert variant="warning" className="text-xs">
                             Credentials are sent unencrypted without SSL. Prefer port 563 with SSL enabled.
@@ -1346,17 +1346,18 @@ function ProviderModal({ show, provider, onClose, onSave, onApplyPipelining, def
                     )}
                     {useSsl && (
                         <>
-                            <label htmlFor="provider-skip-tls-verification" className="mt-2 flex items-center gap-2">
-                                <Checkbox
+                            <Tooltip content="TLS stays encrypted, but accepts an untrusted or mismatched certificate. Only enable for a provider you trust.">
+                                <Toggle
                                     id="provider-skip-tls-verification"
+                                    className="mt-2 cursor-pointer gap-2 p-0"
                                     checked={skipTlsVerification}
                                     onChange={(e) => {
                                         setSkipTlsVerification(e.target.checked);
                                         setConnectionTested(false);
                                     }}
+                                    label={<span className="text-sm text-base-content">Skip TLS certificate verification</span>}
                                 />
-                                <span className="text-sm text-base-content/80">Skip TLS certificate verification</span>
-                            </label>
+                            </Tooltip>
                             {skipTlsVerification && (
                                 <Alert variant="warning" className="text-xs">
                                     TLS remains encrypted, but this accepts an untrusted or mismatched certificate.
@@ -1564,24 +1565,26 @@ function BenchmarkPanel(props: BenchmarkPanelProps) {
                 </div>
             </div>
 
-            <label htmlFor="bench-pipe-only" className="label mt-3 cursor-pointer justify-start gap-2">
-                <input
+            <Tooltip
+                className="mt-3 block"
+                content={pipeliningOnly
+                    ? "Won't change your connection count — tests pipelining depth at the Max Connections you've set. Run idle for the cleanest read."
+                    : "When off, also sweeps connection counts. Prefer idle for the cleanest read."}
+            >
+                <Toggle
                     id="bench-pipe-only"
-                    type="checkbox"
-                    className="toggle toggle-sm"
+                    className="cursor-pointer gap-2 p-0"
                     checked={pipeliningOnly}
                     disabled={isBenchmarking}
                     onChange={(e) => setPipeliningOnly(e.target.checked)}
+                    label={<span className="text-sm text-base-content">Only tune pipelining (keep my Max Connections)</span>}
                 />
-                <span className="text-sm text-base-content/80">Only tune pipelining (keep my Max Connections)</span>
-            </label>
+            </Tooltip>
 
             <HelpText>
-                {pipeliningOnly
-                    ? "Won't change your connection count — it tests pipelining depth at the Max Connections you've set. Run it idle for the cleanest read."
-                    : (intensity === "quick"
-                        ? "Quick sizes each step to your line speed, up to the data budget (default 500 MB) — light on metered / block accounts."
-                        : "Thorough runs longer measurement windows for steadier numbers, up to the data budget (default 2 GB). Gigabit-class lines often need 10–20 GB for a full sweep.")}
+                {intensity === "quick"
+                    ? "Quick sizes each step to your line speed, up to the data budget (default 500 MB) — light on metered / block accounts."
+                    : "Thorough runs longer measurement windows for steadier numbers, up to the data budget (default 2 GB). Gigabit-class lines often need 10–20 GB for a full sweep."}
             </HelpText>
 
             {error && (

--- a/frontend/app/routes/settings/warden/warden.tsx
+++ b/frontend/app/routes/settings/warden/warden.tsx
@@ -1,6 +1,6 @@
 import { type ChangeEvent, type DragEvent, type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
-import { Alert, Button, Icon, ManagedSetting, Modal, NativeForm as Form, SettingsIntro, SettingsPage, Spinner, Textarea } from "~/components/ui";
+import { Alert, Button, Icon, ManagedSetting, Modal, NativeForm as Form, SettingsIntro, SettingsPage, Spinner, Textarea, Tooltip } from "~/components/ui";
 
 type WardenSettingsProps = {
     config: Record<string, string>;
@@ -402,17 +402,15 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
 
             <ManagedSetting configKey="warden.hide-dead">
             <Form.Group className={"flex flex-col gap-2"}>
-                <Form.Check
-                    type="switch"
-                    id="warden-hide-dead"
-                    label="Filter out anything on the list"
-                    checked={hideDead}
-                    onChange={e => set("warden.hide-dead", String(e.target.checked))} />
-                <p className={"m-0 text-[11px] leading-relaxed text-base-content/45"}>
-                    When on, anything whose fingerprint is filtered by your sources is removed from
-                    what your search profiles return. If everything matches, results are shown anyway
-                    as a last resort.
-                </p>
+                <Tooltip content="Remove search results whose fingerprint is filtered by your sources. If everything matches, results are shown anyway as a last resort.">
+                    <Form.Check
+                        type="switch"
+                        id="warden-hide-dead"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Filter out anything on the list"
+                        checked={hideDead}
+                        onChange={e => set("warden.hide-dead", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
             </ManagedSetting>
 
@@ -432,16 +430,15 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
 
             <ManagedSetting configKey="warden.backbone-scope">
             <Form.Group className={"flex flex-col gap-2"}>
-                <Form.Check
-                    type="switch"
-                    id="warden-backbone-scope"
-                    label="Only filter when the provider matches"
-                    checked={backboneScope}
-                    onChange={e => set("warden.backbone-scope", String(e.target.checked))} />
-                <p className={"m-0 text-[11px] leading-relaxed text-base-content/45"}>
-                    A verdict from a remote or imported list only filters when its provider matches one
-                    of yours. Your own list always filters.
-                </p>
+                <Tooltip content="A remote/imported verdict only filters when its provider matches one of yours. Your own list always filters.">
+                    <Form.Check
+                        type="switch"
+                        id="warden-backbone-scope"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Only filter when the provider matches"
+                        checked={backboneScope}
+                        onChange={e => set("warden.backbone-scope", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
             </ManagedSetting>
 
@@ -549,9 +546,12 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                         </div>}
 
                                     {!isLocal &&
-                                        <Form.Check type="switch" id={`enabled-${s.id}`} label="Enabled"
-                                            checked={s.enabled} disabled={rowBusy}
-                                            onChange={e => updateSource(s.id, { enabled: String(e.target.checked) })} />}
+                                        <Tooltip content="Include fingerprints from this remote source in filtering.">
+                                            <Form.Check type="switch" id={`enabled-${s.id}`} label="Enabled"
+                                                className="cursor-pointer gap-2 p-0"
+                                                checked={s.enabled} disabled={rowBusy}
+                                                onChange={e => updateSource(s.id, { enabled: String(e.target.checked) })} />
+                                        </Tooltip>}
 
                                     {s.kind === "remote" &&
                                         <div className={"flex items-center gap-1.5"}>
@@ -800,8 +800,11 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                         setExportSources(next);
                                     }} />)}
                         </div>}
-                    <Form.Check type="switch" id="export-dedup" label="Deduplicate identical fingerprints"
-                        checked={exportDedup} onChange={e => setExportDedup(e.target.checked)} style={{ marginTop: 8 }} />
+                    <Tooltip content="Collapse identical fingerprints into a single export line.">
+                        <Form.Check type="switch" id="export-dedup" label="Deduplicate identical fingerprints"
+                            className="cursor-pointer gap-2 p-0"
+                            checked={exportDedup} onChange={e => setExportDedup(e.target.checked)} style={{ marginTop: 8 }} />
+                    </Tooltip>
             </Modal>
 
             <Modal
@@ -854,8 +857,11 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                 onChange={e => setBInterval(e.target.value)} />
                         </Form.Group>
                     </div>
-                    <Form.Check type="switch" id="backup-enabled" label="Back up automatically on this schedule"
-                        checked={bEnabled} onChange={e => setBEnabled(e.target.checked)} style={{ marginTop: 12 }} />
+                    <Tooltip content="Push an automatic backup of your list to GitHub on the schedule below.">
+                        <Form.Check type="switch" id="backup-enabled" label="Back up automatically on this schedule"
+                            className="cursor-pointer gap-2 p-0"
+                            checked={bEnabled} onChange={e => setBEnabled(e.target.checked)} style={{ marginTop: 12 }} />
+                    </Tooltip>
             </Modal>
 
             <ConfirmModal

--- a/frontend/app/routes/settings/watchdog/watchdog.tsx
+++ b/frontend/app/routes/settings/watchdog/watchdog.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
-import { Icon, NativeForm as Form, ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
+import { Icon, NativeForm as Form, ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
 
 type WatchdogSettingsProps = {
     config: Record<string, string>
@@ -79,17 +79,20 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             >
 
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="play-watchdog-enabled"
-                    label="Enable failover watchdog"
-                    checked={enabled}
-                    onChange={e => set("play.watchdog-enabled", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    When off, a request just processes the single chosen release (legacy behavior).
-                    When on, the watchdog tries alternative releases on failure and dedupes in-flight queue items.
-                    {enabled && <> Live reports appear in the <Link to="/watchdog">Watchdog</Link> tab in the sidebar.</>}
-                </p>
+                <Tooltip content="When off, only the chosen release is tried (legacy). When on, alternatives are tried on failure and in-flight queue items are deduped.">
+                    <Form.Check
+                        type="switch"
+                        id="play-watchdog-enabled"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Enable failover watchdog"
+                        checked={enabled}
+                        onChange={e => set("play.watchdog-enabled", String(e.target.checked))} />
+                </Tooltip>
+                {enabled && (
+                    <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
+                        Live reports appear in the <Link to="/watchdog">Watchdog</Link> tab.
+                    </p>
+                )}
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
@@ -209,19 +212,16 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="play-prefer-subtitles"
-                    label="Prefer releases with subtitles on failover"
-                    disabled={!enabled}
-                    checked={subtitlePreference}
-                    onChange={e => set("play.prefer-subtitles", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    During failover, releases that carry subtitles are tried before releases without
-                    them — and when the indexer reports languages, releases sharing a subtitle language
-                    with the one you clicked come first. Candidates are only reordered, never dropped.
-                    On by default.
-                </p>
+                <Tooltip content="On failover, try subtitle-bearing releases first; when languages are known, prefer matching subtitle language. Candidates are reordered, never dropped. On by default.">
+                    <Form.Check
+                        type="switch"
+                        id="play-prefer-subtitles"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Prefer releases with subtitles on failover"
+                        disabled={!enabled}
+                        checked={subtitlePreference}
+                        onChange={e => set("play.prefer-subtitles", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
             </SettingsCard>
 
@@ -237,17 +237,16 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             >
 
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="grab-stall-failover-enabled"
-                    label="Enable stall failover"
-                    disabled={!enabled}
-                    checked={stallFailoverEnabled}
-                    onChange={e => set("grab.stall-failover-enabled", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    When a candidate stops progressing, it is set aside and the next one is attempted.
-                    On by default.
-                </p>
+                <Tooltip content="When a candidate stops progressing, set it aside and try the next one without recording it as failed. On by default.">
+                    <Form.Check
+                        type="switch"
+                        id="grab-stall-failover-enabled"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Enable stall failover"
+                        disabled={!enabled}
+                        checked={stallFailoverEnabled}
+                        onChange={e => set("grab.stall-failover-enabled", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
@@ -363,18 +362,16 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="variants-fallback-on-failure"
-                    label="Fallback to closest existing on fetch failure"
-                    disabled={!variantsEnabled}
-                    checked={variantsFallback}
-                    onChange={e => set("variants.fallback-on-failure", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    When you pick a size we don't have AND no working source can be fetched,
-                    serve the closest existing copy instead of returning an error. Strictly
-                    safer than today's behavior. On by default.
-                </p>
+                <Tooltip content="If the requested size can't be fetched, serve the closest existing copy instead of an error. On by default.">
+                    <Form.Check
+                        type="switch"
+                        id="variants-fallback-on-failure"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Fallback to closest existing on fetch failure"
+                        disabled={!variantsEnabled}
+                        checked={variantsFallback}
+                        onChange={e => set("variants.fallback-on-failure", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">

--- a/frontend/app/routes/settings/watchtower/watchtower.tsx
+++ b/frontend/app/routes/settings/watchtower/watchtower.tsx
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction } from "react";
-import { NativeForm as Form, ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
+import { NativeForm as Form, ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
 
 const GB = 1024 * 1024 * 1024;
 
@@ -75,16 +75,15 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
                 "watchtower.verbose-logging",
             ]}>
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="watchtower-enabled"
-                    label="Enable Watchtower"
-                    checked={enabled}
-                    onChange={e => set("watchtower.enabled", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    When on, the background engine syncs your lists, resolves the biggest healthy
-                    release for each item, and keeps it verified over time. When off, nothing runs.
-                </p>
+                <Tooltip content="When on, syncs lists, resolves the biggest healthy release per item, and keeps it verified. When off, nothing runs.">
+                    <Form.Check
+                        type="switch"
+                        id="watchtower-enabled"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Enable Watchtower"
+                        checked={enabled}
+                        onChange={e => set("watchtower.enabled", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
@@ -169,35 +168,30 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
             {(scope === "latest-season" || scope === "first-season" || scope === "all-aired") && (
                 <>
                     <Form.Group className="flex flex-col gap-2">
-                        <Form.Check
-                            type="switch"
-                            id="watchtower-season-bundles"
-                            label="Prefer season bundles for finished seasons"
-                            disabled={!enabled}
-                            checked={seasonBundles}
-                            onChange={e => set("watchtower.season-bundles", String(e.target.checked))} />
-                        <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                            Warm one season bundle per completed season, a single release that covers the
-                            whole season and plays per episode, instead of every episode. Still-airing
-                            seasons always use single episodes. Default on.
-                        </p>
+                        <Tooltip content="Warm one season bundle per completed season instead of every episode. Still-airing seasons always use single episodes. Default on.">
+                            <Form.Check
+                                type="switch"
+                                id="watchtower-season-bundles"
+                                className="cursor-pointer gap-2 p-0"
+                                label="Prefer season bundles for finished seasons"
+                                disabled={!enabled}
+                                checked={seasonBundles}
+                                onChange={e => set("watchtower.season-bundles", String(e.target.checked))} />
+                        </Tooltip>
                     </Form.Group>
 
                     {seasonBundles && (
                         <Form.Group className="flex flex-col gap-2">
-                            <Form.Check
-                                type="switch"
-                                id="watchtower-season-bundle-fallback"
-                                label="Fall back to episodes when no season bundle is found"
-                                disabled={!enabled}
-                                checked={bundleFallback}
-                                onChange={e => set("watchtower.season-bundle-fallback", String(e.target.checked))} />
-                            <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                                When a finished season has no healthy bundle, warm its individual episodes
-                                instead so the season is still covered. The bundle is parked and stops being
-                                searched, so this will not keep hitting your indexers. Use "check now" on a
-                                parked pack to try for it again. Off by default.
-                            </p>
+                            <Tooltip content="If no healthy bundle exists, warm individual episodes instead. The pack is parked and stops being searched. Off by default.">
+                                <Form.Check
+                                    type="switch"
+                                    id="watchtower-season-bundle-fallback"
+                                    className="cursor-pointer gap-2 p-0"
+                                    label="Fall back to episodes when no season bundle is found"
+                                    disabled={!enabled}
+                                    checked={bundleFallback}
+                                    onChange={e => set("watchtower.season-bundle-fallback", String(e.target.checked))} />
+                            </Tooltip>
                         </Form.Group>
                     )}
 
@@ -324,19 +318,16 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="watchtower-auto-throughput"
-                    label="Auto throughput (match indexer limits)"
-                    disabled={!enabled}
-                    checked={autoThroughput}
-                    onChange={e => set("watchtower.auto-throughput", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    Resolve as fast as your indexers allow instead of pacing with the daily budget below.
-                    Every search and grab still obeys each indexer's requests-per-minute and daily caps
-                    from <b>Indexer settings</b>, and the engine pauses automatically when an indexer is
-                    tapped out. Best for clearing a large backlog. Default off.
-                </p>
+                <Tooltip content="Resolve as fast as indexers allow instead of pacing with the daily budget. Still obeys each indexer's RPM and daily caps. Default off.">
+                    <Form.Check
+                        type="switch"
+                        id="watchtower-auto-throughput"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Auto throughput (match indexer limits)"
+                        disabled={!enabled}
+                        checked={autoThroughput}
+                        onChange={e => set("watchtower.auto-throughput", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
 
             <Form.Group className="flex flex-col gap-2">
@@ -458,19 +449,15 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
             </div>
 
             <Form.Group className="flex flex-col gap-2">
-                <Form.Check
-                    type="switch"
-                    id="watchtower-verbose-logging"
-                    label="Verbose activity logging"
-                    checked={verboseLogging}
-                    onChange={e => set("watchtower.verbose-logging", String(e.target.checked))} />
-                <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
-                    Writes Watchtower's per-item activity to the <b>Logs</b> page at the Information
-                    level: each resolve, why an item is left unavailable, dead releases it skips or
-                    finds, backup promotions, and a short heartbeat every cycle so you can confirm it's
-                    still running. Useful when an item gets stuck or stops updating. Only emits while
-                    Watchtower is enabled. Leave off for normal use — it's chatty.
-                </p>
+                <Tooltip content="Log per-item Watchtower activity at Information level (resolves, skips, heartbeats). Chatty — leave off for normal use.">
+                    <Form.Check
+                        type="switch"
+                        id="watchtower-verbose-logging"
+                        className="cursor-pointer gap-2 p-0"
+                        label="Verbose activity logging"
+                        checked={verboseLogging}
+                        onChange={e => set("watchtower.verbose-logging", String(e.target.checked))} />
+                </Tooltip>
             </Form.Group>
             </ManagedSetting>
         </SettingsPage>

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -1,5 +1,5 @@
-import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
-import { Checkbox, Input, Select, Toggle } from "~/components/ui/form";
+import { ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
+import { Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type ReactNode, type SetStateAction } from "react";
 import { className } from "~/utils/styling";
@@ -95,69 +95,51 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     description="How content appears to WebDAV clients and the Dav Explorer."
                 >
                     <ManagedSetting configKey="webdav.enforce-readonly">
-                        <div className="space-y-2">
-                            <label className="flex items-center gap-2 text-sm text-base-content/80">
-                                <Checkbox
-                                    id="readonly-checkbox"
-                                    aria-describedby="readonly-help"
-                                    checked={config["webdav.enforce-readonly"] === "true"}
-                                    onChange={e => setNewConfig({ ...config, "webdav.enforce-readonly": "" + e.target.checked })} />
-                                <span>{`Enforce Read-Only`}</span>
-                            </label>
-                            <p className="text-[11px] leading-relaxed text-base-content/45" id="readonly-help">
-                                The WebDAV `/content` folder will be readonly when checked. WebDAV clients will not be able to delete files within this directory.
-                            </p>
-                        </div>
+                        <Tooltip content="Make the WebDAV /content folder read-only so clients cannot delete files there.">
+                            <Toggle
+                                id="readonly-checkbox"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={config["webdav.enforce-readonly"] === "true"}
+                                onChange={e => setNewConfig({ ...config, "webdav.enforce-readonly": "" + e.target.checked })}
+                                label={<span className="text-sm text-base-content">Enforce Read-Only</span>}
+                            />
+                        </Tooltip>
                     </ManagedSetting>
 
                     <ManagedSetting configKey="webdav.windows-safe-paths">
-                        <div className="space-y-2">
-                            <label className="flex items-center gap-2 text-sm text-base-content/80">
-                                <Checkbox
-                                    id="windows-safe-paths-checkbox"
-                                    aria-describedby="windows-safe-paths-help"
-                                    checked={config["webdav.windows-safe-paths"] !== "false"}
-                                    onChange={e => setNewConfig({ ...config, "webdav.windows-safe-paths": String(e.target.checked) })} />
-                                <span>Sanitize paths for Windows</span>
-                            </label>
-                            <p className="text-[11px] leading-relaxed text-base-content/45" id="windows-safe-paths-help">
-                                Replace characters that are invalid on Windows (<code>{`<>:"/\\|?*`}</code>), trim trailing
-                                dots/spaces, and prefix reserved device names. Recommended when using Windows WebDAV
-                                clients or rclone on Windows. Applies to newly mounted content only.
-                            </p>
-                        </div>
+                        <Tooltip content='Replace characters invalid on Windows (<>:"/\|?*), trim trailing dots/spaces, and prefix reserved device names. Applies to newly mounted content only.'>
+                            <Toggle
+                                id="windows-safe-paths-checkbox"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={config["webdav.windows-safe-paths"] !== "false"}
+                                onChange={e => setNewConfig({ ...config, "webdav.windows-safe-paths": String(e.target.checked) })}
+                                label={<span className="text-sm text-base-content">Sanitize paths for Windows</span>}
+                            />
+                        </Tooltip>
                     </ManagedSetting>
 
                     <ManagedSetting configKey="webdav.show-hidden-files">
-                        <div className="space-y-2">
-                            <label className="flex items-center gap-2 text-sm text-base-content/80">
-                                <Checkbox
-                                    id="show-hidden-files-checkbox"
-                                    aria-describedby="show-hidden-files-help"
-                                    checked={config["webdav.show-hidden-files"] === "true"}
-                                    onChange={e => setNewConfig({ ...config, "webdav.show-hidden-files": "" + e.target.checked })} />
-                                <span>{`Show hidden files on Dav Explorer`}</span>
-                            </label>
-                            <p className="text-[11px] leading-relaxed text-base-content/45" id="show-hidden-files-help">
-                                Hidden files or directories are those whose names are prefixed by a period.
-                            </p>
-                        </div>
+                        <Tooltip content="Show files and directories whose names are prefixed by a period in Dav Explorer.">
+                            <Toggle
+                                id="show-hidden-files-checkbox"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={config["webdav.show-hidden-files"] === "true"}
+                                onChange={e => setNewConfig({ ...config, "webdav.show-hidden-files": "" + e.target.checked })}
+                                label={<span className="text-sm text-base-content">Show hidden files on Dav Explorer</span>}
+                            />
+                        </Tooltip>
                     </ManagedSetting>
 
                     <ManagedSetting configKey="webdav.preview-par2-files">
-                        <div className="space-y-2">
-                            <label className="flex items-center gap-2 text-sm text-base-content/80">
-                                <Checkbox
-                                    id="preview-par2-files-checkbox"
-                                    aria-describedby="preview-par2-files-help"
-                                    checked={config["webdav.preview-par2-files"] === "true"}
-                                    onChange={e => setNewConfig({ ...config, "webdav.preview-par2-files": "" + e.target.checked })} />
-                                <span>{`Preview par2 files on Dav Explorer`}</span>
-                            </label>
-                            <p className="text-[11px] leading-relaxed text-base-content/45" id="preview-par2-files-help">
-                                When enabled, par2 files will be rendered as text files on the Dav Explorer page, displaying all File-Descriptor entries.
-                            </p>
-                        </div>
+                        <Tooltip content="Render par2 files as text in Dav Explorer, showing all File-Descriptor entries.">
+                            <Toggle
+                                id="preview-par2-files-checkbox"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={config["webdav.preview-par2-files"] === "true"}
+                                onChange={e => setNewConfig({ ...config, "webdav.preview-par2-files": "" + e.target.checked })}
+                                label={<span className="text-sm text-base-content">Preview par2 files on Dav Explorer</span>}
+                            />
+                        </Tooltip>
                     </ManagedSetting>
                 </SettingsCard>
             </div>
@@ -210,45 +192,38 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                 <ManagedSetting configKey="usenet.max-download-connections">
                     <div className="space-y-2">
                         <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-auto-checkbox">Max Download Connections</label>
-                        <Toggle
-                            id="max-download-connections-auto-checkbox"
-                            aria-describedby="max-download-connections-help"
-                            label="Auto — use all Pool provider connections"
-                            checked={isAutoMaxDownloadConnections(config["usenet.max-download-connections"])}
-                            onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.checked ? "0" : "15" })} />
+                        <Tooltip content="Connections used for WebDAV streaming. Auto uses the combined Pool provider limit; turn off to set a fixed number. Queue imports use their own budget above.">
+                            <Toggle
+                                id="max-download-connections-auto-checkbox"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={isAutoMaxDownloadConnections(config["usenet.max-download-connections"])}
+                                onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.checked ? "0" : "15" })}
+                                label={<span className="text-sm text-base-content">Auto — use all Pool provider connections</span>}
+                            />
+                        </Tooltip>
                         {!isAutoMaxDownloadConnections(config["usenet.max-download-connections"]) && (
                             <Input
                                 {...className(['w-full', !isValidMaxDownloadConnections(config["usenet.max-download-connections"]) && 'input-error'])}
                                 type="text"
                                 id="max-download-connections-input"
-                                aria-describedby="max-download-connections-help"
                                 placeholder="15"
                                 value={config["usenet.max-download-connections"]}
                                 onChange={e => setNewConfig({ ...config, "usenet.max-download-connections": e.target.value })} />
                         )}
-                        <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-help">
-                            The total connections used for <strong>webdav streaming</strong> (playback). Leave on
-                            <strong> Auto</strong> to use the combined connection limit of your Pool providers — it
-                            tracks changes as you add or remove providers — or turn Auto off to set a fixed number.
-                            Queue imports use their own budget — see Queue Download Connections above.
-                        </p>
                     </div>
                 </ManagedSetting>
 
                 <ManagedSetting configKeys={["usenet.max-download-connections-per-stream", "usenet.max-download-connections-per-stream-preset"]}>
                     <div className="space-y-2">
-                        <Toggle
-                            id="max-download-connections-per-stream-checkbox"
-                            aria-describedby="max-download-connections-per-stream-help"
-                            label="Apply limit per stream"
-                            checked={config["usenet.max-download-connections-per-stream"] === "true"}
-                            onChange={e => setNewConfig({ ...config, "usenet.max-download-connections-per-stream": String(e.target.checked) })} />
-                        <p className="text-[11px] leading-relaxed text-base-content/45" id="max-download-connections-per-stream-help">
-                            By default the budget above is a <strong>shared total</strong> across all active playback
-                            streams. Enable this to give each concurrent stream <strong>its own budget</strong> instead,
-                            sized by the performance preset below. Your provider&apos;s connection limit still applies as a
-                            hard ceiling on the total connections actually opened.
-                        </p>
+                        <Tooltip content="By default the budget above is shared across streams. Enable to give each concurrent stream its own budget, sized by the preset below. Provider limits still cap total connections.">
+                            <Toggle
+                                id="max-download-connections-per-stream-checkbox"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={config["usenet.max-download-connections-per-stream"] === "true"}
+                                onChange={e => setNewConfig({ ...config, "usenet.max-download-connections-per-stream": String(e.target.checked) })}
+                                label={<span className="text-sm text-base-content">Apply limit per stream</span>}
+                            />
+                        </Tooltip>
                         {config["usenet.max-download-connections-per-stream"] === "true" && (
                             <div className="space-y-2 border-l border-base-content/10 pl-4">
                                 <label className="block text-sm font-medium text-base-content" htmlFor="max-download-connections-per-stream-preset-select">Per-stream performance</label>
@@ -300,17 +275,15 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
             >
                 <ManagedSetting configKeys={["usenet.segment-cache.enabled", "usenet.segment-cache.path", "usenet.segment-cache.max-gb"]}>
                     <div className="space-y-2">
-                        <label className="flex items-center gap-2 text-sm text-base-content/80">
-                            <Checkbox
+                        <Tooltip content="Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.">
+                            <Toggle
                                 id="segment-cache-enabled-checkbox"
-                                aria-describedby="segment-cache-enabled-help"
+                                className="cursor-pointer gap-2 p-0"
                                 checked={config["usenet.segment-cache.enabled"] === "true"}
-                                onChange={e => setNewConfig({ ...config, "usenet.segment-cache.enabled": String(e.target.checked) })} />
-                            <span>Enable Segment Cache</span>
-                        </label>
-                        <p className="text-[11px] leading-relaxed text-base-content/45" id="segment-cache-enabled-help">
-                            Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.
-                        </p>
+                                onChange={e => setNewConfig({ ...config, "usenet.segment-cache.enabled": String(e.target.checked) })}
+                                label={<span className="text-sm text-base-content">Enable Segment Cache</span>}
+                            />
+                        </Tooltip>
                         {config["usenet.segment-cache.enabled"] === "true" && (
                             <div className="grid gap-4 border-l border-base-content/10 pl-4 sm:grid-cols-2">
                                 <label className="space-y-2 text-sm text-base-content/80">
@@ -448,21 +421,15 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                 </ManagedSetting>
 
                 <ManagedSetting configKey="usenet.pipelined-body-requests">
-                    <div className="space-y-2">
-                        <label className="flex items-center gap-2 text-sm text-base-content/80">
-                            <Checkbox
-                                id="pipelined-body-requests-checkbox"
-                                aria-describedby="pipelined-body-requests-help"
-                                checked={config["usenet.pipelined-body-requests"] === "true"}
-                                onChange={e => setNewConfig({ ...config, "usenet.pipelined-body-requests": "" + e.target.checked })} />
-                            <span>Pipelined article downloads</span>
-                        </label>
-                        <p className="text-[11px] leading-relaxed text-base-content/45" id="pipelined-body-requests-help">
-                            Fetch articles in small NNTP batches for smoother WebDAV streaming. Queue imports use the
-                            separate <strong>Enable NNTP pipelining</strong> toggle under Usenet settings. Disable this
-                            to use the legacy one-at-a-time API while retaining the configured article buffer.
-                        </p>
-                    </div>
+                    <Tooltip content="Fetch articles in small NNTP batches for smoother WebDAV streaming. Queue imports use the separate NNTP pipelining toggle under Usenet settings.">
+                        <Toggle
+                            id="pipelined-body-requests-checkbox"
+                            className="cursor-pointer gap-2 p-0"
+                            checked={config["usenet.pipelined-body-requests"] === "true"}
+                            onChange={e => setNewConfig({ ...config, "usenet.pipelined-body-requests": "" + e.target.checked })}
+                            label={<span className="text-sm text-base-content">Pipelined article downloads</span>}
+                        />
+                    </Tooltip>
                 </ManagedSetting>
             </SettingsCard>
         </SettingsPage>


### PR DESCRIPTION
## Summary
- Boolean settings now use shared daisyUI success toggles instead of checkboxes
- Each switch is wrapped in a short operator-facing tooltip; long inline help under dense controls is trimmed
- Multi-select, master/tri-state, and list-selection checkboxes are unchanged

## Test plan
- [ ] Spot-check WebDAV, SAB, repairs, rclone, maintenance, backup, indexers, and usenet settings for green on-state toggles
- [ ] Hover toggles and confirm tooltips explain the setting without broken layout
- [ ] Confirm SAB article-health master checkbox + category multi-select still work
- [ ] Confirm backup Preserve checkboxes and Warden export multi-select still work
- [ ] `cd frontend && npm run typecheck`