### PR TITLE
fix(nntp): stop connection-count thrash and disposed-pool warning spam after recovery

### DIFF
--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -253,7 +253,6 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         {
             DisposeConnection(connection);
             Interlocked.Decrement(ref _live);
-            TriggerConnectionPoolChangedEvent();
             return;
         }
 
@@ -271,13 +270,15 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         if (Volatile.Read(ref _disposed) == 0)
         {
             _gate.Release();
+            TriggerConnectionPoolChangedEvent();
         }
-
-        TriggerConnectionPoolChangedEvent();
     }
 
     private void TriggerConnectionPoolChangedEvent()
     {
+        if (Volatile.Read(ref _disposed) == 1)
+            return;
+
         OnConnectionPoolChanged?.Invoke(this, new ConnectionPoolStats.ConnectionPoolChangedEventArgs(
             _live,
             _idleConnections.Count,
@@ -342,6 +343,10 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
+
+        // Drop handlers before draining so late Return/Destroy from in-flight locks
+        // cannot overwrite the live generation's connection-count websocket updates.
+        OnConnectionPoolChanged = null;
 
         await _sweepCts.CancelAsync();
 

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -51,6 +51,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     public int IdleConnections => _idleConnections.Count;
     public int ActiveConnections => _live - _idleConnections.Count;
     public int AvailableConnections => _maxConnections - ActiveConnections;
+    internal bool IsDisposed => Volatile.Read(ref _disposed) == 1;
 
     public event EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs>? OnConnectionPoolChanged;
 

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -65,6 +65,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     private readonly SemaphoreSlim _handshakeGate = new(MaxConcurrentHandshakes, MaxConcurrentHandshakes);
     private readonly CancellationTokenSource _sweepCts = new();
     private readonly Task _sweeperTask; // keeps timer alive
+    private readonly Lock _lifecycleLock = new();
 
     private int _live; // number of connections currently alive
     private int _disposed; // 0 == false, 1 == true
@@ -140,19 +141,23 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         await _gate.WaitAsync(priority, linked.Token).ConfigureAwait(false);
         Interlocked.Add(ref _gateWaitTicks, Stopwatch.GetElapsedTime(gateWaitStarted).Ticks);
 
-        // Pool might have been disposed after wait returned:
-        if (Volatile.Read(ref _disposed) == 1)
+        // Claim an idle connection atomically with respect to disposal. Once popped,
+        // it is active and disposal leaves it for the borrower to return or destroy.
+        T? reused = default;
+        var reusedConnection = false;
+        lock (_lifecycleLock)
         {
-            _gate.Release();
-            ThrowDisposed();
-        }
+            if (_disposed == 1)
+                ThrowDisposed();
 
-        // Try to reuse an existing idle connection.
-        if (TryTakeIdleConnection(out var reused))
+            reusedConnection = TryTakeIdleConnection(out reused!);
+            if (reusedConnection)
+                Interlocked.Increment(ref _connectionsReused);
+        }
+        if (reusedConnection)
         {
-            Interlocked.Increment(ref _connectionsReused);
             TriggerConnectionPoolChangedEvent();
-            return BuildLock(reused, wasReused: true);
+            return BuildLock(reused!, wasReused: true);
         }
 
         // Need a fresh connection. Pace handshakes so a cold burst of borrowers
@@ -166,23 +171,27 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         }
         catch
         {
-            _gate.Release();
+            ReleaseGateIfActive();
             throw;
         }
 
         try
         {
-            if (Volatile.Read(ref _disposed) == 1)
+            reused = default;
+            reusedConnection = false;
+            lock (_lifecycleLock)
             {
-                _gate.Release();
-                ThrowDisposed();
-            }
+                if (_disposed == 1)
+                    ThrowDisposed();
 
-            if (TryTakeIdleConnection(out reused))
+                reusedConnection = TryTakeIdleConnection(out reused!);
+                if (reusedConnection)
+                    Interlocked.Increment(ref _connectionsReused);
+            }
+            if (reusedConnection)
             {
-                Interlocked.Increment(ref _connectionsReused);
                 TriggerConnectionPoolChangedEvent();
-                return BuildLock(reused, wasReused: true);
+                return BuildLock(reused!, wasReused: true);
             }
 
             T conn;
@@ -193,18 +202,40 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             catch
             {
                 Interlocked.Increment(ref _handshakeFailures);
-                _gate.Release(); // free the permit on failure
+                ReleaseGateIfActive(); // free the permit on failure
                 throw;
             }
 
-            Interlocked.Increment(ref _connectionsOpened);
-            Interlocked.Increment(ref _live);
+            var disposeConnection = false;
+            lock (_lifecycleLock)
+            {
+                if (_disposed == 1)
+                {
+                    disposeConnection = true;
+                }
+                else
+                {
+                    Interlocked.Increment(ref _connectionsOpened);
+                    Interlocked.Increment(ref _live);
+                }
+            }
+
+            if (disposeConnection)
+            {
+                DisposeConnection(conn);
+                ThrowDisposed();
+            }
+
             TriggerConnectionPoolChangedEvent();
             return BuildLock(conn, wasReused: false);
         }
         finally
         {
-            _handshakeGate.Release();
+            lock (_lifecycleLock)
+            {
+                if (_disposed == 0)
+                    _handshakeGate.Release();
+            }
         }
 
         ConnectionLock<T> BuildLock(T c, bool wasReused)
@@ -212,6 +243,15 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
         static void ThrowDisposed()
             => throw new ObjectDisposedException(nameof(ConnectionPool<T>));
+    }
+
+    private void ReleaseGateIfActive()
+    {
+        lock (_lifecycleLock)
+        {
+            if (_disposed == 0)
+                _gate.Release();
+        }
     }
 
     private bool TryTakeIdleConnection(out T connection)
