### PR TITLE
fix(ui): stop Connections tile clipping when the window narrows

### DIFF
--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -28,7 +28,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
 
   return (
     <>
-      <div className="navbar-start gap-1 px-2 md:px-4">
+      <div className="navbar-start !w-auto shrink-0 gap-1 px-2 md:px-4">
         <label
           htmlFor={drawerToggleId}
           aria-label={isHamburgerMenuOpen ? "Close navigation" : "Open navigation"}
@@ -47,7 +47,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
         </button>
       </div>
 
-      <div className="navbar-end items-center gap-2 px-2 md:px-4">
+      <div className="navbar-end !w-auto ml-auto min-w-0 items-center gap-2 px-2 md:px-4">
         <LiveUsenetConnections hasUsenetProviders={!!hasUsenetProviders} />
         <div className="dropdown dropdown-end">
           <div


### PR DESCRIPTION
## Summary
- Override daisyUI’s `navbar-start` / `navbar-end` 50% widths so branding is content-sized and the Connections + version controls can use the leftover space.
- Prevents the header Connections tile from clipping at mid widths while empty space sits next to the logo.

## Test plan
- [ ] Narrow the viewport through `sm`–tablet widths with Connections visible: tile and version pill fully visible, no right-edge clip
- [ ] Wide desktop: logo left, controls right — same hierarchy
- [ ] Mobile (`<sm`): Connections hidden; hamburger + logo + version pill still lay out cleanly