### PR TITLE
perf(webdav): lower memory use while streaming large files

### DIFF
--- a/backend/Streams/BudgetedStream.cs
+++ b/backend/Streams/BudgetedStream.cs
@@ -6,10 +6,10 @@ namespace NzbWebDAV.Streams;
 /// </summary>
 public sealed class BudgetedStream : Stream
 {
-    private readonly MemoryStream _inner;
+    private readonly Stream _inner;
     private ArticleByteLease? _lease;
 
-    public BudgetedStream(MemoryStream inner, ArticleByteLease lease)
+    public BudgetedStream(Stream inner, ArticleByteLease lease)
     {
         _inner = inner;
         _lease = lease;

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -710,7 +710,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return SegmentDownloadResult.ZeroFill(
-            new MemoryStream(new byte[fill], writable: false),
+            new ZeroStream(fill),
             messageTemplate,
             segmentId,
             fill,

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -774,12 +774,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             // source disposal succeeds. A disposal failure must not strand either.
             sourceDisposeAttempted = true;
             await source.DisposeAsync().ConfigureAwait(false);
+            // Build the wrapper that takes over the buffer and lease before dropping
+            // local ownership, so a failure here still routes both through the catch.
+            var result = ReferenceEquals(lease, ArticleByteLease.Empty)
+                ? (Stream)buffer
+                : new BudgetedStream(buffer, lease);
             ownsLease = false;
-            var owned = buffer;
             buffer = null;
-            return ReferenceEquals(lease, ArticleByteLease.Empty)
-                ? owned
-                : new BudgetedStream(owned, lease);
+            return result;
         }
         catch
         {

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -739,6 +739,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         ArticleByteLease? lease = existingLease;
         var ownsLease = existingLease is null;
         PooledBufferStream? buffer = null;
+        var sourceDisposeAttempted = false;
         try
         {
             var hasExactSize = _segmentSizes.TryGetExactSize(segmentIndex, out var exactSize);
@@ -769,6 +770,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 lease.Adjust(actual - estimate);
 
             buffer.Position = 0;
+            // Keep the buffer and any internally acquired lease locally owned until
+            // source disposal succeeds. A disposal failure must not strand either.
+            sourceDisposeAttempted = true;
+            await source.DisposeAsync().ConfigureAwait(false);
             ownsLease = false;
             var owned = buffer;
             buffer = null;
@@ -786,7 +791,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
         finally
         {
-            await source.DisposeAsync().ConfigureAwait(false);
+            if (!sourceDisposeAttempted)
+                await source.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -738,6 +738,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         ArticleByteLease? lease = existingLease;
         var ownsLease = existingLease is null;
+        PooledBufferStream? buffer = null;
         try
         {
             var hasExactSize = _segmentSizes.TryGetExactSize(segmentIndex, out var exactSize);
@@ -750,7 +751,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
 
             var capacity = estimate is > 0 and <= int.MaxValue ? (int)estimate : 0;
-            var buffer = new MemoryStream(capacity);
+            buffer = new PooledBufferStream(capacity);
             var drainStarted = Stopwatch.GetTimestamp();
             await source.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
             StreamTrace.TryStall(
@@ -769,12 +770,16 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             buffer.Position = 0;
             ownsLease = false;
+            var owned = buffer;
+            buffer = null;
             return ReferenceEquals(lease, ArticleByteLease.Empty)
-                ? buffer
-                : new BudgetedStream(buffer, lease);
+                ? owned
+                : new BudgetedStream(owned, lease);
         }
         catch
         {
+            if (buffer is not null)
+                await buffer.DisposeAsync().ConfigureAwait(false);
             if (ownsLease)
                 lease?.Dispose();
             throw;
@@ -799,7 +804,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     /// shortfall or an overrun would shift every following byte, so short bodies are
     /// padded and long bodies are truncated to the recorded size.
     /// </summary>
-    private void AlignDrainedSegment(MemoryStream buffer, int segmentIndex, long drained, long expected)
+    private void AlignDrainedSegment(PooledBufferStream buffer, int segmentIndex, long drained, long expected)
     {
         if (drained == expected) return;
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -342,9 +342,10 @@ public class NzbFileStream(
                 // its first read (head never becomes current). Idempotent dispose is safe
                 // when CombinedStream also disposes head after consuming it.
                 var owned = head;
-                head = null;
-                return new CombinedStream(SpliceHeadThenRest(owned, index + 1, ct))
+                var spliced = new CombinedStream(SpliceHeadThenRest(owned, index + 1, ct))
                     .OnDispose(() => owned.Dispose());
+                head = null;
+                return spliced;
             }
             finally
             {

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -294,6 +294,7 @@ public class NzbFileStream(
             }
 
             PooledBufferStream? head = null;
+            var bodyDisposeAttempted = false;
             try
             {
                 try
@@ -304,6 +305,11 @@ public class NzbFileStream(
                     head = new PooledBufferStream(capacity);
                     await body.CopyToAsync(head, ct).ConfigureAwait(false);
                     head.Position = 0;
+                    // Do not relinquish the pooled head until body disposal succeeds.
+                    // Otherwise a disposal exception aborts the return with no owner
+                    // left to return the rented array.
+                    bodyDisposeAttempted = true;
+                    await body.DisposeAsync().ConfigureAwait(false);
                 }
                 catch (Exception e) when (!ct.IsCancellationRequested)
                 {
@@ -342,9 +348,16 @@ public class NzbFileStream(
             }
             finally
             {
-                await body.DisposeAsync().ConfigureAwait(false);
-                if (head is not null)
-                    await head.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    if (!bodyDisposeAttempted)
+                        await body.DisposeAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (head is not null)
+                        await head.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -293,48 +293,59 @@ public class NzbFileStream(
                 continue;
             }
 
-            MemoryStream head;
+            PooledBufferStream? head = null;
             try
             {
-                await body.DiscardExactBytesAsync(rangeStart - start, ct).ConfigureAwait(false);
-                var tail = end - rangeStart;
-                var capacity = tail is > 0 and <= int.MaxValue ? (int)tail : 0;
-                head = new MemoryStream(capacity);
-                await body.CopyToAsync(head, ct).ConfigureAwait(false);
-                head.Position = 0;
-            }
-            catch (Exception e) when (!ct.IsCancellationRequested)
-            {
-                // The guess was right (headers matched) but the body read failed,
-                // e.g. a mid-stream NNTP read timeout. Fall back to the slow seek
-                // path, whose MultiSegmentStream retries and zero-fills instead of
-                // surfacing a hard error to the WebDAV client.
-                var displayName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
-                if (e.TryGetKnownErrorMessage(out var reason))
+                try
                 {
-                    ThrottledSegmentWarning.Write(
-                        displayName,
-                        "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek. Reason: {Reason}",
-                        displayName,
-                        reason);
-                    Log.Debug(e, "Fast seek known failure stack while reading {FileName}", displayName);
+                    await body.DiscardExactBytesAsync(rangeStart - start, ct).ConfigureAwait(false);
+                    var tail = end - rangeStart;
+                    var capacity = tail is > 0 and <= int.MaxValue ? (int)tail : 0;
+                    head = new PooledBufferStream(capacity);
+                    await body.CopyToAsync(head, ct).ConfigureAwait(false);
+                    head.Position = 0;
                 }
-                else
+                catch (Exception e) when (!ct.IsCancellationRequested)
                 {
-                    Log.Warning(
-                        e,
-                        "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek.",
-                        displayName);
+                    // The guess was right (headers matched) but the body read failed,
+                    // e.g. a mid-stream NNTP read timeout. Fall back to the slow seek
+                    // path, whose MultiSegmentStream retries and zero-fills instead of
+                    // surfacing a hard error to the WebDAV client.
+                    var displayName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
+                    if (e.TryGetKnownErrorMessage(out var reason))
+                    {
+                        ThrottledSegmentWarning.Write(
+                            displayName,
+                            "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek. Reason: {Reason}",
+                            displayName,
+                            reason);
+                        Log.Debug(e, "Fast seek known failure stack while reading {FileName}", displayName);
+                    }
+                    else
+                    {
+                        Log.Warning(
+                            e,
+                            "Fast seek failed mid-segment while reading {FileName}. Falling back to segment-index seek.",
+                            displayName);
+                    }
+
+                    return null;
                 }
 
-                return null;
+                // OnDispose returns the rented head if CombinedStream is disposed before
+                // its first read (head never becomes current). Idempotent dispose is safe
+                // when CombinedStream also disposes head after consuming it.
+                var owned = head;
+                head = null;
+                return new CombinedStream(SpliceHeadThenRest(owned, index + 1, ct))
+                    .OnDispose(() => owned.Dispose());
             }
             finally
             {
                 await body.DisposeAsync().ConfigureAwait(false);
+                if (head is not null)
+                    await head.DisposeAsync().ConfigureAwait(false);
             }
-
-            return new CombinedStream(SpliceHeadThenRest(head, index + 1, ct));
         }
 
         return null;

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -1,0 +1,214 @@
+using System.Buffers;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Seekable read/write stream over an <see cref="ArrayPool{T}"/>-rented array.
+/// Logical <see cref="Length"/> is independent of rented capacity so lease accounting
+/// and segment alignment stay on decoded byte counts, not pool bucket sizes.
+/// </summary>
+public sealed class PooledBufferStream : Stream
+{
+    private byte[]? _buffer;
+    private int _length;
+    private int _position;
+    private bool _disposed;
+
+    public PooledBufferStream(int capacityHint)
+    {
+        if (capacityHint < 0)
+            throw new ArgumentOutOfRangeException(nameof(capacityHint));
+
+        _buffer = capacityHint > 0
+            ? ArrayPool<byte>.Shared.Rent(capacityHint)
+            : [];
+    }
+
+    public override bool CanRead => !_disposed;
+    public override bool CanSeek => !_disposed;
+    public override bool CanWrite => !_disposed;
+    public override long Length
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _length;
+        }
+    }
+
+    public override long Position
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _position;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            if (value > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(value));
+            _position = (int)value;
+        }
+    }
+
+    public override void Flush() => ThrowIfDisposed();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ValidateBufferArguments(buffer, offset, count);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        ThrowIfDisposed();
+        var available = _length - _position;
+        if (available <= 0) return 0;
+
+        var toRead = Math.Min(buffer.Length, available);
+        _buffer.AsSpan(_position, toRead).CopyTo(buffer);
+        _position += toRead;
+        return toRead;
+    }
+
+    public override Task<int> ReadAsync(
+        byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Read(buffer, offset, count));
+    }
+
+    public override ValueTask<int> ReadAsync(
+        Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<int>(Read(buffer.Span));
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        ValidateBufferArguments(buffer, offset, count);
+        Write(buffer.AsSpan(offset, count));
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        ThrowIfDisposed();
+        if (buffer.IsEmpty) return;
+
+        var end = checked(_position + buffer.Length);
+        EnsureCapacity(end);
+        if (_position > _length)
+            _buffer.AsSpan(_length, _position - _length).Clear();
+        if (end > _length)
+            _length = end;
+
+        buffer.CopyTo(_buffer.AsSpan(_position));
+        _position = end;
+    }
+
+    public override Task WriteAsync(
+        byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Write(buffer, offset, count);
+        return Task.CompletedTask;
+    }
+
+    public override ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Write(buffer.Span);
+        return ValueTask.CompletedTask;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        ThrowIfDisposed();
+        var next = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+
+        if (next < 0 || next > int.MaxValue)
+            throw new IOException("An attempt was made to move the position before the beginning of the stream.");
+
+        _position = (int)next;
+        return _position;
+    }
+
+    public override void SetLength(long value)
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        if (value > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(value));
+
+        var newLength = (int)value;
+        if (newLength > _length)
+        {
+            EnsureCapacity(newLength);
+            // Rented arrays are dirty; MemoryStream would zero here and AlignDrainedSegment
+            // depends on that guarantee when padding short bodies.
+            _buffer.AsSpan(_length, newLength - _length).Clear();
+        }
+
+        _length = newLength;
+        if (_position > _length)
+            _position = _length;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing) return;
+        ReturnBuffer();
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        ReturnBuffer();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    private void EnsureCapacity(int required)
+    {
+        var current = _buffer!;
+        if (required <= current.Length) return;
+
+        // Rent exactly what is needed so a small overshoot of a good hint does not
+        // jump the Shared pool's 1 MiB bucket and lose pooling.
+        var next = ArrayPool<byte>.Shared.Rent(required);
+        if (_length > 0)
+            current.AsSpan(0, _length).CopyTo(next);
+
+        if (current.Length > 0)
+            ArrayPool<byte>.Shared.Return(current);
+
+        _buffer = next;
+    }
+
+    private void ReturnBuffer()
+    {
+        var buffer = Interlocked.Exchange(ref _buffer, null);
+        if (buffer is { Length: > 0 })
+            ArrayPool<byte>.Shared.Return(buffer);
+
+        _length = 0;
+        _position = 0;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed || _buffer is null, this);
+    }
+}

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -106,7 +106,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                         if (_consecutiveZeroFills >= MaxConsecutiveZeroFills)
                             throw;
 
-                        _stream = new MemoryStream(new byte[fill], writable: false);
+                        _stream = new ZeroStream(fill);
                     }
                 }
             }

