### PR TITLE
feat(health): tolerate a few missing articles in plain video files

### DIFF
--- a/backend/Clients/Usenet/ArticleExistenceChecker.cs
+++ b/backend/Clients/Usenet/ArticleExistenceChecker.cs
@@ -6,11 +6,12 @@ internal static class ArticleExistenceChecker
     /// Checks health/import existence concurrently across the connection pool.
     /// BODY pipelining settings must not collapse these probes onto one connection.
     /// </summary>
-    public static Task CheckAsync(
+    public static Task<IReadOnlyList<int>> CheckAsync(
         INntpClient client,
         IReadOnlyList<string> segmentIds,
         int concurrency,
         IProgress<int>? progress,
-        CancellationToken cancellationToken) =>
-        client.CheckAllSegmentsAsync(segmentIds, concurrency, progress, cancellationToken);
+        CancellationToken cancellationToken,
+        int toleratedMissing = 0) =>
+        client.CheckAllSegmentsAsync(segmentIds, concurrency, progress, cancellationToken, toleratedMissing);
 }

--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -100,8 +100,14 @@ public interface INntpClient : IDisposable
         string[][]? segmentFallbacks = null,
         InFlightArticleBudget? inFlightArticleBudget = null);
 
-    Task CheckAllSegmentsAsync(
-        IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);
+    /// <summary>
+    /// Confirms every segment exists, returning the positions of those missing but tolerated.
+    /// Throws once the missing count passes <paramref name="toleratedMissing"/>, so the
+    /// default of zero fails on the first confirmed miss.
+    /// </summary>
+    Task<IReadOnlyList<int>> CheckAllSegmentsAsync(
+        IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress,
+        CancellationToken cancellationToken, int toleratedMissing = 0);
 
     Task CheckAllSegmentsPipelinedAsync(
         IReadOnlyList<string> segmentIds, int depth, int fallbackConcurrency, IProgress<int>? progress,

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -206,37 +206,52 @@ public abstract class NntpClient : INntpClient
         return string.IsNullOrEmpty(subjectName) ? null : subjectName;
     }
 
-    public virtual async Task CheckAllSegmentsAsync
+    public virtual async Task<IReadOnlyList<int>> CheckAllSegmentsAsync
     (
         IEnumerable<string> segmentIds,
         int concurrency,
         IProgress<int>? progress,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        int toleratedMissing = 0
     )
     {
         using var childCt = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var token = childCt.Token;
 
         var tasks = segmentIds
-            .Select(async segmentId => (
+            .Select(async (segmentId, position) => (
+                Position: position,
                 SegmentId: segmentId,
                 Result: await StatAsync(segmentId, token).ConfigureAwait(false)
             ))
             .WithConcurrencyAsync(concurrency, token);
 
         var processed = 0;
+
+        // Positions, not ids, because only the caller knows where each one sits in the file.
+        // They arrive in completion order rather than input order, so the caller sorts.
+        var missing = new List<int>();
         await foreach (var task in tasks.ConfigureAwait(false))
         {
             progress?.Report(++processed);
             if (task.Result.ResponseType == UsenetResponseType.ArticleExists) continue;
-            await childCt.CancelAsync().ConfigureAwait(false);
 
             // Definitive missing (430 / provider 451) fails the health check; any other
             // response (e.g. a stale connection's goodbye line) must stay retryable.
             if (UsenetArticleAvailability.IsDefinitiveMissing(task.Result))
+            {
+                // Results are consumed on this one loop, so the list needs no synchronization.
+                missing.Add(task.Position);
+                if (missing.Count <= toleratedMissing) continue;
+                await childCt.CancelAsync().ConfigureAwait(false);
                 throw new UsenetArticleNotFoundException(task.SegmentId, task.Result.ResponseMessage);
+            }
+
+            await childCt.CancelAsync().ConfigureAwait(false);
             throw new UsenetUnexpectedResponseException(task.SegmentId, task.Result.ResponseMessage);
         }
+
+        return missing;
     }
 
     public virtual async IAsyncEnumerable<PipelinedStatResult> StatsPipelinedAsync

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -73,6 +73,7 @@ public static class ConfigKeys
     public const string RepairHealthcheckConcurrency = "repair.healthcheck-concurrency";
     public const string RepairHealthcheckDepth = "repair.healthcheck-depth";
     public const string RepairHealthcheckAging = "repair.healthcheck-aging";
+    public const string RepairHealthcheckLenient = "repair.healthcheck-lenient";
     public const string RepairAutoRemoveAfterFailures = "repair.auto-remove-after-failures";
     public const string RepairAutoRemoveUnlinkedOnly = "repair.auto-remove-unlinked-only";
     public const string ArrInstances = "arr.instances";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -364,6 +364,7 @@ public class ConfigManager
                 case ConfigKeys.WardenBackboneScope:
                 case ConfigKeys.RepairEnable:
                 case ConfigKeys.RepairHealthcheckAging:
+                case ConfigKeys.RepairHealthcheckLenient:
                 case ConfigKeys.RepairAutoRemoveUnlinkedOnly:
                 case ConfigKeys.RcloneRcEnabled:
                 case ConfigKeys.DbIsStartupVacuumEnabled:
@@ -1423,6 +1424,16 @@ public class ConfigManager
     public bool IsHealthCheckAgingEnabled()
     {
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckAging));
+        return configValue != null && bool.Parse(configValue);
+    }
+
+    /// <summary>
+    /// Whether a health check may accept a few missing articles in a plain video container
+    /// instead of repairing it. Off by default, so any confirmed miss fails the check.
+    /// </summary>
+    public bool IsHealthCheckLenient()
+    {
+        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairHealthcheckLenient));
         return configValue != null && bool.Parse(configValue);
     }
 

