### PR TITLE
fix(usenet): streaming no longer wedges until restart after a corrupt article

### DIFF
--- a/backend/Streams/CorruptionDetectingYencStream.cs
+++ b/backend/Streams/CorruptionDetectingYencStream.cs
@@ -46,7 +46,8 @@ public sealed class CorruptionDetectingYencStream(
     {
         if (Interlocked.Exchange(ref _reported, 1) == 0)
         {
-            Log.Warning(
+            ThrottledSegmentWarning.Write(
+                $"{providerKey}\n{segmentId}",
                 "Provider {Provider} returned corrupt yEnc data for segment {SegmentId}. Reason: {Reason}",
                 providerKey,
                 segmentId,

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -93,12 +93,20 @@ public sealed class InFlightArticleBudget
     private void RemoveWaiter(Waiter? waiter)
     {
         if (waiter?.Node is null) return;
+        TaskCompletionSource<bool>? nextTcs = null;
         lock (_gate)
         {
             if (waiter.Node is null) return;
+            var wasHead = ReferenceEquals(_waiters.First, waiter.Node);
             _waiters.Remove(waiter.Node);
             waiter.Node = null;
+            // A Release that raced with cancellation may have signalled only this
+            // waiter; wake the new head so FIFO waiters do not stall forever.
+            if (wasHead)
+                nextTcs = _waiters.First?.Value.Tcs;
         }
+
+        nextTcs?.TrySetResult(true);
     }
 
     private bool TryLease(long bytes)

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -38,6 +38,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private Stream? _stream;
     private int _consecutiveZeroFills;
     private bool _disposed;
+    private readonly Task _downloadTask;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
 
     public static Stream Create(
         Memory<string> segmentIds,
@@ -140,7 +143,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _bodyPipelineBatchSize = Math.Min(BodyPipelineBatchSize, articleBufferSize);
         _streamTasks = Channel.CreateBounded<Task<SegmentDownloadResult>>(articleBufferSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _ = DownloadSegments(usePipelinedBodyRequests, _cts.Token);
+        _downloadTask = DownloadSegments(usePipelinedBodyRequests, _cts.Token);
     }
 
     private async Task DownloadSegments(
@@ -375,7 +378,27 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 lease?.Dispose();
                 lease = null;
                 if (attempt >= MaxCorruptionRetries)
-                    throw;
+                {
+                    var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (fallback is not null)
+                        return SegmentDownloadResult.Success(fallback, estimate);
+
+                    if (_failFastOnFirstSegment && isFirstSegment)
+                    {
+                        e.LogWarningKnownOrStack(
+                            "First article {SegmentId} persistently corrupt at playback start while reading {FileName}. " +
+                            "Failing the stream so the player surfaces an error.",
+                            segmentId, _fileName);
+                        throw;
+                    }
+
+                    return ZeroFillSegment(
+                        "Article {SegmentId} persistently corrupt while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                        segmentId,
+                        segmentIndex,
+                        e);
+                }
 
                 Log.Debug(
                     e,
@@ -462,10 +485,22 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             lease?.Dispose();
             lease = null;
-            var stream = await RetryCorruptSegmentAsync(
-                    segmentId, segmentIndex, e, cancellationToken)
-                .ConfigureAwait(false);
-            return SegmentDownloadResult.Success(stream, estimate);
+            try
+            {
+                var stream = await RetryCorruptSegmentAsync(
+                        segmentId, segmentIndex, e, cancellationToken)
+                    .ConfigureAwait(false);
+                return SegmentDownloadResult.Success(stream, estimate);
+            }
+            catch (UsenetCorruptArticleException persistent)
+            {
+                if (_failFastOnFirstSegment && isFirstSegment) throw;
+                return ZeroFillSegment(
+                    "Article {SegmentId} persistently corrupt while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                    segmentId,
+                    segmentIndex,
+                    persistent);
+            }
         }
         catch (Exception e) when (!cancellationToken.IsCancellationRequested)
         {
@@ -573,6 +608,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
         }
 
+        var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
+            .ConfigureAwait(false);
+        if (fallback is not null)
+            return fallback;
+
         ExceptionDispatchInfo.Capture(failure).Throw();
         throw new InvalidOperationException("Unreachable after rethrowing a corrupt segment failure.");
     }
@@ -605,6 +645,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             catch (UsenetArticleNotFoundException)
             {
                 // Try the next alternate MessageId.
+            }
+            catch (UsenetCorruptArticleException)
+            {
+                // Corrupt fallback — try the next alternate MessageId.
             }
             catch (UsenetUnexpectedResponseException e)
             {
@@ -837,19 +881,72 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
     protected override void Dispose(bool disposing)
     {
-        if (_disposed) return;
         if (!disposing) return;
-        _disposed = true;
-        _cts.Cancel();
-        _cts.Dispose();
-        _stream?.Dispose();
+        // Sync Dispose must stay non-blocking (Seek calls it). Start the same
+        // idempotent cleanup that DisposeAsync awaits for lease release.
+        _ = EnsureDisposeAsync();
+        base.Dispose();
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await EnsureDisposeAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    private Task EnsureDisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null) return _disposeTask;
+            // Mark disposed before async cleanup so sync Dispose immediately rejects reads.
+            _disposed = true;
+            _disposeTask = DisposeCoreAsync();
+            return _disposeTask;
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        try
+        {
+            _cts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already torn down.
+        }
+
         _streamTasks.Writer.TryComplete();
 
-        // ensure that streams that were never read from the channel get disposed
-        while (_streamTasks.Reader.TryRead(out var streamTask))
-            _ = DisposeStreamAsync(streamTask, releaseInFlight: true);
+        if (_stream is not null)
+        {
+            await _stream.DisposeAsync().ConfigureAwait(false);
+            _stream = null;
+        }
 
-        base.Dispose();
+        // Drain queued segments concurrently so a task blocked on LeaseAsync can
+        // wake when another queued BudgetedStream releases its lease.
+        var pending = new List<Task>();
+        while (_streamTasks.Reader.TryRead(out var streamTask))
+            pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
+
+        try
+        {
+            await _downloadTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Producer failures are surfaced on ReadAsync; teardown only needs cleanup.
+        }
+
+        while (_streamTasks.Reader.TryRead(out var streamTask))
+            pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
+
+        if (pending.Count > 0)
+            await Task.WhenAll(pending).ConfigureAwait(false);
+
+        _cts.Dispose();
     }
 
     private sealed record SegmentDownloadResult(

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -231,6 +231,13 @@ public class NzbFileStream(
                 $"Byte position {rangeStart} of \"{fileName ?? "unknown"}\" is past the data " +
                 $"available in segment {foundSegment.FoundIndex + 1}. {e.Message}");
         }
+        catch
+        {
+            // Any other failure (corrupt article, cancel, transport) must release the
+            // prefetched BudgetedStream leases before the exception escapes.
+            await stream.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
 
         return stream;
     }
@@ -302,9 +309,24 @@ public class NzbFileStream(
                 // e.g. a mid-stream NNTP read timeout. Fall back to the slow seek
                 // path, whose MultiSegmentStream retries and zero-fills instead of
                 // surfacing a hard error to the WebDAV client.
-                e.LogWarningKnownOrStack(
-                    "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek.",
-                    string.IsNullOrEmpty(fileName) ? "unknown" : fileName);
+                var displayName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
+                if (e.TryGetKnownErrorMessage(out var reason))
+                {
+                    ThrottledSegmentWarning.Write(
+                        displayName,
+                        "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek. Reason: {Reason}",
+                        displayName,
+                        reason);
+                    Log.Debug(e, "Fast seek known failure stack while reading {FileName}", displayName);
+                }
+                else
+                {
+                    Log.Warning(
+                        e,
+                        "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek.",
+                        displayName);
+                }
+
                 return null;
             }
             finally

--- a/backend/Streams/ThrottledSegmentWarning.cs
+++ b/backend/Streams/ThrottledSegmentWarning.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using Serilog;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Coalesces repeated operator warnings for the same provider/segment/file key so a
+/// stuck corrupt article cannot flood the application log.
+/// </summary>
+internal static class ThrottledSegmentWarning
+{
+    private static readonly ConcurrentDictionary<string, WindowState> Windows =
+        new(StringComparer.Ordinal);
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
+    private static int _callCount;
+
+    public static void Write(
+        string key,
+        string messageTemplate,
+        params object?[] propertyValues)
+    {
+        var now = DateTime.UtcNow;
+        var state = Windows.GetOrAdd(key, static _ => new WindowState());
+        var shouldLog = false;
+        var suppressed = 0;
+
+        lock (state)
+        {
+            if (state.WindowStarted == default || now - state.WindowStarted >= Window)
+            {
+                suppressed = state.Suppressed;
+                state.WindowStarted = now;
+                state.Suppressed = 0;
+                shouldLog = true;
+            }
+            else
+            {
+                state.Suppressed++;
+            }
+        }
+
+        if (!shouldLog) return;
+
+        if (suppressed > 0)
+        {
+            Log.Warning(
+                "Suppressed {SuppressedCount} additional warnings for {WarningKey} in the previous 60 seconds.",
+                suppressed,
+                key);
+        }
+
+        Log.Warning(messageTemplate, propertyValues);
+
+        if (Interlocked.Increment(ref _callCount) % 256 == 0)
+            Cleanup(now);
+    }
+
+    private static void Cleanup(DateTime now)
+    {
+        foreach (var entry in Windows)
+        {
+            lock (entry.Value)
+            {
+                if (now - entry.Value.WindowStarted >= CleanupThreshold)
+                    Windows.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+
+    private sealed class WindowState
+    {
+        public DateTime WindowStarted { get; set; }
+        public int Suppressed { get; set; }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -1,6 +1,7 @@
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.Exceptions;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -167,9 +168,118 @@ public class MultiSegmentStreamPrefetchBudgetTests
         cts.Cancel();
         await stream.DisposeAsync();
 
-        for (var i = 0; i < 50 && budget.LeasedBytes != 0; i++)
-            await Task.Delay(20);
+        Assert.Equal(0, budget.LeasedBytes);
+    }
 
+    [Fact]
+    public async Task DisposeAsync_ReleasesQueuedLeasesBeforeReturning()
+    {
+        const int segmentSize = 20_000;
+        var budget = new InFlightArticleBudget(segmentSize * 16);
+        var segments = Enumerable.Range(0, 20)
+            .ToDictionary(
+                i => $"seg-{i}",
+                _ => Enumerable.Repeat((byte)3, segmentSize).ToArray());
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true);
+
+        var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            client,
+            articleBufferSize: 8,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "dispose.bin",
+            readBudget: null,
+            inFlightArticleBudget: budget);
+
+        var buffer = new byte[1024];
+        _ = await stream.ReadAsync(buffer);
+        Assert.True(budget.LeasedBytes > 0);
+
+        await stream.DisposeAsync();
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task RemoveHeadWaiter_WakesNextWaiterWhenCapacityAvailable()
+    {
+        const long cap = 1000;
+        var budget = new InFlightArticleBudget(cap);
+        var held = await budget.LeaseAsync(cap, CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+        var head = budget.LeaseAsync(cap, cts.Token).AsTask();
+        for (var i = 0; i < 50 && budget.ThrottleEvents == 0; i++)
+            await Task.Delay(10);
+        Assert.True(budget.ThrottleEvents > 0);
+
+        var next = budget.LeaseAsync(cap, CancellationToken.None).AsTask();
+        for (var i = 0; i < 50 && budget.ThrottleEvents < 2; i++)
+            await Task.Delay(10);
+
+        // Free capacity and cancel the head before/while it observes the wake so
+        // RemoveWaiter must signal the new FIFO head.
+        held.Dispose();
+        await cts.CancelAsync();
+        try
+        {
+            await head;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the head loses the race to TryLease.
+        }
+
+        if (head.IsCompletedSuccessfully)
+            (await head).Dispose();
+
+        using var lease = await next.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(cap, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task PersistentCorruption_ZeroFillsAndContinues()
+    {
+        const int segmentSize = 50;
+        var budget = new InFlightArticleBudget(segmentSize * 8);
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["a"] = Enumerable.Repeat((byte)1, segmentSize).ToArray(),
+            ["b"] = Enumerable.Repeat((byte)2, segmentSize).ToArray(),
+            ["c"] = Enumerable.Repeat((byte)3, segmentSize).ToArray(),
+        };
+        var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (key, bytes) => key == "b"
+                ? new ThrowingCorruptStream("b")
+                : new MemoryStream(bytes, writable: false));
+
+        await using var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "corrupt.bin",
+            exactSegmentSizes: new long[] { segmentSize, segmentSize, segmentSize },
+            inFlightArticleBudget: budget);
+
+        var buffer = new byte[segmentSize];
+        Assert.Equal(segmentSize, await stream.ReadAsync(buffer));
+        Assert.All(buffer, b => Assert.Equal((byte)1, b));
+
+        Assert.Equal(segmentSize, await stream.ReadAsync(buffer));
+        Assert.All(buffer, b => Assert.Equal((byte)0, b));
+
+        Assert.Equal(segmentSize, await stream.ReadAsync(buffer));
+        Assert.All(buffer, b => Assert.Equal((byte)3, b));
+
+        await stream.DisposeAsync();
         Assert.Equal(0, budget.LeasedBytes);
     }
 
@@ -285,6 +395,41 @@ public class MultiSegmentStreamPrefetchBudgetTests
         {
             Log.Logger = previous;
         }
+    }
+
+    private sealed class ThrowingCorruptStream(string segmentId) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new UsenetCorruptArticleException(
+                segmentId, "fake-provider", new InvalidDataException("bad crc"));
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<int>(
+                new UsenetCorruptArticleException(
+                    segmentId, "fake-provider", new InvalidDataException("bad crc")));
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
     }
 
     private sealed class CollectingSink : ILogEventSink

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -322,6 +322,80 @@ public class NzbFileStreamTests
         Assert.All(openedBodies, body => Assert.True(body.Disposed));
     }
 
+    [Fact]
+    public async Task Seek_WhenSegmentReadFails_ReleasesArticleBudget()
+    {
+        const int segmentSize = 1000;
+        const int segmentCount = 6;
+        var budget = new InFlightArticleBudget(segmentSize * 40);
+        var segmentIds = Enumerable.Range(0, segmentCount).Select(i => $"seg-{i}").ToArray();
+        var segments = segmentIds.ToDictionary(
+            id => id,
+            _ => Enumerable.Repeat((byte)1, segmentSize).ToArray());
+        var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (key, bytes) => key == "seg-2"
+                ? new ThrowingReadStream(() => new IOException("provider reset"))
+                : new MemoryStream(bytes, writable: false));
+
+        await using var stream = new NzbFileStream(
+            segmentIds,
+            fileSize: segmentSize * segmentCount,
+            client,
+            articleBufferSize: 4,
+            segmentByteRanges: null,
+            usePipelinedBodyRequests: false,
+            fileName: "seek-fail.bin",
+            inFlightArticleBudget: budget);
+        stream.Seek(segmentSize * 2 + 10, SeekOrigin.Begin);
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            async () => await stream.ReadAtLeastAsync(
+                new byte[16], 16, throwOnEndOfStream: false));
+
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task Seek_RepeatedSegmentReadFailures_DoNotAccumulateArticleBudget()
+    {
+        const int segmentSize = 1000;
+        const int segmentCount = 6;
+        var budget = new InFlightArticleBudget(segmentSize * 40);
+        var segmentIds = Enumerable.Range(0, segmentCount).Select(i => $"seg-{i}").ToArray();
+        var segments = segmentIds.ToDictionary(
+            id => id,
+            _ => Enumerable.Repeat((byte)1, segmentSize).ToArray());
+
+        for (var attempt = 0; attempt < 12; attempt++)
+        {
+            var client = new FakeNntpClient(
+                segments,
+                useCachedYencStreams: true,
+                decodedStreamFactory: (key, bytes) => key == "seg-2"
+                    ? new ThrowingReadStream(() => new IOException("provider reset"))
+                    : new MemoryStream(bytes, writable: false));
+
+            await using var stream = new NzbFileStream(
+                segmentIds,
+                fileSize: segmentSize * segmentCount,
+                client,
+                articleBufferSize: 4,
+                segmentByteRanges: null,
+                usePipelinedBodyRequests: false,
+                fileName: "seek-fail-repeat.bin",
+                inFlightArticleBudget: budget);
+            stream.Seek(segmentSize * 2 + 10, SeekOrigin.Begin);
+
+            await Assert.ThrowsAnyAsync<Exception>(
+                async () => await stream.ReadAtLeastAsync(
+                    new byte[16], 16, throwOnEndOfStream: false));
+
+            Assert.Equal(0, budget.LeasedBytes);
+        }
+    }
+
     private static FakeNntpClient CreateClient()
     {
         return new FakeNntpClient(


### PR DESCRIPTION
## Summary
- Release in-flight article byte leases when seek-prefix setup fails, and make `MultiSegmentStream.DisposeAsync` wait until queued segment buffers are drained so Article RAM cannot stay permanently saturated after abandoned reads.
- After corruption retries are exhausted, try fallback MessageIds then zero-fill (same path as missing articles) so one bad segment cannot rebuild streams forever, and throttle repeated corrupt-yEnc / fast-seek warnings.
- Wake the next FIFO budget waiter when a cancelled head is removed to close a lost-wakeup race.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1162 passed, 14 skipped)
- [x] Focused coverage for seek-failure lease release, repeated failed seeks, DisposeAsync drain, FIFO waiter wakeup, and persistent-corruption zero-fill
- [ ] Manual: replay a ranged GET against a file with a persistently corrupt segment and confirm Article RAM returns to 0 when Active reads is 0