--- a/backend/Streams/ZeroStream.cs
+++ b/backend/Streams/ZeroStream.cs
@@ -1,0 +1,111 @@
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Read-only stream that emits a fixed number of zero bytes with no backing buffer.
+/// Replaces <c>new MemoryStream(new byte[n], writable: false)</c> for zero-filled segments.
+/// </summary>
+public sealed class ZeroStream : Stream
+{
+    private readonly long _length;
+    private long _position;
+    private bool _disposed;
+
+    public ZeroStream(long length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        _length = length;
+    }
+
+    public override bool CanRead => !_disposed;
+    public override bool CanSeek => !_disposed;
+    public override bool CanWrite => false;
+
+    public override long Length
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _length;
+        }
+    }
+
+    public override long Position
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _position;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _position = value;
+        }
+    }
+
+    public override void Flush() => ThrowIfDisposed();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ValidateBufferArguments(buffer, offset, count);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        ThrowIfDisposed();
+        var remaining = _length - _position;
+        if (remaining <= 0) return 0;
+
+        var toRead = (int)Math.Min(buffer.Length, remaining);
+        buffer[..toRead].Clear();
+        _position += toRead;
+        return toRead;
+    }
+
+    public override Task<int> ReadAsync(
+        byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Read(buffer, offset, count));
+    }
+
+    public override ValueTask<int> ReadAsync(
+        Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<int>(Read(buffer.Span));
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        ThrowIfDisposed();
+        var next = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+
+        if (next < 0)
+            throw new IOException("An attempt was made to move the position before the beginning of the stream.");
+
+        _position = next;
+        return _position;
+    }
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+}

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -172,6 +172,39 @@ public class MultiSegmentStreamPrefetchBudgetTests
     }
 
     [Fact]
