### PR TITLE
fix(ui): Save Provider in the Usenet modal actually saves without a second click

### DIFF
--- a/frontend/app/components/ui/modal.tsx
+++ b/frontend/app/components/ui/modal.tsx
@@ -10,9 +10,11 @@ export type ModalProps = {
   footer?: ReactNode;
   onClose: () => void;
   className?: string;
+  /** When true, backdrop / Escape / X cannot dismiss the dialog. */
+  preventClose?: boolean;
 };
 
-export function Modal({ open, title, children, footer, onClose, className = "" }: ModalProps) {
+export function Modal({ open, title, children, footer, onClose, className = "", preventClose = false }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
@@ -30,7 +32,16 @@ export function Modal({ open, title, children, footer, onClose, className = "" }
     <dialog
       ref={dialogRef}
       className="modal"
+      onCancel={(event) => {
+        if (preventClose) {
+          event.preventDefault();
+        }
+      }}
       onClose={() => {
+        if (preventClose) {
+          dialogRef.current?.showModal();
+          return;
+        }
         if (open) onClose();
       }}
     >
@@ -42,6 +53,7 @@ export function Modal({ open, title, children, footer, onClose, className = "" }
             size="xsmall"
             className="btn-circle absolute top-2 right-2"
             aria-label="Close"
+            disabled={preventClose}
           >
             <Icon name="close" className="!text-[20px]" />
           </Button>
@@ -51,7 +63,7 @@ export function Modal({ open, title, children, footer, onClose, className = "" }
         {footer && <div className="modal-action">{footer}</div>}
       </div>
       <form method="dialog" className="modal-backdrop">
-        <button type="submit">close</button>
+        <button type="submit" disabled={preventClose}>close</button>
       </form>
     </dialog>
   );

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -240,6 +240,20 @@ function Body(props: BodyProps) {
         setSaveError(null);
     }, [config]);
 
+    const postConfigUpdate = useCallback(async (changedConfig: Record<string, string>) => {
+        const response = await fetch("/settings/update", {
+            method: "POST",
+            body: (() => {
+                const form = new FormData();
+                form.append("config", JSON.stringify(changedConfig));
+                return form;
+            })()
+        });
+        if (!response.ok) {
+            throw new Error(`Settings update failed with status ${response.status}`);
+        }
+    }, []);
+
     const onSave = useCallback(async () => {
         setIsSaving(true);
         setIsSaved(false);
@@ -255,17 +269,7 @@ function Body(props: BodyProps) {
                 setIsSaved(true);
                 return;
             }
-            const response = await fetch("/settings/update", {
-                method: "POST",
-                body: (() => {
-                    const form = new FormData();
-                    form.append("config", JSON.stringify(changedConfig));
-                    return form;
-                })()
-            });
-            if (!response.ok) {
-                throw new Error(`Settings update failed with status ${response.status}`);
-            }
+            await postConfigUpdate(changedConfig);
             setConfig(newConfig);
             setIsSaved(true);
         } catch {
@@ -273,7 +277,41 @@ function Body(props: BodyProps) {
         } finally {
             setIsSaving(false);
         }
-    }, [config, newConfig, managedEnv]);
+    }, [config, newConfig, managedEnv, postConfigUpdate]);
+
+    const persistConfigPatch = useCallback(async (patch: Record<string, string>) => {
+        const nextNew = pinManagedConfigKeys(
+            { ...newConfig, ...patch },
+            config,
+            managedEnv,
+        );
+        setNewConfigState(nextNew);
+        setSaveError(null);
+
+        const changedFromPatch: Record<string, string> = {};
+        for (const key of Object.keys(patch)) {
+            if (config[key] !== nextNew[key]) {
+                changedFromPatch[key] = nextNew[key];
+            }
+        }
+        const changedConfig = omitManagedConfigKeys(changedFromPatch, managedEnv);
+
+        if (Object.keys(changedConfig).length > 0) {
+            await postConfigUpdate(changedConfig);
+        }
+
+        const nextSaved = { ...config };
+        for (const key of Object.keys(patch)) {
+            nextSaved[key] = nextNew[key];
+        }
+        setConfig(nextSaved);
+
+        const remaining = omitManagedConfigKeys(
+            getChangedConfig(nextSaved, nextNew),
+            managedEnv,
+        );
+        setIsSaved(Object.keys(remaining).length === 0);
+    }, [config, newConfig, managedEnv, postConfigUpdate]);
 
     return (
         <ManagedEnvProvider value={managedEnv}>
@@ -295,7 +333,13 @@ function Body(props: BodyProps) {
                         </span>
                     </Alert>
                 )}
-                {activeTab === "usenet" && <UsenetSettings config={newConfig} setNewConfig={setNewConfig} />}
+                {activeTab === "usenet" && (
+                    <UsenetSettings
+                        config={newConfig}
+                        setNewConfig={setNewConfig}
+                        persistConfigPatch={persistConfigPatch}
+                    />
+                )}
                 {activeTab === "indexers" && <IndexersSettings config={newConfig} setNewConfig={setNewConfig} savedConfig={config} />}
                 {activeTab === "profiles" && <ProfilesSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "watchdog" && <WatchdogSettings config={newConfig} setNewConfig={setNewConfig} />}

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -68,6 +68,7 @@ type BenchmarkIntensity = "quick" | "thorough";
 type UsenetSettingsProps = {
     config: Record<string, string>
     setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
+    persistConfigPatch: (patch: Record<string, string>) => Promise<void>
 };
 
 enum ProviderType {
@@ -292,7 +293,7 @@ function SortableItem({ id, disabled, children }: { id: string; disabled: boolea
     return <>{children({ setNodeRef, setActivatorNodeRef, attributes, listeners, style, isDragging })}</>;
 }
 
-export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
+export function UsenetSettings({ config, setNewConfig, persistConfigPatch }: UsenetSettingsProps) {
     // state
     const [showModal, setShowModal] = useState(false);
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -388,7 +389,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
         setEditingIndex(null);
     }, []);
 
-    const handleSaveProvider = useCallback((provider: ConnectionDetails) => {
+    const handleSaveProvider = useCallback(async (provider: ConnectionDetails) => {
         const providers = [...providerConfig.Providers];
         if (editingIndex !== null) {
             providers[editingIndex] = provider;
@@ -399,9 +400,14 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
                 Priority: providers.length,
             });
         }
-        setNewConfig({ ...config, "usenet.providers": serializeProviderConfig({ ...providerConfig, Providers: providers }) });
+        const patch: Record<string, string> = {
+            "usenet.providers": serializeProviderConfig({ ...providerConfig, Providers: providers }),
+            // Include current draft so a speed-test "Apply" pipelining change persists with the provider.
+            "usenet.pipelining.enabled": config["usenet.pipelining.enabled"] ?? "false",
+        };
+        await persistConfigPatch(patch);
         handleCloseModal();
-    }, [config, providerConfig, editingIndex, setNewConfig, handleCloseModal]);
+    }, [config, providerConfig, editingIndex, persistConfigPatch, handleCloseModal]);
 
     const handleApplyPipelining = useCallback((enabled: boolean) => {
         setNewConfig(prev => ({
@@ -936,7 +942,7 @@ type ProviderModalProps = {
     provider: ConnectionDetails | null;
     existingStorageGroups: string[];
     onClose: () => void;
-    onSave: (provider: ConnectionDetails) => void;
+    onSave: (provider: ConnectionDetails) => void | Promise<void>;
     onApplyPipelining: (enabled: boolean) => void;
     defaultPipeliningDepth: string;
 };
@@ -972,6 +978,8 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
     const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkResult | null>(null);
     const [benchmarkError, setBenchmarkError] = useState<string | null>(null);
     const [pipeliningOnly, setPipeliningOnly] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
     const benchmarkAbortRef = useRef<AbortController | null>(null);
     const passIsMasked = isMaskedSecret(pass);
     // Stable across parent re-parses of the same provider so Apply recommendation
@@ -1010,6 +1018,8 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
             setBenchmarkResult(null);
             setBenchmarkError(null);
             setPipeliningOnly(false);
+            setIsSaving(false);
+            setSaveError(null);
         }
         // Intentionally keyed on providerIdentity, not provider object identity —
         // parent config updates re-parse providers and would otherwise reset the form.
@@ -1197,7 +1207,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
         setBenchmarkProgress(null);
     }, []);
 
-    const handleSave = useCallback(() => {
+    const handleSave = useCallback(async () => {
         const byteLimit = valueAndUnitToBytes(limitValue, limitUnit);
         const initialUsedBytes = valueAndUnitToBytes(initialUsedValue, initialUsedUnit);
 
@@ -1213,25 +1223,33 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
 
         const trimmedNickname = nickname.trim();
         const trimmedStorageGroup = storageGroup.trim();
-        onSave({
-            ProviderId: provider?.ProviderId,
-            Type: type,
-            Host: host,
-            Port: parseInt(port, 10),
-            UseSsl: useSsl,
-            SkipTlsVerification: useSsl && skipTlsVerification,
-            User: user,
-            Pass: pass,
-            MaxConnections: parseInt(maxConnections, 10),
-            PipeliningDepth: pipeliningDepth.trim() === "" ? null : parseInt(pipeliningDepth, 10),
-            Priority: provider?.Priority ?? 0,
-            Nickname: trimmedNickname === "" ? undefined : trimmedNickname,
-            StorageGroup: trimmedStorageGroup,
-            PreviousType: type === ProviderType.Disabled ? provider?.PreviousType : undefined,
-            ByteLimit: byteLimit,
-            BytesUsedOffset: offsetToPersist,
-            BytesUsedResetAt: resetAtToPersist,
-        });
+        setIsSaving(true);
+        setSaveError(null);
+        try {
+            await onSave({
+                ProviderId: provider?.ProviderId,
+                Type: type,
+                Host: host,
+                Port: parseInt(port, 10),
+                UseSsl: useSsl,
+                SkipTlsVerification: useSsl && skipTlsVerification,
+                User: user,
+                Pass: pass,
+                MaxConnections: parseInt(maxConnections, 10),
+                PipeliningDepth: pipeliningDepth.trim() === "" ? null : parseInt(pipeliningDepth, 10),
+                Priority: provider?.Priority ?? 0,
+                Nickname: trimmedNickname === "" ? undefined : trimmedNickname,
+                StorageGroup: trimmedStorageGroup,
+                PreviousType: type === ProviderType.Disabled ? provider?.PreviousType : undefined,
+                ByteLimit: byteLimit,
+                BytesUsedOffset: offsetToPersist,
+                BytesUsedResetAt: resetAtToPersist,
+            });
+        } catch {
+            setSaveError("Could not save provider settings. Check the server logs and try again.");
+        } finally {
+            setIsSaving(false);
+        }
     }, [type, host, port, useSsl, skipTlsVerification, user, pass, maxConnections, pipeliningDepth, nickname, storageGroup, provider, isEditing, limitValue, limitUnit, initialUsedValue, initialUsedUnit, onSave]);
 
     const isPipeliningDepthValid = pipeliningDepth.trim() === ""
@@ -1264,17 +1282,18 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
             open={show}
             title={provider ? "Edit Provider" : "Add Provider"}
             onClose={onClose}
+            preventClose={isSaving}
             className="!max-w-4xl"
             footer={
                 <>
-                    <Button variant="outline" onClick={onClose}>
+                    <Button variant="outline" onClick={onClose} disabled={isSaving}>
                         Cancel
                     </Button>
                     {canSave && type !== ProviderType.Disabled && (
                         <Button
                             variant="outline"
                             onClick={handleTestConnection}
-                            disabled={!isFormValid || isTestingConnection}
+                            disabled={!isFormValid || isTestingConnection || isSaving}
                         >
                             {isTestingConnection ? "Testing..." : "Test Connection"}
                         </Button>
@@ -1283,19 +1302,24 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
                         <Button
                             variant="primary"
                             onClick={handleTestConnection}
-                            disabled={!isFormValid || isTestingConnection}
+                            disabled={!isFormValid || isTestingConnection || isSaving}
                         >
                             {isTestingConnection ? "Testing..." : "Test Connection"}
                         </Button>
                     ) : (
-                        <Button variant="primary" onClick={handleSave} disabled={!canSave}>
-                            Save Provider
+                        <Button variant="primary" onClick={handleSave} disabled={!canSave || isSaving}>
+                            {isSaving ? "Saving..." : "Save Provider"}
                         </Button>
                     )}
                 </>
             }
         >
             <div className="flex flex-col gap-5">
+                {saveError && (
+                    <Alert variant="danger" className="text-sm">
+                        {saveError}
+                    </Alert>
+                )}
                 <ProviderModalSection title="Connection">
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_7.5rem]">
                         <div className="flex flex-col gap-1.5">


### PR DESCRIPTION
## Summary
- Fixes [#710](https://github.com/nzbdav/nzbdav/issues/710): **Save Provider** in the Usenet Add/Edit Provider modal now persists to the backend immediately via `/settings/update`.
- Also persists a dirty `usenet.pipelining.enabled` value when the speed-test Apply path changed it in the same modal session.
- Other Usenet fields (and provider reorder/delete/toggle) still use the page-level Save; modal shows Saving… / error and blocks dismiss while the request is in flight.

## Test plan
- [ ] Add a provider → Save Provider → reload Settings → Usenet → provider is still present (no page Save)
- [ ] Edit an existing provider → Save Provider → reload → changes persist
- [ ] Apply a speed-test pipelining recommendation → Save Provider → pipelining setting persists
- [ ] Dirty another Usenet field, then Save Provider → provider persists; page Save still enabled for the other field
- [ ] Simulate save failure (e.g. offline) → modal stays open with error; draft remains for page Save retry