--- a/backend/Database/Models/HealthCheckResult.cs
+++ b/backend/Database/Models/HealthCheckResult.cs
@@ -22,5 +22,8 @@ public class HealthCheckResult
         Repaired = 1,
         Deleted = 2,
         ActionNeeded = 3,
+
+        /// <summary>Missing articles stayed within tolerance, so no repair was attempted.</summary>
+        Degraded = 4,
     }
 }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -11,6 +11,7 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -30,6 +31,14 @@ public class HealthCheckService : BackgroundService
     // A release keeps full depth for its first year, then tapers until it stops aging at ten.
     private const double FullDepthDays = 365;
     private const double MinDepthDays = 3650;
+
+    // Two caps rather than one, because a missing article costs a viewer two separate things.
+    // An article is a fixed size, so the ratio is the share of runtime that plays back silent,
+    // which scales with the file. The number of interruptions does not scale: a viewer tolerates
+    // about as many on an episode as on a feature, which is what the flat count bounds. Whichever
+    // is lower wins, so the ratio protects small files and the count protects everything else.
+    private const double LenientMissingRatio = 0.02;
+    private const int LenientMissingCeiling = 64;
 
     private readonly ConfigManager _configManager;
     private readonly INntpClient _usenetClient;
@@ -192,7 +201,8 @@ public class HealthCheckService : BackgroundService
             }
 
             // update the release date, if null
-            var segments = await GetAllSegments(davItem, dbClient, ct).ConfigureAwait(false);
+            var item = await GetAllSegments(davItem, dbClient, ct).ConfigureAwait(false);
+            var segments = item.Segments;
             if (davItem.ReleaseDate == null) await UpdateReleaseDate(davItem, segments, ct).ConfigureAwait(false);
 
             // sample large files to reduce NNTP load while keeping head/tail/stride coverage
@@ -200,7 +210,8 @@ public class HealthCheckService : BackgroundService
             var age = _configManager.IsHealthCheckAgingEnabled() && davItem.ReleaseDate is { } posted
                 ? DateTimeOffset.UtcNow - posted
                 : (TimeSpan?)null;
-            var sampled = SampleSegments(segments, _configManager.GetHealthCheckDepth(), age);
+            var sampledIndexes = SampleSegmentIndexes(segments, _configManager.GetHealthCheckDepth(), age);
+            var sampled = sampledIndexes.Select(i => segments[i]).ToList();
 
             // setup progress tracking
             var progressHook = new Progress<int>();
@@ -213,8 +224,22 @@ public class HealthCheckService : BackgroundService
 
             // perform health check
             var progress = progressHook.ToPercentage(sampled.Count);
-            await ArticleExistenceChecker.CheckAsync(_usenetClient, sampled, concurrency, progress, ct)
+            var tolerated = ToleratedMissingArticles(
+                davItem.Name, totalSegments, _configManager.IsHealthCheckLenient(), item.CarriesOwnBytes);
+            var missingPositions = await ArticleExistenceChecker
+                .CheckAsync(_usenetClient, sampled, concurrency, progress, ct, tolerated)
                 .ConfigureAwait(false);
+            var missing = missingPositions.Count;
+
+            // Staying inside the budget is not enough: some damage a read refuses outright, and
+            // passing it here would hand back a file that errors instead of playing. Fail as if
+            // the budget had been exceeded, and let the same catch schedule the repair.
+            var missingIndexes = missingPositions.Select(p => sampledIndexes[p]).ToList();
+            if (FindUnreadableDamage(missingIndexes, totalSegments) is { } unreadable)
+            {
+                throw new UsenetArticleNotFoundException(segments[unreadable.Index], unreadable.Reason);
+            }
+
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
 
@@ -225,15 +250,39 @@ public class HealthCheckService : BackgroundService
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
-            _failureTracker.ClearFailure(davItem.Id);
-            var healthyMessage = sampled.Count < totalSegments
-                ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
-                : "File is healthy.";
-            await RecordHealthResult(
-                dbClient, davItem,
-                HealthCheckResult.HealthResult.Healthy,
-                HealthCheckResult.RepairAction.None,
-                healthyMessage, ct).ConfigureAwait(false);
+            var coverage = sampled.Count < totalSegments
+                ? $" (sampled {sampled.Count}/{totalSegments} segments)"
+                : "";
+
+            if (missing > 0)
+            {
+                // Leave the streaming failure counter alone. Playback is still the backstop for a
+                // gap too long to zero-fill, and it needs its own count of hard failures to do it.
+                Log.Warning(
+                    "Tolerating {MissingCount} of {ToleratedCount} allowed missing article(s) for {FilePath}",
+                    missing, tolerated, davItem.Path);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Healthy,
+                    HealthCheckResult.RepairAction.Degraded,
+                    // The count is of what was checked, so say so rather than implying the
+                    // whole file was measured.
+                    sampled.Count < totalSegments
+                        ? $"File is degraded: {missing} missing from a {sampled.Count}-segment " +
+                          $"sample of {totalSegments}, within the {tolerated} allowed."
+                        : $"File is degraded: {missing} of {totalSegments} articles missing, " +
+                          $"within the {tolerated} allowed.",
+                    ct).ConfigureAwait(false);
+            }
+            else
+            {
+                _failureTracker.ClearFailure(davItem.Id);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Healthy,
+                    HealthCheckResult.RepairAction.None,
+                    $"File is healthy{coverage}.", ct).ConfigureAwait(false);
+            }
         }
         catch (UsenetArticleNotFoundException e)
         {
@@ -398,6 +447,24 @@ public class HealthCheckService : BackgroundService
     }
 
     /// <summary>