+    public async Task SourceDisposeFailure_ReleasesFallbackLease()
+    {
+        const int segmentSize = 10_000;
+        var budget = new InFlightArticleBudget(segmentSize * 4);
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["fallback"] = Enumerable.Repeat((byte)7, segmentSize).ToArray(),
+            },
+            useCachedYencStreams: true,
+            decodedStreamFactory: (_, bytes) => new ThrowingDisposeMemoryStream(bytes));
+
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "missing" }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "dispose-failure.bin",
+            segmentFallbacks: [["fallback"]],
+            exactSegmentSizes: new long[] { segmentSize },
+            inFlightArticleBudget: budget);
+
+        await Assert.ThrowsAsync<IOException>(
+            async () => await stream.ReadAtLeastAsync(
+                new byte[segmentSize], segmentSize, throwOnEndOfStream: false));
+
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
     public async Task DisposeAsync_ReleasesQueuedLeasesBeforeReturning()
     {
         const int segmentSize = 20_000;
@@ -430,6 +463,17 @@ public class MultiSegmentStreamPrefetchBudgetTests
 
         public override void Write(byte[] buffer, int offset, int count) =>
             throw new NotSupportedException();
+    }
+
+    private sealed class ThrowingDisposeMemoryStream(byte[] bytes)
+        : MemoryStream(bytes, writable: false)
+    {
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+                throw new IOException("Simulated source disposal failure.");
+        }
     }
 
     private sealed class CollectingSink : ILogEventSink

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -286,6 +286,23 @@ public class NzbFileStreamTests
     }
 
     [Fact]
