### PR TITLE
fix(health): keep diagnostics faithful under write storms, circuit misses, and scrubbing

### DIFF
--- a/backend/Api/Controllers/DiscardStreamTraces/DiscardStreamTracesController.cs
+++ b/backend/Api/Controllers/DiscardStreamTraces/DiscardStreamTracesController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Api.Controllers.SetStreamTracing;
+using NzbWebDAV.Services.StreamTrace;
+using Serilog;
+
+namespace NzbWebDAV.Api.Controllers.DiscardStreamTraces;
+
+[ApiController]
+[Route("api/discard-stream-traces")]
+public sealed class DiscardStreamTracesController(
+    StreamTraceBuffer buffer,
+    StreamTraceStatusBroadcaster broadcaster) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var before = buffer.GetStatus();
+        var status = buffer.Discard();
+        Log.Information(
+            "Discarded {Events:n0} retained stream-trace events from the UI",
+            before.EventCount);
+        await broadcaster.BroadcastAsync(status).ConfigureAwait(false);
+        return Ok(SetStreamTracingResponse.From(status));
+    }
+}

--- a/backend/Api/Controllers/GetStreamTraces/GetStreamTracesController.cs
+++ b/backend/Api/Controllers/GetStreamTraces/GetStreamTracesController.cs
@@ -19,8 +19,10 @@ public class GetStreamTracesController(StreamTraceBuffer buffer) : BaseApiContro
         {
             Status = true,
             Enabled = status.Enabled,
+            Retained = status.Retained,
             Source = status.Source,
             ExpiresAtUnixMs = status.ExpiresAtUnixMs,
+            RetainedUntilUnixMs = status.RetainedUntilUnixMs,
             Capacity = status.Capacity,
             EventCount = status.EventCount,
             SessionCount = status.SessionCount,

--- a/backend/Api/Controllers/GetStreamTraces/GetStreamTracesResponse.cs
+++ b/backend/Api/Controllers/GetStreamTraces/GetStreamTracesResponse.cs
@@ -5,8 +5,10 @@ namespace NzbWebDAV.Api.Controllers.GetStreamTraces;
 public class GetStreamTracesResponse : BaseApiResponse
 {
     [JsonPropertyName("enabled")] public required bool Enabled { get; init; }
+    [JsonPropertyName("retained")] public required bool Retained { get; init; }
     [JsonPropertyName("source")] public required string Source { get; init; }
     [JsonPropertyName("expiresAtUnixMs")] public required long ExpiresAtUnixMs { get; init; }
+    [JsonPropertyName("retainedUntilUnixMs")] public required long RetainedUntilUnixMs { get; init; }
     [JsonPropertyName("capacity")] public required int Capacity { get; init; }
     [JsonPropertyName("eventCount")] public required long EventCount { get; init; }
     [JsonPropertyName("sessionCount")] public required int SessionCount { get; init; }

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -223,7 +223,8 @@ public class GetWebdavItemController(
         string? message = null)
     {
         activeReadRegistry.SetEndReason(sessionId, reason);
-        streamTrace.RangeEnd(traceRange, reason, activeReadRegistry.GetBytesRead(sessionId), message);
+        streamTrace.RangeEnd(
+            sessionId, traceRange, reason, activeReadRegistry.GetBytesRead(sessionId), message);
     }
 
     private async Task CopyAndReportAsync(

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -163,6 +163,7 @@ public class GetWebdavItemController(
             readCts.CancelAfter(configManager.GetStreamingReadTimeout());
             var ct = readCts.Token;
 
+            StreamTraceRangeContext? traceRange = null;
             try
             {
                 await using var response = await GetWebdavItem(request, ct);
@@ -170,7 +171,7 @@ public class GetWebdavItemController(
                     return;
                 var effectiveStart = (long)(HttpContext.Items["effectiveRangeStart"] ?? 0L);
                 var rangeEnd = HttpContext.Items["effectiveRangeEnd"] as long?;
-                streamTrace.RangeOpen(
+                traceRange = streamTrace.RangeOpen(
                     sessionId,
                     request.Item,
                     "GET",
@@ -179,28 +180,29 @@ public class GetWebdavItemController(
                     response.CanSeek ? response.Length : null,
                     Request.Headers.UserAgent.ToString(),
                     HttpContext.Connection.RemoteIpAddress?.ToString());
+                using var traceRangeScope = MultiProviderNntpClient.BeginStreamTraceRangeScope(traceRange);
                 try
                 {
                     // Body transfer can run for minutes; drop the admission/open
                     // deadline and rely on per-segment mid-stream timeouts.
                     readCts.CancelAfter(Timeout.InfiniteTimeSpan);
-                    await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, ct);
-                    FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+                    await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, traceRange, ct);
+                    FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Completed);
                 }
                 catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
                 {
-                    FinishRange(sessionId, ReadSession.EndReasonCode.Aborted);
+                    FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Aborted);
                     throw;
                 }
                 catch (Exception ex)
                 {
-                    FinishRange(sessionId, ReadSession.EndReasonCode.Error, ex.Message);
+                    FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Error, ex.Message);
                     throw;
                 }
             }
             catch (OperationCanceledException oce) when (!HttpContext.RequestAborted.IsCancellationRequested)
             {
-                FinishRange(sessionId, ReadSession.EndReasonCode.Error, "streaming-read-timeout");
+                FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Error, "streaming-read-timeout");
                 throw new StreamingReadTimeoutException(
                     "WebDAV /view read exceeded the " +
                     $"{configManager.GetStreamingReadTimeout().TotalSeconds:0}s streaming-read-timeout " +
@@ -214,13 +216,23 @@ public class GetWebdavItemController(
         }
     }
 
-    private void FinishRange(Guid sessionId, ReadSession.EndReasonCode reason, string? message = null)
+    private void FinishRange(
+        Guid sessionId,
+        StreamTraceRangeContext? traceRange,
+        ReadSession.EndReasonCode reason,
+        string? message = null)
     {
         activeReadRegistry.SetEndReason(sessionId, reason);
-        streamTrace.RangeEnd(sessionId, reason, activeReadRegistry.GetBytesRead(sessionId), message);
+        streamTrace.RangeEnd(traceRange, reason, activeReadRegistry.GetBytesRead(sessionId), message);
     }
 
-    private async Task CopyAndReportAsync(Stream src, Stream dest, Guid sessionId, long startOffset, CancellationToken ct)
+    private async Task CopyAndReportAsync(
+        Stream src,
+        Stream dest,
+        Guid sessionId,
+        long startOffset,
+        StreamTraceRangeContext? traceRange,
+        CancellationToken ct)
     {
         // 64 KB chunks; after each write report (bytesRead, absolutePosition)
         // so the Right-Now panel can show real playback location and the
@@ -254,7 +266,7 @@ public class GetWebdavItemController(
             var writeStarted = Stopwatch.GetTimestamp();
             await dest.WriteAsync(buffer, 0, read, ct).ConfigureAwait(false);
             streamTrace.AddStall(
-                sessionId, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
+                traceRange, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
             position += read;
             activeReadRegistry.Touch(sessionId, read, position);
         }

--- a/backend/Api/Controllers/SetStreamTracing/SetStreamTracingController.cs
+++ b/backend/Api/Controllers/SetStreamTracing/SetStreamTracingController.cs
@@ -16,23 +16,34 @@ public sealed class SetStreamTracingController(
         StreamTraceStatus status;
         if (request.Enabled)
         {
+            var before = buffer.GetStatus();
             status = buffer.EnableFor(
                 TimeSpan.FromMinutes(request.Minutes),
                 StreamTraceBuffer.DefaultUiCapacity,
                 StreamTraceBuffer.SourceUi);
             // Recorded so a support pack shows when tracing started and for how
             // long — the env-var path logs an equivalent line at startup.
-            Log.Information(
-                "Stream tracing enabled from the UI for {Minutes} minutes with a capacity of {Capacity} events",
-                request.Minutes,
-                status.Capacity);
+            if (before.Retained)
+            {
+                Log.Information(
+                    "Stream tracing resumed from the UI for {Minutes} minutes with a capacity of {Capacity} events",
+                    request.Minutes,
+                    status.Capacity);
+            }
+            else
+            {
+                Log.Information(
+                    "Stream tracing enabled from the UI for {Minutes} minutes with a capacity of {Capacity} events",
+                    request.Minutes,
+                    status.Capacity);
+            }
         }
         else
         {
             var before = buffer.GetStatus();
-            status = buffer.Disable();
+            status = buffer.StopRecording();
             Log.Information(
-                "Stream tracing disabled from the UI; released {Events:n0} buffered events",
+                "Stream tracing stopped from the UI; retaining {Events:n0} events for support packs",
                 before.EventCount);
         }
 

--- a/backend/Api/Controllers/SetStreamTracing/SetStreamTracingResponse.cs
+++ b/backend/Api/Controllers/SetStreamTracing/SetStreamTracingResponse.cs
@@ -6,8 +6,10 @@ namespace NzbWebDAV.Api.Controllers.SetStreamTracing;
 public sealed class SetStreamTracingResponse : BaseApiResponse
 {
     [JsonPropertyName("enabled")] public required bool Enabled { get; init; }
+    [JsonPropertyName("retained")] public required bool Retained { get; init; }
     [JsonPropertyName("source")] public required string Source { get; init; }
     [JsonPropertyName("expiresAtUnixMs")] public required long ExpiresAtUnixMs { get; init; }
+    [JsonPropertyName("retainedUntilUnixMs")] public required long RetainedUntilUnixMs { get; init; }
     [JsonPropertyName("capacity")] public required int Capacity { get; init; }
     [JsonPropertyName("eventCount")] public required long EventCount { get; init; }
     [JsonPropertyName("sessionCount")] public required int SessionCount { get; init; }
@@ -16,8 +18,10 @@ public sealed class SetStreamTracingResponse : BaseApiResponse
     {
         Status = true,
         Enabled = status.Enabled,
+        Retained = status.Retained,
         Source = status.Source,
         ExpiresAtUnixMs = status.ExpiresAtUnixMs,
+        RetainedUntilUnixMs = status.RetainedUntilUnixMs,
         Capacity = status.Capacity,
         EventCount = status.EventCount,
         SessionCount = status.SessionCount,

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -128,13 +128,28 @@ public class ProviderCircuitBreaker
     }
 
     /// <summary>
-    /// Article permanently missing from retention. Counts as a miss for diagnostics
-    /// but does not contribute to provider-failure tripping.
+    /// Article permanently missing from retention. A 430 is a clean server response and
+    /// says nothing about provider health, so it counts as a miss for diagnostics and
+    /// nothing else: it must not undo a trip, reset the cooldown ladder, satisfy the
+    /// half-open probe, or emit a Closed transition. On a closed circuit it does clear the
+    /// failure sampling window, because the provider demonstrably answered.
+    /// <para>
+    /// A miss recorded during a half-open probe leaves the probe slot claimed. It is not
+    /// evidence of recovery, so the slot is released by <see cref="ProbeAbandonTimeout"/>
+    /// rather than here.
+    /// </para>
     /// </summary>
     public void RecordArticleNotFound()
     {
         Interlocked.Increment(ref _articleMissCount);
-        RecordSuccess();
+
+        lock (_lock)
+        {
+            if (_trippedUntilMs != 0 || Volatile.Read(ref _halfOpenProbeInFlight) != 0)
+                return;
+
+            _window.Clear();
+        }
     }
 
     /// <summary>Read-only snapshot for dashboards. Does not claim a half-open probe.</summary>

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -696,15 +696,15 @@ public class MultiConnectionNntpClient(
         SemaphorePriority priority,
         CancellationToken ct)
     {
-        var sessionId = MultiProviderNntpClient.CurrentReadSessionId;
-        if (sessionId is null || !StreamTrace.IsRecording)
+        var traceRange = MultiProviderNntpClient.CurrentStreamTraceRange;
+        if (traceRange is null)
             return await connectionPool.GetConnectionLockAsync(priority, ct).ConfigureAwait(false);
 
         var started = Stopwatch.GetTimestamp();
         var connectionLock = await connectionPool.GetConnectionLockAsync(priority, ct)
             .ConfigureAwait(false);
         StreamTrace.TryConnectionAcquired(
-            sessionId, Stopwatch.GetElapsedTime(started), connectionLock.WasReused);
+            traceRange, Stopwatch.GetElapsedTime(started), connectionLock.WasReused);
         return connectionLock;
     }
 

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -68,6 +68,9 @@ public class MultiProviderNntpClient(
     private static readonly AsyncLocal<Guid?> ReadSessionScope = new();
     internal static Guid? CurrentReadSessionId => ReadSessionScope.Value;
 
+    private static readonly AsyncLocal<StreamTraceRangeContext?> StreamTraceRangeScope = new();
+    internal static StreamTraceRangeContext? CurrentStreamTraceRange => StreamTraceRangeScope.Value;
+
     /// <summary>
     /// Tag the current async flow with a read-session id so SegmentFetch rows
     /// emitted while fulfilling this read can be correlated back to the session.
@@ -84,6 +87,18 @@ public class MultiProviderNntpClient(
             logProp.Dispose();
             ReadSessionScope.Value = previous;
         });
+    }
+
+    /// <summary>
+    /// Bind the exact <see cref="StreamTraceRangeContext"/> returned by RangeOpen to this
+    /// async flow so overlapping ranges on the same read session keep independent stall
+    /// attribution. Disposing restores the previous token.
+    /// </summary>
+    public static IDisposable BeginStreamTraceRangeScope(StreamTraceRangeContext? range)
+    {
+        var previous = StreamTraceRangeScope.Value;
+        StreamTraceRangeScope.Value = range;
+        return new ScopeReleaser(() => StreamTraceRangeScope.Value = previous);
     }
 
     private sealed class ScopeReleaser(Action onDispose) : IDisposable
@@ -258,6 +273,7 @@ public class MultiProviderNntpClient(
             fallbackAdmission.TrySetResult();
         }
 
+        var primaryTraceRange = CurrentStreamTraceRange;
         var primaryStopwatch = Stopwatch.StartNew();
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses = null;
         // Fresh per article resolution. When primary re-probe is enabled, do not mark the
@@ -276,7 +292,8 @@ public class MultiProviderNntpClient(
             {
                 primaryStopwatch.Stop();
                 var reason = ClassifyAndRecordFailure(
-                    primaryProvider.MetricsKey, e, primaryStopwatch.ElapsedMilliseconds, 0);
+                    primaryProvider.MetricsKey, e, primaryStopwatch.ElapsedMilliseconds, 0,
+                    primaryTraceRange);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
             }
@@ -286,7 +303,7 @@ public class MultiProviderNntpClient(
                 primaryStopwatch.Stop();
                 _usageTracker.RecordSuccess(primaryProvider.MetricsKey);
                 RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                    primaryStopwatch.ElapsedMilliseconds, 0);
+                    primaryStopwatch.ElapsedMilliseconds, 0, primaryTraceRange);
                 return WrapProviderResponse(response, primaryProvider.MetricsKey);
             }
 
@@ -296,7 +313,7 @@ public class MultiProviderNntpClient(
             {
                 primaryStopwatch.Stop();
                 RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                    primaryStopwatch.ElapsedMilliseconds, 0);
+                    primaryStopwatch.ElapsedMilliseconds, 0, primaryTraceRange);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing));
             }
 
