### PR TITLE
feat(health): support packs report peak CPU during playback, not just an idle snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ BenchmarkDotNet.Artifacts/
 
 .idea/
 .vscode/
+.cursor/
 
 ########
 # macOS #

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -18,6 +18,7 @@ using NzbWebDAV.Logging;
 using NzbWebDAV.Middlewares;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.SupportPack;
 using NzbWebDAV.Services.StreamTrace;
@@ -217,6 +218,8 @@ class Program
                 .AddSingleton<NzbWebDAV.Services.Benchmark.BenchmarkRunControl>()
                 .AddHostedService<LogBroadcaster>()
                 .AddSingleton<ActiveReadRegistry>()
+                .AddSingleton(_ => new RuntimeUsageTracker())
+                .AddHostedService<RuntimeUsageSampler>()
                 .AddSingleton<ProviderUsageTracker>(sp =>
                     new ProviderUsageTracker(sp.GetRequiredService<ActiveReadRegistry>()))
                 .AddSingleton<QueueItemSourceTracker>()

--- a/backend/Services/Diagnostics/RuntimeUsageSampler.cs
+++ b/backend/Services/Diagnostics/RuntimeUsageSampler.cs
@@ -1,0 +1,80 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace NzbWebDAV.Services.Diagnostics;
+
+/// <summary>
+/// Feeds <see cref="RuntimeUsageTracker"/> from the process CPU and GC-pause
+/// counters on a fixed tick, tagging each sample with the number of reads in
+/// flight so a peak can be attributed to playback rather than to a queue import
+/// or a health sweep. One timer and a few counter reads; nothing touches a hot path.
+/// </summary>
+public sealed class RuntimeUsageSampler(
+    RuntimeUsageTracker tracker,
+    ActiveReadRegistry activeReadRegistry) : BackgroundService
+{
+    public static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(5);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var previous = TryReadCounters();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TickInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var current = TryReadCounters();
+
+            // A failed read on either side leaves no interval to measure. Re-baseline
+            // rather than treating the gap as one sample, which would otherwise bill
+            // every second since the last good read into a five-second bucket and
+            // invent an enormous peak.
+            if (previous is { } before && current is { } after)
+            {
+                try
+                {
+                    tracker.Record(
+                        after.Cpu - before.Cpu,
+                        after.GcPause - before.GcPause,
+                        Stopwatch.GetElapsedTime(before.Timestamp, after.Timestamp),
+                        activeReadRegistry.Snapshot().Count,
+                        DateTimeOffset.UtcNow);
+                }
+                catch (Exception e)
+                {
+                    Log.Debug(e, "Runtime usage sampler could not record a sample");
+                }
+            }
+
+            previous = current;
+        }
+    }
+
+    private static Counters? TryReadCounters()
+    {
+        try
+        {
+            // Read CPU first: it is the one that can throw, and taking the timestamp
+            // after it keeps the measured interval aligned with the CPU delta.
+            var cpu = Environment.CpuUsage.TotalTime;
+            return new Counters(cpu, GC.GetTotalPauseDuration(), Stopwatch.GetTimestamp());
+        }
+        catch (Exception e)
+        {
+            // Debug only: a counter that is unavailable on this platform would
+            // otherwise dump a stack into the operator's log every five seconds.
+            Log.Debug(e, "Runtime usage sampler could not read the process CPU and GC counters");
+            return null;
+        }
+    }
+
+    private readonly record struct Counters(TimeSpan Cpu, TimeSpan GcPause, long Timestamp);
+}

