### PR TITLE
fix(ui): queue length badge updates live without refreshing

### DIFF
--- a/frontend/app/routes/queue/controllers/events-controller.test.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { adjustTotalCount } from "./events-controller";
+
+describe("adjustTotalCount", () => {
+    it("increments on add", () => {
+        expect(adjustTotalCount(0, 1)).toBe(1);
+        expect(adjustTotalCount(5, 1)).toBe(6);
+    });
+
+    it("increments even when the visible page is already full", () => {
+        // Totals track the full queue, not the pageSize window.
+        const pageSize = 25;
+        expect(adjustTotalCount(pageSize, 1)).toBe(pageSize + 1);
+        expect(adjustTotalCount(pageSize * 4, 1)).toBe(pageSize * 4 + 1);
+    });
+
+    it("decrements on remove by id count", () => {
+        expect(adjustTotalCount(3, -1)).toBe(2);
+        expect(adjustTotalCount(10, -3)).toBe(7);
+    });
+
+    it("clamps at zero on over-remove", () => {
+        expect(adjustTotalCount(0, -1)).toBe(0);
+        expect(adjustTotalCount(2, -5)).toBe(0);
+    });
+
+    it("supports history-style add then remove", () => {
+        let total = 0;
+        total = adjustTotalCount(total, 1);
+        total = adjustTotalCount(total, 1);
+        expect(total).toBe(2);
+        total = adjustTotalCount(total, -1);
+        expect(total).toBe(1);
+        total = adjustTotalCount(total, -1);
+        expect(total).toBe(0);
+        total = adjustTotalCount(total, -1);
+        expect(total).toBe(0);
+    });
+});

--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -20,6 +20,11 @@ export type HistoryEvents = {
     onRemoveHistorySlots: (ids: Set<string>) => void
 };
 
