### PR TITLE
feat(health): support packs show CPU, memory and per-stage playback stalls

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -250,7 +251,10 @@ public class GetWebdavItemController(
                 throw;
             }
             if (read <= 0) break;
+            var writeStarted = Stopwatch.GetTimestamp();
             await dest.WriteAsync(buffer, 0, read, ct).ConfigureAwait(false);
+            streamTrace.AddStall(
+                sessionId, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
             position += read;
             activeReadRegistry.Touch(sessionId, read, position);
         }

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -1,9 +1,24 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Contexts;
 
 namespace NzbWebDAV.Clients.Usenet.Connections;
+
+/// <summary>
+/// Lifetime connection churn for one pool. Distinguishes a pool that opened its
+/// connections once from one that keeps replacing them, which the live/idle
+/// gauges cannot show.
+/// </summary>
+public sealed record ConnectionPoolChurn(
+    long ConnectionsOpened,
+    long ConnectionsReused,
+    long ConnectionsDestroyed,
+    long StaleEvictions,
+    long HandshakeFailures,
+    long GateWaitMs,
+    long HandshakeWaitMs);
 
 /// <summary>
 /// Thread-safe, lazy connection pool.
@@ -52,6 +67,26 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     private int _live; // number of connections currently alive
     private int _disposed; // 0 == false, 1 == true
 
+    // Lifetime churn counters. A pool that keeps destroying and re-opening connections
+    // pays the handshake cost repeatedly and can never reach its configured width, which
+    // is invisible from the live/idle gauges alone.
+    private long _connectionsOpened;
+    private long _connectionsReused;
+    private long _connectionsDestroyed;
+    private long _staleEvictions;
+    private long _handshakeFailures;
+    private long _gateWaitTicks;
+    private long _handshakeWaitTicks;
+
+    public ConnectionPoolChurn GetChurn() => new(
+        ConnectionsOpened: Interlocked.Read(ref _connectionsOpened),
+        ConnectionsReused: Interlocked.Read(ref _connectionsReused),
+        ConnectionsDestroyed: Interlocked.Read(ref _connectionsDestroyed),
+        StaleEvictions: Interlocked.Read(ref _staleEvictions),
+        HandshakeFailures: Interlocked.Read(ref _handshakeFailures),
+        GateWaitMs: Interlocked.Read(ref _gateWaitTicks) / TimeSpan.TicksPerMillisecond,
+        HandshakeWaitMs: Interlocked.Read(ref _handshakeWaitTicks) / TimeSpan.TicksPerMillisecond);
+
     /* ------------------------------------------------------------------------------ */
 
     public ConnectionPool(
@@ -92,7 +127,9 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken, _sweepCts.Token);
 
+        var gateWaitStarted = Stopwatch.GetTimestamp();
         await _gate.WaitAsync(priority, linked.Token).ConfigureAwait(false);
+        Interlocked.Add(ref _gateWaitTicks, Stopwatch.GetElapsedTime(gateWaitStarted).Ticks);
 
         // Pool might have been disposed after wait returned:
         if (Volatile.Read(ref _disposed) == 1)
@@ -104,6 +141,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         // Try to reuse an existing idle connection.
         if (TryTakeIdleConnection(out var reused))
         {
+            Interlocked.Increment(ref _connectionsReused);
             TriggerConnectionPoolChangedEvent();
             return BuildLock(reused, wasReused: true);
         }
@@ -113,7 +151,9 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         // connections may return to the idle stack — prefer those over a new handshake.
         try
         {
+            var handshakeWaitStarted = Stopwatch.GetTimestamp();
             await _handshakeGate.WaitAsync(linked.Token).ConfigureAwait(false);
+            Interlocked.Add(ref _handshakeWaitTicks, Stopwatch.GetElapsedTime(handshakeWaitStarted).Ticks);
         }
         catch
         {
@@ -131,6 +171,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
             if (TryTakeIdleConnection(out reused))
             {
+                Interlocked.Increment(ref _connectionsReused);
                 TriggerConnectionPoolChangedEvent();
                 return BuildLock(reused, wasReused: true);
             }
@@ -142,10 +183,12 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             }
             catch
             {
+                Interlocked.Increment(ref _handshakeFailures);
                 _gate.Release(); // free the permit on failure
                 throw;
             }
 
+            Interlocked.Increment(ref _connectionsOpened);
             Interlocked.Increment(ref _live);
             TriggerConnectionPoolChangedEvent();
             return BuildLock(conn, wasReused: false);
@@ -175,6 +218,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             // Stale – destroy and continue looking.
             DisposeConnection(item.Connection);
             Interlocked.Decrement(ref _live);
+            Interlocked.Increment(ref _staleEvictions);
             TriggerConnectionPoolChangedEvent();
         }
 
@@ -214,6 +258,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         // When a lock requests replacement, we dispose the connection instead of reusing.
         DisposeConnection(connection);
         Interlocked.Decrement(ref _live);
