### PR TITLE
fix(webdav): metadata-writing clients no longer flood logs against the read-only mount

### DIFF
--- a/backend/Logging/LogThrottle.cs
+++ b/backend/Logging/LogThrottle.cs
@@ -1,14 +1,15 @@
 using System.Collections.Concurrent;
 
-namespace NzbWebDAV.Services;
+namespace NzbWebDAV.Logging;
 
 /// <summary>
-/// Rate-limits repeating Watchtower heartbeat messages. The cycle loop ticks every
-/// 20 seconds forever, so an idle-but-enabled Watchtower would otherwise fill the
-/// whole in-memory log buffer with the same two lines and evict the events support
-/// actually needs (see LogBufferSink).
+/// Rate-limits repeating log messages so a condition that recurs on a loop cannot fill
+/// the whole in-memory log buffer and evict the events support actually needs
+/// (see LogBufferSink). Used for the Watchtower cycle heartbeat, which ticks every
+/// 20 seconds forever, and for read-only WebDAV write rejections, which a client can
+/// re-attempt many times per second.
 /// </summary>
-public sealed class WatchtowerLogThrottle
+public sealed class LogThrottle
 {
     private readonly ConcurrentDictionary<string, State> _states = new();
 

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -35,7 +36,7 @@ public class WatchtowerService(
     private static readonly TimeSpan NoProfileLogInterval = TimeSpan.FromMinutes(60);
     private const string CycleStartLogKey = "cycle-starting";
     private const string NoProfileLogKey = "no-search-profile";
-    private readonly WatchtowerLogThrottle _logThrottle = new();
+    private readonly LogThrottle _logThrottle = new();
     private const int ResolvesPerTick = 3;
     private const int AutoResolveBatch = 25;
     private static readonly TimeSpan AutoStageBudget = TimeSpan.FromSeconds(120);

--- a/backend/WebDav/Base/BaseStoreReadonlyCollection.cs
+++ b/backend/WebDav/Base/BaseStoreReadonlyCollection.cs
@@ -1,39 +1,49 @@
 ﻿using NWebDav.Server;
 using NWebDav.Server.Stores;
 using NzbWebDAV.WebDav.Requests;
-using Serilog;
 
 namespace NzbWebDAV.WebDav.Base;
 
 public abstract class BaseStoreReadonlyCollection : BaseStoreCollection
 {
+    // NWebDav's DavStatusCode enum has no 405 member. SetStatus only assigns
+    // response.StatusCode, so the reason phrase falls back to the server default.
+    private const DavStatusCode MethodNotAllowed = (DavStatusCode)405;
+
     protected override Task<StoreItemResult> CopyAsync(CopyRequest request)
     {
-        Log.Warning("Cannot copy item {ItemName}: forbidden", request.Name);
+        LogRejected("copy item", request.Name);
         return Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
     }
 
     protected override Task<StoreItemResult> CreateItemAsync(CreateItemRequest request)
     {
-        Log.Warning("Cannot create item {ItemName}: forbidden", request.Name);
+        LogRejected("create item", request.Name);
         return Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
     }
 
-    protected override Task<StoreCollectionResult> CreateCollectionAsync(CreateCollectionRequest request)
+    protected override async Task<StoreCollectionResult> CreateCollectionAsync(CreateCollectionRequest request)
     {
-        Log.Warning("Cannot create directory {DirectoryName}: forbidden", request.Name);
-        return Task.FromResult(new StoreCollectionResult(DavStatusCode.Forbidden));
+        // RFC 4918 9.3.1: MKCOL may only be executed on an unmapped URL, so a directory
+        // that is already there is 405, not 403. Clients read 403 as a permission problem
+        // worth retrying; 405 tells them the directory exists and they can move on.
+        var existing = await GetItemAsync(request.Name, request.CancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+            return new StoreCollectionResult(MethodNotAllowed);
+
+        LogRejected("create directory", request.Name);
+        return new StoreCollectionResult(DavStatusCode.Forbidden);
     }
 
     protected override Task<StoreItemResult> MoveItemAsync(MoveItemRequest request)
     {
-        Log.Warning("Cannot move item {ItemName}: forbidden", request.SourceName);
+        LogRejected("move item", request.SourceName);
         return Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
     }
 
     protected override Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)
     {
-        Log.Warning("Cannot delete item {ItemName}: forbidden", request.Name);
+        LogRejected("delete item", request.Name);
         return Task.FromResult(DavStatusCode.Forbidden);
     }
 
@@ -41,4 +51,7 @@ public abstract class BaseStoreReadonlyCollection : BaseStoreCollection
     {
         return false;
     }
+
+    private void LogRejected(string operation, string itemName) =>
+        ReadonlyWriteRejectionLog.Rejected(operation, itemName, Name, UniqueKey);
 }

--- a/backend/WebDav/Base/BaseStoreReadonlyItem.cs
+++ b/backend/WebDav/Base/BaseStoreReadonlyItem.cs
@@ -1,7 +1,6 @@
 ﻿using NWebDav.Server;
 using NWebDav.Server.Stores;
 using NzbWebDAV.WebDav.Requests;
-using Serilog;
 
 namespace NzbWebDAV.WebDav.Base;
 
@@ -9,13 +8,13 @@ public abstract class BaseStoreReadonlyItem : BaseStoreItem
 {
     protected override Task<DavStatusCode> UploadFromStreamAsync(UploadFromStreamRequest request)
     {
-        Log.Warning("Cannot upload item {ItemName}: forbidden", Name);
+        ReadonlyWriteRejectionLog.Rejected("upload item", Name, Name, UniqueKey);
         return Task.FromResult(DavStatusCode.Forbidden);
     }
 
     protected override Task<StoreItemResult> CopyAsync(CopyRequest request)
     {
-        Log.Warning("Cannot copy item {ItemName}: forbidden", request.Name);
+        ReadonlyWriteRejectionLog.Rejected("copy item", request.Name, Name, UniqueKey);
         return Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
     }
 }

--- a/backend/WebDav/Base/ReadonlyWriteRejectionLog.cs
+++ b/backend/WebDav/Base/ReadonlyWriteRejectionLog.cs
@@ -1,0 +1,31 @@
+using NzbWebDAV.Logging;
+using Serilog;
+
+namespace NzbWebDAV.WebDav.Base;
+
+/// <summary>
+/// Throttled logging for writes refused by the read-only parts of the WebDAV tree.
+/// Clients that write metadata sidecars into the mount (media scanners, *Arr metadata
+/// writers) re-attempt on every scan, so a large library can produce many rejections
+/// per second indefinitely. Logging each one at Warning drowns the Warning-only ring
+/// buffer that support packs are collected from, so the individual rejection goes to
+/// Debug and one aggregated Warning names the path per window.
+/// </summary>
+internal static class ReadonlyWriteRejectionLog
+{
+    private static readonly LogThrottle Throttle = new();
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(5);
+
+    internal static void Rejected(string operation, string itemName, string scopeName, string scopeKey)
+    {
+        Log.Debug("Refused to {Operation} {ItemName} under {Scope}: read-only", operation, itemName, scopeName);
+
+        if (!Throttle.ShouldLog($"{scopeKey}/{operation}", Interval, out var suppressed))
+            return;
+
+        Log.Warning(
+            "Refused to {Operation} under read-only path {Scope} — {Attempts} attempt(s) in the last {Minutes} minutes, " +
+            "most recently {ItemName}. A client is trying to write into the NzbDav mount, which does not accept writes.",
+            operation, scopeName, suppressed + 1, Interval.TotalMinutes, itemName);
+    }
+}

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -20,6 +20,24 @@
 - STRM: Base URL reachable from Emby/Jellyfin?
 - Check Automatic Queue Management rules — [Arrs](../configuration/arrs.md).
 
+## 403 / 405 on MKCOL, PUT or DELETE
+
+The mount is a **read-only** virtual filesystem — `/content`, `/completed-symlinks` and `/.ids`
+serve data streamed from Usenet and accept no writes. Refused writes are expected, not a fault:
+
+- `403 Forbidden` — a client tried to create, copy, move or upload something.
+- `405 Method Not Allowed` — `MKCOL` targeted a directory that already exists.
+
+Logs show one aggregated warning per read-only path every 5 minutes (`Refused to create item under
+read-only path …`), with per-attempt detail at `LOG_LEVEL=debug`. NzbDAV cannot stop a client from
+re-attempting, so fix it at the source — the warning and the access-log line both name the client IP
+and User-Agent:
+
+- Media servers (Emby/Jellyfin/Plex/Kodi): turn off saving metadata, artwork or `.nfo`/`.srt`
+  sidecars **into media folders**, or scan your library rather than the NzbDAV mount.
+- *Arr: disable metadata/extra-file writing for the affected root folder.
+- rclone: mount with `--read-only` so it stops probing for writability.
+
 ## `addurl` SSRF / private indexer [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }
 
 Allow Docker DNS or LAN hosts under **Trusted local hosts** — [SABnzbd API](../features/sab-api.md).

--- a/frontend/server/logger.ts
+++ b/frontend/server/logger.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from "express";
 import { createColors } from "picocolors";
+import { clientErrorKey, shouldLogClientError } from "./request-log-throttle.js";
 import { isWithinBackendStartupGrace } from "./startup-grace.js";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
@@ -121,11 +122,11 @@ export const requestLogger: RequestHandler = (req, res, next) => {
     // but no way to tell WHICH downstream client is responsible. `req.ip`
     // honors trust-proxy; the raw socket address is included when it
     // differs (i.e. behind a reverse proxy), plus the User-Agent.
+    const socketAddr = req.socket?.remoteAddress ?? "-";
+    const ip = req.ip ?? socketAddr;
+    const userAgent = req.headers["user-agent"] ?? "-";
     const clientInfo = () => {
-      const socketAddr = req.socket?.remoteAddress ?? "-";
-      const ip = req.ip ?? socketAddr;
       const via = ip === socketAddr ? ip : `${ip} (via ${socketAddr})`;
-      const userAgent = req.headers["user-agent"] ?? "-";
       return color.dim(`${via} "${userAgent}"`);
     };
     const message =
@@ -141,7 +142,19 @@ export const requestLogger: RequestHandler = (req, res, next) => {
     } else if (res.statusCode >= 500) {
       logger.error(message);
     } else if (res.statusCode >= 400) {
-      logger.warn(message);
+      // A client repeatedly probing the read-only tree (writing metadata sidecars,
+      // an rclone mount retrying MKCOL/PUT) would otherwise emit a warn per attempt
+      // and bury every other line. Keep the first, collapse the rest to debug.
+      const key = clientErrorKey(
+        req.method, res.statusCode, req.path ?? req.originalUrl, `${ip} ${userAgent}`);
+      const { log, suppressed } = shouldLogClientError(key);
+      if (!log) {
+        logger.debug(message);
+      } else if (suppressed > 0) {
+        logger.warn(`${message} ${color.dim(`(+${suppressed} similar suppressed)`)}`);
+      } else {
+        logger.warn(message);
+      }
     } else if (process.env.NODE_ENV === "development") {
       logger.debug(message);
     }

--- a/frontend/server/request-log-throttle.test.ts
+++ b/frontend/server/request-log-throttle.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  CLIENT_ERROR_LOG_THROTTLE_MS,
+  clientErrorKey,
+  resetClientErrorLogThrottleForTests,
+  shouldLogClientError,
+} from "./request-log-throttle";
+
+describe("request-log-throttle", () => {
+  beforeEach(() => {
+    resetClientErrorLogThrottleForTests();
+  });
+
+  it("logs the first line and suppresses the rest of the window", () => {
+    const now = 1_000_000;
+
+    expect(shouldLogClientError("key", now)).toEqual({ log: true, suppressed: 0 });
+
+    for (let i = 1; i <= 50; i++) {
+      expect(shouldLogClientError("key", now + i)).toEqual({ log: false, suppressed: 0 });
+    }
+  });
+
+  it("reports the suppressed count on the next line once the window elapses", () => {
+    const now = 1_000_000;
+
+    shouldLogClientError("key", now);
+    shouldLogClientError("key", now + 1);
+    shouldLogClientError("key", now + 2);
+
+    expect(shouldLogClientError("key", now + CLIENT_ERROR_LOG_THROTTLE_MS))
+      .toEqual({ log: true, suppressed: 2 });
+
+    // The count resets once reported.
+    expect(shouldLogClientError("key", now + CLIENT_ERROR_LOG_THROTTLE_MS * 2))
+      .toEqual({ log: true, suppressed: 0 });
+  });
+
+  it("tracks keys independently", () => {
+    const now = 1_000_000;
+
+    expect(shouldLogClientError("a", now).log).toBe(true);
+    expect(shouldLogClientError("b", now).log).toBe(true);
+    expect(shouldLogClientError("a", now + 1).log).toBe(false);
+    expect(shouldLogClientError("b", now + 1).log).toBe(false);
+  });
+
+  it("collapses a per-release path storm onto one mount key", () => {
+    const client = "10.0.0.5 Emby/4.8";
+
+    expect(clientErrorKey("MKCOL", 403, "/completed-symlinks/tv-unmatched/release-1", client))
+      .toEqual(clientErrorKey("MKCOL", 403, "/completed-symlinks/tv-unmatched/release-2", client));
+  });
+
+  it("keeps different clients, methods, statuses and mounts distinct", () => {
+    const path = "/completed-symlinks/tv-unmatched/release-1";
+    const base = clientErrorKey("MKCOL", 403, path, "10.0.0.5 Emby/4.8");
+
+    expect(clientErrorKey("PUT", 403, path, "10.0.0.5 Emby/4.8")).not.toEqual(base);
+    expect(clientErrorKey("MKCOL", 404, path, "10.0.0.5 Emby/4.8")).not.toEqual(base);
+    expect(clientErrorKey("MKCOL", 403, "/content/release-1", "10.0.0.5 Emby/4.8")).not.toEqual(base);
+    expect(clientErrorKey("MKCOL", 403, path, "10.0.0.9 Emby/4.8")).not.toEqual(base);
+  });
+
+  it("handles root and empty paths without throwing", () => {
+    expect(clientErrorKey("GET", 404, "/", "c")).toBe("GET 404 / c");
+    expect(clientErrorKey("GET", 404, "", "c")).toBe("GET 404 / c");
+  });
+});

--- a/frontend/server/request-log-throttle.ts
+++ b/frontend/server/request-log-throttle.ts
@@ -1,0 +1,61 @@
+/**
+ * Throttles repeated client-error access-log lines.
+ *
+ * A client that writes metadata sidecars into the read-only WebDAV tree re-attempts
+ * on every scan, so a large library produces a steady stream of 4xx lines — enough to
+ * bury every other log line and, in the reported case, roughly 10 requests/sec forever.
+ * Keeping the first line per client and collapsing the rest preserves the signal that
+ * something is failing without the flood.
+ */
+export const CLIENT_ERROR_LOG_THROTTLE_MS = 60_000;
+
+type ThrottleEntry = { lastLogAt: number; suppressed: number };
+
+/** Parked on `process` so duplicated bundles of this module share one window. */
+const throttleState = process as typeof process & {
+  __nzbdavClientErrorLogState?: Map<string, ThrottleEntry>;
+};
+
+function getState(): Map<string, ThrottleEntry> {
+  return throttleState.__nzbdavClientErrorLogState ??= new Map();
+}
+
+/**
+ * Coarse enough that a per-release path storm collapses to one key, specific enough
+ * that a different client, method, status or mount stays independently visible.
+ */
+export function clientErrorKey(
+  method: string,
+  status: number,
+  path: string,
+  client: string,
+): string {
+  const [mount = ""] = path.replace(/^\/+/, "").split(/[/?#]/, 1);
+  return `${method} ${status} /${mount} ${client}`;
+}
+
+/**
+ * Returns whether the caller should emit a line for this key, plus how many lines were
+ * suppressed since the last emitted one so the message can say what was skipped.
+ */
+export function shouldLogClientError(
+  key: string,
+  now = Date.now(),
+): { log: boolean; suppressed: number } {
+  const state = getState();
+  const entry = state.get(key);
+
+  if (entry && now - entry.lastLogAt < CLIENT_ERROR_LOG_THROTTLE_MS) {
+    entry.suppressed += 1;
+    return { log: false, suppressed: 0 };
+  }
+
+  const suppressed = entry?.suppressed ?? 0;
+  state.set(key, { lastLogAt: now, suppressed: 0 });
+  return { log: true, suppressed };
+}
+
+/** Test-only: reset throttle state between cases. */
+export function resetClientErrorLogThrottleForTests(): void {
+  getState().clear();
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/compression-filter.ts", "server/startup-grace.ts", "server/security-headers.ts", "vite.config.ts", "vitest.config.ts"],
+  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/compression-filter.ts", "server/request-log-throttle.ts", "server/startup-grace.ts", "server/security-headers.ts", "vite.config.ts", "vitest.config.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,

--- a/tests/NzbWebDAV.Tests/Logging/LogThrottleTests.cs
+++ b/tests/NzbWebDAV.Tests/Logging/LogThrottleTests.cs
@@ -1,13 +1,13 @@
-using NzbWebDAV.Services;
+using NzbWebDAV.Logging;
 
-namespace NzbWebDAV.Tests.Services.Watchtower;
+namespace NzbWebDAV.Tests.Logging;
 
-public class WatchtowerLogThrottleTests
+public class LogThrottleTests
 {
     [Fact]
     public void ShouldLog_AllowsFirstCallThenSuppressesWithinTheInterval()
     {
-        var throttle = new WatchtowerLogThrottle();
+        var throttle = new LogThrottle();
         var interval = TimeSpan.FromMinutes(15);
 
         Assert.True(throttle.ShouldLog("cycle", interval, out var firstSuppressed));
@@ -20,7 +20,7 @@ public class WatchtowerLogThrottleTests
     [Fact]
     public void ShouldLog_ReportsSuppressedCountOnceTheIntervalElapses()
     {
-        var throttle = new WatchtowerLogThrottle();
+        var throttle = new LogThrottle();
 
         Assert.True(throttle.ShouldLog("cycle", TimeSpan.Zero, out _));
         Assert.False(throttle.ShouldLog("cycle", TimeSpan.FromMinutes(15), out _));
@@ -38,7 +38,7 @@ public class WatchtowerLogThrottleTests
     [Fact]
     public void ShouldLog_TracksKeysIndependently()
     {
-        var throttle = new WatchtowerLogThrottle();
+        var throttle = new LogThrottle();
         var interval = TimeSpan.FromMinutes(60);
 
         Assert.True(throttle.ShouldLog("cycle", interval, out _));
@@ -50,7 +50,7 @@ public class WatchtowerLogThrottleTests
     [Fact]
     public void Reset_LetsTheNextCallLogImmediately()
     {
-        var throttle = new WatchtowerLogThrottle();
+        var throttle = new LogThrottle();
         var interval = TimeSpan.FromMinutes(60);
 
         Assert.True(throttle.ShouldLog("no-profile", interval, out _));

--- a/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
@@ -2,11 +2,16 @@ using NWebDav.Server;
 using NWebDav.Server.Stores;
 using NzbWebDAV.WebDav.Base;
 using NzbWebDAV.WebDav.Requests;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace NzbWebDAV.Tests.WebDav;
 
 public sealed class BaseStoreCollectionTests
 {
+    private const int MethodNotAllowed = 405;
+
     [Fact]
     public async Task ReadonlyCollection_RejectsEmptyPutWithoutAddingPhantomFile()
     {
@@ -44,14 +49,118 @@ public sealed class BaseStoreCollectionTests
         Assert.Equal(InfiniteDepthMode.Rejected, collection.InfiniteDepthMode);
     }
 
+    [Fact]
+    public async Task ReadonlyCollection_RejectsMkcolForAnUnmappedNameWithForbidden()
+    {
+        var collection = new ReadonlyCollection();
+
+        var result = await collection.CreateCollectionAsync(
+            "new-folder", overwrite: false, CancellationToken.None);
+
+        Assert.Equal(DavStatusCode.Forbidden, result.Result);
+    }
+
+    [Fact]
+    public async Task ReadonlyCollection_RejectsMkcolForAnExistingNameWithMethodNotAllowed()
+    {
+        // RFC 4918 9.3.1: MKCOL may only run against an unmapped URL. Returning 403 for a
+        // directory that already exists reads as a retryable permission problem, which kept
+        // metadata-writing clients re-attempting the same MKCOL forever (issue #680).
+        var collection = new ReadonlyCollection { ExistingItemName = "release-name-1" };
+
+        var result = await collection.CreateCollectionAsync(
+            "release-name-1", overwrite: false, CancellationToken.None);
+
+        Assert.Equal(MethodNotAllowed, (int)result.Result);
+    }
+
+    [Fact]
+    public async Task ReadonlyCollection_AggregatesRepeatedWriteRejectionsIntoOneWarning()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            // A distinct UniqueKey keeps this case independent of the process-wide throttle
+            // state left behind by other tests.
+            var collection = new ReadonlyCollection
+            {
+                Key = $"flood-{Guid.NewGuid()}",
+            };
+
+            for (var i = 0; i < 25; i++)
+            {
+                await collection.CreateItemAsync(
+                    $"metadata-{i}.nfo", Stream.Null, overwrite: true, CancellationToken.None);
+            }
+
+            var warnings = sink.Events.Where(e => e.Level == LogEventLevel.Warning).ToList();
+            var debugs = sink.Events.Where(e => e.Level == LogEventLevel.Debug).ToList();
+
+            Assert.Single(warnings);
+            Assert.Equal(25, debugs.Count);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToList();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+
     private sealed class ReadonlyCollection : BaseStoreReadonlyCollection
     {
+        public string Key { get; init; } = "base-store-collection-tests";
+
+        /// <summary>Name that <see cref="GetItemAsync"/> resolves, standing in for an existing child.</summary>
+        public string? ExistingItemName { get; init; }
+
         public override string Name => "root";
-        public override string UniqueKey => "base-store-collection-tests";
+        public override string UniqueKey => Key;
         public override DateTime CreatedAt => DateTime.UnixEpoch;
 
-        protected override Task<StoreItemResult> CopyAsync(CopyRequest request)
-            => Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
+        protected override Task<IStoreItem?> GetItemAsync(GetItemRequest request)
+        {
+            if (ExistingItemName is not null && request.Name == ExistingItemName)
+                return Task.FromResult<IStoreItem?>(new ExistingCollection(request.Name));
+
+            return Task.FromResult<IStoreItem?>(null);
+        }
+
+        protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class ExistingCollection(string name) : BaseStoreReadonlyCollection
+    {
+        public override string Name => name;
+        public override string UniqueKey => $"existing/{name}";
+        public override DateTime CreatedAt => DateTime.UnixEpoch;
 
         protected override Task<IStoreItem?> GetItemAsync(GetItemRequest request)
             => Task.FromResult<IStoreItem?>(null);
@@ -62,9 +171,5 @@ public sealed class BaseStoreCollectionTests
             await Task.CompletedTask;
             yield break;
         }
-
-        protected override Task<StoreCollectionResult> CreateCollectionAsync(
-            CreateCollectionRequest request)
-            => Task.FromResult(new StoreCollectionResult(DavStatusCode.Forbidden));
     }
 }


### PR DESCRIPTION
Fixes the NzbDAV-side defects behind #680.

## Context

A client (a media scanner or *Arr metadata writer) re-attempts `MKCOL` + `PUT metadata.nfo` + `DELETE` against `/completed-symlinks/<category>-unmatched/...` on every scan. The reporter framed this as NzbDAV retrying forever, but the retry loop is **client-side** — we are the server being written to, so there is no loop here to add backoff to. Two things on our side were genuinely wrong, and those are what this PR fixes.

## Summary

- **`MKCOL` returned the wrong status.** Read-only collections answered 403 even when the target directory already existed. RFC 4918 §9.3.1 requires 405 there. Clients read 403 as a retryable permission problem; 405 tells them the directory exists.
- **Write rejections had no log throttle.** Every refused write logged a Warning per request from the backend store *and* a Warning access-log line from the frontend proxy. At the reported ~10 req/s that is roughly 2,000 warnings per 5 minutes, which flushed the 500-entry Warning-only ring buffer that support packs are collected from — so affected installs had no usable diagnostics. Per-attempt detail now goes to Debug, with one aggregated Warning per read-only path per 5 minutes carrying the attempt count.
- **4xx access-log lines are throttled per client.** First line per method/status/mount/client is kept, the rest collapse to debug, and the suppressed count is reported on the next emitted line. 5xx stays unthrottled.
- `WatchtowerLogThrottle` was already generic, so it moved to `NzbWebDAV.Logging.LogThrottle` and is now shared rather than duplicated.
- Documented the behavior, since the only way to stop the writes entirely is client-side (disable writing metadata into media folders, or mount rclone `--read-only`).

No database migration.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 1189 passed
- [x] `cd frontend && npm run typecheck && npm run build && npm test` — 274 passed
- [x] `zensical build --clean --strict` — no issues
- [x] New backend coverage: `MKCOL` on an existing name returns 405, on an unmapped name returns 403, and 25 repeated rejections produce one Warning plus 25 Debug events
- [x] New frontend coverage: throttle window, suppressed count, key independence, and that a per-release path storm collapses onto one mount key
- [ ] Manual: confirm an affected install shows one aggregated warning per 5 minutes instead of a per-request stream

## Note

Left open pending a reply on #680 — I asked the reporter for the User-Agent from one of the 4xx lines so the docs can name the specific client. Will revisit before merge if that arrives.