### PR TITLE
feat(ui): confirm before turning off stream tracing so captured traces are not lost

### DIFF
--- a/docs/operations/logs-crash-dumps.md
+++ b/docs/operations/logs-crash-dumps.md
@@ -19,7 +19,8 @@ Capture per-segment playback events while reproducing buffering or seek stalls:
 2. Choose 15, 30, or 60 minutes and turn tracing on. A warning banner appears while it is active.
 3. Reproduce the issue (Explore `/view` playback is ideal because it skips rclone and your media server).
 4. Download a support pack from the same page while tracing is still on — `stream-traces/` rides along in the archive.
-5. Tracing auto-disables when the timer elapses, and UI-enabled tracing always resets on restart. It is memory-only (capped at 20,000 events) and never written to disk outside the support pack.
+5. Turning tracing off asks for confirmation when the buffer holds events, because that releases the captured traces immediately.
+6. Tracing auto-disables when the timer elapses, and UI-enabled tracing always resets on restart. It is memory-only (capped at 20,000 events) and never written to disk outside the support pack.
 
 Setting `STREAM_TRACE_EVENTS` still enables tracing from startup with no expiry, which is handy for local dev. Dump a single session with `./scripts/dump-stream-trace.sh` — see [Contributing](../community/contributing.md).
 