+        Interlocked.Increment(ref _connectionsDestroyed);
         if (Volatile.Read(ref _disposed) == 0)
         {
             _gate.Release();

--- a/backend/Clients/Usenet/Models/ProviderConnectionSnapshot.cs
+++ b/backend/Clients/Usenet/Models/ProviderConnectionSnapshot.cs
@@ -1,0 +1,19 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Clients.Usenet.Models;
+
+/// <summary>
+/// Live connection-pool state plus lifetime churn for one configured provider
+/// account, keyed by metrics ProviderId.
+/// </summary>
+public sealed record ProviderConnectionSnapshot(
+    string MetricsKey,
+    string Host,
+    ProviderType ProviderType,
+    int LiveConnections,
+    int IdleConnections,
+    int ActiveConnections,
+    int AvailableConnections,
+    int PendingSelections,
+    ConnectionPoolChurn Churn);

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
@@ -8,6 +9,7 @@ using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
+using NzbWebDAV.Services.StreamTrace;
 using Serilog;
 using UsenetSharp.Models;
 
@@ -95,6 +97,7 @@ public class MultiConnectionNntpClient(
     public int ActiveConnections => connectionPool.ActiveConnections;
     public int AvailableConnections => connectionPool.AvailableConnections;
     public int InFlightConnections => ActiveConnections + PendingSelections;
+    public ConnectionPoolChurn GetConnectionChurn() => connectionPool.GetChurn();
 
     private int _pendingSelections;
     public int PendingSelections => Volatile.Read(ref _pendingSelections);
@@ -210,8 +213,7 @@ public class MultiConnectionNntpClient(
             CancellationTokenSource? attemptCts = null;
             try
             {
-                connectionLock = await connectionPool
-                    .GetConnectionLockAsync(GetDownloadPriority(ct), ct)
+                connectionLock = await AcquireConnectionLockAsync(GetDownloadPriority(ct), ct)
                     .ConfigureAwait(false);
 
                 var batchCt = ct;
@@ -381,7 +383,7 @@ public class MultiConnectionNntpClient(
             ConnectionLock<INntpClient>? connectionLock = null;
             try
             {
-                connectionLock = await connectionPool.GetConnectionLockAsync(priority, ct).ConfigureAwait(false);
+                connectionLock = await AcquireConnectionLockAsync(priority, ct).ConfigureAwait(false);
             }
             catch (Exception e) when (e.IsCancellationException(ct))
             {
@@ -642,7 +644,8 @@ public class MultiConnectionNntpClient(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var priority = GetDownloadPriority(cancellationToken);
-        var connectionLock = await connectionPool.GetConnectionLockAsync(priority, cancellationToken).ConfigureAwait(false);
+        var connectionLock = await AcquireConnectionLockAsync(priority, cancellationToken)
+            .ConfigureAwait(false);
         var completed = false;
         try
         {
@@ -682,6 +685,27 @@ public class MultiConnectionNntpClient(
     private static SemaphorePriority GetDownloadPriority(CancellationToken ct)
     {
         return ct.GetContext<DownloadPriorityContext>()?.Priority ?? SemaphorePriority.Low;
+    }
+
+    /// <summary>
+    /// Borrows a pooled connection, attributing the wait to the current read session so a
+    /// range that spends its time queued behind the pool (or behind handshake pacing after
+    /// a burst of replacements) is distinguishable from one waiting on the provider.
+    /// </summary>
+    private async Task<ConnectionLock<INntpClient>> AcquireConnectionLockAsync(
+        SemaphorePriority priority,
+        CancellationToken ct)
+    {
+        var sessionId = MultiProviderNntpClient.CurrentReadSessionId;
+        if (sessionId is null || !StreamTrace.IsRecording)
+            return await connectionPool.GetConnectionLockAsync(priority, ct).ConfigureAwait(false);
+
+        var started = Stopwatch.GetTimestamp();
+        var connectionLock = await connectionPool.GetConnectionLockAsync(priority, ct)
+            .ConfigureAwait(false);
+        StreamTrace.TryConnectionAcquired(
+            sessionId, Stopwatch.GetElapsedTime(started), connectionLock.WasReused);
+        return connectionLock;
     }
 
     private static void LogException(Action? action)

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -48,6 +48,22 @@ public class MultiProviderNntpClient(
                 p.GetCircuitBreakerSnapshot()))
             .ToList();
     }
+
+    public IReadOnlyList<ProviderConnectionSnapshot> GetProviderConnectionSnapshots()
+    {
+        return providers
+            .Select(p => new ProviderConnectionSnapshot(
+                p.MetricsKey,
+                p.Host,
+                p.ProviderType,
+                p.LiveConnections,
+                p.IdleConnections,
+                p.ActiveConnections,
+                p.AvailableConnections,
+                p.PendingSelections,
+                p.GetConnectionChurn()))
+            .ToList();
+    }
     private readonly ProviderUsageTracker _usageTracker = usageTracker ?? new ProviderUsageTracker();
     private static readonly AsyncLocal<Guid?> ReadSessionScope = new();
     internal static Guid? CurrentReadSessionId => ReadSessionScope.Value;
@@ -818,6 +834,8 @@ public class MultiProviderNntpClient(
         if (ReadSessionScope.Value is { } sessionId)
         {
             streamTrace?.Segment(sessionId, metricsKey, status, (int)Math.Min(int.MaxValue, durationMs), retries);
+            streamTrace?.AddStall(
+                sessionId, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(durationMs));
         }
 
         if (metricsWriter == null) return;

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -98,6 +98,13 @@ public class UsenetStreamingClient : WrappingNntpClient
             : Array.Empty<ProviderCircuitRuntimeSnapshot>();
     }
 
+    public IReadOnlyList<ProviderConnectionSnapshot> GetProviderConnectionSnapshots()
+    {
+        return WrappingNntpClient.Unwrap(InnerClient) is MultiProviderNntpClient multi
+            ? multi.GetProviderConnectionSnapshots()
+            : Array.Empty<ProviderConnectionSnapshot>();
+    }
+
     private static MultiProviderNntpClient CreateMultiProviderClient
     (
         ConfigManager configManager,

--- a/backend/Services/StreamTrace/StreamStallKind.cs
+++ b/backend/Services/StreamTrace/StreamStallKind.cs
@@ -1,0 +1,26 @@
+namespace NzbWebDAV.Services.StreamTrace;
+
+/// <summary>
+/// Stages a ranged read can block on. Accumulated per range so a slow playback
+/// says which side was waiting instead of only how long the range took: a range
+/// dominated by <see cref="ClientWrite"/> is limited by the player's own link,
+/// while <see cref="ConsumerWait"/> with little provider time means prefetch is
+/// not running ahead of the consumer.
+/// </summary>
+public enum StreamStallKind
+{
+    /// <summary>Waiting for a pooled NNTP connection, including handshake pacing.</summary>
+    ConnectionWait,
+
+    /// <summary>Request dispatched until the provider's response header arrived.</summary>
+    ProviderWait,
+
+    /// <summary>Reading an article body off the socket into its buffer.</summary>
+    BodyDrain,
+
+    /// <summary>Consumer blocked waiting for the next prefetched segment to arrive.</summary>
+    ConsumerWait,
+
+    /// <summary>Blocked writing the response body to the HTTP client.</summary>
+    ClientWrite,
+}

--- a/backend/Services/StreamTrace/StreamTrace.cs
+++ b/backend/Services/StreamTrace/StreamTrace.cs
@@ -21,4 +21,20 @@ public static class StreamTrace
 
     public static void TryRetry(Guid sessionId, string segmentId, int attempt, string? message = null)
         => _buffer?.Retry(sessionId, segmentId, attempt, message);
+
+    public static void TryStall(Guid? sessionId, StreamStallKind kind, TimeSpan elapsed)
+    {
+        if (sessionId is { } id) _buffer?.AddStall(id, kind, elapsed);
+    }
+
+    public static void TryConnectionAcquired(Guid? sessionId, TimeSpan wait, bool wasReused)
+    {
+        if (sessionId is { } id) _buffer?.ConnectionAcquired(id, wait, wasReused);
+    }
+
+    /// <summary>
+    /// True when a stall measurement is worth taking. Callers in hot loops check this
+    /// before reading timestamps so tracing stays free when it is off.
+    /// </summary>
+    public static bool IsRecording => _buffer?.Enabled == true;
 }

--- a/backend/Services/StreamTrace/StreamTraceBuffer.cs
+++ b/backend/Services/StreamTrace/StreamTraceBuffer.cs
@@ -278,12 +278,41 @@ public sealed class StreamTraceBuffer
         });
     }
 
+    /// <summary>
+    /// Adds time spent blocked on <paramref name="kind"/> to the current range of
+    /// <paramref name="sessionId"/>. Ticks are accumulated rather than milliseconds so
+    /// the many sub-millisecond client writes in a range still add up. No-ops when
+    /// tracing is off or the session has no open range.
+    /// </summary>
+    public void AddStall(Guid sessionId, StreamStallKind kind, TimeSpan elapsed)
+    {
+        if (!Enabled || elapsed <= TimeSpan.Zero) return;
+        if (!_sessions.TryGetValue(sessionId, out var session)) return;
+        session.Stalls.Add(kind, elapsed.Ticks);
+    }
+
+    /// <summary>
+    /// Records a connection acquisition for the current range: how long the borrower
+    /// waited, and whether the pool handed back an idle connection or had to open a
+    /// new one. A range full of fresh handshakes points at connection churn.
+    /// </summary>
+    public void ConnectionAcquired(Guid sessionId, TimeSpan wait, bool wasReused)
+    {
+        if (!Enabled) return;
+        if (!_sessions.TryGetValue(sessionId, out var session)) return;
+        session.Stalls.AddConnection(wait.Ticks, wasReused);
+    }
+
     public void RangeEnd(
         Guid sessionId,
         ReadSession.EndReasonCode endReason,
         long bytesServed,
         string? message = null)
     {
+        var stalls = _sessions.TryGetValue(sessionId, out var session)
+            ? session.Stalls.DrainForRange()
+            : default;
+
         Record(new StreamTraceEvent
         {
             Sequence = 0,
@@ -293,6 +322,13 @@ public sealed class StreamTraceBuffer
             EndReason = StreamTraceEvent.EndReasonName(endReason),
             BytesServed = bytesServed,
             Message = message,
+            ConnectionWaitMs = stalls.ConnectionWaitMs,
+            ProviderWaitMs = stalls.ProviderWaitMs,
+            BodyDrainMs = stalls.BodyDrainMs,
+            ConsumerWaitMs = stalls.ConsumerWaitMs,
+            ClientWriteMs = stalls.ClientWriteMs,
+            ConnectionsOpened = stalls.ConnectionsOpened,
+            ConnectionsReused = stalls.ConnectionsReused,
         });
     }
 
@@ -384,7 +420,85 @@ public sealed class StreamTraceBuffer
         public string? Path { get; set; }
         public int EventCount { get; set; }
         public string? LastKind { get; set; }
+        public StallTotals Stalls { get; } = new();
     }
+
+    /// <summary>
+    /// Per-range stall accumulator. Written concurrently by every prefetch task and the
+    /// consumer, so every field moves through Interlocked; drained and zeroed when the
+    /// range ends so the next range on the same session starts clean.
+    /// </summary>
+    private sealed class StallTotals
+    {
+        private long _connectionWaitTicks;
+        private long _providerWaitTicks;
+        private long _bodyDrainTicks;
+        private long _consumerWaitTicks;
+        private long _clientWriteTicks;
+        private long _connectionsOpened;
+        private long _connectionsReused;
+
+        public void Add(StreamStallKind kind, long ticks)
+        {
+            switch (kind)
+            {
+                case StreamStallKind.ConnectionWait:
+                    Interlocked.Add(ref _connectionWaitTicks, ticks);
+                    break;
+                case StreamStallKind.ProviderWait:
+                    Interlocked.Add(ref _providerWaitTicks, ticks);
+                    break;
+                case StreamStallKind.BodyDrain:
+                    Interlocked.Add(ref _bodyDrainTicks, ticks);
+                    break;
+                case StreamStallKind.ConsumerWait:
+                    Interlocked.Add(ref _consumerWaitTicks, ticks);
+                    break;
+                case StreamStallKind.ClientWrite:
+                    Interlocked.Add(ref _clientWriteTicks, ticks);
+                    break;
+            }
+        }
+
+        public void AddConnection(long waitTicks, bool wasReused)
+        {
+            if (waitTicks > 0) Interlocked.Add(ref _connectionWaitTicks, waitTicks);
+            if (wasReused)
+                Interlocked.Increment(ref _connectionsReused);
+            else
+                Interlocked.Increment(ref _connectionsOpened);
+        }
+
+        public StallSnapshot DrainForRange() => new(
+            Milliseconds(ref _connectionWaitTicks),
+            Milliseconds(ref _providerWaitTicks),
+            Milliseconds(ref _bodyDrainTicks),
+            Milliseconds(ref _consumerWaitTicks),
+            Milliseconds(ref _clientWriteTicks),
+            Count(ref _connectionsOpened),
+            Count(ref _connectionsReused));
+
+        private static long? Milliseconds(ref long ticks)
+        {
+            var drained = Interlocked.Exchange(ref ticks, 0);
+            return drained <= 0 ? null : drained / TimeSpan.TicksPerMillisecond;
+        }
+
+        private static long? Count(ref long counter)
+        {
+            var drained = Interlocked.Exchange(ref counter, 0);
+            return drained <= 0 ? null : drained;
+        }
+    }
+
+    private readonly record struct StallSnapshot(
+        long? ConnectionWaitMs,
+        long? ProviderWaitMs,
+        long? BodyDrainMs,
+        long? ConsumerWaitMs,
+        long? ClientWriteMs,
+        long? ConnectionsOpened,
+        long? ConnectionsReused);
 }
 
 public sealed record StreamTraceSessionSummary(

--- a/backend/Services/StreamTrace/StreamTraceEvent.cs
+++ b/backend/Services/StreamTrace/StreamTraceEvent.cs
@@ -34,6 +34,17 @@ public sealed record StreamTraceEvent
     [JsonPropertyName("attempt")] public int? Attempt { get; init; }
     [JsonPropertyName("message")] public string? Message { get; init; }
 
+    // Stall attribution, emitted on RangeEnd and reset per range. These overlap by
+    // design — segments are fetched concurrently — so they are shares of a range's
+    // wall clock, not a partition of it.
+    [JsonPropertyName("connWaitMs")] public long? ConnectionWaitMs { get; init; }
+    [JsonPropertyName("providerWaitMs")] public long? ProviderWaitMs { get; init; }
+    [JsonPropertyName("bodyDrainMs")] public long? BodyDrainMs { get; init; }
+    [JsonPropertyName("consumerWaitMs")] public long? ConsumerWaitMs { get; init; }
+    [JsonPropertyName("clientWriteMs")] public long? ClientWriteMs { get; init; }
+    [JsonPropertyName("connOpened")] public long? ConnectionsOpened { get; init; }
+    [JsonPropertyName("connReused")] public long? ConnectionsReused { get; init; }
+
     public static string StatusName(SegmentFetch.FetchStatus status) => status.ToString();
 
     public static string EndReasonName(ReadSession.EndReasonCode reason) => reason.ToString();

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Runtime;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -71,7 +72,7 @@ public sealed class SupportPackService(
         await WriteJsonAsync(
             archive,
             "environment.json",
-            BuildEnvironment(generatedAt),
+            await BuildEnvironmentAsync(generatedAt, cancellationToken).ConfigureAwait(false),
             redactor,
             cancellationToken).ConfigureAwait(false);
 
@@ -132,9 +133,21 @@ public sealed class SupportPackService(
         the last 500 warnings and errors separately for that reason - check it first
         when the main log looks like it only contains routine activity.
 
+        environment.json reports a live CPU sample taken while the pack was being
+        built, GC counters (including large-object-heap sizes and pause time), thread
+        pool occupancy, and per-provider connection-pool state with lifetime churn.
+        Collect the pack while the problem is happening - the CPU sample is a
+        half-second window, not a lifetime average.
+
         stream-traces/ is included only while developer stream tracing is enabled
         (Settings → Support, or STREAM_TRACE_EVENTS). Tracing is opt-in, memory-only,
-        and resets on restart.
+        and resets on restart. RangeEnd events carry stall attribution for the range
+        that just finished: connWaitMs (waiting for an NNTP connection),
+        providerWaitMs (waiting for provider response headers), bodyDrainMs (reading
+        article bodies), consumerWaitMs (playback starved waiting for prefetch), and
+        clientWriteMs (blocked writing to the player). They overlap, because segments
+        are fetched concurrently, so read them as shares of the range rather than a
+        breakdown that sums to its duration.
 
         The archive deliberately excludes database files, backups, blobs/NZBs,
         environment files, session/API key files, crash dumps, and segment-cache
@@ -160,7 +173,9 @@ public sealed class SupportPackService(
             }),
         };
 
-    private object BuildEnvironment(DateTimeOffset generatedAt)
+    private async Task<object> BuildEnvironmentAsync(
+        DateTimeOffset generatedAt,
+        CancellationToken cancellationToken)
     {
         ThreadPool.GetMinThreads(out var minWorkerThreads, out var minIoThreads);
         ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxIoThreads);
@@ -169,6 +184,7 @@ public sealed class SupportPackService(
         var drive = new DriveInfo(root);
         var uptime = ProcessUptime();
         var streamTracing = streamTraceBuffer.GetStatus();
+        var cpu = await SampleCpuAsync(uptime, cancellationToken).ConfigureAwait(false);
 
         return new
         {
@@ -191,7 +207,20 @@ public sealed class SupportPackService(
                 inFlightArticleThrottleEvents = inFlightArticleBudget.ThrottleEvents,
                 timeZone = TimeZoneInfo.Local.Id,
             },
-            threadPool = new { minWorkerThreads, minIoThreads, maxWorkerThreads, maxIoThreads },
+            cpu,
+            gc = BuildGcDiagnostics(),
+            threadPool = new
+            {
+                minWorkerThreads,
+                minIoThreads,
+                maxWorkerThreads,
+                maxIoThreads,
+                threadCount = ThreadPool.ThreadCount,
+                pendingWorkItems = ThreadPool.PendingWorkItemCount,
+                completedWorkItems = ThreadPool.CompletedWorkItemCount,
+                processThreadCount = ProcessThreadCount(),
+            },
+            connections = BuildConnectionDiagnostics(),
             storage = new
             {
                 configPath,
@@ -219,6 +248,154 @@ public sealed class SupportPackService(
                 ["MAX_REQUEST_BODY_SIZE"] = Environment.GetEnvironmentVariable("MAX_REQUEST_BODY_SIZE"),
             },
         };
+    }
+
+    /// <summary>
+    /// CPU usage as both a live sample and a process-lifetime average. The sample is what
+    /// matters when a pack is collected while the problem is happening: a lifetime average
+    /// over a mostly-idle process hides a core that is pegged right now. Percentages are
+    /// of the whole machine, so 100 means every core busy.
+    /// </summary>
+    private static async Task<object> SampleCpuAsync(TimeSpan uptime, CancellationToken cancellationToken)
+    {
+        var cores = Math.Max(1, Environment.ProcessorCount);
+        try
+        {
+            var before = Environment.CpuUsage;
+            var sampleWindow = TimeSpan.FromMilliseconds(500);
+            await Task.Delay(sampleWindow, cancellationToken).ConfigureAwait(false);
+            var after = Environment.CpuUsage;
+
+            var sampleMs = (after.TotalTime - before.TotalTime).TotalMilliseconds;
+            return new
+            {
+                processorCount = cores,
+                sampleWindowMs = (long)sampleWindow.TotalMilliseconds,
+                samplePercentAllCores = Percent(sampleMs, sampleWindow.TotalMilliseconds * cores),
+                samplePercentOneCore = Percent(sampleMs, sampleWindow.TotalMilliseconds),
+                lifetimeUserMs = (long)after.UserTime.TotalMilliseconds,
+                lifetimePrivilegedMs = (long)after.PrivilegedTime.TotalMilliseconds,
+                lifetimeTotalMs = (long)after.TotalTime.TotalMilliseconds,
+                lifetimePercentAllCores = Percent(
+                    after.TotalTime.TotalMilliseconds, uptime.TotalMilliseconds * cores),
+            };
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            Log.Debug(e, "Support pack: could not sample CPU usage");
+            return new { processorCount = cores, unavailable = true };
+        }
+
+        static double? Percent(double used, double capacity) =>
+            capacity <= 0 ? null : Math.Round(used / capacity * 100, 1);
+    }
+
+    /// <summary>
+    /// GC shape and cost. Generation sizes include the large-object heap, which is where
+    /// article buffers land, and <c>pauseTimePercentage</c> says how much of recent wall
+    /// clock the process spent stopped.
+    /// </summary>
+    private static object BuildGcDiagnostics()
+    {
+        try
+        {
+            var info = GC.GetGCMemoryInfo();
+            var generations = new List<object>(info.GenerationInfo.Length);
+            for (var generation = 0; generation < info.GenerationInfo.Length; generation++)
+            {
+                var entry = info.GenerationInfo[generation];
+                generations.Add(new
+                {
+                    name = GenerationName(generation),
+                    sizeAfterBytes = entry.SizeAfterBytes,
+                    fragmentationAfterBytes = entry.FragmentationAfterBytes,
+                });
+            }
+
+            return new
+            {
+                isServerGc = GCSettings.IsServerGC,
+                latencyMode = GCSettings.LatencyMode.ToString(),
+                gen0Collections = GC.CollectionCount(0),
+                gen1Collections = GC.CollectionCount(1),
+                gen2Collections = GC.CollectionCount(2),
+                totalAllocatedBytes = GC.GetTotalAllocatedBytes(precise: false),
+                totalPauseDurationMs = (long)GC.GetTotalPauseDuration().TotalMilliseconds,
+                pauseTimePercentage = info.PauseTimePercentage,
+                heapSizeBytes = info.HeapSizeBytes,
+                committedBytes = info.TotalCommittedBytes,
+                generations,
+            };
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e, "Support pack: could not read GC diagnostics");
+            return new { unavailable = true };
+        }
+
+        static string GenerationName(int generation) => generation switch
+        {
+            0 => "gen0",
+            1 => "gen1",
+            2 => "gen2",
+            3 => "loh",
+            4 => "poh",
+            _ => $"gen{generation}",
+        };
+    }
+
+    /// <summary>
+    /// Live pool occupancy plus lifetime churn per provider. High
+    /// <c>connectionsDestroyed</c> against low <c>connectionsReused</c> means connections
+    /// are being replaced rather than pooled, and the handshake wait shows what that costs.
+    /// </summary>
+    private object BuildConnectionDiagnostics()
+    {
+        try
+        {
+            return usenetStreamingClient.GetProviderConnectionSnapshots()
+                .Select(snapshot => new
+                {
+                    providerKey = snapshot.MetricsKey,
+                    host = snapshot.Host,
+                    providerType = snapshot.ProviderType.ToString(),
+                    snapshot.LiveConnections,
+                    snapshot.IdleConnections,
+                    snapshot.ActiveConnections,
+                    snapshot.AvailableConnections,
+                    snapshot.PendingSelections,
+                    churn = new
+                    {
+                        snapshot.Churn.ConnectionsOpened,
+                        snapshot.Churn.ConnectionsReused,
+                        snapshot.Churn.ConnectionsDestroyed,
+                        snapshot.Churn.StaleEvictions,
+                        snapshot.Churn.HandshakeFailures,
+                        snapshot.Churn.GateWaitMs,
+                        snapshot.Churn.HandshakeWaitMs,
+                    },
+                })
+                .ToList<object>();
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e, "Support pack: could not read connection-pool diagnostics");
+            return Array.Empty<object>();
+        }
+    }
+
+    private static int? ProcessThreadCount()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.Threads.Count;
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e, "Support pack: could not read the process thread count");
+            return null;
+        }
     }
 
     private async Task<object> BuildMetricsAsync(DateTimeOffset generatedAt, CancellationToken cancellationToken)

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.ExceptionServices;
+﻿using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
@@ -750,7 +751,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             var capacity = estimate is > 0 and <= int.MaxValue ? (int)estimate : 0;
             var buffer = new MemoryStream(capacity);
