### PR TITLE
feat(usenet): size queue connections as a share of the provider pool

### DIFF
--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -44,6 +44,7 @@ public class DownloadingNntpClient : WrappingNntpClient
             _streamingSemaphore.UpdateMaxAllowed(_configManager.GetMaxDownloadConnections());
 
         if (e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxQueueConnections)
+            || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxQueueConnectionsPreset)
             || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetMaxDownloadConnections)
             || e.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders))
             _queueSemaphore.UpdateMaxAllowed(_configManager.GetMaxQueueConnections());

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -43,6 +43,7 @@ public static class ConfigKeys
     public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";
     public const string UsenetMaxQueueConnections = "usenet.max-queue-connections";
+    public const string UsenetMaxQueueConnectionsPreset = "usenet.max-queue-connections-preset";
     public const string QueueWorkerCount = "queue.worker-count";
     public const string QueuePaused = "queue.paused";
     public const string QueueSpeedLimitKbps = "queue.speed-limit-kbps";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -377,6 +377,10 @@ public class ConfigManager
                     RequireOneOf(item.ConfigName, value, "standard", "enhanced", "deep", "complete");
                     break;
 
+                case ConfigKeys.UsenetMaxQueueConnectionsPreset:
+                    RequireOneOf(item.ConfigName, value, "low", "medium", "high", "max");
+                    break;
+
                 case ConfigKeys.UsenetProviders:
                     RequireValidUsenetProviders(item.ConfigName, value, jsonOptions);
                     break;
@@ -645,7 +649,8 @@ public class ConfigManager
     // Mirrors the per-stream preset: a fraction of the pooled-connection budget
     // rather than an absolute count, so one setting means the same thing whatever
     // a user's providers add up to. Null when unset, which keeps the historical
-    // default of "the queue may use the whole pool".
+    // default of "the queue may use the whole pool". Unknown values are rejected
+    // by ValidateConfigItems, so the fall-through only covers hand-edited rows.
     private double? GetMaxQueueConnectionsFraction()
     {
         var preset = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxQueueConnectionsPreset));

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -635,9 +635,28 @@ public class ConfigManager
     {
         var pool = Math.Max(1, GetUsenetProviderConfig().TotalPooledConnections);
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxQueueConnections));
-        if (configured is null || !int.TryParse(configured, out var value))
-            return pool;
-        return Math.Clamp(value, 1, pool);
+        if (configured is not null && int.TryParse(configured, out var value))
+            return Math.Clamp(value, 1, pool);
+
+        var fraction = GetMaxQueueConnectionsFraction();
+        return fraction is null ? pool : Math.Max(1, (int)Math.Round(pool * fraction.Value));
+    }
+
+    // Mirrors the per-stream preset: a fraction of the pooled-connection budget
+    // rather than an absolute count, so one setting means the same thing whatever
+    // a user's providers add up to. Null when unset, which keeps the historical
+    // default of "the queue may use the whole pool".
+    private double? GetMaxQueueConnectionsFraction()
+    {
+        var preset = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetMaxQueueConnectionsPreset));
+        return preset?.ToLowerInvariant() switch
+        {
+            "low" => 0.25,
+            "medium" => 0.5,
+            "high" => 0.75,
+            "max" => 1.0,
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -13,6 +13,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | WebDAV User | `webdav.user` | `admin` / `WEBDAV_USER` | Alphanumeric + `_` `-` |
 | WebDAV Password | `webdav.pass` | env `WEBDAV_PASSWORD` | Required for rclone/clients |
 | Queue Download Connections | `usenet.max-queue-connections` | blank = all | Cap queue NNTP use |
+| Queue connection preset [since 0.9.1](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.1){ .nzbdav-since } | `usenet.max-queue-connections-preset` | blank = all | `low`/`medium`/`high`/`max` = 25/50/75/100% of the pooled total, so one value fits any provider count. Ignored when the absolute setting above is set |
 | Concurrent Queue Downloads [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Concurrent NZB imports (1–4); the oldest item is preferred while other workers share the connection budget |
 | Enable Segment Cache | `usenet.segment-cache.enabled` | off | Disk cache; **restart required** |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | |

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -37,6 +39,40 @@ public class DownloadingNntpClientStatGateTests
         await Task.WhenAll(tasks);
 
         Assert.True(maxInFlight <= 2);
+        Assert.Equal(0, Volatile.Read(ref inFlight));
+    }
+
+    [Fact]
+    public async Task QueueBudget_FollowsPresetChangesWithoutRestart()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var inFlight = 0;
+        var fake = new BlockingStatNntpClient(gate,
+            () => Interlocked.Increment(ref inFlight),
+            () => Interlocked.Decrement(ref inFlight));
+
+        // "low" is a quarter of the eight pooled connections.
+        var config = CreatePresetConfig("low", poolConnections: 8);
+        Assert.Equal(2, config.GetMaxQueueConnections());
+        using var client = new DownloadingNntpClient(fake, config);
+
+        var tasks = Enumerable.Range(0, 8)
+            .Select(i => client.StatAsync(new SegmentId($"seg-{i}"), CancellationToken.None))
+            .ToArray();
+
+        await WaitUntilAsync(() => Volatile.Read(ref inFlight) == 2, TimeSpan.FromSeconds(2));
+        await Task.Delay(50);
+        Assert.Equal(2, Volatile.Read(ref inFlight));
+
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnectionsPreset, ConfigValue = "max" },
+        ]);
+
+        await WaitUntilAsync(() => Volatile.Read(ref inFlight) == 8, TimeSpan.FromSeconds(2));
+
+        gate.Set();
+        await Task.WhenAll(tasks);
         Assert.Equal(0, Volatile.Read(ref inFlight));
     }
 