+    public async Task FastSeek_BodyDisposeFailure_FallsBackToSlowSeekPath()
+    {
+        var client = CreateFlakyClient(
+            () => new ThrowingDisposeMemoryStream(SegmentBytes[1]));
+        await using var stream = new NzbFileStream(
+            SegmentIds, 15, client, 2, SegmentRanges, usePipelinedBodyRequests: false);
+        stream.Seek(7, SeekOrigin.Begin);
+        var buffer = new byte[3];
+
+        var read = await stream.ReadAtLeastAsync(
+            buffer, buffer.Length, throwOnEndOfStream: false);
+
+        Assert.Equal("hij", Encoding.ASCII.GetString(buffer, 0, read));
+        Assert.True(client.BodyRequestCounts["two"] >= 2);
+    }
+
+    [Fact]
     public async Task Seek_WhenIndexedSegmentEndsBeforeOffset_ThrowsAndDisposesBodies()
     {
         string[] segmentIds = ["short"];
@@ -575,6 +592,17 @@ public class NzbFileStreamTests
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class ThrowingDisposeMemoryStream(byte[] bytes)
+        : MemoryStream(bytes, writable: false)
+    {
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+                throw new IOException("Simulated source disposal failure.");
+        }
     }
 
     private sealed class TrackingMemoryStream(byte[] bytes) : MemoryStream(bytes, writable: false)

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -135,3 +135,39 @@ public class PooledBufferStreamTests
         Assert.Throws<ObjectDisposedException>(() => _ = stream.Length);
     }
 }
