### PR TITLE
feat(sonarr): resolve the next episode of a series through Sonarr

### DIFF
--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Text.RegularExpressions;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.RadarrSonarr.SonarrModels;
 using NzbWebDAV.Utils;
@@ -34,11 +35,52 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public Task<List<SonarrEpisode>> GetEpisodesFromEpisodeFileId(int episodeFileId) =>
         Get<List<SonarrEpisode>>($"/episode?episodeFileId={episodeFileId}");
 
+    public Task<List<SonarrEpisode>> GetAllEpisodesForSeries(int seriesId) =>
+        Get<List<SonarrEpisode>>($"/episode?seriesId={seriesId}");
+
     public Task<HttpStatusCode> DeleteEpisodeFile(int episodeFileId) =>
         Delete($"/episodefile/{episodeFileId}");
 
     public Task<ArrCommand> SearchEpisodesAsync(List<int> episodeIds) =>
         CommandAsync(new { name = "EpisodeSearch", episodeIds });
+
+    /// <summary>
+    /// Finds a series by name using progressively looser tiers: exact title,
+    /// then title normalized (year-suffix/punctuation/whitespace stripped),
+    /// then normalized match against Sonarr's own alternate/localized titles.
+    /// Stops at the first tier with exactly one match; an ambiguous (&gt;1) or
+    /// empty result at any tier is treated as "no match" rather than guessing.
+    /// </summary>
+    public async Task<SonarrSeries?> FindSeriesByTitle(string seriesName)
+    {
+        var allSeries = await GetAllSeries();
+
+        var exactMatches = allSeries
+            .Where(s => s.Title != null && s.Title.Equals(seriesName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (exactMatches.Count == 1) return exactMatches[0];
+        if (exactMatches.Count > 1) return null;
+
+        var normalizedName = NormalizeTitle(seriesName);
+        var normalizedMatches = allSeries
+            .Where(s => s.Title != null && NormalizeTitle(s.Title) == normalizedName)
+            .ToList();
+        if (normalizedMatches.Count == 1) return normalizedMatches[0];
+        if (normalizedMatches.Count > 1) return null;
+
+        var alternateTitleMatches = allSeries
+            .Where(s => s.AlternateTitles?.Any(a => a.Title != null && NormalizeTitle(a.Title) == normalizedName) == true)
+            .ToList();
+        return alternateTitleMatches.Count == 1 ? alternateTitleMatches[0] : null;
+    }
+
+    private static string NormalizeTitle(string title)
+    {
+        var withoutYear = Regex.Replace(title, @"\s*\(\d{4}\)\s*$", "");
+        var withoutPunctuation = Regex.Replace(withoutYear, @"[^\w\s]", "");
+        var collapsedWhitespace = Regex.Replace(withoutPunctuation, @"\s+", " ").Trim();
+        return collapsedWhitespace.ToLowerInvariant();
+    }
 
     public override async Task<bool> RemoveAndSearch(string symlinkOrStrmPath)
     {

--- a/backend/Clients/RadarrSonarr/SonarrModels/SonarrAlternateTitle.cs
+++ b/backend/Clients/RadarrSonarr/SonarrModels/SonarrAlternateTitle.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Clients.RadarrSonarr.SonarrModels;
+
+public class SonarrAlternateTitle
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+}

--- a/backend/Clients/RadarrSonarr/SonarrModels/SonarrEpisode.cs
+++ b/backend/Clients/RadarrSonarr/SonarrModels/SonarrEpisode.cs
@@ -18,4 +18,10 @@ public class SonarrEpisode
 
     [JsonPropertyName("title")]
     public string? Title { get; set; }
+
+    [JsonPropertyName("hasFile")]
+    public bool HasFile { get; set; }
+
+    [JsonPropertyName("episodeFileId")]
+    public int EpisodeFileId { get; set; }
 }

--- a/backend/Clients/RadarrSonarr/SonarrModels/SonarrSeries.cs
+++ b/backend/Clients/RadarrSonarr/SonarrModels/SonarrSeries.cs
@@ -12,4 +12,7 @@ public class SonarrSeries
 
     [JsonPropertyName("path")]
     public string? Path { get; set; }
+
+    [JsonPropertyName("alternateTitles")]
+    public List<SonarrAlternateTitle>? AlternateTitles { get; set; }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -19,6 +19,7 @@ using NzbWebDAV.Middlewares;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.PrefetchCache;
 using NzbWebDAV.Services.SupportPack;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
@@ -247,6 +248,7 @@ class Program
                 .AddSingleton<AnimeListMappingResolver>()
                 .AddSingleton<ExternalIdResolver>()
                 .AddSingleton<ImdbTitleResolver>()
+                .AddSingleton<SonarrNextEpisodeResolver>()
                 .AddSingleton<SearchProfileService>()
                 .AddSingleton<VariantResolver>()
                 .AddSingleton<MetricsWriter>()

--- a/backend/Services/PrefetchCache/SonarrNextEpisodeResolver.cs
+++ b/backend/Services/PrefetchCache/SonarrNextEpisodeResolver.cs
@@ -1,0 +1,64 @@
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Config;
+using Serilog;
+
+namespace NzbWebDAV.Services.PrefetchCache;
+
+/// <summary>
+/// Resolves the file path of the episode that follows a given (series, season, episode)
+/// across every configured Sonarr instance, using Sonarr's own episode ordering rather
+/// than season/episode-number arithmetic (which breaks on specials and season-count
+/// mismatches between metadata providers).
+/// </summary>
+public class SonarrNextEpisodeResolver(ConfigManager configManager)
+{
+    public Task<string?> ResolveNextEpisodePath(string seriesName, int currentSeasonNumber, int currentEpisodeNumber) =>
+        ResolveNextEpisodePath(
+            configManager.GetArrConfig().GetArrClients().OfType<SonarrClient>(),
+            seriesName, currentSeasonNumber, currentEpisodeNumber);
+
+    internal static async Task<string?> ResolveNextEpisodePath(
+        IEnumerable<SonarrClient> sonarrClients, string seriesName, int currentSeasonNumber, int currentEpisodeNumber)
+    {
+        foreach (var sonarrClient in sonarrClients)
+        {
+            var path = await TryResolveFromInstance(sonarrClient, seriesName, currentSeasonNumber, currentEpisodeNumber)
+                .ConfigureAwait(false);
+            if (path != null) return path;
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> TryResolveFromInstance(
+        SonarrClient sonarrClient, string seriesName, int currentSeasonNumber, int currentEpisodeNumber)
+    {
+        var series = await sonarrClient.FindSeriesByTitle(seriesName).ConfigureAwait(false);
+        if (series == null)
+        {
+            Log.Debug("SonarrNextEpisodeResolver: no series match for {SeriesName} on {Host}",
+                seriesName, sonarrClient.Host);
+            return null;
+        }
+
+        var episodes = await sonarrClient.GetAllEpisodesForSeries(series.Id).ConfigureAwait(false);
+        var nextEpisode = episodes
+            .Where(e => IsAfter(e.SeasonNumber, e.EpisodeNumber, currentSeasonNumber, currentEpisodeNumber))
+            .OrderBy(e => e.SeasonNumber)
+            .ThenBy(e => e.EpisodeNumber)
+            .FirstOrDefault();
+
+        if (nextEpisode is not { HasFile: true })
+        {
+            Log.Debug("SonarrNextEpisodeResolver: no downloaded next episode after S{Season}E{Episode} for {SeriesName}",
+                currentSeasonNumber, currentEpisodeNumber, seriesName);
+            return null;
+        }
+
+        var episodeFile = await sonarrClient.GetEpisodeFile(nextEpisode.EpisodeFileId).ConfigureAwait(false);
+        return episodeFile.Path;
+    }
+
+    private static bool IsAfter(int season, int episode, int currentSeason, int currentEpisode) =>
+        season > currentSeason || (season == currentSeason && episode > currentEpisode);
+}

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -30,6 +30,84 @@ public class RadarrSonarrClientTests
     }
 
     [Fact]
+    public async Task FindSeriesByTitle_ExactMatch_ReturnsSeries()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Breaking Bad"}]"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var series = await client.FindSeriesByTitle("Breaking Bad");
+
+        Assert.NotNull(series);
+        Assert.Equal(1, series!.Id);
+    }
+
+    [Fact]
+    public async Task FindSeriesByTitle_IncomingHasYearSuffixSonarrDoesNot_MatchesViaNormalizedTier()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse("""[{"id":2,"title":"The Office"}]"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var series = await client.FindSeriesByTitle("The Office (2005)");
+
+        Assert.NotNull(series);
+        Assert.Equal(2, series!.Id);
+    }
+
+    [Fact]
+    public async Task FindSeriesByTitle_PunctuationDiffers_MatchesViaNormalizedTier()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse("""[{"id":8,"title":"Grey's Anatomy"}]"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var series = await client.FindSeriesByTitle("Greys Anatomy");
+
+        Assert.NotNull(series);
+        Assert.Equal(8, series!.Id);
+    }
+
+    [Fact]
+    public async Task FindSeriesByTitle_MatchesViaAlternateTitle()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse(
+                """[{"id":3,"title":"It: Welcome to Derry","alternateTitles":[{"title":"Es - Welcome to Derry"}]}]"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var series = await client.FindSeriesByTitle("Es - Welcome to Derry");
+
+        Assert.NotNull(series);
+        Assert.Equal(3, series!.Id);
+    }
+
+    [Fact]
+    public async Task FindSeriesByTitle_AmbiguousNormalizedMatch_ReturnsNullWithoutFallingThroughToAlternateTitles()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse(
+                """[{"id":4,"title":"Foo (2001)"},{"id":5,"title":"Foo (2019)","alternateTitles":[{"title":"Foo"}]}]"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var series = await client.FindSeriesByTitle("Foo");
+
+        Assert.Null(series);
+    }
+
+    [Fact]
+    public async Task FindSeriesByTitle_NoMatchAtAnyTier_ReturnsNull()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse("""[{"id":6,"title":"Some Other Show"}]"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var series = await client.FindSeriesByTitle("Completely Unrelated");
+
+        Assert.Null(series);
+    }
+
+    [Fact]
     public async Task RadarrStaleCachedMovie_ReturnsFalseAfter404()
     {
         const string filePath = "/library/movies/Stale Movie/Stale Movie.mkv";

--- a/tests/NzbWebDAV.Tests/Services/PrefetchCache/SonarrNextEpisodeResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/PrefetchCache/SonarrNextEpisodeResolverTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Text;
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Services.PrefetchCache;
+
+namespace NzbWebDAV.Tests.Services.PrefetchCache;
+
+public class SonarrNextEpisodeResolverTests
+{
+    [Fact]
+    public async Task ResolveNextEpisodePath_NextEpisodeInSameSeason_ReturnsItsFilePath()
+    {
+        var client = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Breaking Bad"}]""")),
+            ("GET /api/v3/episode?seriesId=1", JsonResponse(
+                """
+                [
+                  {"id":10,"seriesId":1,"seasonNumber":2,"episodeNumber":5,"hasFile":true,"episodeFileId":100},
+                  {"id":11,"seriesId":1,"seasonNumber":2,"episodeNumber":6,"hasFile":true,"episodeFileId":101}
+                ]
+                """)),
+            ("GET /api/v3/episodefile/101", JsonResponse("""{"id":101,"seriesId":1,"path":"/tv/Breaking Bad/S02E06.mkv"}""")));
+
+        var path = await SonarrNextEpisodeResolver.ResolveNextEpisodePath([client], "Breaking Bad", 2, 5);
+
+        Assert.Equal("/tv/Breaking Bad/S02E06.mkv", path);
+    }
+
+    [Fact]
+    public async Task ResolveNextEpisodePath_CurrentIsLastEpisodeOfSeason_CrossesSeasonBoundary()
+    {
+        var client = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Breaking Bad"}]""")),
+            ("GET /api/v3/episode?seriesId=1", JsonResponse(
+                """
+                [
+                  {"id":10,"seriesId":1,"seasonNumber":1,"episodeNumber":7,"hasFile":true,"episodeFileId":100},
+                  {"id":11,"seriesId":1,"seasonNumber":2,"episodeNumber":1,"hasFile":true,"episodeFileId":101}
+                ]
+                """)),
+            ("GET /api/v3/episodefile/101", JsonResponse("""{"id":101,"seriesId":1,"path":"/tv/Breaking Bad/S02E01.mkv"}""")));
+
+        var path = await SonarrNextEpisodeResolver.ResolveNextEpisodePath([client], "Breaking Bad", 1, 7);
+
+        Assert.Equal("/tv/Breaking Bad/S02E01.mkv", path);
+    }
+
+    [Fact]
+    public async Task ResolveNextEpisodePath_SpecialsSeasonZero_NeverChosenOverLaterRegularSeason()
+    {
+        var client = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Breaking Bad"}]""")),
+            ("GET /api/v3/episode?seriesId=1", JsonResponse(
+                """
+                [
+                  {"id":9,"seriesId":1,"seasonNumber":0,"episodeNumber":1,"hasFile":true,"episodeFileId":99},
+                  {"id":10,"seriesId":1,"seasonNumber":2,"episodeNumber":5,"hasFile":true,"episodeFileId":100},
+                  {"id":11,"seriesId":1,"seasonNumber":2,"episodeNumber":6,"hasFile":true,"episodeFileId":101}
+                ]
+                """)),
+            ("GET /api/v3/episodefile/101", JsonResponse("""{"id":101,"seriesId":1,"path":"/tv/Breaking Bad/S02E06.mkv"}""")));
+
+        var path = await SonarrNextEpisodeResolver.ResolveNextEpisodePath([client], "Breaking Bad", 2, 5);
+
+        Assert.Equal("/tv/Breaking Bad/S02E06.mkv", path);
+    }
+
+    [Fact]
+    public async Task ResolveNextEpisodePath_NextEpisodeNotYetDownloaded_ReturnsNullWithoutSkippingAhead()
+    {
+        var client = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Breaking Bad"}]""")),
+            ("GET /api/v3/episode?seriesId=1", JsonResponse(
+                """
+                [
+                  {"id":10,"seriesId":1,"seasonNumber":2,"episodeNumber":5,"hasFile":true,"episodeFileId":100},
+                  {"id":11,"seriesId":1,"seasonNumber":2,"episodeNumber":6,"hasFile":false,"episodeFileId":0},
+                  {"id":12,"seriesId":1,"seasonNumber":2,"episodeNumber":7,"hasFile":true,"episodeFileId":102}
+                ]
+                """)));
+
+        var path = await SonarrNextEpisodeResolver.ResolveNextEpisodePath([client], "Breaking Bad", 2, 5);
+
+        Assert.Null(path);
+    }
+
+    [Fact]
+    public async Task ResolveNextEpisodePath_EndOfSeries_ReturnsNull()
+    {
+        var client = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Breaking Bad"}]""")),
+            ("GET /api/v3/episode?seriesId=1", JsonResponse(
+                """[{"id":10,"seriesId":1,"seasonNumber":5,"episodeNumber":16,"hasFile":true,"episodeFileId":100}]""")));
+
+        var path = await SonarrNextEpisodeResolver.ResolveNextEpisodePath([client], "Breaking Bad", 5, 16);
+
+        Assert.Null(path);
+    }
+
+    [Fact]
+    public async Task ResolveNextEpisodePath_NoSeriesMatchOnFirstInstance_FallsThroughToSecondInstance()
+    {
+        var noMatchClient = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":1,"title":"Some Other Show"}]""")));
+        var matchClient = CreateClient(
+            ("GET /api/v3/series", JsonResponse("""[{"id":7,"title":"Breaking Bad"}]""")),
+            ("GET /api/v3/episode?seriesId=7", JsonResponse(
+                """[{"id":10,"seriesId":7,"seasonNumber":1,"episodeNumber":2,"hasFile":true,"episodeFileId":200}]""")),
+            ("GET /api/v3/episodefile/200", JsonResponse("""{"id":200,"seriesId":7,"path":"/tv/Breaking Bad/S01E02.mkv"}""")));
+
+        var path = await SonarrNextEpisodeResolver.ResolveNextEpisodePath(
+            [noMatchClient, matchClient], "Breaking Bad", 1, 1);
+
+        Assert.Equal("/tv/Breaking Bad/S01E02.mkv", path);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static SonarrClient CreateClient(params (string request, HttpResponseMessage response)[] responses)
+    {
+        var handler = new ResponseQueueHandler(responses
+            .GroupBy(x => x.request)
+            .ToDictionary(x => x.Key, x => new Queue<HttpResponseMessage>(x.Select(y => y.response))));
+        return new TestSonarrClient(new HttpClient(handler));
+    }
+
+    private sealed class TestSonarrClient(HttpClient client) : SonarrClient("http://arr.test", "test-key")
+    {
+        protected override HttpClient Client => client;
+    }
+
+    private sealed class ResponseQueueHandler(
+        Dictionary<string, Queue<HttpResponseMessage>> responses) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var key = $"{request.Method} {request.RequestUri!.PathAndQuery}";
+            if (!responses.TryGetValue(key, out var queuedResponses) || !queuedResponses.TryDequeue(out var response))
+                throw new InvalidOperationException($"Unexpected request: {key}");
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- First slice of a four-part effort adding predictive episode prefetch caching, a cache management page, Usenet bandwidth throttling, and related config hardening (full plan discussed with maintainer, implementation continuing across follow-up PRs).
- Adds `SonarrClient.FindSeriesByTitle` (tiered match: exact → year-suffix/punctuation-normalized → alternate titles, returning `null` on no match or ambiguity rather than guessing) and `GetAllEpisodesForSeries`.
- Adds `SonarrNextEpisodeResolver`, which walks each configured Sonarr instance, matches the series by name, and finds the episode that follows a given (season, episode) using Sonarr's own episode ordering — not `episodeNumber + 1` arithmetic, which breaks on specials and season-count mismatches.
- `SonarrEpisode` gains `HasFile`/`EpisodeFileId`; `SonarrSeries` gains `AlternateTitles`.

Series-level TVDB/TMDB matching (as prefetcharr does by polling the media server's own API) isn't available from a passive Jellyfin webhook payload — confirmed by reading `jellyfin-plugin-webhook`'s `DataObjectHelpers.cs`, which only ever surfaces the episode's own provider IDs for an `Episode` notification, never the parent series'. The title-tier approach here follows episeerr's own Jellyfin-webhook path for the same reason.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — full suite green (1191 tests)
- [x] New unit tests: `FindSeriesByTitle` tier coverage (exact, year-suffix, punctuation, alternate title, ambiguous, no-match) and `SonarrNextEpisodeResolver` coverage (same-season next, season-boundary crossing, specials never chosen as "next", next-episode-not-yet-downloaded returns null without skipping ahead, end-of-series, multi-instance fallthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMK3fdg7uWurg2JkK6SUr1