### PR TITLE
fix(metrics): Overview Backup rescues no longer counts same-provider retries

### DIFF
--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -407,12 +407,14 @@ public class MultiProviderNntpClient(
                         if (responseType == UsenetResponseType.ArticleRetrievedBodyFollows)
                         {
                             _usageTracker.RecordSuccess(provider.MetricsKey);
+                            var crossMisses = FilterCrossProviderMisses(
+                                priorMisses, provider.MetricsKey);
                             RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0, traceRange);
-                            if (priorMisses is { Count: > 0 })
+                                stopwatch.ElapsedMilliseconds, crossMisses?.Count ?? 0, traceRange);
+                            if (crossMisses is { Count: > 0 })
                             {
                                 _usageTracker.RecordFailoverSave();
-                                RecordFailoverMisses(priorMisses, provider.MetricsKey);
+                                RecordFailoverMisses(crossMisses, provider.MetricsKey);
                             }
                             response = WrapProviderResponse(response, provider.MetricsKey);
                             gateOwnedByTransfer = true;
@@ -618,12 +620,14 @@ public class MultiProviderNntpClient(
                 {
                     if (attribution != null) attribution.Host = provider.Host;
                     _usageTracker.RecordSuccess(provider.MetricsKey);
+                    var crossMisses = FilterCrossProviderMisses(
+                        priorMisses, provider.MetricsKey);
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
-                    if (attemptIndex > 0)
+                        stopwatch.ElapsedMilliseconds, crossMisses?.Count ?? 0, traceRange);
+                    if (crossMisses is { Count: > 0 })
                     {
                         _usageTracker.RecordFailoverSave();
-                        RecordFailoverMisses(priorMisses, provider.MetricsKey);
+                        RecordFailoverMisses(crossMisses, provider.MetricsKey);
                     }
                     result = WrapProviderResponse(result, provider.MetricsKey);
                     deferredCallback.Activate(onConnectionReadyAgain ?? (_ => { }));
@@ -766,12 +770,14 @@ public class MultiProviderNntpClient(
                                           or UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
                 {
                     _usageTracker.RecordSuccess(provider.MetricsKey);
+                    var crossMisses = FilterCrossProviderMisses(
+                        priorMisses, provider.MetricsKey);
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
-                    if (attemptIndex > 0)
+                        stopwatch.ElapsedMilliseconds, crossMisses?.Count ?? 0, traceRange);
+                    if (crossMisses is { Count: > 0 })
                     {
                         _usageTracker.RecordFailoverSave();
-                        RecordFailoverMisses(priorMisses, rescuer: provider.MetricsKey);
+                        RecordFailoverMisses(crossMisses, rescuer: provider.MetricsKey);
                     }
                     result = WrapProviderResponse(result, provider.MetricsKey);
                 }
@@ -913,6 +919,25 @@ public class MultiProviderNntpClient(
                 metricsKey, exception.GetType().FullName);
         }
         return status;
+    }
+
+    /// <summary>
+    /// Same-provider self-retries (timeout → re-probe primary) are not backup rescues.
+    /// Overview FailoverSaves / FailoverMisses only keep misses from a different provider.
+    /// </summary>
+    private static List<(string Host, SegmentFetch.FetchStatus Reason)>? FilterCrossProviderMisses(
+        List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses,
+        string rescuer)
+    {
+        if (priorMisses is not { Count: > 0 }) return null;
+        List<(string Host, SegmentFetch.FetchStatus Reason)>? cross = null;
+        foreach (var miss in priorMisses)
+        {
+            if (string.Equals(miss.Host, rescuer, StringComparison.OrdinalIgnoreCase))
+                continue;
+            (cross ??= []).Add(miss);
+        }
+        return cross;
     }
 
     private void RecordFailoverMisses(

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -410,11 +410,12 @@ public class MultiProviderNntpClient(
                             var crossMisses = FilterCrossProviderMisses(
                                 priorMisses, provider.MetricsKey);
                             RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                                stopwatch.ElapsedMilliseconds, crossMisses?.Count ?? 0, traceRange);
-                            if (crossMisses is { Count: > 0 })
+                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0, traceRange);
+                            if (priorMisses is { Count: > 0 })
                             {
-                                _usageTracker.RecordFailoverSave();
-                                RecordFailoverMisses(crossMisses, provider.MetricsKey);
+                                if (crossMisses is { Count: > 0 })
+                                    _usageTracker.RecordFailoverSave();
+                                RecordRescue(priorMisses, crossMisses, provider.MetricsKey);
                             }
                             response = WrapProviderResponse(response, provider.MetricsKey);
                             gateOwnedByTransfer = true;
@@ -623,11 +624,12 @@ public class MultiProviderNntpClient(
                     var crossMisses = FilterCrossProviderMisses(
                         priorMisses, provider.MetricsKey);
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, crossMisses?.Count ?? 0, traceRange);
-                    if (crossMisses is { Count: > 0 })
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
+                    if (priorMisses is { Count: > 0 })
                     {
-                        _usageTracker.RecordFailoverSave();
-                        RecordFailoverMisses(crossMisses, provider.MetricsKey);
+                        if (crossMisses is { Count: > 0 })
+                            _usageTracker.RecordFailoverSave();
+                        RecordRescue(priorMisses, crossMisses, provider.MetricsKey);
                     }
                     result = WrapProviderResponse(result, provider.MetricsKey);
                     deferredCallback.Activate(onConnectionReadyAgain ?? (_ => { }));
