### PR TITLE
chore(docs): recommend rclone mount flags that avoid overnight Usenet spikes

### DIFF
--- a/docs/configuration/rclone.md
+++ b/docs/configuration/rclone.md
@@ -1,6 +1,6 @@
 # Rclone Server
 
-Notify rclone RC when WebDAV files change (useful with high `dir-cache-time`).
+Notify rclone RC when WebDAV files change (useful with a longer `dir-cache-time` such as `1h`).
 
 !!! tip "Headless ENV"
 
@@ -12,9 +12,9 @@ Notify rclone RC when WebDAV files change (useful with high `dir-cache-time`).
 |---------|------------|---------|--------|
 | Enable Rclone RC notifications | `rclone.rc-enabled` | off | Auto `vfs/forget` on add/remove |
 | Rclone Server Host | `rclone.host` | empty | e.g. `http://nzbdav_rclone:5572` |
-| Rclone Server User | `rclone.user` | empty | Optional |
-| Rclone Server Password | `rclone.pass` | empty | Optional |
+| Rclone Server User | `rclone.user` | empty | Optional — leave empty with `--rc-no-auth` |
+| Rclone Server Password | `rclone.pass` | empty | Optional — leave empty with `--rc-no-auth` |
+
+The recommended mount command, RC bind address notes, and optional RC auth are in [Mounting WebDAV](../guides/mounting-webdav.md).
 
 Mount directory for symlink imports is configured on the [SABnzbd](sabnzbd.md) tab (`rclone.mount-dir`).
-
-[Mounting WebDAV](../guides/mounting-webdav.md)

--- a/docs/guides/media-servers.md
+++ b/docs/guides/media-servers.md
@@ -5,7 +5,7 @@
 Use **Symlinks — Plex** import strategy and an [rclone mount](mounting-webdav.md).
 
 1. Library folders should follow the symlinks under your media root (often via *Arr hardlink/move into `/mnt/media/...` that still points at `.ids` content).
-2. Prefer analysis settings that do not thrash the entire WebDAV tree continuously. Even with intro detection / loudness / preview thumbnails / deep analysis off, routine library scans still probe files — pair that with a conservative [rclone mount](mounting-webdav.md) (`--buffer-size=0M`, modest read-ahead).
+2. Prefer analysis settings that do not thrash the entire WebDAV tree continuously. Even with intro detection / loudness / preview thumbnails / deep analysis off, routine library scans still probe files — pair that with a conservative [rclone mount](mounting-webdav.md) (`--buffer-size=0M`, no `--vfs-read-ahead`).
 3. Disable **Empty trash automatically after every scan**. An rclone remount (for example when a compose `depends_on.restart` bounces the mount with NzbDAV) can briefly look empty; empty-trash would treat that as a mass delete.
 4. Watch Overview **Active Reads** and **Served** — unexpected sustained bandwidth often means library scans or VFS cache churn.
 

--- a/docs/guides/media-servers.md
+++ b/docs/guides/media-servers.md
@@ -5,8 +5,9 @@
 Use **Symlinks — Plex** import strategy and an [rclone mount](mounting-webdav.md).
 
 1. Library folders should follow the symlinks under your media root (often via *Arr hardlink/move into `/mnt/media/...` that still points at `.ids` content).
-2. Prefer analysis settings that do not thrash the entire WebDAV tree continuously.
-3. Watch Overview **Active Reads** — unexpected sustained bandwidth often means library scans or VFS cache churn.
+2. Prefer analysis settings that do not thrash the entire WebDAV tree continuously. Even with intro detection / loudness / preview thumbnails / deep analysis off, routine library scans still probe files — pair that with a conservative [rclone mount](mounting-webdav.md) (`--buffer-size=0M`, modest read-ahead).
+3. Disable **Empty trash automatically after every scan**. An rclone remount (for example when a compose `depends_on.restart` bounces the mount with NzbDAV) can briefly look empty; empty-trash would treat that as a mass delete.
+4. Watch Overview **Active Reads** and **Served** — unexpected sustained bandwidth often means library scans or VFS cache churn.
 
 ## Emby / Jellyfin
 

--- a/docs/guides/mounting-webdav.md
+++ b/docs/guides/mounting-webdav.md
@@ -73,6 +73,7 @@ The recommended mount enables rclone RC notifications so directory listings stay
         --vfs-cache-max-size=50G
         --vfs-cache-max-age=2160h
         --buffer-size=0M
+        --vfs-read-chunk-size=16M
         --vfs-read-chunk-size-limit=512M
         --no-modtime
         --no-checksum
