### PR TITLE
fix(api): support packs keep streaming warnings instead of filling with Watchtower noise

### DIFF
--- a/backend/Logging/WarningLogBuffer.cs
+++ b/backend/Logging/WarningLogBuffer.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Logging;
+
+/// <summary>
+/// Holds a second, Warning-and-above ring buffer so a flood of Debug/Information
+/// events cannot evict the warnings and errors support packs are collected for.
+/// The main <see cref="LogBufferSink"/> keeps only the last LOG_BUFFER_SIZE entries
+/// of every level, which a chatty background service can consume within hours.
+/// Exists as a distinct type purely so DI can tell the two buffers apart.
+/// </summary>
+public sealed class WarningLogBuffer(LogBufferSink sink)
+{
+    public LogBufferSink Sink { get; } = sink;
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -50,6 +50,10 @@ class Program
         var level = Enum.TryParse<LogEventLevel>(envLevel, true, out var parsed) ? parsed : defaultLevel;
         var bufferSize = (int)Math.Clamp(EnvironmentUtil.GetLongVariable("LOG_BUFFER_SIZE") ?? 2000, 100, 50000);
         var logBufferSink = new LogBufferSink(bufferSize);
+        // Warnings and errors also land in their own small buffer so a chatty
+        // background service running at Debug cannot evict them before a support
+        // pack is collected.
+        var warningLogBuffer = new WarningLogBuffer(new LogBufferSink(500));
         // Stream tracing is opt-in: unset or 0 disables it. scripts/run-backend.sh
         // enables it for local dev; Docker/production leave it off by default.
         var streamTraceEvents = EnvironmentUtil.GetLongVariable("STREAM_TRACE_EVENTS") ?? 0;
@@ -76,6 +80,7 @@ class Program
                 "{#end}{@m}\n{@x}",
                 theme: TemplateTheme.Code))
             .WriteTo.Sink(logBufferSink)
+            .WriteTo.Sink(warningLogBuffer.Sink, restrictedToMinimumLevel: LogEventLevel.Warning)
             .CreateLogger();
 
         try
@@ -189,6 +194,7 @@ class Program
                 .AddSingleton(configManager)
                 .AddSingleton(websocketManager)
                 .AddSingleton(logBufferSink)
