### PR TITLE
fix(db): backend no longer starts against a stale schema or hangs on a stale migration lock

### DIFF
--- a/backend/Database/DatabaseMigrationLease.cs
+++ b/backend/Database/DatabaseMigrationLease.cs
@@ -1,0 +1,101 @@
+using System.Collections.Concurrent;
+using Serilog;
+
+namespace NzbWebDAV.Database;
+
+/// <summary>
+/// Serializes all NzbDAV database-maintenance processes before they recover
+/// EF's non-crash-safe SQLite migration lock.
+/// </summary>
+internal sealed class DatabaseMigrationLease : IAsyncDisposable
+{
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> InProcessLocks = new(
+        StringComparer.Ordinal);
+
+    private readonly FileStream _stream;
+    private readonly SemaphoreSlim _inProcessLock;
+    private bool _disposed;
+
+    private DatabaseMigrationLease(FileStream stream, SemaphoreSlim inProcessLock)
+    {
+        _stream = stream;
+        _inProcessLock = inProcessLock;
+    }
+
+    public static async Task<DatabaseMigrationLease> AcquireAsync(
+        string databasePath,
+        CancellationToken cancellationToken = default)
+    {
+        var fullDatabasePath = Path.GetFullPath(databasePath);
+        var leasePath = fullDatabasePath + ".maintenance.lock";
+        var directory = Path.GetDirectoryName(leasePath)
+            ?? throw new InvalidOperationException($"Database path has no parent directory: {databasePath}");
+        Directory.CreateDirectory(directory);
+
+        var inProcessLock = InProcessLocks.GetOrAdd(
+            leasePath,
+            static _ => new SemaphoreSlim(1, 1));
+        await inProcessLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        FileStream? stream = null;
+        var loggedWait = false;
+        try
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    stream = new FileStream(
+                        leasePath,
+                        new FileStreamOptions
+                        {
+                            Mode = FileMode.OpenOrCreate,
+                            Access = FileAccess.ReadWrite,
+                            Share = FileShare.None,
+                            Options = FileOptions.Asynchronous,
+                        });
+                    return new DatabaseMigrationLease(stream, inProcessLock);
+                }
+                catch (IOException)
+                {
+                    if (stream is not null)
+                        await stream.DisposeAsync().ConfigureAwait(false);
+                    stream = null;
+                    if (!loggedWait)
+                    {
+                        Log.Information(
+                            "Waiting for another NzbDAV process to finish database maintenance");
+                        loggedWait = true;
+                    }
+
+                    await Task.Delay(RetryDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch
+        {
+            if (stream is not null)
+                await stream.DisposeAsync().ConfigureAwait(false);
+            inProcessLock.Release();
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        try
+        {
+            await _stream.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _inProcessLock.Release();
+        }
+    }
+}

--- a/backend/Database/DatabaseStartupGuards.cs
+++ b/backend/Database/DatabaseStartupGuards.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 
 namespace NzbWebDAV.Database;
 
@@ -11,19 +13,85 @@ internal static class DatabaseStartupGuards
     /// True when the operational database has a <c>ConfigItems</c> table.
     /// Fresh / WAL-created empty files do not, so callers must not query config yet.
     /// </summary>
-    public static async Task<bool> ConfigItemsTableExistsAsync(
+    public static Task<bool> ConfigItemsTableExistsAsync(
         DbContext databaseContext,
+        CancellationToken cancellationToken = default) =>
+        TableExistsAsync(databaseContext, "ConfigItems", cancellationToken);
+
+    public static async Task<bool> TableExistsAsync(
+        DbContext databaseContext,
+        string tableName,
         CancellationToken cancellationToken = default)
     {
         var count = await databaseContext.Database
-            .SqlQueryRaw<int>(
-                """
+            .SqlQuery<int>(
+                $"""
                 SELECT COUNT(*) AS Value
                 FROM sqlite_master
-                WHERE type = 'table' AND name = 'ConfigItems'
+                WHERE type = 'table' AND name = {tableName}
                 """)
             .FirstAsync(cancellationToken)
             .ConfigureAwait(false);
         return count > 0;
+    }
+
+    /// <summary>
+    /// Clears EF's SQLite migration-lock row after the caller has acquired the
+    /// crash-safe <see cref="DatabaseMigrationLease"/>.
+    /// </summary>
+    public static async Task ClearAbandonedMigrationLockAsync(
+        DbContext databaseContext,
+        CancellationToken cancellationToken = default)
+    {
+        if (!await TableExistsAsync(databaseContext, "__EFMigrationsLock", cancellationToken)
+                .ConfigureAwait(false))
+        {
+            return;
+        }
+
+        var timestamps = await databaseContext.Database
+            .SqlQueryRaw<string>(
+                """
+                SELECT "Timestamp" AS Value
+                FROM "__EFMigrationsLock"
+                WHERE "Id" = 1
+                LIMIT 1
+                """)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (timestamps.Count == 0)
+            return;
+
+        var cleared = await databaseContext.Database
+            .ExecuteSqlRawAsync("DELETE FROM \"__EFMigrationsLock\"", cancellationToken)
+            .ConfigureAwait(false);
+        if (cleared == 0)
+            return;
+
+        var timestamp = timestamps[0];
+        if (DateTimeOffset.TryParse(
+                timestamp,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces,
+                out var acquiredAt))
+        {
+            var age = DateTimeOffset.UtcNow - acquiredAt;
+            if (age < TimeSpan.Zero)
+                age = TimeSpan.Zero;
+            Log.Warning(
+                "Cleared {Count} abandoned EF migration lock row(s) acquired at {Timestamp} "
+                + "({Age} old); the prior migration did not exit cleanly",
+                cleared,
+                acquiredAt,
+                age);
+        }
+        else
+        {
+            Log.Warning(
+                "Cleared {Count} abandoned EF migration lock row(s) with timestamp {Timestamp}; "
+                + "the prior migration did not exit cleanly",
+                cleared,
+                timestamp);
+        }
     }
 }

--- a/backend/Database/StartupDatabaseMigrator.cs
+++ b/backend/Database/StartupDatabaseMigrator.cs
@@ -23,8 +23,16 @@ internal static class StartupDatabaseMigrator
         Func<MigrationProgress, CancellationToken, Task<IAsyncDisposable?>> startStatusServer,
         CancellationToken cancellationToken)
     {
+        var databasePath = databaseContext.Database.GetDbConnection().DataSource;
+        await using var lease = await DatabaseMigrationLease
+            .AcquireAsync(databasePath, cancellationToken)
+            .ConfigureAwait(false);
+
         await databaseContext.Database
             .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", cancellationToken)
+            .ConfigureAwait(false);
+        await DatabaseStartupGuards
+            .ClearAbandonedMigrationLockAsync(databaseContext, cancellationToken)
             .ConfigureAwait(false);
 
         var pendingMigrations = (await databaseContext.Database

--- a/backend/Database/StartupDatabaseMigrator.cs
+++ b/backend/Database/StartupDatabaseMigrator.cs
@@ -34,6 +34,9 @@ internal static class StartupDatabaseMigrator
         await DatabaseStartupGuards
             .ClearAbandonedMigrationLockAsync(databaseContext, cancellationToken)
             .ConfigureAwait(false);
+        await DatabaseStartupGuards
+            .ClearAbandonedMigrationLockAsync(metricsContext, cancellationToken)
+            .ConfigureAwait(false);
 
         var pendingMigrations = (await databaseContext.Database
             .GetPendingMigrationsAsync(cancellationToken)

--- a/backend/Database/StartupDatabaseMigrator.cs
+++ b/backend/Database/StartupDatabaseMigrator.cs
@@ -1,0 +1,103 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Services;
+using Serilog;
+
+namespace NzbWebDAV.Database;
+
+internal static class StartupDatabaseMigrator
+{
+    public static Task RunAsync(
+        DavDatabaseContext databaseContext,
+        MetricsDbContext metricsContext,
+        CancellationToken cancellationToken) =>
+        RunAsync(
+            databaseContext,
+            metricsContext,
+            static async (progress, ct) =>
+                await MigrationStatusServer.StartAsync(progress, ct).ConfigureAwait(false),
+            cancellationToken);
+
+    internal static async Task RunAsync(
+        DavDatabaseContext databaseContext,
+        MetricsDbContext metricsContext,
+        Func<MigrationProgress, CancellationToken, Task<IAsyncDisposable?>> startStatusServer,
+        CancellationToken cancellationToken)
+    {
+        await databaseContext.Database
+            .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", cancellationToken)
+            .ConfigureAwait(false);
+
+        var pendingMigrations = (await databaseContext.Database
+            .GetPendingMigrationsAsync(cancellationToken)
+            .ConfigureAwait(false))
+            .ToList();
+        var pendingMetricsMigrations = (await metricsContext.Database
+            .GetPendingMigrationsAsync(cancellationToken)
+            .ConfigureAwait(false))
+            .ToList();
+
+        if (pendingMigrations.Count == 0 && pendingMetricsMigrations.Count == 0)
+        {
+            Log.Information("No pending database migrations");
+            await metricsContext.Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var steps = pendingMigrations
+            .Select(id => new MigrationProgress.MigrationStep(
+                id,
+                MigrationProgress.FriendlyName(id),
+                MigrationProgress.IsSlow(id)))
+            .ToList();
+        steps.Add(new MigrationProgress.MigrationStep(
+            MigrationProgress.MetricsStepId,
+            "Metrics database",
+            false));
+
+        var progress = new MigrationProgress();
+        progress.Initialize(steps);
+        await using var statusServer = await startStatusServer(progress, cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            for (var i = 0; i < steps.Count; i++)
+            {
+                var step = steps[i];
+                Log.Information(
+                    "Startup database migration step {Index}/{Total}: {Name}",
+                    i + 1,
+                    steps.Count,
+                    step.Name);
+                progress.BeginStep(step.Id);
+
+                if (step.Id == MigrationProgress.MetricsStepId)
+                    await metricsContext.Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+                else
+                    await databaseContext.Database.MigrateAsync(step.Id, cancellationToken).ConfigureAwait(false);
+
+                progress.CompleteStep(step.Id);
+            }
+
+            progress.Complete();
+            Log.Information("Database migrations completed");
+        }
+        catch (Exception ex)
+        {
+            progress.Fail(ex.Message);
+            if (statusServer is not null)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort grace period before the status server is disposed.
+                }
+            }
+
+            throw;
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NWebDav.Server;
@@ -124,6 +125,9 @@ class Program
                 .ExecuteSqlRawAsync(
                     "PRAGMA journal_mode = WAL;",
                     SigtermUtil.GetCancellationToken())
+                .ConfigureAwait(false);
+
+            await ClearStaleMigrationLockAsync(databaseContext, SigtermUtil.GetCancellationToken())
                 .ConfigureAwait(false);
 
             // The stock entrypoint runs `--db-migration` (the maintenance
@@ -371,6 +375,39 @@ class Program
     }
 
     /// <summary>
+    /// Clears any stale EF Core migration lock before applying migrations.
+    ///
+    /// A migration killed mid-flight (OOM, container eviction, SIGKILL, a node reboot)
+    /// leaves a committed row in EF Core's <c>__EFMigrationsLock</c> table. On the next
+    /// start, <c>SqliteHistoryRepository.AcquireDatabaseLock()</c> retries the acquire in
+    /// a <c>Thread.Sleep</c> loop with no timeout, so migration hangs forever — zero CPU,
+    /// no WAL writes, no progress — and the app never finishes starting. nzbdav only ever
+    /// applies migrations single-threaded at startup (the entrypoint runs
+    /// <c>--db-migration</c> to completion before the server, and the in-process path runs
+    /// before the host is built), so there is never a legitimate concurrent lock holder:
+    /// any pre-existing lock is stale and safe to clear.
+    /// </summary>
+    private static async Task ClearStaleMigrationLockAsync(DavDatabaseContext db, CancellationToken ct)
+    {
+        try
+        {
+            var cleared = await db.Database
+                .ExecuteSqlRawAsync("DELETE FROM \"__EFMigrationsLock\"", ct)
+                .ConfigureAwait(false);
+            if (cleared > 0)
+                Log.Warning(
+                    "Cleared {Count} stale EF migration lock row(s) left by an interrupted "
+                    + "migration; SQLite AcquireDatabaseLock would otherwise hang indefinitely",
+                    cleared);
+        }
+        catch (SqliteException ex) when (ex.SqliteErrorCode == 1)
+        {
+            // "no such table" — __EFMigrationsLock has not been created yet on a
+            // brand-new database. Nothing to clear.
+        }
+    }
+
+    /// <summary>
     /// Exercises P/Invoke into rapidyenc. Managed failures become Log.Fatal; a hard
     /// native crash still leaves the preceding Information line as a smoking gun.
     /// </summary>
@@ -462,6 +499,7 @@ class Program
             await databaseContext.Database
                 .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
                 .ConfigureAwait(false);
+            await ClearStaleMigrationLockAsync(databaseContext, ct).ConfigureAwait(false);
             Log.Information("Applying database migrations through {Target}", targetMigration);
             await databaseContext.Database.MigrateAsync(targetMigration, ct).ConfigureAwait(false);
             Log.Information("Database migrations completed");
@@ -527,6 +565,7 @@ class Program
             await databaseContext.Database
                 .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
                 .ConfigureAwait(false);
+            await ClearStaleMigrationLockAsync(databaseContext, ct).ConfigureAwait(false);
 
             var pending = (await databaseContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
             var vacuumEnabled = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,7 +3,6 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NWebDav.Server;
@@ -345,39 +344,6 @@ class Program
     }
 
     /// <summary>
-    /// Clears any stale EF Core migration lock before applying migrations.
-    ///
-    /// A migration killed mid-flight (OOM, container eviction, SIGKILL, a node reboot)
-    /// leaves a committed row in EF Core's <c>__EFMigrationsLock</c> table. On the next
-    /// start, <c>SqliteHistoryRepository.AcquireDatabaseLock()</c> retries the acquire in
-    /// a <c>Thread.Sleep</c> loop with no timeout, so migration hangs forever — zero CPU,
-    /// no WAL writes, no progress — and the app never finishes starting. nzbdav only ever
-    /// applies migrations single-threaded at startup (the entrypoint runs
-    /// <c>--db-migration</c> to completion before the server, and the in-process path runs
-    /// before the host is built), so there is never a legitimate concurrent lock holder:
-    /// any pre-existing lock is stale and safe to clear.
-    /// </summary>
-    private static async Task ClearStaleMigrationLockAsync(DavDatabaseContext db, CancellationToken ct)
-    {
-        try
-        {
-            var cleared = await db.Database
-                .ExecuteSqlRawAsync("DELETE FROM \"__EFMigrationsLock\"", ct)
-                .ConfigureAwait(false);
-            if (cleared > 0)
-                Log.Warning(
-                    "Cleared {Count} stale EF migration lock row(s) left by an interrupted "
-                    + "migration; SQLite AcquireDatabaseLock would otherwise hang indefinitely",
-                    cleared);
-        }
-        catch (SqliteException ex) when (ex.SqliteErrorCode == 1)
-        {
-            // "no such table" — __EFMigrationsLock has not been created yet on a
-            // brand-new database. Nothing to clear.
-        }
-    }
-
-    /// <summary>
     /// Exercises P/Invoke into rapidyenc. Managed failures become Log.Fatal; a hard
     /// native crash still leaves the preceding Information line as a smoking gun.
     /// </summary>
@@ -431,6 +397,9 @@ class Program
     private static async Task RunDatabaseMigrationsAsync(string[] args)
     {
         var ct = SigtermUtil.GetCancellationToken();
+        await using var maintenanceLease = await DatabaseMigrationLease
+            .AcquireAsync(DavDatabaseContext.DatabaseFilePath, ct)
+            .ConfigureAwait(false);
         var argIndex = args.ToList().IndexOf("--db-migration");
         var targetMigration = args.Length > argIndex + 1 ? args[argIndex + 1] : null;
         var backupStore = new DatabaseBackupStore();
@@ -469,7 +438,9 @@ class Program
             await databaseContext.Database
                 .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
                 .ConfigureAwait(false);
-            await ClearStaleMigrationLockAsync(databaseContext, ct).ConfigureAwait(false);
+            await DatabaseStartupGuards
+                .ClearAbandonedMigrationLockAsync(databaseContext, ct)
+                .ConfigureAwait(false);
             Log.Information("Applying database migrations through {Target}", targetMigration);
             await databaseContext.Database.MigrateAsync(targetMigration, ct).ConfigureAwait(false);
             Log.Information("Database migrations completed");
@@ -535,7 +506,9 @@ class Program
             await databaseContext.Database
                 .ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;", ct)
                 .ConfigureAwait(false);
-            await ClearStaleMigrationLockAsync(databaseContext, ct).ConfigureAwait(false);
+            await DatabaseStartupGuards
+                .ClearAbandonedMigrationLockAsync(databaseContext, ct)
+                .ConfigureAwait(false);
 
             var pending = (await databaseContext.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false)).ToList();
             var vacuumEnabled = await IsDatabaseStartupVacuumEnabledAsync().ConfigureAwait(false);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -445,6 +445,9 @@ class Program
             await databaseContext.Database.MigrateAsync(targetMigration, ct).ConfigureAwait(false);
             Log.Information("Database migrations completed");
             await using var metricsContext = new MetricsDbContext();
+            await DatabaseStartupGuards
+                .ClearAbandonedMigrationLockAsync(metricsContext, ct)
+                .ConfigureAwait(false);
             await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
             await PerformDatabaseVacuumIfEnabled().ConfigureAwait(false);
             return;
@@ -475,6 +478,9 @@ class Program
             {
                 Log.Information("No pending database migrations");
                 await using var metricsContext = new MetricsDbContext();
+                await DatabaseStartupGuards
+                    .ClearAbandonedMigrationLockAsync(metricsContext, ct)
+                    .ConfigureAwait(false);
                 await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
                 Log.Information("Database migrations completed");
                 return;
@@ -552,6 +558,9 @@ class Program
                 if (step.Id == MigrationProgress.MetricsStepId)
                 {
                     await using var metricsContext = new MetricsDbContext();
+                    await DatabaseStartupGuards
+                        .ClearAbandonedMigrationLockAsync(metricsContext, ct)
+                        .ConfigureAwait(false);
                     await metricsContext.Database.MigrateAsync(ct).ConfigureAwait(false);
                 }
                 else if (step.Id == MigrationProgress.VacuumStepId)

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -119,45 +119,15 @@ class Program
                 return;
             }
 
-            // initialize database
+            // Keep both database schemas current before config or application services
+            // read them. The stock entrypoint already does this through --db-migration;
+            // direct backend launches use the same progress UI here.
+            var startupCancellationToken = SigtermUtil.GetCancellationToken();
             await using var databaseContext = new DavDatabaseContext();
-            await databaseContext.Database
-                .ExecuteSqlRawAsync(
-                    "PRAGMA journal_mode = WAL;",
-                    SigtermUtil.GetCancellationToken())
+            await using var metricsBootstrap = new MetricsDbContext();
+            await StartupDatabaseMigrator
+                .RunAsync(databaseContext, metricsBootstrap, startupCancellationToken)
                 .ConfigureAwait(false);
-
-            await ClearStaleMigrationLockAsync(databaseContext, SigtermUtil.GetCancellationToken())
-                .ConfigureAwait(false);
-
-            // The stock entrypoint runs `--db-migration` (the maintenance
-            // runner) before the server starts, so this is a no-op there.
-            // Deployments that launch the backend directly (e.g. separate
-            // chart-managed containers that bypass entrypoint.sh) would
-            // otherwise never migrate the main database and fail at runtime
-            // with missing tables/columns.
-            var pendingMigrations = (await databaseContext.Database
-                .GetPendingMigrationsAsync(SigtermUtil.GetCancellationToken())
-                .ConfigureAwait(false)).ToList();
-            if (pendingMigrations.Count > 0)
-            {
-                Log.Warning(
-                    "Applying {Count} pending database migrations at startup ({First} .. {Last})",
-                    pendingMigrations.Count, pendingMigrations[0], pendingMigrations[^1]);
-                await databaseContext.Database
-                    .MigrateAsync(SigtermUtil.GetCancellationToken())
-                    .ConfigureAwait(false);
-                Log.Information("Database migrations completed");
-            }
-
-            // The metrics database has its own schema and must also be current on
-            // normal startup, where the operational migration runner is skipped.
-            await using (var metricsBootstrap = new MetricsDbContext())
-            {
-                await metricsBootstrap.Database
-                    .MigrateAsync(SigtermUtil.GetCancellationToken())
-                    .ConfigureAwait(false);
-            }
 
             // initialize the config-manager
             var configManager = new ConfigManager();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -126,6 +126,26 @@ class Program
                     SigtermUtil.GetCancellationToken())
                 .ConfigureAwait(false);
 
+            // The stock entrypoint runs `--db-migration` (the maintenance
+            // runner) before the server starts, so this is a no-op there.
+            // Deployments that launch the backend directly (e.g. separate
+            // chart-managed containers that bypass entrypoint.sh) would
+            // otherwise never migrate the main database and fail at runtime
+            // with missing tables/columns.
+            var pendingMigrations = (await databaseContext.Database
+                .GetPendingMigrationsAsync(SigtermUtil.GetCancellationToken())
+                .ConfigureAwait(false)).ToList();
+            if (pendingMigrations.Count > 0)
+            {
+                Log.Warning(
+                    "Applying {Count} pending database migrations at startup ({First} .. {Last})",
+                    pendingMigrations.Count, pendingMigrations[0], pendingMigrations[^1]);
+                await databaseContext.Database
+                    .MigrateAsync(SigtermUtil.GetCancellationToken())
+                    .ConfigureAwait(false);
+                Log.Information("Database migrations completed");
+            }
+
             // The metrics database has its own schema and must also be current on
             // normal startup, where the operational migration runner is skipped.
             await using (var metricsBootstrap = new MetricsDbContext())

--- a/tests/NzbWebDAV.Tests/Database/DatabaseMigrationLeaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseMigrationLeaseTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class DatabaseMigrationLeaseTests
+{
+    private const string PriorMainMigration = "20260713120000_Add-Path-Index-To-DavItems";
+
+    [Fact]
+    public async Task AcquireAsync_SerializesCallersForTheSameDatabase()
+    {
+        var path = TempDatabasePath();
+        try
+        {
+            await using var first = await DatabaseMigrationLease.AcquireAsync(path);
+            var secondTask = DatabaseMigrationLease.AcquireAsync(path);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            Assert.False(secondTask.IsCompleted);
+
+            await first.DisposeAsync();
+            await using var second = await secondTask.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Fact]
+    public async Task ClearAbandonedMigrationLockAsync_UnblocksPendingMigration()
+    {
+        var path = TempDatabasePath();
+        try
+        {
+            await using var context = CreateMainContext(path);
+            await context.Database.MigrateAsync(PriorMainMigration);
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT OR REPLACE INTO "__EFMigrationsLock" ("Id", "Timestamp")
+                VALUES (1, '2026-07-23 01:40:05+00:00')
+                """);
+
+            await using var lease = await DatabaseMigrationLease.AcquireAsync(path);
+            await DatabaseStartupGuards.ClearAbandonedMigrationLockAsync(context);
+            await context.Database.MigrateAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.Empty(await context.Database.GetPendingMigrationsAsync());
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Fact]
+    public async Task ClearAbandonedMigrationLockAsync_IsNoOpBeforeLockTableExists()
+    {
+        var path = TempDatabasePath();
+        try
+        {
+            await using var context = CreateMainContext(path);
+            await using var lease = await DatabaseMigrationLease.AcquireAsync(path);
+
+            await DatabaseStartupGuards.ClearAbandonedMigrationLockAsync(context);
+
+            Assert.False(await DatabaseStartupGuards.TableExistsAsync(context, "__EFMigrationsLock"));
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Fact]
+    public async Task AcquireAsync_IgnoresLeftoverUnlockedSidecarFile()
+    {
+        var path = TempDatabasePath();
+        try
+        {
+            await File.WriteAllTextAsync(path + ".maintenance.lock", "left by interrupted process");
+
+            await using var lease = await DatabaseMigrationLease
+                .AcquireAsync(path)
+                .WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    private static DavDatabaseContext CreateMainContext(string path)
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={path};Pooling=False")
+            .AddInterceptors(new SqliteMainDbPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        return new DavDatabaseContext(options);
+    }
+
+    private static string TempDatabasePath() =>
+        Path.Combine(Path.GetTempPath(), $"nzbdav-migration-lease-{Guid.NewGuid():N}.sqlite");
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        TryDelete(path);
+        TryDelete(path + "-wal");
+        TryDelete(path + "-shm");
+        TryDelete(path + ".maintenance.lock");
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best effort */ }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/StartupDatabaseMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/StartupDatabaseMigrationTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class StartupDatabaseMigrationTests
+{
+    private const string PriorMainMigration = "20260713120000_Add-Path-Index-To-DavItems";
+
+    [Fact]
+    public async Task RunAsync_AppliesPendingMainAndMetricsMigrations()
+    {
+        var mainPath = TempDatabasePath("main");
+        var metricsPath = TempDatabasePath("metrics");
+        try
+        {
+            await using var mainContext = CreateMainContext(mainPath);
+            await mainContext.Database.MigrateAsync(PriorMainMigration);
+            await using var metricsContext = CreateMetricsContext(metricsPath);
+
+            await StartupDatabaseMigrator.RunAsync(
+                mainContext,
+                metricsContext,
+                static (_, _) => Task.FromResult<IAsyncDisposable?>(null),
+                CancellationToken.None);
+
+            Assert.Empty(await mainContext.Database.GetPendingMigrationsAsync());
+            Assert.Empty(await metricsContext.Database.GetPendingMigrationsAsync());
+        }
+        finally
+        {
+            DeleteDatabaseFiles(mainPath);
+            DeleteDatabaseFiles(metricsPath);
+        }
+    }
+
+    private static DavDatabaseContext CreateMainContext(string path)
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={path};Pooling=False")
+            .AddInterceptors(new SqliteMainDbPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        return new DavDatabaseContext(options);
+    }
+
+    private static MetricsDbContext CreateMetricsContext(string path)
+    {
+        var options = new DbContextOptionsBuilder<MetricsDbContext>()
+            .UseSqlite($"Data Source={path};Pooling=False")
+            .AddInterceptors(new SqliteMetricsPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        return new MetricsDbContext(options);
+    }
+
+    private static string TempDatabasePath(string name) =>
+        Path.Combine(Path.GetTempPath(), $"nzbdav-startup-{name}-{Guid.NewGuid():N}.sqlite");
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        TryDelete(path);
+        TryDelete(path + "-wal");
+        TryDelete(path + "-shm");
+        TryDelete(path + ".maintenance.lock");
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best effort */ }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/StartupDatabaseMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/StartupDatabaseMigrationTests.cs
@@ -9,6 +9,7 @@ namespace NzbWebDAV.Tests.Database;
 public sealed class StartupDatabaseMigrationTests
 {
     private const string PriorMainMigration = "20260713120000_Add-Path-Index-To-DavItems";
+    private const string PriorMetricsMigration = "20260601104313_AddFailoverEdges";
 
     [Fact]
     public async Task RunAsync_AppliesPendingMainAndMetricsMigrations()
@@ -20,12 +21,20 @@ public sealed class StartupDatabaseMigrationTests
             await using var mainContext = CreateMainContext(mainPath);
             await mainContext.Database.MigrateAsync(PriorMainMigration);
             await using var metricsContext = CreateMetricsContext(metricsPath);
+            await metricsContext.Database.MigrateAsync(PriorMetricsMigration);
+            await metricsContext.Database.ExecuteSqlRawAsync(
+                """
+                INSERT OR REPLACE INTO "__EFMigrationsLock" ("Id", "Timestamp")
+                VALUES (1, '2026-07-23 01:40:05+00:00')
+                """);
 
-            await StartupDatabaseMigrator.RunAsync(
-                mainContext,
-                metricsContext,
-                static (_, _) => Task.FromResult<IAsyncDisposable?>(null),
-                CancellationToken.None);
+            await StartupDatabaseMigrator
+                .RunAsync(
+                    mainContext,
+                    metricsContext,
+                    static (_, _) => Task.FromResult<IAsyncDisposable?>(null),
+                    CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(10));
 
             Assert.Empty(await mainContext.Database.GetPendingMigrationsAsync());
             Assert.Empty(await metricsContext.Database.GetPendingMigrationsAsync());


### PR DESCRIPTION
## Summary
- carry forward @funkypenguin's two authored commits from #530 so direct backend launches apply pending main-database migrations
- expose the existing migration progress/status server during in-process upgrades instead of leaving health checks with a silent pre-bind wait
- serialize restore, migration, metrics migration, and vacuum behind a crash-safe sidecar lease before clearing abandoned EF migration locks
- recover abandoned locks in both the main and metrics databases, with focused regression coverage

## Review fixes applied
- removed the inaccurate claim that `scripts/run-backend.sh` skips migrations by default
- replaced the unconditional `DELETE FROM \"__EFMigrationsLock\"` with lease-protected recovery, preserving protection against concurrent NzbDAV migrators
- replaced the broad `SQLITE_ERROR` catch with an explicit `sqlite_master` table probe
- use Information-level progress events and a human-friendly Warning only when an abandoned lock is actually cleared

## Deployment scope
Direct binary launches now migrate schemas, but they still do not process staged restores, run the optional startup vacuum, or implement the exit-86 restore restart handshake. Operators must also avoid running an older NzbDAV binary or an external migration tool concurrently against the same SQLite files because those processes do not participate in the new maintenance lease.

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1,281 passed, 14 skipped)
- [x] roll a temporary main database back, insert an abandoned EF lock row, and launch without `--db-migration`; lock recovery and both pending migration steps completed
- [x] hold the sidecar lease from a second process and confirm `--db-migration` waits, then proceeds after release
- [ ] post-migration local health bind was not exercised because the macOS development host lacks the RapidYenc native library; startup reached and completed the migration phase before that existing self-test failure

Supersedes #530 because the original head branch is hosted in the `elfhosted` organization and maintainer edits return 403.