+
+public class ZeroStreamTests
+{
+    [Fact]
+    public void Read_EmitsExactZerosAcrossOddSizedReads()
+    {
+        using var stream = new ZeroStream(17);
+        Assert.Equal(17, stream.Length);
+        Assert.Equal(0, stream.Position);
+
+        var first = new byte[5];
+        Assert.Equal(5, stream.Read(first));
+        Assert.Equal(new byte[5], first);
+        Assert.Equal(5, stream.Position);
+
+        var second = new byte[10];
+        Assert.Equal(10, stream.Read(second));
+        Assert.Equal(new byte[10], second);
+
+        var third = new byte[8];
+        Assert.Equal(2, stream.Read(third));
+        Assert.Equal(new byte[2], third[..2]);
+        Assert.Equal(17, stream.Position);
+        Assert.Equal(0, stream.Read(third));
+    }
+
+    [Fact]
+    public void Seek_TracksPosition()
+    {
+        using var stream = new ZeroStream(100);
+        Assert.Equal(50, stream.Seek(50, SeekOrigin.Begin));
+        Assert.Equal(50, stream.Position);
+        Assert.Equal(75, stream.Seek(25, SeekOrigin.Current));
+        Assert.Equal(90, stream.Seek(-10, SeekOrigin.End));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -1,0 +1,137 @@
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class PooledBufferStreamTests
+{
+    [Fact]
+    public async Task CopyToAsync_RoundTripsBytes()
+    {
+        var sourceBytes = Enumerable.Range(0, 1000).Select(i => (byte)(i % 256)).ToArray();
+        await using var source = new MemoryStream(sourceBytes);
+        await using var buffer = new PooledBufferStream(capacityHint: 64);
+        await source.CopyToAsync(buffer);
+        buffer.Position = 0;
+
+        using var output = new MemoryStream();
+        await buffer.CopyToAsync(output);
+        Assert.Equal(sourceBytes, output.ToArray());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    [InlineData(100)]
+    public void Write_GrowsPastCapacityHint_PreservesData(int capacityHint)
+    {
+        var payload = Enumerable.Range(0, 100).Select(i => (byte)(i + 1)).ToArray();
+        using var stream = new PooledBufferStream(capacityHint);
+        stream.Write(payload);
+        stream.Position = 0;
+
+        var read = new byte[payload.Length];
+        Assert.Equal(payload.Length, stream.Read(read));
+        Assert.Equal(payload, read);
+        Assert.Equal(payload.Length, stream.Length);
+    }
+
+    [Fact]
+    public void SetLength_Growth_ExposesZerosIncludingTruncateThenGrow()
+    {
+        using var stream = new PooledBufferStream(16);
+        stream.Write(Enumerable.Repeat((byte)0xAB, 16).ToArray());
+        stream.SetLength(8);
+        Assert.Equal(8, stream.Length);
+
+        // Dirty the region beyond Length by writing into a rented-looking pattern:
+        // grow again and require zeros in the newly exposed region.
+        stream.SetLength(16);
+        stream.Position = 8;
+        var tail = new byte[8];
+        Assert.Equal(8, stream.Read(tail));
+        Assert.Equal(new byte[8], tail);
+    }
+
+    [Fact]
+    public void SetLength_Growth_ClearsDirtyRentedRegion()
+    {
+        using var stream = new PooledBufferStream(32);
+        // Force a rent, then truncate without clearing the physical array past Length.
+        stream.Write(Enumerable.Repeat((byte)0xFF, 32).ToArray());
+        stream.SetLength(0);
+        stream.SetLength(32);
+        stream.Position = 0;
+        var bytes = new byte[32];
+        Assert.Equal(32, stream.Read(bytes));
+        Assert.Equal(new byte[32], bytes);
+    }
+
+    [Fact]
+    public async Task SyncAndAsyncWrites_LandSameBytes()
+    {
+        var payload = Enumerable.Range(0, 40).Select(i => (byte)i).ToArray();
+
+        using var sync = new PooledBufferStream(0);
+        sync.Write(payload, 0, payload.Length);
+
+        await using var asyncMemory = new PooledBufferStream(0);
+        await asyncMemory.WriteAsync(payload.AsMemory());
+
+        await using var asyncArray = new PooledBufferStream(0);
+        await asyncArray.WriteAsync(payload, 0, payload.Length);
+
+        sync.Position = 0;
+        asyncMemory.Position = 0;
+        asyncArray.Position = 0;
+        var syncBytes = new byte[payload.Length];
+        var asyncMemoryBytes = new byte[payload.Length];
+        var asyncArrayBytes = new byte[payload.Length];
+        Assert.Equal(payload.Length, sync.Read(syncBytes));
+        Assert.Equal(payload.Length, asyncMemory.Read(asyncMemoryBytes));
+        Assert.Equal(payload.Length, asyncArray.Read(asyncArrayBytes));
+        Assert.Equal(syncBytes, asyncMemoryBytes);
+        Assert.Equal(syncBytes, asyncArrayBytes);
+        Assert.Equal(payload, syncBytes);
+    }
+
+    [Fact]
+    public void Write_AfterSeekingPastEnd_ZeroesTheGap()
+    {
+        using var stream = new PooledBufferStream(16);
+        stream.Write(Enumerable.Repeat((byte)0xFF, 16).ToArray());
+        stream.SetLength(0);
+        stream.Position = 8;
+        stream.WriteByte(1);
+        stream.Position = 0;
+
+        var bytes = new byte[9];
+        Assert.Equal(9, stream.Read(bytes));
+        Assert.Equal(new byte[8], bytes[..8]);
+        Assert.Equal(1, bytes[8]);
+    }
+
+    [Fact]
+    public void SpanWrite_LandsSameBytes()
+    {
+        var payload = Enumerable.Range(0, 20).Select(i => (byte)(255 - i)).ToArray();
+        using var stream = new PooledBufferStream(4);
+        stream.Write(payload.AsSpan());
+        stream.Position = 0;
+        var read = new byte[payload.Length];
+        Assert.Equal(payload.Length, stream.Read(read.AsSpan()));
+        Assert.Equal(payload, read);
+    }
+
+    [Fact]
+    public void DoubleDispose_IsSafe_AndUseAfterDisposeThrows()
+    {
+        var stream = new PooledBufferStream(8);
+        stream.WriteByte(1);
+        stream.Dispose();
+        stream.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
+        Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(2));
+        Assert.Throws<ObjectDisposedException>(() => _ = stream.Length);
+    }
+}


### PR DESCRIPTION
## Summary
- pool decoded article and fast-seek buffers instead of allocating each segment on the large-object heap
- preserve logical lengths, zero-padding, byte-budget accounting, and exact-once buffer return across cancellation, teardown, and source disposal failures
- emit failed-segment zeros without allocating backing arrays

Fixes #686

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [x] full backend suite: 1,213 passed, 14 skipped
- [x] `PooledBufferStream` unit coverage for growth past the capacity hint, zeroing of dirty rented regions on `SetLength` growth and writes past the end, all four write overloads, and idempotent dispose
- [x] source-disposal regressions verified to fail without the fix: `SourceDisposeFailure_ReleasesFallbackLease` leaks the full 10,000-byte lease on the unfixed build, and `FastSeek_BodyDisposeFailure_FallsBackToSlowSeekPath` throws instead of falling back
- [x] existing alignment, budget, fallback and corruption suites pass unchanged
- [x] BenchmarkDotNet `SegmentStreamBenchmarks` ShortRun, before/after, using a local rapidyenc native library
- [ ] compare equal-load support packs for LOH size, LOH fragmentation and working set on a live-provider install

## Allocation benchmark

Managed allocation per operation, `main` vs this branch:

- buffered full read: 10.66 MB → 8.65 MB (-18.9%)
- buffered random seeks: 144.95 MB → 129.83 MB (-10.4%)
- buffered exact zero-fill read: 9.57 MB → 7.57 MB (-20.9%)

**Read these as a proxy, not as the headline result.** #686 is about *retained* memory (LOH size, fragmentation, RSS), which `MemoryDiagnoser` does not measure. The percentages are also diluted by the benchmark's fake NNTP client, which allocates yEnc-encoded arrays that pooling cannot affect — so they understate the effect on real article buffers. The before/after support-pack comparison is the acceptance evidence for the memory claim.

## Notes for reviewers

`ArrayPool<byte>.Shared` only pools arrays up to 1 MiB. The 550-710 KB segments reported in #686 land in the 1 MiB bucket and pool; anything larger falls back to plain allocation exactly as it does today, so there is no regression for large-article installs, just no benefit yet. A dedicated pool with a bounded `maxArraysPerBucket` is the follow-up if support packs show such installs still holding LOH.