+            var drainStarted = Stopwatch.GetTimestamp();
             await source.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            StreamTrace.TryStall(
+                MultiProviderNntpClient.CurrentReadSessionId,
+                StreamStallKind.BodyDrain,
+                Stopwatch.GetElapsedTime(drainStarted));
             var drained = buffer.Length;
             if (hasExactSize)
                 AlignDrainedSegment(buffer, segmentIndex, drained, exactSize);
@@ -830,9 +836,17 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             // if the stream is null, get the next stream.
             if (_stream == null)
             {
+                // Time spent here is the consumer starving: prefetch has not yet delivered
+                // the next segment. Low provider time with high consumer wait means the
+                // pipeline is not running far enough ahead, not that the provider is slow.
+                var waitStarted = Stopwatch.GetTimestamp();
                 if (!await _streamTasks.Reader.WaitToReadAsync(cancellationToken)) return 0;
                 if (!_streamTasks.Reader.TryRead(out var streamTask)) return 0;
                 var result = await streamTask;
+                StreamTrace.TryStall(
+                    MultiProviderNntpClient.CurrentReadSessionId,
+                    StreamStallKind.ConsumerWait,
+                    Stopwatch.GetElapsedTime(waitStarted));
                 ReleaseInFlightPrefetchBytes(result.PlannedBytes);
                 _stream = AcceptSegment(result);
             }

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using NWebDav.Server;
 using NWebDav.Server.Handlers;
