### PR TITLE
fix(deps): bump UsenetSharp to 3.3.0 for bounded decoded body pipelines

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -24,7 +24,7 @@
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="NzbDav.SharpCompress" Version="0.54.0" />
-      <PackageReference Include="NzbDav.UsenetSharp" Version="3.2.0" />
+      <PackageReference Include="NzbDav.UsenetSharp" Version="3.3.0" />
       <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bumps `NzbDav.UsenetSharp` from 3.2.0 → 3.3.0 (confirmed on NuGet.org).
- Pulls in UsenetSharp's bounded/observable decoded body pipeline work from [v3.3.0](https://github.com/nzbdav/UsenetSharp/releases/tag/v3.3.0).

## Test plan
- [x] `dotnet restore` resolves `NzbDav.UsenetSharp` 3.3.0 from NuGet.org
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1156 passed)