+                .AddSingleton(warningLogBuffer)
                 .AddSingleton(streamTraceBuffer)
                 .AddSingleton(sp =>
                 {

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -17,6 +17,7 @@ namespace NzbWebDAV.Services.SupportPack;
 
 public sealed class SupportPackService(
     LogBufferSink logBuffer,
+    WarningLogBuffer warningLogBuffer,
     ConfigManager configManager,
     MetricsWriter metricsWriter,
     ProviderBytesTracker bytesTracker,
@@ -35,9 +36,12 @@ public sealed class SupportPackService(
         var config = configManager.GetDiagnosticSnapshot();
         var redactor = new SupportPackRedactor(CollectSecrets(config));
         var logSnapshot = logBuffer.Snapshot(logBuffer.Capacity, null, null, null, null);
+        var warningSink = warningLogBuffer.Sink;
+        var warningSnapshot = warningSink.Snapshot(warningSink.Capacity, null, null, null, null);
         var sectionStatus = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["logs"] = "included",
+            ["warnings"] = "included",
             ["configuration"] = "included",
             ["environment"] = "included",
         };
@@ -48,6 +52,11 @@ public sealed class SupportPackService(
             archive,
             "logs/backend.log",
             redactor.RedactText(FormatLogs(logSnapshot.Entries)),
+            cancellationToken).ConfigureAwait(false);
+        await WriteTextAsync(
+            archive,
+            "logs/warnings.log",
+            redactor.RedactText(FormatLogs(warningSnapshot.Entries)),
             cancellationToken).ConfigureAwait(false);
         await WriteJsonAsync(
             archive,
@@ -77,7 +86,8 @@ public sealed class SupportPackService(
         await WriteJsonAsync(
             archive,
             "manifest.json",
-            await BuildManifestAsync(generatedAt, logSnapshot, sectionStatus, redactor, cancellationToken)
+            await BuildManifestAsync(generatedAt, logSnapshot, warningSnapshot, sectionStatus, redactor,
+                    cancellationToken)
                 .ConfigureAwait(false),
             redactor,
             cancellationToken).ConfigureAwait(false);
@@ -91,6 +101,11 @@ public sealed class SupportPackService(
         active Settings snapshot, runtime information, and aggregate metrics.
         Backend logs are cleared when NzbDAV restarts. Frontend and container logs
         are not included.
+
+        logs/backend.log holds the most recent events of every level, so a busy or
+        debug-level install can push older events out of it. logs/warnings.log keeps
+        the last 500 warnings and errors separately for that reason - check it first
+        when the main log looks like it only contains routine activity.
 
         The archive deliberately excludes database files, backups, blobs/NZBs,
         environment files, session/API key files, crash dumps, stream traces, and
@@ -326,6 +341,7 @@ public sealed class SupportPackService(
     private async Task<object> BuildManifestAsync(
         DateTimeOffset generatedAt,
         LogSnapshot logs,
+        LogSnapshot warnings,
         IReadOnlyDictionary<string, string> sectionStatus,
         SupportPackRedactor redactor,
         CancellationToken cancellationToken)
@@ -339,6 +355,13 @@ public sealed class SupportPackService(
             commit = Environment.GetEnvironmentVariable("NZBDAV_COMMIT_SHA"),
             migrations = new { main = mainMigration, metrics = metricsMigration },
             logs = new { count = logs.Entries.Count, logs.OldestSequence, logs.NewestSequence, capacity = logBuffer.Capacity },
+            warnings = new
+            {
+                count = warnings.Entries.Count,
+                warnings.OldestSequence,
+                warnings.NewestSequence,
+                capacity = warningLogBuffer.Sink.Capacity,
+            },
             sections = sectionStatus,
             redaction = new { secrets = redactor.SecretsRedacted, ipAddresses = redactor.AddressesPseudonymized },
         };

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -10,6 +11,7 @@ using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Streams;
+using Serilog;
 
 namespace NzbWebDAV.Services.SupportPack;
 
@@ -26,7 +28,6 @@ public sealed class SupportPackService(
     private const long HourMs = 60 * MinuteMs;
     private const long DayMs = 24 * HourMs;
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
-    private readonly DateTimeOffset _startedAt = DateTimeOffset.UtcNow;
 
     internal async Task WriteAsync(Stream output, CancellationToken cancellationToken)
     {
@@ -122,13 +123,15 @@ public sealed class SupportPackService(
         var configPath = DavDatabaseContext.ConfigPath;
         var root = Path.GetPathRoot(Path.GetFullPath(configPath)) ?? configPath;
         var drive = new DriveInfo(root);
+        var uptime = ProcessUptime();
 
         return new
         {
             generatedAtUtc = generatedAt,
             appVersion = ConfigManager.AppVersion,
             commit = Environment.GetEnvironmentVariable("NZBDAV_COMMIT_SHA"),
-            uptimeSeconds = (long)(generatedAt - _startedAt).TotalSeconds,
+            uptimeSeconds = (long)uptime.TotalSeconds,
+            processStartedAtUtc = generatedAt - uptime,
             runtime = new
             {
                 framework = RuntimeInformation.FrameworkDescription,
@@ -451,6 +454,30 @@ public sealed class SupportPackService(
 
     private static long? FileSize(string path) =>
         File.Exists(path) ? new FileInfo(path).Length : null;
+
+    /// <summary>
+    /// Real uptime of the backend process. This used to be measured from this service's
+    /// own construction, but DI creates it lazily on the first support-pack download, so a
+    /// backend running for hours reported a few seconds and made the log buffer's
+    /// timestamps look impossible. Process start time is absolute, so reading it on demand
+    /// stays accurate. Note that Environment.TickCount64 is unusable here: inside a
+    /// container it reports the host's uptime, not this process's.
+    /// </summary>
+    private static TimeSpan ProcessUptime()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            var uptime = DateTimeOffset.UtcNow - process.StartTime.ToUniversalTime();
+            if (uptime > TimeSpan.Zero) return uptime;
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e, "Support pack: could not read the process start time");
+        }
+
+        return TimeSpan.Zero;
+    }
 
     private static string FormatLogs(IEnumerable<LogEntry> entries)
     {

--- a/backend/Services/Watchtower/WatchtowerLogThrottle.cs
+++ b/backend/Services/Watchtower/WatchtowerLogThrottle.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Rate-limits repeating Watchtower heartbeat messages. The cycle loop ticks every
+/// 20 seconds forever, so an idle-but-enabled Watchtower would otherwise fill the
+/// whole in-memory log buffer with the same two lines and evict the events support
+/// actually needs (see LogBufferSink).
+/// </summary>
+public sealed class WatchtowerLogThrottle
+{
+    private readonly ConcurrentDictionary<string, State> _states = new();
+
+    /// <summary>
+    /// Returns true when the caller should emit the message for <paramref name="key"/>,
+    /// which is at most once per <paramref name="interval"/>. <paramref name="suppressed"/>
+    /// reports how many calls were swallowed since the last emitted one so the message can
+    /// say what was skipped.
+    /// </summary>
+    public bool ShouldLog(string key, TimeSpan interval, out int suppressed)
+    {
+        var now = Environment.TickCount64;
+        var intervalMs = (long)interval.TotalMilliseconds;
+        var state = _states.GetOrAdd(key, _ => new State());
+
+        lock (state)
+        {
+            if (state.HasLogged && now - state.LastLoggedAtMs < intervalMs)
+            {
+                state.Suppressed++;
+                suppressed = 0;
+                return false;
+            }
+
+            suppressed = state.Suppressed;
+            state.Suppressed = 0;
+            state.LastLoggedAtMs = now;
+            state.HasLogged = true;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Forgets the throttle window for <paramref name="key"/> so the next call logs
+    /// immediately. Used when the underlying condition changes and the fresh state is
+    /// worth reporting right away.
+    /// </summary>
+    public void Reset(string key) => _states.TryRemove(key, out _);
+
+    private sealed class State
+    {
+        public long LastLoggedAtMs;
+        public bool HasLogged;
+        public int Suppressed;
+    }
+}

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -28,6 +28,14 @@ public class WatchtowerService(
 {
     private static readonly TimeSpan Tick = TimeSpan.FromSeconds(20);
     private static readonly TimeSpan NzbFetchTimeout = TimeSpan.FromSeconds(15);
+
+    // Heartbeat throttles. The cycle loop ticks every 20s forever, so logging each
+    // tick would fill the whole log buffer and evict everything support needs.
+    private static readonly TimeSpan CycleStartLogInterval = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan NoProfileLogInterval = TimeSpan.FromMinutes(60);
+    private const string CycleStartLogKey = "cycle-starting";
+    private const string NoProfileLogKey = "no-search-profile";
+    private readonly WatchtowerLogThrottle _logThrottle = new();
     private const int ResolvesPerTick = 3;
     private const int AutoResolveBatch = 25;
     private static readonly TimeSpan AutoStageBudget = TimeSpan.FromSeconds(120);
@@ -70,7 +78,14 @@ public class WatchtowerService(
                     lock (_ctsLock) _disabledCts = cycleCts;
                     var ct = cycleCts.Token;
                     var cycleWatch = Stopwatch.StartNew();
-                    LogActivity("Watchtower: cycle starting");
+                    if (_logThrottle.ShouldLog(CycleStartLogKey, CycleStartLogInterval, out var skippedCycles))
+                    {
+                        if (skippedCycles > 0)
+                            LogActivity("Watchtower: cycle starting ({Skipped:n0} cycles since the last log)",
+                                skippedCycles);
+                        else
+                            LogActivity("Watchtower: cycle starting");
+                    }
                     try
                     {
                         var cycle = RunCycleAsync(cycleWatch, ct);
@@ -129,8 +144,15 @@ public class WatchtowerService(
     private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs e)
     {
         if (e.ChangedConfig.ContainsKey(ConfigKeys.WatchtowerVerboseLogging))
+        {
             Log.Information("Watchtower: verbose activity logging {State}",
                 configManager.IsWatchtowerVerboseLoggingEnabled() ? "enabled" : "disabled");
+            _logThrottle.Reset(CycleStartLogKey);
+        }
+
+        // Report the fresh state on the next cycle instead of waiting out the throttle.
+        if (e.ChangedConfig.ContainsKey(ConfigKeys.WatchtowerProfileToken))
+            _logThrottle.Reset(NoProfileLogKey);
 
         if (!e.ChangedConfig.ContainsKey(ConfigKeys.WatchtowerEnabled)) return;
         if (configManager.IsWatchtowerEnabled()) return;
@@ -705,9 +727,21 @@ public class WatchtowerService(
         var profileToken = ResolveProfileToken();
         if (profileToken is null)
         {
-            LogActivity("Watchtower: no search profile configured; skipping resolve");
+            if (_logThrottle.ShouldLog(NoProfileLogKey, NoProfileLogInterval, out var skippedResolves))
+            {
+                if (skippedResolves > 0)
+                    LogActivity(
+                        "Watchtower: no search profile configured; skipping resolve " +
+                        "({Skipped:n0} cycles skipped since the last log)",
+                        skippedResolves);
+                else
+                    LogActivity("Watchtower: no search profile configured; skipping resolve");
+            }
+
             return;
         }
+
+        _logThrottle.Reset(NoProfileLogKey);
 
         var concurrency = configManager.GetWatchtowerResolveConcurrency();
         var stageWatch = Stopwatch.StartNew();

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -37,4 +37,15 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 
     Raise **Max Download Connections** until throughput plateaus without pegging CPU. Baseline with a host speed test, then time a `/view` download from inside the container against the backend.
 
+## Capturing a buffering support pack
+
+Playback stalls are only diagnosable if the evidence is still in the log buffer when you collect the pack:
+
+1. Set `LOG_LEVEL=INFO`. At `DEBUG`, routine background activity can fill the whole buffer within hours and evict the streaming events. `logs/warnings.log` in the pack keeps the last 500 warnings and errors regardless, so check it first.
+2. Set `STREAM_TRACE_EVENTS=20000` to record per-segment playback traces.
+3. Reproduce the stall — play the file from Explore so the read goes straight to `/view`, skipping rclone and your media server.
+4. Download the pack from **Settings → Support** immediately afterwards. The buffer is in-memory and is cleared on restart.
+
+Stream traces are not part of the archive; read them from the Stream Traces API (`/api/get-stream-traces`) or `scripts/dump-stream-trace.sh` while the backend is still running. See [Logs and crash dumps](../operations/logs-crash-dumps.md).
+
 [Streaming](../features/streaming-seeking.md) · [NNTP pipelining](../features/nntp-pipelining.md)

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -1,0 +1,137 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Logging;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Services.SupportPack;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+using Serilog;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services.SupportPack;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class SupportPackContentsTests : IDisposable
+{
+    private readonly string _configRoot =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-support-{Guid.NewGuid():N}");
+
+    private readonly string? _previousConfigPath;
+
+    public SupportPackContentsTests()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Pack_KeepsWarningsThatOverflowedTheMainLogBuffer()
+    {
+        // Mirrors the production wiring: one small all-level buffer plus a
+        // Warning-and-above lane, both fed by the same logger.
+        var mainSink = new LogBufferSink(10);
+        var warningBuffer = new WarningLogBuffer(new LogBufferSink(500));
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(mainSink)
+            .WriteTo.Sink(warningBuffer.Sink, restrictedToMinimumLevel: LogEventLevel.Warning)
+            .CreateLogger();
+
+        logger.Warning("Streaming timeout executing nntp BODY command");
+        for (var i = 0; i < 50; i++)
+            logger.Debug("Watchtower: cycle starting {Index}", i);
+
+        var entries = await ReadPackEntriesAsync(mainSink, warningBuffer);
+
+        var backendLog = entries["logs/backend.log"];
+        var warningsLog = entries["logs/warnings.log"];
+
+        Assert.DoesNotContain("Streaming timeout", backendLog);
+        Assert.Contains("Watchtower: cycle starting", backendLog);
+        Assert.Contains("Streaming timeout executing nntp BODY command", warningsLog);
+        Assert.DoesNotContain("Watchtower: cycle starting", warningsLog);
+
+        using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+        var warnings = manifest.RootElement.GetProperty("warnings");
+        Assert.Equal(1, warnings.GetProperty("count").GetInt32());
+        Assert.Equal(500, warnings.GetProperty("capacity").GetInt32());
+        Assert.Equal("included", manifest.RootElement.GetProperty("sections").GetProperty("warnings").GetString());
+    }
+
+    [Fact]
+    public async Task Pack_ReportsProcessUptimeRatherThanServiceConstructionTime()
+    {
+        var entries = await ReadPackEntriesAsync(new LogBufferSink(10), new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var root = environment.RootElement;
+        var generatedAt = root.GetProperty("generatedAtUtc").GetDateTimeOffset();
+        var reportedStart = root.GetProperty("processStartedAtUtc").GetDateTimeOffset();
+        var uptimeSeconds = root.GetProperty("uptimeSeconds").GetInt64();
+
+        using var process = Process.GetCurrentProcess();
+        var actualStart = new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+
+        // The service is constructed moments before the pack is written, so anything
+        // measured from construction would report ~0. It must track the OS process.
+        Assert.True(
+            Math.Abs((reportedStart - actualStart).TotalSeconds) < 5,
+            $"reported process start {reportedStart:O} should match {actualStart:O}");
+        Assert.Equal((long)(generatedAt - reportedStart).TotalSeconds, uptimeSeconds);
+    }
+
+    private static async Task<Dictionary<string, string>> ReadPackEntriesAsync(
+        LogBufferSink logBuffer,
+        WarningLogBuffer warningBuffer)
+    {
+        var configManager = new ConfigManager();
+        var websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100, enabled: false),
+            new ActiveReadRegistry());
+
+        var service = new SupportPackService(
+            logBuffer,
+            warningBuffer,
+            configManager,
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            usenet,
+            new ArticleMissNegativeCache(configManager),
+            new InFlightArticleBudget(64 * 1024 * 1024));
+
+        using var buffer = new MemoryStream();
+        await service.WriteAsync(buffer, CancellationToken.None);
+
+        buffer.Position = 0;
+        using var archive = new ZipArchive(buffer, ZipArchiveMode.Read);
+        var entries = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in archive.Entries)
+        {
+            await using var stream = entry.Open();
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            entries[entry.FullName] = await reader.ReadToEndAsync();
+        }
+
+        return entries;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Watchtower/WatchtowerLogThrottleTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Watchtower/WatchtowerLogThrottleTests.cs
@@ -1,0 +1,64 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services.Watchtower;
+
+public class WatchtowerLogThrottleTests
+{
+    [Fact]
+    public void ShouldLog_AllowsFirstCallThenSuppressesWithinTheInterval()
+    {
+        var throttle = new WatchtowerLogThrottle();
+        var interval = TimeSpan.FromMinutes(15);
+
+        Assert.True(throttle.ShouldLog("cycle", interval, out var firstSuppressed));
+        Assert.Equal(0, firstSuppressed);
+
+        for (var i = 0; i < 45; i++)
+            Assert.False(throttle.ShouldLog("cycle", interval, out _));
+    }
+
+    [Fact]
+    public void ShouldLog_ReportsSuppressedCountOnceTheIntervalElapses()
+    {
+        var throttle = new WatchtowerLogThrottle();
+
+        Assert.True(throttle.ShouldLog("cycle", TimeSpan.Zero, out _));
+        Assert.False(throttle.ShouldLog("cycle", TimeSpan.FromMinutes(15), out _));
+        Assert.False(throttle.ShouldLog("cycle", TimeSpan.FromMinutes(15), out _));
+
+        // A zero interval always elapses, standing in for the wall-clock wait.
+        Assert.True(throttle.ShouldLog("cycle", TimeSpan.Zero, out var suppressed));
+        Assert.Equal(2, suppressed);
+
+        // The count resets once reported.
+        Assert.True(throttle.ShouldLog("cycle", TimeSpan.Zero, out var afterReport));
+        Assert.Equal(0, afterReport);
+    }
+
+    [Fact]
+    public void ShouldLog_TracksKeysIndependently()
+    {
+        var throttle = new WatchtowerLogThrottle();
+        var interval = TimeSpan.FromMinutes(60);
+
+        Assert.True(throttle.ShouldLog("cycle", interval, out _));
+        Assert.True(throttle.ShouldLog("no-profile", interval, out _));
+        Assert.False(throttle.ShouldLog("cycle", interval, out _));
+        Assert.False(throttle.ShouldLog("no-profile", interval, out _));
+    }
+
+    [Fact]
+    public void Reset_LetsTheNextCallLogImmediately()
+    {
+        var throttle = new WatchtowerLogThrottle();
+        var interval = TimeSpan.FromMinutes(60);
+
+        Assert.True(throttle.ShouldLog("no-profile", interval, out _));
+        Assert.False(throttle.ShouldLog("no-profile", interval, out _));
+
+        throttle.Reset("no-profile");
+
+        Assert.True(throttle.ShouldLog("no-profile", interval, out var suppressed));
+        Assert.Equal(0, suppressed);
+    }
+}


### PR DESCRIPTION
## Summary
- Throttle idle Watchtower heartbeat Debug logs so they cannot fill the entire in-memory log buffer
- Report real process uptime in support packs instead of measuring from the first pack download
- Keep a separate 500-entry Warning/Error lane shipped as `logs/warnings.log`
- Document how to capture a buffering support pack while the evidence is still in memory

## Test plan
- [ ] Enable Watchtower without a search profile, set `LOG_LEVEL=DEBUG`, wait ~20 minutes, download a support pack — `logs/backend.log` should no longer be wall-to-wall `Watchtower: cycle starting`
- [ ] Trigger a streaming Warning (e.g. force a segment timeout), flood Debug messages past the main buffer capacity, download a pack — `logs/warnings.log` still contains the Warning
- [ ] Download two packs a minute apart and confirm `uptimeSeconds` advances and `processStartedAtUtc` stays stable
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~SupportPack|FullyQualifiedName~WatchtowerLogThrottle"`