### PR TITLE
fix(usenet): stop estimated segment buffers allocating twice what they need

### DIFF
--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -748,8 +748,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             if (lease is null)
                 lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
 
-            var capacity = estimate is > 0 and <= int.MaxValue ? (int)estimate : 0;
-            var buffer = new MemoryStream(capacity);
+            var buffer = new MemoryStream(DrainBufferCapacity(estimate, hasExactSize));
             await source.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
             var drained = buffer.Length;
             if (hasExactSize)
@@ -777,6 +776,33 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             await source.DisposeAsync().ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Capacity for a segment drain buffer.
+    ///
+    /// An exact size is used as-is. An estimate is not: the estimate is
+    /// fileSize/segmentCount, an average that the shorter final segment drags
+    /// strictly below the size of a full segment. Used directly, every full
+    /// segment overflows it by a few hundred bytes and MemoryStream answers an
+    /// overflow by doubling — so each buffered segment ends up holding twice the
+    /// memory it needs, on the Large Object Heap, and a stream keeps
+    /// <c>usenet.article-buffer-size</c> of them at once.
+    ///
+    /// For a file of n-1 uniform segments plus a partial tail, the worst case (an
+    /// empty tail) puts a full segment at <c>average * n / (n - 1)</c> — an
+    /// overshoot of <c>1 / (n - 1)</c> — so 1/16 covers every file with 17 or
+    /// more segments. The division rounds up because truncating leaves the bound
+    /// a byte short exactly at the boundary. Anything still short simply grows
+    /// once, as it did before.
+    /// </summary>
+    internal static int DrainBufferCapacity(long estimate, bool isExact)
+    {
+        if (estimate is <= 0 or > int.MaxValue) return 0;
+        if (isExact) return (int)estimate;
+
+        var padded = estimate + (estimate + 15) / 16;
+        return padded > int.MaxValue ? (int)estimate : (int)padded;
     }
 
     private async ValueTask<ArticleByteLease> LeaseSegmentBytesAsync(

--- a/tests/NzbWebDAV.Tests/Streams/DrainBufferCapacityTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DrainBufferCapacityTests.cs
@@ -1,0 +1,80 @@
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class DrainBufferCapacityTests
+{
+    /// <summary>
+    /// The estimate a drain gets is fileSize/segmentCount. Reproduce that
+    /// arithmetic, because the bug lives in the gap between that average and a
+    /// real full segment.
+    /// </summary>
+    private static long Estimate(int segmentCount, int fullSegment, int lastSegment)
+    {
+        var fileSize = (long)(segmentCount - 1) * fullSegment + lastSegment;
+        return Math.Max(1, fileSize / segmentCount);
+    }
+
+    /// <summary>What MemoryStream ends up allocating for a given starting capacity.</summary>
+    private static int CapacityAfterWriting(int initialCapacity, int payloadLength)
+    {
+        var buffer = new MemoryStream(initialCapacity);
+        new MemoryStream(new byte[payloadLength]).CopyTo(buffer);
+        return buffer.Capacity;
+    }
+
+    [Theory]
+    [InlineData(5000, 716_800, 300_000)] // large file, ~700KB segments
+    [InlineData(1000, 768_000, 12_345)]
+    [InlineData(50, 384_000, 1)]
+    [InlineData(17, 716_800, 1)] // worst case at the smallest n the headroom covers
+    [InlineData(17, 720_897, 1)] // lands on a boundary; truncating the headroom would fall a byte short
+    public void FullSegment_FitsWithoutDoubling(int segmentCount, int fullSegment, int lastSegment)
+    {
+        var estimate = Estimate(segmentCount, fullSegment, lastSegment);
+        Assert.True(estimate < fullSegment, "the estimate must under-shoot a full segment, else this proves nothing");
+
+        // Before: the raw estimate overflows and MemoryStream doubles.
+        Assert.Equal(2 * (int)estimate, CapacityAfterWriting((int)estimate, fullSegment));
+
+        // After: it fits.
+        var capacity = MultiSegmentStream.DrainBufferCapacity(estimate, isExact: false);
+        Assert.True(capacity >= fullSegment, $"capacity {capacity} < full segment {fullSegment}");
+        Assert.Equal(capacity, CapacityAfterWriting(capacity, fullSegment));
+    }
+
+    [Fact]
+    public void HeadroomIsSmall()
+    {
+        var estimate = Estimate(5000, 716_800, 300_000);
+        var capacity = MultiSegmentStream.DrainBufferCapacity(estimate, isExact: false);
+
+        // ~6.25%, versus the 100% the doubling cost.
+        Assert.InRange(capacity, estimate, estimate + estimate / 8);
+    }
+
+    [Fact]
+    public void ExactSize_GetsNoHeadroom()
+    {
+        // A recorded per-segment size is the real length; padding it would only
+        // waste memory, and it cannot overflow.
+        Assert.Equal(716_800, MultiSegmentStream.DrainBufferCapacity(716_800, isExact: true));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData((long)int.MaxValue + 1)]
+    public void UnusableEstimate_LetsMemoryStreamPickItsOwnCapacity(long estimate)
+    {
+        Assert.Equal(0, MultiSegmentStream.DrainBufferCapacity(estimate, isExact: false));
+        Assert.Equal(0, MultiSegmentStream.DrainBufferCapacity(estimate, isExact: true));
+    }
+
+    [Fact]
+    public void EstimateNearIntMax_DoesNotOverflow()
+    {
+        var capacity = MultiSegmentStream.DrainBufferCapacity(int.MaxValue, isExact: false);
+        Assert.Equal(int.MaxValue, capacity);
+    }
+}


### PR DESCRIPTION
## The problem

`DrainSegmentAsync` sizes each segment's buffer from `estimate`. When a file has recorded per-segment byte ranges that's the exact length — but otherwise it's `_estimatedSegmentSize`, i.e. `fileSize / segmentCount`, an average.

The shorter final segment drags that average **strictly below** the size of a full segment. So a full segment overflows its buffer by a few hundred bytes, and `MemoryStream` answers an overflow by doubling.

The result is exact and consistent: **every buffered segment holds 2× the memory it needs**, on the Large Object Heap, and a stream keeps `usenet.article-buffer-size` of them at once. At a ~700KB segment with the default buffer size of 40, that's **55 MiB of buffer per open read instead of 30 MiB**.

The existing comment on the field already notes the average "is off by a few bytes for every segment" — this is the consequence of that.

## The fix

Add 1/16 headroom when the size is an estimate, so a full segment fits without growing. Exact sizes are used as-is and get no padding.

For a file of `n-1` uniform segments plus a partial tail, the worst case (an empty tail) puts a full segment at `average * n / (n - 1)` — an overshoot of `1/(n-1)` — so 1/16 covers every file with 17+ segments, which is every file large enough for its buffers to matter. Smaller files may still grow once, exactly as they do today.

The division rounds up deliberately: truncating leaves the bound a byte short right at the boundary. There's a regression case for that (`InlineData(17, 720_897, 1)`).

## Side benefit for `InFlightArticleBudget`

The lease is adjusted against `buffer.Length`, while the memory actually retained is `buffer.Capacity`. A doubled buffer therefore costs roughly twice what the budget believes it does. With the doubling gone, the two agree to within the headroom — so the budget added in #651 becomes considerably more accurate for files without recorded ranges.

## Measurements

At a real segment size (716,800 bytes, average 716,716):

| | capacity |
|---|---|
| before | 1,433,432 |
| after | 761,511 |

47% less, with **no change to how many bytes are read or emitted** — only to how much is allocated to hold them.

## Testing

`dotnet test tests/NzbWebDAV.Tests` — **1176 passed, 0 failed**, including 10 new cases covering the doubling regression, the boundary case, exact sizes, unusable estimates, and `int.MaxValue` overflow.

## Context

We run a large fleet of nzbdav instances and hit this while investigating a backend that was aborting with a managed `OutOfMemoryException` under concurrent reads. #651 bounds the aggregate, which is the bigger fix; this removes the constant factor underneath it for libraries imported before per-segment ranges were recorded.