### PR TITLE
fix(usenet): backend no longer aborts mid-playback while tearing down a stream

### DIFF
--- a/backend/Streams/CancellableStream.cs
+++ b/backend/Streams/CancellableStream.cs
@@ -95,6 +95,6 @@ public class CancellableStream(Stream innerStream, CancellationToken token) : Fa
         if (!disposing) return;
         _disposed = true;
         _innerStream.Dispose();
-        base.Dispose();
+        base.Dispose(disposing);
     }
 }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -885,7 +885,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         // Sync Dispose must stay non-blocking (Seek calls it). Start the same
         // idempotent cleanup that DisposeAsync awaits for lease release.
         _ = EnsureDisposeAsync();
-        base.Dispose();
+        // Must be the protected overload: the parameterless Stream.Dispose() routes
+        // back through Close() into this method and recurses until the stack overflows.
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -230,6 +230,6 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         if (!disposing) return;
         _disposed = true;
         _stream?.Dispose();
-        base.Dispose();
+        base.Dispose(disposing);
     }
 }

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamDisposeTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamDisposeTests.cs
@@ -1,0 +1,48 @@
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Streams;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public class MultiSegmentStreamDisposeTests
+{
+    // Dispose(bool) must call the protected base overload. The parameterless
+    // Stream.Dispose() routes back through Close() into Dispose(bool) and recurses
+    // until the stack overflows, which aborted the container mid-playback (#665).
+    [Fact]
+    public async Task SyncDispose_StartsCleanupWithoutRecursingThroughClose()
+    {
+        const int segmentSize = 20_000;
+        var budget = new InFlightArticleBudget(segmentSize * 16);
+        var segments = Enumerable.Range(0, 20)
+            .ToDictionary(
+                i => $"seg-{i}",
+                _ => Enumerable.Repeat((byte)5, segmentSize).ToArray());
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true);
+
+        var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            client,
+            articleBufferSize: 8,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "sync-dispose.bin",
+            readBudget: null,
+            inFlightArticleBudget: budget);
+
+        var buffer = new byte[1024];
+        _ = await stream.ReadAsync(buffer);
+        Assert.True(budget.LeasedBytes > 0);
+
+        stream.Dispose();
+        stream.Dispose();
+
+        // Sync Dispose is non-blocking, so await the cleanup it started to prove it
+        // ran rather than merely returning.
+        await stream.DisposeAsync();
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the **second** failure reported in [#665](https://github.com/nzbdav/nzbdav/issues/665) — the one the reporter hit after working around the boot-loop by raising `MAX_BACKEND_HEALTH_RETRIES`. The backend died with `exit code 134 (SIGABRT)` and an endless `MultiSegmentStream.Dispose(Boolean)` / `Stream.Close()` stack while serving a WebDAV read.

`Dispose(bool)` called the parameterless `base.Dispose()`. That is `Stream.Dispose()`, which calls `Close()`, which calls `Dispose(true)` — straight back into the override, recursing until the stack overflows. `MultiSegmentStream` has no `_disposed` early-return on the sync path, so the recursion is unbounded. Introduced in #663.

`CancellableStream` and `UnbufferedMultiSegmentStream` make the same call but set `_disposed` before it, so they only recurse one level. Corrected as well so a future guard reordering cannot resurrect the crash.

Sync `Dispose()` had no test coverage — only `DisposeAsync` — which is how this shipped. Added a regression test that reads a segment, disposes synchronously, and asserts the article-budget leases are released.

Note: with the fix reverted, the new test reproduces the reporter's stack and aborts the test run rather than failing an assertion, because a `StackOverflowException` cannot be caught in .NET. That is the same failure the container hits.

This is independent of [#666](https://github.com/nzbdav/nzbdav/pull/666), which fixes the startup boot-loop in the same issue. Both are needed to close #665.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1163 passed, 14 skipped)
- [x] Verified the new test aborts with the reporter's exact recursion stack when the fix is reverted
- [ ] Manual: play a multi-part/encrypted file and seek repeatedly (sync `Dispose` runs on the fast-seek path); backend stays up