--- a/backend/Services/Diagnostics/RuntimeUsageTracker.cs
+++ b/backend/Services/Diagnostics/RuntimeUsageTracker.cs
@@ -1,0 +1,160 @@
+namespace NzbWebDAV.Services.Diagnostics;
+
+/// <summary>
+/// Rolling CPU and GC-pause figures for the support pack. Packs are almost always
+/// collected after the symptom has passed, so an instantaneous sample taken at
+/// pack-generation time describes an idle process and answers the wrong question.
+/// This keeps a short window for "recently" plus process-lifetime peaks, which do
+/// span the period under investigation.
+///
+/// A peak is also tracked separately for samples taken while a read was in flight.
+/// An unqualified peak is usually container startup (JIT, migrations, the first
+/// scan), so the read-attributed peak is the one that says whether playback itself
+/// is what loads the cores.
+///
+/// Pure accumulator: <see cref="RuntimeUsageSampler"/> owns the timer and the
+/// counter reads.
+/// </summary>
+public sealed class RuntimeUsageTracker(int? processorCount = null)
+{
+    /// <summary>Retained samples. Twelve at the sampler's five-second tick is one minute.</summary>
+    public const int WindowSampleCount = 12;
+
+    private readonly int _cores = Math.Max(1, processorCount ?? Environment.ProcessorCount);
+    private readonly Lock _gate = new();
+    private readonly Sample[] _window = new Sample[WindowSampleCount];
+
+    private int _windowNext;
+    private int _windowCount;
+    private long _sampleCount;
+    private DateTimeOffset? _lastSampleAt;
+    private RuntimeUsagePeak? _cpuPeak;
+    private RuntimeUsagePeak? _cpuPeakWhileReading;
+    private RuntimeUsagePeak? _gcPeak;
+    private RuntimeUsagePeak? _gcPeakWhileReading;
+
+    public void Record(
+        TimeSpan cpuDelta,
+        TimeSpan gcPauseDelta,
+        TimeSpan elapsed,
+        int activeReads,
+        DateTimeOffset at)
+    {
+        // A non-positive window means the clock moved backwards or two ticks
+        // landed on the same instant; there is nothing to divide by.
+        if (elapsed <= TimeSpan.Zero) return;
+
+        var wallMs = elapsed.TotalMilliseconds;
+        var cpuMs = Math.Max(0, cpuDelta.TotalMilliseconds);
+        var gcPauseMs = Math.Max(0, gcPauseDelta.TotalMilliseconds);
+        var reads = Math.Max(0, activeReads);
+
+        // CPU is a share of the whole machine, so 100 means every core busy. A GC
+        // pause stops the process regardless of core count, so it is a share of
+        // wall clock only.
+        var cpuPercent = Round(cpuMs / (wallMs * _cores) * 100);
+        var gcPercent = Round(gcPauseMs / wallMs * 100);
+
+        lock (_gate)
+        {
+            _window[_windowNext] = new Sample(cpuMs, gcPauseMs, wallMs);
+            _windowNext = (_windowNext + 1) % WindowSampleCount;
+            if (_windowCount < WindowSampleCount) _windowCount++;
+            _sampleCount++;
+            _lastSampleAt = at;
+
+            _cpuPeak = Higher(_cpuPeak, cpuPercent, at, reads);
+            _gcPeak = Higher(_gcPeak, gcPercent, at, reads);
+            if (reads > 0)
+            {
+                _cpuPeakWhileReading = Higher(_cpuPeakWhileReading, cpuPercent, at, reads);
+                _gcPeakWhileReading = Higher(_gcPeakWhileReading, gcPercent, at, reads);
+            }
+        }
+    }
+
+    public RuntimeUsageSnapshot Snapshot()
+    {
+        lock (_gate)
+        {
+            if (_windowCount == 0)
+            {
+                return new RuntimeUsageSnapshot(
+                    _cores,
+                    SampleCount: 0,
+                    WindowSpanMs: 0,
+                    LastSampleAtUtc: null,
+                    Cpu: new RuntimeUsageMetric(null, null, null, null),
+                    GcPause: new RuntimeUsageMetric(null, null, null, null));
+            }
+
+            // Newest first, so index 0 is the most recent tick.
+            var newest = _window[(_windowNext - 1 + WindowSampleCount) % WindowSampleCount];
+            double cpuMs = 0, gcPauseMs = 0, wallMs = 0;
+            for (var i = 0; i < _windowCount; i++)
+            {
+                var sample = _window[(_windowNext - 1 - i + 2 * WindowSampleCount) % WindowSampleCount];
+                cpuMs += sample.CpuMs;
+                gcPauseMs += sample.GcPauseMs;
+                wallMs += sample.WallMs;
+            }
+
+            return new RuntimeUsageSnapshot(
+                _cores,
+                _sampleCount,
+                (long)wallMs,
+                _lastSampleAt,
+                new RuntimeUsageMetric(
+                    Round(newest.CpuMs / (newest.WallMs * _cores) * 100),
+                    Round(cpuMs / (wallMs * _cores) * 100),
+                    _cpuPeak,
+                    _cpuPeakWhileReading),
+                new RuntimeUsageMetric(
+                    Round(newest.GcPauseMs / newest.WallMs * 100),
+                    Round(gcPauseMs / wallMs * 100),
+                    _gcPeak,
+                    _gcPeakWhileReading));
+        }
+    }
+
+    private static RuntimeUsagePeak Higher(
+        RuntimeUsagePeak? current,
+        double percent,
+        DateTimeOffset at,
+        int activeReads) =>
+        current is null || percent > current.Percent
+            ? new RuntimeUsagePeak(percent, at, activeReads)
+            : current;
+
+    private static double Round(double percent) => Math.Round(percent, 1);
+
+    private readonly record struct Sample(double CpuMs, double GcPauseMs, double WallMs);
+}
+
+/// <param name="SampleCount">
+/// Samples recorded since startup. Zero means the sampler has not ticked yet, which
+/// is the only case where the figures below are null.
+/// </param>
+/// <param name="WindowSpanMs">
+/// Wall clock covered by the retained window. Under 60_000 means the one-minute
+/// averages are over a partial window and should be read as such.
+/// </param>
+/// <param name="LastSampleAtUtc">
+/// When the sampler last ticked. Far behind the pack's generation time means the
+/// sampler is wedged and the rolling figures are stale.
+/// </param>
+public sealed record RuntimeUsageSnapshot(
+    int ProcessorCount,
+    long SampleCount,
+    long WindowSpanMs,
+    DateTimeOffset? LastSampleAtUtc,
+    RuntimeUsageMetric Cpu,
+    RuntimeUsageMetric GcPause);
+
+public sealed record RuntimeUsageMetric(
+    double? CurrentPercent,
+    double? OneMinutePercent,
+    RuntimeUsagePeak? Peak,
+    RuntimeUsagePeak? PeakWhileReading);
+
+public sealed record RuntimeUsagePeak(double Percent, DateTimeOffset AtUtc, int ActiveReads);

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -10,6 +10,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
@@ -26,7 +27,8 @@ public sealed class SupportPackService(
     UsenetStreamingClient usenetStreamingClient,
     ArticleMissNegativeCache articleMissCache,
     InFlightArticleBudget inFlightArticleBudget,
-    StreamTraceBuffer streamTraceBuffer)
+    StreamTraceBuffer streamTraceBuffer,
+    RuntimeUsageTracker runtimeUsage)
 {
     private const long MinuteMs = 60_000;
     private const long HourMs = 60 * MinuteMs;
@@ -133,11 +135,18 @@ public sealed class SupportPackService(
         the last 500 warnings and errors separately for that reason - check it first
         when the main log looks like it only contains routine activity.
 
-        environment.json reports a live CPU sample taken while the pack was being
-        built, GC counters (including large-object-heap sizes and pause time), thread
-        pool occupancy, and per-provider connection-pool state with lifetime churn.
-        Collect the pack while the problem is happening - the CPU sample is a
-        half-second window, not a lifetime average.
+        environment.json reports CPU and GC pause figures, thread pool occupancy, and
+        per-provider connection-pool state with lifetime churn. Read cpu.rolling and
+        gc.rolling first: a background sampler records them every few seconds, so
+        their peaks span the whole time the backend has been running rather than the
+        moment the pack was collected. peakWhileReading only counts samples taken
+        while a read was in flight, which tells playback cost apart from container
+        startup, a queue import or a health sweep. cpu.onDemandSample is a half-second
+        window measured while this pack was written - packs are usually collected
+        after the symptom has passed, so treat it as a footnote, not the headline.
+        Prefer the cumulative GC counters (totalPauseDurationMs, totalAllocatedBytes,
+        collection counts) over pauseTimePercentage, which reflects only the most
+        recent collection.
 
         stream-traces/ is included only while developer stream tracing is enabled
         (Settings → Support, or STREAM_TRACE_EVENTS). Tracing is opt-in, memory-only,
@@ -184,7 +193,8 @@ public sealed class SupportPackService(
         var drive = new DriveInfo(root);
         var uptime = ProcessUptime();
         var streamTracing = streamTraceBuffer.GetStatus();
-        var cpu = await SampleCpuAsync(uptime, cancellationToken).ConfigureAwait(false);
+        var usage = runtimeUsage.Snapshot();
+        var cpu = await BuildCpuDiagnosticsAsync(usage, uptime, cancellationToken).ConfigureAwait(false);
 
         return new
         {
@@ -207,8 +217,9 @@ public sealed class SupportPackService(
                 inFlightArticleThrottleEvents = inFlightArticleBudget.ThrottleEvents,
                 timeZone = TimeZoneInfo.Local.Id,
             },
+            runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),
             cpu,
-            gc = BuildGcDiagnostics(),
+            gc = BuildGcDiagnostics(usage),
             threadPool = new
             {
                 minWorkerThreads,
@@ -251,14 +262,43 @@ public sealed class SupportPackService(
     }
 
     /// <summary>
-    /// CPU usage as both a live sample and a process-lifetime average. The sample is what
-    /// matters when a pack is collected while the problem is happening: a lifetime average
-    /// over a mostly-idle process hides a core that is pegged right now. Percentages are
-    /// of the whole machine, so 100 means every core busy.
+    /// Health of the background sampler that produces the rolling CPU and GC figures.
+    /// A <c>lastSampleAtUtc</c> far behind the pack's generation time, or a
+    /// <c>windowSpanMs</c> well under a minute, means the rolling numbers are stale or
+    /// cover a partial window and should be read with that in mind.
     /// </summary>
-    private static async Task<object> SampleCpuAsync(TimeSpan uptime, CancellationToken cancellationToken)
+    private static object BuildRuntimeSamplerDiagnostics(RuntimeUsageSnapshot usage) =>
+        new
+        {
+            intervalMs = (long)RuntimeUsageSampler.TickInterval.TotalMilliseconds,
+            sampleCount = usage.SampleCount,
+            windowSpanMs = usage.WindowSpanMs,
+            lastSampleAtUtc = usage.LastSampleAtUtc,
+        };
+
+    /// <summary>
+    /// CPU cost of the process. Read <c>rolling</c> first. A pack is nearly always
+    /// collected after the symptom has passed, so <c>onDemandSample</c> — measured while
+    /// the pack was being written — usually describes an idle process and answers the
+    /// wrong question. The peaks span the whole process lifetime, and
+    /// <c>peakWhileReading</c> only counts samples taken with a read in flight, which
+    /// separates playback cost from container startup, a queue import or a health sweep.
+    /// Percentages are of the whole machine, so 100 means every core busy.
+    /// </summary>
+    private static async Task<object> BuildCpuDiagnosticsAsync(
+        RuntimeUsageSnapshot usage,
+        TimeSpan uptime,
+        CancellationToken cancellationToken)
     {
         var cores = Math.Max(1, Environment.ProcessorCount);
+        var rolling = new
+        {
+            currentPercentAllCores = usage.Cpu.CurrentPercent,
+            oneMinutePercentAllCores = usage.Cpu.OneMinutePercent,
+            peak = BuildPeak(usage.Cpu.Peak),
+            peakWhileReading = BuildPeak(usage.Cpu.PeakWhileReading),
+        };
+
         try
         {
             var before = Environment.CpuUsage;
@@ -270,33 +310,54 @@ public sealed class SupportPackService(
             return new
             {
                 processorCount = cores,
-                sampleWindowMs = (long)sampleWindow.TotalMilliseconds,
-                samplePercentAllCores = Percent(sampleMs, sampleWindow.TotalMilliseconds * cores),
-                samplePercentOneCore = Percent(sampleMs, sampleWindow.TotalMilliseconds),
+                rolling,
                 lifetimeUserMs = (long)after.UserTime.TotalMilliseconds,
                 lifetimePrivilegedMs = (long)after.PrivilegedTime.TotalMilliseconds,
                 lifetimeTotalMs = (long)after.TotalTime.TotalMilliseconds,
                 lifetimePercentAllCores = Percent(
                     after.TotalTime.TotalMilliseconds, uptime.TotalMilliseconds * cores),
+                onDemandSample = new
+                {
+                    windowMs = (long)sampleWindow.TotalMilliseconds,
+                    percentAllCores = Percent(sampleMs, sampleWindow.TotalMilliseconds * cores),
+                    percentOneCore = Percent(sampleMs, sampleWindow.TotalMilliseconds),
+                },
             };
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
             Log.Debug(e, "Support pack: could not sample CPU usage");
-            return new { processorCount = cores, unavailable = true };
+            // The rolling figures come from counters already banked by the sampler, so
+            // they survive a failure to read the lifetime totals here.
+            return new { processorCount = cores, rolling, unavailable = true };
         }
 
         static double? Percent(double used, double capacity) =>
             capacity <= 0 ? null : Math.Round(used / capacity * 100, 1);
     }
 
+    private static object? BuildPeak(RuntimeUsagePeak? peak) =>
+        peak is null
+            ? null
+            : new { percent = peak.Percent, atUtc = peak.AtUtc, activeReads = peak.ActiveReads };
+
     /// <summary>
     /// GC shape and cost. Generation sizes include the large-object heap, which is where
-    /// article buffers land, and <c>pauseTimePercentage</c> says how much of recent wall
-    /// clock the process spent stopped.
+    /// article buffers land. Prefer the cumulative <c>totalPauseDurationMs</c> and the
+    /// rolling block over <c>pauseTimePercentage</c>, which reflects only the most recent
+    /// collection. Pause percentages are of wall clock, not of core time, because a pause
+    /// stops the whole process.
     /// </summary>
-    private static object BuildGcDiagnostics()
+    private static object BuildGcDiagnostics(RuntimeUsageSnapshot usage)
     {
+        var rolling = new
+        {
+            currentPausePercent = usage.GcPause.CurrentPercent,
+            oneMinutePausePercent = usage.GcPause.OneMinutePercent,
+            peak = BuildPeak(usage.GcPause.Peak),
+            peakWhileReading = BuildPeak(usage.GcPause.PeakWhileReading),
+        };
+
         try
         {
             var info = GC.GetGCMemoryInfo();
@@ -316,6 +377,7 @@ public sealed class SupportPackService(
             {
                 isServerGc = GCSettings.IsServerGC,
                 latencyMode = GCSettings.LatencyMode.ToString(),
+                rolling,
                 gen0Collections = GC.CollectionCount(0),
                 gen1Collections = GC.CollectionCount(1),
                 gen2Collections = GC.CollectionCount(2),
@@ -330,7 +392,7 @@ public sealed class SupportPackService(
         catch (Exception e)
         {
             Log.Debug(e, "Support pack: could not read GC diagnostics");
-            return new { unavailable = true };
+            return new { rolling, unavailable = true };
         }
 
         static string GenerationName(int generation) => generation switch
@@ -565,7 +627,7 @@ public sealed class SupportPackService(
         var (mainMigration, metricsMigration) = await ReadMigrationsAsync(cancellationToken).ConfigureAwait(false);
         return new
         {
-            schemaVersion = 1,
+            schemaVersion = 2,
             generatedAtUtc = generatedAt,
             appVersion = ConfigManager.AppVersion,
             commit = Environment.GetEnvironmentVariable("NZBDAV_COMMIT_SHA"),

--- a/tests/NzbWebDAV.Tests/Services/Diagnostics/RuntimeUsageTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Diagnostics/RuntimeUsageTrackerTests.cs
@@ -1,0 +1,147 @@
+using NzbWebDAV.Services.Diagnostics;
+
+namespace NzbWebDAV.Tests.Services.Diagnostics;
+
+public class RuntimeUsageTrackerTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Snapshot_BeforeTheFirstTick_ReportsNullsRatherThanDividingByZero()
+    {
+        var snapshot = new RuntimeUsageTracker(processorCount: 4).Snapshot();
+
+        Assert.Equal(0, snapshot.SampleCount);
+        Assert.Equal(0, snapshot.WindowSpanMs);
+        Assert.Null(snapshot.LastSampleAtUtc);
+        Assert.Null(snapshot.Cpu.CurrentPercent);
+        Assert.Null(snapshot.Cpu.OneMinutePercent);
+        Assert.Null(snapshot.Cpu.Peak);
+        Assert.Null(snapshot.GcPause.CurrentPercent);
+    }
+
+    [Fact]
+    public void Record_IgnoresSamplesWithNoMeasurableInterval()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+
+        // A clock that moved backwards, or two ticks landing on the same instant,
+        // leaves nothing to divide by.
+        Record(tracker, cpuMs: 1000, wallMs: 0);
+        Record(tracker, cpuMs: 1000, wallMs: -5000);
+
+        Assert.Equal(0, tracker.Snapshot().SampleCount);
+    }
+
+    [Fact]
+    public void CpuPercent_IsAShareOfEveryCore()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+
+        // One core fully busy for the whole five seconds is a quarter of a four-core box.
+        Record(tracker, cpuMs: 5000, wallMs: 5000);
+
+        Assert.Equal(25, tracker.Snapshot().Cpu.CurrentPercent);
+    }
+
+    [Fact]
+    public void GcPausePercent_IsAShareOfWallClockNotOfCoreTime()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+
+        // A pause stops the whole process, so the core count must not dilute it.
+        Record(tracker, cpuMs: 0, wallMs: 5000, gcPauseMs: 500);
+
+        Assert.Equal(10, tracker.Snapshot().GcPause.CurrentPercent);
+    }
+
+    [Fact]
+    public void OneMinuteAverage_WeightsByWallClockInsteadOfAveragingPerTickPercentages()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+
+        Record(tracker, cpuMs: 4000, wallMs: 5000); // 20% of four cores
+        Record(tracker, cpuMs: 4000, wallMs: 1000); // 100% of four cores
+
+        var snapshot = tracker.Snapshot();
+
+        // Averaging the two percentages would claim 60%. The long quiet sample has to
+        // carry more weight than the short busy one: 8000ms over 6000ms of four cores.
+        Assert.Equal(33.3, snapshot.Cpu.OneMinutePercent);
+        Assert.Equal(100, snapshot.Cpu.CurrentPercent);
+        Assert.Equal(6000, snapshot.WindowSpanMs);
+        Assert.Equal(2, snapshot.SampleCount);
+    }
+
+    [Fact]
+    public void Peak_OutlivesEvictionFromTheRollingWindow()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+        var busyAt = Origin;
+
+        Record(tracker, cpuMs: 20000, wallMs: 5000, at: busyAt); // every core pegged
+        for (var i = 1; i <= RuntimeUsageTracker.WindowSampleCount; i++)
+            Record(tracker, cpuMs: 0, wallMs: 5000, at: Origin.AddSeconds(5 * i));
+
+        var snapshot = tracker.Snapshot();
+
+        // The window has rolled past the incident, which is exactly the case this
+        // exists for: a pack collected minutes later must still show what happened.
+        Assert.Equal(0, snapshot.Cpu.OneMinutePercent);
+        Assert.Equal(0, snapshot.Cpu.CurrentPercent);
+        Assert.NotNull(snapshot.Cpu.Peak);
+        Assert.Equal(100, snapshot.Cpu.Peak.Percent);
+        Assert.Equal(busyAt, snapshot.Cpu.Peak.AtUtc);
+    }
+
+    [Fact]
+    public void PeakWhileReading_ReportsTheBusiestSampleThatHadALiveRead()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+        var startupAt = Origin;
+        var playbackAt = Origin.AddMinutes(30);
+
+        // Container startup with nothing playing, then a quieter moment during playback.
+        Record(tracker, cpuMs: 16000, wallMs: 5000, at: startupAt, activeReads: 0);
+        Record(tracker, cpuMs: 8000, wallMs: 5000, at: playbackAt, activeReads: 2);
+
+        var cpu = tracker.Snapshot().Cpu;
+
+        Assert.Equal(80, cpu.Peak!.Percent);
+        Assert.Equal(startupAt, cpu.Peak.AtUtc);
+        Assert.Equal(0, cpu.Peak.ActiveReads);
+
+        // The unqualified peak is startup noise. Attribution is the whole point: the
+        // figure that speaks to playback cost is the one taken with reads in flight.
+        Assert.Equal(40, cpu.PeakWhileReading!.Percent);
+        Assert.Equal(playbackAt, cpu.PeakWhileReading.AtUtc);
+        Assert.Equal(2, cpu.PeakWhileReading.ActiveReads);
+    }
+
+    [Fact]
+    public void PeakWhileReading_StaysNullUntilASampleCoincidesWithARead()
+    {
+        var tracker = new RuntimeUsageTracker(processorCount: 4);
+
+        Record(tracker, cpuMs: 16000, wallMs: 5000, activeReads: 0);
+
+        var snapshot = tracker.Snapshot();
+        Assert.NotNull(snapshot.Cpu.Peak);
+        Assert.Null(snapshot.Cpu.PeakWhileReading);
+        Assert.Null(snapshot.GcPause.PeakWhileReading);
+    }
+
+    private static void Record(
+        RuntimeUsageTracker tracker,
+        double cpuMs,
+        double wallMs,
+        double gcPauseMs = 0,
+        int activeReads = 0,
+        DateTimeOffset? at = null) =>
+        tracker.Record(
+            TimeSpan.FromMilliseconds(cpuMs),
+            TimeSpan.FromMilliseconds(gcPauseMs),
+            TimeSpan.FromMilliseconds(wallMs),
+            activeReads,
+            at ?? Origin);
+}

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Services.SupportPack;
@@ -112,13 +113,14 @@ public sealed class SupportPackContentsTests : IDisposable
         using var environment = JsonDocument.Parse(entries["environment.json"]);
         var root = environment.RootElement;
 
-        // CPU must be a live sample, not only a lifetime average: a pack collected while
-        // playback stutters has to show what the cores are doing right now.
         var cpu = root.GetProperty("cpu");
         Assert.True(cpu.GetProperty("processorCount").GetInt32() >= 1);
-        Assert.True(cpu.GetProperty("sampleWindowMs").GetInt64() > 0);
-        Assert.True(cpu.GetProperty("samplePercentAllCores").GetDouble() >= 0);
         Assert.True(cpu.GetProperty("lifetimeTotalMs").GetInt64() >= 0);
+
+        // The on-demand probe is kept as a footnote, so it must still be readable.
+        var onDemand = cpu.GetProperty("onDemandSample");
+        Assert.True(onDemand.GetProperty("windowMs").GetInt64() > 0);
+        Assert.True(onDemand.GetProperty("percentAllCores").GetDouble() >= 0);
 
         var gc = root.GetProperty("gc");
         Assert.True(gc.GetProperty("gen0Collections").GetInt32() >= 0);
@@ -139,6 +141,80 @@ public sealed class SupportPackContentsTests : IDisposable
 
         // No providers are configured in this fixture, so the section is present but empty.
         Assert.Equal(JsonValueKind.Array, root.GetProperty("connections").ValueKind);
+    }
+
+    [Fact]
+    public async Task Pack_ReportsPeakCpuAttributedToPlaybackRatherThanOnlyAnIdleSnapshot()
+    {
+        // Packs are collected after the symptom has passed, so an instantaneous sample
+        // describes an idle process. These are the counters that span the incident.
+        var busyAt = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+        var playbackAt = busyAt.AddMinutes(30);
+        var runtimeUsage = new RuntimeUsageTracker(processorCount: 4);
+        runtimeUsage.Record(
+            TimeSpan.FromMilliseconds(16000),
+            TimeSpan.FromMilliseconds(250),
+            TimeSpan.FromSeconds(5),
+            activeReads: 0,
+            busyAt);
+        runtimeUsage.Record(
+            TimeSpan.FromMilliseconds(8000),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromSeconds(5),
+            activeReads: 2,
+            playbackAt);
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            runtimeUsage);
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var root = environment.RootElement;
+
+        var sampler = root.GetProperty("runtimeSampler");
+        Assert.True(sampler.GetProperty("intervalMs").GetInt64() > 0);
+        Assert.Equal(2, sampler.GetProperty("sampleCount").GetInt64());
+        Assert.Equal(10_000, sampler.GetProperty("windowSpanMs").GetInt64());
+        Assert.Equal(playbackAt, sampler.GetProperty("lastSampleAtUtc").GetDateTimeOffset());
+
+        var rolling = root.GetProperty("cpu").GetProperty("rolling");
+        Assert.Equal(40, rolling.GetProperty("currentPercentAllCores").GetDouble());
+        Assert.Equal(60, rolling.GetProperty("oneMinutePercentAllCores").GetDouble());
+
+        var peak = rolling.GetProperty("peak");
+        Assert.Equal(80, peak.GetProperty("percent").GetDouble());
+        Assert.Equal(busyAt, peak.GetProperty("atUtc").GetDateTimeOffset());
+        Assert.Equal(0, peak.GetProperty("activeReads").GetInt32());
+
+        // Without the read count a peak cannot be told apart from a queue import or a
+        // health sweep, which is what made the original figure unusable.
+        var peakWhileReading = rolling.GetProperty("peakWhileReading");
+        Assert.Equal(40, peakWhileReading.GetProperty("percent").GetDouble());
+        Assert.Equal(playbackAt, peakWhileReading.GetProperty("atUtc").GetDateTimeOffset());
+        Assert.Equal(2, peakWhileReading.GetProperty("activeReads").GetInt32());
+
+        var gcRolling = root.GetProperty("gc").GetProperty("rolling");
+        Assert.Equal(2, gcRolling.GetProperty("currentPausePercent").GetDouble());
+        Assert.Equal(5, gcRolling.GetProperty("peak").GetProperty("percent").GetDouble());
+        Assert.Equal(2, gcRolling.GetProperty("peakWhileReading").GetProperty("percent").GetDouble());
+    }
+
+    [Fact]
+    public async Task Pack_ReportsRollingFiguresAsNullBeforeTheSamplerHasTicked()
+    {
+        var entries = await ReadPackEntriesAsync(new LogBufferSink(10), new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var root = environment.RootElement;
+
+        // A pack pulled in the first seconds of process life has nothing banked yet.
+        // Null is honest here; zero would read as a genuinely idle backend.
+        Assert.Equal(0, root.GetProperty("runtimeSampler").GetProperty("sampleCount").GetInt64());
+        var rolling = root.GetProperty("cpu").GetProperty("rolling");
+        Assert.Equal(JsonValueKind.Null, rolling.GetProperty("currentPercentAllCores").ValueKind);
+        Assert.Equal(JsonValueKind.Null, rolling.GetProperty("peak").ValueKind);
+        Assert.Equal(JsonValueKind.Null, rolling.GetProperty("peakWhileReading").ValueKind);
     }
 
     [Fact]
@@ -193,13 +269,15 @@ public sealed class SupportPackContentsTests : IDisposable
 
     private static Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,
-        WarningLogBuffer warningBuffer) =>
-        ReadPackEntriesAsync(logBuffer, warningBuffer, new StreamTraceBuffer(100, enabled: false));
+        WarningLogBuffer warningBuffer,
+        RuntimeUsageTracker? runtimeUsage = null) =>
+        ReadPackEntriesAsync(logBuffer, warningBuffer, new StreamTraceBuffer(100, enabled: false), runtimeUsage);
 
     private static async Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,
         WarningLogBuffer warningBuffer,
-        StreamTraceBuffer streamTraceBuffer)
+        StreamTraceBuffer streamTraceBuffer,
+        RuntimeUsageTracker? runtimeUsage = null)
     {
         var configManager = new ConfigManager();
         var websocketManager = new WebsocketManager();
@@ -221,7 +299,8 @@ public sealed class SupportPackContentsTests : IDisposable
             usenet,
             new ArticleMissNegativeCache(configManager),
             new InFlightArticleBudget(64 * 1024 * 1024),
-            streamTraceBuffer);
+            streamTraceBuffer,
+            runtimeUsage ?? new RuntimeUsageTracker());
 
         using var memory = new MemoryStream();
         await service.WriteAsync(memory, CancellationToken.None);