@@ -249,29 +289,47 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     private void Return(T connection)
     {
-        if (Volatile.Read(ref _disposed) == 1)
+        var disposeConnection = false;
+        var notify = false;
+        lock (_lifecycleLock)
         {
-            DisposeConnection(connection);
-            Interlocked.Decrement(ref _live);
-            return;
+            if (_disposed == 1)
+            {
+                Interlocked.Decrement(ref _live);
+                disposeConnection = true;
+            }
+            else
+            {
+                _idleConnections.Push(new Pooled(connection, Environment.TickCount64));
+                _gate.Release();
+                notify = true;
+            }
         }
 
-        _idleConnections.Push(new Pooled(connection, Environment.TickCount64));
-        _gate.Release();
-        TriggerConnectionPoolChangedEvent();
+        if (disposeConnection)
+            DisposeConnection(connection);
+        if (notify)
+            TriggerConnectionPoolChangedEvent();
     }
 
     private void Destroy(T connection)
     {
         // When a lock requests replacement, we dispose the connection instead of reusing.
         DisposeConnection(connection);
-        Interlocked.Decrement(ref _live);
-        Interlocked.Increment(ref _connectionsDestroyed);
-        if (Volatile.Read(ref _disposed) == 0)
+        var notify = false;
+        lock (_lifecycleLock)
         {
-            _gate.Release();
-            TriggerConnectionPoolChangedEvent();
+            Interlocked.Decrement(ref _live);
+            Interlocked.Increment(ref _connectionsDestroyed);
+            if (_disposed == 0)
+            {
+                _gate.Release();
+                notify = true;
+            }
         }
+
+        if (notify)
+            TriggerConnectionPoolChangedEvent();
     }
 
     private void TriggerConnectionPoolChangedEvent()
@@ -342,11 +400,15 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
+        lock (_lifecycleLock)
+        {
+            if (_disposed == 1) return;
+            _disposed = 1;
 
-        // Drop handlers before draining so late Return/Destroy from in-flight locks
-        // cannot overwrite the live generation's connection-count websocket updates.
-        OnConnectionPoolChanged = null;
+            // Drop handlers before draining so late Return/Destroy from in-flight locks
+            // cannot overwrite the live generation's connection-count websocket updates.
+            OnConnectionPoolChanged = null;
+        }
 
         await _sweepCts.CancelAsync();
 
@@ -363,9 +425,12 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         while (_idleConnections.TryPop(out var item))
             DisposeConnection(item.Connection);
 
-        _sweepCts.Dispose();
-        _gate.Dispose();
-        _handshakeGate.Dispose();
+        lock (_lifecycleLock)
+        {
+            _sweepCts.Dispose();
+            _gate.Dispose();
+            _handshakeGate.Dispose();
+        }
         GC.SuppressFinalize(this);
     }
 

--- a/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
@@ -21,9 +21,12 @@ public class ConnectionPoolStats
     private int _totalLive;
     private int _totalIdle;
     private int _flushScheduled; // 0 == false, 1 == true
+    private int _active = 1;
     private readonly Lock _lock = new();
     private readonly UsenetProviderConfig _providerConfig;
     private readonly WebsocketManager _websocketManager;