@@ -368,6 +385,7 @@ public class MultiProviderNntpClient(
 
                     coordinator.AddTransfer();
                     var deferredCallback = new DeferredArticleBodyCallback();
+                    var traceRange = CurrentStreamTraceRange;
                     var stopwatch = Stopwatch.StartNew();
                     try
                     {
@@ -379,7 +397,7 @@ public class MultiProviderNntpClient(
                         {
                             _usageTracker.RecordSuccess(provider.MetricsKey);
                             RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0);
+                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0, traceRange);
                             if (priorMisses is { Count: > 0 })
                             {
                                 _usageTracker.RecordFailoverSave();
@@ -402,7 +420,7 @@ public class MultiProviderNntpClient(
                         else
                         {
                             RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0);
+                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0, traceRange);
                             (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                             if (UsenetArticleAvailability.IsDefinitiveMissing(response))
                             {
@@ -420,7 +438,7 @@ public class MultiProviderNntpClient(
                         stopwatch.Stop();
                         var reason = ClassifyAndRecordFailure(
                             provider.MetricsKey, e, stopwatch.ElapsedMilliseconds,
-                            priorMisses?.Count ?? 0);
+                            priorMisses?.Count ?? 0, traceRange);
                         (priorMisses ??= []).Add((provider.MetricsKey, reason));
                         deferredCallback.Discard();
                         coordinator.CompleteAttempt();
@@ -577,6 +595,7 @@ public class MultiProviderNntpClient(
             }
 
             var deferredCallback = new DeferredArticleBodyCallback();
+            var traceRange = CurrentStreamTraceRange;
             var stopwatch = Stopwatch.StartNew();
             try
             {
@@ -589,7 +608,7 @@ public class MultiProviderNntpClient(
                     if (attribution != null) attribution.Host = provider.Host;
                     _usageTracker.RecordSuccess(provider.MetricsKey);
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                     if (attemptIndex > 0)
                     {
                         _usageTracker.RecordFailoverSave();
@@ -604,7 +623,7 @@ public class MultiProviderNntpClient(
                 if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                        stopwatch.ElapsedMilliseconds, attemptIndex);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                     (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                     lastNoArticleResult = result;
                     lastOutcomeWasException = false;
@@ -615,7 +634,7 @@ public class MultiProviderNntpClient(
                 }
 
                 RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                    stopwatch.ElapsedMilliseconds, attemptIndex);
+                    stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                 InvokeCompletionCallback(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 return result;
@@ -624,7 +643,8 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 var reason = ClassifyAndRecordFailure(
-                    provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
+                    traceRange);
                 (priorMisses ??= []).Add((provider.MetricsKey, reason));
                 deferredCallback.Discard();
                 lastException = ExceptionDispatchInfo.Capture(e);
@@ -701,6 +721,7 @@ public class MultiProviderNntpClient(
             }
 
             lastAttemptedProvider = provider;
+            var traceRange = CurrentStreamTraceRange;
             var stopwatch = Stopwatch.StartNew();
             try
             {
@@ -712,7 +733,8 @@ public class MultiProviderNntpClient(
                 // never a connection error.
                 if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
-                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                     (priorMisses ??= new()).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                     lastNoArticleResult = result;
                     lastOutcomeWasException = false;
@@ -733,7 +755,8 @@ public class MultiProviderNntpClient(
                                           or UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
                 {
                     _usageTracker.RecordSuccess(provider.MetricsKey);
-                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                     if (attemptIndex > 0)
                     {
                         _usageTracker.RecordFailoverSave();
@@ -744,7 +767,8 @@ public class MultiProviderNntpClient(
                 else if (result is UsenetDecodedBodyResponse or UsenetDecodedArticleResponse)
                 {
                     // BODY/ARTICLE response with an unexpected (non-success, non-430) response type.
-                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                 }
                 // STAT/HEAD/DATE successes: intentionally no SegmentFetch row (not a segment transfer;
                 // matches StatsPipelinedAsync which records nothing).
@@ -755,7 +779,8 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 var reason = ClassifyAndRecordFailure(
-                    provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex);
+                    provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
+                    traceRange);
                 (priorMisses ??= new()).Add((provider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
                 lastOutcomeWasException = true;
@@ -829,13 +854,20 @@ public class MultiProviderNntpClient(
         }
     }
 
-    private void RecordFetch(string metricsKey, SegmentFetch.FetchStatus status, long durationMs, int retries)
+    private void RecordFetch(
+        string metricsKey,
+        SegmentFetch.FetchStatus status,
+        long durationMs,
+        int retries,
+        StreamTraceRangeContext? traceRange)
     {
-        if (ReadSessionScope.Value is { } sessionId)
+        if (traceRange is { } range)
         {
-            streamTrace?.Segment(sessionId, metricsKey, status, (int)Math.Min(int.MaxValue, durationMs), retries);
-            streamTrace?.AddStall(
-                sessionId, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(durationMs));
+            streamTrace?.Segment(
+                range.SessionId, metricsKey, status, (int)Math.Min(int.MaxValue, durationMs), retries);
+            // Billed to the generation captured when the stopwatch started, not the range
+            // that happens to be open now — a prefetch can outlive the range that asked for it.
+            streamTrace?.AddFetchWait(traceRange, TimeSpan.FromMilliseconds(durationMs));
         }
 
         if (metricsWriter == null) return;
@@ -857,10 +889,11 @@ public class MultiProviderNntpClient(
     /// packs stay diagnosable without a schema change.
     /// </summary>
     private SegmentFetch.FetchStatus ClassifyAndRecordFailure(
-        string metricsKey, Exception exception, long durationMs, int retries)
+        string metricsKey, Exception exception, long durationMs, int retries,
+        StreamTraceRangeContext? traceRange)
     {
         var status = ClassifyException(exception);
-        RecordFetch(metricsKey, status, durationMs, retries);
+        RecordFetch(metricsKey, status, durationMs, retries, traceRange);
         if (status == SegmentFetch.FetchStatus.Other)
         {
             Log.Debug(

--- a/backend/Logging/LogThrottle.cs
+++ b/backend/Logging/LogThrottle.cs
@@ -49,6 +49,9 @@ public sealed class LogThrottle
     /// </summary>
     public void Reset(string key) => _states.TryRemove(key, out _);
 
+    /// <summary>Drops every throttle window. Test-only; production keys age out on their own.</summary>
+    internal void Clear() => _states.Clear();
+
     private sealed class State
     {
         public long LastLoggedAtMs;

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -53,6 +53,11 @@ public class ArrMonitoringService : BackgroundService
 
     private async Task HandleStuckQueueItems(ArrConfig arrConfig, ArrClient client, CancellationToken ct)
     {
+        // A season pack yields one record per episode, so a single stuck release can be
+        // hundreds of removals. Logging each at Warning evicted every other warning from
+        // the buffer support packs are built from, so detail goes to Debug and the pass
+        // reports one Warning per release and action.
+        var resolutions = new List<(string? Title, ArrConfig.QueueAction Action)>();
         try
         {
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -63,7 +68,12 @@ public class ArrMonitoringService : BackgroundService
             var actionableStatuses = arrConfig.QueueRules.Select(x => x.Message);
             var stuckRecords = queue.Records.Where(x => actionableStatuses.Any(x.HasStatusMessage));
             foreach (var record in stuckRecords)
-                await HandleStuckQueueItem(record, arrConfig, client, timeout.Token).ConfigureAwait(false);
+            {
+                var action = await HandleStuckQueueItem(record, arrConfig, client, timeout.Token)
+                    .ConfigureAwait(false);
+                if (action is null) continue;
+                resolutions.Add((record.Title, action.Value));
+            }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
         catch (Exception e) when (e is HttpRequestException { InnerException: System.Net.Sockets.SocketException })
@@ -74,9 +84,16 @@ public class ArrMonitoringService : BackgroundService
         {
             Log.Error(e, "Error occurred while monitoring queue for {Host}", client.Host);
         }
+        finally
+        {
+            // Preserve the summary even if a later record fails and aborts the pass:
+            // earlier successful removals must not disappear from the Warning lane.
+            LogResolutionSummary(resolutions, client.Host);
+        }
     }
 
-    private async Task HandleStuckQueueItem(ArrQueueRecord item, ArrConfig arrConfig, ArrClient client, CancellationToken ct)
+    private async Task<ArrConfig.QueueAction?> HandleStuckQueueItem(
+        ArrQueueRecord item, ArrConfig arrConfig, ArrClient client, CancellationToken ct)
     {
         // since there may be multiple status messages, multiple actions may apply.
         // in such case, always perform the strongest action.
@@ -86,12 +103,33 @@ public class ArrMonitoringService : BackgroundService
             .DefaultIfEmpty(ArrConfig.QueueAction.DoNothing)
             .Max();
 
-        if (action is ArrConfig.QueueAction.DoNothing) return;
+        if (action is ArrConfig.QueueAction.DoNothing) return null;
         await client.DeleteQueueRecord(item.Id, action).ConfigureAwait(false);
-        Log.Warning(
-            "Resolved stuck queue item {QueueItemTitle} from {Host} with action {Action}",
-            item.Title,
-            client.Host,
-            action);
+        Log.Debug(
+            "Resolved stuck queue record {QueueRecordId} ({QueueItemTitle}) from {Host} with action {Action}",
+            item.Id, item.Title, client.Host, action);
+        return action;
+    }
+
+    internal static IReadOnlyList<((string Title, ArrConfig.QueueAction Action) Key, int Count)>
+        GroupResolutions(IEnumerable<(string? Title, ArrConfig.QueueAction Action)> resolutions) =>
+        resolutions
+            .GroupBy(x => (x.Title ?? "(untitled)", x.Action))
+            .Select(g => (g.Key, g.Count()))
+            .ToList();
+
+    internal static void LogResolutionSummary(
+        IEnumerable<(string? Title, ArrConfig.QueueAction Action)> resolutions,
+        string host)
+    {
+        foreach (var entry in GroupResolutions(resolutions))
+        {
+            Log.Warning(
+                "Resolved {Count} stuck queue item(s) for {QueueItemTitle} from {Host} with action {Action}",
+                entry.Count,
+                entry.Key.Title,
+                host,
+                entry.Key.Action);
+        }
     }
 }

--- a/backend/Services/StreamTrace/StreamTrace.cs
+++ b/backend/Services/StreamTrace/StreamTrace.cs
@@ -27,10 +27,4 @@ public static class StreamTrace
 
     public static void TryConnectionAcquired(StreamTraceRangeContext? range, TimeSpan wait, bool wasReused)
         => _buffer?.ConnectionAcquired(range, wait, wasReused);
-
-    /// <summary>
-    /// True when a stall measurement is worth taking. Callers in hot loops check this
-    /// before reading timestamps so tracing stays free when it is off.
-    /// </summary>
-    public static bool IsRecording => _buffer?.Enabled == true;
 }

--- a/backend/Services/StreamTrace/StreamTrace.cs
+++ b/backend/Services/StreamTrace/StreamTrace.cs
@@ -22,15 +22,11 @@ public static class StreamTrace
     public static void TryRetry(Guid sessionId, string segmentId, int attempt, string? message = null)
         => _buffer?.Retry(sessionId, segmentId, attempt, message);
 
-    public static void TryStall(Guid? sessionId, StreamStallKind kind, TimeSpan elapsed)
-    {
-        if (sessionId is { } id) _buffer?.AddStall(id, kind, elapsed);
-    }
+    public static void TryStall(StreamTraceRangeContext? range, StreamStallKind kind, TimeSpan elapsed)
+        => _buffer?.AddStall(range, kind, elapsed);
 
-    public static void TryConnectionAcquired(Guid? sessionId, TimeSpan wait, bool wasReused)
-    {
-        if (sessionId is { } id) _buffer?.ConnectionAcquired(id, wait, wasReused);
-    }
+    public static void TryConnectionAcquired(StreamTraceRangeContext? range, TimeSpan wait, bool wasReused)
+        => _buffer?.ConnectionAcquired(range, wait, wasReused);
 
     /// <summary>
     /// True when a stall measurement is worth taking. Callers in hot loops check this

--- a/backend/Services/StreamTrace/StreamTraceBuffer.cs
+++ b/backend/Services/StreamTrace/StreamTraceBuffer.cs
@@ -28,6 +28,7 @@ public sealed class StreamTraceBuffer
     private readonly object _gate = new();
     private volatile StreamTraceEvent?[] _buffer = [];
     private long _nextSequence;
+    private long _nextRangeGeneration;
     private long _expiresAtUnixMs;
     private string _source = SourceEnv;
     private int _capacity;
@@ -139,21 +140,21 @@ public sealed class StreamTraceBuffer
         }
     }
 
-    public void Record(StreamTraceEvent entry)
+    private SessionMeta? Record(StreamTraceEvent entry)
     {
-        if (!Enabled) return;
+        if (!Enabled) return null;
         var sequence = Interlocked.Increment(ref _nextSequence);
         var withSeq = entry with { Sequence = sequence };
         var buffer = _buffer;
-        if (buffer.Length == 0) return;
+        if (buffer.Length == 0) return null;
         lock (_gate)
         {
             buffer = _buffer;
-            if (buffer.Length == 0) return;
+            if (buffer.Length == 0) return null;
             buffer[(sequence - 1) % buffer.Length] = withSeq;
         }
 
-        _sessions.AddOrUpdate(
+        var session = _sessions.AddOrUpdate(
             entry.SessionId,
             _ => new SessionMeta
             {
@@ -174,9 +175,14 @@ public sealed class StreamTraceBuffer
             });
 
         TrimSessionsIfNeeded();
+        return session;
     }
 
-    public void RangeOpen(
+    /// <summary>
+    /// Opens a trace generation for this exact HTTP range and returns the token the
+    /// request must carry through its async flow. Returning null means tracing is off.
+    /// </summary>
+    public StreamTraceRangeContext? RangeOpen(
         Guid sessionId,
         string path,
         string method,
@@ -186,7 +192,9 @@ public sealed class StreamTraceBuffer
         string? userAgent,
         string? clientIp)
     {
-        Record(new StreamTraceEvent
+        if (!Enabled) return null;
+        var generation = Interlocked.Increment(ref _nextRangeGeneration);
+        var session = Record(new StreamTraceEvent
         {
             Sequence = 0,
             AtUnixMs = Now(),
@@ -199,7 +207,12 @@ public sealed class StreamTraceBuffer
             FileSize = fileSize,
             UserAgent = userAgent,
             ClientIp = clientIp,
+            RangeGeneration = generation,
         });
+        if (session is null)
+            return null;
+        session.OpenGeneration(generation);
+        return new StreamTraceRangeContext(sessionId, generation);
     }
 
     public void Seek(Guid sessionId, long offset)
@@ -279,56 +292,65 @@ public sealed class StreamTraceBuffer
     }
 
     /// <summary>
-    /// Adds time spent blocked on <paramref name="kind"/> to the current range of
-    /// <paramref name="sessionId"/>. Ticks are accumulated rather than milliseconds so
+    /// Adds time spent blocked on <paramref name="kind"/> to the range identified by
+    /// <paramref name="range"/>. Ticks are accumulated rather than milliseconds so
     /// the many sub-millisecond client writes in a range still add up. No-ops when
-    /// tracing is off or the session has no open range.
+    /// the token is null or the generation bucket is gone.
     /// </summary>
-    public void AddStall(Guid sessionId, StreamStallKind kind, TimeSpan elapsed)
+    public void AddStall(StreamTraceRangeContext? range, StreamStallKind kind, TimeSpan elapsed)
     {
-        if (!Enabled || elapsed <= TimeSpan.Zero) return;
-        if (!_sessions.TryGetValue(sessionId, out var session)) return;
-        session.Stalls.Add(kind, elapsed.Ticks);
+        if (range is not { } value) return;
+        if (elapsed <= TimeSpan.Zero) return;
+        if (!_sessions.TryGetValue(value.SessionId, out var session)) return;
+        session.Bucket(value.Generation)?.Add(kind, elapsed.Ticks);
     }
 
     /// <summary>
-    /// Records a connection acquisition for the current range: how long the borrower
+    /// Records provider-wait time for a fetch started under <paramref name="range"/>.
+    /// Late completions still credit the originating generation via the live totals
+    /// referenced by that range's <c>RangeEnd</c> event.
+    /// </summary>
+    public void AddFetchWait(StreamTraceRangeContext? range, TimeSpan elapsed)
+    {
+        if (range is not { } value) return;
+        if (!_sessions.TryGetValue(value.SessionId, out var session)) return;
+        session.Bucket(value.Generation)?.AddFetch(Math.Max(0, elapsed.Ticks));
+    }
+
+    /// <summary>
+    /// Records a connection acquisition for the given range: how long the borrower
     /// waited, and whether the pool handed back an idle connection or had to open a
     /// new one. A range full of fresh handshakes points at connection churn.
     /// </summary>
-    public void ConnectionAcquired(Guid sessionId, TimeSpan wait, bool wasReused)
+    public void ConnectionAcquired(StreamTraceRangeContext? range, TimeSpan wait, bool wasReused)
     {
-        if (!Enabled) return;
-        if (!_sessions.TryGetValue(sessionId, out var session)) return;
-        session.Stalls.AddConnection(wait.Ticks, wasReused);
+        if (range is not { } value) return;
+        if (!_sessions.TryGetValue(value.SessionId, out var session)) return;
+        session.Bucket(value.Generation)?.AddConnection(wait.Ticks, wasReused);
     }
 
     public void RangeEnd(
-        Guid sessionId,
+        StreamTraceRangeContext? range,
         ReadSession.EndReasonCode endReason,
         long bytesServed,
         string? message = null)
     {
-        var stalls = _sessions.TryGetValue(sessionId, out var session)
-            ? session.Stalls.DrainForRange()
-            : default;
+        if (range is not { } value) return;
+        var stalls = _sessions.TryGetValue(value.SessionId, out var session)
+            ? session.Bucket(value.Generation)
+            : null;
 
         Record(new StreamTraceEvent
         {
             Sequence = 0,
             AtUnixMs = Now(),
-            SessionId = sessionId,
+            SessionId = value.SessionId,
             Kind = StreamTraceKind.RangeEnd.ToString(),
             EndReason = StreamTraceEvent.EndReasonName(endReason),
             BytesServed = bytesServed,
             Message = message,
-            ConnectionWaitMs = stalls.ConnectionWaitMs,
-            ProviderWaitMs = stalls.ProviderWaitMs,
-            BodyDrainMs = stalls.BodyDrainMs,
-            ConsumerWaitMs = stalls.ConsumerWaitMs,
-            ClientWriteMs = stalls.ClientWriteMs,
-            ConnectionsOpened = stalls.ConnectionsOpened,
-            ConnectionsReused = stalls.ConnectionsReused,
+            RangeGeneration = value.Generation,
+            RangeStalls = stalls,
         });
     }
 
@@ -414,91 +436,37 @@ public sealed class StreamTraceBuffer
 
     private sealed class SessionMeta
     {
+        // Ranges are attributed by generation because a fetch started in one range can
+        // resolve after it ended. A handful of closed generations stay addressable so
+        // late completions can still update the RangeEnd event that references that bucket.
+        // Sixteen remains tiny but avoids dropping ordinary rapid-scrub completions.
+        private const int RetainedGenerations = 16;
+        private readonly object _generationGate = new();
+        private readonly Dictionary<long, StreamTraceRangeStalls> _buckets = new();
+
         public Guid SessionId { get; init; }
         public long FirstAt { get; set; }
         public long LastAt { get; set; }
         public string? Path { get; set; }
         public int EventCount { get; set; }
         public string? LastKind { get; set; }
-        public StallTotals Stalls { get; } = new();
-    }
 
-    /// <summary>
-    /// Per-range stall accumulator. Written concurrently by every prefetch task and the
-    /// consumer, so every field moves through Interlocked; drained and zeroed when the
-    /// range ends so the next range on the same session starts clean.
-    /// </summary>
-    private sealed class StallTotals
-    {
-        private long _connectionWaitTicks;
-        private long _providerWaitTicks;
-        private long _bodyDrainTicks;
-        private long _consumerWaitTicks;
-        private long _clientWriteTicks;
-        private long _connectionsOpened;
-        private long _connectionsReused;
-
-        public void Add(StreamStallKind kind, long ticks)
+        public void OpenGeneration(long generation)
         {
-            switch (kind)
+            lock (_generationGate)
             {
-                case StreamStallKind.ConnectionWait:
-                    Interlocked.Add(ref _connectionWaitTicks, ticks);
-                    break;
-                case StreamStallKind.ProviderWait:
-                    Interlocked.Add(ref _providerWaitTicks, ticks);
-                    break;
-                case StreamStallKind.BodyDrain:
-                    Interlocked.Add(ref _bodyDrainTicks, ticks);
-                    break;
-                case StreamStallKind.ConsumerWait:
-                    Interlocked.Add(ref _consumerWaitTicks, ticks);
-                    break;
-                case StreamStallKind.ClientWrite:
-                    Interlocked.Add(ref _clientWriteTicks, ticks);
-                    break;
+                _buckets[generation] = new StreamTraceRangeStalls();
+                while (_buckets.Count > RetainedGenerations)
+                    _buckets.Remove(_buckets.Keys.Min());
             }
         }
 
-        public void AddConnection(long waitTicks, bool wasReused)
+        public StreamTraceRangeStalls? Bucket(long generation)
         {
-            if (waitTicks > 0) Interlocked.Add(ref _connectionWaitTicks, waitTicks);
-            if (wasReused)
-                Interlocked.Increment(ref _connectionsReused);
-            else
-                Interlocked.Increment(ref _connectionsOpened);
-        }
-
-        public StallSnapshot DrainForRange() => new(
-            Milliseconds(ref _connectionWaitTicks),
-            Milliseconds(ref _providerWaitTicks),
-            Milliseconds(ref _bodyDrainTicks),
-            Milliseconds(ref _consumerWaitTicks),
-            Milliseconds(ref _clientWriteTicks),
-            Count(ref _connectionsOpened),
-            Count(ref _connectionsReused));
-
-        private static long? Milliseconds(ref long ticks)
-        {
-            var drained = Interlocked.Exchange(ref ticks, 0);
-            return drained <= 0 ? null : drained / TimeSpan.TicksPerMillisecond;
-        }
-
-        private static long? Count(ref long counter)
-        {
-            var drained = Interlocked.Exchange(ref counter, 0);
-            return drained <= 0 ? null : drained;
+            if (generation <= 0) return null;
+            lock (_generationGate) return _buckets.GetValueOrDefault(generation);
         }
     }
-
-    private readonly record struct StallSnapshot(
-        long? ConnectionWaitMs,
-        long? ProviderWaitMs,
-        long? BodyDrainMs,
-        long? ConsumerWaitMs,
-        long? ClientWriteMs,
-        long? ConnectionsOpened,
-        long? ConnectionsReused);
 }
 
 public sealed record StreamTraceSessionSummary(

--- a/backend/Services/StreamTrace/StreamTraceBuffer.cs
+++ b/backend/Services/StreamTrace/StreamTraceBuffer.cs
@@ -19,6 +19,7 @@ public sealed class StreamTraceBuffer
     public const int DefaultUiCapacity = 20_000;
     public static readonly int[] AllowedUiMinutes = [15, 30, 60];
 
+    private static readonly TimeSpan RetentionWindow = TimeSpan.FromHours(1);
     private static readonly JsonSerializerOptions CompactJson = new()
     {
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
@@ -30,8 +31,10 @@ public sealed class StreamTraceBuffer
     private long _nextSequence;
     private long _nextRangeGeneration;
     private long _expiresAtUnixMs;
+    private long _retainedUntilUnixMs;
     private string _source = SourceEnv;
     private int _capacity;
+    private int _recording;
 
     // Newest session first for summary listing.
     private readonly ConcurrentDictionary<Guid, SessionMeta> _sessions = new();
@@ -62,6 +65,7 @@ public sealed class StreamTraceBuffer
     {
         get
         {
+            if (Volatile.Read(ref _recording) != 1) return false;
             var buffer = _buffer;
             if (buffer.Length == 0) return false;
             var expiresAt = Volatile.Read(ref _expiresAtUnixMs);
@@ -69,10 +73,16 @@ public sealed class StreamTraceBuffer
         }
     }
 
+    /// <summary>Recording has stopped but the capture is still held for a support pack.</summary>
+    public bool HasRetainedEvents =>
+        Volatile.Read(ref _recording) == 0
+        && _buffer.Length > 0
+        && Volatile.Read(ref _nextSequence) > 0;
+
     /// <summary>
     /// Turns tracing on for <paramref name="ttl"/>. A zero TTL means no expiry
     /// (used by the STREAM_TRACE_EVENTS bootstrap path). UI callers must pass a
-    /// positive TTL — the expiry sweeper will Disable() when it elapses.
+    /// positive TTL — the expiry sweeper will StopRecording() when it elapses.
     /// </summary>
     public StreamTraceStatus EnableFor(TimeSpan ttl, int capacity, string source)
     {
@@ -84,98 +94,174 @@ public sealed class StreamTraceBuffer
 
         lock (_gate)
         {
-            _buffer = new StreamTraceEvent?[capped];
-            _capacity = capped;
-            _source = isUi ? SourceUi : SourceEnv;
-            Volatile.Write(ref _expiresAtUnixMs, expiresAt);
-            _sessions.Clear();
-            Interlocked.Exchange(ref _nextSequence, 0);
+            if (_recording == 0 && _buffer.Length > 0 && _nextSequence > 0)
+            {
+                // Resume the retained ring exactly as-is. Capacity stays unchanged;
+                // especially do not shrink an env-originated capture behind the operator's back.
+                _source = isUi ? SourceUi : SourceEnv;
+                Volatile.Write(ref _expiresAtUnixMs, expiresAt);
+                Volatile.Write(ref _retainedUntilUnixMs, 0);
+                Volatile.Write(ref _recording, 1);
+            }
+            else
+            {
+                // No retained evidence: start a fresh capture as today.
+                _buffer = new StreamTraceEvent?[capped];
+                _capacity = capped;
+                _source = isUi ? SourceUi : SourceEnv;
+                Volatile.Write(ref _expiresAtUnixMs, expiresAt);
+                Volatile.Write(ref _retainedUntilUnixMs, 0);
+                _sessions.Clear();
+                _nextSequence = 0;
+                Volatile.Write(ref _recording, 1);
+            }
         }
 
         return GetStatus();
     }
 
     /// <summary>
-    /// Releases the ring buffer and session index so the GC can reclaim the RAM.
-    /// Safe to call when already disabled.
+    /// Stops recording but keeps the capture addressable so a support pack collected
+    /// afterwards still contains it. The natural flow is enable, reproduce, turn off,
+    /// download — clearing here silently destroyed the evidence that was just captured.
+    /// The retention deadline releases the memory later if nobody discards it.
     /// </summary>
-    public StreamTraceStatus Disable()
+    public StreamTraceStatus StopRecording()
     {
         lock (_gate)
         {
-            _buffer = [];
+            if (_recording == 0)
+                return GetStatusNoLock();
+
+            Volatile.Write(ref _recording, 0);
             Volatile.Write(ref _expiresAtUnixMs, 0);
-            _sessions.Clear();
-            Interlocked.Exchange(ref _nextSequence, 0);
+            if (_nextSequence > 0)
+                Volatile.Write(ref _retainedUntilUnixMs, Now() + (long)RetentionWindow.TotalMilliseconds);
+            else
+                ReleaseBufferNoLock();
         }
 
         return GetStatus();
     }
 
     /// <summary>
-    /// True when a positive TTL has elapsed and Disable() has not yet run.
+    /// Releases the ring buffer and session index so the GC can reclaim the RAM,
+    /// discarding anything captured. Safe to call at any time.
+    /// </summary>
+    public StreamTraceStatus Discard()
+    {
+        lock (_gate)
+            ReleaseBufferNoLock();
+
+        return GetStatus();
+    }
+
+    /// <summary>
+    /// True when a positive TTL has elapsed and StopRecording() has not yet run.
     /// </summary>
     public bool IsExpired
     {
         get
         {
             var expiresAt = Volatile.Read(ref _expiresAtUnixMs);
-            return expiresAt > 0 && expiresAt <= Now() && _buffer.Length > 0;
+            return Volatile.Read(ref _recording) != 0
+                && expiresAt > 0
+                && expiresAt <= Now()
+                && _buffer.Length > 0;
+        }
+    }
+
+    /// <summary>True once the retention deadline has passed and Discard() has not yet run.</summary>
+    public bool IsRetentionExpired
+    {
+        get
+        {
+            var until = Volatile.Read(ref _retainedUntilUnixMs);
+            return until > 0 && until <= Now() && HasRetainedEvents;
         }
     }
 
     public StreamTraceStatus GetStatus()
     {
         lock (_gate)
+            return GetStatusNoLock();
+    }
+
+    private StreamTraceStatus GetStatusNoLock()
+    {
+        var expiresAt = Volatile.Read(ref _expiresAtUnixMs);
+        var retainedUntil = Volatile.Read(ref _retainedUntilUnixMs);
+        var recording = Volatile.Read(ref _recording) == 1;
+        var enabled = recording && _buffer.Length > 0 && (expiresAt == 0 || expiresAt > Now());
+        return new StreamTraceStatus(
+            Enabled: enabled,
+            Source: _source,
+            ExpiresAtUnixMs: expiresAt,
+            Capacity: Math.Max(_capacity, 100),
+            EventCount: Volatile.Read(ref _nextSequence),
+            SessionCount: _sessions.Count,
+            Retained: !recording && _buffer.Length > 0 && _nextSequence > 0,
+            RetainedUntilUnixMs: retainedUntil);
+    }
+
+    private void ReleaseBufferNoLock()
+    {
+        _buffer = [];
+        Volatile.Write(ref _recording, 0);
+        Volatile.Write(ref _expiresAtUnixMs, 0);
+        Volatile.Write(ref _retainedUntilUnixMs, 0);
+        _sessions.Clear();
+        _nextSequence = 0;
+    }
+
+    internal void ExpireRetentionForTests()
+    {
+        lock (_gate)
         {
-            var expiresAt = Volatile.Read(ref _expiresAtUnixMs);
-            var enabled = _buffer.Length > 0 && (expiresAt == 0 || expiresAt > Now());
-            return new StreamTraceStatus(
-                Enabled: enabled,
-                Source: _source,
-                ExpiresAtUnixMs: expiresAt,
-                Capacity: Math.Max(_capacity, 100),
-                EventCount: Volatile.Read(ref _nextSequence),
-                SessionCount: _sessions.Count);
+            if (_recording == 0 && _buffer.Length > 0 && _nextSequence > 0)
+                Volatile.Write(ref _retainedUntilUnixMs, Now() - 1);
         }
     }
 
     private SessionMeta? Record(StreamTraceEvent entry)
     {
         if (!Enabled) return null;
-        var sequence = Interlocked.Increment(ref _nextSequence);
-        var withSeq = entry with { Sequence = sequence };
-        var buffer = _buffer;
-        if (buffer.Length == 0) return null;
         lock (_gate)
         {
-            buffer = _buffer;
-            if (buffer.Length == 0) return null;
+            var expiresAt = Volatile.Read(ref _expiresAtUnixMs);
+            if (_recording != 1
+                || _buffer.Length == 0
+                || (expiresAt > 0 && expiresAt <= Now()))
+                return null;
+
+            var sequence = ++_nextSequence;
+            var withSeq = entry with { Sequence = sequence };
+            var buffer = _buffer;
             buffer[(sequence - 1) % buffer.Length] = withSeq;
+
+            var session = _sessions.AddOrUpdate(
+                entry.SessionId,
+                _ => new SessionMeta
+                {
+                    SessionId = entry.SessionId,
+                    FirstAt = entry.AtUnixMs,
+                    LastAt = entry.AtUnixMs,
+                    Path = entry.Path,
+                    EventCount = 1,
+                    LastKind = entry.Kind,
+                },
+                (_, existing) =>
+                {
+                    existing.LastAt = entry.AtUnixMs;
+                    existing.EventCount++;
+                    existing.LastKind = entry.Kind;
+                    if (!string.IsNullOrEmpty(entry.Path)) existing.Path = entry.Path;
+                    return existing;
+                });
+
+            TrimSessionsIfNeeded();
+            return session;
         }
-
-        var session = _sessions.AddOrUpdate(
-            entry.SessionId,
-            _ => new SessionMeta
-            {
-                SessionId = entry.SessionId,
-                FirstAt = entry.AtUnixMs,
-                LastAt = entry.AtUnixMs,
-                Path = entry.Path,
-                EventCount = 1,
-                LastKind = entry.Kind,
-            },
-            (_, existing) =>
-            {
-                existing.LastAt = entry.AtUnixMs;
-                existing.EventCount++;
-                existing.LastKind = entry.Kind;
-                if (!string.IsNullOrEmpty(entry.Path)) existing.Path = entry.Path;
-                return existing;
-            });
-
-        TrimSessionsIfNeeded();
-        return session;
     }
 
     /// <summary>
@@ -371,7 +457,7 @@ public sealed class StreamTraceBuffer
 
     public IReadOnlyList<StreamTraceEvent> GetSessionEvents(Guid sessionId)
     {
-        if (!Enabled && _buffer.Length == 0) return [];
+        if (_buffer.Length == 0) return [];
 
         StreamTraceEvent?[] copy;
         lock (_gate)

--- a/backend/Services/StreamTrace/StreamTraceBuffer.cs
+++ b/backend/Services/StreamTrace/StreamTraceBuffer.cs
@@ -94,7 +94,16 @@ public sealed class StreamTraceBuffer
 
         lock (_gate)
         {
-            if (_recording == 0 && _buffer.Length > 0 && _nextSequence > 0)
+            if (_recording == 1)
+            {
+                // Already capturing (UI re-enable, or UI enable while STREAM_TRACE_EVENTS
+                // is recording). Refresh TTL/source only — wiping would destroy the
+                // evidence StopRecording/Discard exist to protect.
+                _source = isUi ? SourceUi : SourceEnv;
+                Volatile.Write(ref _expiresAtUnixMs, expiresAt);
+                Volatile.Write(ref _retainedUntilUnixMs, 0);
+            }
+            else if (_buffer.Length > 0 && _nextSequence > 0)
             {
                 // Resume the retained ring exactly as-is. Capacity stays unchanged;
                 // especially do not shrink an env-originated capture behind the operator's back.

--- a/backend/Services/StreamTrace/StreamTraceBuffer.cs
+++ b/backend/Services/StreamTrace/StreamTraceBuffer.cs
@@ -130,6 +130,7 @@ public sealed class StreamTraceBuffer
     {
         lock (_gate)
         {
+            // Idempotent: repeated "off" calls must not extend the retention deadline.
             if (_recording == 0)
                 return GetStatusNoLock();
 
@@ -139,9 +140,9 @@ public sealed class StreamTraceBuffer
                 Volatile.Write(ref _retainedUntilUnixMs, Now() + (long)RetentionWindow.TotalMilliseconds);
             else
                 ReleaseBufferNoLock();
-        }
 
-        return GetStatus();
+            return GetStatusNoLock();
+        }
     }
 
     /// <summary>
@@ -151,9 +152,10 @@ public sealed class StreamTraceBuffer
     public StreamTraceStatus Discard()
     {
         lock (_gate)
+        {
             ReleaseBufferNoLock();
-
-        return GetStatus();
+            return GetStatusNoLock();
+        }
     }
 
     /// <summary>
@@ -415,14 +417,20 @@ public sealed class StreamTraceBuffer
         session.Bucket(value.Generation)?.AddConnection(wait.Ticks, wasReused);
     }
 
+    /// <summary>
+    /// Records how a range finished. <paramref name="range"/> may be null when no range was
+    /// opened — tracing started mid-read, or the read timed out while the stream was still
+    /// opening. That terminal event is the most useful one in the trace, so it is still
+    /// recorded; it simply carries no generation and no stall attribution.
+    /// </summary>
     public void RangeEnd(
+        Guid sessionId,
         StreamTraceRangeContext? range,
         ReadSession.EndReasonCode endReason,
         long bytesServed,
         string? message = null)
     {
-        if (range is not { } value) return;
-        var stalls = _sessions.TryGetValue(value.SessionId, out var session)
+        var stalls = range is { } value && _sessions.TryGetValue(value.SessionId, out var session)
             ? session.Bucket(value.Generation)
             : null;
 
@@ -430,12 +438,12 @@ public sealed class StreamTraceBuffer
         {
             Sequence = 0,
             AtUnixMs = Now(),
-            SessionId = value.SessionId,
+            SessionId = sessionId,
             Kind = StreamTraceKind.RangeEnd.ToString(),
             EndReason = StreamTraceEvent.EndReasonName(endReason),
             BytesServed = bytesServed,
             Message = message,
-            RangeGeneration = value.Generation,
+            RangeGeneration = range?.Generation,
             RangeStalls = stalls,
         });
     }

--- a/backend/Services/StreamTrace/StreamTraceEvent.cs
+++ b/backend/Services/StreamTrace/StreamTraceEvent.cs
@@ -34,16 +34,25 @@ public sealed record StreamTraceEvent
     [JsonPropertyName("attempt")] public int? Attempt { get; init; }
     [JsonPropertyName("message")] public string? Message { get; init; }
 
-    // Stall attribution, emitted on RangeEnd and reset per range. These overlap by
-    // design — segments are fetched concurrently — so they are shares of a range's
-    // wall clock, not a partition of it.
-    [JsonPropertyName("connWaitMs")] public long? ConnectionWaitMs { get; init; }
-    [JsonPropertyName("providerWaitMs")] public long? ProviderWaitMs { get; init; }
-    [JsonPropertyName("bodyDrainMs")] public long? BodyDrainMs { get; init; }
-    [JsonPropertyName("consumerWaitMs")] public long? ConsumerWaitMs { get; init; }
-    [JsonPropertyName("clientWriteMs")] public long? ClientWriteMs { get; init; }
-    [JsonPropertyName("connOpened")] public long? ConnectionsOpened { get; init; }
-    [JsonPropertyName("connReused")] public long? ConnectionsReused { get; init; }
+    [JsonPropertyName("rangeGeneration")] public long? RangeGeneration { get; init; }
+
+    /// <summary>
+    /// Live totals for this range generation. Kept after RangeEnd so late fetch
+    /// completions still update exported JSON; ignored by the serializer.
+    /// </summary>
+    [JsonIgnore]
+    internal StreamTraceRangeStalls? RangeStalls { get; init; }
+
+    // Stall attribution on RangeEnd. These overlap by design — segments are fetched
+    // concurrently — so they are shares of a range's wall clock, not a partition of it.
+    [JsonPropertyName("connWaitMs")] public long? ConnectionWaitMs => RangeStalls?.ConnectionWaitMs;
+    [JsonPropertyName("providerWaitMs")] public long? ProviderWaitMs => RangeStalls?.ProviderWaitMs;
+    [JsonPropertyName("bodyDrainMs")] public long? BodyDrainMs => RangeStalls?.BodyDrainMs;
+    [JsonPropertyName("consumerWaitMs")] public long? ConsumerWaitMs => RangeStalls?.ConsumerWaitMs;
+    [JsonPropertyName("clientWriteMs")] public long? ClientWriteMs => RangeStalls?.ClientWriteMs;
+    [JsonPropertyName("connOpened")] public long? ConnectionsOpened => RangeStalls?.ConnectionsOpened;
+    [JsonPropertyName("connReused")] public long? ConnectionsReused => RangeStalls?.ConnectionsReused;
+    [JsonPropertyName("fetches")] public long? Fetches => RangeStalls?.Fetches;
 
     public static string StatusName(SegmentFetch.FetchStatus status) => status.ToString();
 

--- a/backend/Services/StreamTrace/StreamTraceExpiryService.cs
+++ b/backend/Services/StreamTrace/StreamTraceExpiryService.cs
@@ -4,9 +4,9 @@ using Serilog;
 namespace NzbWebDAV.Services.StreamTrace;
 
 /// <summary>
-/// Disables UI-enabled stream tracing when its TTL elapses so RAM is released
-/// even if the operator forgets to turn it off. Env-sourced tracing (no expiry)
-/// is left alone.
+/// Stops UI-enabled stream tracing when its TTL elapses, then releases retained
+/// captures after their support-pack window. Env-sourced tracing (no expiry) is
+/// left alone until explicitly stopped.
 /// </summary>
 public sealed class StreamTraceExpiryService(
     StreamTraceBuffer buffer,
@@ -27,11 +27,20 @@ public sealed class StreamTraceExpiryService(
                 if (buffer.IsExpired)
                 {
                     var before = buffer.GetStatus();
-                    var status = buffer.Disable();
+                    var status = buffer.StopRecording();
                     Log.Information(
-                        "Stream tracing expired; released {Events:n0} buffered events from {Source}",
+                        "Stream tracing expired; retaining {Events:n0} events from {Source} for support packs",
                         before.EventCount,
                         before.Source);
+                    await broadcaster.BroadcastAsync(status).ConfigureAwait(false);
+                }
+                else if (buffer.IsRetentionExpired)
+                {
+                    var before = buffer.GetStatus();
+                    var status = buffer.Discard();
+                    Log.Information(
+                        "Released {Events:n0} retained stream-trace events after the retention window",
+                        before.EventCount);
                     await broadcaster.BroadcastAsync(status).ConfigureAwait(false);
                 }
                 else

--- a/backend/Services/StreamTrace/StreamTraceRangeStalls.cs
+++ b/backend/Services/StreamTrace/StreamTraceRangeStalls.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace NzbWebDAV.Services.StreamTrace;
 
 /// <summary>

--- a/backend/Services/StreamTrace/StreamTraceRangeStalls.cs
+++ b/backend/Services/StreamTrace/StreamTraceRangeStalls.cs
@@ -1,0 +1,77 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Services.StreamTrace;
+
+/// <summary>
+/// Identifies the HTTP range generation that started a fetch or stall measurement.
+/// Captured when the stopwatch starts so late completions bill the originating range.
+/// </summary>
+public readonly record struct StreamTraceRangeContext(Guid SessionId, long Generation);
+
+/// <summary>
+/// Live per-range stall totals. <see cref="StreamTraceEvent"/> holds a reference so
+/// completions after <c>RangeEnd</c> still update the exported event.
+/// </summary>
+internal sealed class StreamTraceRangeStalls
+{
+    private long _connectionWaitTicks;
+    private long _providerWaitTicks;
+    private long _bodyDrainTicks;
+    private long _consumerWaitTicks;
+    private long _clientWriteTicks;
+    private long _connectionsOpened;
+    private long _connectionsReused;
+    private long _fetches;
+
+    public long? ConnectionWaitMs => Milliseconds(Interlocked.Read(ref _connectionWaitTicks));
+    public long? ProviderWaitMs => Milliseconds(Interlocked.Read(ref _providerWaitTicks));
+    public long? BodyDrainMs => Milliseconds(Interlocked.Read(ref _bodyDrainTicks));
+    public long? ConsumerWaitMs => Milliseconds(Interlocked.Read(ref _consumerWaitTicks));
+    public long? ClientWriteMs => Milliseconds(Interlocked.Read(ref _clientWriteTicks));
+    public long? ConnectionsOpened => Count(Interlocked.Read(ref _connectionsOpened));
+    public long? ConnectionsReused => Count(Interlocked.Read(ref _connectionsReused));
+    public long? Fetches => Count(Interlocked.Read(ref _fetches));
+
+    public void Add(StreamStallKind kind, long ticks)
+    {
+        switch (kind)
+        {
+            case StreamStallKind.ConnectionWait:
+                Interlocked.Add(ref _connectionWaitTicks, ticks);
+                break;
+            case StreamStallKind.ProviderWait:
+                Interlocked.Add(ref _providerWaitTicks, ticks);
+                break;
+            case StreamStallKind.BodyDrain:
+                Interlocked.Add(ref _bodyDrainTicks, ticks);
+                break;
+            case StreamStallKind.ConsumerWait:
+                Interlocked.Add(ref _consumerWaitTicks, ticks);
+                break;
+            case StreamStallKind.ClientWrite:
+                Interlocked.Add(ref _clientWriteTicks, ticks);
+                break;
+        }
+    }
+
+    public void AddConnection(long waitTicks, bool wasReused)
+    {
+        if (waitTicks > 0) Interlocked.Add(ref _connectionWaitTicks, waitTicks);
+        if (wasReused)
+            Interlocked.Increment(ref _connectionsReused);
+        else
+            Interlocked.Increment(ref _connectionsOpened);
+    }
+
+    public void AddFetch(long providerWaitTicks)
+    {
+        if (providerWaitTicks > 0)
+            Interlocked.Add(ref _providerWaitTicks, providerWaitTicks);
+        Interlocked.Increment(ref _fetches);
+    }
+
+    private static long? Milliseconds(long ticks) =>
+        ticks <= 0 ? null : ticks / TimeSpan.TicksPerMillisecond;
+
+    private static long? Count(long value) => value <= 0 ? null : value;
+}

--- a/backend/Services/StreamTrace/StreamTraceStatus.cs
+++ b/backend/Services/StreamTrace/StreamTraceStatus.cs
@@ -10,4 +10,6 @@ public sealed record StreamTraceStatus(
     long ExpiresAtUnixMs,
     int Capacity,
     long EventCount,
-    int SessionCount);
+    int SessionCount,
+    bool Retained,
+    long RetainedUntilUnixMs);

--- a/backend/Services/StreamTrace/StreamTraceStatusBroadcaster.cs
+++ b/backend/Services/StreamTrace/StreamTraceStatusBroadcaster.cs
@@ -37,8 +37,10 @@ public sealed class StreamTraceStatusBroadcaster(WebsocketManager websocketManag
         JsonSerializer.Serialize(new
         {
             enabled = status.Enabled,
+            retained = status.Retained,
             source = status.Source,
             expiresAtUnixMs = status.ExpiresAtUnixMs,
+            retainedUntilUnixMs = status.RetainedUntilUnixMs,
             capacity = status.Capacity,
             eventCount = status.EventCount,
             sessionCount = status.SessionCount,

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -159,6 +159,21 @@ public sealed class SupportPackService(
         are fetched concurrently, so read them as shares of the range rather than a
         breakdown that sums to its duration.
 
+        Each RangeEnd also reports fetches, the number of segment fetches attributed to
+        that range. providerWaitMs is an aggregate across concurrent fetches, so it can
+        exceed wall clock; compare providerWaitMs / fetches (average provider wait) and
+        providerWaitMs / elapsed RangeOpen-to-RangeEnd time (implied concurrency) with
+        the configured pool size. Attribution is by the range that started each fetch,
+        including fetches that finish after an aborted RangeEnd, so late work is not
+        billed to the next range. Pair RangeOpen and RangeEnd by rangeGeneration when
+        requests overlap or finish out of order.
+
+        Trace connWaitMs and the connection pool's GateWaitMs are not comparable. Trace
+        stalls are scoped to read sessions captured while tracing was active; pool churn
+        counters are process-wide and cumulative, so they also include queue imports and
+        health sweeps. On a scan-heavy install the two legitimately differ by orders of
+        magnitude.
+
         The archive deliberately excludes database files, backups, blobs/NZBs,
         environment files, session/API key files, crash dumps, and segment-cache
         data. Credentials, API keys, tokens, URL credentials and sensitive URL query

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -148,10 +148,11 @@ public sealed class SupportPackService(
         collection counts) over pauseTimePercentage, which reflects only the most
         recent collection.
 
-        stream-traces/ is included only while developer stream tracing is enabled
-        (Settings → Support, or STREAM_TRACE_EVENTS). Tracing is opt-in, memory-only,
-        and resets on restart. RangeEnd events carry stall attribution for the range
-        that just finished: connWaitMs (waiting for an NNTP connection),
+        stream-traces/ is included while developer stream tracing is enabled or while
+        a stopped capture is retained for one hour (Settings → Support, or
+        STREAM_TRACE_EVENTS). Tracing is opt-in, memory-only, and resets on restart.
+        RangeEnd events carry stall attribution for the range that just finished:
+        connWaitMs (waiting for an NNTP connection),
         providerWaitMs (waiting for provider response headers), bodyDrainMs (reading
         article bodies), consumerWaitMs (playback starved waiting for prefetch), and
         clientWriteMs (blocked writing to the player). They overlap, because segments
@@ -242,8 +243,10 @@ public sealed class SupportPackService(
             streamTracing = new
             {
                 enabled = streamTracing.Enabled,
+                retained = streamTracing.Retained,
                 source = streamTracing.Source,
                 expiresAtUnixMs = streamTracing.ExpiresAtUnixMs,
+                retainedUntilUnixMs = streamTracing.RetainedUntilUnixMs,
                 capacity = streamTracing.Capacity,
                 eventCount = streamTracing.EventCount,
                 sessionCount = streamTracing.SessionCount,

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -753,10 +753,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             var capacity = estimate is > 0 and <= int.MaxValue ? (int)estimate : 0;
             buffer = new PooledBufferStream(capacity);
+            var traceRange = MultiProviderNntpClient.CurrentStreamTraceRange;
             var drainStarted = Stopwatch.GetTimestamp();
             await source.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
             StreamTrace.TryStall(
-                MultiProviderNntpClient.CurrentReadSessionId,
+                traceRange,
                 StreamStallKind.BodyDrain,
                 Stopwatch.GetElapsedTime(drainStarted));
             var drained = buffer.Length;
@@ -852,12 +853,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 // Time spent here is the consumer starving: prefetch has not yet delivered
                 // the next segment. Low provider time with high consumer wait means the
                 // pipeline is not running far enough ahead, not that the provider is slow.
+                var traceRange = MultiProviderNntpClient.CurrentStreamTraceRange;
                 var waitStarted = Stopwatch.GetTimestamp();
                 if (!await _streamTasks.Reader.WaitToReadAsync(cancellationToken)) return 0;
                 if (!_streamTasks.Reader.TryRead(out var streamTask)) return 0;
                 var result = await streamTask;
                 StreamTrace.TryStall(
-                    MultiProviderNntpClient.CurrentReadSessionId,
+                    traceRange,
                     StreamStallKind.ConsumerWait,
                     Stopwatch.GetElapsedTime(waitStarted));
                 ReleaseInFlightPrefetchBytes(result.PlannedBytes);

--- a/backend/WebDav/Base/BaseStoreReadonlyCollection.cs
+++ b/backend/WebDav/Base/BaseStoreReadonlyCollection.cs
@@ -52,6 +52,15 @@ public abstract class BaseStoreReadonlyCollection : BaseStoreCollection
         return false;
     }
 
+    /// <summary>
+    /// Throttle scope for refused writes. Deliberately coarser than <see cref="UniqueKey"/>:
+    /// a client writing metadata sidecars touches one directory per release, so keying on
+    /// the directory produced one warning per release and still flooded the buffer. The
+    /// concrete store type is the safe default; mounts that need a shared key (e.g.
+    /// completed-symlinks) override this. The refused path is still reported in the message.
+    /// </summary>
+    protected virtual string WriteRejectionScopeKey => GetType().Name;
+
     private void LogRejected(string operation, string itemName) =>
-        ReadonlyWriteRejectionLog.Rejected(operation, itemName, Name, UniqueKey);
+        ReadonlyWriteRejectionLog.Rejected(operation, itemName, Name, WriteRejectionScopeKey);
 }

--- a/backend/WebDav/Base/BaseStoreReadonlyItem.cs
+++ b/backend/WebDav/Base/BaseStoreReadonlyItem.cs
@@ -6,15 +6,21 @@ namespace NzbWebDAV.WebDav.Base;
 
 public abstract class BaseStoreReadonlyItem : BaseStoreItem
 {
+    /// <summary>
+    /// Throttle scope for refused writes. Coarser than <see cref="UniqueKey"/> so
+    /// per-instance keys (e.g. empty-file staging GUIDs) cannot bypass the window.
+    /// </summary>
+    protected virtual string WriteRejectionScopeKey => GetType().Name;
+
     protected override Task<DavStatusCode> UploadFromStreamAsync(UploadFromStreamRequest request)
     {
-        ReadonlyWriteRejectionLog.Rejected("upload item", Name, Name, UniqueKey);
+        ReadonlyWriteRejectionLog.Rejected("upload item", Name, Name, WriteRejectionScopeKey);
         return Task.FromResult(DavStatusCode.Forbidden);
     }
 
     protected override Task<StoreItemResult> CopyAsync(CopyRequest request)
     {
-        ReadonlyWriteRejectionLog.Rejected("copy item", request.Name, Name, UniqueKey);
+        ReadonlyWriteRejectionLog.Rejected("copy item", request.Name, Name, WriteRejectionScopeKey);
         return Task.FromResult(new StoreItemResult(DavStatusCode.Forbidden));
     }
 }

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -351,7 +351,8 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         string? message = null)
     {
         _activeReadRegistry.SetEndReason(sessionId, reason);
-        _streamTrace.RangeEnd(traceRange, reason, _activeReadRegistry.GetBytesRead(sessionId), message);
+        _streamTrace.RangeEnd(
+            sessionId, traceRange, reason, _activeReadRegistry.GetBytesRead(sessionId), message);
     }
 
     private async Task CopyToAsync(

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -254,11 +254,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                     var sessionId = _activeReadRegistry.GetOrCreate(
                         path, clientKey, fileName, stream.CanSeek ? stream.Length : null,
                         userAgent, clientIp);
-                    _streamTrace.RangeOpen(
+                    var traceRange = _streamTrace.RangeOpen(
                         sessionId, path, request.Method, copyStart, copyEnd,
                         stream.CanSeek ? stream.Length : null, userAgent, clientIp);
                     using var scope = _providerUsageTracker.BeginScope(sessionId);
                     using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
+                    using var traceRangeScope = MultiProviderNntpClient.BeginStreamTraceRangeScope(traceRange);
                     try
                     {
                         // Body transfer can run for minutes; drop the admission/open
@@ -266,8 +267,8 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                            sessionId, ct).ConfigureAwait(false);
-                        FinishRange(sessionId, ReadSession.EndReasonCode.Completed);
+                            traceRange, ct).ConfigureAwait(false);
+                        FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Completed);
                         ClearStreamingFailureAfterCompletedRead(
                             _failureTracker,
                             httpContext.Items["DavItem"],
@@ -279,12 +280,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                     }
                     catch (OperationCanceledException) when (httpContext.RequestAborted.IsCancellationRequested)
                     {
-                        FinishRange(sessionId, ReadSession.EndReasonCode.Aborted);
+                        FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Aborted);
                         throw;
                     }
                     catch (Exception ex)
                     {
-                        FinishRange(sessionId, ReadSession.EndReasonCode.Error, ex.Message);
+                        FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Error, ex.Message);
                         throw;
                     }
                 }
@@ -343,10 +344,14 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         return null;
     }
 
-    private void FinishRange(Guid sessionId, ReadSession.EndReasonCode reason, string? message = null)
+    private void FinishRange(
+        Guid sessionId,
+        StreamTraceRangeContext? traceRange,
+        ReadSession.EndReasonCode reason,
+        string? message = null)
     {
         _activeReadRegistry.SetEndReason(sessionId, reason);
-        _streamTrace.RangeEnd(sessionId, reason, _activeReadRegistry.GetBytesRead(sessionId), message);
+        _streamTrace.RangeEnd(traceRange, reason, _activeReadRegistry.GetBytesRead(sessionId), message);
     }
 
     private async Task CopyToAsync(
@@ -355,7 +360,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         long start,
         long? end,
         Action<long, long>? onBytesServed,
-        Guid? sessionId,
+        StreamTraceRangeContext? traceRange,
         CancellationToken cancellationToken)
     {
         // Skip to the first offset
@@ -392,9 +397,8 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                 var writeStarted = Stopwatch.GetTimestamp();
                 await dest.WriteAsync(
                     buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
-                if (sessionId is { } id)
-                    _streamTrace.AddStall(
-                        id, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
+                _streamTrace.AddStall(
+                    traceRange, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
 
                 // Report chunk size + new absolute file position so dashboards can
                 // surface real playback location (not cumulative transferred bytes).

--- a/backend/WebDav/Base/ReadonlyWriteRejectionLog.cs
+++ b/backend/WebDav/Base/ReadonlyWriteRejectionLog.cs
@@ -24,8 +24,11 @@ internal static class ReadonlyWriteRejectionLog
             return;
 
         Log.Warning(
-            "Refused to {Operation} under read-only path {Scope} — {Attempts} attempt(s) in the last {Minutes} minutes, " +
-            "most recently {ItemName}. A client is trying to write into the NzbDav mount, which does not accept writes.",
-            operation, scopeName, suppressed + 1, Interval.TotalMinutes, itemName);
+            "Refused to {Operation} under a read-only path — {Attempts} attempt(s) in the last " +
+            "{Minutes} minutes, most recently {ItemName} in {Scope}. A client is trying to write " +
+            "into the NzbDav mount, which does not accept writes.",
+            operation, suppressed + 1, Interval.TotalMinutes, itemName, scopeName);
     }
+
+    internal static void ResetForTests() => Throttle.Clear();
 }

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -21,6 +21,10 @@ public class DatabaseStoreSymlinkCollection(
     public override string UniqueKey => davDirectory.Id.ToString();
     public override DateTime CreatedAt => davDirectory.CreatedAt;
 
+    // Every nested collection under the virtual mount shares one throttle window so a
+    // per-release metadata write storm cannot emit one Warning per directory.
+    protected override string WriteRejectionScopeKey => "completed-symlinks";
+
     private Guid TargetId => davDirectory.Id == DavItem.SymlinkFolder.Id ? DavItem.ContentFolder.Id : davDirectory.Id;
     private DeletedFileManager DeletedFiles => new(davDirectory.Id);
 

--- a/docs/operations/logs-crash-dumps.md
+++ b/docs/operations/logs-crash-dumps.md
@@ -18,9 +18,10 @@ Capture per-segment playback events while reproducing buffering or seek stalls:
 1. Open **Settings → Support → Developer stream tracing**.
 2. Choose 15, 30, or 60 minutes and turn tracing on. A warning banner appears while it is active.
 3. Reproduce the issue (Explore `/view` playback is ideal because it skips rclone and your media server).
-4. Download a support pack from the same page while tracing is still on — `stream-traces/` rides along in the archive.
-5. Turning tracing off asks for confirmation when the buffer holds events, because that releases the captured traces immediately.
-6. Tracing auto-disables when the timer elapses, and UI-enabled tracing always resets on restart. It is memory-only (capped at 20,000 events) and never written to disk outside the support pack.
+4. Turn tracing off when you are done, or let the timer elapse. The capture is **kept in memory** so you can still collect it.
+5. Download a support pack from the same page — `stream-traces/` rides along whether tracing is still on or the capture is retained.
+6. Turning tracing on again resumes a retained capture. Use **Discard captured traces** first only when you intentionally want a fresh capture.
+7. Retained traces are released automatically an hour after tracing stops, or immediately via **Discard captured traces**. UI-enabled tracing always resets on restart, and nothing is written to disk outside the support pack.
 
 Setting `STREAM_TRACE_EVENTS` still enables tracing from startup with no expiry, which is handy for local dev. Dump a single session with `./scripts/dump-stream-trace.sh` — see [Contributing](../community/contributing.md).
 

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -253,4 +253,68 @@ describe("BackendClient", () => {
       message: "Failed to fetch onboarding status: backend is starting or migrating",
     });
   });
+
+  it("maps stream tracing status fields and defaults retained values", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      enabled: true,
+      source: "ui",
+      expiresAtUnixMs: 123,
+      capacity: 20000,
+      eventCount: 4,
+      sessionCount: 1,
+    }));
+
+    await expect(backendClient.getStreamTracingStatus()).resolves.toEqual({
+      enabled: true,
+      source: "ui",
+      expiresAtUnixMs: 123,
+      capacity: 20000,
+      eventCount: 4,
+      sessionCount: 1,
+      retained: false,
+      retainedUntilUnixMs: 0,
+    });
+  });
+
+  it("posts discard-stream-traces and maps the clean status", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      enabled: false,
+      source: "ui",
+      expiresAtUnixMs: 0,
+      capacity: 20000,
+      eventCount: 0,
+      sessionCount: 0,
+      retained: false,
+      retainedUntilUnixMs: 0,
+    }));
+
+    await expect(backendClient.discardStreamTraces()).resolves.toMatchObject({
+      retained: false,
+      eventCount: 0,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://backend/api/discard-stream-traces", {
+      method: "POST",
+      headers: { "x-api-key": "test-api-key" },
+    });
+  });
+
+  it("maps a retained response after disabling stream tracing", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      enabled: false,
+      source: "ui",
+      expiresAtUnixMs: 0,
+      capacity: 20000,
+      eventCount: 12,
+      sessionCount: 2,
+      retained: true,
+      retainedUntilUnixMs: 999,
+    }));
+
+    await expect(backendClient.setStreamTracing(false)).resolves.toMatchObject({
+      enabled: false,
+      retained: true,
+      retainedUntilUnixMs: 999,
+      eventCount: 12,
+    });
+  });
 });

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -1,3 +1,10 @@
+import {
+    toStreamTracingStatus,
+    type StreamTracingStatus,
+} from "~/utils/stream-tracing-status";
+
+export type { StreamTracingStatus };
+
 export class WebdavDirectoryNotFoundError extends Error {
     public constructor(public readonly directory: string) {
         super("The WebDAV directory does not exist.");
@@ -296,14 +303,7 @@ class BackendClient {
         const data = await call("/api/get-stream-traces?limit=1", "Failed to get stream tracing status", {
             method: "GET",
         });
-        return {
-            enabled: Boolean(data.enabled),
-            source: data.source ?? "env",
-            expiresAtUnixMs: Number(data.expiresAtUnixMs ?? 0),
-            capacity: Number(data.capacity ?? 0),
-            eventCount: Number(data.eventCount ?? 0),
-            sessionCount: Number(data.sessionCount ?? 0),
-        };
+        return toStreamTracingStatus(data);
     }
 
     public async setStreamTracing(enabled: boolean, minutes: number = 30): Promise<StreamTracingStatus> {
@@ -314,14 +314,14 @@ class BackendClient {
                 ["minutes", String(minutes)],
             ),
         });
-        return {
-            enabled: Boolean(data.enabled),
-            source: data.source ?? "ui",
-            expiresAtUnixMs: Number(data.expiresAtUnixMs ?? 0),
-            capacity: Number(data.capacity ?? 0),
-            eventCount: Number(data.eventCount ?? 0),
-            sessionCount: Number(data.sessionCount ?? 0),
-        };
+        return toStreamTracingStatus(data);
+    }
+
+    public async discardStreamTraces(): Promise<StreamTracingStatus> {
+        const data = await call("/api/discard-stream-traces", "Failed to discard stream traces", {
+            method: "POST",
+        });
+        return toStreamTracingStatus(data);
     }
 
     public async getWatchtower(params: WatchtowerQuery = {}): Promise<WatchtowerData> {
@@ -859,15 +859,6 @@ export type GetLogsResponse = {
     oldestSequence: number,
     newestSequence: number,
     capacity: number,
-}
-
-export type StreamTracingStatus = {
-    enabled: boolean,
-    source: string,
-    expiresAtUnixMs: number,
-    capacity: number,
-    eventCount: number,
-    sessionCount: number,
 }
 
 export type LogBroadcastMessage = {

--- a/frontend/app/components/stream-tracing-banner.tsx
+++ b/frontend/app/components/stream-tracing-banner.tsx
@@ -1,16 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Icon } from "~/components/ui";
-import { DisableTracingConfirmModal } from "~/components/stream-tracing-confirm";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
-
-export type StreamTracingStatus = {
-    enabled: boolean;
-    source: string;
-    expiresAtUnixMs: number;
-    capacity: number;
-    eventCount: number;
-    sessionCount: number;
-};
+import {
+    toStreamTracingStatus,
+    type StreamTracingStatus,
+} from "~/utils/stream-tracing-status";
 
 const TOPIC = "strt";
 
@@ -31,12 +25,11 @@ export function StreamTracingBanner() {
     const [status, setStatus] = useState<StreamTracingStatus | null>(null);
     const [now, setNow] = useState(() => Date.now());
     const [busy, setBusy] = useState(false);
-    const [confirmDisable, setConfirmDisable] = useState(false);
 
     useWebsocketTopic(TOPIC, "state", (message) => {
         try {
-            const parsed = JSON.parse(message) as StreamTracingStatus;
-            setStatus(parsed);
+            const parsed = JSON.parse(message) as Record<string, unknown>;
+            setStatus(toStreamTracingStatus(parsed));
         } catch {
             // ignore malformed payloads
         }
@@ -55,21 +48,13 @@ export function StreamTracingBanner() {
             form.append("enabled", "false");
             const response = await fetch("/settings/stream-tracing", { method: "POST", body: form });
             if (response.ok) {
-                const next = await response.json() as StreamTracingStatus;
-                setStatus(next);
+                const next = await response.json() as Record<string, unknown>;
+                setStatus(toStreamTracingStatus(next));
             }
         } finally {
             setBusy(false);
         }
     }, []);
-
-    const requestTurnOff = useCallback(() => {
-        if ((status?.eventCount ?? 0) > 0) {
-            setConfirmDisable(true);
-            return;
-        }
-        void turnOff();
-    }, [status?.eventCount, turnOff]);
 
     if (!status?.enabled) return null;
 
@@ -77,32 +62,18 @@ export function StreamTracingBanner() {
     const counts = `${status.eventCount.toLocaleString()} events across ${status.sessionCount.toLocaleString()} sessions`;
 
     return (
-        <>
-            <Alert variant="warning" className="mb-4 items-center justify-between gap-3 text-sm">
-                <div className="flex min-w-0 items-start gap-2">
-                    <Icon name="bug_report" className="mt-0.5 shrink-0 !text-[20px]" />
-                    <span>
-                        Developer stream tracing is on ({remaining}
-                        {status.source === "ui" ? "" : ", from STREAM_TRACE_EVENTS"}). {counts}.
-                        Tracing uses RAM only and resets on restart.
-                    </span>
-                </div>
-                <Button variant="ghost" size="small" disabled={busy} onClick={requestTurnOff}>
-                    Turn off
-                </Button>
-            </Alert>
-
-            <DisableTracingConfirmModal
-                show={confirmDisable}
-                eventCount={status.eventCount}
-                sessionCount={status.sessionCount}
-                includeSettingsLink
-                onCancel={() => setConfirmDisable(false)}
-                onConfirm={() => {
-                    setConfirmDisable(false);
-                    void turnOff();
-                }}
-            />
-        </>
+        <Alert variant="warning" className="mb-4 items-center justify-between gap-3 text-sm">
+            <div className="flex min-w-0 items-start gap-2">
+                <Icon name="bug_report" className="mt-0.5 shrink-0 !text-[20px]" />
+                <span>
+                    Developer stream tracing is on ({remaining}
+                    {status.source === "ui" ? "" : ", from STREAM_TRACE_EVENTS"}). {counts}.
+                    Tracing uses RAM only and resets on restart.
+                </span>
+            </div>
+            <Button variant="ghost" size="small" disabled={busy} onClick={() => void turnOff()}>
+                Turn off
+            </Button>
+        </Alert>
     );
 }

--- a/frontend/app/components/stream-tracing-confirm.tsx
+++ b/frontend/app/components/stream-tracing-confirm.tsx
@@ -1,52 +1,35 @@
-import { Link } from "react-router";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
-import { settingsPath } from "~/routes/settings/settings-tabs";
 
-export type DisableTracingConfirmModalProps = {
+export type DiscardTracesConfirmModalProps = {
     show: boolean;
     eventCount: number;
     sessionCount: number;
-    includeSettingsLink?: boolean;
     onCancel: () => void;
     onConfirm: () => void;
 };
 
-export function DisableTracingConfirmModal({
+export function DiscardTracesConfirmModal({
     show,
     eventCount,
     sessionCount,
-    includeSettingsLink = false,
     onCancel,
     onConfirm,
-}: DisableTracingConfirmModalProps) {
+}: DiscardTracesConfirmModalProps) {
     const counts = `${eventCount.toLocaleString()} events across ${sessionCount.toLocaleString()} sessions`;
 
     return (
         <ConfirmModal
             show={show}
-            title="Turn off stream tracing?"
+            title="Discard captured traces?"
             message={
                 <>
-                    Tracing is holding {counts} in memory. Turning it off releases the buffer
-                    immediately, and those traces cannot be recovered. Generate a support pack
-                    first if you want them included.
-                    {includeSettingsLink && (
-                        <>
-                            {" "}
-                            <Link
-                                to={settingsPath("support")}
-                                className="link link-primary"
-                                onClick={onCancel}
-                            >
-                                Open Support settings
-                            </Link>
-                            {" "}to generate a pack.
-                        </>
-                    )}
+                    {counts} are held in memory for a support pack. Discarding frees that memory
+                    now and the traces cannot be recovered. Generate a support pack first if you
+                    have not already.
                 </>
             }
-            cancelText="Keep tracing on"
-            confirmText="Turn off and discard"
+            cancelText="Keep traces"
+            confirmText="Discard traces"
             onCancel={onCancel}
             onConfirm={onConfirm}
         />

--- a/frontend/app/routes/settings.stream-tracing/route.tsx
+++ b/frontend/app/routes/settings.stream-tracing/route.tsx
@@ -7,9 +7,11 @@ export async function loader() {
 
 export async function action({ request }: { request: Request }) {
     const formData = await request.formData();
+    if (formData.get("intent")?.toString() === "discard") {
+        return Response.json(await backendClient.discardStreamTraces());
+    }
     const enabled = formData.get("enabled")?.toString() === "true";
     const minutesRaw = Number(formData.get("minutes")?.toString() ?? "30");
     const minutes = [15, 30, 60].includes(minutesRaw) ? minutesRaw : 30;
-    const status = await backendClient.setStreamTracing(enabled, minutes);
-    return Response.json(status);
+    return Response.json(await backendClient.setStreamTracing(enabled, minutes));
 }

--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -12,9 +12,12 @@ import {
     Spinner,
     Toggle,
 } from "~/components/ui";
+import { DiscardTracesConfirmModal } from "~/components/stream-tracing-confirm";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
-import type { StreamTracingStatus } from "~/components/stream-tracing-banner";
-import { DisableTracingConfirmModal } from "~/components/stream-tracing-confirm";
+import {
+    toStreamTracingStatus,
+    type StreamTracingStatus,
+} from "~/utils/stream-tracing-status";
 
 type Message = { text: string; variant: "success" | "danger" } | null;
 
@@ -42,15 +45,15 @@ export function SupportSettings() {
     const [minutes, setMinutes] = useState<number>(30);
     const [status, setStatus] = useState<StreamTracingStatus | null>(null);
     const [now, setNow] = useState(() => Date.now());
-    const [confirmDisable, setConfirmDisable] = useState(false);
+    const [confirmDiscard, setConfirmDiscard] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
         void fetch("/settings/stream-tracing")
             .then(async (response) => {
                 if (!response.ok) return;
-                const next = await response.json() as StreamTracingStatus;
-                if (!cancelled) setStatus(next);
+                const next = await response.json() as Record<string, unknown>;
+                if (!cancelled) setStatus(toStreamTracingStatus(next));
             })
             .catch(() => { /* banner / websocket will catch up */ });
         return () => { cancelled = true; };
@@ -58,17 +61,17 @@ export function SupportSettings() {
 
     useWebsocketTopic("strt", "state", (messageText) => {
         try {
-            setStatus(JSON.parse(messageText) as StreamTracingStatus);
+            setStatus(toStreamTracingStatus(JSON.parse(messageText) as Record<string, unknown>));
         } catch {
             // ignore malformed payloads
         }
     });
 
     useEffect(() => {
-        if (!status?.enabled) return;
+        if (!status?.enabled && !status?.retained) return;
         const id = window.setInterval(() => setNow(Date.now()), 60_000);
         return () => window.clearInterval(id);
-    }, [status?.enabled]);
+    }, [status?.enabled, status?.retained]);
 
     const download = useCallback(async () => {
         setBusy(true);
@@ -103,6 +106,7 @@ export function SupportSettings() {
     const setTracing = useCallback(async (enabled: boolean, durationMinutes: number = minutes) => {
         setTracingBusy(true);
         setTracingMessage(null);
+        const wasRetained = Boolean(status?.retained);
         try {
             const form = new FormData();
             form.append("enabled", enabled ? "true" : "false");
@@ -112,14 +116,19 @@ export function SupportSettings() {
                 const body = await response.json().catch(() => null);
                 throw new Error(body?.error || `Could not update stream tracing (${response.status})`);
             }
-            const next = await response.json() as StreamTracingStatus;
+            const next = toStreamTracingStatus(await response.json() as Record<string, unknown>);
             setStatus(next);
-            setTracingMessage({
-                text: enabled
-                    ? `Stream tracing enabled for ${durationMinutes} minutes. Reproduce the issue, then download a support pack.`
-                    : "Stream tracing turned off and the buffer was released.",
-                variant: "success",
-            });
+            let text: string;
+            if (enabled) {
+                text = wasRetained
+                    ? `Stream tracing resumed for ${durationMinutes} minutes. Reproduce the issue, then download a support pack.`
+                    : `Stream tracing enabled for ${durationMinutes} minutes. Reproduce the issue, then download a support pack.`;
+            } else if (next.retained) {
+                text = `Stream tracing stopped. ${next.eventCount.toLocaleString()} events are still held — generate a support pack, resume tracing, or discard them below.`;
+            } else {
+                text = "Stream tracing stopped. No events were captured.";
+            }
+            setTracingMessage({ text, variant: "success" });
         } catch (error) {
             setTracingMessage({
                 text: error instanceof Error ? error.message : "Could not update stream tracing.",
@@ -128,20 +137,43 @@ export function SupportSettings() {
         } finally {
             setTracingBusy(false);
         }
-    }, [minutes]);
+    }, [minutes, status?.retained]);
 
-    const requestDisable = useCallback(() => {
-        if ((status?.eventCount ?? 0) > 0) {
-            setConfirmDisable(true);
-            return;
+    const discardTraces = useCallback(async () => {
+        setTracingBusy(true);
+        setTracingMessage(null);
+        try {
+            const form = new FormData();
+            form.append("intent", "discard");
+            const response = await fetch("/settings/stream-tracing", { method: "POST", body: form });
+            if (!response.ok) {
+                const body = await response.json().catch(() => null);
+                throw new Error(body?.error || `Could not discard stream traces (${response.status})`);
+            }
+            const next = toStreamTracingStatus(await response.json() as Record<string, unknown>);
+            setStatus(next);
+            setTracingMessage({
+                text: "Captured stream traces were discarded.",
+                variant: "success",
+            });
+        } catch (error) {
+            setTracingMessage({
+                text: error instanceof Error ? error.message : "Could not discard stream traces.",
+                variant: "danger",
+            });
+        } finally {
+            setTracingBusy(false);
         }
-        void setTracing(false);
-    }, [status?.eventCount, setTracing]);
+    }, []);
 
     const enabled = Boolean(status?.enabled);
-    const statusLine = enabled && status
-        ? `Tracing active — ${formatRemaining(status.expiresAtUnixMs, now)}, ${status.eventCount.toLocaleString()} events across ${status.sessionCount.toLocaleString()} sessions`
-        : "Tracing is off.";
+    const retained = Boolean(status?.retained && (status?.eventCount ?? 0) > 0);
+    let statusLine = "Tracing is off.";
+    if (enabled && status) {
+        statusLine = `Tracing active — ${formatRemaining(status.expiresAtUnixMs, now)}, ${status.eventCount.toLocaleString()} events across ${status.sessionCount.toLocaleString()} sessions`;
+    } else if (retained && status) {
+        statusLine = `Tracing is off — ${status.eventCount.toLocaleString()} events across ${status.sessionCount.toLocaleString()} sessions retained for a support pack (released automatically in ${formatRemaining(status.retainedUntilUnixMs, now)})`;
+    }
 
     return (
         <SettingsPage>
@@ -167,7 +199,7 @@ export function SupportSettings() {
                     <li>Current backend logs from the in-memory buffer, plus a separate warnings lane</li>
                     <li>Redacted active settings and runtime information</li>
                     <li>Recent provider outage, failover, and consumption metrics</li>
-                    <li>Stream traces, when developer stream tracing is enabled</li>
+                    <li>Stream traces, while developer stream tracing is on or a capture is retained</li>
                 </ul>
                 <p className="text-xs text-base-content/50">
                     It excludes frontend and container logs, databases, backups, NZBs, blobs, environment files,
@@ -194,7 +226,8 @@ export function SupportSettings() {
                     <span>
                         Tracing is memory-only (up to 20,000 events), never written to disk, and resets on
                         restart. Leave it off unless you are collecting a support pack — a warning banner
-                        appears while it is active.
+                        appears while it is active. Turning it off keeps the capture for about an hour so
+                        you can still download a pack.
                     </span>
                 </Alert>
 
@@ -222,7 +255,7 @@ export function SupportSettings() {
                             if (event.target.checked) {
                                 void setTracing(true, minutes);
                             } else {
-                                requestDisable();
+                                void setTracing(false);
                             }
                         }}
                     />
@@ -235,9 +268,21 @@ export function SupportSettings() {
                         <Button
                             variant="outline"
                             disabled={tracingBusy}
-                            onClick={requestDisable}
+                            onClick={() => void setTracing(false)}
                         >
                             Turn off now
+                        </Button>
+                    </div>
+                )}
+
+                {retained && (
+                    <div>
+                        <Button
+                            variant="outline"
+                            disabled={tracingBusy}
+                            onClick={() => setConfirmDiscard(true)}
+                        >
+                            Discard captured traces
                         </Button>
                     </div>
                 )}
@@ -252,14 +297,14 @@ export function SupportSettings() {
                 {tracingMessage && <Alert variant={tracingMessage.variant}>{tracingMessage.text}</Alert>}
             </SettingsCard>
 
-            <DisableTracingConfirmModal
-                show={confirmDisable}
+            <DiscardTracesConfirmModal
+                show={confirmDiscard}
                 eventCount={status?.eventCount ?? 0}
                 sessionCount={status?.sessionCount ?? 0}
-                onCancel={() => setConfirmDisable(false)}
+                onCancel={() => setConfirmDiscard(false)}
                 onConfirm={() => {
-                    setConfirmDisable(false);
-                    void setTracing(false);
+                    setConfirmDiscard(false);
+                    void discardTraces();
                 }}
             />
         </SettingsPage>

--- a/frontend/app/utils/stream-tracing-status.ts
+++ b/frontend/app/utils/stream-tracing-status.ts
@@ -1,0 +1,23 @@
+export type StreamTracingStatus = {
+    enabled: boolean;
+    source: string;
+    expiresAtUnixMs: number;
+    capacity: number;
+    eventCount: number;
+    sessionCount: number;
+    retained: boolean;
+    retainedUntilUnixMs: number;
+};
+
+export function toStreamTracingStatus(data: Record<string, unknown>): StreamTracingStatus {
+    return {
+        enabled: Boolean(data.enabled),
+        source: typeof data.source === "string" ? data.source : "env",
+        expiresAtUnixMs: Number(data.expiresAtUnixMs ?? 0),
+        capacity: Number(data.capacity ?? 0),
+        eventCount: Number(data.eventCount ?? 0),
+        sessionCount: Number(data.sessionCount ?? 0),
+        retained: Boolean(data.retained),
+        retainedUntilUnixMs: Number(data.retainedUntilUnixMs ?? 0),
+    };
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -15,6 +16,25 @@ namespace NzbWebDAV.Tests.Clients.Usenet;
 
 public class MultiProviderNntpClientTests
 {
+    [Fact]
+    public void BeginStreamTraceRangeScope_RestoresNestedContext()
+    {
+        var rangeA = new StreamTraceRangeContext(Guid.NewGuid(), 1);
+        var rangeB = new StreamTraceRangeContext(Guid.NewGuid(), 2);
+
+        Assert.Null(MultiProviderNntpClient.CurrentStreamTraceRange);
+        using (MultiProviderNntpClient.BeginStreamTraceRangeScope(rangeA))
+        {
+            Assert.Equal(rangeA, MultiProviderNntpClient.CurrentStreamTraceRange);
+            using (MultiProviderNntpClient.BeginStreamTraceRangeScope(rangeB))
+            {
+                Assert.Equal(rangeB, MultiProviderNntpClient.CurrentStreamTraceRange);
+            }
+            Assert.Equal(rangeA, MultiProviderNntpClient.CurrentStreamTraceRange);
+        }
+        Assert.Null(MultiProviderNntpClient.CurrentStreamTraceRange);
+    }
+
     [Fact]
     public async Task BatchResponse_WithUnexpectedResponse_RetriesOnSameProvider()
     {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerHalfOpenTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerHalfOpenTests.cs
@@ -50,6 +50,71 @@ public class ProviderCircuitBreakerHalfOpenTests
         Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
     }
 
+    [Fact]
+    public void ArticleNotFound_DoesNotCloseAnOpenCircuit()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("miss-while-open", transitions.Add);
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+
+        var trippedUntil = breaker.TrippedUntilMs;
+        var cooldown = breaker.CurrentCooldown;
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+
+        for (var i = 0; i < 20; i++) breaker.RecordArticleNotFound();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.Equal(trippedUntil, breaker.TrippedUntilMs);
+        Assert.Equal(cooldown, breaker.CurrentCooldown);
+        Assert.Equal(20, snapshot.ArticleMissCount);
+        Assert.NotNull(snapshot.LastFailureReason);
+        Assert.DoesNotContain(
+            transitions, t => t.State == ProviderCircuitTransitionState.Closed);
+    }
+
+    [Fact]
+    public void ArticleNotFound_DoesNotSatisfyTheHalfOpenProbe()
+    {
+        var breaker = HalfOpen();
+
+        // Claim the probe so _halfOpenProbeInFlight is set, then miss.
+        Assert.False(breaker.IsTripped);
+        breaker.RecordArticleNotFound();
+
+        Assert.Equal(ProviderCircuitState.HalfOpen, breaker.GetSnapshot().State);
+        Assert.Equal(1, breaker.GetSnapshot().ArticleMissCount);
+        // Probe slot stays claimed; only ProbeAbandonTimeout releases it. A real
+        // success would close; a real failure would re-trip. A miss does neither.
+    }
+
+    [Fact]
+    public void CooldownLadderStillDoublesWhenMissesArriveWhileOpen()
+    {
+        // Do NOT interleave misses between the failures that trip the breaker.
+        // On a closed circuit RecordArticleNotFound clears the sampling window, so
+        // interleaved misses would prevent the trip entirely and make this test
+        // assert the wrong property.
+        var breaker = new ProviderCircuitBreaker("ladder-with-misses");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        // Misses while open must not reset the ladder.
+        for (var i = 0; i < 10; i++) breaker.RecordArticleNotFound();
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped); // claim half-open probe
+        breaker.RecordFailure(); // half-open failure re-trips and doubles again
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(TimeSpan.FromSeconds(240), breaker.CurrentCooldown);
+    }
+
     /// <summary>Trips a breaker and lets its cooldown lapse so it lands half-open.</summary>
     private static ProviderCircuitBreaker HalfOpen()
     {

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
@@ -1,0 +1,131 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class ArrMonitoringAggregationTests
+{
+    [Fact]
+    public void GroupResolutions_CollapsesIdenticalTitleAndAction()
+    {
+        var title = "Gintama.S01.1080p.NF.WEB-DL.DDP2.0.H.264-Kitsune";
+        var resolutions = Enumerable.Repeat(
+            ((string?)title, ArrConfig.QueueAction.Remove), 367);
+
+        var groups = ArrMonitoringService.GroupResolutions(resolutions);
+
+        Assert.Single(groups);
+        Assert.Equal(title, groups[0].Key.Title);
+        Assert.Equal(ArrConfig.QueueAction.Remove, groups[0].Key.Action);
+        Assert.Equal(367, groups[0].Count);
+    }
+
+    [Fact]
+    public void GroupResolutions_KeepsDistinctTitlesSeparate()
+    {
+        var resolutions = new (string? Title, ArrConfig.QueueAction Action)[]
+        {
+            ("Release-A", ArrConfig.QueueAction.Remove),
+            ("Release-A", ArrConfig.QueueAction.Remove),
+            ("Release-B", ArrConfig.QueueAction.Remove),
+        };
+
+        var groups = ArrMonitoringService.GroupResolutions(resolutions)
+            .OrderBy(g => g.Key.Title)
+            .ToList();
+
+        Assert.Equal(2, groups.Count);
+        Assert.Equal(("Release-A", ArrConfig.QueueAction.Remove), groups[0].Key);
+        Assert.Equal(2, groups[0].Count);
+        Assert.Equal(("Release-B", ArrConfig.QueueAction.Remove), groups[1].Key);
+        Assert.Equal(1, groups[1].Count);
+    }
+
+    [Fact]
+    public void GroupResolutions_KeepsDistinctActionsSeparate()
+    {
+        var resolutions = new (string? Title, ArrConfig.QueueAction Action)[]
+        {
+            ("Release-A", ArrConfig.QueueAction.Remove),
+            ("Release-A", ArrConfig.QueueAction.RemoveAndBlocklist),
+        };
+
+        var groups = ArrMonitoringService.GroupResolutions(resolutions);
+
+        Assert.Equal(2, groups.Count);
+    }
+
+    [Fact]
+    public void GroupResolutions_MapsNullTitleToUntitled()
+    {
+        var groups = ArrMonitoringService.GroupResolutions(
+        [
+            (null, ArrConfig.QueueAction.Remove),
+            (null, ArrConfig.QueueAction.Remove),
+        ]);
+
+        Assert.Single(groups);
+        Assert.Equal("(untitled)", groups[0].Key.Title);
+        Assert.Equal(2, groups[0].Count);
+    }
+
+    [Fact]
+    public void LogResolutionSummary_EmitsOneWarningPerGroup()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            var title = "Gintama.S01.1080p.NF.WEB-DL.DDP2.0.H.264-Kitsune";
+            var resolutions = Enumerable.Repeat(
+                ((string?)title, ArrConfig.QueueAction.Remove), 367);
+
+            ArrMonitoringService.LogResolutionSummary(resolutions, "http://sonarr:8989");
+
+            var warning = Assert.Single(sink.Events, e => e.Level == LogEventLevel.Warning);
+            Assert.Equal(367, warning.Properties["Count"].LiteralValue());
+            Assert.Equal(title, warning.Properties["QueueItemTitle"].LiteralValue());
+            Assert.Equal("http://sonarr:8989", warning.Properties["Host"].LiteralValue());
+            Assert.Equal(ArrConfig.QueueAction.Remove, warning.Properties["Action"].LiteralValue());
+            Assert.DoesNotContain(sink.Events, e => e.Level == LogEventLevel.Debug);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToList();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}
+
+file static class LogEventPropertyValueExtensions
+{
+    public static object? LiteralValue(this LogEventPropertyValue value) =>
+        value is ScalarValue scalar ? scalar.Value : value.ToString();
+}

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
@@ -92,12 +92,19 @@ public sealed class ArrMonitoringAggregationTests
 
             ArrMonitoringService.LogResolutionSummary(resolutions, "http://sonarr:8989");
 
-            var warning = Assert.Single(sink.Events, e => e.Level == LogEventLevel.Warning);
+            // Filter by template property — other tests (and parallel classes) may write
+            // Warnings to the process-wide Serilog logger while this sink is installed.
+            var warning = Assert.Single(
+                sink.Events,
+                e => e.Level == LogEventLevel.Warning
+                     && e.Properties.ContainsKey("QueueItemTitle"));
             Assert.Equal(367, warning.Properties["Count"].LiteralValue());
             Assert.Equal(title, warning.Properties["QueueItemTitle"].LiteralValue());
             Assert.Equal("http://sonarr:8989", warning.Properties["Host"].LiteralValue());
             Assert.Equal(ArrConfig.QueueAction.Remove, warning.Properties["Action"].LiteralValue());
-            Assert.DoesNotContain(sink.Events, e => e.Level == LogEventLevel.Debug);
+            Assert.DoesNotContain(
+                sink.Events,
+                e => e.Level == LogEventLevel.Debug && e.Properties.ContainsKey("QueueItemTitle"));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 
@@ -12,12 +13,12 @@ public class StreamTraceBufferTests
         var sessionA = Guid.NewGuid();
         var sessionB = Guid.NewGuid();
 
-        buffer.RangeOpen(sessionA, "/view/a.mkv", "GET", 0, 99, 1000, "ua", "127.0.0.1");
+        var rangeA = buffer.RangeOpen(sessionA, "/view/a.mkv", "GET", 0, 99, 1000, "ua", "127.0.0.1");
         buffer.Seek(sessionA, 50);
         buffer.Segment(sessionA, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
         buffer.RangeOpen(sessionB, "/view/b.mkv", "GET", 0, null, 2000, null, null);
         buffer.ZeroFill(sessionA, "missing@a", 64);
-        buffer.RangeEnd(sessionA, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(rangeA, ReadSession.EndReasonCode.Completed, 100);
         buffer.Failover(sessionB, "p1", "p2", "Missing");
 
         var eventsA = buffer.GetSessionEvents(sessionA);
@@ -33,21 +34,21 @@ public class StreamTraceBufferTests
     }
 
     [Fact]
-    public void RangeEnd_ReportsStallAttributionAndResetsItForTheNextRange()
+    public void RangeEnd_IsolatesStallAttributionPerGeneration()
     {
         var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
         var session = Guid.NewGuid();
 
-        buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 1000, null, null);
-        buffer.AddStall(session, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(120));
-        buffer.AddStall(session, StreamStallKind.BodyDrain, TimeSpan.FromMilliseconds(30));
-        buffer.AddStall(session, StreamStallKind.ConsumerWait, TimeSpan.FromMilliseconds(400));
+        var firstRange = buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 1000, null, null);
+        buffer.AddStall(firstRange, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(120));
+        buffer.AddStall(firstRange, StreamStallKind.BodyDrain, TimeSpan.FromMilliseconds(30));
+        buffer.AddStall(firstRange, StreamStallKind.ConsumerWait, TimeSpan.FromMilliseconds(400));
         // Sub-millisecond writes must still accumulate rather than truncate to zero.
         for (var i = 0; i < 10; i++)
-            buffer.AddStall(session, StreamStallKind.ClientWrite, TimeSpan.FromMicroseconds(300));
-        buffer.ConnectionAcquired(session, TimeSpan.FromMilliseconds(70), wasReused: true);
-        buffer.ConnectionAcquired(session, TimeSpan.FromMilliseconds(500), wasReused: false);
-        buffer.RangeEnd(session, ReadSession.EndReasonCode.Aborted, 4096);
+            buffer.AddStall(firstRange, StreamStallKind.ClientWrite, TimeSpan.FromMicroseconds(300));
+        buffer.ConnectionAcquired(firstRange, TimeSpan.FromMilliseconds(70), wasReused: true);
+        buffer.ConnectionAcquired(firstRange, TimeSpan.FromMilliseconds(500), wasReused: false);
+        buffer.RangeEnd(firstRange, ReadSession.EndReasonCode.Aborted, 4096);
 
         var first = buffer.GetSessionEvents(session).Last();
         Assert.Equal(120, first.ProviderWaitMs);
@@ -58,9 +59,9 @@ public class StreamTraceBufferTests
         Assert.Equal(1, first.ConnectionsReused);
         Assert.Equal(1, first.ConnectionsOpened);
 
-        buffer.RangeOpen(session, "/view/a.mkv", "GET", 4096, null, 1000, null, null);
-        buffer.AddStall(session, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(15));
-        buffer.RangeEnd(session, ReadSession.EndReasonCode.Completed, 8192);
+        var secondRange = buffer.RangeOpen(session, "/view/a.mkv", "GET", 4096, null, 1000, null, null);
+        buffer.AddStall(secondRange, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(15));
+        buffer.RangeEnd(secondRange, ReadSession.EndReasonCode.Completed, 8192);
 
         var second = buffer.GetSessionEvents(session).Last();
         Assert.Equal(15, second.ProviderWaitMs);
@@ -70,18 +71,132 @@ public class StreamTraceBufferTests
     }
 
     [Fact]
-    public void AddStall_BeforeAnyRangeOpen_IsIgnored()
+    public void AddStall_WithoutRangeToken_IsIgnored()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+
+        // No range has opened, so there is no generation to attribute to. This must not
+        // create a session — otherwise background work would grow the session index forever.
+        buffer.AddStall(null, StreamStallKind.ClientWrite, TimeSpan.FromSeconds(1));
+        buffer.ConnectionAcquired(null, TimeSpan.FromSeconds(1), wasReused: false);
+
+        Assert.Empty(buffer.ListSessions());
+    }
+
+    [Fact]
+    public void LateFetchCompletion_IsNotBilledToTheNextRange()
     {
         var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
         var session = Guid.NewGuid();
 
-        // No range has opened, so there is no session to attribute to. This must not
-        // create one — otherwise background work would grow the session index forever.
-        buffer.AddStall(session, StreamStallKind.ClientWrite, TimeSpan.FromSeconds(1));
-        buffer.ConnectionAcquired(session, TimeSpan.FromSeconds(1), wasReused: false);
+        var aborted = buffer.RangeOpen(
+            session, "/view/a.mkv", "GET", 0, null, 1_000_000, null, null);
+        buffer.RangeEnd(aborted, ReadSession.EndReasonCode.Aborted, 4096);
 
-        Assert.Empty(buffer.ListSessions());
-        Assert.Empty(buffer.GetSessionEvents(session));
+        var next = buffer.RangeOpen(
+            session, "/view/a.mkv", "GET", 4096, null, 1_000_000, null, null);
+        // Prefetch from the aborted range finally resolves.
+        buffer.AddFetchWait(aborted, TimeSpan.FromMilliseconds(12_580));
+        buffer.AddStall(aborted, StreamStallKind.BodyDrain, TimeSpan.FromMilliseconds(900));
+        buffer.AddFetchWait(next, TimeSpan.FromMilliseconds(15));
+        buffer.RangeEnd(next, ReadSession.EndReasonCode.Completed, 8192);
+
+        var ends = buffer.GetSessionEvents(session)
+            .Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString())
+            .ToList();
+
+        // The already-emitted aborted RangeEnd gains the late totals.
+        Assert.Equal(12_580, ends[0].ProviderWaitMs);
+        Assert.Equal(900, ends[0].BodyDrainMs);
+        Assert.Equal(1, ends[0].Fetches);
+
+        // The next range reports only work that started in that range.
+        Assert.Equal(15, ends[1].ProviderWaitMs);
+        Assert.Null(ends[1].BodyDrainMs);
+        Assert.Equal(1, ends[1].Fetches);
+
+        var jsonl = buffer.FormatEventsJsonl(100);
+        Assert.Contains("\"providerWaitMs\":12580", jsonl);
+        Assert.Contains("\"fetches\":1", jsonl);
+    }
+
+    [Fact]
+    public void RangeEnd_ReportsTheFetchCountAttributedToTheRange()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+        var session = Guid.NewGuid();
+
+        var range = buffer.RangeOpen(
+            session, "/view/a.mkv", "GET", 0, null, 1_000_000, null, null);
+        buffer.AddFetchWait(range, TimeSpan.FromMilliseconds(100));
+        buffer.AddFetchWait(range, TimeSpan.FromMilliseconds(150));
+        buffer.RangeEnd(range, ReadSession.EndReasonCode.Completed, 8192);
+
+        var end = buffer.GetSessionEvents(session).Last();
+        Assert.Equal(250, end.ProviderWaitMs);
+        Assert.Equal(2, end.Fetches);
+    }
+
+    [Fact]
+    public void OverlappingRangesOnTheSameSession_KeepIndependentTokens()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+        var session = Guid.NewGuid();
+
+        var first = buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, 99, 1000, null, null);
+        var second = buffer.RangeOpen(session, "/view/a.mkv", "GET", 100, 199, 1000, null, null);
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotEqual(first!.Value.Generation, second!.Value.Generation);
+
+        buffer.AddFetchWait(first, TimeSpan.FromMilliseconds(40));
+        buffer.AddFetchWait(second, TimeSpan.FromMilliseconds(90));
+
+        // End in reverse open order.
+        buffer.RangeEnd(second, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(first, ReadSession.EndReasonCode.Aborted, 50);
+
+        var events = buffer.GetSessionEvents(session);
+        var opens = events.Where(e => e.Kind == StreamTraceKind.RangeOpen.ToString()).ToList();
+        var ends = events.Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString()).ToList();
+
+        Assert.Equal(first.Value.Generation, opens[0].RangeGeneration);
+        Assert.Equal(second.Value.Generation, opens[1].RangeGeneration);
+        Assert.Equal(second.Value.Generation, ends[0].RangeGeneration);
+        Assert.Equal(90, ends[0].ProviderWaitMs);
+        Assert.Equal(first.Value.Generation, ends[1].RangeGeneration);
+        Assert.Equal(40, ends[1].ProviderWaitMs);
+
+        var json = JsonSerializer.Serialize(ends[0]);
+        Assert.Contains($"\"rangeGeneration\":{second.Value.Generation}", json);
+    }
+
+    [Fact]
+    public void OldGenerationBeyondRetention_IsDroppedRatherThanChargedToCurrentRange()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 200, maxSessions: 50);
+        var session = Guid.NewGuid();
+
+        var oldest = buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 1000, null, null);
+        buffer.RangeEnd(oldest, ReadSession.EndReasonCode.Aborted, 1);
+
+        for (var i = 0; i < 16; i++)
+        {
+            var mid = buffer.RangeOpen(session, "/view/a.mkv", "GET", i + 1, null, 1000, null, null);
+            buffer.RangeEnd(mid, ReadSession.EndReasonCode.Completed, 1);
+        }
+
+        var current = buffer.RangeOpen(session, "/view/a.mkv", "GET", 100, null, 1000, null, null);
+        buffer.AddFetchWait(oldest, TimeSpan.FromMilliseconds(9999));
+        buffer.AddFetchWait(current, TimeSpan.FromMilliseconds(11));
+        buffer.RangeEnd(current, ReadSession.EndReasonCode.Completed, 2);
+
+        var ends = buffer.GetSessionEvents(session)
+            .Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString())
+            .ToList();
+        var currentEnd = ends.Last(e => e.RangeGeneration == current!.Value.Generation);
+        Assert.Equal(11, currentEnd.ProviderWaitMs);
+        Assert.Null(ends[0].ProviderWaitMs);
     }
 
     [Fact]
@@ -90,11 +205,12 @@ public class StreamTraceBufferTests
         var buffer = new StreamTraceBuffer(100, enabled: false);
         var session = Guid.NewGuid();
 
-        buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 10, null, null);
+        var range = buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 10, null, null);
         buffer.Seek(session, 5);
-        buffer.RangeEnd(session, ReadSession.EndReasonCode.Completed, 10);
+        buffer.RangeEnd(range, ReadSession.EndReasonCode.Completed, 10);
 
         Assert.False(buffer.Enabled);
+        Assert.Null(range);
         Assert.Empty(buffer.GetSessionEvents(session));
         Assert.Empty(buffer.ListSessions());
     }

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -18,7 +18,7 @@ public class StreamTraceBufferTests
         buffer.Segment(sessionA, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
         buffer.RangeOpen(sessionB, "/view/b.mkv", "GET", 0, null, 2000, null, null);
         buffer.ZeroFill(sessionA, "missing@a", 64);
-        buffer.RangeEnd(rangeA, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(sessionA, rangeA, ReadSession.EndReasonCode.Completed, 100);
         buffer.Failover(sessionB, "p1", "p2", "Missing");
 
         var eventsA = buffer.GetSessionEvents(sessionA);
@@ -48,7 +48,7 @@ public class StreamTraceBufferTests
             buffer.AddStall(firstRange, StreamStallKind.ClientWrite, TimeSpan.FromMicroseconds(300));
         buffer.ConnectionAcquired(firstRange, TimeSpan.FromMilliseconds(70), wasReused: true);
         buffer.ConnectionAcquired(firstRange, TimeSpan.FromMilliseconds(500), wasReused: false);
-        buffer.RangeEnd(firstRange, ReadSession.EndReasonCode.Aborted, 4096);
+        buffer.RangeEnd(session, firstRange, ReadSession.EndReasonCode.Aborted, 4096);
 
         var first = buffer.GetSessionEvents(session).Last();
         Assert.Equal(120, first.ProviderWaitMs);
@@ -61,7 +61,7 @@ public class StreamTraceBufferTests
 
         var secondRange = buffer.RangeOpen(session, "/view/a.mkv", "GET", 4096, null, 1000, null, null);
         buffer.AddStall(secondRange, StreamStallKind.ProviderWait, TimeSpan.FromMilliseconds(15));
-        buffer.RangeEnd(secondRange, ReadSession.EndReasonCode.Completed, 8192);
+        buffer.RangeEnd(session, secondRange, ReadSession.EndReasonCode.Completed, 8192);
 
         var second = buffer.GetSessionEvents(session).Last();
         Assert.Equal(15, second.ProviderWaitMs);
@@ -91,7 +91,7 @@ public class StreamTraceBufferTests
 
         var aborted = buffer.RangeOpen(
             session, "/view/a.mkv", "GET", 0, null, 1_000_000, null, null);
-        buffer.RangeEnd(aborted, ReadSession.EndReasonCode.Aborted, 4096);
+        buffer.RangeEnd(session, aborted, ReadSession.EndReasonCode.Aborted, 4096);
 
         var next = buffer.RangeOpen(
             session, "/view/a.mkv", "GET", 4096, null, 1_000_000, null, null);
@@ -99,7 +99,7 @@ public class StreamTraceBufferTests
         buffer.AddFetchWait(aborted, TimeSpan.FromMilliseconds(12_580));
         buffer.AddStall(aborted, StreamStallKind.BodyDrain, TimeSpan.FromMilliseconds(900));
         buffer.AddFetchWait(next, TimeSpan.FromMilliseconds(15));
-        buffer.RangeEnd(next, ReadSession.EndReasonCode.Completed, 8192);
+        buffer.RangeEnd(session, next, ReadSession.EndReasonCode.Completed, 8192);
 
         var ends = buffer.GetSessionEvents(session)
             .Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString())
@@ -130,7 +130,7 @@ public class StreamTraceBufferTests
             session, "/view/a.mkv", "GET", 0, null, 1_000_000, null, null);
         buffer.AddFetchWait(range, TimeSpan.FromMilliseconds(100));
         buffer.AddFetchWait(range, TimeSpan.FromMilliseconds(150));
-        buffer.RangeEnd(range, ReadSession.EndReasonCode.Completed, 8192);
+        buffer.RangeEnd(session, range, ReadSession.EndReasonCode.Completed, 8192);
 
         var end = buffer.GetSessionEvents(session).Last();
         Assert.Equal(250, end.ProviderWaitMs);
@@ -153,8 +153,8 @@ public class StreamTraceBufferTests
         buffer.AddFetchWait(second, TimeSpan.FromMilliseconds(90));
 
         // End in reverse open order.
-        buffer.RangeEnd(second, ReadSession.EndReasonCode.Completed, 100);
-        buffer.RangeEnd(first, ReadSession.EndReasonCode.Aborted, 50);
+        buffer.RangeEnd(session, second, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(session, first, ReadSession.EndReasonCode.Aborted, 50);
 
         var events = buffer.GetSessionEvents(session);
         var opens = events.Where(e => e.Kind == StreamTraceKind.RangeOpen.ToString()).ToList();
@@ -178,18 +178,18 @@ public class StreamTraceBufferTests
         var session = Guid.NewGuid();
 
         var oldest = buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 1000, null, null);
-        buffer.RangeEnd(oldest, ReadSession.EndReasonCode.Aborted, 1);
+        buffer.RangeEnd(session, oldest, ReadSession.EndReasonCode.Aborted, 1);
 
         for (var i = 0; i < 16; i++)
         {
             var mid = buffer.RangeOpen(session, "/view/a.mkv", "GET", i + 1, null, 1000, null, null);
-            buffer.RangeEnd(mid, ReadSession.EndReasonCode.Completed, 1);
+            buffer.RangeEnd(session, mid, ReadSession.EndReasonCode.Completed, 1);
         }
 
         var current = buffer.RangeOpen(session, "/view/a.mkv", "GET", 100, null, 1000, null, null);
         buffer.AddFetchWait(oldest, TimeSpan.FromMilliseconds(9999));
         buffer.AddFetchWait(current, TimeSpan.FromMilliseconds(11));
-        buffer.RangeEnd(current, ReadSession.EndReasonCode.Completed, 2);
+        buffer.RangeEnd(session, current, ReadSession.EndReasonCode.Completed, 2);
 
         var ends = buffer.GetSessionEvents(session)
             .Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString())
@@ -200,6 +200,24 @@ public class StreamTraceBufferTests
     }
 
     [Fact]
+    public void RangeEnd_WithoutAnOpenRange_StillRecordsTheTerminalEvent()
+    {
+        var buffer = new StreamTraceBuffer(capacity: 100, maxSessions: 50);
+        var session = Guid.NewGuid();
+
+        // A read that timed out while the stream was still opening never reached RangeOpen.
+        // Dropping its RangeEnd would hide the stall this trace exists to explain.
+        buffer.RangeEnd(
+            session, null, ReadSession.EndReasonCode.Error, 0, "streaming-read-timeout");
+
+        var end = Assert.Single(buffer.GetSessionEvents(session));
+        Assert.Equal(StreamTraceKind.RangeEnd.ToString(), end.Kind);
+        Assert.Equal("streaming-read-timeout", end.Message);
+        Assert.Null(end.RangeGeneration);
+        Assert.Null(end.ProviderWaitMs);
+    }
+
+    [Fact]
     public void DisabledBuffer_RecordsNothing()
     {
         var buffer = new StreamTraceBuffer(100, enabled: false);
@@ -207,7 +225,7 @@ public class StreamTraceBufferTests
 
         var range = buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, null, 10, null, null);
         buffer.Seek(session, 5);
-        buffer.RangeEnd(range, ReadSession.EndReasonCode.Completed, 10);
+        buffer.RangeEnd(session, range, ReadSession.EndReasonCode.Completed, 10);
 
         Assert.False(buffer.Enabled);
         Assert.Null(range);

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -361,6 +361,28 @@ public class StreamTraceBufferTests
     }
 
     [Fact]
+    public void EnableFor_WhileAlreadyRecording_PreservesEventsAndRefreshesTtl()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        var session = Guid.NewGuid();
+        buffer.EnableFor(TimeSpan.FromMinutes(15), 5_000, StreamTraceBuffer.SourceEnv);
+        buffer.Seek(session, 5);
+        var before = buffer.GetStatus().EventCount;
+
+        var refreshed = buffer.EnableFor(
+            TimeSpan.FromMinutes(60),
+            StreamTraceBuffer.DefaultUiCapacity,
+            StreamTraceBuffer.SourceUi);
+
+        Assert.True(refreshed.Enabled);
+        Assert.Equal(StreamTraceBuffer.SourceUi, refreshed.Source);
+        Assert.Equal(before, refreshed.EventCount);
+        Assert.Equal(5_000, refreshed.Capacity);
+        Assert.Single(buffer.GetSessionEvents(session));
+        Assert.True(refreshed.ExpiresAtUnixMs > 0);
+    }
+
+    [Fact]
     public void ExpireRetentionForTests_SetsExpiryUntilDiscard()
     {
         var buffer = new StreamTraceBuffer(100);

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -231,25 +231,132 @@ public class StreamTraceBufferTests
     }
 
     [Fact]
-    public void EnableFor_UiSource_CapturesEventsUntilDisabled()
+    public void StopRecording_RetainsTheCaptureAndStopsAcceptingEvents()
     {
         var buffer = new StreamTraceBuffer(100, enabled: false);
-        Assert.False(buffer.Enabled);
-
-        var status = buffer.EnableFor(TimeSpan.FromMinutes(15), 5_000, StreamTraceBuffer.SourceUi);
-        Assert.True(status.Enabled);
-        Assert.Equal(StreamTraceBuffer.SourceUi, status.Source);
-        Assert.True(status.ExpiresAtUnixMs > 0);
-        Assert.Equal(5_000, status.Capacity);
-
         var session = Guid.NewGuid();
+        buffer.EnableFor(TimeSpan.FromMinutes(15), 5_000, StreamTraceBuffer.SourceUi);
         buffer.RangeOpen(session, "/view/a.mkv", "GET", 0, 1, 10, null, null);
-        Assert.Single(buffer.GetSessionEvents(session));
 
-        buffer.Disable();
-        Assert.False(buffer.Enabled);
+        var status = buffer.StopRecording();
+        buffer.Seek(session, 5);
+
+        Assert.False(status.Enabled);
+        Assert.True(status.Retained);
+        Assert.True(buffer.HasRetainedEvents);
+        Assert.True(status.RetainedUntilUnixMs > 0);
+        Assert.Equal(0, status.ExpiresAtUnixMs);
+        Assert.Single(buffer.GetSessionEvents(session));
+        Assert.Single(buffer.ListSessions());
+        Assert.NotEmpty(buffer.FormatEventsJsonl(100));
+    }
+
+    [Fact]
+    public void Discard_ReleasesTheRetainedCapture()
+    {
+        var buffer = new StreamTraceBuffer(100);
+        var session = Guid.NewGuid();
+        buffer.Seek(session, 5);
+        buffer.StopRecording();
+
+        var status = buffer.Discard();
+
+        Assert.False(status.Enabled);
+        Assert.False(status.Retained);
+        Assert.False(buffer.HasRetainedEvents);
+        Assert.Equal(0, status.RetainedUntilUnixMs);
+        Assert.Equal(0, status.EventCount);
         Assert.Empty(buffer.ListSessions());
         Assert.Empty(buffer.GetSessionEvents(session));
+    }
+
+    [Fact]
+    public void StopRecording_WithNoEvents_ReleasesTheEmptyRing()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        buffer.EnableFor(
+            TimeSpan.FromMinutes(15),
+            StreamTraceBuffer.DefaultUiCapacity,
+            StreamTraceBuffer.SourceUi);
+
+        var first = buffer.StopRecording();
+        var second = buffer.StopRecording();
+
+        Assert.False(first.Enabled);
+        Assert.False(first.Retained);
+        Assert.False(buffer.HasRetainedEvents);
+        Assert.Equal(0, first.RetainedUntilUnixMs);
+        Assert.Equal(0, first.EventCount);
+        Assert.Equal(0, first.SessionCount);
+        Assert.Equal(first, second);
+        Assert.Empty(buffer.GetRecentEvents(100));
+    }
+
+    [Fact]
+    public void StopRecording_IsIdempotentAndDoesNotExtendRetention()
+    {
+        var buffer = new StreamTraceBuffer(100);
+        buffer.Seek(Guid.NewGuid(), 5);
+
+        var first = buffer.StopRecording();
+        Thread.Sleep(5);
+        var second = buffer.StopRecording();
+
+        Assert.True(first.Retained);
+        Assert.True(second.Retained);
+        Assert.Equal(first.RetainedUntilUnixMs, second.RetainedUntilUnixMs);
+        Assert.Equal(first.EventCount, second.EventCount);
+    }
+
+    [Fact]
+    public void EnableFor_ResumesRetainedCapture()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        var session = Guid.NewGuid();
+        buffer.EnableFor(TimeSpan.FromMinutes(15), 5_000, StreamTraceBuffer.SourceUi);
+        buffer.Seek(session, 5);
+        var stopped = buffer.StopRecording();
+
+        var resumed = buffer.EnableFor(
+            TimeSpan.FromMinutes(30),
+            StreamTraceBuffer.DefaultUiCapacity,
+            StreamTraceBuffer.SourceUi);
+        buffer.Seek(session, 6);
+
+        Assert.True(stopped.Retained);
+        Assert.True(resumed.Enabled);
+        Assert.False(resumed.Retained);
+        Assert.False(buffer.HasRetainedEvents);
+        Assert.Equal(0, resumed.RetainedUntilUnixMs);
+        Assert.Equal(5_000, resumed.Capacity);
+        var events = buffer.GetSessionEvents(session);
+        Assert.Equal(2, events.Count);
+        Assert.Equal([1L, 2L], events.Select(entry => entry.Sequence));
+        Assert.Equal(2, buffer.ListSessions().Single().EventCount);
+        Assert.Equal(2, buffer.FormatEventsJsonl(100).Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+
+        buffer.Discard();
+        var fresh = buffer.EnableFor(TimeSpan.FromMinutes(15), 100, StreamTraceBuffer.SourceUi);
+        Assert.Equal(0, fresh.EventCount);
+        Assert.Equal(0, fresh.SessionCount);
+        Assert.Empty(buffer.GetSessionEvents(session));
+    }
+
+    [Fact]
+    public void ExpireRetentionForTests_SetsExpiryUntilDiscard()
+    {
+        var buffer = new StreamTraceBuffer(100);
+        buffer.Seek(Guid.NewGuid(), 5);
+        buffer.StopRecording();
+
+        buffer.ExpireRetentionForTests();
+
+        Assert.True(buffer.IsRetentionExpired);
+        Assert.True(buffer.GetStatus().Retained);
+
+        var discarded = buffer.Discard();
+        Assert.False(buffer.IsRetentionExpired);
+        Assert.False(discarded.Retained);
     }
 
     [Fact]
@@ -277,7 +384,7 @@ public class StreamTraceBufferTests
         Assert.True(buffer.IsExpired);
         Assert.False(buffer.Enabled);
 
-        buffer.Disable();
+        buffer.StopRecording();
         Assert.False(buffer.IsExpired);
         Assert.False(buffer.Enabled);
     }

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -218,7 +218,7 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
-    public async Task Pack_IncludesStreamTracesOnlyWhileTracingIsEnabled()
+    public async Task Pack_IncludesStreamTracesWhileTracingIsEnabled()
     {
         var disabled = await ReadPackEntriesAsync(
             new LogBufferSink(10),
@@ -265,6 +265,53 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.Equal("ui", tracing.GetProperty("source").GetString());
         Assert.True(tracing.GetProperty("expiresAtUnixMs").GetInt64() > 0);
         Assert.True(tracing.GetProperty("eventCount").GetInt64() >= 4);
+    }
+
+    [Fact]
+    public async Task Pack_IncludesRetainedStreamTracesUntilDiscarded()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        buffer.EnableFor(TimeSpan.FromMinutes(15), 100, StreamTraceBuffer.SourceUi);
+        var session = Guid.NewGuid();
+        buffer.RangeOpen(session, "/view/retained.mkv", "GET", 0, 99, 1000, null, null);
+        buffer.StopRecording();
+
+        var retained = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            buffer);
+
+        using (var manifest = JsonDocument.Parse(retained["manifest.json"]))
+        {
+            Assert.Equal(
+                "included",
+                manifest.RootElement.GetProperty("sections").GetProperty("streamTraces").GetString());
+        }
+
+        Assert.Contains("/view/retained.mkv", retained["stream-traces/sessions.json"]);
+        Assert.Contains("RangeOpen", retained["stream-traces/events.jsonl"]);
+
+        using (var environment = JsonDocument.Parse(retained["environment.json"]))
+        {
+            var tracing = environment.RootElement.GetProperty("streamTracing");
+            Assert.False(tracing.GetProperty("enabled").GetBoolean());
+            Assert.True(tracing.GetProperty("retained").GetBoolean());
+            Assert.True(tracing.GetProperty("retainedUntilUnixMs").GetInt64() > 0);
+            Assert.True(tracing.GetProperty("eventCount").GetInt64() > 0);
+        }
+
+        buffer.Discard();
+        var discarded = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            buffer);
+
+        using var discardedManifest = JsonDocument.Parse(discarded["manifest.json"]);
+        Assert.Equal(
+            "disabled",
+            discardedManifest.RootElement.GetProperty("sections").GetProperty("streamTraces").GetString());
+        Assert.False(discarded.ContainsKey("stream-traces/sessions.json"));
+        Assert.False(discarded.ContainsKey("stream-traces/events.jsonl"));
     }
 
     private static Task<Dictionary<string, string>> ReadPackEntriesAsync(

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -241,7 +241,7 @@ public sealed class SupportPackContentsTests : IDisposable
         var range = buffer.RangeOpen(session, "/view/movie.mkv", "GET", 0, 99, 1000, "ua", "203.0.113.10");
         buffer.Seek(session, 50);
         buffer.Segment(session, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
-        buffer.RangeEnd(range, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(session, range, ReadSession.EndReasonCode.Completed, 100);
 
         var enabled = await ReadPackEntriesAsync(
             new LogBufferSink(10),

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -238,10 +238,10 @@ public sealed class SupportPackContentsTests : IDisposable
         var buffer = new StreamTraceBuffer(100, enabled: false);
         buffer.EnableFor(TimeSpan.FromMinutes(15), 100, StreamTraceBuffer.SourceUi);
         var session = Guid.NewGuid();
-        buffer.RangeOpen(session, "/view/movie.mkv", "GET", 0, 99, 1000, "ua", "203.0.113.10");
+        var range = buffer.RangeOpen(session, "/view/movie.mkv", "GET", 0, 99, 1000, "ua", "203.0.113.10");
         buffer.Seek(session, 50);
         buffer.Segment(session, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
-        buffer.RangeEnd(session, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(range, ReadSession.EndReasonCode.Completed, 100);
 
         var enabled = await ReadPackEntriesAsync(
             new LogBufferSink(10),

--- a/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
@@ -1,5 +1,6 @@
 using NWebDav.Server;
 using NWebDav.Server.Stores;
+using NzbWebDAV.Tests.TestUtils;
 using NzbWebDAV.WebDav.Base;
 using NzbWebDAV.WebDav.Requests;
 using Serilog;
@@ -8,6 +9,7 @@ using Serilog.Events;
 
 namespace NzbWebDAV.Tests.WebDav;
 
+[Collection(nameof(GlobalLoggerCollection))]
 public sealed class BaseStoreCollectionTests
 {
     private const int MethodNotAllowed = 405;
@@ -77,6 +79,7 @@ public sealed class BaseStoreCollectionTests
     [Fact]
     public async Task ReadonlyCollection_AggregatesRepeatedWriteRejectionsIntoOneWarning()
     {
+        ReadonlyWriteRejectionLog.ResetForTests();
         var sink = new CollectingSink();
         var previous = Log.Logger;
         Log.Logger = new LoggerConfiguration()
@@ -86,12 +89,7 @@ public sealed class BaseStoreCollectionTests
 
         try
         {
-            // A distinct UniqueKey keeps this case independent of the process-wide throttle
-            // state left behind by other tests.
-            var collection = new ReadonlyCollection
-            {
-                Key = $"flood-{Guid.NewGuid()}",
-            };
+            var collection = new ReadonlyCollection();
 
             for (var i = 0; i < 25; i++)
             {
@@ -104,6 +102,65 @@ public sealed class BaseStoreCollectionTests
 
             Assert.Single(warnings);
             Assert.Equal(25, debugs.Count);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ReadonlyCollections_AcrossManyDirectories_ShareOneWarningWindow()
+    {
+        ReadonlyWriteRejectionLog.ResetForTests();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            // One collection per release, exactly as a per-release sidecar write storm sees it.
+            for (var release = 0; release < 40; release++)
+            {
+                var collection = new ReadonlyCollection { Key = $"release-{release}" };
+                await collection.CreateItemAsync(
+                    "metadata.nfo", Stream.Null, overwrite: true, CancellationToken.None);
+            }
+
+            Assert.Single(sink.Events, e => e.Level == LogEventLevel.Warning);
+            Assert.Equal(40, sink.Events.Count(e => e.Level == LogEventLevel.Debug));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task CompletedSymlinksScopeKey_CollapsesManyDirectoriesOntoOneWindow()
+    {
+        ReadonlyWriteRejectionLog.ResetForTests();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            for (var release = 0; release < 40; release++)
+            {
+                var collection = new SymlinkScopedCollection { Key = $"release-{release}" };
+                await collection.CreateItemAsync(
+                    "metadata.nfo", Stream.Null, overwrite: true, CancellationToken.None);
+            }
+
+            Assert.Single(sink.Events, e => e.Level == LogEventLevel.Warning);
+            Assert.Equal(40, sink.Events.Count(e => e.Level == LogEventLevel.Debug));
         }
         finally
         {
@@ -147,6 +204,26 @@ public sealed class BaseStoreCollectionTests
 
             return Task.FromResult<IStoreItem?>(null);
         }
+
+        protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class SymlinkScopedCollection : BaseStoreReadonlyCollection
+    {
+        public string Key { get; init; } = "symlink-scoped";
+
+        public override string Name => "release";
+        public override string UniqueKey => Key;
+        public override DateTime CreatedAt => DateTime.UnixEpoch;
+        protected override string WriteRejectionScopeKey => "completed-symlinks";
+
+        protected override Task<IStoreItem?> GetItemAsync(GetItemRequest request)
+            => Task.FromResult<IStoreItem?>(null);
 
         protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)

--- a/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/BaseStoreCollectionTests.cs
@@ -139,8 +139,10 @@ public sealed class BaseStoreCollectionTests
         }
     }
 
+    // Covers the override shape DatabaseStoreSymlinkCollection uses ("completed-symlinks"),
+    // where sibling release directories are distinct types-per-instance only by UniqueKey.
     [Fact]
-    public async Task CompletedSymlinksScopeKey_CollapsesManyDirectoriesOntoOneWindow()
+    public async Task OverriddenScopeKey_CollapsesManyDirectoriesOntoOneWindow()
     {
         ReadonlyWriteRejectionLog.ResetForTests();
         var sink = new CollectingSink();


### PR DESCRIPTION
## Summary
- **#682** — a missing article (430) no longer resets an open provider circuit breaker, clears its cooldown ladder, or satisfies the half-open probe
- **#680** — residual after #687: read-only write rejections throttle per mount (`completed-symlinks` shares one window) so a per-release metadata write storm collapses to one Warning (MKCOL 405 already landed in #687; the client-side write loop cannot be stopped server-side)
- **#684** — Arr stuck-queue removals log one Warning per release+action instead of one per episode record
- **#683** — range stall totals bill the range that started each fetch; late prefetch completions update the old `RangeEnd` via live generation buckets instead of the next scrub range
- **#685** — stopping stream tracing retains the capture for one hour (or until Discard) so support packs collected after turn-off still include `stream-traces/`; UI exposes retained status and an explicit discard action; re-enable resumes without wiping

## Test plan
- [ ] Backend: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Frontend: `cd frontend && npm run typecheck && npm run build && npm test`
- [ ] Docs: `zensical build --clean --strict`
- [ ] Reproduce a 430 storm against a tripped provider — breaker stays open / half-open; no Closed transition from misses alone
- [ ] Point a metadata-writing client at completed-symlinks — one Warning per operation type per window, not one per release directory
- [ ] Configure Arr remove-on-stuck for a season pack — one Warning summarizing N removals, Debug per record
- [ ] Enable stream tracing, scrub/abort ranges under load, collect a support pack — aborted `RangeEnd` shows late `providerWaitMs`/`fetches`; next range stays clean; pair events by `rangeGeneration`
- [ ] Turn tracing off, download a support pack — `stream-traces/` included with `retained: true`; Discard clears; re-enable resumes without wiping

Fixes #680
Fixes #682
Fixes #683
Fixes #684
Fixes #685