### PR TITLE
fix(ui): color overview charts only when activity occurs

### DIFF
--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { OutageBuckets } from "./provider-scoreboard";
+import { OutageBuckets, Sparkline } from "./provider-scoreboard";
 
 describe("OutageBuckets", () => {
     it("keeps a brief trip inside its single time bucket", () => {
@@ -19,5 +19,25 @@ describe("OutageBuckets", () => {
         expect(markup).toContain('height="9"');
         expect(markup).toContain('height="18"');
         expect(markup).toContain('aria-label="Circuit-open time by interval, peak 100%"');
+    });
+});
+
+describe("Sparkline event mode", () => {
+    it("uses only the neutral line when every bucket is zero", () => {
+        const errors = renderToStaticMarkup(<Sparkline values={[0, 0, 0]} tone="error" eventsOnly />);
+        const retries = renderToStaticMarkup(<Sparkline values={[0, 0, 0]} tone="warning" eventsOnly />);
+
+        expect(errors).toContain("var(--color-base-content)");
+        expect(errors).not.toContain("var(--color-error)");
+        expect(retries).toContain("var(--color-base-content)");
+        expect(retries).not.toContain("var(--color-warning)");
+    });
+
+    it("colors only the portions surrounding event buckets", () => {
+        const markup = renderToStaticMarkup(<Sparkline values={[0, 2, 0, 0, 4, 0]} tone="error" eventsOnly />);
+
+        expect(markup.match(/<path/g)).toHaveLength(2);
+        expect(markup).toContain("var(--color-base-content)");
+        expect(markup).toContain("var(--color-error)");
     });
 });

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -79,7 +79,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                             </td>
                                             <td>
                                                 <div className="flex flex-col gap-0.5">
-                                                    <Sparkline values={p.errorSpark ?? []} tone="error" />
+                                                    <Sparkline values={p.errorSpark ?? []} tone="error" eventsOnly />
                                                     <div className={`font-mono text-[11px] tabular-nums ${p.errorRate > 0.05 ? "text-error" : "text-base-content/60"}`}>
                                                         {formatNumber(p.errors)}
                                                         {p.errorRate > 0 && (
@@ -92,7 +92,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                             </td>
                                             <td>
                                                 <div className="flex flex-col gap-0.5">
-                                                    <Sparkline values={p.retrySpark ?? []} tone="warning" />
+                                                    <Sparkline values={p.retrySpark ?? []} tone="warning" eventsOnly />
                                                     <div className={`font-mono text-[11px] tabular-nums ${p.retries > 0 ? "text-warning" : "text-base-content/60"}`}>
                                                         {formatNumber(p.retries)}
                                                     </div>
@@ -227,12 +227,40 @@ export function OutageBuckets({ values }: { values: number[] }) {
     );
 }
 
-function Sparkline({
+type SparklineTone = "success" | "error" | "warning";
+
+function buildEventPath(values: number[], step: number, y: (value: number) => number) {
+    const parts: string[] = [];
+    for (let index = 0; index < values.length;) {
+        if (values[index] <= 0) {
+            index++;
+            continue;
+        }
+
+        const firstEventIndex = index;
+        while (index + 1 < values.length && values[index + 1] > 0) index++;
+        const lastEventIndex = index;
+        const startIndex = Math.max(0, firstEventIndex - 1);
+        const endIndex = Math.min(values.length - 1, lastEventIndex + 1);
+        for (let pointIndex = startIndex; pointIndex <= endIndex; pointIndex++) {
+            parts.push(
+                `${pointIndex === startIndex ? "M" : "L"}${(pointIndex * step).toFixed(1)},${y(values[pointIndex]).toFixed(1)}`,
+            );
+        }
+        index = lastEventIndex + 1;
+    }
+
+    return parts.join(" ");
+}
+
+export function Sparkline({
     values,
     tone = "success",
+    eventsOnly = false,
 }: {
     values: number[],
-    tone?: "success" | "error" | "warning",
+    tone?: SparklineTone,
+    eventsOnly?: boolean,
 }) {
     if (values.length === 0) return <div className="h-[22px] w-[110px] rounded-sm bg-base-content/[0.04]" />;
     const w = 110;
@@ -244,16 +272,31 @@ function Sparkline({
         .map((v, i) => `${i === 0 ? "M" : "L"}${(i * step).toFixed(1)},${y(v).toFixed(1)}`)
         .join(" ");
     const area = `${path} L${((values.length - 1) * step).toFixed(1)},${h} L0,${h} Z`;
-    const colorVar = tone === "error"
-        ? "var(--color-error)"
-        : tone === "warning"
-            ? "var(--color-warning)"
-            : "var(--color-success)";
+    const colorVar = sparklineColor(tone);
     const fill = `color-mix(in srgb, ${colorVar} 16%, transparent)`;
+    const eventPath = eventsOnly ? buildEventPath(values, step, y) : path;
     return (
         <svg viewBox={`0 0 ${w} ${h}`} className="block h-[22px] w-[110px]" preserveAspectRatio="none">
-            <path d={area} fill={fill} />
-            <path d={path} fill="none" stroke={colorVar} strokeWidth="1.2" vectorEffect="non-scaling-stroke" />
+            {eventsOnly ? (
+                <path
+                    d={path}
+                    fill="none"
+                    stroke="var(--color-base-content)"
+                    strokeOpacity="0.12"
+                    strokeWidth="1.2"
+                    vectorEffect="non-scaling-stroke" />
+            ) : (
+                <path d={area} fill={fill} />
+            )}
+            {eventPath && (
+                <path d={eventPath} fill="none" stroke={colorVar} strokeWidth="1.2" vectorEffect="non-scaling-stroke" />
+            )}
         </svg>
     );
+}
+
+function sparklineColor(tone: SparklineTone) {
+    if (tone === "error") return "var(--color-error)";
+    if (tone === "warning") return "var(--color-warning)";
+    return "var(--color-success)";
 }

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { ThroughputPoint } from "~/clients/backend-client.server";
+import { ThroughputChart } from "./throughput-chart";
+
+const point = (articles: number, errors = 0): ThroughputPoint => ({
+    bucket: 0,
+    articles,
+    misses: 0,
+    errors,
+    bytesServed: 0,
+    bytesFetched: 0,
+});
+
+function render(points: ThroughputPoint[], totalErrors = 0) {
+    return renderToStaticMarkup(
+        <ThroughputChart
+            points={points}
+            totalArticles={points.reduce((sum, item) => sum + item.articles, 0)}
+            totalMisses={0}
+            totalErrors={totalErrors}
+            totalBytesServed={0}
+            bucketSizeMs={60_000}
+            window="24h" />,
+    );
+}
+
+describe("ThroughputChart", () => {
+    it("does not draw the green series when every article bucket is zero", () => {
+        const markup = render([point(0, 1), point(0)], 1);
+
+        expect(markup).not.toContain('data-series="articles"');
+        expect(markup).toContain('data-series="errors"');
+    });
+
+    it("draws the green series when an article bucket has activity", () => {
+        const markup = render([point(0), point(2)]);
+
+        expect(markup).toContain('data-series="articles"');
+    });
+});

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -42,22 +42,23 @@ export function ThroughputChart({
                 yPercent: (_: number) => 0,
             };
         }
-        const max = Math.max(1, ...points.map(p => p.articles));
+        const peakArticles = Math.max(0, ...points.map(p => p.articles));
+        const scaleMax = Math.max(1, peakArticles);
         const maxRate = Math.max(0, ...points.map(p => (p.bytesFetched ?? 0) / bucketSeconds));
         const xStep = points.length > 1 ? VB_W / (points.length - 1) : 0;
         const innerH = VB_H - TOP_PAD - BOT_PAD;
-        const y = (v: number) => VB_H - BOT_PAD - (v / max) * innerH;
+        const y = (v: number) => VB_H - BOT_PAD - (v / scaleMax) * innerH;
 
         const buildArticlesPath = () =>
             points.map((p, i) => `${i === 0 ? "M" : "L"}${(i * xStep).toFixed(1)},${y(p.articles).toFixed(1)}`).join(" ");
 
         const xPct = (i: number) => points.length > 1 ? (i / (points.length - 1)) * 100 : 50;
-        const yPct = (v: number) => 100 - ((v / max) * (1 - (TOP_PAD + BOT_PAD) / VB_H) * 100 + (BOT_PAD / VB_H) * 100);
+        const yPct = (v: number) => 100 - ((v / scaleMax) * (1 - (TOP_PAD + BOT_PAD) / VB_H) * 100 + (BOT_PAD / VB_H) * 100);
 
         return {
             articlesPath: buildArticlesPath(),
             errorsPath: buildSparseErrorsPath(points, xStep, y),
-            maxArticles: max,
+            maxArticles: peakArticles,
             maxNetworkRate: maxRate,
             xPercent: xPct,
             yPercent: yPct,
@@ -93,7 +94,8 @@ export function ThroughputChart({
         if (t) onMove(t.clientX, e.currentTarget);
     };
 
-    const hasData = points.length > 0 && maxArticles > 0;
+    const hasData = points.length > 0;
+    const hasArticleActivity = maxArticles > 0;
     const bucketLabel = window === "1h" || window === "24h" ? "min" : (window === "all" ? "day" : "hour");
     const hover = hoverIdx !== null ? points[hoverIdx] : null;
     const hoverNetworkRate = hover ? (hover.bytesFetched ?? 0) / bucketSeconds : 0;
@@ -142,8 +144,8 @@ export function ThroughputChart({
                                 <line x1="0" y1={(VB_H - BOT_PAD).toFixed(1)} x2={VB_W} y2={(VB_H - BOT_PAD).toFixed(1)} className={styles.gridline} />
                                 <line x1="0" y1={(VB_H / 2).toFixed(1)} x2={VB_W} y2={(VB_H / 2).toFixed(1)} className={styles.gridline} />
                                 <line x1="0" y1={TOP_PAD.toFixed(1)} x2={VB_W} y2={TOP_PAD.toFixed(1)} className={styles.gridline} />
-                                <path d={articlesPath} className={styles.lineArticles} />
-                                {totalErrors > 0 && errorsPath && <path d={errorsPath} className={styles.lineErrors} />}
+                                {hasArticleActivity && <path d={articlesPath} className={styles.lineArticles} data-series="articles" />}
+                                {totalErrors > 0 && errorsPath && <path d={errorsPath} className={styles.lineErrors} data-series="errors" />}
                             </svg>
 
                             {hover && hoverIdx !== null && (


### PR DESCRIPTION
## Summary
- draw idle provider error and retry history with a neutral baseline
- apply red and yellow only to provider chart segments containing events
- omit the green overview activity series when every article bucket is zero
- report the true zero article peak while retaining the chart grid and any error events

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm run lint`
- [x] Preview the 24-hour overview with zero article activity