+
+    internal bool IsActive => Volatile.Read(ref _active) == 1;
 
     public ConnectionPoolStats(UsenetProviderConfig providerConfig, WebsocketManager websocketManager)
     {
@@ -48,8 +51,14 @@ public class ConnectionPoolStats
 
         void OnEvent(object? _, ConnectionPoolChangedEventArgs args)
         {
+            if (Volatile.Read(ref _active) == 0)
+                return;
+
             lock (_lock)
             {
+                if (_active == 0)
+                    return;
+
                 _latestLive[providerIndex] = args.Live;
                 _latestIdle[providerIndex] = args.Idle;
                 _dirty[providerIndex] = true;
@@ -79,6 +88,11 @@ public class ConnectionPoolStats
         List<string> messages;
         lock (_lock)
         {
+            // Re-check under the lock so a concurrent Retire()/Deactivate() cannot
+            // let a stale generation publish after its replacement is already live.
+            if (_active == 0)
+                return;
+
             messages = new List<string>();
             for (var i = 0; i < _dirty.Length; i++)
             {
@@ -90,6 +104,19 @@ public class ConnectionPoolStats
 
         foreach (var message in messages)
             _ = _websocketManager.SendMessage(WebsocketTopic.UsenetConnections, message);
+    }
+
+    /// <summary>
+    /// Stops a retired client generation from overwriting connection totals published by
+    /// its replacement while its existing streams finish draining.
+    /// </summary>
+    internal void Deactivate()
+    {
+        lock (_lock)
+        {
+            _active = 0;
+            Array.Clear(_dirty);
+        }
     }
 
     public sealed class ConnectionPoolChangedEventArgs(int live, int idle, int max) : EventArgs

--- a/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
@@ -85,25 +85,23 @@ public class ConnectionPoolStats
         // so events arriving after the snapshot are never lost.
         Volatile.Write(ref _flushScheduled, 0);
 
-        List<string> messages;
         lock (_lock)
         {
-            // Re-check under the lock so a concurrent Retire()/Deactivate() cannot
-            // let a stale generation publish after its replacement is already live.
+            // Publish while holding the same lock used by Deactivate(). SendMessage is
+            // synchronous, so once Deactivate returns no stale flush can still win the
+            // last-message race against the replacement generation.
             if (_active == 0)
                 return;
 
-            messages = new List<string>();
             for (var i = 0; i < _dirty.Length; i++)
             {
                 if (!_dirty[i]) continue;
                 _dirty[i] = false;
-                messages.Add($"{i}|{_latestLive[i]}|{_latestIdle[i]}|{_totalLive}|{_max}|{_totalIdle}");
+                var message =
+                    $"{i}|{_latestLive[i]}|{_latestIdle[i]}|{_totalLive}|{_max}|{_totalIdle}";
+                _ = _websocketManager.SendMessage(WebsocketTopic.UsenetConnections, message);
             }
         }
-
-        foreach (var message in messages)
-            _ = _websocketManager.SendMessage(WebsocketTopic.UsenetConnections, message);
     }
 
     /// <summary>

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -319,4 +319,12 @@ public class DownloadingNntpClient : WrappingNntpClient
         base.Dispose();
         GC.SuppressFinalize(this);
     }
+
+    internal override void Retire()
+    {
+        // Retired generations may remain alive while active BODY streams drain, but they
+        // must stop reacting to subsequent settings saves immediately.
+        _configManager.OnConfigChanged -= OnConfigChanged;
+        base.Retire();
+    }
 }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -112,6 +112,7 @@ public class MultiConnectionNntpClient(
     public void UpdatePriorityOdds(SemaphorePriorityOdds odds) => connectionPool.UpdatePriorityOdds(odds);
 
     private int _pendingSelections;
+    private int _retiredPoolWarningLogged;
     public int PendingSelections => Volatile.Read(ref _pendingSelections);
     public void ReservePending() => Interlocked.Increment(ref _pendingSelections);
     public void ReleasePending() => Interlocked.Decrement(ref _pendingSelections);
@@ -799,10 +800,13 @@ public class MultiConnectionNntpClient(
 
     private IOException CreateRetiredPoolException(Exception inner)
     {
-        Log.Warning(
-            "Connection pool for provider {Provider} retired while a request was waiting. " +
-            "Abandoning the stale request without retrying or penalizing provider health.",
-            providerName);
+        if (Interlocked.Exchange(ref _retiredPoolWarningLogged, 1) == 0)
+        {
+            Log.Warning(
+                "Connection pool for provider {Provider} retired while requests were waiting. " +
+                "Abandoning stale requests without retrying or penalizing provider health.",
+                providerName);
+        }
         return new IOException(
             $"Connection pool for provider '{providerName}' retired while the request was waiting.",
             inner);

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -326,7 +326,7 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
-            catch (Exception e) when (IsRetiredPoolAcquisitionFailure(e))
+            catch (NntpClientRetiredException)
             {
                 deferredCallback.Discard();
                 // Normally this branch is reached while waiting to acquire and the lock is
@@ -335,7 +335,7 @@ public class MultiConnectionNntpClient(
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
-                throw CreateRetiredPoolException(e);
+                throw;
             }
             catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
             {
@@ -432,10 +432,10 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
-            catch (Exception e) when (IsRetiredPoolAcquisitionFailure(e))
+            catch (NntpClientRetiredException)
             {
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
-                throw CreateRetiredPoolException(e);
+                throw;
             }
             catch (Exception e)
             {
@@ -783,8 +783,16 @@ public class MultiConnectionNntpClient(
     {
         var traceRange = MultiProviderNntpClient.CurrentStreamTraceRange;
         var started = Stopwatch.GetTimestamp();
-        var connectionLock = await connectionPool.GetConnectionLockAsync(priority, ct)
-            .ConfigureAwait(false);
+        ConnectionLock<INntpClient> connectionLock;
+        try
+        {
+            connectionLock = await connectionPool.GetConnectionLockAsync(priority, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception e) when (IsRetiredPoolAcquisitionFailure(e))
+        {
+            throw CreateRetiredPoolException(e);
+        }
         var elapsed = Stopwatch.GetElapsedTime(started);
         latencyTracker?.Record(MetricsKey, LatencyPhase.PoolWait, workload, operation, elapsed);
         StreamTrace.TryConnectionAcquired(traceRange, elapsed, connectionLock.WasReused);
@@ -798,7 +806,7 @@ public class MultiConnectionNntpClient(
     private bool IsRetiredPoolAcquisitionFailure(Exception e) =>
         connectionPool.IsDisposed && e is ObjectDisposedException or OperationCanceledException;
 
-    private IOException CreateRetiredPoolException(Exception inner)
+    private NntpClientRetiredException CreateRetiredPoolException(Exception inner)
     {
         if (Interlocked.Exchange(ref _retiredPoolWarningLogged, 1) == 0)
         {
@@ -807,7 +815,7 @@ public class MultiConnectionNntpClient(
                 "Abandoning stale requests without retrying or penalizing provider health.",
                 providerName);
         }
-        return new IOException(
+        return new NntpClientRetiredException(
             $"Connection pool for provider '{providerName}' retired while the request was waiting.",
             inner);
     }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -328,6 +328,11 @@ public class MultiConnectionNntpClient(
             catch (Exception e) when (IsRetiredPoolAcquisitionFailure(e))
             {
                 deferredCallback.Discard();
+                // Normally this branch is reached while waiting to acquire and the lock is
+                // null. Keep cleanup here for the concurrent-dispose edge where the command
+                // itself observes disposal after acquisition.
+                LogException(() => connectionLock?.Replace());
+                LogException(() => connectionLock?.Dispose());
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw CreateRetiredPoolException(e);
             }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -325,6 +325,12 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
+            catch (Exception e) when (IsRetiredPoolAcquisitionFailure(e))
+            {
+                deferredCallback.Discard();
+                LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
+                throw CreateRetiredPoolException(e);
+            }
             catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
             {
                 // Permanently missing / invalid segment ids are not connection failures.
@@ -420,18 +426,10 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
-            catch (Exception e) when (
-                connectionPool.IsDisposed &&
-                e is ObjectDisposedException or OperationCanceledException)
+            catch (Exception e) when (IsRetiredPoolAcquisitionFailure(e))
             {
-                Log.Warning(
-                    "Connection pool for provider {Provider} retired while a request was waiting. " +
-                    "Abandoning the stale request without retrying or penalizing provider health.",
-                    providerName);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
-                throw new IOException(
-                    $"Connection pool for provider '{providerName}' retired while the request was waiting.",
-                    e);
+                throw CreateRetiredPoolException(e);
             }
             catch (Exception e)
             {
@@ -785,6 +783,24 @@ public class MultiConnectionNntpClient(
         latencyTracker?.Record(MetricsKey, LatencyPhase.PoolWait, workload, operation, elapsed);
         StreamTrace.TryConnectionAcquired(traceRange, elapsed, connectionLock.WasReused);
         return connectionLock;
+    }
+
+    /// <summary>
+    /// Pool disposal (client retirement / shutdown) is not a provider-health failure.
+    /// Stale requests must abandon without retrying the same dead pool or feeding the breaker.
+    /// </summary>
+    private bool IsRetiredPoolAcquisitionFailure(Exception e) =>
+        connectionPool.IsDisposed && e is ObjectDisposedException or OperationCanceledException;
+
+    private IOException CreateRetiredPoolException(Exception inner)
+    {
+        Log.Warning(
+            "Connection pool for provider {Provider} retired while a request was waiting. " +
+            "Abandoning the stale request without retrying or penalizing provider health.",
+            providerName);
+        return new IOException(
+            $"Connection pool for provider '{providerName}' retired while the request was waiting.",
+            inner);
     }
 
     private async Task<UsenetDecodedBodyResponse> RecordSuccessfulResponseAsync(

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -420,6 +420,19 @@ public class MultiConnectionNntpClient(
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
+            catch (Exception e) when (
+                connectionPool.IsDisposed &&
+                e is ObjectDisposedException or OperationCanceledException)
+            {
+                Log.Warning(
+                    "Connection pool for provider {Provider} retired while a request was waiting. " +
+                    "Abandoning the stale request without retrying or penalizing provider health.",
+                    providerName);
+                LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
+                throw new IOException(
+                    $"Connection pool for provider '{providerName}' retired while the request was waiting.",
+                    e);
+            }
             catch (Exception e)
             {
                 circuitBreaker.RecordFailure($"get-connection-{e.GetType().Name}");

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Database.Models.Metrics;
@@ -27,7 +28,8 @@ public class MultiProviderNntpClient(
     Func<bool>? retryPrimaryOnMiss = null,
     StreamTraceBuffer? streamTrace = null,
     ActiveReadRegistry? activeReadRegistry = null,
-    ArticleMissNegativeCache? articleMissCache = null
+    ArticleMissNegativeCache? articleMissCache = null,
+    ConnectionPoolStats? connectionPoolStats = null
 ) : NntpClient, INntpConnectionStats
 {
     /// <summary>
@@ -1161,9 +1163,12 @@ public class MultiProviderNntpClient(
 
     public override void Dispose()
     {
+        connectionPoolStats?.Deactivate();
         foreach (var provider in providers)
             provider.Dispose();
         _batchFallbackStartGate.Dispose();
         GC.SuppressFinalize(this);
     }
+
+    internal override void Retire() => connectionPoolStats?.Deactivate();
 }

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -241,6 +241,15 @@ public class MultiProviderNntpClient(
                 }
                 return new UsenetDecodedBodyBatch { Responses = responses };
             }
+            catch (NntpClientRetiredException)
+            {
+                // Every provider in this client belongs to the same retired generation.
+                // Do not walk the remaining disposed pools or record network failures.
+                deferredCallback.Discard();
+                InvokeCompletionCallback(
+                    onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
+                throw;
+            }
             catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
             {
                 // Invalid / permanently missing segment ids are invalid on every provider.
@@ -300,6 +309,10 @@ public class MultiProviderNntpClient(
             try
             {
                 response = await primaryResponse.ConfigureAwait(false);
+            }
+            catch (NntpClientRetiredException)
+            {
+                throw;
             }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken))
             {
@@ -445,6 +458,13 @@ public class MultiProviderNntpClient(
                         }
 
                         lastException = null;
+                    }
+                    catch (NntpClientRetiredException)
+                    {
+                        // The whole provider set belongs to the retired generation.
+                        deferredCallback.Discard();
+                        coordinator.CompleteAttempt();
+                        throw;
                     }
                     catch (Exception e) when (!e.IsCancellationException(cancellationToken))
                     {
@@ -652,6 +672,13 @@ public class MultiProviderNntpClient(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 return result;
             }
+            catch (NntpClientRetiredException)
+            {
+                deferredCallback.Discard();
+                InvokeCompletionCallback(
+                    onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
+                throw;
+            }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken))
             {
                 stopwatch.Stop();
@@ -787,6 +814,10 @@ public class MultiProviderNntpClient(
                 // matches StatsPipelinedAsync which records nothing).
 
                 return result;
+            }
+            catch (NntpClientRetiredException)
+            {
+                throw;
             }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken))
             {

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -18,6 +18,14 @@ public abstract class NntpClient : INntpClient
 {
     public virtual int PipeliningDepth => 0;
 
+    /// <summary>
+    /// Stops generation-scoped side effects when a wrapper replaces this client while
+    /// allowing work already in flight to finish before disposal.
+    /// </summary>
+    internal virtual void Retire()
+    {
+    }
+
     public abstract Task ConnectAsync(
         string host, int port, bool useSsl, CancellationToken cancellationToken);
 

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -15,6 +15,8 @@ namespace NzbWebDAV.Clients.Usenet;
 
 public class UsenetStreamingClient : WrappingNntpClient
 {
+    private readonly Lock _configChangeLock = new();
+
     public UsenetStreamingClient(
         ConfigManager configManager,
         WebsocketManager websocketManager,
@@ -39,29 +41,32 @@ public class UsenetStreamingClient : WrappingNntpClient
             // if unrelated config changed, do nothing
             if (!providersChanged && !streamingPriorityChanged) return;
 
-            try
+            lock (_configChangeLock)
             {
-                if (providersChanged)
+                try
                 {
-                    // update the connection-pool according to the new config. New pools are
-                    // built with the current odds, so a save that changes both needs no
-                    // separate update (and must not touch the retired client).
-                    var newUsenetClient = CreateDownloadingNntpClient(
-                        configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
-                        streamTrace, activeReadRegistry, articleMissCache, latencyTracker);
-                    ReplaceUnderlyingClient(newUsenetClient);
-                    return;
-                }
+                    if (providersChanged)
+                    {
+                        // update the connection-pool according to the new config. New pools are
+                        // built with the current odds, so a save that changes both needs no
+                        // separate update (and must not touch the retired client).
+                        var newUsenetClient = CreateDownloadingNntpClient(
+                            configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
+                            streamTrace, activeReadRegistry, articleMissCache, latencyTracker);
+                        ReplaceUnderlyingClient(newUsenetClient);
+                        return;
+                    }
 
-                // Streaming Priority alone only re-arms the provider gates; rebuilding pools
-                // would drop healthy TLS connections mid-playback.
-                UpdateProviderPriorityOdds(configManager.GetStreamingPriority());
-            }
-            catch (Exception e)
-            {
-                // Keep the previous (working) client and let remaining OnConfigChanged
-                // subscribers run — a throw from a multicast handler aborts the rest.
-                Log.Error(e, "Failed to rebuild usenet client after provider config change; keeping previous client");
+                    // Streaming Priority alone only re-arms the provider gates; rebuilding pools
+                    // would drop healthy TLS connections mid-playback.
+                    UpdateProviderPriorityOdds(configManager.GetStreamingPriority());
+                }
+                catch (Exception e)
+                {
+                    // Keep the previous (working) client and let remaining OnConfigChanged
+                    // subscribers run — a throw from a multicast handler aborts the rest.
+                    Log.Error(e, "Failed to rebuild usenet client after provider config change; keeping previous client");
+                }
             }
         };
     }

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -168,7 +168,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             retryPrimaryOnMiss: configManager.IsCascadeRetryPrimaryOnMiss,
             streamTrace: streamTrace,
             activeReadRegistry: activeReadRegistry,
-            articleMissCache: articleMissCache);
+            articleMissCache: articleMissCache,
+            connectionPoolStats: connectionPoolStats);
     }
 
     private static MultiConnectionNntpClient CreateProviderClient

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -8,8 +8,6 @@ namespace NzbWebDAV.Clients.Usenet;
 
 public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpConnectionStats
 {
-    private const int MaxRetiringClients = 4;
-    private static readonly TimeSpan RetirementGracePeriod = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan DrainPollInterval = TimeSpan.FromMilliseconds(250);
 
     private INntpClient _usenetClient = usenetClient;
@@ -21,9 +19,7 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
             client = wrap.InnerClient;
         return client;
     }
-    private readonly ConcurrentQueue<(INntpClient Client, DateTimeOffset Deadline)> _retiringClients = new();
-    private int _retiringCount;
-    private int _drainLoopRunning;
+    private readonly ConcurrentDictionary<INntpClient, byte> _retiringClients = new();
 
     public int InFlightConnections =>
         _usenetClient is INntpConnectionStats stats ? stats.InFlightConnections : 0;
@@ -112,103 +108,66 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
         _usenetClient.DecodedArticlesPipelinedAsync(segmentIds, depth, cancellationToken);
 
     /// <summary>
-    /// Swap the live client immediately so new requests use new pools, then retire the
-    /// old client after in-flight borrows drain (or a bounded grace period).
+    /// Swap the live client immediately so new requests use new pools, then dispose the
+    /// old client after all in-flight borrows drain.
     /// </summary>
     protected void ReplaceUnderlyingClient(INntpClient usenetClient)
     {
-        var old = _usenetClient;
-        _usenetClient = usenetClient;
+        var old = Interlocked.Exchange(ref _usenetClient, usenetClient);
+        if (old is NntpClient oldNntpClient)
+            oldNntpClient.Retire();
         EnqueueForRetirement(old);
     }
 
     /// <summary>
-    /// Test hook: swap with an explicit grace period and wait for the drain loop to finish.
+    /// Test hook: swap and wait for the old client to drain.
     /// Drains inline (no background loop) so exactly one consumer works the queue.
     /// </summary>
     internal Task ReplaceUnderlyingClientForTestsAsync(
-        INntpClient usenetClient, TimeSpan gracePeriod, CancellationToken cancellationToken = default)
+        INntpClient usenetClient, CancellationToken cancellationToken = default)
     {
-        var old = _usenetClient;
-        _usenetClient = usenetClient;
-        EnqueueForRetirement(old, DateTimeOffset.UtcNow + gracePeriod, startDrainLoop: false);
-        return DrainRetiringClientsAsync(cancellationToken);
+        var old = Interlocked.Exchange(ref _usenetClient, usenetClient);
+        if (old is NntpClient oldNntpClient)
+            oldNntpClient.Retire();
+        EnqueueForRetirement(old, startDrain: false);
+        return DrainRetiringClientAsync(old, cancellationToken);
     }
 
-    private void EnqueueForRetirement(
-        INntpClient old, DateTimeOffset? deadline = null, bool startDrainLoop = true)
+    private void EnqueueForRetirement(INntpClient old, bool startDrain = true)
     {
-        deadline ??= DateTimeOffset.UtcNow + RetirementGracePeriod;
-
-        // Bound stacked rapid saves: force-dispose the oldest excess clients.
-        while (Volatile.Read(ref _retiringCount) >= MaxRetiringClients
-               && _retiringClients.TryDequeue(out var excess))
-        {
-            Interlocked.Decrement(ref _retiringCount);
-            TryDispose(excess.Client, forced: true);
-        }
-
-        Interlocked.Increment(ref _retiringCount);
-        _retiringClients.Enqueue((old, deadline.Value));
-        if (startDrainLoop)
-            EnsureDrainLoop();
-    }
-
-    private void EnsureDrainLoop()
-    {
-        if (Interlocked.CompareExchange(ref _drainLoopRunning, 1, 0) != 0)
+        if (!_retiringClients.TryAdd(old, 0))
             return;
 
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await DrainRetiringClientsAsync(CancellationToken.None).ConfigureAwait(false);
-            }
-            finally
-            {
-                Interlocked.Exchange(ref _drainLoopRunning, 0);
-                // A replace may have enqueued while we were clearing the flag.
-                if (!_retiringClients.IsEmpty)
-                    EnsureDrainLoop();
-            }
-        });
+        if (startDrain)
+            _ = Task.Run(() => DrainRetiringClientAsync(old, CancellationToken.None));
     }
 
-    private async Task DrainRetiringClientsAsync(CancellationToken cancellationToken)
+    private async Task DrainRetiringClientAsync(
+        INntpClient client,
+        CancellationToken cancellationToken)
     {
-        while (!_retiringClients.IsEmpty)
+        while (_retiringClients.ContainsKey(client))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!_retiringClients.TryPeek(out var next))
-                break;
-
-            var inFlight = next.Client is INntpConnectionStats stats
+            var inFlight = client is INntpConnectionStats stats
                 ? stats.InFlightConnections
                 : 0;
-            var expired = DateTimeOffset.UtcNow >= next.Deadline;
 
-            if (inFlight > 0 && !expired)
-            {
-                await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
-                continue;
-            }
-
-            if (!_retiringClients.TryDequeue(out next))
+            if (inFlight == 0)
                 break;
 
-            Interlocked.Decrement(ref _retiringCount);
-            TryDispose(next.Client, forced: inFlight > 0);
+            await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
         }
+
+        if (_retiringClients.TryRemove(client, out _))
+            TryDispose(client);
     }
 
-    private static void TryDispose(INntpClient client, bool forced)
+    private static void TryDispose(INntpClient client)
     {
         try
         {
-            if (forced)
-                Log.Debug("Force-disposing replaced NNTP client after grace period with in-flight work remaining");
             client.Dispose();
         }
         catch (Exception e)
@@ -220,13 +179,19 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
     public override void Dispose()
     {
         // Dispose the live client and anything still retiring.
-        while (_retiringClients.TryDequeue(out var retiring))
+        foreach (var retiring in _retiringClients.Keys)
         {
-            Interlocked.Decrement(ref _retiringCount);
-            TryDispose(retiring.Client, forced: true);
+            if (_retiringClients.TryRemove(retiring, out _))
+                TryDispose(retiring);
         }
 
         _usenetClient.Dispose();
         GC.SuppressFinalize(this);
+    }
+
+    internal override void Retire()
+    {
+        if (_usenetClient is NntpClient nntpClient)
+            nntpClient.Retire();
     }
 }

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -8,6 +8,7 @@ namespace NzbWebDAV.Clients.Usenet;
 
 public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpConnectionStats
 {
+    private const int MaxRetiringClients = 4;
     private static readonly TimeSpan DrainPollInterval = TimeSpan.FromMilliseconds(250);
 
     private INntpClient _usenetClient = usenetClient;
@@ -20,6 +21,10 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
         return client;
     }
     private readonly ConcurrentDictionary<INntpClient, byte> _retiringClients = new();
+    // Weak entries preserve retirement order for the cap without retaining every
+    // successfully drained client for the lifetime of the wrapper.
+    private readonly ConcurrentQueue<WeakReference<INntpClient>> _retirementOrder = new();
+    private readonly Lock _retirementLock = new();
 
     public int InFlightConnections =>
         _usenetClient is INntpConnectionStats stats ? stats.InFlightConnections : 0;
@@ -135,11 +140,45 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
 
     private void EnqueueForRetirement(INntpClient old, bool startDrain = true)
     {
-        if (!_retiringClients.TryAdd(old, 0))
-            return;
+        lock (_retirementLock)
+        {
+            if (!_retiringClients.TryAdd(old, 0))
+                return;
+
+            _retirementOrder.Enqueue(new WeakReference<INntpClient>(old));
+            TrimExcessRetiringClients();
+        }
 
         if (startDrain)
             _ = Task.Run(() => DrainRetiringClientAsync(old, CancellationToken.None));
+    }
+
+    private void TrimExcessRetiringClients()
+    {
+        while (_retirementOrder.TryPeek(out var oldestReference))
+        {
+            // Completed drains remain in the ordering queue. Remove stale entries eagerly
+            // so routine sequential saves do not accumulate ordering metadata.
+            if (!oldestReference.TryGetTarget(out var oldest)
+                || !_retiringClients.ContainsKey(oldest))
+            {
+                _retirementOrder.TryDequeue(out _);
+                continue;
+            }
+
+            if (_retiringClients.Count <= MaxRetiringClients)
+                break;
+
+            _retirementOrder.TryDequeue(out _);
+            if (!_retiringClients.TryRemove(oldest, out _))
+                continue;
+
+            Log.Warning(
+                "Force-disposing the oldest retired NNTP client because more than " +
+                "{MaxRetiringClients} client generations are still draining.",
+                MaxRetiringClients);
+            TryDispose(oldest);
+        }
     }
 
     private async Task DrainRetiringClientAsync(

--- a/backend/Exceptions/NntpClientRetiredException.cs
+++ b/backend/Exceptions/NntpClientRetiredException.cs
@@ -1,0 +1,9 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Signals that work captured an NNTP client generation which has since retired.
+/// This is a lifecycle outcome, not a provider/network failure, so callers must not
+/// continue through the other providers from the same retired generation.
+/// </summary>
+public sealed class NntpClientRetiredException(string message, Exception innerException)
+    : IOException(message, innerException);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolPriorityTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolPriorityTests.cs
@@ -104,6 +104,24 @@ public class ConnectionPoolPriorityTests
         await DrainAsync([secondHigh]);
     }
 
+    [Fact]
+    public async Task Dispose_StopsPublishingConnectionCountEvents()
+    {
+        var events = 0;
+        await using var pool = CreatePool(maxConnections: 1);
+        pool.OnConnectionPoolChanged += (_, _) => Interlocked.Increment(ref events);
+
+        var borrowed = await pool.GetConnectionLockAsync(SemaphorePriority.Low);
+        var beforeDispose = Volatile.Read(ref events);
+        Assert.True(beforeDispose > 0);
+
+        await pool.DisposeAsync();
+        borrowed.Dispose();
+        await Task.Delay(50);
+
+        Assert.Equal(beforeDispose, Volatile.Read(ref events));
+    }
+
     /// <summary>
     /// Saturates a one-connection pool, queues waiters in both lanes, then releases
     /// <paramref name="releases"/> times and reports which lane won each admission.

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolPriorityTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolPriorityTests.cs
@@ -122,6 +122,30 @@ public class ConnectionPoolPriorityTests
         Assert.Equal(beforeDispose, Volatile.Read(ref events));
     }
 
+    [Fact]
+    public async Task Dispose_DuringConnectionFactory_DiscardsLateConnection()
+    {
+        var factoryEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFactory = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new DisposableProbe();
+        var pool = new ConnectionPool<DisposableProbe>(
+            maxConnections: 1,
+            async _ =>
+            {
+                factoryEntered.SetResult();
+                await releaseFactory.Task;
+                return connection;
+            });
+
+        var acquisition = pool.GetConnectionLockAsync(SemaphorePriority.Low);
+        await factoryEntered.Task.WaitAsync(WaitBudget);
+        await pool.DisposeAsync();
+        releaseFactory.SetResult();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => acquisition);
+        Assert.True(connection.IsDisposed);
+    }
+
     /// <summary>
     /// Saturates a one-connection pool, queues waiters in both lanes, then releases
     /// <paramref name="releases"/> times and reports which lane won each admission.
@@ -192,5 +216,12 @@ public class ConnectionPoolPriorityTests
                 // expected: the pool may retire waiters when it is disposed.
             }
         }
+    }
+
+    private sealed class DisposableProbe : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -17,6 +17,38 @@ namespace NzbWebDAV.Tests.Clients.Usenet;
 public class StreamingTimeoutTests
 {
     [Fact]
+    public async Task RunWithConnection_DisposedPool_DoesNotRetryOrPenalizeProvider()
+    {
+        var breaker = new ProviderCircuitBreaker("retired-pool");
+        var created = 0;
+        var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref created);
+                return ValueTask.FromResult<INntpClient>(new HangingNntpClient());
+            });
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "retired-pool");
+        using var heldConnection = await pool.GetConnectionLockAsync(SemaphorePriority.Low);
+
+        var callbacks = 0;
+        var request = client.DecodedBodyAsync(
+            "seg",
+            _ => Interlocked.Increment(ref callbacks),
+            CancellationToken.None);
+        await Task.Delay(50);
+
+        await pool.DisposeAsync();
+
+        var exception = await Assert.ThrowsAsync<IOException>(() => request);
+        Assert.IsAssignableFrom<OperationCanceledException>(exception.InnerException);
+        Assert.Equal(1, created);
+        Assert.Equal(1, callbacks);
+        Assert.Equal(0, breaker.GetSnapshot().FailureCount);
+    }
+
+    [Fact]
     public async Task RunWithConnection_WithStreamingTimeout_FailsFastAndRetriesOnFreshConnection()
     {
         HangingNntpClient? hanging = null;

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -49,6 +49,38 @@ public class StreamingTimeoutTests
     }
 
     [Fact]
+    public async Task DecodedBodiesAsync_DisposedPool_DoesNotRetryOrPenalizeProvider()
+    {
+        var breaker = new ProviderCircuitBreaker("retired-batch-pool");
+        var created = 0;
+        var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref created);
+                return ValueTask.FromResult<INntpClient>(new HangingNntpClient());
+            });
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "retired-batch-pool");
+        using var heldConnection = await pool.GetConnectionLockAsync(SemaphorePriority.Low);
+
+        var callbacks = 0;
+        var request = client.DecodedBodiesAsync(
+            ["seg-a", "seg-b"],
+            _ => Interlocked.Increment(ref callbacks),
+            CancellationToken.None);
+        await Task.Delay(50);
+
+        await pool.DisposeAsync();
+
+        var exception = await Assert.ThrowsAsync<IOException>(() => request);
+        Assert.IsAssignableFrom<OperationCanceledException>(exception.InnerException);
+        Assert.Equal(1, created);
+        Assert.Equal(1, callbacks);
+        Assert.Equal(0, breaker.GetSnapshot().FailureCount);
+    }
+
+    [Fact]
     public async Task RunWithConnection_WithStreamingTimeout_FailsFastAndRetriesOnFreshConnection()
     {
         HangingNntpClient? hanging = null;

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
@@ -33,18 +34,24 @@ public class StreamingTimeoutTests
         using var heldConnection = await pool.GetConnectionLockAsync(SemaphorePriority.Low);
 
         var callbacks = 0;
+        ArticleBodyResult? callbackResult = null;
         var request = client.DecodedBodyAsync(
             "seg",
-            _ => Interlocked.Increment(ref callbacks),
+            result =>
+            {
+                callbackResult = result;
+                Interlocked.Increment(ref callbacks);
+            },
             CancellationToken.None);
         await Task.Delay(50);
 
         await pool.DisposeAsync();
 
-        var exception = await Assert.ThrowsAsync<IOException>(() => request);
+        var exception = await Assert.ThrowsAsync<NntpClientRetiredException>(() => request);
         Assert.IsAssignableFrom<OperationCanceledException>(exception.InnerException);
         Assert.Equal(1, created);
         Assert.Equal(1, callbacks);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, callbackResult);
         Assert.Equal(0, breaker.GetSnapshot().FailureCount);
     }
 
