### PR TITLE
fix(queue): container no longer boot-loops on startup while restoring search play links

### DIFF
--- a/backend/Services/NzbResolutionCache.cs
+++ b/backend/Services/NzbResolutionCache.cs
@@ -68,7 +68,7 @@ public class NzbResolutionCache(Func<DavDatabaseContext> contextFactory)
     /// Load non-expired groups from SQLite into the in-memory dictionary.
     /// Deserializes each group's candidates list once and shares it across that group's tokens.
     /// </summary>
-    public async Task HydrateAsync(TimeSpan ttl, CancellationToken ct)
+    public virtual async Task HydrateAsync(TimeSpan ttl, CancellationToken ct)
     {
         var cutoffUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - (long)ttl.TotalMilliseconds;
         await using var ctx = contextFactory();
@@ -122,7 +122,7 @@ public class NzbResolutionCache(Func<DavDatabaseContext> contextFactory)
     /// <summary>
     /// Evict expired in-memory entries and delete expired rows from SQLite.
     /// </summary>
-    public async Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct)
+    public virtual async Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct)
     {
         var cutoffDateTime = DateTime.UtcNow - ttl;
         var cutoffUnixMs = new DateTimeOffset(cutoffDateTime).ToUnixTimeMilliseconds();

--- a/backend/Services/NzbResolutionCache.cs
+++ b/backend/Services/NzbResolutionCache.cs
@@ -122,7 +122,7 @@ public class NzbResolutionCache(Func<DavDatabaseContext> contextFactory)
     /// <summary>
     /// Evict expired in-memory entries and delete expired rows from SQLite.
     /// </summary>
-    public virtual async Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct)
+    public async Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct)
     {
         var cutoffDateTime = DateTime.UtcNow - ttl;
         var cutoffUnixMs = new DateTimeOffset(cutoffDateTime).ToUnixTimeMilliseconds();

--- a/backend/Services/NzbResolutionCacheRetentionService.cs
+++ b/backend/Services/NzbResolutionCacheRetentionService.cs
@@ -1,12 +1,14 @@
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 using Serilog;
 
 namespace NzbWebDAV.Services;
 
 /// <summary>
-/// Hydrates the in-memory play-token cache from SQLite on startup, then
+/// Hydrates the in-memory play-token cache from SQLite after the host has started
+/// scheduling background work (so Kestrel can bind and /health can answer), then
 /// hourly purges groups older than the configured TTL.
 /// </summary>
 public class NzbResolutionCacheRetentionService(
@@ -14,25 +16,29 @@ public class NzbResolutionCacheRetentionService(
 {
     private static readonly TimeSpan TickInterval = TimeSpan.FromHours(1);
 
-    // Hydrate before the server accepts requests so pre-restart tokens
-    // never 404 during startup.
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // Hydrate in ExecuteAsync (not StartAsync) so host StartAsync returns and
+        // Kestrel can bind before SQLite open/query finishes. Blocking StartAsync on
+        // hydrate caused a container boot-loop when the entrypoint's 30s /health
+        // window expired mid-open (#665).
         try
         {
-            await cache.HydrateAsync(configManager.GetPlayResolutionCacheTtl(), cancellationToken)
+            await cache.HydrateAsync(configManager.GetPlayResolutionCacheTtl(), stoppingToken)
                 .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex.IsCancellationException(stoppingToken))
+        {
+            Log.Warning("Play-token cache hydrate skipped. Reason: {Reason}", "nzbdav is shutting down");
+            Log.Debug(ex, "Play-token cache hydrate cancelled stack");
+            return;
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Failed to hydrate play-token cache; starting empty");
+            Log.Warning("Failed to hydrate play-token cache; starting empty. Reason: {Reason}", ex.Message);
+            Log.Debug(ex, "Play-token cache hydrate failure stack");
         }
 
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -45,9 +51,14 @@ public class NzbResolutionCacheRetentionService(
             {
                 return;
             }
+            catch (Exception ex) when (ex.IsCancellationException(stoppingToken))
+            {
+                return;
+            }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Play-token retention sweep failed");
+                Log.Warning("Play-token retention sweep failed. Reason: {Reason}", ex.Message);
+                Log.Debug(ex, "Play-token retention sweep failure stack");
             }
         }
     }

--- a/backend/Services/NzbResolutionCacheRetentionService.cs
+++ b/backend/Services/NzbResolutionCacheRetentionService.cs
@@ -18,10 +18,9 @@ public class NzbResolutionCacheRetentionService(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Hydrate in ExecuteAsync (not StartAsync) so host StartAsync returns and
-        // Kestrel can bind before SQLite open/query finishes. Blocking StartAsync on
-        // hydrate caused a container boot-loop when the entrypoint's 30s /health
-        // window expired mid-open (#665).
+        // Hydrate here rather than in StartAsync: reading the whole non-expired token
+        // table can outlast the entrypoint's /health retry window, and gating host
+        // startup on it boot-looped containers on upgrade (#665).
         try
         {
             await cache.HydrateAsync(configManager.GetPlayResolutionCacheTtl(), stoppingToken)
@@ -29,8 +28,8 @@ public class NzbResolutionCacheRetentionService(
         }
         catch (Exception ex) when (ex.IsCancellationException(stoppingToken))
         {
-            Log.Warning("Play-token cache hydrate skipped. Reason: {Reason}", "nzbdav is shutting down");
-            Log.Debug(ex, "Play-token cache hydrate cancelled stack");
+            Log.Warning("Play-token cache hydrate stopped because nzbdav is shutting down");
+            Log.Debug(ex, "Play-token cache hydrate cancellation stack");
             return;
         }
         catch (Exception ex)
@@ -47,11 +46,9 @@ public class NzbResolutionCacheRetentionService(
                 await cache.PurgeExpiredAsync(configManager.GetPlayResolutionCacheTtl(), stoppingToken)
                     .ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
-            {
-                return;
-            }
-            catch (Exception ex) when (ex.IsCancellationException(stoppingToken))
+            catch (Exception ex) when (ex.IsCancellationException() &&
+                                      (stoppingToken.IsCancellationRequested ||
+                                       SigtermUtil.IsSigtermTriggered()))
             {
                 return;
             }

--- a/tests/NzbWebDAV.Tests/Services/NzbResolutionCacheRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbResolutionCacheRetentionServiceTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class NzbResolutionCacheRetentionServiceTests
+{
+    [Fact]
+    public async Task HostStartAsync_CompletesWhileHydrateIsStillBlocked()
+    {
+        var hydrateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHydrate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cache = new BlockingHydrateCache(hydrateEntered, releaseHydrate);
+
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<NzbResolutionCache>(cache);
+                services.AddSingleton(new ConfigManager());
+                services.AddHostedService<NzbResolutionCacheRetentionService>();
+            })
+            .Build();
+
+        using var startCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await host.StartAsync(startCts.Token);
+
+        // Host StartAsync must return before hydrate finishes — otherwise /health
+        // stays down for the entrypoint's 30s window (#665).
+        await hydrateEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(releaseHydrate.Task.IsCompleted);
+
+        await host.StopAsync(CancellationToken.None);
+        releaseHydrate.TrySetResult();
+    }
+
+    [Fact]
+    public async Task CancelledHydrate_DoesNotFaultTheHost()
+    {
+        var hydrateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHydrate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cache = new BlockingHydrateCache(hydrateEntered, releaseHydrate);
+
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<NzbResolutionCache>(cache);
+                services.AddSingleton(new ConfigManager());
+                services.AddHostedService<NzbResolutionCacheRetentionService>();
+            })
+            .Build();
+
+        await host.StartAsync(CancellationToken.None);
+        await hydrateEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Cancel while hydrate is blocked; service must catch and not stop the host
+        // via BackgroundServiceExceptionBehavior.
+        var stopTask = host.StopAsync(CancellationToken.None);
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
+        releaseHydrate.TrySetResult();
+    }
+
+    private sealed class BlockingHydrateCache(
+        TaskCompletionSource hydrateEntered,
+        TaskCompletionSource releaseHydrate)
+        : NzbResolutionCache(() => throw new InvalidOperationException("test cache must not open SQLite"))
+    {
+        public override async Task HydrateAsync(TimeSpan ttl, CancellationToken ct)
+        {
+            hydrateEntered.TrySetResult();
+            using var reg = ct.Register(() => releaseHydrate.TrySetCanceled(ct));
+            await releaseHydrate.Task.WaitAsync(ct).ConfigureAwait(false);
+        }
+
+        public override Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct) =>
+            Task.CompletedTask;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/NzbResolutionCacheRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbResolutionCacheRetentionServiceTests.cs
@@ -7,73 +7,89 @@ namespace NzbWebDAV.Tests.Services;
 
 public sealed class NzbResolutionCacheRetentionServiceTests
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    // The #665 boot-loop guard: the entrypoint kills the backend when /health does not
+    // answer within its retry window, so hydrating the play-token cache must never hold
+    // up host startup.
     [Fact]
-    public async Task HostStartAsync_CompletesWhileHydrateIsStillBlocked()
+    public async Task HostStartAsync_ReturnsWhileHydrateBlocksItsThread()
     {
         var hydrateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseHydrate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cache = new BlockingHydrateCache(hydrateEntered, releaseHydrate);
+        using var releaseHydrate = new ManualResetEventSlim(false);
+        using var host = BuildHost(new ThreadBlockingHydrateCache(hydrateEntered, releaseHydrate));
 
-        using var host = new HostBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton<NzbResolutionCache>(cache);
-                services.AddSingleton(new ConfigManager());
-                services.AddHostedService<NzbResolutionCacheRetentionService>();
-            })
-            .Build();
-
-        using var startCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await host.StartAsync(startCts.Token);
-
-        // Host StartAsync must return before hydrate finishes — otherwise /health
-        // stays down for the entrypoint's 30s window (#665).
-        await hydrateEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.False(releaseHydrate.Task.IsCompleted);
-
-        await host.StopAsync(CancellationToken.None);
-        releaseHydrate.TrySetResult();
-    }
-
-    [Fact]
-    public async Task CancelledHydrate_DoesNotFaultTheHost()
-    {
-        var hydrateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseHydrate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cache = new BlockingHydrateCache(hydrateEntered, releaseHydrate);
-
-        using var host = new HostBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton<NzbResolutionCache>(cache);
-                services.AddSingleton(new ConfigManager());
-                services.AddHostedService<NzbResolutionCacheRetentionService>();
-            })
-            .Build();
-
-        await host.StartAsync(CancellationToken.None);
-        await hydrateEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        // Cancel while hydrate is blocked; service must catch and not stop the host
-        // via BackgroundServiceExceptionBehavior.
-        var stopTask = host.StopAsync(CancellationToken.None);
-        await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
-        releaseHydrate.TrySetResult();
-    }
-
-    private sealed class BlockingHydrateCache(
-        TaskCompletionSource hydrateEntered,
-        TaskCompletionSource releaseHydrate)
-        : NzbResolutionCache(() => throw new InvalidOperationException("test cache must not open SQLite"))
-    {
-        public override async Task HydrateAsync(TimeSpan ttl, CancellationToken ct)
+        var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+        try
         {
-            hydrateEntered.TrySetResult();
-            using var reg = ct.Register(() => releaseHydrate.TrySetCanceled(ct));
-            await releaseHydrate.Task.WaitAsync(ct).ConfigureAwait(false);
+            await hydrateEntered.Task.WaitAsync(Timeout);
+            var startCompleted = await Task.WhenAny(startTask, Task.Delay(Timeout)) == startTask;
+            Assert.True(startCompleted, "Host startup must not wait for the play-token hydrate to finish.");
+        }
+        finally
+        {
+            // Always unblock the hydrate thread, otherwise a regression hangs the suite
+            // instead of failing this test.
+            releaseHydrate.Set();
         }
 
-        public override Task PurgeExpiredAsync(TimeSpan ttl, CancellationToken ct) =>
-            Task.CompletedTask;
+        await startTask.WaitAsync(Timeout);
+        await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task HydrateCancelledByShutdown_DoesNotFaultTheHostedService()
+    {
+        var hydrateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseHydrate = new ManualResetEventSlim(false);
+        using var host = BuildHost(new ThreadBlockingHydrateCache(hydrateEntered, releaseHydrate));
+
+        // Start off the test thread: a regression that hydrates inside StartAsync blocks
+        // its caller outright, and this keeps that a timeout instead of a hung suite.
+        var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+        try
+        {
+            await startTask.WaitAsync(Timeout);
+            await hydrateEntered.Task.WaitAsync(Timeout);
+
+            // Shutdown mid-hydrate must be swallowed, otherwise the faulted ExecuteAsync
+            // stops the host through BackgroundServiceExceptionBehavior.
+            await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+
+            var service = host.Services
+                .GetServices<IHostedService>()
+                .OfType<NzbResolutionCacheRetentionService>()
+                .Single();
+            Assert.True(service.ExecuteTask!.IsCompletedSuccessfully);
+        }
+        finally
+        {
+            releaseHydrate.Set();
+        }
+    }
+
+    private static IHost BuildHost(NzbResolutionCache cache) =>
+        new HostBuilder()
+            .ConfigureServices(services => services
+                .AddSingleton(cache)
+                .AddSingleton(new ConfigManager())
+                .AddHostedService<NzbResolutionCacheRetentionService>())
+            .Build();
+
+    /// <summary>
+    /// Blocks the calling thread inside HydrateAsync, mirroring a SQLite read that
+    /// completes synchronously rather than yielding back to the host.
+    /// </summary>
+    private sealed class ThreadBlockingHydrateCache(
+        TaskCompletionSource hydrateEntered,
+        ManualResetEventSlim releaseHydrate)
+        : NzbResolutionCache(() => throw new InvalidOperationException("the test cache must not open SQLite"))
+    {
+        public override Task HydrateAsync(TimeSpan ttl, CancellationToken ct)
+        {
+            hydrateEntered.TrySetResult();
+            releaseHydrate.Wait(ct);
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes [#665](https://github.com/nzbdav/nzbdav/issues/665): play-token cache hydrate no longer blocks `IHostedService.StartAsync`, so Kestrel can bind and `/health` can answer within the entrypoint's 30s window.
- Hydrate runs at the start of `ExecuteAsync`; cancel/other failures log a single-line Warning (Debug stack) and start empty instead of dumping `Log.Warning(ex, …)` stacks.
- Adds a hosted-service regression test that `Host.StartAsync` completes while hydrate is still blocked, and that cancelling mid-hydrate does not fault the host.

**Note for operators:** kube probes should target frontend `/healthz`, not `/login` (the `/login` 500s in the #665 log are collateral SSR noise while the backend is down).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1164 passed)
- [ ] On `:dev` after merge: entrypoint reaches "Backend is healthy" without hydrate/`Hosting failed to start` cancel stacks
- [ ] Optional: confirm search play links still restore shortly after listen