@@ -773,11 +775,12 @@ public class MultiProviderNntpClient(
                     var crossMisses = FilterCrossProviderMisses(
                         priorMisses, provider.MetricsKey);
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, crossMisses?.Count ?? 0, traceRange);
-                    if (crossMisses is { Count: > 0 })
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
+                    if (priorMisses is { Count: > 0 })
                     {
-                        _usageTracker.RecordFailoverSave();
-                        RecordFailoverMisses(crossMisses, rescuer: provider.MetricsKey);
+                        if (crossMisses is { Count: > 0 })
+                            _usageTracker.RecordFailoverSave();
+                        RecordRescue(priorMisses, crossMisses, rescuer: provider.MetricsKey);
                     }
                     result = WrapProviderResponse(result, provider.MetricsKey);
                 }
@@ -940,19 +943,24 @@ public class MultiProviderNntpClient(
         return cross;
     }
 
-    private void RecordFailoverMisses(
-        List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses,
+    /// <summary>
+    /// Stream traces keep every prior-miss edge (including same-provider retries) for
+    /// support-pack stall attribution. Overview FailoverMisses only get cross-provider edges.
+    /// </summary>
+    private void RecordRescue(
+        List<(string Host, SegmentFetch.FetchStatus Reason)>? allMisses,
+        List<(string Host, SegmentFetch.FetchStatus Reason)>? crossMisses,
         string rescuer)
     {
-        if (priorMisses != null && ReadSessionScope.Value is { } sessionId)
+        if (allMisses != null && ReadSessionScope.Value is { } sessionId)
         {
-            foreach (var (from, reason) in priorMisses)
+            foreach (var (from, reason) in allMisses)
                 streamTrace?.Failover(sessionId, from, rescuer, reason.ToString());
         }
 
-        if (metricsWriter == null || priorMisses == null) return;
+        if (metricsWriter == null || crossMisses is not { Count: > 0 }) return;
         var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        foreach (var (from, reason) in priorMisses)
+        foreach (var (from, reason) in crossMisses)
         {
             metricsWriter.RecordFailoverMiss(new FailoverMiss
             {

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -407,16 +407,10 @@ public class MultiProviderNntpClient(
                         if (responseType == UsenetResponseType.ArticleRetrievedBodyFollows)
                         {
                             _usageTracker.RecordSuccess(provider.MetricsKey);
-                            var crossMisses = FilterCrossProviderMisses(
-                                priorMisses, provider.MetricsKey);
-                            RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0, traceRange);
-                            if (priorMisses is { Count: > 0 })
-                            {
-                                if (crossMisses is { Count: > 0 })
-                                    _usageTracker.RecordFailoverSave();
-                                RecordRescue(priorMisses, crossMisses, provider.MetricsKey);
-                            }
+                            RecordSuccessfulFetch(
+                                provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
+                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0,
+                                traceRange, priorMisses);
                             response = WrapProviderResponse(response, provider.MetricsKey);
                             gateOwnedByTransfer = true;
                             deferredCallback.Activate(result =>
@@ -621,16 +615,9 @@ public class MultiProviderNntpClient(
                 {
                     if (attribution != null) attribution.Host = provider.Host;
                     _usageTracker.RecordSuccess(provider.MetricsKey);
-                    var crossMisses = FilterCrossProviderMisses(
-                        priorMisses, provider.MetricsKey);
-                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
-                    if (priorMisses is { Count: > 0 })
-                    {
-                        if (crossMisses is { Count: > 0 })
-                            _usageTracker.RecordFailoverSave();
-                        RecordRescue(priorMisses, crossMisses, provider.MetricsKey);
-                    }
+                    RecordSuccessfulFetch(
+                        provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange, priorMisses);
                     result = WrapProviderResponse(result, provider.MetricsKey);
                     deferredCallback.Activate(onConnectionReadyAgain ?? (_ => { }));
                     return result;
@@ -772,16 +759,9 @@ public class MultiProviderNntpClient(
                                           or UsenetResponseType.ArticleRetrievedHeadAndBodyFollow)
                 {
                     _usageTracker.RecordSuccess(provider.MetricsKey);
-                    var crossMisses = FilterCrossProviderMisses(
-                        priorMisses, provider.MetricsKey);
-                    RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
-                    if (priorMisses is { Count: > 0 })
-                    {
-                        if (crossMisses is { Count: > 0 })
-                            _usageTracker.RecordFailoverSave();
-                        RecordRescue(priorMisses, crossMisses, rescuer: provider.MetricsKey);
-                    }
+                    RecordSuccessfulFetch(
+                        provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
+                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange, priorMisses);
                     result = WrapProviderResponse(result, provider.MetricsKey);
                 }
                 else if (result is UsenetDecodedBodyResponse or UsenetDecodedArticleResponse)
@@ -874,12 +854,13 @@ public class MultiProviderNntpClient(
         }
     }
 
-    private void RecordFetch(
+    private SegmentFetch RecordFetch(
         string metricsKey,
         SegmentFetch.FetchStatus status,
         long durationMs,
         int retries,
-        StreamTraceRangeContext? traceRange)
+        StreamTraceRangeContext? traceRange,
+        bool enqueue = true)
     {
         if (traceRange is { } range)
         {
@@ -890,8 +871,7 @@ public class MultiProviderNntpClient(
             streamTrace?.AddFetchWait(traceRange, TimeSpan.FromMilliseconds(durationMs));
         }
 
-        if (metricsWriter == null) return;
-        metricsWriter.RecordFetch(new SegmentFetch
+        var fetch = new SegmentFetch
         {
             At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             Provider = metricsKey,
@@ -900,7 +880,32 @@ public class MultiProviderNntpClient(
             DurationMs = (int)Math.Min(int.MaxValue, durationMs),
             Status = status,
             Retries = retries,
-        });
+        };
+        if (enqueue)
+            metricsWriter?.RecordFetch(fetch);
+        return fetch;
+    }
+
+    private void RecordSuccessfulFetch(
+        string metricsKey,
+        SegmentFetch.FetchStatus status,
+        long durationMs,
+        int retries,
+        StreamTraceRangeContext? traceRange,
+        List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses)
+    {
+        var fetch = RecordFetch(
+            metricsKey, status, durationMs, retries, traceRange, enqueue: false);
+        if (priorMisses is not { Count: > 0 })
+        {
+            metricsWriter?.RecordFetch(fetch);
+            return;
+        }
+
+        var crossMisses = FilterCrossProviderMisses(priorMisses, metricsKey);
+        if (crossMisses is { Count: > 0 })
+            _usageTracker.RecordFailoverSave();
+        RecordRescue(priorMisses, crossMisses, metricsKey, fetch);
     }
 
     /// <summary>
@@ -950,7 +955,8 @@ public class MultiProviderNntpClient(
     private void RecordRescue(
         List<(string Host, SegmentFetch.FetchStatus Reason)>? allMisses,
         List<(string Host, SegmentFetch.FetchStatus Reason)>? crossMisses,
-        string rescuer)
+        string rescuer,
+        SegmentFetch fetch)
     {
         if (allMisses != null && ReadSessionScope.Value is { } sessionId)
         {
@@ -958,18 +964,33 @@ public class MultiProviderNntpClient(
                 streamTrace?.Failover(sessionId, from, rescuer, reason.ToString());
         }
 
-        if (metricsWriter == null || crossMisses is not { Count: > 0 }) return;
-        var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (metricsWriter == null) return;
+        if (crossMisses is not { Count: > 0 })
+        {
+            metricsWriter.RecordFetch(fetch);
+            return;
+        }
+
+        var misses = new List<FailoverMiss>(crossMisses.Count);
         foreach (var (from, reason) in crossMisses)
         {
-            metricsWriter.RecordFailoverMiss(new FailoverMiss
+            misses.Add(new FailoverMiss
             {
-                At = at,
+                At = fetch.At,
                 FromProvider = from,
                 ToProvider = rescuer,
                 Reason = reason,
             });
         }
+        metricsWriter.RecordRescue(
+            fetch,
+            new MetricEvent
+            {
+                At = fetch.At,
+                Kind = MetricsWriter.FailoverSaveEventKind,
+                Tag1 = rescuer,
+            },
+            misses);
     }
 
     private T WrapProviderResponse<T>(T result, string metricsKey) where T : UsenetResponse

--- a/backend/Services/Metrics/MetricsRollupService.cs
+++ b/backend/Services/Metrics/MetricsRollupService.cs
@@ -184,9 +184,9 @@ public class MetricsRollupService(
 
         // ProviderMinute: per-provider counters. BytesFetched intentionally omitted from
         // ON CONFLICT — the tracker is the sole writer of that column.
-        // FailoverSaves come from FailoverMisses (cross-provider rescue edges only), not from
+        // FailoverSaves come from one event per cross-provider rescue, not from
         // SegmentFetch.Retries — Retries still counts same-provider self-retries for the
-        // scoreboard. Each RecordRescue call stamps one shared At, so distinct At = one save.
+        // scoreboard. FailoverMisses can contain multiple edges for one rescue.
         await db.Database.ExecuteSqlRawAsync(
             """
             INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
@@ -196,8 +196,9 @@ public class MetricsRollupService(
                 SUM(CASE WHEN Status = 1 THEN 1 ELSE 0 END),
                 SUM(CASE WHEN Status NOT IN (0, 1) THEN 1 ELSE 0 END),
                 SUM(Retries),
-                (SELECT COUNT(DISTINCT f.At) FROM FailoverMisses f
-                    WHERE f.ToProvider = SegmentFetches.Provider AND f.At >= {0} AND f.At < {1}),
+                (SELECT COUNT(*) FROM MetricEvents e
+                    WHERE e.Kind = {2} AND e.Tag1 = SegmentFetches.Provider
+                        AND e.At >= {0} AND e.At < {1}),
                 -- Ok-only durations so Overview "Avg ok ms" is not inflated by misses/errors.
                 SUM(CASE WHEN Status = 0 THEN DurationMs ELSE 0 END),
                 NULL
@@ -212,7 +213,7 @@ public class MetricsRollupService(
                 FailoverSaves = excluded.FailoverSaves,
                 SumDurationMs = excluded.SumDurationMs;
             """,
-            minute, next).ConfigureAwait(false);
+            minute, next, MetricsWriter.FailoverSaveEventKind).ConfigureAwait(false);
     }
 
     private static async Task RollupHourAsync(MetricsDbContext db, long hour)

--- a/backend/Services/Metrics/MetricsRollupService.cs
+++ b/backend/Services/Metrics/MetricsRollupService.cs
@@ -155,7 +155,7 @@ public class MetricsRollupService(
         }
     }
 
-    private static async Task RollupMinuteAsync(MetricsDbContext db, long minute)
+    internal static async Task RollupMinuteAsync(MetricsDbContext db, long minute)
     {
         var next = minute + OneMinute;
 
@@ -184,6 +184,9 @@ public class MetricsRollupService(
 
         // ProviderMinute: per-provider counters. BytesFetched intentionally omitted from
         // ON CONFLICT — the tracker is the sole writer of that column.
+        // FailoverSaves come from FailoverMisses (cross-provider rescue edges only), not from
+        // SegmentFetch.Retries — Retries still counts same-provider self-retries for the
+        // scoreboard. Each RecordRescue call stamps one shared At, so distinct At = one save.
         await db.Database.ExecuteSqlRawAsync(
             """
             INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
@@ -193,7 +196,8 @@ public class MetricsRollupService(
                 SUM(CASE WHEN Status = 1 THEN 1 ELSE 0 END),
                 SUM(CASE WHEN Status NOT IN (0, 1) THEN 1 ELSE 0 END),
                 SUM(Retries),
-                SUM(CASE WHEN Status = 0 AND Retries > 0 THEN 1 ELSE 0 END),
+                (SELECT COUNT(DISTINCT f.At) FROM FailoverMisses f
+                    WHERE f.ToProvider = SegmentFetches.Provider AND f.At >= {0} AND f.At < {1}),
                 -- Ok-only durations so Overview "Avg ok ms" is not inflated by misses/errors.
                 SUM(CASE WHEN Status = 0 THEN DurationMs ELSE 0 END),
                 NULL

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -33,6 +33,7 @@ public enum EventEnqueueResult
 /// </summary>
 public class MetricsWriter : BackgroundService
 {
+    internal const string FailoverSaveEventKind = "failover-save";
     private const int FlushThreshold = 1000;
     private const int MaxQueueLength = 10_000;
     private static readonly TimeSpan FlushInterval = TimeSpan.FromSeconds(5);
@@ -124,6 +125,11 @@ public class MetricsWriter : BackgroundService
 
     public void RecordFetch(SegmentFetch f)
     {
+        EnqueueFetch(f);
+    }
+
+    private void EnqueueFetch(SegmentFetch f)
+    {
         if (_fetches.Count >= MaxQueueLength)
         {
             Interlocked.Increment(ref _droppedFetches);
@@ -133,6 +139,11 @@ public class MetricsWriter : BackgroundService
     }
 
     public void RecordEvent(MetricEvent e)
+    {
+        EnqueueEvent(e);
+    }
+
+    private void EnqueueEvent(MetricEvent e)
     {
         if (_events.Count >= MaxQueueLength)
         {
@@ -173,12 +184,35 @@ public class MetricsWriter : BackgroundService
 
     public void RecordFailoverMiss(FailoverMiss m)
     {
+        EnqueueFailoverMiss(m);
+    }
+
+    private void EnqueueFailoverMiss(FailoverMiss m)
+    {
         if (_failoverMisses.Count >= MaxQueueLength)
         {
             Interlocked.Increment(ref _droppedFailoverMisses);
             return;
         }
         _failoverMisses.Enqueue(m);
+    }
+
+    /// <summary>
+    /// Enqueues one successful fetch, its save event, and detailed miss edges as one
+    /// drain unit so the minute rollup cannot observe only part of the rescue.
+    /// </summary>
+    public void RecordRescue(
+        SegmentFetch fetch,
+        MetricEvent save,
+        IReadOnlyList<FailoverMiss> misses)
+    {
+        lock (_enqueueGate)
+        {
+            EnqueueFetch(fetch);
+            EnqueueEvent(save);
+            foreach (var miss in misses)
+                EnqueueFailoverMiss(miss);
+        }
     }
 
     public IReadOnlyList<MetricEvent> SnapshotQueuedEvents(string kind)
@@ -276,11 +310,19 @@ public class MetricsWriter : BackgroundService
             return;
         }
 
-        var generation = Volatile.Read(ref _resetGeneration);
-        var fetches = Drain(_fetches);
-        var events = Drain(_events);
-        var sessions = Drain(_sessions);
-        var failoverMisses = Drain(_failoverMisses);
+        int generation;
+        List<SegmentFetch> fetches;
+        List<MetricEvent> events;
+        List<ReadSession> sessions;
+        List<FailoverMiss> failoverMisses;
+        lock (_enqueueGate)
+        {
+            generation = Volatile.Read(ref _resetGeneration);
+            fetches = Drain(_fetches);
+            events = Drain(_events);
+            sessions = Drain(_sessions);
+            failoverMisses = Drain(_failoverMisses);
+        }
         if (fetches.Count == 0 && events.Count == 0 && sessions.Count == 0 && failoverMisses.Count == 0) return;
 
         // BeginReset ran between the pause check and Drain — abandon.
@@ -366,17 +408,21 @@ public class MetricsWriter : BackgroundService
     /// </summary>
     public void DiscardQueuedForProvider(string providerKey)
     {
-        FilterQueue(_fetches, f => !string.Equals(f.Provider, providerKey, StringComparison.Ordinal));
-        FilterQueue(_events, e =>
-            !(IsProviderKeyedEvent(e) && string.Equals(e.Tag1, providerKey, StringComparison.Ordinal)));
-        FilterQueue(_failoverMisses, m =>
-            !string.Equals(m.FromProvider, providerKey, StringComparison.Ordinal)
-            && !string.Equals(m.ToProvider, providerKey, StringComparison.Ordinal));
+        lock (_enqueueGate)
+        {
+            FilterQueue(_fetches, f => !string.Equals(f.Provider, providerKey, StringComparison.Ordinal));
+            FilterQueue(_events, e =>
+                !(IsProviderKeyedEvent(e) && string.Equals(e.Tag1, providerKey, StringComparison.Ordinal)));
+            FilterQueue(_failoverMisses, m =>
+                !string.Equals(m.FromProvider, providerKey, StringComparison.Ordinal)
+                && !string.Equals(m.ToProvider, providerKey, StringComparison.Ordinal));
+        }
     }
 
     private static bool IsProviderKeyedEvent(MetricEvent e) =>
         string.Equals(e.Kind, "circuit", StringComparison.Ordinal)
-        || string.Equals(e.Kind, "latency", StringComparison.Ordinal);
+        || string.Equals(e.Kind, "latency", StringComparison.Ordinal)
+        || string.Equals(e.Kind, FailoverSaveEventKind, StringComparison.Ordinal);
 
     private static void FilterQueue<T>(ConcurrentQueue<T> queue, Func<T, bool> keep)
     {

--- a/backend/Services/Metrics/OverviewStatsReset.cs
+++ b/backend/Services/Metrics/OverviewStatsReset.cs
@@ -122,7 +122,10 @@ public static class OverviewStatsReset
             .Where(x => x.Provider == providerKey).ExecuteDeleteAsync(ct).ConfigureAwait(false);
         deleted += await db.MetricEvents
             .Where(x =>
-                (x.Kind == "circuit" || x.Kind == "latency") && x.Tag1 == providerKey)
+                (x.Kind == "circuit"
+                 || x.Kind == "latency"
+                 || x.Kind == MetricsWriter.FailoverSaveEventKind)
+                && x.Tag1 == providerKey)
             .ExecuteDeleteAsync(ct).ConfigureAwait(false);
         deleted += await db.FailoverMisses
             .Where(x => x.FromProvider == providerKey || x.ToProvider == providerKey)

--- a/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
+++ b/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
@@ -49,7 +49,7 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
             <div>
                 <h3 className="card-title text-base">Backup rescues</h3>
                 <p className="text-xs text-base-content/50">
-                    When your main provider misses a piece mid-session, a backup delivers it before anything fails ({sinceLabel})
+                    When one provider misses a piece mid-session, a different provider delivers it before anything fails ({sinceLabel})
                 </p>
             </div>
 
@@ -58,10 +58,10 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                     <div className="mb-3.5 flex items-center gap-4">
                         <span className="shrink-0 text-[40px] leading-[0.95] font-bold tracking-tight text-base-content tabular-nums">{formatNumber(articlesRecovered)}</span>
                         <div className="min-w-0 flex-1">
-                            <div className="text-[13px] font-medium text-base-content/80">segments your backups rescued</div>
+                            <div className="text-[13px] font-medium text-base-content/80">segments rescued by another provider</div>
                             <div className="mt-0.5 text-xs text-base-content/50">
                                 {totalArticles > 0 ? (
-                                    <>that&rsquo;s <strong className="font-semibold text-base-content">{formatSmallPercent(saveRate)}</strong> of all fetches a backup had to cover</>
+                                    <>that&rsquo;s <strong className="font-semibold text-base-content">{formatSmallPercent(saveRate)}</strong> of all fetches that needed a second provider</>
                                 ) : (
                                     <>your stack self-healed every time it mattered</>
                                 )}
@@ -221,7 +221,7 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                 <div className="py-6 text-center text-xs text-base-content/50">
                     No backup rescues in this window.
                     <div className="mt-1.5 text-base-content/40">
-                        Every segment was served on the first try. When a provider misses, a backup steps in.
+                        Every segment was served without needing another provider. Same-provider retries after timeouts do not count here.
                         You&rsquo;ll see who failed, who covered, and why, right here.
                     </div>
                 </div>

--- a/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
+++ b/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
@@ -221,7 +221,7 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                 <div className="py-6 text-center text-xs text-base-content/50">
                     No backup rescues in this window.
                     <div className="mt-1.5 text-base-content/40">
-                        Every segment was served without needing another provider. Same-provider retries after timeouts do not count here.
+                        No segment was rescued by another provider. Same-provider retries after timeouts do not count here.
                         You&rsquo;ll see who failed, who covered, and why, right here.
                     </div>
                 </div>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -96,6 +96,7 @@ public class MultiProviderNntpClientTests
             (await batch.Responses[0]).ResponseType);
 
         Assert.Equal(0, writer.Stats.QueuedFailoverMisses);
+        Assert.Empty(writer.SnapshotQueuedEvents(MetricsWriter.FailoverSaveEventKind));
         Assert.Equal(1, connection.SingularRequests);
     }
 
@@ -120,6 +121,7 @@ public class MultiProviderNntpClientTests
             (await batch.Responses[0]).ResponseType);
 
         Assert.Equal(0, writer.Stats.QueuedFailoverMisses);
+        Assert.Empty(writer.SnapshotQueuedEvents(MetricsWriter.FailoverSaveEventKind));
         Assert.Equal(1, connection.SingularRequests);
     }
 
@@ -151,6 +153,7 @@ public class MultiProviderNntpClientTests
         Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
         Assert.True(backup.SingularRequests >= 1);
         Assert.Equal(1, writer.Stats.QueuedFailoverMisses);
+        Assert.Single(writer.SnapshotQueuedEvents(MetricsWriter.FailoverSaveEventKind));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -75,6 +75,85 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task BatchResponse_SameProviderRetry_DoesNotRecordFailoverRescue()
+    {
+        // Primary batch miss, then same host succeeds on the singular re-probe.
+        // That is a self-retry, not a backup rescue — Overview must not count it.
+        var writer = new MetricsWriter();
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+            [CreateProvider(connection, host: "news.example")],
+            metricsWriter: writer);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["segment"], onConnectionReadyAgain: null, CancellationToken.None);
+        Assert.Equal(
+            UsenetResponseType.ArticleRetrievedBodyFollows,
+            (await batch.Responses[0]).ResponseType);
+
+        Assert.Equal(0, writer.Stats.QueuedFailoverMisses);
+        Assert.Equal(1, connection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task BatchResponse_SameProviderTimeoutRetry_DoesNotRecordFailoverRescue()
+    {
+        var writer = new MetricsWriter();
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+            FaultBatchResponsesWith = () => new TimeoutException("nntp read timed out"),
+        };
+        using var client = new MultiProviderNntpClient(
+            [CreateProvider(connection, host: "solo.example")],
+            metricsWriter: writer);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["segment"], onConnectionReadyAgain: null, CancellationToken.None);
+        Assert.Equal(
+            UsenetResponseType.ArticleRetrievedBodyFollows,
+            (await batch.Responses[0]).ResponseType);
+
+        Assert.Equal(0, writer.Stats.QueuedFailoverMisses);
+        Assert.Equal(1, connection.SingularRequests);
+    }
+
+    [Fact]
+    public async Task DecodedBodyAsync_CrossProviderRescue_RecordsFailoverMiss()
+    {
+        var writer = new MetricsWriter();
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = (int)UsenetResponseType.NoArticleWithThatMessageId,
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+            [
+                CreateProvider(primary, host: "a.example"),
+                CreateProvider(backup, host: "b.example", providerType: ProviderType.BackupOnly),
+            ],
+            metricsWriter: writer,
+            cascadeEnabled: () => true,
+            retryPrimaryOnMiss: () => false);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.True(backup.SingularRequests >= 1);
+        Assert.Equal(1, writer.Stats.QueuedFailoverMisses);
+    }
+
+    [Fact]
     public async Task BatchResponse_WithUnexpectedResponse_ThrowsRetryableWhenRetriesFail()
     {
         var connection = new ScriptedNntpClient
@@ -1764,6 +1843,7 @@ public class MultiProviderNntpClientTests
         public required int BatchResponseCode { get; init; }
         public int SingularResponseCode { get; init; } = 222;
         public Func<int, Exception?>? BatchException { get; init; }
+        public Func<Exception>? FaultBatchResponsesWith { get; init; }
         public Func<string, Exception>? SingularException { get; init; }
         public bool DeferSingularCompletion { get; init; }
         public int BatchRequests { get; private set; }
@@ -1781,9 +1861,19 @@ public class MultiProviderNntpClientTests
                 throw exception;
 
             var responses = segmentIds
-                .Select(segmentId => Task.FromResult(CreateResponse(segmentId, BatchResponseCode)))
+                .Select(segmentId =>
+                {
+                    if (FaultBatchResponsesWith != null)
+                        return Task.FromException<UsenetDecodedBodyResponse>(FaultBatchResponsesWith());
+                    return Task.FromResult(CreateResponse(segmentId, BatchResponseCode));
+                })
                 .ToArray();
-            onConnectionReadyAgain?.Invoke(ToArticleBodyResult(BatchResponseCode));
+            // Faulted per-segment tasks are resolved by MultiProvider failover; do not claim
+            // Retrieved here or the batch coordinator will treat the body as already done.
+            onConnectionReadyAgain?.Invoke(
+                FaultBatchResponsesWith != null
+                    ? ArticleBodyResult.NotRetrieved
+                    : ToArticleBodyResult(BatchResponseCode));
             return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
         }
 

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+/// <summary>
+/// Backup rescues (ProviderMinutes.FailoverSaves) come from FailoverMisses edges,
+/// not from SegmentFetch.Retries. Same-provider self-retries keep Retries visible
+/// on the scoreboard without inflating Overview Backup rescues.
+/// </summary>
+public sealed class MetricsRollupFailoverSavesTests
+{
+    private const long Minute = 1_700_000_060_000L;
+
+    [Fact]
+    public async Task RollupMinute_SameProviderRetry_PreservesRetriesWithoutFailoverSave()
+    {
+        await withMetricsDb(async context =>
+        {
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Bytes, DurationMs, Status, Retries)
+                VALUES
+                    ({0}, 'solo', NULL, NULL, 0, 50, 2, 0),
+                    ({1}, 'solo', NULL, NULL, 0, 20, 0, 1);
+                """,
+                Minute + 1, Minute + 2);
+
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+
+            var row = await context.ProviderMinutes.AsNoTracking().SingleAsync();
+            Assert.Equal("solo", row.Provider);
+            Assert.Equal(1, row.Retries);
+            Assert.Equal(0, row.FailoverSaves);
+            Assert.Equal(2, row.Articles);
+        });
+    }
+
+    [Fact]
+    public async Task RollupMinute_CrossProviderRescue_CountsDistinctFailoverSave()
+    {
+        await withMetricsDb(async context =>
+        {
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Bytes, DurationMs, Status, Retries)
+                VALUES
+                    ({0}, 'primary', NULL, NULL, 0, 50, 1, 0),
+                    ({1}, 'backup', NULL, NULL, 0, 30, 0, 1);
+
+                INSERT INTO FailoverMisses
+                    (At, FromProvider, ToProvider, Reason)
+                VALUES
+                    ({2}, 'primary', 'backup', 1);
+                """,
+                Minute + 1, Minute + 2, Minute + 2);
+
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+
+            var rows = await context.ProviderMinutes.AsNoTracking()
+                .OrderBy(r => r.Provider)
+                .ToListAsync();
+            Assert.Equal(2, rows.Count);
+
+            var backup = Assert.Single(rows, r => r.Provider == "backup");
+            Assert.Equal(1, backup.Retries);
+            Assert.Equal(1, backup.FailoverSaves);
+
+            var primary = Assert.Single(rows, r => r.Provider == "primary");
+            Assert.Equal(0, primary.FailoverSaves);
+        });
+    }
+
+    [Fact]
+    public async Task RollupMinute_MultipleEdgeRowsSameAt_CountAsOneSave()
+    {
+        await withMetricsDb(async context =>
+        {
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Bytes, DurationMs, Status, Retries)
+                VALUES
+                    ({0}, 'rescuer', NULL, NULL, 0, 30, 0, 2);
+
+                INSERT INTO FailoverMisses
+                    (At, FromProvider, ToProvider, Reason)
+                VALUES
+                    ({1}, 'a', 'rescuer', 2),
+                    ({1}, 'b', 'rescuer', 1);
+                """,
+                Minute + 1, Minute + 5);
+
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+
+            var row = await context.ProviderMinutes.AsNoTracking().SingleAsync();
+            Assert.Equal(2, row.Retries);
+            Assert.Equal(1, row.FailoverSaves);
+        });
+    }
+
+    private static async Task withMetricsDb(Func<MetricsDbContext, Task> body)
+    {
+        var databasePath = Path.Combine(
+            Path.GetTempPath(),
+            $"nzbdav-metrics-rollup-{Guid.NewGuid():N}.sqlite");
+        var options = new DbContextOptionsBuilder<MetricsDbContext>()
+            .UseSqlite($"Data Source={databasePath};Pooling=False")
+            .AddInterceptors(new SqliteMetricsPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+
+        try
+        {
+            await using var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            await body(context);
+        }
+        finally
+        {
+            File.Delete(databasePath);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
@@ -8,7 +8,7 @@ using NzbWebDAV.Services.Metrics;
 namespace NzbWebDAV.Tests.Services.Metrics;
 
 /// <summary>
-/// Backup rescues (ProviderMinutes.FailoverSaves) come from FailoverMisses edges,
+/// Backup rescues (ProviderMinutes.FailoverSaves) come from one event per rescue,
 /// not from SegmentFetch.Retries. Same-provider self-retries keep Retries visible
 /// on the scoreboard without inflating Overview Backup rescues.
 /// </summary>
@@ -58,6 +58,11 @@ public sealed class MetricsRollupFailoverSavesTests
                     (At, FromProvider, ToProvider, Reason)
                 VALUES
                     ({2}, 'primary', 'backup', 1);
+
+                INSERT INTO MetricEvents
+                    (At, Kind, RefId, Tag1, Tag2, Num, Note)
+                VALUES
+                    ({2}, 'failover-save', NULL, 'backup', NULL, NULL, NULL);
                 """,
                 Minute + 1, Minute + 2, Minute + 2);
 
@@ -78,7 +83,7 @@ public sealed class MetricsRollupFailoverSavesTests
     }
 
     [Fact]
-    public async Task RollupMinute_MultipleEdgeRowsSameAt_CountAsOneSave()
+    public async Task RollupMinute_ConcurrentSavesWithSameTimestamp_CountSeparately()
     {
         await withMetricsDb(async context =>
         {
@@ -94,6 +99,12 @@ public sealed class MetricsRollupFailoverSavesTests
                 VALUES
                     ({1}, 'a', 'rescuer', 2),
                     ({1}, 'b', 'rescuer', 1);
+
+                INSERT INTO MetricEvents
+                    (At, Kind, RefId, Tag1, Tag2, Num, Note)
+                VALUES
+                    ({1}, 'failover-save', NULL, 'rescuer', NULL, NULL, NULL),
+                    ({1}, 'failover-save', NULL, 'rescuer', NULL, NULL, NULL);
                 """,
                 Minute + 1, Minute + 5);
 
@@ -101,7 +112,7 @@ public sealed class MetricsRollupFailoverSavesTests
 
             var row = await context.ProviderMinutes.AsNoTracking().SingleAsync();
             Assert.Equal(2, row.Retries);
-            Assert.Equal(1, row.FailoverSaves);
+            Assert.Equal(2, row.FailoverSaves);
         });
     }
 

--- a/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
@@ -90,6 +90,18 @@ public class OverviewStatsResetTests
         db.MetricEvents.AddRange(
             new MetricEvent { At = now, Kind = "circuit", Tag1 = target, Tag2 = "open" },
             new MetricEvent { At = now, Kind = "circuit", Tag1 = other, Tag2 = "open" },
+            new MetricEvent
+            {
+                At = now,
+                Kind = MetricsWriter.FailoverSaveEventKind,
+                Tag1 = target,
+            },
+            new MetricEvent
+            {
+                At = now,
+                Kind = MetricsWriter.FailoverSaveEventKind,
+                Tag1 = other,
+            },
             new MetricEvent { At = now, Kind = "global" });
         db.FailoverMisses.AddRange(
             new FailoverMiss
@@ -145,7 +157,9 @@ public class OverviewStatsResetTests
         Assert.Equal(1, await db.ProviderHourly.CountAsync(x => x.Provider == other));
         Assert.Equal(0, await db.MetricEvents.CountAsync(x =>
             x.Kind == "circuit" && x.Tag1 == target));
-        Assert.Equal(2, await db.MetricEvents.CountAsync());
+        Assert.Equal(0, await db.MetricEvents.CountAsync(x =>
+            x.Kind == MetricsWriter.FailoverSaveEventKind && x.Tag1 == target));
+        Assert.Equal(3, await db.MetricEvents.CountAsync());
         Assert.Equal(0, await db.FailoverMisses.CountAsync(x =>
             x.FromProvider == target || x.ToProvider == target));
         Assert.Equal(1, await db.FailoverMisses.CountAsync());
@@ -387,11 +401,26 @@ public class OverviewStatsResetTests
                 ToProvider = "c",
                 Reason = SegmentFetch.FetchStatus.Missing,
             });
+            writer.RecordEvent(new MetricEvent
+            {
+                At = 1,
+                Kind = MetricsWriter.FailoverSaveEventKind,
+                Tag1 = "a",
+            });
+            writer.RecordEvent(new MetricEvent
+            {
+                At = 2,
+                Kind = MetricsWriter.FailoverSaveEventKind,
+                Tag1 = "b",
+            });
 
             writer.DiscardQueuedForProvider("a");
 
             Assert.Equal(1, writer.Stats.QueuedFetches);
             Assert.Equal(1, writer.Stats.QueuedFailoverMisses);
+            var saveEvents = writer.SnapshotQueuedEvents(MetricsWriter.FailoverSaveEventKind);
+            var saveEvent = Assert.Single(saveEvents);
+            Assert.Equal("b", saveEvent.Tag1);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Fixes #713: same-provider self-retries (e.g. Newshosting timeout → retry succeeds) no longer inflate Overview **Backup rescues**
- Failover save / miss metrics and Ok `Retries` for rollup only include cross-provider edges
- Clarifies Backup rescues card copy to say “another provider”

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~MultiProviderNntpClientTests`
- [ ] Single-provider setup: play something that used to show same-host timeout rescues; new window should stay empty (or only true multi-provider failover)
- [ ] Two providers: force a miss on primary and success on backup; Backup rescues still increments
- [ ] Note: historical metrics already written keep old same-provider counts until retention ages them out