@@ -65,18 +72,120 @@ public class StreamingTimeoutTests
         using var heldConnection = await pool.GetConnectionLockAsync(SemaphorePriority.Low);
 
         var callbacks = 0;
+        ArticleBodyResult? callbackResult = null;
         var request = client.DecodedBodiesAsync(
             ["seg-a", "seg-b"],
-            _ => Interlocked.Increment(ref callbacks),
+            result =>
+            {
+                callbackResult = result;
+                Interlocked.Increment(ref callbacks);
+            },
             CancellationToken.None);
         await Task.Delay(50);
 
         await pool.DisposeAsync();
 
-        var exception = await Assert.ThrowsAsync<IOException>(() => request);
+        var exception = await Assert.ThrowsAsync<NntpClientRetiredException>(() => request);
         Assert.IsAssignableFrom<OperationCanceledException>(exception.InnerException);
         Assert.Equal(1, created);
         Assert.Equal(1, callbacks);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, callbackResult);
+        Assert.Equal(0, breaker.GetSnapshot().FailureCount);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_AlreadyDisposedPool_TranslatesObjectDisposedException()
+    {
+        var breaker = new ProviderCircuitBreaker("already-retired-pool");
+        var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ => ValueTask.FromResult<INntpClient>(new HangingNntpClient()));
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "already-retired-pool");
+        await pool.DisposeAsync();
+
+        ArticleBodyResult? callbackResult = null;
+        var exception = await Assert.ThrowsAsync<NntpClientRetiredException>(() =>
+            client.DecodedBodyAsync(
+                "seg",
+                result => callbackResult = result,
+                CancellationToken.None));
+
+        Assert.IsAssignableFrom<ObjectDisposedException>(exception.InnerException);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, callbackResult);
+        Assert.Equal(0, breaker.GetSnapshot().FailureCount);
+    }
+
+    [Fact]
+    public async Task MultiProvider_RetiredGeneration_DoesNotTryNextProvider()
+    {
+        var retiredBreaker = new ProviderCircuitBreaker("retired-primary");
+        var retiredPool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ => ValueTask.FromResult<INntpClient>(new HangingNntpClient()));
+        var retired = new MultiConnectionNntpClient(
+            retiredPool, ProviderType.Pooled, retiredBreaker, "retired-primary", priority: 0);
+        await retiredPool.DisposeAsync();
+
+        var fallbackCreated = 0;
+        var fallbackPool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref fallbackCreated);
+                return ValueTask.FromResult<INntpClient>(
+                    new HealthyNntpClient(new Dictionary<string, byte[]>
+                    {
+                        ["seg"] = [1, 2, 3, 4],
+                    }));
+            });
+        var fallback = new MultiConnectionNntpClient(
+            fallbackPool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("fallback"),
+            "fallback",
+            priority: 1);
+        using var client = new MultiProviderNntpClient([retired, fallback]);
+
+        var callbacks = 0;
+        ArticleBodyResult? callbackResult = null;
+        await Assert.ThrowsAsync<NntpClientRetiredException>(() =>
+            client.DecodedBodyAsync(
+                "seg",
+                result =>
+                {
+                    callbackResult = result;
+                    Interlocked.Increment(ref callbacks);
+                },
+                CancellationToken.None));
+
+        Assert.Equal(0, fallbackCreated);
+        Assert.Equal(1, callbacks);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, callbackResult);
+        Assert.Equal(0, retiredBreaker.GetSnapshot().FailureCount);
+    }
+
+    [Fact]
+    public async Task PipelinedBody_AlreadyDisposedPool_ThrowsRetiredGenerationException()
+    {
+        var breaker = new ProviderCircuitBreaker("retired-pipeline");
+        var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ => ValueTask.FromResult<INntpClient>(new HangingNntpClient()));
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "retired-pipeline");
+        await pool.DisposeAsync();
+
+        async Task EnumerateAsync()
+        {
+            await foreach (var _ in client.DecodedBodiesPipelinedAsync(
+                               ["seg"], depth: 1, CancellationToken.None))
+            {
+            }
+        }
+
+        var exception = await Assert.ThrowsAsync<NntpClientRetiredException>(EnumerateAsync);
+        Assert.IsAssignableFrom<ObjectDisposedException>(exception.InnerException);
         Assert.Equal(0, breaker.GetSnapshot().FailureCount);
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
@@ -50,6 +50,30 @@ public class WrappingNntpClientRetirementTests
     }
 
     [Fact]
