### PR TITLE
fix(usenet): prefer the configured primary over larger idle backup pools

### DIFF
--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -46,6 +46,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     private const int MaxConcurrentHandshakes = 3;
 
     public TimeSpan IdleTimeout { get; }
+    public int MaxConnections => _maxConnections;
     public int LiveConnections => _live;
     public int IdleConnections => _idleConnections.Count;
     public int ActiveConnections => _live - _idleConnections.Count;

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -92,6 +92,7 @@ public class MultiConnectionNntpClient(
     /// </summary>
     public bool IsTripped => circuitBreaker.IsTripped;
     public ProviderCircuitBreakerSnapshot GetCircuitBreakerSnapshot() => circuitBreaker.GetSnapshot();
+    public int MaxConnections => connectionPool.MaxConnections;
     public int LiveConnections => connectionPool.LiveConnections;
     public int IdleConnections => connectionPool.IdleConnections;
     public int ActiveConnections => connectionPool.ActiveConnections;
@@ -106,6 +107,12 @@ public class MultiConnectionNntpClient(
 
     public int UnreservedConnections => Math.Max(0, AvailableConnections - PendingSelections);
     public bool HasSpareConnection => UnreservedConnections > 0;
+    /// <summary>
+    /// Unreserved capacity as a fraction of the configured pool size. Used by cascade
+    /// ranking so unequal MaxConnections do not outweigh configured Priority.
+    /// </summary>
+    public double SpareFraction =>
+        (double)UnreservedConnections / Math.Max(1, MaxConnections);
 
     public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken)
     {

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1051,8 +1051,10 @@ public class MultiProviderNntpClient(
         if (!provider.HasSpareConnection)
             return provider.Priority + saturationDemotion;
 
-        // At most 25% of the configured pool remains unreserved.
-        var thinSpareDemotion = provider.SpareFraction <= 0.25 ? 1 : 0;
+        // At most 25% of the configured pool remains unreserved (integer form of
+        // spare/max <= 1/4 so boundary cases like 2/8 do not depend on float rounding).
+        var max = Math.Max(1, provider.MaxConnections);
+        var thinSpareDemotion = provider.UnreservedConnections * 4 <= max ? 1 : 0;
         return provider.Priority + thinSpareDemotion;
     }
 

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -114,30 +114,6 @@ public class MultiProviderNntpClient(
     public sealed class ResponderAttribution { public string? Host; }
     public static readonly AsyncLocal<ResponderAttribution?> AttributionContext = new();
 
-    /// <summary>
-    /// Providers to skip for the current async call only (e.g. the account that just
-    /// returned corrupt yEnc for this segment). Cleared when the scope disposes.
-    /// If every enabled provider is excluded, selection falls back to the full set so
-    /// a lone provider can still be retried.
-    /// </summary>
-    private static readonly AsyncLocal<HashSet<string>?> ExcludedProvidersScope = new();
-
-    public static IDisposable ExcludeProviders(IEnumerable<string> providerKeys)
-    {
-        var previous = ExcludedProvidersScope.Value;
-        var next = previous != null
-            ? new HashSet<string>(previous, StringComparer.Ordinal)
-            : new HashSet<string>(StringComparer.Ordinal);
-        foreach (var key in providerKeys)
-        {
-            if (!string.IsNullOrEmpty(key))
-                next.Add(key);
-        }
-
-        ExcludedProvidersScope.Value = next.Count > 0 ? next : null;
-        return new ScopeReleaser(() => ExcludedProvidersScope.Value = previous);
-    }
-
     private readonly object _selectLock = new();
 
     public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken ct)
@@ -1019,18 +995,6 @@ public class MultiProviderNntpClient(
                 .Where(x => x.ProviderType != ProviderType.Disabled)
                 .Where(x => !IsOverLimit(x))
                 .ToList();
-
-            var excluded = ExcludedProvidersScope.Value;
-            if (excluded is { Count: > 0 })
-            {
-                var withoutExcluded = enabled
-                    .Where(x => !excluded.Contains(x.MetricsKey))
-                    .ToList();
-                // Fall back to the full set when every remaining provider was excluded so
-                // a single-provider install can still retry after corruption.
-                if (withoutExcluded.Count > 0)
-                    enabled = withoutExcluded;
-            }
 
             // Reading state here must not claim the half-open probe slot. IsTripped claims
             // it, so one selection ends up holding a probe it may never dispatch while

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -114,6 +114,30 @@ public class MultiProviderNntpClient(
     public sealed class ResponderAttribution { public string? Host; }
     public static readonly AsyncLocal<ResponderAttribution?> AttributionContext = new();
 
+    /// <summary>
+    /// Providers to skip for the current async call only (e.g. the account that just
+    /// returned corrupt yEnc for this segment). Cleared when the scope disposes.
+    /// If every enabled provider is excluded, selection falls back to the full set so
+    /// a lone provider can still be retried.
+    /// </summary>
+    private static readonly AsyncLocal<HashSet<string>?> ExcludedProvidersScope = new();
+
+    public static IDisposable ExcludeProviders(IEnumerable<string> providerKeys)
+    {
+        var previous = ExcludedProvidersScope.Value;
+        var next = previous != null
+            ? new HashSet<string>(previous, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in providerKeys)
+        {
+            if (!string.IsNullOrEmpty(key))
+                next.Add(key);
+        }
+
+        ExcludedProvidersScope.Value = next.Count > 0 ? next : null;
+        return new ScopeReleaser(() => ExcludedProvidersScope.Value = previous);
+    }
+
     private readonly object _selectLock = new();
 
     public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken ct)
@@ -996,6 +1020,18 @@ public class MultiProviderNntpClient(
                 .Where(x => !IsOverLimit(x))
                 .ToList();
 
+            var excluded = ExcludedProvidersScope.Value;
+            if (excluded is { Count: > 0 })
+            {
+                var withoutExcluded = enabled
+                    .Where(x => !excluded.Contains(x.MetricsKey))
+                    .ToList();
+                // Fall back to the full set when every remaining provider was excluded so
+                // a single-provider install can still retry after corruption.
+                if (withoutExcluded.Count > 0)
+                    enabled = withoutExcluded;
+            }
+
             // Reading state here must not claim the half-open probe slot. IsTripped claims
             // it, so one selection ends up holding a probe it may never dispatch while
             // every other selection treats the provider as tripped.
@@ -1022,9 +1058,12 @@ public class MultiProviderNntpClient(
                 : byRecovery;
             var byUsage = prioritized.ThenByDescending(x => GetRemainingBytes(x));
             // Prefer providers with more spare capacity. In cascade mode this is a
-            // tie-break after EffectivePriority (which already soft-scores contention);
-            // in pool mode it outranks learned speed so a full pool cannot monopolize.
-            var capacityBalanced = byUsage.ThenByDescending(x => x.UnreservedConnections);
+            // tie-break after EffectivePriority and uses spare *fraction* so unequal
+            // MaxConnections cannot outweigh Priority. In pool mode absolute spare
+            // outranks learned speed so a full pool cannot monopolize.
+            var capacityBalanced = cascade
+                ? byUsage.ThenByDescending(x => x.SpareFraction)
+                : byUsage.ThenByDescending(x => x.UnreservedConnections);
             var ordered = capacityBalanced
                 .ThenBy(EstimatedDeliveryScore)
                 .ToList();
@@ -1036,10 +1075,11 @@ public class MultiProviderNntpClient(
     }
 
     /// <summary>
-    /// Cascade sort key: configured priority, plus a soft contention score while spare
-    /// capacity remains, plus a large demotion when fully saturated. Among providers that
-    /// still have spare connections, a thinly-spared primary can lose to a same-tier peer
-    /// with meaningfully more idle capacity without waiting for hard saturation.
+    /// Cascade sort key: configured priority, plus one priority step when at most 25% of
+    /// the provider's pool remains unreserved, plus a large demotion when fully
+    /// saturated. Absolute spare is not used — that made larger MaxConnections pools
+    /// outrank a healthier Priority-0 primary while idle. Thin-spare still lets a
+    /// Priority-0 pool with 1/8 free yield to an idle Priority-1 peer (#650).
     /// </summary>
     private static int EffectivePriority(MultiConnectionNntpClient provider)
     {
@@ -1047,10 +1087,9 @@ public class MultiProviderNntpClient(
         if (!provider.HasSpareConnection)
             return provider.Priority + saturationDemotion;
 
-        // Smaller UnreservedConnections => slightly worse (still << saturationDemotion).
-        var spare = Math.Clamp(provider.UnreservedConnections, 0, 1024);
-        var contention = 1024 - spare;
-        return provider.Priority + contention;
+        // At most 25% of the configured pool remains unreserved.
+        var thinSpareDemotion = provider.SpareFraction <= 0.25 ? 1 : 0;
+        return provider.Priority + thinSpareDemotion;
     }
 
     private double EstimatedDeliveryScore(MultiConnectionNntpClient provider)

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -330,8 +330,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     )
     {
         var estimate = GetPlannedSegmentBytes(segmentIndex);
+        HashSet<string>? excludeCorruptProviders = null;
         for (var attempt = 0; ; attempt++)
         {
+            using var excludeScope = excludeCorruptProviders is { Count: > 0 }
+                ? MultiProviderNntpClient.ExcludeProviders(excludeCorruptProviders)
+                : null;
             var lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
             try
             {
@@ -407,6 +411,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     segmentId,
                     e.ProviderKey,
                     attempt + 1);
+                // Segment-scoped only: skip the account that returned corrupt bytes on the
+                // next attempt. Falls back to it when no other provider remains.
+                excludeCorruptProviders ??= new HashSet<string>(StringComparer.Ordinal);
+                if (!string.IsNullOrEmpty(e.ProviderKey))
+                    excludeCorruptProviders.Add(e.ProviderKey);
                 await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -584,6 +593,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         CancellationToken cancellationToken)
     {
         var failure = initialFailure;
+        var excludeCorruptProviders = new HashSet<string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(failure.ProviderKey))
+            excludeCorruptProviders.Add(failure.ProviderKey);
+
         for (var attempt = 1; attempt <= MaxCorruptionRetries; attempt++)
         {
             Log.Debug(
@@ -597,6 +610,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             try
             {
+                using var excludeScope = MultiProviderNntpClient.ExcludeProviders(excludeCorruptProviders);
                 var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
                     .ConfigureAwait(false);
                 await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
@@ -606,6 +620,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             catch (UsenetCorruptArticleException exception)
             {
                 failure = exception;
+                if (!string.IsNullOrEmpty(exception.ProviderKey))
+                    excludeCorruptProviders.Add(exception.ProviderKey);
             }
         }
 

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -330,12 +330,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     )
     {
         var estimate = GetPlannedSegmentBytes(segmentIndex);
-        HashSet<string>? excludeCorruptProviders = null;
         for (var attempt = 0; ; attempt++)
         {
-            using var excludeScope = excludeCorruptProviders is { Count: > 0 }
-                ? MultiProviderNntpClient.ExcludeProviders(excludeCorruptProviders)
-                : null;
             var lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
             try
             {
@@ -411,11 +407,6 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     segmentId,
                     e.ProviderKey,
                     attempt + 1);
-                // Segment-scoped only: skip the account that returned corrupt bytes on the
-                // next attempt. Falls back to it when no other provider remains.
-                excludeCorruptProviders ??= new HashSet<string>(StringComparer.Ordinal);
-                if (!string.IsNullOrEmpty(e.ProviderKey))
-                    excludeCorruptProviders.Add(e.ProviderKey);
                 await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -593,10 +584,6 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         CancellationToken cancellationToken)
     {
         var failure = initialFailure;
-        var excludeCorruptProviders = new HashSet<string>(StringComparer.Ordinal);
-        if (!string.IsNullOrEmpty(failure.ProviderKey))
-            excludeCorruptProviders.Add(failure.ProviderKey);
-
         for (var attempt = 1; attempt <= MaxCorruptionRetries; attempt++)
         {
             Log.Debug(
@@ -610,7 +597,6 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             try
             {
-                using var excludeScope = MultiProviderNntpClient.ExcludeProviders(excludeCorruptProviders);
                 var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
                     .ConfigureAwait(false);
                 await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
@@ -620,8 +606,6 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             catch (UsenetCorruptArticleException exception)
             {
                 failure = exception;
-                if (!string.IsNullOrEmpty(exception.ProviderKey))
-                    excludeCorruptProviders.Add(exception.ProviderKey);
             }
         }
 

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -44,7 +44,7 @@ a man-in-the-middle attacker to impersonate the provider and read credentials.
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
-| Enable cascade routing | `usenet.cascade.enabled` | off | Prefer providers in drag order; off = shared pool. Contended primaries yield to idler peers. |
+| Enable cascade routing | `usenet.cascade.enabled` | off | Prefer providers in drag order; off = shared pool. Thinly-spared primaries (≤25% free) yield to idler peers; larger MaxConnections alone does not outrank priority. |
 | Re-probe primary after miss | `usenet.cascade.retry-primary-on-miss` | on | After a clean 430/451 on the first batch attempt, try the primary once more before cascading (multi-node spool). Off = skip straight to backups. |
 | Enable NNTP pipelining | `usenet.pipelining.enabled` | off | Batch first-segment BODY during queue imports/benchmarks |
 | Default pipeline depth | `usenet.pipelining.depth` | `8` | Requests in flight per connection (1–64) |

--- a/docs/features/multi-provider.md
+++ b/docs/features/multi-provider.md
@@ -5,7 +5,7 @@ Add multiple NNTP accounts under **Settings → Usenet**.
 ## Routing
 
 - **Pool (default)** — connections shared across enabled providers.
-- **Cascade** — prefer providers in drag order; fail over down the list. Among providers that still have spare capacity, a thinly-spared primary can yield to a same-tier peer with meaningfully more idle connections. Fully saturated providers are still skipped.
+- **Cascade** — prefer providers in drag order; fail over down the list. Among providers that still have spare capacity, a thinly-spared primary (at most 25% of its pool free) can yield to an idle same-tier peer. Fully saturated providers are still skipped. Absolute pool width does not outrank configured priority while both providers are healthy.
 
 Optional **Re-probe primary after article miss** (`usenet.cascade.retry-primary-on-miss`, default on) retries the primary once after a clean 430/451 before cascading — useful when providers route across spool nodes. Turn it off to go straight to backups after the first miss.
 

--- a/docs/use-cases/multi-provider-failover.md
+++ b/docs/use-cases/multi-provider-failover.md
@@ -9,7 +9,7 @@
 ## Setup
 
 1. Add each provider under **Settings → Usenet** with accurate max connections.
-2. Enable **cascade routing** if you want strict priority order; leave off to share a pool.
+2. Enable **cascade routing** if you want priority order (thinly-spared primaries can still yield to idle peers); leave off to share a pool.
 3. Mark pure backups as **Backup Only**.
 4. Set **storage groups** only for true same-upstream resellers.
 5. Optional data caps + usage offsets when migrating mid-block.

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -621,7 +621,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
 
                     <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
                         <Tooltip
-                            content="Prefer providers in drag order. While off, all enabled providers share work in the pool. Contended primaries with little spare capacity yield to idler same-tier peers."
+                            content="Prefer providers in drag order. While off, all enabled providers share work in the pool. Thinly-spared primaries (at most 25% of their pool free) yield to idler same-tier peers; larger MaxConnections alone does not outrank priority."
                             className="min-w-0"
                         >
                             <Toggle

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -1320,6 +1320,34 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task CascadeMode_PriorityBeatsLargerIdlePool()
+    {
+        var primaryConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var largerLowerPriority = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        // Reproduce the field failure: Priority 0 / max 20 was losing to Priority 3 / max 32
+        // while both were idle because absolute spare outweighed Priority.
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primaryConnection, host: "primary.example", maxConnections: 20, priority: 0),
+            CreateProvider(largerLowerPriority, host: "large.example", maxConnections: 32, priority: 3),
+        ], cascadeEnabled: () => true);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+        await response.Stream!.DisposeAsync();
+
+        Assert.Equal(1, primaryConnection.SingularRequests);
+        Assert.Equal(0, largerLowerPriority.SingularRequests);
+    }
+
+    [Fact]
     public async Task CascadeMode_PrefersIdlePeerWhenPrimaryIsContended()
     {
         var primaryConnection = new ScriptedNntpClient
@@ -1334,7 +1362,7 @@ public class MultiProviderNntpClientTests
         };
         var primary = CreateProvider(primaryConnection, host: "primary.example", maxConnections: 8, priority: 0);
         var idle = CreateProvider(idleConnection, host: "idle.example", maxConnections: 8, priority: 1);
-        // Leave primary with a single spare connection so soft contention demotes it.
+        // Leave primary with a single spare connection (12.5% <= 25%) so thin-spare demotes it.
         for (var i = 0; i < 7; i++)
             primary.ReservePending();
         using var client = new MultiProviderNntpClient([primary, idle], cascadeEnabled: () => true);
@@ -1344,6 +1372,64 @@ public class MultiProviderNntpClientTests
 
         Assert.Equal(0, primaryConnection.SingularRequests);
         Assert.Equal(1, idleConnection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task CascadeMode_KeepsPrimaryAboveThinSpareThreshold()
+    {
+        var primaryConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var secondaryConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var primary = CreateProvider(primaryConnection, host: "primary.example", maxConnections: 8, priority: 0);
+        var secondary = CreateProvider(secondaryConnection, host: "secondary.example", maxConnections: 8, priority: 1);
+        // 6/8 unreserved = 75% spare — above the 25% thin-spare band, so Priority still wins.
+        for (var i = 0; i < 2; i++)
+            primary.ReservePending();
+        using var client = new MultiProviderNntpClient([primary, secondary], cascadeEnabled: () => true);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+        await response.Stream!.DisposeAsync();
+
+        Assert.Equal(1, primaryConnection.SingularRequests);
+        Assert.Equal(0, secondaryConnection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task CascadeMode_TieBreakUsesSpareFractionNotAbsoluteSpare()
+    {
+        var smallerConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var largerConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var larger = CreateProvider(largerConnection, host: "large.example", maxConnections: 32, priority: 0);
+        var smaller = CreateProvider(smallerConnection, host: "small.example", maxConnections: 20, priority: 0);
+        // Equal utilization (50% spare) but unequal absolute spare. Absolute spare would
+        // pick the larger pool (16 > 10). Fraction tie-break keeps list order, so the
+        // smaller pool listed first must win.
+        for (var i = 0; i < 16; i++)
+            larger.ReservePending();
+        for (var i = 0; i < 10; i++)
+            smaller.ReservePending();
+        using var client = new MultiProviderNntpClient([smaller, larger], cascadeEnabled: () => true);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+        await response.Stream!.DisposeAsync();
+
+        Assert.Equal(1, smallerConnection.SingularRequests);
+        Assert.Equal(0, largerConnection.SingularRequests);
     }
 
     [Fact]
@@ -1370,6 +1456,89 @@ public class MultiProviderNntpClientTests
 
         Assert.Equal(0, primaryConnection.SingularRequests);
         Assert.Equal(1, backupConnection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task CascadeMode_PooledTierStillPrecedeBackupOnly()
+    {
+        var backupConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var primaryConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        // Backup Only with a larger pool must not leapfrog a pooled Priority 0 primary.
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(
+                backupConnection,
+                host: "backup.example",
+                maxConnections: 32,
+                priority: 0,
+                providerType: ProviderType.BackupOnly),
+            CreateProvider(primaryConnection, host: "primary.example", maxConnections: 20, priority: 0),
+        ], cascadeEnabled: () => true);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+        await response.Stream!.DisposeAsync();
+
+        Assert.Equal(1, primaryConnection.SingularRequests);
+        Assert.Equal(0, backupConnection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task ExcludeProviders_SkipsCorruptProviderWhenPeerAvailable()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primary, host: "primary.example", maxConnections: 4, priority: 0),
+            CreateProvider(backup, host: "backup.example", maxConnections: 4, priority: 1),
+        ], cascadeEnabled: () => true);
+
+        using (MultiProviderNntpClient.ExcludeProviders(["primary.example"]))
+        {
+            var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+            await response.Stream!.DisposeAsync();
+        }
+
+        Assert.Equal(0, primary.SingularRequests);
+        Assert.Equal(1, backup.SingularRequests);
+    }
+
+    [Fact]
+    public async Task ExcludeProviders_FallsBackWhenEveryProviderIsExcluded()
+    {
+        var only = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(only, host: "only.example", maxConnections: 4, priority: 0),
+        ], cascadeEnabled: () => true);
+
+        using (MultiProviderNntpClient.ExcludeProviders(["only.example"]))
+        {
+            var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+            await response.Stream!.DisposeAsync();
+        }
+
+        Assert.Equal(1, only.SingularRequests);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -1389,8 +1389,8 @@ public class MultiProviderNntpClientTests
         };
         var primary = CreateProvider(primaryConnection, host: "primary.example", maxConnections: 8, priority: 0);
         var secondary = CreateProvider(secondaryConnection, host: "secondary.example", maxConnections: 8, priority: 1);
-        // 6/8 unreserved = 75% spare — above the 25% thin-spare band, so Priority still wins.
-        for (var i = 0; i < 2; i++)
+        // 3/8 unreserved = 37.5% spare — just above the 25% thin-spare band.
+        for (var i = 0; i < 5; i++)
             primary.ReservePending();
         using var client = new MultiProviderNntpClient([primary, secondary], cascadeEnabled: () => true);
 
@@ -1399,6 +1399,33 @@ public class MultiProviderNntpClientTests
 
         Assert.Equal(1, primaryConnection.SingularRequests);
         Assert.Equal(0, secondaryConnection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task CascadeMode_YieldsAtThinSpareThreshold()
+    {
+        var primaryConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var secondaryConnection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var primary = CreateProvider(primaryConnection, host: "primary.example", maxConnections: 8, priority: 0);
+        var secondary = CreateProvider(secondaryConnection, host: "secondary.example", maxConnections: 8, priority: 1);
+        // 2/8 unreserved = exactly 25%, so the idle next-priority peer wins.
+        for (var i = 0; i < 6; i++)
+            primary.ReservePending();
+        using var client = new MultiProviderNntpClient([primary, secondary], cascadeEnabled: () => true);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+        await response.Stream!.DisposeAsync();
+
+        Assert.Equal(0, primaryConnection.SingularRequests);
+        Assert.Equal(1, secondaryConnection.SingularRequests);
     }
 
     [Fact]
@@ -1459,7 +1486,7 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
-    public async Task CascadeMode_PooledTierStillPrecedeBackupOnly()
+    public async Task CascadeMode_PooledTierStillPrecedesBackupOnly()
     {
         var backupConnection = new ScriptedNntpClient
         {
@@ -1488,57 +1515,6 @@ public class MultiProviderNntpClientTests
 
         Assert.Equal(1, primaryConnection.SingularRequests);
         Assert.Equal(0, backupConnection.SingularRequests);
-    }
-
-    [Fact]
-    public async Task ExcludeProviders_SkipsCorruptProviderWhenPeerAvailable()
-    {
-        var primary = new ScriptedNntpClient
-        {
-            BatchResponseCode = 222,
-            SingularResponseCode = 222,
-        };
-        var backup = new ScriptedNntpClient
-        {
-            BatchResponseCode = 222,
-            SingularResponseCode = 222,
-        };
-        using var client = new MultiProviderNntpClient(
-        [
-            CreateProvider(primary, host: "primary.example", maxConnections: 4, priority: 0),
-            CreateProvider(backup, host: "backup.example", maxConnections: 4, priority: 1),
-        ], cascadeEnabled: () => true);
-
-        using (MultiProviderNntpClient.ExcludeProviders(["primary.example"]))
-        {
-            var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
-            await response.Stream!.DisposeAsync();
-        }
-
-        Assert.Equal(0, primary.SingularRequests);
-        Assert.Equal(1, backup.SingularRequests);
-    }
-
-    [Fact]
-    public async Task ExcludeProviders_FallsBackWhenEveryProviderIsExcluded()
-    {
-        var only = new ScriptedNntpClient
-        {
-            BatchResponseCode = 222,
-            SingularResponseCode = 222,
-        };
-        using var client = new MultiProviderNntpClient(
-        [
-            CreateProvider(only, host: "only.example", maxConnections: 4, priority: 0),
-        ], cascadeEnabled: () => true);
-
-        using (MultiProviderNntpClient.ExcludeProviders(["only.example"]))
-        {
-            var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
-            await response.Stream!.DisposeAsync();
-        }
-
-        Assert.Equal(1, only.SingularRequests);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Cascade was ranking providers by absolute idle connection count, so a Priority-0 primary with fewer MaxConnections lost to larger lower-priority pools even while idle (seen in support packs where Frugal Bonus served ~85% of fetches while Newshosting was ~8× faster in the small observed sample).
- Cascade now preserves configured priority while more than 25% of a provider pool remains free, then lets an idle next-priority peer take work when the primary becomes thinly spared.
- Equal-utilization cascade ties use spare fraction rather than absolute connection count, preventing larger pools from regaining the same bias in the later tie-break.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~MultiProviderNntpClient`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] After merge: ask the original reporter to restore all-Pool Connections briefly, re-collect a Plex stream trace, and confirm Newshosting receives most successful fetches while it has healthy spare capacity

## Reporter interim guidance
Keep cascade on. If Newshosting is the intended primary, mark true fallbacks as **Backup Only** until this ships — do not inflate MaxConnections or raise article-buffer-size as the first workaround.