@@ -242,6 +278,38 @@ public class DownloadingNntpClientStatGateTests
             },
             new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = maxQueueConnections.ToString() },
             new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = maxDownloadConnections.ToString() },
+        ]);
+        return config;
+    }
+
+    // Provider JSON is serialized from the model rather than hand-written: config
+    // deserialization is case-sensitive, so camelCased literals bind to nothing and
+    // the pooled total silently collapses to 1.
+    private static ConfigManager CreatePresetConfig(string preset, int poolConnections)
+    {
+        var providers = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    Type = ProviderType.Pooled,
+                    Host = "nntp.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "u",
+                    Pass = "p",
+                    MaxConnections = poolConnections,
+                },
+            ]
+        });
+
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.UsenetProviders, ConfigValue = providers },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnectionsPreset, ConfigValue = preset },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = "10" },
         ]);
         return config;
     }

--- a/tests/NzbWebDAV.Tests/Config/MaxQueueConnectionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MaxQueueConnectionsTests.cs
@@ -56,8 +56,36 @@ public class MaxQueueConnectionsTests
     [InlineData("0.5")]
     public void UnrecognisedPreset_FallsBackToWholePool(string preset)
     {
+        // Defensive only: writes are validated below, so this covers hand-edited rows.
         var config = CreateConfig(absolute: null, preset: preset, pooled: 20);
         Assert.Equal(20, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("low")]
+    [InlineData("MEDIUM")]
+    [InlineData("High")]
+    [InlineData("max")]
+    public void ValidateConfigItems_AcceptsAnyCasingTheGetterResolves(string preset)
+    {
+        ConfigManager.ValidateConfigItems(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnectionsPreset, ConfigValue = preset },
+        ]);
+    }
+
+    [Theory]
+    [InlineData("nonsense")]
+    [InlineData("0.5")]
+    public void ValidateConfigItems_RejectsAnUnknownPreset(string preset)
+    {
+        // A typo must fail the write rather than silently meaning "the whole pool",
+        // which is the failure mode the preset exists to remove. ENV-configured
+        // installs have no Settings page to notice the value was ignored.
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnectionsPreset, ConfigValue = preset },
+        ]));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Config/MaxQueueConnectionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MaxQueueConnectionsTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class MaxQueueConnectionsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Unset_UsesWholePool(string? preset)
+    {
+        var config = CreateConfig(absolute: null, preset: preset, pooled: 20);
+        Assert.Equal(20, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("low", 20, 5)]
+    [InlineData("medium", 20, 10)]
+    [InlineData("high", 20, 15)]
+    [InlineData("max", 20, 20)]
+    [InlineData("low", 220, 55)]
+    [InlineData("medium", 220, 110)]
+    [InlineData("high", 220, 165)]
+    [InlineData("max", 220, 220)]
+    public void Preset_ScalesWithTheUsersOwnPool(string preset, int pooled, int expected)
+    {
+        // The point of the preset: one setting means the same share of the
+        // budget whatever a user's providers happen to add up to.
+        var config = CreateConfig(absolute: null, preset: preset, pooled: pooled);
+        Assert.Equal(expected, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("LOW", 20, 5)]
+    [InlineData("Medium", 20, 10)]
+    public void Preset_IsCaseInsensitive(string preset, int pooled, int expected)
+    {
+        var config = CreateConfig(absolute: null, preset: preset, pooled: pooled);
+        Assert.Equal(expected, config.GetMaxQueueConnections());
+    }
+
+    [Fact]
+    public void Preset_NeverYieldsZero()
+    {
+        // A quarter of a two-connection pool rounds to zero; the queue must
+        // still be able to make progress.
+        var config = CreateConfig(absolute: null, preset: "low", pooled: 2);
+        Assert.Equal(1, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("nonsense")]
+    [InlineData("0.5")]
+    public void UnrecognisedPreset_FallsBackToWholePool(string preset)
+    {
+        var config = CreateConfig(absolute: null, preset: preset, pooled: 20);
+        Assert.Equal(20, config.GetMaxQueueConnections());
+    }
+
+    [Fact]
+    public void AbsoluteValue_StillWins()
+    {
+        // Back-compat: an explicit count keeps its existing meaning even when a
+        // preset is also present.
+        var config = CreateConfig(absolute: "7", preset: "max", pooled: 20);
+        Assert.Equal(7, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("500", 20)]
+    [InlineData("0", 1)]
+    [InlineData("-3", 1)] // parses, then clamps up to the floor of 1
+    public void AbsoluteValue_ClampsToPool(string absolute, int expected)
+    {
+        var config = CreateConfig(absolute: absolute, preset: null, pooled: 20);
+        Assert.Equal(expected, config.GetMaxQueueConnections());
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("")]
+    public void UnparseableAbsolute_DefersToThePreset(string absolute)
+    {
+        var config = CreateConfig(absolute: absolute, preset: "medium", pooled: 20);
+        Assert.Equal(10, config.GetMaxQueueConnections());
+    }
+
+    private static ConfigManager CreateConfig(string? absolute, string? preset, int pooled)
+    {
+        var providers = JsonSerializer.Serialize(new UsenetProviderConfig
+        {
+            Providers =
+            [
+                new UsenetProviderConfig.ConnectionDetails
+                {
+                    Type = ProviderType.Pooled,
+                    Host = "pool.example",
+                    Port = 563,
+                    UseSsl = true,
+                    User = "u",
+                    Pass = "p",
+                    MaxConnections = pooled,
+                },
+            ]
+        });
+
+        var items = new List<ConfigItem>
+        {
+            new() { ConfigName = "usenet.providers", ConfigValue = providers },
+        };
+        if (absolute is not null)
+            items.Add(new ConfigItem { ConfigName = "usenet.max-queue-connections", ConfigValue = absolute });
+        if (preset is not null)
+            items.Add(new ConfigItem { ConfigName = "usenet.max-queue-connections-preset", ConfigValue = preset });
+
+        var config = new ConfigManager();
+        config.UpdateValues(items);
+        return config;
+    }
+}


### PR DESCRIPTION
Supersedes #673 (fork branch could not be pushed to; @funkypenguin's original commit is preserved unchanged as the first commit here).

## Summary

- Adds `usenet.max-queue-connections-preset` (`low`/`medium`/`high`/`max` = 25/50/75/100% of the pooled connection total), so one value means the same thing whether a user's providers add up to 20 connections or 220. The absolute `usenet.max-queue-connections` still wins when set, and leaving both unset keeps the historical "queue may use the whole pool" default. (original commit by @funkypenguin)
- Resizes the queue admission semaphore when the preset changes. `DownloadingNntpClient` only watched the absolute setting, the streaming setting and the provider list, so a preset-only update left the gate at its previous size until an unrelated key changed or the process restarted.
- Rejects unknown preset values at write time. An unrecognised value resolved to "the whole pool" — the same silent, nothing-reserved outcome the preset exists to prevent — and headless installs configuring this through `NZBDAV_CONFIG__USENET__MAX_QUEUE_CONNECTIONS_PRESET` have no Settings page to reveal that the value was ignored.
- Documents the setting in the WebDAV configuration table, which is currently the only place to discover it or derive its ENV name (no UI control yet).

## Test plan

- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 1276 passed, 0 failed
- [x] New `QueueBudget_FollowsPresetChangesWithoutRestart` fails without the listener fix and passes with it
- [x] Preset getter coverage across 20- and 220-connection pools, casing, floor-of-1, absolute precedence
- [x] Validation accepts the four presets in any casing and rejects unknown values

## Notes

- The new regression test serializes provider JSON from the model rather than hand-writing it: config deserialization is case-sensitive, so the camelCase literal used elsewhere in that fixture binds to nothing and collapses the pooled total to 1, which would have made the budget assertions vacuous.
- The docs `since` pill assumes the next release is `0.9.1`; adjust if a breaking change lands in the same cycle.