+    public async Task ReplaceUnderlyingClient_BoundsStackedRetiringGenerations()
+    {
+        var oldest = new CountingDisposableClient { InFlightConnections = 1 };
+        var wrapper = new TestWrappingClient(oldest);
+        var replacements = Enumerable.Range(0, 5)
+            .Select(_ => new CountingDisposableClient { InFlightConnections = 1 })
+            .ToArray();
+
+        var drains = replacements
+            .Select(replacement => wrapper.ReplaceUnderlyingClientForTestsAsync(replacement))
+            .ToArray();
+
+        Assert.True(oldest.Disposed);
+        Assert.All(replacements, replacement => Assert.False(replacement.Disposed));
+
+        foreach (var replacement in replacements)
+            replacement.InFlightConnections = 0;
+        await Task.WhenAll(drains).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.All(replacements[..^1], replacement => Assert.True(replacement.Disposed));
+        Assert.False(replacements[^1].Disposed);
+    }
+
+    [Fact]
     public async Task ReplaceUnderlyingClient_DeactivatesRetiredConnectionStatsImmediately()
     {
         var connectionStats = new ConnectionPoolStats(

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
@@ -1,6 +1,10 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Websocket;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -14,10 +18,10 @@ public class WrappingNntpClientRetirementTests
         var wrapper = new TestWrappingClient(oldClient);
         var newClient = new CountingDisposableClient();
 
-        var drainTask = wrapper.ReplaceUnderlyingClientForTestsAsync(
-            newClient, TimeSpan.FromSeconds(5));
+        var drainTask = wrapper.ReplaceUnderlyingClientForTestsAsync(newClient);
 
         Assert.False(oldClient.Disposed);
+        Assert.True(oldClient.Retired);
 
         oldClient.InFlightConnections = 0;
         await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -28,16 +32,71 @@ public class WrappingNntpClientRetirementTests
     }
 
     [Fact]
-    public async Task ReplaceUnderlyingClient_ForceDisposesAfterGracePeriod()
+    public async Task ReplaceUnderlyingClient_DoesNotForceDisposeInFlightWork()
     {
         var oldClient = new CountingDisposableClient { InFlightConnections = 5 };
         var wrapper = new TestWrappingClient(oldClient);
         var newClient = new CountingDisposableClient();
 
-        await wrapper.ReplaceUnderlyingClientForTestsAsync(
-            newClient, TimeSpan.FromMilliseconds(50));
+        var drainTask = wrapper.ReplaceUnderlyingClientForTestsAsync(newClient);
+        await Task.Delay(500);
+
+        Assert.False(oldClient.Disposed);
+
+        oldClient.InFlightConnections = 0;
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.True(oldClient.Disposed);
+    }
+
+    [Fact]
+    public async Task ReplaceUnderlyingClient_DeactivatesRetiredConnectionStatsImmediately()
+    {
+        var connectionStats = new ConnectionPoolStats(
+            new UsenetProviderConfig(),
+            new WebsocketManager());
+        var oldClient = new MultiProviderNntpClient([], connectionPoolStats: connectionStats);
+        var wrapper = new TestWrappingClient(oldClient);
+
+        await wrapper.ReplaceUnderlyingClientForTestsAsync(new CountingDisposableClient());
+
+        Assert.False(connectionStats.IsActive);
+    }
+
+    [Fact]
+    public async Task ConnectionPoolStats_Deactivate_DropsScheduledAndFutureUpdates()
+    {
+        var websocketManager = new WebsocketManager();
+        var connectionStats = new ConnectionPoolStats(
+            new UsenetProviderConfig
+            {
+                Providers =
+                [
+                    new UsenetProviderConfig.ConnectionDetails
+                    {
+                        Type = ProviderType.Pooled,
+                        Host = "news.example.com",
+                        Port = 563,
+                        UseSsl = true,
+                        User = "user",
+                        Pass = "pass",
+                        MaxConnections = 50,
+                    },
+                ],
+            },
+            websocketManager);
+        var onChanged = connectionStats.GetOnConnectionPoolChanged(0);
+
+        onChanged(
+            this,
+            new ConnectionPoolStats.ConnectionPoolChangedEventArgs(25, 5, 50));
+        connectionStats.Deactivate();
+        onChanged(
+            this,
+            new ConnectionPoolStats.ConnectionPoolChangedEventArgs(1, 0, 50));
+        await Task.Delay(500);
+
+        Assert.Null(websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
     }
 
     private sealed class TestWrappingClient(INntpClient inner) : WrappingNntpClient(inner);
@@ -46,6 +105,9 @@ public class WrappingNntpClientRetirementTests
     {
         public int InFlightConnections { get; set; }
         public bool Disposed { get; private set; }
+        public bool Retired { get; private set; }
+
+        internal override void Retire() => Retired = true;
 
         public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
             Task.CompletedTask;


### PR DESCRIPTION
## Summary
- Fixes [#718](https://github.com/nzbdav/nzbdav/issues/718): after recovery/client replacement, retired pools no longer overwrite live connection totals or force-dispose healthy in-flight work after a fixed 60s deadline.
- Requests waiting on a disposed pool abandon with a single-line Warning (no stack), including pipelined work, and do not retry, fall back through other providers in the retired generation, or feed provider circuit breakers.
- Pool acquisition, connection return, late connection factories, and disposal are synchronized so completion callbacks cannot release disposed gates or leak connections created during retirement.
- Provider rebuilds are serialized; retired generations stop observing future config saves, drain until idle, and remain capped at four during repeated saves.
- Adds regression coverage for disposed-pool acquisition, callback completion, stale connection stats, multi-provider fallback, pipelined acquisition, late factories, and stacked retirement.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (1,364 passed, 14 skipped)
- [ ] Save Usenet provider settings during active playback/queue download; confirm connection count does not bounce between generations
- [ ] Confirm no `ObjectDisposedException` / `Error getting connection-lock` stacks after a provider rebuild or outage recovery
- [ ] Confirm a real provider outage can still trip the breaker on genuine BODY failures