@@ -107,6 +108,7 @@ Then **Settings → Rclone Server**: enable notifications, host `http://nzbdav_r
 | `--use-cookies` | Avoid re-auth on every request |
 | `--vfs-cache-mode=full` | Disk-backed read cache for smooth seeks |
 | `--buffer-size=0M` | Avoid double-caching with VFS full mode (large buffers amplify scan probes) |
+| `--vfs-read-chunk-size=16M` | Initial range size for uncached reads (smaller probes before chunk growth) |
 | `--vfs-read-chunk-size-limit=512M` | Cap rclone's unbounded chunk-size doubling |
 | `--vfs-cache-max-age=2160h` | Immutable content — prefer size-based eviction over daily expiry (~90 days) |
 | `--no-modtime` / `--no-checksum` | Skip irrelevant WebDAV metadata churn |

--- a/docs/guides/mounting-webdav.md
+++ b/docs/guides/mounting-webdav.md
@@ -38,6 +38,8 @@ chmod 600 rclone.conf
 
 ## Sidecar Compose service
 
+The recommended mount enables rclone RC notifications so directory listings stay fresh without a very short `--dir-cache-time`. NzbDAV content is immutable after import: prefer a large VFS cache sized to disk, a long `--vfs-cache-max-age`, and modest read-ahead — large `--buffer-size` / `--vfs-read-ahead` values amplify media-server scan probes into multi‑hundred‑MB Usenet fetches per touched file.
+
 ```yaml
   nzbdav_rclone:
     image: rclone/rclone:latest
@@ -68,11 +70,18 @@ chmod 600 rclone.conf
         --links
         --use-cookies
         --vfs-cache-mode=full
-        --vfs-cache-max-size=20G
-        --vfs-cache-max-age=24h
+        --vfs-cache-max-size=50G
+        --vfs-cache-max-age=1000h
         --buffer-size=0M
-        --vfs-read-ahead=512M
-        --dir-cache-time=20s
+        --vfs-read-ahead=64M
+        --vfs-read-chunk-size-limit=512M
+        --no-modtime
+        --no-checksum
+        --dir-cache-time=1h
+        --poll-interval=0
+        --rc
+        --rc-addr=:5572
+        --rc-no-auth
 ```
 
 ```bash
@@ -81,6 +90,16 @@ ls -la /mnt/remote/nzbdav
 # Expect: .ids, completed-symlinks, content, nzbs
 ```
 
+Then **Settings → Rclone Server**: enable notifications, host `http://nzbdav_rclone:5572`, leave User and Password empty (matches `--rc-no-auth`). Use the Test connection button to confirm NzbDAV can reach the RC endpoint — bind `--rc-addr` to `:5572` (or `0.0.0.0:5572`), not `127.0.0.1`, when NzbDAV runs in another container.
+
+!!! tip "Sizing the VFS cache"
+
+    Raise `--vfs-cache-max-size` to fit available disk (for example `200G`). Age-based eviction uses last access time; `--vfs-cache-max-age=off` is not valid in rclone — use a large duration such as `1000h` and let max-size do the real eviction.
+
+!!! warning "Plex and remounts"
+
+    `depends_on.restart: true` remounts rclone whenever the `nzbdav` service restarts. During that remount the mount point can briefly look empty, which Plex may treat as a library-wide delete. Disable **Empty trash automatically after every scan** in Plex, and prefer upgrading or restarting during off-hours.
+
 ## Flag cheat sheet
 
 | Flag | Why |
@@ -88,21 +107,38 @@ ls -la /mnt/remote/nzbdav
 | `--links` | Turn `*.rclonelink` into real symlinks (rclone ≥ 1.70.3) |
 | `--use-cookies` | Avoid re-auth on every request |
 | `--vfs-cache-mode=full` | Disk-backed read cache for smooth seeks |
-| `--buffer-size=0M` | Avoid double-caching with VFS |
-| `--vfs-read-ahead=512M` | Buffer ahead for high-bitrate spikes |
-| `--dir-cache-time=20s` | Fresh listings without RC; raise if using RC notifications |
+| `--buffer-size=0M` | Avoid double-caching with VFS full mode (large buffers amplify scan probes) |
+| `--vfs-read-ahead=64M` | Modest ahead-buffer for playback; NzbDAV already read-aheads server-side |
+| `--vfs-read-chunk-size-limit=512M` | Cap rclone's unbounded chunk-size doubling |
+| `--vfs-cache-max-age=1000h` | Immutable content — prefer size-based eviction over daily expiry |
+| `--no-modtime` / `--no-checksum` | Skip irrelevant WebDAV metadata churn |
+| `--dir-cache-time=1h` | With RC notifications, listings stay fresh via `vfs/forget`; 1h is a self-heal backstop |
+| `--poll-interval=0` | Disable remote polling; RC notifications own invalidation |
+| `--rc` / `--rc-addr=:5572` / `--rc-no-auth` | Let NzbDAV notify the mount on add/remove |
 