--- a/frontend/app/components/stream-tracing-banner.tsx
+++ b/frontend/app/components/stream-tracing-banner.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Icon } from "~/components/ui";
+import { DisableTracingConfirmModal } from "~/components/stream-tracing-confirm";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 
 export type StreamTracingStatus = {
@@ -30,6 +31,7 @@ export function StreamTracingBanner() {
     const [status, setStatus] = useState<StreamTracingStatus | null>(null);
     const [now, setNow] = useState(() => Date.now());
     const [busy, setBusy] = useState(false);
+    const [confirmDisable, setConfirmDisable] = useState(false);
 
     useWebsocketTopic(TOPIC, "state", (message) => {
         try {
@@ -61,24 +63,46 @@ export function StreamTracingBanner() {
         }
     }, []);
 
+    const requestTurnOff = useCallback(() => {
+        if ((status?.eventCount ?? 0) > 0) {
+            setConfirmDisable(true);
+            return;
+        }
+        void turnOff();
+    }, [status?.eventCount, turnOff]);
+
     if (!status?.enabled) return null;
 
     const remaining = formatRemaining(status.expiresAtUnixMs, now);
     const counts = `${status.eventCount.toLocaleString()} events across ${status.sessionCount.toLocaleString()} sessions`;
 
     return (
-        <Alert variant="warning" className="mb-4 items-center justify-between gap-3 text-sm">
-            <div className="flex min-w-0 items-start gap-2">
-                <Icon name="bug_report" className="mt-0.5 shrink-0 !text-[20px]" />
-                <span>
-                    Developer stream tracing is on ({remaining}
-                    {status.source === "ui" ? "" : ", from STREAM_TRACE_EVENTS"}). {counts}.
-                    Tracing uses RAM only and resets on restart.
-                </span>
-            </div>
-            <Button variant="ghost" size="small" disabled={busy} onClick={() => void turnOff()}>
-                Turn off
-            </Button>
-        </Alert>
+        <>
+            <Alert variant="warning" className="mb-4 items-center justify-between gap-3 text-sm">
+                <div className="flex min-w-0 items-start gap-2">
+                    <Icon name="bug_report" className="mt-0.5 shrink-0 !text-[20px]" />
+                    <span>
+                        Developer stream tracing is on ({remaining}
+                        {status.source === "ui" ? "" : ", from STREAM_TRACE_EVENTS"}). {counts}.
+                        Tracing uses RAM only and resets on restart.
+                    </span>
+                </div>
+                <Button variant="ghost" size="small" disabled={busy} onClick={requestTurnOff}>
+                    Turn off
+                </Button>
+            </Alert>
+
+            <DisableTracingConfirmModal
+                show={confirmDisable}
+                eventCount={status.eventCount}
+                sessionCount={status.sessionCount}
+                includeSettingsLink
+                onCancel={() => setConfirmDisable(false)}
+                onConfirm={() => {
+                    setConfirmDisable(false);
+                    void turnOff();
+                }}
+            />
+        </>
     );
 }

--- a/frontend/app/components/stream-tracing-confirm.tsx
+++ b/frontend/app/components/stream-tracing-confirm.tsx
@@ -1,0 +1,54 @@
+import { Link } from "react-router";
+import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
+import { settingsPath } from "~/routes/settings/settings-tabs";
+
+export type DisableTracingConfirmModalProps = {
+    show: boolean;
+    eventCount: number;
+    sessionCount: number;
+    includeSettingsLink?: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+};
+
+export function DisableTracingConfirmModal({
+    show,
+    eventCount,
+    sessionCount,
+    includeSettingsLink = false,
+    onCancel,
+    onConfirm,
+}: DisableTracingConfirmModalProps) {
+    const counts = `${eventCount.toLocaleString()} events across ${sessionCount.toLocaleString()} sessions`;
+
+    return (
+        <ConfirmModal
+            show={show}
+            title="Turn off stream tracing?"
+            message={
+                <>
+                    Tracing is holding {counts} in memory. Turning it off releases the buffer
+                    immediately, and those traces cannot be recovered. Generate a support pack
+                    first if you want them included.
+                    {includeSettingsLink && (
+                        <>
+                            {" "}
+                            <Link
+                                to={settingsPath("support")}
+                                className="link link-primary"
+                                onClick={onCancel}
+                            >
+                                Open Support settings
+                            </Link>
+                            {" "}to generate a pack.
+                        </>
+                    )}
+                </>
+            }
+            cancelText="Keep tracing on"
+            confirmText="Turn off and discard"
+            onCancel={onCancel}
+            onConfirm={onConfirm}
+        />
+    );
+}

--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/components/ui";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 import type { StreamTracingStatus } from "~/components/stream-tracing-banner";
+import { DisableTracingConfirmModal } from "~/components/stream-tracing-confirm";
 
 type Message = { text: string; variant: "success" | "danger" } | null;
 
@@ -41,6 +42,7 @@ export function SupportSettings() {
     const [minutes, setMinutes] = useState<number>(30);
     const [status, setStatus] = useState<StreamTracingStatus | null>(null);
     const [now, setNow] = useState(() => Date.now());
+    const [confirmDisable, setConfirmDisable] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
@@ -128,6 +130,14 @@ export function SupportSettings() {
         }
     }, [minutes]);
 
+    const requestDisable = useCallback(() => {
+        if ((status?.eventCount ?? 0) > 0) {
+            setConfirmDisable(true);
+            return;
+        }
+        void setTracing(false);
+    }, [status?.eventCount, setTracing]);
+
     const enabled = Boolean(status?.enabled);
     const statusLine = enabled && status
         ? `Tracing active — ${formatRemaining(status.expiresAtUnixMs, now)}, ${status.eventCount.toLocaleString()} events across ${status.sessionCount.toLocaleString()} sessions`
@@ -208,7 +218,13 @@ export function SupportSettings() {
                         label={enabled ? "Tracing on" : "Tracing off"}
                         checked={enabled}
                         disabled={tracingBusy}
-                        onChange={(event) => void setTracing(event.target.checked, minutes)}
+                        onChange={(event) => {
+                            if (event.target.checked) {
+                                void setTracing(true, minutes);
+                            } else {
+                                requestDisable();
+                            }
+                        }}
                     />
                 </div>
 
@@ -219,7 +235,7 @@ export function SupportSettings() {
                         <Button
                             variant="outline"
                             disabled={tracingBusy}
-                            onClick={() => void setTracing(false)}
+                            onClick={requestDisable}
                         >
                             Turn off now
                         </Button>
@@ -235,6 +251,17 @@ export function SupportSettings() {
 
                 {tracingMessage && <Alert variant={tracingMessage.variant}>{tracingMessage.text}</Alert>}
             </SettingsCard>
+
+            <DisableTracingConfirmModal
+                show={confirmDisable}
+                eventCount={status?.eventCount ?? 0}
+                sessionCount={status?.sessionCount ?? 0}
+                onCancel={() => setConfirmDisable(false)}
+                onConfirm={() => {
+                    setConfirmDisable(false);
+                    void setTracing(false);
+                }}
+            />
         </SettingsPage>
     );
 }


### PR DESCRIPTION
## Summary
- Asks for confirmation when turning off developer stream tracing if the in-memory buffer still holds events, so traces are not discarded before a support pack is generated.
- Covers the Support settings toggle/"Turn off now" controls and the global warning banner; empty buffers still turn off immediately.
- Banner confirmation links to Support settings so users can generate a pack first.

## Test plan
- [ ] Enable stream tracing with an empty buffer and turn it off from Support settings — no dialog; tracing disables immediately
- [ ] Accumulate events (stream playback), then try Toggle, "Turn off now", and banner "Turn off" — each shows the confirmation
- [ ] Choose "Keep tracing on" — tracing stays enabled and event counts remain
- [ ] Choose "Turn off and discard" — tracing disables and the buffer is released
- [ ] From the banner dialog, "Open Support settings" navigates to the support tab