+    /// How many missing articles a check may accept before the file fails. Zero unless every
+    /// condition holds, so anything not covered keeps failing on its first confirmed miss.
+    /// </summary>
+    /// <remarks>
+    /// Counted against the file's whole segment count rather than the sampled subset, so a
+    /// shallow depth can pass a file carrying more missing articles than the caps name. The
+    /// alternative, scaling the budget down by coverage, makes the caps mean different things
+    /// at different depths for no gain in what a viewer actually experiences.
+    /// </remarks>
+    internal static int ToleratedMissingArticles(
+        string filename, int totalSegments, bool lenient, bool carriesOwnBytes)
+    {
+        if (!lenient || !carriesOwnBytes || totalSegments <= 0) return 0;
+        if (!FilenameUtil.IsDegradableVideoFile(filename)) return 0;
+        return (int)Math.Min(LenientMissingRatio * totalSegments, LenientMissingCeiling);
+    }
+
+    /// <summary>
     /// How many segments to STAT for one file. Files up to the floor are checked in full,
     /// larger ones are sampled based on their size, and an optional age scales the result
     /// down from there. <see cref="HealthCheckDepth.Complete"/> skips all of it.
@@ -442,9 +509,25 @@ public class HealthCheckService : BackgroundService
         HealthCheckDepth depth = ConfigManager.DefaultHealthCheckDepth,
         TimeSpan? age = null)
     {
+        // Hand back the caller's own list when the sample covers everything, so checking a large
+        // file in full does not copy it.
+        if (segments.Count <= SampleTarget(segments.Count, depth, age)) return segments;
+        return SampleSegmentIndexes(segments, depth, age).Select(i => segments[i]).ToList();
+    }
+
+    /// <summary>
+    /// The same sample as <see cref="SampleSegments"/>, as ascending positions in the file.
+    /// A caller holding these can tell whether two missing articles were neighbours, which the
+    /// article ids alone cannot answer.
+    /// </summary>
+    internal static List<int> SampleSegmentIndexes(
+        List<string> segments,
+        HealthCheckDepth depth = ConfigManager.DefaultHealthCheckDepth,
+        TimeSpan? age = null)
+    {
         var count = segments.Count;
         var target = SampleTarget(count, depth, age);
-        if (count <= target) return segments;
+        if (count <= target) return Enumerable.Range(0, count).ToList();
 
         const int headCount = 100;
         const int tailCount = 100;
@@ -468,7 +551,70 @@ public class HealthCheckService : BackgroundService
             result.Add(i);
         }
 
-        return result.OrderBy(i => i).Select(i => segments[i]).ToList();
+        return result.OrderBy(i => i).ToList();
+    }
+
+    /// <summary>
+    /// The first missing article a read would refuse rather than skip past, with the reason, or
+    /// null when the damage is one playback survives. Positions are in the file, not the sample.
+    /// </summary>
+    /// <remarks>
+    /// A read fails outright on the first article instead of zero-filling it, cannot always size
+    /// the last one to fill it, and drops the stream once
+    /// <see cref="ZeroFillPolicy.MaxConsecutive"/> in a row are filled. Both ends are always
+    /// sampled, so all three are visible here.
+    /// </remarks>
+    internal static (int Index, string Reason)? FindUnreadableDamage(
+        IReadOnlyCollection<int> missingIndexes, int totalSegments)
+    {
+        if (missingIndexes.Count == 0) return null;
+        if (missingIndexes.Contains(0)) return (0, "the first article is missing");
+
+        var lastIndex = totalSegments - 1;
+        if (missingIndexes.Contains(lastIndex)) return (lastIndex, "the last article is missing");
+
+        var (length, start) = LongestMissingRun(missingIndexes);
+        return length >= ZeroFillPolicy.MaxConsecutive
+            ? (start, $"{length} consecutive articles missing")
+            : null;
+    }
+
+    /// <summary>
+    /// The longest run of consecutive missing articles among <paramref name="missingIndexes"/>,
+    /// which must be positions in the file rather than in the sample, and where that run starts.
+    /// Start is -1 when nothing is missing.
+    /// </summary>
+    internal static (int Length, int Start) LongestMissingRun(IEnumerable<int> missingIndexes)
+    {
+        var longest = 0;
+        var longestStart = -1;
+        var run = 0;
+        var runStart = 0;
+        var previous = int.MinValue;
+        foreach (var index in missingIndexes.OrderBy(i => i))
+        {
+            if (index == previous)
+            {
+                continue;
+            }
+
+            if (index == previous + 1)
+            {
+                run++;
+            }
+            else
+            {
+                run = 1;
+                runStart = index;
+            }
+
+            previous = index;
+            if (run <= longest) continue;
+            longest = run;
+            longestStart = runStart;
+        }
+
+        return (longest, longestStart);
     }
 
     private async Task UpdateReleaseDate(DavItem davItem, List<string> segments, CancellationToken ct)
