### PR TITLE
fix(queue): Remove Orphaned Files no longer stays broken after an interrupted run

### DIFF
--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -63,12 +63,47 @@ public class RemoveUnlinkedFilesTask : BaseTask
         catch (Exception e)
         {
             Complete($"Failed: {e.Message}");
-            Log.Error(e, "Failed to remove unlinked files.");
+            if (TryGetKnownFailureReason(e, out var reason))
+            {
+                Log.Warning("Could not remove unlinked files. Reason: {Reason}", reason);
+                Log.Debug(e, "Remove unlinked files known failure stack");
+            }
+            else
+            {
+                Log.Error(e, "Failed to remove unlinked files.");
+            }
         }
         finally
         {
             _progressHeartbeat = null;
         }
+    }
+
+    /// <summary>
+    /// Environmental failures an operator can act on from a single log line: a database that is
+    /// busy, locked, read-only or full, and shutdown mid-run. Everything else keeps its stack so
+    /// genuine bugs and corruption stay diagnosable.
+    /// </summary>
+    private bool TryGetKnownFailureReason(Exception exception, out string reason)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current.IsCancellationException(CancellationToken))
+            {
+                reason = "nzbdav is shutting down";
+                return true;
+            }
+
+            // SQLITE_BUSY, SQLITE_LOCKED, SQLITE_READONLY, SQLITE_FULL
+            if (current is SqliteException { SqliteErrorCode: 5 or 6 or 8 or 13 })
+            {
+                reason = current.Message;
+                return true;
+            }
+        }
+
+        reason = string.Empty;
+        return false;
     }
 
     private async Task RemoveUnlinkedFiles()
@@ -138,9 +173,13 @@ public class RemoveUnlinkedFilesTask : BaseTask
 
         // Create a new table "TMP_LINKED_FILES", dropping old one if it already exists.
         // No index initially for fast writes.
+        // TMP_LINKED_FILES_UNIQUE is dropped too: the indexing step below commits each
+        // statement separately, so a failure between its CREATE and RENAME strands the
+        // unique table and every later run would fail on "table already exists".
         await dbContext.Database.ExecuteSqlRawAsync(
             """
             DROP TABLE IF EXISTS TMP_LINKED_FILES;
+            DROP TABLE IF EXISTS TMP_LINKED_FILES_UNIQUE;
             CREATE TABLE TMP_LINKED_FILES (Id TEXT NOT NULL);
             """).ConfigureAwait(false);
 

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -398,6 +398,80 @@ public class RemoveUnlinkedFilesTaskTests
     }
 
     [Fact]
+    public async Task DryRun_Succeeds_WhenPreviousRunLeftUniqueTempTableBehind()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Combine(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+
+            var linkedIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToList();
+            var orphanId = Guid.NewGuid();
+            foreach (var id in linkedIds.Append(orphanId))
+            {
+                ctx.Items.Add(DavItem.New(
+                    id,
+                    DavItem.ContentFolder,
+                    $"{id:N}.mkv",
+                    10,
+                    DavItem.ItemType.UsenetFile,
+                    DavItem.ItemSubType.NzbFile,
+                    null,
+                    null,
+                    null,
+                    null));
+            }
+
+            await ctx.SaveChangesAsync();
+
+            foreach (var id in linkedIds)
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(libraryDir, $"{id:N}.strm"),
+                    $"http://localhost/view/.ids/{id}.mkv");
+            }
+
+            // Strand the unique temp table the way a run interrupted between its CREATE and
+            // RENAME does. Every later run used to fail on "table already exists".
+            await ctx.Database.ExecuteSqlRawAsync(
+                "CREATE TABLE TMP_LINKED_FILES_UNIQUE (Id TEXT NOT NULL COLLATE NOCASE PRIMARY KEY);");
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var task = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            // Assert on progress, not the return value: ExecuteInternal catches the failure and
+            // reports "Failed: ...", so Execute() returns true either way.
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.DoesNotContain("already exists", progress);
+            Assert.StartsWith("Dry Run - Done.", progress);
+            Assert.Contains("Identified 1 unlinked files", progress);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task InsertLinkedIdBatchAsync_InsertsAllIds()
     {
         await using var harness = await TempDb.CreateAsync();


### PR DESCRIPTION
## Summary

Reported on v0.8.1 (still present on `main`): Remove Orphaned Files fails with `SQLite Error 1: 'table TMP_LINKED_FILES_UNIQUE already exists'` and keeps failing on every retry.

The linked-id indexing step runs `CREATE` / `INSERT` / `DROP` / `RENAME` as a single multi-statement command, and Microsoft.Data.Sqlite commits each statement separately. If anything interrupts that sequence after the `CREATE` — `SQLITE_BUSY` on the interim `DROP` from concurrent WebDAV/queue writers, a full disk, or a container restart — `TMP_LINKED_FILES_UNIQUE` is left behind. Startup cleanup only dropped `TMP_LINKED_FILES`, so the leftover was permanent: every manual run **and** every nightly scheduled run failed until the database was edited by hand.

- Drop `TMP_LINKED_FILES_UNIQUE` alongside `TMP_LINKED_FILES` before rebuilding, so an interrupted run self-heals on the next attempt. Affected users recover by upgrading and re-running; no manual SQL needed.
- Log known environmental failures (busy, locked, read-only or full database, and shutdown mid-run) as a single-line warning with a reason instead of an error stack dump, per the AGENTS.md logging guidance. Unexpected failures keep their full stack.

Deliberately not included: wrapping the swap in an explicit transaction, which would hold a write lock across the full `INSERT … SELECT` of every linked id and make `SQLITE_BUSY` for live WebDAV traffic more likely. The idempotent drops already recover. `CREATE TEMP TABLE` is also not viable, since later phases read the table over separate connections.

## Test plan

- [x] New `DryRun_Succeeds_WhenPreviousRunLeftUniqueTempTableBehind` strands the unique table, then runs the full task and asserts on the reported progress message. Verified it fails with the exact reported error when the fix is reverted, and passes with it. It asserts on progress rather than the return value because `ExecuteInternal` catches the failure and reports `Failed: …`, so `Execute()` returns `true` either way.
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 1157 passed, 0 failed, 14 skipped (platform-specific).

## Follow-up (not in this PR)

After a successful run, `TMP_LINKED_FILES` persists in the live database with one row per linked item and rides along in backups and restore staging. Pre-existing since `7e3dcab1`; worth a separate issue.