### PR TITLE
fix(ui): stop settings help tips from being cut off at the top of cards

### DIFF
--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -367,7 +367,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                     </div>
 
                     <div className="space-y-4 p-4">
-                        <Tooltip content="Writes a logical .sql dump of all databases under the config volume once per day.">
+                        <Tooltip placement="bottom" content="Writes a logical .sql dump of all databases under the config volume once per day.">
                             <Toggle
                                 id="backup-schedule-enabled"
                                 className="cursor-pointer gap-2 rounded-lg bg-base-200/40 p-3"

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -63,7 +63,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 description="Notify the rclone mount whenever WebDAV content is added or removed."
             >
             <ManagedSetting configKey="rclone.rc-enabled">
-            <Tooltip content="Notify your rclone mount via the RC API when files are added or removed on the WebDAV, so you can use a high dir-cache-time.">
+            <Tooltip placement="bottom" content="Notify your rclone mount via the RC API when files are added or removed on the WebDAV, so you can use a high dir-cache-time.">
                 <Toggle
                     id="rclone-rc-enabled-checkbox"
                     className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -41,7 +41,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
             >
             <ManagedSetting configKey="repair.enable">
-            <Tooltip content={helpText}>
+            <Tooltip placement="bottom" content={helpText}>
                 <Toggle
                     id="enable-repairs-checkbox"
                     className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/watchdog/watchdog.tsx
+++ b/frontend/app/routes/settings/watchdog/watchdog.tsx
@@ -79,7 +79,7 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             >
 
             <Form.Group className="flex flex-col gap-2">
-                <Tooltip content="When off, only the chosen release is tried (legacy). When on, alternatives are tried on failure and in-flight queue items are deduped.">
+                <Tooltip placement="bottom" content="When off, only the chosen release is tried (legacy). When on, alternatives are tried on failure and in-flight queue items are deduped.">
                     <Form.Check
                         type="switch"
                         id="play-watchdog-enabled"
@@ -237,7 +237,7 @@ export function WatchdogSettings({ config, setNewConfig }: WatchdogSettingsProps
             >
 
             <Form.Group className="flex flex-col gap-2">
-                <Tooltip content="When a candidate stops progressing, set it aside and try the next one without recording it as failed. On by default.">
+                <Tooltip placement="bottom" content="When a candidate stops progressing, set it aside and try the next one without recording it as failed. On by default.">
                     <Form.Check
                         type="switch"
                         id="grab-stall-failover-enabled"

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -95,7 +95,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     description="How content appears to WebDAV clients and the Dav Explorer."
                 >
                     <ManagedSetting configKey="webdav.enforce-readonly">
-                        <Tooltip content="Make the WebDAV /content folder read-only so clients cannot delete files there.">
+                        <Tooltip placement="bottom" content="Make the WebDAV /content folder read-only so clients cannot delete files there.">
                             <Toggle
                                 id="readonly-checkbox"
                                 className="cursor-pointer gap-2 p-0"
@@ -275,7 +275,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
             >
                 <ManagedSetting configKeys={["usenet.segment-cache.enabled", "usenet.segment-cache.path", "usenet.segment-cache.max-gb"]}>
                     <div className="space-y-2">
-                        <Tooltip content="Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.">
+                        <Tooltip placement="bottom" content="Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.">
                             <Toggle
                                 id="segment-cache-enabled-checkbox"
                                 className="cursor-pointer gap-2 p-0"


### PR DESCRIPTION
## Summary
- DaisyUI tooltips on the first control in overflow-hidden settings cards were clipped at the top (reported on Repairs → Enable Background Repairs).
- Flip those high-risk tips to `placement="bottom"` across Repairs, Rclone, WebDAV, Watchdog, and Backup.

## Test plan
- [ ] Settings → Repairs: hover **Enable Background Repairs** — full tip visible below the toggle
- [ ] Settings → Rclone: hover **Enable Rclone RC Server Notifications**
- [ ] Settings → WebDAV: hover **Enforce Read-Only** and **Enable Segment Cache**
- [ ] Settings → Watchdog: hover **Enable failover watchdog** and **Enable stall failover**
- [ ] Settings → Backup: hover **Enable daily backup**