### PR TITLE
fix(webdav): tell WebDAV clients why a deep directory listing was refused

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -310,6 +311,31 @@ class Program
             app.Map("/ws", websocketManager.HandleRoute);
             app.MapControllers();
             app.UseWebdavBasicAuthentication();
+            // RFC 4918 §9.1: a server that does not support infinite-depth
+            // PROPFIND must reject it with 403 + <propfind-finite-depth/>.
+            // NWebDav instead answers 207 with only depth-1 results, which
+            // silently lies to clients: the `webdav` npm library's deep mode
+            // (used by AIOStreams and friends) trusts the "successful" shallow
+            // listing, sees no files for releases whose video sits in a nested
+            // folder, and reports the download as empty instead of falling
+            // back to manual traversal. Returning the RFC error makes those
+            // clients throw and recover via their own recursive walk.
+            // Requests WITHOUT a Depth header keep NWebDav's existing
+            // behavior — some clients omit it while expecting a shallow
+            // answer, and rejecting them would regress working setups.
+            app.Use(async (context, next) =>
+            {
+                if (string.Equals(context.Request.Method, "PROPFIND", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(context.Request.Headers["Depth"], "infinity", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.StatusCode = 403;
+                    context.Response.ContentType = "application/xml; charset=utf-8";
+                    await context.Response.WriteAsync(
+                        "<?xml version=\"1.0\" encoding=\"utf-8\"?><D:error xmlns:D=\"DAV:\"><D:propfind-finite-depth/></D:error>");
+                    return;
+                }
+                await next();
+            });
             app.UseNWebDav();
             app.Lifetime.ApplicationStopping.Register(SigtermUtil.Cancel);
             // Remap legacy host-keyed metrics rows onto ProviderIds after the app is

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -2,7 +2,6 @@
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -291,11 +290,13 @@ class Program
                 .AddScoped<DatabaseStore>()
                 .AddScoped<IStore, DatabaseStore>()
                 .AddScoped<GetAndHeadHandlerPatch>()
+                .AddScoped<PropFindHandlerPatch>()
                 .AddScoped<SabApiController>()
                 .AddNWebDav(opts =>
                 {
                     opts.Handlers["GET"] = typeof(GetAndHeadHandlerPatch);
                     opts.Handlers["HEAD"] = typeof(GetAndHeadHandlerPatch);
+                    opts.Handlers["PROPFIND"] = typeof(PropFindHandlerPatch);
                     opts.Filter = opts.GetFilter();
                     opts.RequireAuthentication = !WebApplicationAuthExtensions
                         .IsWebdavAuthDisabled();
@@ -311,31 +312,6 @@ class Program
             app.Map("/ws", websocketManager.HandleRoute);
             app.MapControllers();
             app.UseWebdavBasicAuthentication();
-            // RFC 4918 §9.1: a server that does not support infinite-depth
-            // PROPFIND must reject it with 403 + <propfind-finite-depth/>.
-            // NWebDav instead answers 207 with only depth-1 results, which
-            // silently lies to clients: the `webdav` npm library's deep mode
-            // (used by AIOStreams and friends) trusts the "successful" shallow
-            // listing, sees no files for releases whose video sits in a nested
-            // folder, and reports the download as empty instead of falling
-            // back to manual traversal. Returning the RFC error makes those
-            // clients throw and recover via their own recursive walk.
-            // Requests WITHOUT a Depth header keep NWebDav's existing
-            // behavior — some clients omit it while expecting a shallow
-            // answer, and rejecting them would regress working setups.
-            app.Use(async (context, next) =>
-            {
-                if (string.Equals(context.Request.Method, "PROPFIND", StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(context.Request.Headers["Depth"], "infinity", StringComparison.OrdinalIgnoreCase))
-                {
-                    context.Response.StatusCode = 403;
-                    context.Response.ContentType = "application/xml; charset=utf-8";
-                    await context.Response.WriteAsync(
-                        "<?xml version=\"1.0\" encoding=\"utf-8\"?><D:error xmlns:D=\"DAV:\"><D:propfind-finite-depth/></D:error>");
-                    return;
-                }
-                await next();
-            });
             app.UseNWebDav();
             app.Lifetime.ApplicationStopping.Register(SigtermUtil.Cancel);
             // Remap legacy host-keyed metrics rows onto ProviderIds after the app is

--- a/backend/WebDav/Base/PropFindHandlerPatch.cs
+++ b/backend/WebDav/Base/PropFindHandlerPatch.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using NWebDav.Server.Handlers;
+
+namespace NzbWebDAV.WebDav.Base;
+
+public class PropFindHandlerPatch(PropFindHandler inner) : IRequestHandler
+{
+    internal const string FiniteDepthErrorBody =
+        """<?xml version="1.0" encoding="utf-8"?><D:error xmlns:D="DAV:"><D:propfind-finite-depth/></D:error>""";
+
+    public async Task<bool> HandleRequestAsync(HttpContext httpContext)
+    {
+        var handled = await inner.HandleRequestAsync(httpContext).ConfigureAwait(false);
+        await TryWriteFiniteDepthErrorAsync(httpContext).ConfigureAwait(false);
+        return handled;
+    }
+
+    internal static async Task<bool> TryWriteFiniteDepthErrorAsync(HttpContext httpContext)
+    {
+        var response = httpContext.Response;
+        if (response.HasStarted || response.StatusCode != StatusCodes.Status403Forbidden)
+            return false;
+
+        response.ContentType = "application/xml; charset=utf-8";
+        await response.WriteAsync(FiniteDepthErrorBody, httpContext.RequestAborted).ConfigureAwait(false);
+        return true;
+    }
+}

--- a/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
@@ -1,0 +1,85 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using NzbWebDAV.WebDav.Base;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+public class PropFindHandlerPatchTests
+{
+    [Fact]
+    public async Task ForbiddenResponse_GetsFiniteDepthErrorBody()
+    {
+        var (context, body) = CreateContext(StatusCodes.Status403Forbidden);
+
+        var written = await PropFindHandlerPatch.TryWriteFiniteDepthErrorAsync(context);
+
+        Assert.True(written);
+        Assert.Equal("application/xml; charset=utf-8", context.Response.ContentType);
+        Assert.Equal(PropFindHandlerPatch.FiniteDepthErrorBody, Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Status207MultiStatus)]
+    [InlineData(StatusCodes.Status404NotFound)]
+    public async Task NonForbiddenResponse_IsUnchanged(int statusCode)
+    {
+        var (context, body) = CreateContext(statusCode, contentType: "text/plain");
+        await body.WriteAsync("existing"u8.ToArray());
+
+        var written = await PropFindHandlerPatch.TryWriteFiniteDepthErrorAsync(context);
+
+        Assert.False(written);
+        Assert.Equal("text/plain", context.Response.ContentType);
+        Assert.Equal("existing", Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    [Fact]
+    public async Task StartedForbiddenResponse_IsUnchanged()
+    {
+        var (context, body) = CreateContext(
+            StatusCodes.Status403Forbidden,
+            hasStarted: true,
+            contentType: "text/plain");
+        await body.WriteAsync("existing"u8.ToArray());
+
+        var written = await PropFindHandlerPatch.TryWriteFiniteDepthErrorAsync(context);
+
+        Assert.False(written);
+        Assert.Equal("text/plain", context.Response.ContentType);
+        Assert.Equal("existing", Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    private static (DefaultHttpContext Context, MemoryStream Body) CreateContext(
+        int statusCode,
+        bool hasStarted = false,
+        string? contentType = null)
+    {
+        var body = new MemoryStream();
+        var context = new DefaultHttpContext();
+        context.Features.Set<IHttpResponseFeature>(new TestHttpResponseFeature(hasStarted)
+        {
+            StatusCode = statusCode
+        });
+        context.Response.Body = body;
+        context.Response.ContentType = contentType;
+        return (context, body);
+    }
+
+    private sealed class TestHttpResponseFeature(bool hasStarted) : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted { get; } = hasStarted;
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+        }
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- carry forward @funkypenguin's original contribution from #633 with its authorship and co-author trailer preserved
- add the RFC 4918 `DAV:propfind-finite-depth` body from inside NWebDav's PROPFIND handler, preserving the existing authentication challenge and WebDAV path filter
- cover the exact error body and ensure other or already-started responses remain unchanged

## Context
#608 already changed NzbDAV to reject unsupported deep PROPFIND requests with 403, so current `main` no longer returns the shallow 207 described by the original commit. The remaining gap from #581 was that NWebDav's rejection only set a reason phrase and emitted no DAV error body. The follow-up commit corrects the implementation while retaining the original contributor commit for provenance.

[Viren070/AIOStreams#1134](https://github.com/Viren070/AIOStreams/pull/1134) remains useful independently for servers that still silently clamp deep listings.

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`