### PR TITLE
fix(ui): make stream tracing banner Turn off button readable

### DIFF
--- a/frontend/app/components/stream-tracing-banner.tsx
+++ b/frontend/app/components/stream-tracing-banner.tsx
@@ -79,7 +79,13 @@ export function StreamTracingBanner() {
                     Tracing uses RAM only and resets on restart.
                 </span>
             </div>
-            <Button variant="ghost" size="small" disabled={busy} onClick={() => void turnOff()}>
+            <Button
+                variant="ghost"
+                size="small"
+                className="shrink-0 text-warning-content hover:bg-warning-content/10"
+                disabled={busy}
+                onClick={() => void turnOff()}
+            >
                 Turn off
             </Button>
         </Alert>


### PR DESCRIPTION
## Summary
- The developer stream tracing banner used a ghost button whose light text blended into the yellow warning background.
- Force `text-warning-content` (and a light hover wash) so Turn off stays readable on the alert.

## Test plan
- [ ] Enable developer stream tracing from Support settings
- [ ] Confirm the yellow banner shows a clearly readable dark **Turn off** label
- [ ] Confirm hover and disabled states still look usable
- [ ] Click **Turn off** and confirm tracing disables as before