### PR TITLE
fix(ui): make the stream tracing toggle easier to find on Support settings

### DIFF
--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -231,8 +231,8 @@ export function SupportSettings() {
                     </span>
                 </Alert>
 
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
-                    <div className="flex-1 space-y-2">
+                <div className="flex flex-col gap-4">
+                    <div className="space-y-2">
                         <Label htmlFor="stream-tracing-duration">Duration</Label>
                         <Select
                             id="stream-tracing-duration"
@@ -247,45 +247,41 @@ export function SupportSettings() {
                         </Select>
                         <HelpText>Auto-disables after the timer so tracing cannot be left on indefinitely.</HelpText>
                     </div>
-                    <Toggle
-                        label={enabled ? "Tracing on" : "Tracing off"}
-                        checked={enabled}
-                        disabled={tracingBusy}
-                        onChange={(event) => {
-                            if (event.target.checked) {
-                                void setTracing(true, minutes);
-                            } else {
-                                void setTracing(false);
-                            }
-                        }}
-                    />
+                    <div className="flex flex-wrap items-center gap-3">
+                        <Toggle
+                            label={enabled ? "Tracing on" : "Tracing off"}
+                            checked={enabled}
+                            disabled={tracingBusy}
+                            onChange={(event) => {
+                                if (event.target.checked) {
+                                    void setTracing(true, minutes);
+                                } else {
+                                    void setTracing(false);
+                                }
+                            }}
+                        />
+                        {enabled && (
+                            <Button
+                                variant="outline"
+                                disabled={tracingBusy}
+                                onClick={() => void setTracing(false)}
+                            >
+                                Turn off now
+                            </Button>
+                        )}
+                        {retained && (
+                            <Button
+                                variant="outline"
+                                disabled={tracingBusy}
+                                onClick={() => setConfirmDiscard(true)}
+                            >
+                                Discard captured traces
+                            </Button>
+                        )}
+                    </div>
                 </div>
 
                 <p className="text-sm text-base-content/70" aria-live="polite">{statusLine}</p>
-
-                {enabled && (
-                    <div>
-                        <Button
-                            variant="outline"
-                            disabled={tracingBusy}
-                            onClick={() => void setTracing(false)}
-                        >
-                            Turn off now
-                        </Button>
-                    </div>
-                )}
-
-                {retained && (
-                    <div>
-                        <Button
-                            variant="outline"
-                            disabled={tracingBusy}
-                            onClick={() => setConfirmDiscard(true)}
-                        >
-                            Discard captured traces
-                        </Button>
-                    </div>
-                )}
 
                 {status?.source === "env" && enabled && (
                     <HelpText>


### PR DESCRIPTION
## Summary
- Moves the Developer stream tracing enable toggle off the far-right of the settings card
- Groups the toggle with Turn off / Discard actions in a left-aligned row under Duration

## Test plan
- [ ] Open Settings → Support at a wide viewport
- [ ] Confirm the Tracing on/off toggle sits under Duration on the left, not at the card’s right edge
- [ ] Enable tracing, confirm Turn off now appears in the same row and works
- [ ] With a retained capture, confirm Discard captured traces appears and works