### PR TITLE
feat(usenet): allow a preset fraction for max-queue-connections

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -43,6 +43,7 @@ public static class ConfigKeys
     public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";
     public const string UsenetMaxQueueConnections = "usenet.max-queue-connections";
+    public const string UsenetMaxQueueConnectionsPreset = "usenet.max-queue-connections-preset";
     public const string QueueWorkerCount = "queue.worker-count";
     public const string QueuePaused = "queue.paused";
     public const string QueueSpeedLimitKbps = "queue.speed-limit-kbps";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -635,9 +635,28 @@ public class ConfigManager
     {
         var pool = Math.Max(1, GetUsenetProviderConfig().TotalPooledConnections);
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxQueueConnections));
-        if (configured is null || !int.TryParse(configured, out var value))
-            return pool;
-        return Math.Clamp(value, 1, pool);
+        if (configured is not null && int.TryParse(configured, out var value))
+            return Math.Clamp(value, 1, pool);
+
+        var fraction = GetMaxQueueConnectionsFraction();
+        return fraction is null ? pool : Math.Max(1, (int)Math.Round(pool * fraction.Value));
+    }
+
+    // Mirrors the per-stream preset: a fraction of the pooled-connection budget
+    // rather than an absolute count, so one setting means the same thing whatever
+    // a user's providers add up to. Null when unset, which keeps the historical
+    // default of "the queue may use the whole pool".
+    private double? GetMaxQueueConnectionsFraction()
+    {
+        var preset = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxQueueConnectionsPreset));
+        return preset?.ToLowerInvariant() switch
+        {
+            "low" => 0.25,
+            "medium" => 0.5,
+            "high" => 0.75,
+            "max" => 1.0,
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/tests/NzbWebDAV.Tests/Config/MaxQueueConnectionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MaxQueueConnectionsTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class MaxQueueConnectionsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Unset_UsesWholePool(string? preset)
+    {
+        var config = CreateConfig(absolute: null, preset: preset, pooled: 20);
+        Assert.Equal(20, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("low", 20, 5)]
+    [InlineData("medium", 20, 10)]
+    [InlineData("high", 20, 15)]
+    [InlineData("max", 20, 20)]
+    [InlineData("low", 220, 55)]
+    [InlineData("medium", 220, 110)]
+    [InlineData("high", 220, 165)]
+    [InlineData("max", 220, 220)]
+    public void Preset_ScalesWithTheUsersOwnPool(string preset, int pooled, int expected)
+    {
+        // The point of the preset: one setting means the same share of the
+        // budget whatever a user's providers happen to add up to.
+        var config = CreateConfig(absolute: null, preset: preset, pooled: pooled);
+        Assert.Equal(expected, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("LOW", 20, 5)]
+    [InlineData("Medium", 20, 10)]
+    public void Preset_IsCaseInsensitive(string preset, int pooled, int expected)
+    {
+        var config = CreateConfig(absolute: null, preset: preset, pooled: pooled);
+        Assert.Equal(expected, config.GetMaxQueueConnections());
+    }
+
+    [Fact]
+    public void Preset_NeverYieldsZero()
+    {
+        // A quarter of a two-connection pool rounds to zero; the queue must
+        // still be able to make progress.
+        var config = CreateConfig(absolute: null, preset: "low", pooled: 2);
+        Assert.Equal(1, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("nonsense")]
+    [InlineData("0.5")]
+    public void UnrecognisedPreset_FallsBackToWholePool(string preset)
+    {
+        var config = CreateConfig(absolute: null, preset: preset, pooled: 20);
+        Assert.Equal(20, config.GetMaxQueueConnections());
+    }
+
+    [Fact]
+    public void AbsoluteValue_StillWins()
+    {
+        // Back-compat: an explicit count keeps its existing meaning even when a
+        // preset is also present.
+        var config = CreateConfig(absolute: "7", preset: "max", pooled: 20);
+        Assert.Equal(7, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("500", 20)]
+    [InlineData("0", 1)]
+    [InlineData("-3", 1)] // parses, then clamps up to the floor of 1
+    public void AbsoluteValue_ClampsToPool(string absolute, int expected)
+    {
+        var config = CreateConfig(absolute: absolute, preset: null, pooled: 20);
+        Assert.Equal(expected, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("")]
+    public void UnparseableAbsolute_DefersToThePreset(string absolute)
+    {
+        var config = CreateConfig(absolute: absolute, preset: "medium", pooled: 20);
+        Assert.Equal(10, config.GetMaxQueueConnections());
+    }
+
+    private static ConfigManager CreateConfig(string? absolute, string? preset, int pooled)
+    {
+        var providers = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    Type = ProviderType.Pooled,
+                    Host = "pool.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "u",
+                    Pass = "p",
+                    MaxConnections = pooled,
+                },
+            ]
+        });
+
+        var items = new List<ConfigItem>
+        {
+            new() { ConfigName = "usenet.providers", ConfigValue = providers },
+        };
+        if (absolute is not null)
+            items.Add(new ConfigItem { ConfigName = "usenet.max-queue-connections", ConfigValue = absolute });
+        if (preset is not null)
+            items.Add(new ConfigItem { ConfigName = "usenet.max-queue-connections-preset", ConfigValue = preset });
+
+        var config = new ConfigManager();
+        config.UpdateValues(items);
+        return config;
+    }
+}


### PR DESCRIPTION
## The problem

`usenet.max-queue-connections` is an absolute count, clamped to the pooled connection total:

```csharp
var pool = Math.Max(1, GetUsenetProviderConfig().TotalPooledConnections);
...
return Math.Clamp(value, 1, pool);
```

So its meaning depends entirely on what a user's providers add up to, which makes it awkward to set once and leave alone — and the failure is silent:

| Pooled total | Set to 140 | Result |
|---|---|---|
| 220 | 140 | 64% of the pool — as intended |
| 100 | clamped to 100 | **the whole pool; nothing reserved** |
| 20 | clamped to 20 | **the whole pool; nothing reserved** |
| 500 | 140 | 28% — queue far more restricted than intended |

There's no error or warning in the clamped cases; the setting simply stops doing anything.

## The change

Adds `usenet.max-queue-connections-preset`, mirroring `usenet.max-download-connections-per-stream-preset` directly above it in `ConfigManager`: `low`/`medium`/`high`/`max` → `0.25`/`0.5`/`0.75`/`1.0` of the pooled budget, floored at 1 so a tiny pool still makes progress.

**Nothing changes for existing installs:**

- the absolute setting keeps precedence when set
- both unset → the historical default of letting the queue use the whole pool
- an unrecognised preset falls through to that same default, matching how the per-stream preset behaves

## Why it matters

Streaming reads already win admission at the connection pool — it's a `PrioritizedSemaphore` borrowed with `SemaphorePriority.High` while queue work uses `Low`, and the default `HighPriorityOdds = 100` means a waiting stream is always released first.

But that's admission priority, not preemption: a queue download keeps its connection until its current article finishes. So when the queue is busy enough to occupy the whole pool, a stream still waits for an article to complete before it can start. Leaving some headroom is what avoids that, and a fraction is the only way to express it once across installs with very different provider counts.

## Testing

`dotnet test tests/NzbWebDAV.Tests` — **1186 passed, 0 failed**, including 23 new cases covering each preset against both a 20- and a 220-connection pool, case-insensitivity, the floor-of-1 behaviour, unrecognised presets, and that the absolute setting still wins.

## Context

We run a large fleet of nzbdav instances whose users configure anywhere from 20 to 220 connections, which is how the clamping behaviour surfaced — one fleet-wide value is genuinely unusable today. Happy to adjust the preset names or fractions if you'd prefer different ones, or to add the UI control in a follow-up.