### PR TITLE
chore(ci): cut versioned rc pre-releases and rename Refresh :dev

### DIFF
--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -1,0 +1,87 @@
+name: Cut pre-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Next intended stable (e.g. 0.9.0; usually the open release-please PR version)
+        required: true
+      ref:
+        description: Git ref/SHA to cut from (defaults to the triggering branch tip)
+        required: false
+
+concurrency:
+  group: cut-prerelease-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      rc: ${{ steps.vars.outputs.rc }}
+      tag: ${{ steps.vars.outputs.tag }}
+      sha: ${{ steps.vars.outputs.sha }}
+    steps:
+      - id: vars
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RAW_VERSION: ${{ inputs.version }}
+          REF: ${{ inputs.ref || github.sha }}
+        run: |
+          set -euo pipefail
+          VERSION="${RAW_VERSION#v}"
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Invalid version"; exit 1; }
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "v${VERSION} is already released" >&2; exit 1
+          fi
+          SHA=$(gh api "repos/${{ github.repository }}/commits/${REF}" --jq .sha)
+          LAST_RC=$(gh api "repos/${{ github.repository }}/git/matching-refs/tags/v${VERSION}-rc." \
+            --jq '[.[].ref | split("-rc.")[-1] | tonumber] | max // 0')
+          RC=$((LAST_RC + 1))
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rc=${RC}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}-rc.${RC}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve
+    uses: ./.github/workflows/docker-build-push.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      tags: |
+        ghcr.io/${{ github.repository }}:${{ needs.resolve.outputs.tag }}
+        ghcr.io/${{ github.repository }}:rc
+      nzbdav_version: ${{ needs.resolve.outputs.version }}-rc.${{ needs.resolve.outputs.rc }}
+      checkout_ref: ${{ needs.resolve.outputs.sha }}
+    secrets:
+      registry_token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${{ needs.resolve.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --target "${{ needs.resolve.outputs.sha }}" \
+            --title "${{ needs.resolve.outputs.tag }}" \
+            --prerelease --generate-notes
+
+  tag-rc:
+    needs: [resolve, build, publish-release]
+    uses: ./.github/workflows/move-movable-tag.yml
+    permissions:
+      contents: write
+    with:
+      tag_name: rc
+      ref: ${{ needs.resolve.outputs.sha }}

--- a/.github/workflows/move-movable-tag.yml
+++ b/.github/workflows/move-movable-tag.yml
@@ -1,22 +1,26 @@
-name: Move dev tag
+name: Move movable tag
 
 on:
   workflow_call:
     inputs:
+      tag_name:
+        description: Movable git tag name to create or force-update (e.g. dev, rc)
+        required: true
+        type: string
       ref:
-        description: Commit SHA or git ref to point the movable dev tag at
+        description: Commit SHA or git ref to point the movable tag at
         required: true
         type: string
     outputs:
       previous_sha:
-        description: SHA the movable dev tag pointed at before this move (empty if the tag did not exist)
-        value: ${{ jobs.tag-dev.outputs.previous_sha }}
+        description: SHA the movable tag pointed at before this move (empty if the tag did not exist)
+        value: ${{ jobs.move-tag.outputs.previous_sha }}
       sha:
-        description: SHA the movable dev tag now points at
-        value: ${{ jobs.tag-dev.outputs.sha }}
+        description: SHA the movable tag now points at
+        value: ${{ jobs.move-tag.outputs.sha }}
 
 jobs:
-  tag-dev:
+  move-tag:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -24,25 +28,26 @@ jobs:
       previous_sha: ${{ steps.move.outputs.previous_sha }}
       sha: ${{ steps.move.outputs.sha }}
     steps:
-      - name: Recreate dev tag
+      - name: Recreate movable tag
         id: move
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name }}
           REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           SHA=$(gh api "repos/${{ github.repository }}/commits/${REF}" --jq .sha)
           PREVIOUS_SHA=""