### PR DESCRIPTION
## Summary

Fixes #679. A support pack's CPU figure was a 500 ms sample taken while the pack was being written. Packs are almost always collected after the symptom has passed, so that sample described an idle process and answered the wrong question.

- A background sampler ticks every 5 seconds and banks current, one-minute average and process-lifetime peak CPU and GC pause figures, so the numbers in a pack span the period under investigation rather than the moment of collection.
- Each peak records its timestamp and how many reads were in flight. `peakWhileReading` only counts samples taken with a live read, which separates playback cost from container startup, a queue import or a health sweep — an unqualified peak is usually one of those.
- `cpu.rolling` and `gc.rolling` lead their blocks; the old probe is kept as `cpu.onDemandSample` so a pack collected in the first seconds of process life still has a floor of information. Cumulative GC counters are untouched.
- New `runtimeSampler` block reports tick interval, sample count, window span and last sample time, so a reader can tell whether the rolling figures are stale or cover only a partial window.
- Manifest `schemaVersion` is now 2. Nothing outside the support pack read the old field names.

Cost is one timer and a few counters. No hot path is touched.

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj` — clean, no new warnings
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 1196 passed, 0 failed
- [x] New `RuntimeUsageTrackerTests` cover wall-clock weighting of the one-minute average, peak retention after the window rolls past the incident, read attribution beating a higher idle peak, and null-safety before the first tick
- [x] `SupportPackContentsTests` assert the serialized peak, its timestamp and its active-read count, and that rolling figures are null rather than zero before the sampler ticks
- [x] Ran the backend locally, waited past several ticks and downloaded a pack: `runtimeSampler.sampleCount` 10 over a 50 s window, peak recorded with a timestamp, `peakWhileReading` null with nothing playing, `schemaVersion` 2