### PR TITLE
fix(ui): Test Conn shows failure reasons and works with saved Arr/rclone credentials

### DIFF
--- a/backend/Api/Controllers/TestArrConnection/TestArrConnectionController.cs
+++ b/backend/Api/Controllers/TestArrConnection/TestArrConnectionController.cs
@@ -1,11 +1,14 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestArrConnection;
 
 [ApiController]
 [Route("api/test-arr-connection")]
-public class TestArrConnectionController() : BaseApiController
+public class TestArrConnectionController(ConfigManager configManager) : BaseApiController
 {
     private static async Task<TestArrConnectionResponse> TestArrConnection(TestArrConnectionRequest request)
     {
@@ -13,10 +16,42 @@ public class TestArrConnectionController() : BaseApiController
         {
             var client = new ArrClient(request.Host, request.ApiKey);
             var apiInfo = await client.GetApiInfo().ConfigureAwait(false);
+            if (apiInfo.Current?.Length > 0)
+            {
+                return new TestArrConnectionResponse
+                {
+                    Status = true,
+                    Connected = true
+                };
+            }
+
             return new TestArrConnectionResponse
             {
                 Status = true,
-                Connected = apiInfo.Current?.Length > 0
+                Connected = false,
+                Error = "Connected but received empty API info"
+            };
+        }
+        catch (HttpRequestException e) when (
+            e.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            return new TestArrConnectionResponse
+            {
+                Status = true,
+                Connected = false,
+                Error = "Authentication failed"
+            };
+        }
+        catch (HttpRequestException e)
+        {
+            var error = e.StatusCode is { } code
+                ? $"HTTP {(int)code}"
+                : e.Message;
+            return new TestArrConnectionResponse
+            {
+                Status = true,
+                Connected = false,
+                Error = error
             };
         }
         catch (Exception e)
@@ -32,7 +67,7 @@ public class TestArrConnectionController() : BaseApiController
 
     protected override async Task<IActionResult> HandleRequest()
     {
-        var request = new TestArrConnectionRequest(HttpContext);
+        var request = new TestArrConnectionRequest(HttpContext, configManager);
         var response = await TestArrConnection(request).ConfigureAwait(false);
         return Ok(response);
     }

--- a/backend/Api/Controllers/TestArrConnection/TestArrConnectionRequest.cs
+++ b/backend/Api/Controllers/TestArrConnection/TestArrConnectionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestArrConnection;
 
@@ -7,12 +8,13 @@ public class TestArrConnectionRequest
     public string Host { get; init; }
     public string ApiKey { get; init; }
 
-    public TestArrConnectionRequest(HttpContext context)
+    public TestArrConnectionRequest(HttpContext context, ConfigManager configManager)
     {
         Host = context.Request.Form["host"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Arr host is required");
 
-        ApiKey = context.Request.Form["apiKey"].FirstOrDefault()
-                 ?? throw new BadHttpRequestException("Arr apiKey is required");
+        var submittedApiKey = context.Request.Form["apiKey"].FirstOrDefault()
+               ?? throw new BadHttpRequestException("Arr apiKey is required");
+        ApiKey = ArrApiKeyResolver.Resolve(submittedApiKey, configManager);
     }
 }

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
@@ -1,11 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Rclone;
+using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestRcloneConnection;
 
 [ApiController]
 [Route("api/test-rclone-connection")]
-public class TestRcloneConnectionController() : BaseApiController
+public class TestRcloneConnectionController(ConfigManager configManager) : BaseApiController
 {
     private static async Task<TestRcloneConnectionResponse> TestRcloneConnection(TestRcloneConnectionRequest request)
     {
@@ -35,7 +36,7 @@ public class TestRcloneConnectionController() : BaseApiController
 
     protected override async Task<IActionResult> HandleRequest()
     {
-        var request = new TestRcloneConnectionRequest(HttpContext);
+        var request = new TestRcloneConnectionRequest(HttpContext, configManager);
         var response = await TestRcloneConnection(request).ConfigureAwait(false);
         return Ok(response);
     }

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionRequest.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestRcloneConnection;
 
@@ -8,12 +9,12 @@ public class TestRcloneConnectionRequest
     public string? User { get; init; }
     public string? Pass { get; init; }
 
-    public TestRcloneConnectionRequest(HttpContext context)
+    public TestRcloneConnectionRequest(HttpContext context, ConfigManager configManager)
     {
         Host = context.Request.Form["host"].FirstOrDefault()
                ?? throw new BadHttpRequestException("Rclone host is required");
 
         User = context.Request.Form["user"].FirstOrDefault();
-        Pass = context.Request.Form["pass"].FirstOrDefault();
+        Pass = RclonePassResolver.Resolve(context.Request.Form["pass"].FirstOrDefault(), configManager);
     }
 }

--- a/backend/Config/ArrApiKeyResolver.cs
+++ b/backend/Config/ArrApiKeyResolver.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Resolves an Arr instance API key that may be a UI mask token back to the
+/// stored plaintext, so test-connection can auth without forcing re-entry.
+/// </summary>
+public static class ArrApiKeyResolver
+{
+    public const string InstancesConfigName = ConfigKeys.ArrInstances;
+
+    public static string Resolve(string submittedApiKey, ConfigManager configManager)
+    {
+        if (!ConfigSecretMasker.IsMaskToken(submittedApiKey))
+            return submittedApiKey;
+
+        var masker = new ConfigSecretMasker(
+            EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
+        var existingJson = JsonSerializer.Serialize(configManager.GetArrConfig());
+        return masker.ResolveMaskedJsonSecret(InstancesConfigName, submittedApiKey, existingJson);
+    }
+}

--- a/backend/Config/RclonePassResolver.cs
+++ b/backend/Config/RclonePassResolver.cs
@@ -1,0 +1,23 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Resolves an rclone RC password that may be a UI mask token back to the
+/// stored plaintext, so test-connection can auth without forcing re-entry.
+/// </summary>
+public static class RclonePassResolver
+{
+    public static string? Resolve(string? submittedPass, ConfigManager configManager)
+    {
+        if (submittedPass is null || !ConfigSecretMasker.IsMaskToken(submittedPass))
+            return submittedPass;
+
+        var masker = new ConfigSecretMasker(
+            EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
+        return masker.ResolveForUpdate(
+            ConfigKeys.RclonePass,
+            submittedPass,
+            configManager.GetRclonePass());
+    }
+}

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -9,6 +9,10 @@
 | Sonarr Host / API Key | Test Conn available |
 | Automatic Queue Management | Per status message: Do Nothing / Remove / Remove+Blocklist / Remove+Blocklist+Search |
 
+**Test Conn** validates host reachability, API key auth, and a successful API response
+(`GET /api`). It works with already-saved (masked) API keys — you do not need to re-enter
+the key after reload. Failures show a reason (authentication, HTTP status, or network error).
+
 Only **Usenet** queue items are acted upon. Typical mappings:
 
 - **Remove, Blocklist, and Search** — no eligible files, samples, no audio tracks

--- a/docs/configuration/rclone.md
+++ b/docs/configuration/rclone.md
@@ -15,6 +15,11 @@ Notify rclone RC when WebDAV files change (useful with high `dir-cache-time`).
 | Rclone Server User | `rclone.user` | empty | Optional |
 | Rclone Server Password | `rclone.pass` | empty | Optional |
 
+**Test Conn** (next to the host field) validates RC reachability, credentials, and a successful
+API response (`POST core/version`). It works with an already-saved (masked) password — you do
+not need to re-enter it after reload. Failures show a reason (authentication, HTTP status, or
+network error). Password may be left empty when the RC server has no auth.
+
 Mount directory for symlink imports is configured on the [SABnzbd](sabnzbd.md) tab (`rclone.mount-dir`).
 
 [Mounting WebDAV](../guides/mounting-webdav.md)

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -1,10 +1,9 @@
 import { Button } from "~/components/ui/button";
-import { Spinner } from "~/components/ui/feedback";
+import { Alert, Spinner, Tooltip } from "~/components/ui/feedback";
 import { SettingsCard, SettingsIntro, SettingsPage, ManagedSetting } from "~/components/ui";
 import { Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
-import { isMaskedSecret } from "~/utils/config-mask";
 
 type ArrsSettingsProps = {
     config: Record<string, string>
@@ -311,17 +310,20 @@ interface InstanceFormProps {
 
 function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFormProps) {
     const [connectionState, setConnectionState] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+    const [testError, setTestError] = useState<string | null>(null);
 
     useEffect(() => {
         setConnectionState('idle');
+        setTestError(null);
     }, [instance.Host, instance.ApiKey]);
 
     const testConnection = useCallback(async (host: string, apiKey: string) => {
-        if (!host.trim() || !apiKey.trim() || isMaskedSecret(apiKey)) {
+        if (!host.trim() || !apiKey.trim()) {
             return;
         }
 
         setConnectionState('testing');
+        setTestError(null);
 
         try {
             const formData = new FormData();
@@ -337,11 +339,14 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
 
             if (result.status && result.connected) {
                 setConnectionState('success');
+                setTestError(null);
             } else {
                 setConnectionState('error');
+                setTestError(result.error || "Connection test failed");
             }
         } catch (error) {
             setConnectionState('error');
+            setTestError(error instanceof Error ? error.message : "Connection test failed");
         }
     }, []);
 
@@ -363,28 +368,40 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
                             placeholder={type === "radarr" ? "http://localhost:7878" : "http://localhost:8989"}
                             value={instance.Host}
                             onChange={e => onUpdate(index, 'Host', e.target.value)} />
-                        {instance.Host.trim() && instance.ApiKey.trim() && !isMaskedSecret(instance.ApiKey) && (
-                            <Button
-                                variant={connectionState === 'success' ? 'success' :
-                                    connectionState === 'error' ? 'danger' : 'secondary'}
-                                onClick={() => testConnection(instance.Host, instance.ApiKey)}
-                                disabled={connectionState === 'testing'}
-                                className={'shrink-0'}
-                            >
-                                {
-                                    connectionState === 'testing' ? (
-                                        <Spinner />
-                                    ) : connectionState === 'success' ? (
-                                        <Icon name="check" className="!text-[18px]" />
-                                    ) : connectionState === 'error' ? (
-                                        <Icon name="close" className="!text-[18px]" />
-                                    ) : (
-                                        'Test Conn'
-                                    )
-                                }
-                            </Button>
+                        {instance.Host.trim() && instance.ApiKey.trim() && (
+                            <Tooltip content="Tests host, credentials, and API response">
+                                <Button
+                                    variant={connectionState === 'success' ? 'success' :
+                                        connectionState === 'error' ? 'danger' : 'secondary'}
+                                    onClick={() => testConnection(instance.Host, instance.ApiKey)}
+                                    disabled={connectionState === 'testing'}
+                                    className={'shrink-0'}
+                                >
+                                    {
+                                        connectionState === 'testing' ? (
+                                            <Spinner />
+                                        ) : connectionState === 'success' ? (
+                                            <Icon name="check" className="!text-[18px]" />
+                                        ) : connectionState === 'error' ? (
+                                            <Icon name="close" className="!text-[18px]" />
+                                        ) : (
+                                            'Test Conn'
+                                        )
+                                    }
+                                </Button>
+                            </Tooltip>
                         )}
                     </div>
+                    {connectionState === 'error' && testError && (
+                        <Alert variant="danger" className="text-xs py-2">
+                            {testError}
+                        </Alert>
+                    )}
+                    {connectionState === 'success' && (
+                        <Alert variant="success" className="text-xs py-2">
+                            Connection test successful
+                        </Alert>
+                    )}
                 </div>
                 <div className="space-y-2">
                     <label className="block text-sm font-medium text-base-content">API Key</label>

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -1,10 +1,9 @@
 import { Button } from "~/components/ui/button";
-import { Spinner, Tooltip } from "~/components/ui/feedback";
+import { Alert, Spinner, Tooltip } from "~/components/ui/feedback";
 import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Input, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
-import { isMaskedSecret } from "~/utils/config-mask";
 
 type RcloneSettingsProps = {
     config: Record<string, string>
@@ -13,18 +12,21 @@ type RcloneSettingsProps = {
 
 export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
     const [connectionState, setConnectionState] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+    const [testError, setTestError] = useState<string | null>(null);
 
     useEffect(() => {
         setConnectionState('idle');
+        setTestError(null);
     }, [config["rclone.host"], config["rclone.user"], config["rclone.pass"]]);
 
     const testConnection = useCallback(async () => {
         const host = config["rclone.host"];
-        if (!host?.trim() || isMaskedSecret(config["rclone.pass"])) {
+        if (!host?.trim()) {
             return;
         }
 
         setConnectionState('testing');
+        setTestError(null);
 
         try {
             const formData = new FormData();
@@ -41,11 +43,14 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
 
             if (result.status && result.connected) {
                 setConnectionState('success');
+                setTestError(null);
             } else {
                 setConnectionState('error');
+                setTestError(result.error || "Connection test failed");
             }
         } catch (error) {
             setConnectionState('error');
+            setTestError(error instanceof Error ? error.message : "Connection test failed");
         }
     }, [config]);
 
@@ -92,28 +97,40 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                         placeholder="http://localhost:5572"
                         value={config["rclone.host"]}
                         onChange={e => setNewConfig({ ...config, "rclone.host": e.target.value })} />
-                    {config["rclone.host"]?.trim() && !isMaskedSecret(config["rclone.pass"]) && (
-                        <Button
-                            variant={connectionState === 'success' ? 'success' :
-                                connectionState === 'error' ? 'danger' : 'secondary'}
-                            onClick={testConnection}
-                            disabled={connectionState === 'testing'}
-                            className={'shrink-0'}
-                        >
-                            {
-                                connectionState === 'testing' ? (
-                                    <Spinner />
-                                ) : connectionState === 'success' ? (
-                                    <Icon name="check" className="!text-[18px]" />
-                                ) : connectionState === 'error' ? (
-                                    <Icon name="close" className="!text-[18px]" />
-                                ) : (
-                                    'Test Conn'
-                                )
-                            }
-                        </Button>
+                    {config["rclone.host"]?.trim() && (
+                        <Tooltip content="Tests host, credentials, and API response">
+                            <Button
+                                variant={connectionState === 'success' ? 'success' :
+                                    connectionState === 'error' ? 'danger' : 'secondary'}
+                                onClick={testConnection}
+                                disabled={connectionState === 'testing'}
+                                className={'shrink-0'}
+                            >
+                                {
+                                    connectionState === 'testing' ? (
+                                        <Spinner />
+                                    ) : connectionState === 'success' ? (
+                                        <Icon name="check" className="!text-[18px]" />
+                                    ) : connectionState === 'error' ? (
+                                        <Icon name="close" className="!text-[18px]" />
+                                    ) : (
+                                        'Test Conn'
+                                    )
+                                }
+                            </Button>
+                        </Tooltip>
                     )}
                 </div>
+                {connectionState === 'error' && testError && (
+                    <Alert variant="danger" className="text-xs py-2">
+                        {testError}
+                    </Alert>
+                )}
+                {connectionState === 'success' && (
+                    <Alert variant="success" className="text-xs py-2">
+                        Connection test successful
+                    </Alert>
+                )}
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="rclone-host-help">
                     The host address of the rclone RC API.
                 </p>

--- a/tests/NzbWebDAV.Tests/Config/ArrApiKeyResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ArrApiKeyResolverTests.cs
@@ -2,12 +2,11 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
-using NzbWebDAV.Models;
 
 namespace NzbWebDAV.Tests.Config;
 
 [Collection(nameof(SecretResolverCollection))]
-public class UsenetPassResolverTests
+public class ArrApiKeyResolverTests
 {
     [Fact]
     public void Resolve_ReturnsPlaintextUnchanged()
@@ -15,48 +14,51 @@ public class UsenetPassResolverTests
         using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
         var configManager = new ConfigManager();
 
-        var resolved = UsenetPassResolver.Resolve("typed-password", configManager);
+        var resolved = ArrApiKeyResolver.Resolve("typed-api-key", configManager);
 
-        Assert.Equal("typed-password", resolved);
+        Assert.Equal("typed-api-key", resolved);
     }
 
     [Fact]
-    public void Resolve_UnmasksStoredProviderPassword()
+    public void Resolve_UnmasksStoredArrApiKey()
     {
         using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
-        var stored = JsonSerializer.Serialize(new UsenetProviderConfig
+        var stored = JsonSerializer.Serialize(new ArrConfig
         {
-            Providers =
+            RadarrInstances =
             [
-                new UsenetProviderConfig.ConnectionDetails
+                new ArrConfig.ConnectionDetails
                 {
-                    Type = ProviderType.Pooled,
-                    Host = "news.example",
-                    Port = 563,
-                    UseSsl = true,
-                    User = "user",
-                    Pass = "stored-secret",
-                    MaxConnections = 10,
+                    Host = "http://radarr:7878",
+                    ApiKey = "stored-radarr-key",
                 }
-            ]
+            ],
+            SonarrInstances =
+            [
+                new ArrConfig.ConnectionDetails
+                {
+                    Host = "http://sonarr:8989",
+                    ApiKey = "stored-sonarr-key",
+                }
+            ],
         });
         var configManager = new ConfigManager();
         configManager.UpdateValues(
         [
-            new ConfigItem { ConfigName = "usenet.providers", ConfigValue = stored }
+            new ConfigItem { ConfigName = ConfigKeys.ArrInstances, ConfigValue = stored }
         ]);
 
         var masker = new ConfigSecretMasker("test-signing-key");
-        var masked = masker.MaskForResponse("usenet.providers", stored);
+        var masked = masker.MaskForResponse(ConfigKeys.ArrInstances, stored);
         using var document = JsonDocument.Parse(masked);
         var token = document.RootElement
-            .GetProperty("Providers")[0]
-            .GetProperty("Pass")
+            .GetProperty("SonarrInstances")[0]
+            .GetProperty("ApiKey")
             .GetString()!;
 
-        var resolved = UsenetPassResolver.Resolve(token, configManager);
+        var resolved = ArrApiKeyResolver.Resolve(token, configManager);
 
-        Assert.Equal("stored-secret", resolved);
+        Assert.Equal("stored-sonarr-key", resolved);
     }
 
     [Fact]
@@ -68,22 +70,17 @@ public class UsenetPassResolverTests
         [
             new ConfigItem
             {
-                ConfigName = "usenet.providers",
-                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                ConfigName = ConfigKeys.ArrInstances,
+                ConfigValue = JsonSerializer.Serialize(new ArrConfig
                 {
-                    Providers =
+                    RadarrInstances =
                     [
-                        new UsenetProviderConfig.ConnectionDetails
+                        new ArrConfig.ConnectionDetails
                         {
-                            Type = ProviderType.Pooled,
-                            Host = "news.example",
-                            Port = 563,
-                            UseSsl = true,
-                            User = "user",
-                            Pass = "stored-secret",
-                            MaxConnections = 10,
+                            Host = "http://radarr:7878",
+                            ApiKey = "stored-secret",
                         }
-                    ]
+                    ],
                 })
             }
         ]);
@@ -91,7 +88,7 @@ public class UsenetPassResolverTests
         var forged = $"{ConfigSecretMasker.MaskPrefix}AAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
         Assert.Throws<BadHttpRequestException>(() =>
-            UsenetPassResolver.Resolve(forged, configManager));
+            ArrApiKeyResolver.Resolve(forged, configManager));
     }
 
     private static IDisposable TempEnv(string name, string value)

--- a/tests/NzbWebDAV.Tests/Config/RclonePassResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/RclonePassResolverTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+[Collection(nameof(SecretResolverCollection))]
+public class RclonePassResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsPlaintextUnchanged()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+
+        var resolved = RclonePassResolver.Resolve("typed-password", configManager);
+
+        Assert.Equal("typed-password", resolved);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsNullUnchanged()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+
+        var resolved = RclonePassResolver.Resolve(null, configManager);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void Resolve_UnmasksStoredRclonePassword()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        const string stored = "stored-rclone-pass";
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RclonePass, ConfigValue = stored }
+        ]);
+
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var token = masker.MaskForResponse(ConfigKeys.RclonePass, stored);
+
+        var resolved = RclonePassResolver.Resolve(token, configManager);
+
+        Assert.Equal(stored, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ThrowsForUnknownMaskToken()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RclonePass, ConfigValue = "stored-secret" }
+        ]);
+
+        var forged = $"{ConfigSecretMasker.MaskPrefix}AAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Assert.Throws<BadHttpRequestException>(() =>
+            RclonePassResolver.Resolve(forged, configManager));
+    }
+
+    private static IDisposable TempEnv(string name, string value)
+    {
+        var previous = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+        return new RestoreEnv(name, previous);
+    }
+
+    private sealed class RestoreEnv(string name, string? previous) : IDisposable
+    {
+        public void Dispose() => Environment.SetEnvironmentVariable(name, previous);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/SecretResolverCollection.cs
+++ b/tests/NzbWebDAV.Tests/Config/SecretResolverCollection.cs
@@ -1,0 +1,4 @@
+namespace NzbWebDAV.Tests.Config;
+
+[CollectionDefinition(nameof(SecretResolverCollection), DisableParallelization = true)]
+public sealed class SecretResolverCollection;


### PR DESCRIPTION
## Summary
- Test Conn for Sonarr/Radarr and rclone now works with already-saved (masked) credentials — no need to re-enter secrets after reload
- Failed tests show the real reason (auth, HTTP status, or network) instead of only a red X
- Arr failures map 401/403 to “Authentication failed” and empty API responses to a clear message

Closes #691

## Test plan
- [ ] Save an Arr instance → reload settings → Test Conn without retyping the API key → success
- [ ] Wrong Arr API key / wrong rclone password → Alert shows authentication failure
- [ ] Bad host/port → Alert shows a network/DNS-style reason
- [ ] Empty rclone password still testable when RC has no auth
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ArrApiKeyResolverTests|FullyQualifiedName~RclonePassResolverTests"`