-## Optional RC notifications
+### Without RC notifications
 
-Append to the mount command:
+If you skip RC, set `--dir-cache-time` much lower (for example `20s`) so new imports appear promptly, and omit `--poll-interval=0` (or leave rclone's default). Expect more WebDAV listing traffic during library scans.
+
+### Optional RC authentication
+
+For a private Docker network, `--rc-no-auth` is fine. If the RC port is reachable beyond that network, replace `--rc-no-auth` with:
 
 ```yaml
-        --rc
-        --rc-addr=:5572
         --rc-user=rclone
         --rc-pass=your-rc-password
 ```
 
-Then **Settings → Rclone Server**: enable notifications, host `http://nzbdav_rclone:5572`, matching credentials. Raise `--dir-cache-time` once RC works.
+Then set the same User and Password under **Settings → Rclone Server**.
 
 [Rclone settings](../configuration/rclone.md)
+
+## High Overview “Served” overnight
+
+Overview **Served** counts decoded bytes actually written to HTTP clients — not the full size of library items that were only probed. Common amplifiers with rclone mounts:
+
+- Large `--buffer-size` or `--vfs-read-ahead` with `--vfs-cache-mode=full` (each media-server probe can download hundreds of MB)
+- Short `--vfs-cache-max-age` (nightly scans re-fetch previously cached probes)
+- Plex / *Arr / Bazarr scans, embedded-subtitle searches, or backup tools walking the mount
+
+See also [Media servers](media-servers.md) and [Troubleshooting](troubleshooting.md).

--- a/docs/guides/mounting-webdav.md
+++ b/docs/guides/mounting-webdav.md
@@ -38,7 +38,7 @@ chmod 600 rclone.conf
 
 ## Sidecar Compose service
 
-The recommended mount enables rclone RC notifications so directory listings stay fresh without a very short `--dir-cache-time`. NzbDAV content is immutable after import: prefer a large VFS cache sized to disk, a long `--vfs-cache-max-age`, and modest read-ahead — large `--buffer-size` / `--vfs-read-ahead` values amplify media-server scan probes into multi‑hundred‑MB Usenet fetches per touched file.
+The recommended mount enables rclone RC notifications so directory listings stay fresh without a very short `--dir-cache-time`. NzbDAV content is immutable after import: prefer a large VFS cache sized to disk and a long `--vfs-cache-max-age`. Large `--buffer-size` or `--vfs-read-ahead` values amplify media-server scan probes into multi‑hundred‑MB Usenet fetches per touched file — leave them unset (or `0`) and rely on NzbDAV's server-side read-ahead.
 
 ```yaml
   nzbdav_rclone:
@@ -71,9 +71,8 @@ The recommended mount enables rclone RC notifications so directory listings stay
         --use-cookies
         --vfs-cache-mode=full
         --vfs-cache-max-size=50G
-        --vfs-cache-max-age=1000h
+        --vfs-cache-max-age=2160h
         --buffer-size=0M
-        --vfs-read-ahead=64M
         --vfs-read-chunk-size-limit=512M
         --no-modtime
         --no-checksum
@@ -94,7 +93,7 @@ Then **Settings → Rclone Server**: enable notifications, host `http://nzbdav_r
 
 !!! tip "Sizing the VFS cache"
 
-    Raise `--vfs-cache-max-size` to fit available disk (for example `200G`). Age-based eviction uses last access time; `--vfs-cache-max-age=off` is not valid in rclone — use a large duration such as `1000h` and let max-size do the real eviction.
+    Raise `--vfs-cache-max-size` to fit available disk (for example `200G`). Age-based eviction uses last access time; `--vfs-cache-max-age=off` is not valid in rclone — use a large duration such as `2160h` (~90 days) and let max-size do the real eviction.
 
 !!! warning "Plex and remounts"
 
@@ -108,9 +107,8 @@ Then **Settings → Rclone Server**: enable notifications, host `http://nzbdav_r
 | `--use-cookies` | Avoid re-auth on every request |
 | `--vfs-cache-mode=full` | Disk-backed read cache for smooth seeks |
 | `--buffer-size=0M` | Avoid double-caching with VFS full mode (large buffers amplify scan probes) |
-| `--vfs-read-ahead=64M` | Modest ahead-buffer for playback; NzbDAV already read-aheads server-side |
 | `--vfs-read-chunk-size-limit=512M` | Cap rclone's unbounded chunk-size doubling |
-| `--vfs-cache-max-age=1000h` | Immutable content — prefer size-based eviction over daily expiry |
+| `--vfs-cache-max-age=2160h` | Immutable content — prefer size-based eviction over daily expiry (~90 days) |
 | `--no-modtime` / `--no-checksum` | Skip irrelevant WebDAV metadata churn |
 | `--dir-cache-time=1h` | With RC notifications, listings stay fresh via `vfs/forget`; 1h is a self-heal backstop |
 | `--poll-interval=0` | Disable remote polling; RC notifications own invalidation |
@@ -137,7 +135,7 @@ Then set the same User and Password under **Settings → Rclone Server**.
 
 Overview **Served** counts decoded bytes actually written to HTTP clients — not the full size of library items that were only probed. Common amplifiers with rclone mounts:
 
-- Large `--buffer-size` or `--vfs-read-ahead` with `--vfs-cache-mode=full` (each media-server probe can download hundreds of MB)
+- Large `--buffer-size` or `--vfs-read-ahead` with `--vfs-cache-mode=full` (each media-server probe can download hundreds of MB — omit both; NzbDAV read-aheads server-side)
 - Short `--vfs-cache-max-age` (nightly scans re-fetch previously cached probes)
 - Plex / *Arr / Bazarr scans, embedded-subtitle searches, or backup tools walking the mount
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -13,6 +13,14 @@
 - Overview **Active Reads**: unexpected traffic → rclone VFS or media-server scans.
 - Try disabling segment cache or adjusting Max Download Connections — [WebDAV](../configuration/webdav.md).
 
+## Overview “Served” spikes overnight
+
+**Served** is actual bytes delivered over WebDAV/HTTP, not declared file sizes. Overnight spikes with Plex deep-analysis jobs disabled usually mean something is still reading the mount (library scans, Bazarr, backups) and rclone is amplifying each probe:
+
+- Prefer `--buffer-size=0M` and modest `--vfs-read-ahead` (see [Mounting WebDAV](mounting-webdav.md))
+- Prefer a long `--vfs-cache-max-age` and a large `--vfs-cache-max-size` so scan probes are not re-downloaded every night
+- Confirm **Settings → Rclone Server** can reach RC (`--rc-addr` must not be `127.0.0.1` across containers)
+
 ## *Arr won't import
 
 - Paths must match exactly between NzbDAV completed path and *Arr containers.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -17,8 +17,8 @@
 
 **Served** is actual bytes delivered over WebDAV/HTTP, not declared file sizes. Overnight spikes with Plex deep-analysis jobs disabled usually mean something is still reading the mount (library scans, Bazarr, backups) and rclone is amplifying each probe:
 
-- Prefer `--buffer-size=0M` and modest `--vfs-read-ahead` (see [Mounting WebDAV](mounting-webdav.md))
-- Prefer a long `--vfs-cache-max-age` and a large `--vfs-cache-max-size` so scan probes are not re-downloaded every night
+- Prefer `--buffer-size=0M` and omit `--vfs-read-ahead` (see [Mounting WebDAV](mounting-webdav.md))
+- Prefer a long `--vfs-cache-max-age` (for example `2160h`) and a large `--vfs-cache-max-size` so scan probes are not re-downloaded every night
 - Confirm **Settings → Rclone Server** can reach RC (`--rc-addr` must not be `127.0.0.1` across containers)
 
 ## *Arr won't import


### PR DESCRIPTION
## Summary
- Update the published rclone sidecar mount to reduce scan-probe amplification (`--buffer-size=0M`, `--vfs-read-ahead=64M`, long `--vfs-cache-max-age`, `--dir-cache-time=1h` with RC + `--poll-interval=0`).
- Make RC notifications part of the primary setup (`--rc-no-auth` by default; document optional auth and the `127.0.0.1` RC bind pitfall).
- Add guidance for high Overview **Served** overnight, Plex empty-trash/remount risk, and cross-links from Rclone Server / Media servers / Troubleshooting.

## Test plan
- [ ] Review the compose snippet in `docs/guides/mounting-webdav.md`
- [ ] Confirm docs CI (`docs.yml` / zensical) passes
- [ ] Spot-check cross-links from Rclone Server, Media servers, and Troubleshooting


## Current proposed default

```
  nzbdav_rclone:
...
    command: >
      mount nzbdav: /mnt/remote/nzbdav
        --cache-dir=/cache
        --uid=1000
        --gid=1000
        --allow-other
        --links
        --use-cookies
        --vfs-cache-mode=full
        --vfs-cache-max-size=50G
        --vfs-cache-max-age=2160h
        --buffer-size=0M
        --vfs-read-chunk-size=16M
        --vfs-read-chunk-size-limit=512M
        --no-modtime
        --no-checksum
        --dir-cache-time=1h
        --poll-interval=0
        --rc
        --rc-addr=:5572
        --rc-no-auth
```