@@ -482,27 +628,41 @@ public class HealthCheckService : BackgroundService
         davItem.ReleaseDate = articleHeaders.Date;
     }
 
-    private async Task<List<string>> GetAllSegments(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
+    /// <summary>
+    /// An item's segments, and whether those segments carry the file's own bytes. They do not
+    /// when the file was extracted from an archive, and the item's name does not reveal it: the
+    /// aggregators name an archive member after the file within it, so a rar-packed release is
+    /// an item called something.mkv.
+    /// </summary>
+    private sealed record ItemSegments(List<string> Segments, bool CarriesOwnBytes);
+
+    private async Task<ItemSegments> GetAllSegments(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
     {
         if (davItem.SubType == DavItem.ItemSubType.NzbFile)
         {
             var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
-            return nzbFile?.SegmentIds?.ToList() ?? [];
+            return new ItemSegments(nzbFile?.SegmentIds?.ToList() ?? [], true);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.RarFile)
         {
             var rarFile = await dbClient.GetDavRarFileAsync(davItem, ct).ConfigureAwait(false);
-            return rarFile?.RarParts?.SelectMany(x => x.SegmentIds)?.ToList() ?? [];
+            return new ItemSegments(rarFile?.RarParts?.SelectMany(x => x.SegmentIds)?.ToList() ?? [], false);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.MultipartFile)
         {
+            // Rar members, 7z members and a plain video split across .001 parts all land on this
+            // subtype, and nothing stored distinguishes them for every item: only the lazy rar
+            // path records a path within the archive, and byte ranges separate them only when the
+            // entry does not happen to start and end on a part boundary. Treated as packed until
+            // there is a marker that holds for already-imported items too.
             var multipartFile = await dbClient.GetDavMultipartFileAsync(davItem, ct).ConfigureAwait(false);
-            return multipartFile?.Metadata?.FileParts?.SelectMany(x => x.SegmentIds)?.ToList() ?? [];
+            var parts = multipartFile?.Metadata?.FileParts;
+            return new ItemSegments(parts?.SelectMany(x => x.SegmentIds)?.ToList() ?? [], false);
         }
 
-        return [];
+        return new ItemSegments([], false);
     }
 
     /// <summary>

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -18,7 +18,6 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private const int BodyPipelineBatchSize = 4;
     private const int MaxBodyRetries = 2;
     private const int MaxCorruptionRetries = 3;
-    private const int MaxConsecutiveZeroFills = 3;
 
     private readonly Memory<string> _segmentIds;
     private readonly string[][]? _segmentFallbacks;
@@ -1008,7 +1007,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
             StreamTrace.TryZeroFill(sessionId, result.SegmentId!, result.Bytes);
 
-        if (_consecutiveZeroFills < MaxConsecutiveZeroFills)
+        if (_consecutiveZeroFills < ZeroFillPolicy.MaxConsecutive)
             return result.Stream;
 
         result.Stream.Dispose();

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -9,8 +9,6 @@ namespace NzbWebDAV.Streams;
 
 public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 {
-    private const int MaxConsecutiveZeroFills = 3;
-
     private readonly Memory<string> _segmentIds;
     private readonly string[][]? _segmentFallbacks;
     private readonly INntpClient _usenetClient;
@@ -23,7 +21,6 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private long _pendingPadBytes;
     private int _consecutiveZeroFills;
     private bool _disposed;
-
 
     public UnbufferedMultiSegmentStream(
         Memory<string> segmentIds,
@@ -103,7 +100,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                             e);
                         if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
                             StreamTrace.TryZeroFill(sessionId, e.SegmentId, fill);
-                        if (_consecutiveZeroFills >= MaxConsecutiveZeroFills)
+                        if (_consecutiveZeroFills >= ZeroFillPolicy.MaxConsecutive)
                             throw;
 
                         _stream = new ZeroStream(fill);

--- a/backend/Streams/ZeroFillPolicy.cs
+++ b/backend/Streams/ZeroFillPolicy.cs
@@ -1,0 +1,16 @@
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// How many missing articles a read may replace with zeros before it gives up. A player
+/// resynchronizes past a short gap, but a long one is structural damage no decoder recovers
+/// from, so the stream fails instead of handing back an unbounded run of silence.
+/// </summary>
+internal static class ZeroFillPolicy
+{
+    /// <summary>
+    /// A run this long fails the read, so a run one shorter is the most that is ever served.
+    /// Health checks apply the same bound, and the two must agree: a file a health check
+    /// passes but a read refuses is the worst of both.
+    /// </summary>
+    public const int MaxConsecutive = 3;
+}

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -19,6 +19,11 @@ public partial class FilenameUtil
         ".img", ".iso", ".vob", ".mkv", ".mk3d", ".ts", ".wtv", ".m2ts"
     ];
 
+    private static readonly HashSet<string> DegradableVideoExtensions =
+    [
+        ".mp4", ".m4v", ".mov", ".mkv", ".webm"
+    ];
+
     public static bool IsImportantFileType(string filename)
     {
         return IsVideoFile(filename)
@@ -30,6 +35,16 @@ public partial class FilenameUtil
     public static bool IsVideoFile(string filename)
     {
         return VideoExtensions.Contains(Path.GetExtension(filename).ToLower());
+    }
+
+    /// <summary>
+    /// Plain video containers a player can keep decoding through a zero-filled gap.
+    /// Deliberately narrower than <see cref="IsVideoFile"/>, whose list also carries disc
+    /// images, playlists and raw streams, where a hole is corruption rather than a glitch.
+    /// </summary>
+    public static bool IsDegradableVideoFile(string filename)
+    {
+        return DegradableVideoExtensions.Contains(Path.GetExtension(filename).ToLower());
     }
 
     public static bool IsRarFile(string? filename)

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -15,9 +15,34 @@ Background health monitoring and replacement of unhealthy library items.
 | Health Check Concurrency [since 0.9.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.0){ .nzbdav-since } | `repair.healthcheck-concurrency` | `50` | Worker ceiling for concurrent STAT checks; capped by the provider pool. Actual contention with playback is governed by provider-pool admission and **Streaming Priority** |
 | Health Check Depth | `repair.healthcheck-depth` | `standard` | standard / enhanced / deep / complete |
 | Check older releases less thoroughly [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | `repair.healthcheck-aging` | off | Aging taper |
+| Tolerate a few missing articles in video files [since 0.9.2](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.2){ .nzbdav-since } | `repair.healthcheck-lenient` | off | Marks lightly damaged video degraded instead of repairing it |
 | Repair After Streaming Failures | `repair.auto-remove-after-failures` | `0` | Consecutive streaming failures before urgent repair; `0` = immediate repair |
 | Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items use *Arr remove-and-search instead of force-delete |
 | Library Directory | `media.library-dir` | empty | Organized media path in container |
+
+`repair.healthcheck-lenient` changes what a health check does when it confirms a missing article.
+With it off, the first miss fails the file and starts a repair. With it on, an `.mp4`, `.m4v`,
+`.mov`, `.mkv` or `.webm` file may be missing up to 2% of its articles, and never more than 64,
+and is recorded as **degraded** rather than repaired. Players skip past gaps that small, so the
+file stays watchable and *Arr is not asked to fetch a replacement. Past either limit the file fails
+and repairs exactly as when the setting is off.
+
+Only a file posted on its own qualifies. A video packed into a rar or 7z set does not, even though
+NzbDAV lists it under the inner file's name, because a zero-filled gap breaks the extraction rather
+than the picture. Nor does a video split across `.001` parts, which is safe in principle but shares
+its storage shape with archive members closely enough that the two cannot be told apart reliably for
+files imported by earlier versions. Disc images, playlists and other containers stay out as well.
+
+Missing articles that sit next to each other are treated separately from the totals above. Three in
+a row fails the file, because that is the point at which playback stops filling the gap with silence
+and drops the stream, and a file that passed the check and then broke on playback would be the worst
+of both. Whether a run is visible depends on the check finding both of its neighbours: at
+**Complete** depth, or for files small enough to be checked in full, every run is seen. A shallower
+check on a large file reads scattered articles rather than adjacent ones, so a run in the middle of
+such a file can pass unnoticed.
+
+The totals count against the whole file, not the subset a sampled check reads, so a shallow depth on
+a large file can pass one carrying more missing articles than the numbers above name.
 
 `repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
 articles and corrupt archives. With a value greater than `0`, NzbDAV waits for that many
@@ -25,8 +50,8 @@ consecutive failures before it starts an urgent repair. At the threshold, linked
 trigger *Arr remove-and-search when **Auto-remove unlinked files only** is enabled; unlinked files
 are removed. Disable that option to force-delete linked items at the threshold.
 
-Successful full-file playback and a successful background health check reset the in-memory failure
-count. The count resets when NzbDAV restarts, so it is intentionally not a durable replacement for
-health checks.
+Successful full-file playback and a clean background health check reset the in-memory failure
+count; a degraded result leaves it in place. The count resets when NzbDAV restarts, so it is
+intentionally not a durable replacement for health checks.
 
 [Health and repairs](../operations/health-repairs.md)

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -10,12 +10,12 @@ Requires:
 - At least one configured Radarr/Sonarr instance
 - **Enable Background Repairs**
 
-Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }, and streaming-failure thresholds — [Repairs settings](../configuration/repairs.md).
+Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since }, missing-article leniency [since 0.9.2](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.2){ .nzbdav-since }, and streaming-failure thresholds — [Repairs settings](../configuration/repairs.md).
 
 For streaming-triggered failures, **Repair After Streaming Failures** can require consecutive
 failures before NzbDAV starts a repair or asks *Arr to find a replacement. A successful full-file
-playback or background health check resets that count. The counter is in memory, so it also resets
-when NzbDAV restarts.
+playback or a clean background health check resets that count, while a degraded result leaves it in
+place. The counter is in memory, so it also resets when NzbDAV restarts.
 
 ## Health-check retention
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -612,6 +612,7 @@ export enum RepairAction {
     Repaired = 1,
     Deleted = 2,
     ActionNeeded = 3,
+    Degraded = 4,
 }
 
 export type OverviewWindow = "1h" | "24h" | "7d" | "30d" | "all";

--- a/frontend/app/routes/health/components/health-stats/health-stats.tsx
+++ b/frontend/app/routes/health/components/health-stats/health-stats.tsx
@@ -15,6 +15,7 @@ enum RepairAction {
     Repaired = 1,
     Deleted = 2,
     ActionNeeded = 3,
+    Degraded = 4,
 }
 
 export function HealthStats({ stats }: HealthStatsProps) {

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -95,7 +95,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
             </ManagedSetting>
             <ManagedSetting
-                configKeys={["repair.healthcheck-depth", "repair.healthcheck-aging"]}
+                configKeys={["repair.healthcheck-depth", "repair.healthcheck-aging", "repair.healthcheck-lenient"]}
                 className="grid grid-cols-1 gap-4 lg:grid-cols-2"
             >
             <div className="space-y-2">
@@ -120,16 +120,29 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     use more usenet traffic. Complete checks every segment.
                 </p>
             </div>
-            <div className="space-y-2">
-                <Tooltip content="Off by default. When enabled, coverage tapers for releases past their first year (stops at ten years), useful for large libraries of long-posted content.">
-                    <Toggle
-                        id="healthcheck-aging-checkbox"
-                        className="cursor-pointer gap-2 p-0"
-                        checked={(config["repair.healthcheck-aging"] ?? "false") === "true"}
-                        onChange={e => setNewConfig({ ...config, "repair.healthcheck-aging": "" + e.target.checked })}
-                        label={<span className="text-sm text-base-content">Check older releases less thoroughly</span>}
-                    />
-                </Tooltip>
+            <div className="space-y-3">
+                <div>
+                    <Tooltip content="Off by default. When enabled, coverage tapers for releases past their first year (stops at ten years), useful for large libraries of long-posted content.">
+                        <Toggle
+                            id="healthcheck-aging-checkbox"
+                            className="cursor-pointer gap-2 p-0"
+                            checked={(config["repair.healthcheck-aging"] ?? "false") === "true"}
+                            onChange={e => setNewConfig({ ...config, "repair.healthcheck-aging": "" + e.target.checked })}
+                            label={<span className="text-sm text-base-content">Check older releases less thoroughly</span>}
+                        />
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content="Off by default. When enabled, an unpacked video file may be missing up to 2% of its articles, and never more than 64, and is marked degraded instead of repaired.">
+                        <Toggle
+                            id="healthcheck-lenient-checkbox"
+                            className="cursor-pointer gap-2 p-0"
+                            checked={(config["repair.healthcheck-lenient"] ?? "false") === "true"}
+                            onChange={e => setNewConfig({ ...config, "repair.healthcheck-lenient": "" + e.target.checked })}
+                            label={<span className="text-sm text-base-content">Tolerate a few missing articles in video files</span>}
+                        />
+                    </Tooltip>
+                </div>
             </div>
             </ManagedSetting>
             </SettingsCard>
@@ -181,6 +194,7 @@ export function isRepairsSettingsUpdated(config: Record<string, string>, newConf
         || config["repair.healthcheck-concurrency"] !== newConfig["repair.healthcheck-concurrency"]
         || config["repair.healthcheck-depth"] !== newConfig["repair.healthcheck-depth"]
         || config["repair.healthcheck-aging"] !== newConfig["repair.healthcheck-aging"]
+        || config["repair.healthcheck-lenient"] !== newConfig["repair.healthcheck-lenient"]
         || config["repair.auto-remove-after-failures"] !== newConfig["repair.auto-remove-after-failures"]
         || config["repair.auto-remove-unlinked-only"] !== newConfig["repair.auto-remove-unlinked-only"]
         || config["media.library-dir"] !== newConfig["media.library-dir"];

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -109,6 +109,7 @@ const defaultConfig = {
     "repair.healthcheck-concurrency": "50",
     "repair.healthcheck-depth": "standard",
     "repair.healthcheck-aging": "false",
+    "repair.healthcheck-lenient": "false",
     "repair.auto-remove-after-failures": "0",
     "repair.auto-remove-unlinked-only": "true",
     "db.is-startup-vacuum-enabled": "false",

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -45,7 +45,43 @@ public class NntpClientCheckAllSegmentsTests
     {
         var client = new StatCodeClient(223);
 
-        await client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None);
+        var missing = await client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_MissesWithinBudget_ReturnsPositionsWithoutThrowing()
+    {
+        var client = new StatCodeClient(430);
+
+        var missing = await client.CheckAllSegmentsAsync(
+            ["a@example", "b@example", "c@example"], 1, null, CancellationToken.None, toleratedMissing: 3);
+
+        Assert.Equal([0, 1, 2], missing.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_MissPastBudget_ThrowsArticleNotFound()
+    {
+        var client = new StatCodeClient(430);
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.CheckAllSegmentsAsync(
+                ["a@example", "b@example", "c@example"], 1, null, CancellationToken.None,
+                toleratedMissing: 2));
+
+        Assert.Equal("c@example", exception.SegmentId);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_BudgetDoesNotTolerateRetryableResponses()
+    {
+        var client = new StatCodeClient(400);
+
+        await Assert.ThrowsAsync<UsenetUnexpectedResponseException>(() =>
+            client.CheckAllSegmentsAsync(
+                ["a@example"], 1, null, CancellationToken.None, toleratedMissing: 5));
     }
 
     [Fact]
@@ -225,11 +261,12 @@ public class NntpClientCheckAllSegmentsTests
             }
         }
 
-        public override async Task CheckAllSegmentsAsync(
+        public override async Task<IReadOnlyList<int>> CheckAllSegmentsAsync(
             IEnumerable<string> segmentIds,
             int concurrency,
             IProgress<int>? progress,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            int toleratedMissing = 0)
         {
             CheckAllSegmentsCallCount++;
             LastConcurrency = concurrency;
@@ -237,17 +274,18 @@ public class NntpClientCheckAllSegmentsTests
             RecheckedSegmentIds.AddRange(list);
 
             var processed = 0;
-            foreach (var segmentId in list)
+            for (var position = 0; position < list.Count; position++)
             {
                 progress?.Report(++processed);
                 var code = recheckCodes[_recheckIndex++];
                 if (code == (int)UsenetResponseType.ArticleExists) continue;
                 if (code is 430 or 451)
-                    throw new UsenetArticleNotFoundException(segmentId, $"{code} missing");
-                throw new UsenetUnexpectedResponseException(segmentId, $"{code} unexpected");
+                    throw new UsenetArticleNotFoundException(list[position], $"{code} missing");
+                throw new UsenetUnexpectedResponseException(list[position], $"{code} unexpected");
             }
 
             await Task.CompletedTask;
+            return [];
         }
 
         public override Task ConnectAsync(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckToleratedMissingTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckToleratedMissingTests.cs
@@ -1,0 +1,183 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class HealthCheckToleratedMissingTests
+{
+    [Theory]
+    [InlineData("movie.mkv")]
+    [InlineData("movie.mp4")]
+    [InlineData("movie.iso")]
+    [InlineData("movie.rar")]
+    public void LenientOff_ToleratesNothing(string filename)
+    {
+        Assert.Equal(0, HealthCheckService.ToleratedMissingArticles(
+            filename, 10_000, lenient: false, carriesOwnBytes: true));
+    }
+
+    [Theory]
+    [InlineData("movie.mp4")]
+    [InlineData("movie.m4v")]
+    [InlineData("movie.mov")]
+    [InlineData("movie.mkv")]
+    [InlineData("movie.webm")]
+    [InlineData("MOVIE.MKV")]
+    public void PlainVideoContainers_AreEligible(string filename)
+    {
+        Assert.True(HealthCheckService.ToleratedMissingArticles(
+            filename, 10_000, lenient: true, carriesOwnBytes: true) > 0);
+    }
+
+    [Theory]
+    [InlineData("disc.iso")]
+    [InlineData("disc.img")]
+    [InlineData("playlist.m3u")]
+    [InlineData("stream.ts")]
+    [InlineData("movie.avi")]
+    [InlineData("archive.rar")]
+    [InlineData("archive.r01")]
+    [InlineData("noextension")]
+    public void EverythingElse_ToleratesNothing(string filename)
+    {
+        Assert.Equal(0, HealthCheckService.ToleratedMissingArticles(
+            filename, 10_000, lenient: true, carriesOwnBytes: true));
+    }
+
+    [Theory]
+    [InlineData("movie.mkv")]
+    [InlineData("movie.mp4")]
+    public void ArchivedOrEncryptedBytes_ToleratesNothing(string filename)
+    {
+        // The aggregators name an archive member after the file inside the archive, so the
+        // extension alone would let a rar-packed release through.
+        Assert.Equal(0, HealthCheckService.ToleratedMissingArticles(
+            filename, 10_000, lenient: true, carriesOwnBytes: false));
+    }
+
+    [Theory]
+    [InlineData(100, 2)]
+    [InlineData(1_000, 20)]
+    [InlineData(3_200, 64)]
+    public void BelowTheCrossover_TheRatioBinds(int totalSegments, int expected)
+    {
+        Assert.Equal(expected, HealthCheckService.ToleratedMissingArticles(
+            "movie.mkv", totalSegments, lenient: true, carriesOwnBytes: true));
+    }
+
+    [Theory]
+    [InlineData(3_201)]
+    [InlineData(32_000)]
+    [InlineData(75_000)]
+    public void AboveTheCrossover_TheCeilingBinds(int totalSegments)
+    {
+        Assert.Equal(64, HealthCheckService.ToleratedMissingArticles(
+            "movie.mkv", totalSegments, lenient: true, carriesOwnBytes: true));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void NonPositiveSegmentCount_ToleratesNothing(int totalSegments)
+    {
+        Assert.Equal(0, HealthCheckService.ToleratedMissingArticles(
+            "movie.mkv", totalSegments, lenient: true, carriesOwnBytes: true));
+    }
+
+    [Fact]
+    public void VerySmallFiles_ToleratesNothing()
+    {
+        // Two percent of 49 truncates to zero, so a tiny file keeps failing on its first miss.
+        Assert.Equal(0, HealthCheckService.ToleratedMissingArticles(
+            "movie.mkv", 49, lenient: true, carriesOwnBytes: true));
+    }
+
+    [Fact]
+    public void NothingMissing_IsReadable()
+    {
+        Assert.Null(HealthCheckService.FindUnreadableDamage([], 1_000));
+    }
+
+    [Theory]
+    [InlineData(new[] { 4 })]
+    [InlineData(new[] { 4, 9, 400 })]
+    [InlineData(new[] { 4, 5 })]
+    [InlineData(new[] { 998, 4, 5, 100 })]
+    public void ScatteredMissingArticlesAwayFromBothEnds_AreReadable(int[] missing)
+    {
+        Assert.Null(HealthCheckService.FindUnreadableDamage(missing, 1_000));
+    }
+
+    [Fact]
+    public void FirstArticleMissing_IsUnreadable()
+    {
+        // A read fails outright on the first article rather than zero-filling it, so tolerating
+        // this would pass a file that errors the moment anyone plays it from the start.
+        var damage = HealthCheckService.FindUnreadableDamage([0], 1_000);
+
+        Assert.NotNull(damage);
+        Assert.Equal(0, damage.Value.Index);
+    }
+
+    [Fact]
+    public void LastArticleMissing_IsUnreadable()
+    {
+        var damage = HealthCheckService.FindUnreadableDamage([999], 1_000);
+
+        Assert.NotNull(damage);
+        Assert.Equal(999, damage.Value.Index);
+    }
+
+    [Fact]
+    public void TwoInARow_IsReadableButThreeIsNot()
+    {
+        // A read serves two zero-filled articles and drops the stream on the third, so the check
+        // has to draw the line in the same place.
+        Assert.Null(HealthCheckService.FindUnreadableDamage([40, 41], 1_000));
+
+        var damage = HealthCheckService.FindUnreadableDamage([41, 40, 42], 1_000);
+
+        Assert.NotNull(damage);
+        Assert.Equal(40, damage.Value.Index);
+    }
+
+    [Fact]
+    public void NoMissingArticles_HasNoRun()
+    {
+        Assert.Equal((0, -1), HealthCheckService.LongestMissingRun([]));
+    }
+
+    [Theory]
+    [InlineData(new[] { 5 }, 1, 5)]
+    [InlineData(new[] { 5, 9, 20 }, 1, 5)]
+    [InlineData(new[] { 5, 6 }, 2, 5)]
+    [InlineData(new[] { 5, 6, 7 }, 3, 5)]
+    [InlineData(new[] { 20, 3, 21, 2, 22 }, 3, 20)]
+    [InlineData(new[] { 1, 2, 8, 9, 10, 11 }, 4, 8)]
+    [InlineData(new[] { 7, 7, 8, 8, 9 }, 3, 7)]
+    public void RunLengthAndStartCountConsecutivePositions(int[] missing, int length, int start)
+    {
+        // Positions arrive in completion order, so the unsorted cases matter.
+        Assert.Equal((length, start), HealthCheckService.LongestMissingRun(missing));
+    }
+
+    [Fact]
+    public void SampleIndexesCoverEverySegmentWhenNothingIsSampledAway()
+    {
+        var segments = Enumerable.Range(0, 500).Select(i => $"seg{i}").ToList();
+
+        Assert.Equal(Enumerable.Range(0, 500), HealthCheckService.SampleSegmentIndexes(segments));
+    }
+
+    [Fact]
+    public void SampleIndexesAddressTheSameSegmentsTheSamplerPicks()
+    {
+        var segments = Enumerable.Range(0, 200_000).Select(i => $"seg{i}").ToList();
+
+        var indexes = HealthCheckService.SampleSegmentIndexes(segments);
+
+        // The mapping is what lets a missing position become a file position, so pin it against
+        // the sampler itself rather than only checking the indexes look plausible.
+        Assert.Equal(HealthCheckService.SampleSegments(segments), indexes.Select(i => segments[i]));
+        Assert.Equal(indexes.OrderBy(i => i), indexes);
+    }
+}


### PR DESCRIPTION
First pass at issue #461, an optional setting to enable more lenient health checks for certain safe filetypes. Allows up to 64 articles or 2% (whichever is smaller) missing before marking it a failed health check. Seems to significantly reduce the amount of churn in my library for non multipart releases, especially for certain shows, and I haven't noticed a difference in playback. 
Archives and encrypted files are excluded, since a zero filled gap there breaks the extraction or decodes to noise rather than causing a brief glitch. Three consecutive missing articles fails the file regardless of the totals, using the same limit the read path uses before it gives up zero filling, so the health check can't pass something playback would fail.
Future changes would include some UI labels to indicate degraded files, re-checking degraded files sooner than clean ones so damage that grows gets caught earlier, and improving checks to detect missing keyframes.

<img width="1484" height="347" alt="Screenshot 2026-07-28 163702" src="https://github.com/user-attachments/assets/c108b34c-3318-4565-ba09-b975d21d20cb" />