+/** Apply a delta to a live total, never going below zero. */
+export function adjustTotalCount(current: number, delta: number): number {
+    return Math.max(0, current + delta);
+}
+
 export function useQueueEvents(
     setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void,
     setQueueSlots: (value: React.SetStateAction<PresentationQueueSlot[]>) => void,
@@ -31,12 +36,12 @@ export function useQueueEvents(
         uploadQueueRef.current = uploadQueueRef.current.filter(x => x.queueSlot.status === "uploading" || x.queueSlot.filename !== queueSlot.filename);
         setUploadingFiles(files => files.filter(f => f.queueSlot.filename !== queueSlot.filename));
         setQueueSlots(slots => slots.length >= pageSize ? slots : [...slots, queueSlot]);
-    }, [setQueueSlots, pageSize]);
+    }, [setQueueSlots, setUploadingFiles, uploadQueueRef, pageSize]);
 
     const onSelectQueueSlots = useCallback((ids: Set<string>, isSelected: boolean) => {
         setUploadingFiles(files => files.map(x => ids.has(x.queueSlot.nzo_id) ? { ...x, queueSlot: { ...x.queueSlot, isSelected } } : x));
         setQueueSlots(slots => slots.map(x => ids.has(x.nzo_id) ? { ...x, isSelected } : x));
-    }, [setQueueSlots]);
+    }, [setQueueSlots, setUploadingFiles]);
 
     const onRemovingQueueSlots = useCallback((ids: Set<string>, isRemoving: boolean) => {
         setQueueSlots(slots => slots.map(x => ids.has(x.nzo_id) ? { ...x, isRemoving } : x));
@@ -46,7 +51,7 @@ export function useQueueEvents(
         uploadQueueRef.current = uploadQueueRef.current.filter(x => x.queueSlot.status === "uploading" || !ids.has(x.queueSlot.nzo_id));
         setUploadingFiles(files => files.filter(x => x.queueSlot.status === "uploading" || !ids.has(x.queueSlot.nzo_id)));
         setQueueSlots(slots => slots.filter(x => !ids.has(x.nzo_id)));
-    }, [setQueueSlots]);
+    }, [setQueueSlots, setUploadingFiles, uploadQueueRef]);
 
     const onMoveQueueSlotsToTop = useCallback((ids: Set<string>) => {
         if (ids.size === 0) return;
@@ -117,7 +122,7 @@ export function useQueueEvents(
 
 export function useHistoryEvents(
     setHistorySlots: (value: React.SetStateAction<PresentationHistorySlot[]>) => void,
-    pageSize: number
+    pageSize: number,
 ) {
     const onAddHistorySlot = useCallback((historySlot: HistorySlot) => {
         setHistorySlots(slots => [historySlot, ...slots].slice(0, pageSize));

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import type { HistoryEvents, QueueEvents } from "./events-controller";
+import { adjustTotalCount } from "./events-controller";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
 
 const topicNames = {
@@ -29,13 +30,21 @@ export function useQueueHistoryWebsocket(
     historyEvents: HistoryEvents,
     isQueueLive: boolean,
     isHistoryLive: boolean,
+    setTotalQueueCount: (value: React.SetStateAction<number>) => void,
+    setTotalHistoryCount: (value: React.SetStateAction<number>) => void,
 ) {
     const onWebsocketMessage = useCallback((topic: string, message: string) => {
         if (topic == topicNames.queueItemAdded) {
+            // Totals always; slot window only on live page 1.
+            // Count updates live here (not in UI handlers) so optimistic UI remove + qr
+            // do not double-decrement.
+            setTotalQueueCount(count => adjustTotalCount(count, 1));
             if (isQueueLive) queueEvents.onAddQueueSlot(JSON.parse(message));
         }
         else if (topic == topicNames.queueItemRemoved) {
-            if (isQueueLive) queueEvents.onRemoveQueueSlots(new Set<string>(message.split(',')));
+            const ids = message.split(',').filter(Boolean);
+            setTotalQueueCount(count => adjustTotalCount(count, -ids.length));
+            if (isQueueLive) queueEvents.onRemoveQueueSlots(new Set<string>(ids));
         }
         else if (topic == topicNames.queueItemMoved) {
             queueEvents.onMoveQueueSlotsToTop(new Set<string>(message.split(',').filter(Boolean)));
@@ -47,16 +56,21 @@ export function useQueueHistoryWebsocket(
         else if (topic == topicNames.queueItemProviders)
             queueEvents.onChangeQueueSlotProviders(message);
         else if (topic == topicNames.historyItemAdded) {
+            setTotalHistoryCount(count => adjustTotalCount(count, 1));
             if (isHistoryLive) historyEvents.onAddHistorySlot(JSON.parse(message));
         }
         else if (topic == topicNames.historyItemRemoved) {
-            if (isHistoryLive) historyEvents.onRemoveHistorySlots(new Set<string>(message.split(',')));
+            const ids = message.split(',').filter(Boolean);
+            setTotalHistoryCount(count => adjustTotalCount(count, -ids.length));
+            if (isHistoryLive) historyEvents.onRemoveHistorySlots(new Set<string>(ids));
         }
     }, [
         queueEvents,
         historyEvents,
         isQueueLive,
-        isHistoryLive
+        isHistoryLive,
+        setTotalQueueCount,
+        setTotalHistoryCount,
     ]);
 
     useWebsocketTopics(topicSubscriptions, onWebsocketMessage);

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -60,9 +60,11 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export default function Queue(props: Route.ComponentProps) {
-    const { queuePageSize, historyPageSize, queuePage, historyPage, totalQueueCount, totalHistoryCount } = props.loaderData;
+    const { queuePageSize, historyPageSize, queuePage, historyPage } = props.loaderData;
     const [queueSlots, setQueueSlots] = useState<PresentationQueueSlot[]>(props.loaderData.queueSlots);
     const [historySlots, setHistorySlots] = useState<PresentationHistorySlot[]>(props.loaderData.historySlots);
+    const [totalQueueCount, setTotalQueueCount] = useState(props.loaderData.totalQueueCount);
+    const [totalHistoryCount, setTotalHistoryCount] = useState(props.loaderData.totalHistoryCount);
     const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
     const uploadQueueRef = useRef<UploadingFile[]>([]);
     const manualCategoryRef = useRef<string>(props.loaderData.manualCategory);
@@ -71,6 +73,8 @@ export default function Queue(props: Route.ComponentProps) {
 
     useEffect(() => { setQueueSlots(props.loaderData.queueSlots); }, [props.loaderData.queueSlots]);
     useEffect(() => { setHistorySlots(props.loaderData.historySlots); }, [props.loaderData.historySlots]);
+    useEffect(() => { setTotalQueueCount(props.loaderData.totalQueueCount); }, [props.loaderData.totalQueueCount]);
+    useEffect(() => { setTotalHistoryCount(props.loaderData.totalHistoryCount); }, [props.loaderData.totalHistoryCount]);
 
     const queueTotalPages = Math.max(1, Math.ceil(totalQueueCount / queuePageSize));
     const historyTotalPages = Math.max(1, Math.ceil(totalHistoryCount / historyPageSize));
@@ -113,7 +117,14 @@ export default function Queue(props: Route.ComponentProps) {
     const historyEvents = useHistoryEvents(setHistorySlots, historyPageSize);
 
     // websocket
-    useQueueHistoryWebsocket(queueEvents, historyEvents, isQueueLive, isHistoryLive);
+    useQueueHistoryWebsocket(
+        queueEvents,
+        historyEvents,
+        isQueueLive,
+        isHistoryLive,
+        setTotalQueueCount,
+        setTotalHistoryCount,
+    );
 
     // uploads
     const dropzone = useQueueDropzone(setUploadingFiles, uploadQueueRef, manualCategoryRef);
@@ -136,7 +147,7 @@ export default function Queue(props: Route.ComponentProps) {
                     <input {...dropzone.getInputProps()} />
                     <QueueTable
                         queueSlots={combinedQueueSlots}
-                        totalQueueCount={props.loaderData.totalQueueCount + uploadingFiles.length}
+                        totalQueueCount={totalQueueCount + uploadingFiles.length}
                         pageNumber={queuePage}
                         pageSize={queuePageSize}
                         pageSizeOptions={PAGE_SIZE_OPTIONS}
@@ -156,10 +167,10 @@ export default function Queue(props: Route.ComponentProps) {
             </div>
 
             {/* history */}
-            {totalHistoryCount > 0 &&
+            {(totalHistoryCount > 0 || historySlots.length > 0) &&
                 <HistoryTable
                     historySlots={historySlots}
-                    totalHistoryCount={props.loaderData.totalHistoryCount}
+                    totalHistoryCount={totalHistoryCount}
                     pageNumber={historyPage}
                     pageSize={historyPageSize}
                     pageSizeOptions={PAGE_SIZE_OPTIONS}


### PR DESCRIPTION
## Summary
- Queue/history section badges and pagination stay in sync with websocket `qa`/`qr`/`ha`/`hr` instead of freezing at the loader snapshot
- History section can appear live when the first completed item arrives from an empty start
- Totals update on every page; slot list mutations remain page-1-only to avoid double-counting with optimistic UI removes

## Test plan
- [ ] Open `/queue` with an empty queue — no badge
- [ ] Add an NZB (upload or *Arr) without refreshing — row appears and badge increments
- [ ] Let an item complete — queue badge decrements, History section appears/updates
- [ ] Remove an item from the UI — badge decrements once (no double-count)
- [ ] On page 2+, add/remove items elsewhere — badge/pagination update; rows stay page-scoped
- [ ] `cd frontend && npm test -- app/routes/queue/controllers/events-controller.test.ts`