@@ -265,7 +266,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                            ct).ConfigureAwait(false);
+                            sessionId, ct).ConfigureAwait(false);
                         FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
                         ClearStreamingFailureAfterCompletedRead(
                             _failureTracker,
@@ -354,6 +355,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         long start,
         long? end,
         Action<long, long>? onBytesServed,
+        Guid? sessionId,
         CancellationToken cancellationToken)
     {
         // Skip to the first offset
@@ -387,8 +389,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                     return;
 
                 // Write the data to the destination stream
+                var writeStarted = Stopwatch.GetTimestamp();
                 await dest.WriteAsync(
                     buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+                if (sessionId is { } id)
+                    _streamTrace.AddStall(
+                        id, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
 
                 // Report chunk size + new absolute file position so dashboards can
                 // surface real playback location (not cumulative transferred bytes).

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -33,6 +33,58 @@ public class StreamTraceBufferTests
     }
 
     [Fact]
+    public void RangeEnd_ReportsStallAttributionAndResetsItForTheNextRange()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+        var session = Guid.NewGuid();
+
+        buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 1000, null, null);
+        buffer.AddStall(session, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(120));
+        buffer.AddStall(session, StreamStallKind.BodyDrain, TimeSpan.FromMilliseconds(30));
+        buffer.AddStall(session, StreamStallKind.ConsumerWait, TimeSpan.FromMilliseconds(400));
+        // Sub-millisecond writes must still accumulate rather than truncate to zero.
+        for (var i = 0; i < 10; i++)
+            buffer.AddStall(session, StreamStallKind.ClientWrite, TimeSpan.FromMicroseconds(300));
+        buffer.ConnectionAcquired(session, TimeSpan.FromMilliseconds(70), wasReused: true);
+        buffer.ConnectionAcquired(session, TimeSpan.FromMilliseconds(500), wasReused: false);
+        buffer.RangeEnd(session, ReadSession.EndReasonCode.Aborted, 4096);
+
+        var first = buffer.GetSessionEvents(session).Last();
+        Assert.Equal(120, first.ProviderWaitMs);
+        Assert.Equal(30, first.BodyDrainMs);
+        Assert.Equal(400, first.ConsumerWaitMs);
+        Assert.Equal(3, first.ClientWriteMs);
+        Assert.Equal(570, first.ConnectionWaitMs);
+        Assert.Equal(1, first.ConnectionsReused);
+        Assert.Equal(1, first.ConnectionsOpened);
+
+        buffer.RangeOpen(session, "/view/a.mkv", "GET", 4096, null, 1000, null, null);
+        buffer.AddStall(session, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(15));
+        buffer.RangeEnd(session, ReadSession.EndReasonCode.Completed, 8192);
+
+        var second = buffer.GetSessionEvents(session).Last();
+        Assert.Equal(15, second.ProviderWaitMs);
+        Assert.Null(second.ConsumerWaitMs);
+        Assert.Null(second.ConnectionWaitMs);
+        Assert.Null(second.ConnectionsOpened);
+    }
+
+    [Fact]
+    public void AddStall_BeforeAnyRangeOpen_IsIgnored()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+        var session = Guid.NewGuid();
+
+        // No range has opened, so there is no session to attribute to. This must not
+        // create one — otherwise background work would grow the session index forever.
+        buffer.AddStall(session, StreamStallKind.ClientWrite, TimeSpan.FromSeconds(1));
+        buffer.ConnectionAcquired(session, TimeSpan.FromSeconds(1), wasReused: false);
+
+        Assert.Empty(buffer.ListSessions());
+        Assert.Empty(buffer.GetSessionEvents(session));
+    }
+
+    [Fact]
     public void DisabledBuffer_RecordsNothing()
     {
         var buffer = new StreamTraceBuffer(100, enabled: false);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -105,6 +105,43 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_ReportsCpuGcAndThreadPoolCountersForBottleneckTriage()
+    {
+        var entries = await ReadPackEntriesAsync(new LogBufferSink(10), new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var root = environment.RootElement;
+
+        // CPU must be a live sample, not only a lifetime average: a pack collected while
+        // playback stutters has to show what the cores are doing right now.
+        var cpu = root.GetProperty("cpu");
+        Assert.True(cpu.GetProperty("processorCount").GetInt32() >= 1);
+        Assert.True(cpu.GetProperty("sampleWindowMs").GetInt64() > 0);
+        Assert.True(cpu.GetProperty("samplePercentAllCores").GetDouble() >= 0);
+        Assert.True(cpu.GetProperty("lifetimeTotalMs").GetInt64() >= 0);
+
+        var gc = root.GetProperty("gc");
+        Assert.True(gc.GetProperty("gen0Collections").GetInt32() >= 0);
+        Assert.True(gc.GetProperty("gen2Collections").GetInt32() >= 0);
+        Assert.True(gc.GetProperty("totalAllocatedBytes").GetInt64() > 0);
+        Assert.True(gc.GetProperty("totalPauseDurationMs").GetInt64() >= 0);
+        Assert.True(gc.TryGetProperty("isServerGc", out _));
+        // Article buffers land on the large-object heap, so its size must be visible.
+        var generations = gc.GetProperty("generations").EnumerateArray()
+            .Select(entry => entry.GetProperty("name").GetString())
+            .ToList();
+        Assert.Contains("loh", generations);
+
+        var threadPool = root.GetProperty("threadPool");
+        Assert.True(threadPool.GetProperty("threadCount").GetInt32() >= 0);
+        Assert.True(threadPool.GetProperty("pendingWorkItems").GetInt64() >= 0);
+        Assert.True(threadPool.GetProperty("completedWorkItems").GetInt64() >= 0);
+
+        // No providers are configured in this fixture, so the section is present but empty.
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("connections").ValueKind);
+    }
+
+    [Fact]
     public async Task Pack_IncludesStreamTracesOnlyWhileTracingIsEnabled()
     {
         var disabled = await ReadPackEntriesAsync(


### PR DESCRIPTION
## Summary

A user reported buffering while streaming a 40 GB 4K file directly from NzbDAV (no rclone, no Plex). Their support pack showed a stream delivering 2.9 MB/s against the ~6.3 MB/s the file needs, with every article fetch succeeding, zero retries and a closed circuit — and queue imports on the same box and provider reaching 19.9 MB/s. Diagnosing it took several rounds of guessing because the pack records nothing about CPU, garbage collection, or where a read actually waits. Two theories (CPU/GC saturation, then per-stream connection concurrency) were each disproved only after asking the user to run `docker stats` and try settings by hand.

This adds the data that would have answered those questions immediately.

- **Per-stage stall attribution on stream traces.** `RangeEnd` now carries `connWaitMs`, `providerWaitMs`, `bodyDrainMs`, `consumerWaitMs` and `clientWriteMs` for the range that just finished, plus how many connections it borrowed fresh versus reused. This separates "the provider is slow" from "prefetch is not running ahead" from "the player's own link is the limit" — 2.9 MB/s is 23 Mbps, an entirely ordinary browser downlink, and nothing in the pack could rule that out before.
- **Connection-pool churn per provider.** Connections opened, reused, destroyed via `Replace`, stale evictions, handshake failures, and time spent waiting on the pool gate and the 3-at-a-time handshake pacing gate. Client aborts route through `Replace`, which destroys a connection instead of pooling it, so a seek-heavy session can spend its time re-handshaking — invisible in the live/idle gauges.
- **CPU, GC and thread pool in `environment.json`.** A live 500 ms CPU sample next to lifetime totals, GC counts and pause time, per-generation heap sizes including the large-object heap where ~700 KB article buffers land, the Server GC flag, and thread pool occupancy.

No behavior change to streaming itself. Stall measurement is skipped when tracing is off, and stalls attach only to sessions with an open range so background work cannot grow the session index. Every new diagnostic block degrades to an `unavailable` marker rather than failing pack generation.

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj` — clean, no new warnings
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 1186 passed, 0 failed
- [x] New test: `RangeEnd` reports each stall bucket, accumulates sub-millisecond client writes instead of truncating them, and resets per range
- [x] New test: stalls recorded before any `RangeOpen` are dropped rather than creating a session
- [x] New test: a generated pack populates the CPU sample, GC counters (including an `loh` generation entry), thread pool counters, and the connections array
- [ ] Collect a real support pack during a buffering playback and confirm the stall buckets identify the limiting stage