-          if PREV_JSON=$(gh api "repos/${{ github.repository }}/git/ref/tags/dev" 2>/dev/null); then
+          if PREV_JSON=$(gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" 2>/dev/null); then
             PREVIOUS_SHA=$(printf '%s' "$PREV_JSON" | jq -r .object.sha)
-            gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/dev" \
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/${TAG_NAME}" \
               -f sha="$SHA" \
               -F force=true
           else
             gh api --method POST "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/tags/dev" \
+              -f ref="refs/tags/${TAG_NAME}" \
               -f sha="$SHA"
           fi
           echo "previous_sha=${PREVIOUS_SHA}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Moved refs/tags/dev -> $SHA (from ${REF}; previous=${PREVIOUS_SHA:-none})"
+          echo "Moved refs/tags/${TAG_NAME} -> $SHA (from ${REF}; previous=${PREVIOUS_SHA:-none})"

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -1,10 +1,10 @@
-name: Pre-release
+name: Refresh :dev
 
 on:
   workflow_dispatch:
 
 concurrency:
-  group: pre-release-${{ github.repository }}
+  group: refresh-dev-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -30,10 +30,11 @@ jobs:
 
   tag-dev:
     needs: build
-    uses: ./.github/workflows/move-dev-tag.yml
+    uses: ./.github/workflows/move-movable-tag.yml
     permissions:
       contents: write
     with:
+      tag_name: dev
       ref: ${{ github.sha }}
 
   announce-dev:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,11 @@ jobs:
     needs:
       - release-please
       - deploy
-    uses: ./.github/workflows/move-dev-tag.yml
+    uses: ./.github/workflows/move-movable-tag.yml
     permissions:
       contents: write
     with:
+      tag_name: dev
       ref: ${{ needs.release-please.outputs.sha }}
 
   tag-dev-manual:
@@ -119,10 +120,11 @@ jobs:
     needs:
       - resolve-version
       - deploy-manual
-    uses: ./.github/workflows/move-dev-tag.yml
+    uses: ./.github/workflows/move-movable-tag.yml
     permissions:
       contents: write
     with:
+      tag_name: dev
       ref: ${{ needs.resolve-version.outputs.ref }}
 
   announce:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ fix(nntp): skip failing providers with circuit breaker
 feat(ui): add setting to schedule RemoveOrphanedFiles task
 feat(db)!: add orphaned-files index migration
 fix(deps): bump vite in the frontend vite group
-chore(ci): run pre-release image builds on demand
+chore(ci): run Refresh :dev image builds on demand
 chore(docs): expand commit type guidance for release-please sections
 chore(agents): require chore prefix for non-behavior changes
 chore(test): cover range requests past content boundary
@@ -382,13 +382,14 @@ Skip this handoff if there are no local changes and nothing to push or PR. Do no
 | `ci.yml` | PRs and pushes to `main` | Frontend lint/typecheck/build/tests + backend build/tests |
 | `docs.yml` | PRs and pushes to `main` | Zensical docs build (`zensical build --clean --strict`); deploys to GitHub Pages on `main` |
 | `codeql.yml` | PRs, pushes to `main`, and weekly schedule | CodeQL security analysis for C#, TypeScript, and GitHub Actions |
-| `pre-release.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../nzbdav:dev` and moves the git `dev` tag to that commit |
+| `refresh-dev.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../nzbdav:dev` and moves the git `dev` tag to that commit (unversioned snapshot) |
+| `cut-prerelease.yml` | Manual `workflow_dispatch` | Creates numbered `vX.Y.Z-rc.N` GitHub Pre-releases + permanent tags; pushes `:vX.Y.Z-rc.N` and rolling `:rc` images; moves git `rc` tag |
 | `release.yml` | Push to `main` | release-please versioning; publishes release and `dev` Docker tags when a release is created; moves git `dev` tag |
 | `release.yml` | Manual `workflow_dispatch` | Republishes release and `dev` Docker tags to GHCR for an existing version; moves git `dev` tag |
 | `promote-lts.yml` | Manual `workflow_dispatch` | Moves git `lts` and GHCR `:lts` to an existing published version (no rebuild) |
 | `dependency-submission.yml` | GitHub Release `published` (plus manual `workflow_dispatch`) | Dependency graph submission (NuGet + npm) |
-| `docker-build-push.yml` | Reusable (called by pre-release/release) | Multi-arch Docker build with GHA cache |
-| `move-dev-tag.yml` | Reusable (called by pre-release/release) | Force-moves the movable git `dev` tag to a given commit |
+| `docker-build-push.yml` | Reusable (called by refresh-dev/cut-prerelease/release) | Multi-arch Docker build with GHA cache |
+| `move-movable-tag.yml` | Reusable (called by refresh-dev/cut-prerelease/release) | Force-moves a movable git tag (`dev`, `rc`, …) to a given commit |
 
 Docker image builds are shared via the reusable workflow. Branch and dependabot image pipelines were removed — PRs are validated by `ci.yml` instead of publishing throwaway images.
 
@@ -399,7 +400,8 @@ Docker image builds are shared via the reusable workflow. Branch and dependabot 
 - `feat` → minor bump; `fix` → patch bump (pre-1.0 rules in `.release-please-config.json`). Other conventional types that still appear in notes (`perf`, `refactor`, `ux`, `revert`, `build`, and legacy `docs` / `tests`) do not bump the version by themselves. **`chore` commits are omitted from release notes** — use `chore(<scope>)` for CI, tests, docs, agents/skills, and other non-behavior work (do not use bare `docs` / `ci` / `test` / `tests` types).
 - When release-please creates a release on merge to `main`, the same workflow run builds and pushes Docker images to `ghcr.io` (`latest`, `dev`, exact `vMAJOR.MINOR.PATCH`, and rolling `vMAJOR` / `vMAJOR.MINOR` tags) and moves the git `dev` tag to that release commit.
 - To republish images for an existing release (e.g. after fixing CI), run **Release** workflow manually with the `version` input (e.g. `0.6.5`); this also moves the git `dev` tag to that version.
-- Between releases, update the pre-release Docker image (`:dev`) and git `dev` tag on demand via **Actions → Pre-release → Run workflow**.
+- Between releases, refresh the unversioned Docker image (`:dev`) and git `dev` tag on demand via **Actions → Refresh :dev → Run workflow**.
+- Cut a versioned release candidate via **Actions → Cut pre-release → Run workflow** with a `version` input (e.g. `0.9.0`, usually the open release-please PR version). This creates a GitHub Release flagged Pre-release at `vX.Y.Z-rc.N` (permanent tag + image), pushes rolling `:rc`, and moves the git `rc` tag. Release notes come from GitHub `--generate-notes` (vs the previous GitHub Release, which may be another rc).
 - Promote a curated LTS pointer (`:lts` on GHCR and git tag `lts`) to an existing version via **Actions → Promote LTS → Run workflow** with a `version` input (e.g. `0.6.5`). This retags the existing multi-arch image (no rebuild) and is not updated automatically on release.
 - Dependency graph submission runs when a GitHub Release is published (and can be re-run manually via `workflow_dispatch`). Keep GitHub **Automatic dependency submission** disabled to avoid duplicates.
 

--- a/docs/guides/backups-upgrades.md
+++ b/docs/guides/backups-upgrades.md
@@ -33,7 +33,7 @@ Database migrations apply automatically on startup. **Back up `/config` before u
 
 Coming from nzbdav-dev `v0.6.4` or a community fork? See [Migration paths](../getting-started/migration.md).
 
-Tags: `latest`, version tags, and `dev` (pre-release) — see [GitHub Releases](https://github.com/nzbdav/nzbdav/releases) and [Changelog](../community/changelog.md).
+Tags: `latest`, version tags, `dev` (unversioned tip snapshot), and `rc` (latest release candidate) — see [GitHub Releases](https://github.com/nzbdav/nzbdav/releases) and [Changelog](../community/changelog.md).
 
 ## Watchtower / Arr updates
 


### PR DESCRIPTION
## Summary
- Rename the unversioned `:dev` snapshot workflow from **Pre-release** to **Refresh :dev** (`refresh-dev.yml`) so it is not confused with versioned release candidates.
- Add **Cut pre-release** (`cut-prerelease.yml`): on-demand numbered `vX.Y.Z-rc.N` GitHub Pre-releases with permanent tags/images, plus rolling git/`ghcr` `rc` tags.
- Generalize `move-dev-tag.yml` into `move-movable-tag.yml` (shared by refresh-dev, cut-prerelease, and release).

## Test plan
- [ ] Confirm Actions lists **Refresh :dev** and **Cut pre-release** (old Pre-release workflow gone after merge)
- [ ] Dry-run **Cut pre-release** with a future version (e.g. open release-please PR version): resolve picks `rc.1`, Docker builds `:vX.Y.Z-rc.1` + `:rc`, GitHub Release appears as Pre-release, git `rc` tag moves
- [ ] Re-run for the same version and confirm `rc.2` (previous `rc.1` tag/image remain)
- [ ] Confirm **Refresh :dev** still publishes `:dev` and moves git `dev` + Discord announce
- [ ] Confirm a stable release still moves git `dev` via `release.yml`