### PR TITLE
fix(nntp): fail over to backup immediately after streaming BODY timeouts

### DIFF
--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -311,8 +311,8 @@ public class MultiConnectionNntpClient(
 
                 circuitBreaker.RecordFailure("streaming-timeout-pipelined-BODY");
                 Log.Warning(
-                    "Streaming timeout executing pipelined nntp BODY commands after {Timeout}s. No retries left.",
-                    streamingTimeout.PerSegmentTimeout.TotalSeconds);
+                    "Streaming timeout executing pipelined nntp BODY commands for provider {Provider} after {Timeout}s. No retries left.",
+                    providerName, streamingTimeout.PerSegmentTimeout.TotalSeconds);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw new TimeoutException(
                     "Timeout executing pipelined nntp BODY commands after " +
@@ -506,8 +506,8 @@ public class MultiConnectionNntpClient(
                 // providers still trip without over-counting a single segment.
                 circuitBreaker.RecordFailure($"streaming-timeout-{name}");
                 Log.Warning(
-                    "Streaming timeout executing nntp {Command} command after {Timeout}s. No retries left.",
-                    name, streamingTimeout.PerSegmentTimeout.TotalSeconds);
+                    "Streaming timeout executing nntp {Command} command for provider {Provider} after {Timeout}s. No retries left.",
+                    name, providerName, streamingTimeout.PerSegmentTimeout.TotalSeconds);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw new TimeoutException(
                     $"Timeout executing nntp {name} command after {streamingTimeout.MaxRetries + 1} attempts.");

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -345,8 +345,14 @@ public class MultiProviderNntpClient(
 
             // Re-probe primary once on a definitive miss when enabled (default). Multi-node
             // spool routing can return a transient 430/451 on one connection. Operators may
-            // disable via usenet.cascade.retry-primary-on-miss; connection-level failures
-            // always re-try the primary.
+            // disable via usenet.cascade.retry-primary-on-miss; most connection-level
+            // failures also re-try the primary once.
+            //
+            // Exhausted streaming/read timeouts are different: MultiConnectionNntpClient
+            // already spent the per-segment retry budget on this provider. Re-probing it
+            // before backups only burns more playback time (#723). When no fallbacks exist,
+            // keep the primary in the retry list so a solo provider can still recover via
+            // a singular BODY.
             //
             // Coherence with ArticleMissNegativeCache:
             // - Never MarkMissing the primary on this initial batch 430 — that would prime
@@ -356,12 +362,15 @@ public class MultiProviderNntpClient(
             // - MarkMissing only from definitive misses inside the retry/fallback loop below.
             IReadOnlyList<MultiConnectionNntpClient> retryProviders;
             var primaryCachedMiss = IsCachedMissing(segmentId, primaryProvider);
+            var exhaustedTimeout = lastException != null
+                && lastException.SourceException.TryGetCausingException<TimeoutException>(out _);
             var reprobePrimary = !definitiveMiss
                 || (retryPrimaryOnMiss?.Invoke() != false && !primaryCachedMiss);
-            if (definitiveMiss && !reprobePrimary)
+            if ((exhaustedTimeout && fallbackProviders.Count > 0)
+                || (definitiveMiss && !reprobePrimary))
             {
                 var primaryGroup = NormalizeStorageGroup(primaryProvider.StorageGroup);
-                if (primaryGroup.Length > 0) missingGroups.Add(primaryGroup);
+                if (primaryGroup.Length > 0 && definitiveMiss) missingGroups.Add(primaryGroup);
                 retryProviders = fallbackProviders;
             }
             else

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -126,6 +126,71 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task BatchResponse_TimeoutWithBackup_SkipsPrimaryReprobeAndUsesBackup()
+    {
+        // After an exhausted streaming/read timeout the primary already burned its
+        // per-segment retry budget. Re-probing it before backups delays failover (#723).
+        var writer = new MetricsWriter();
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+            FaultBatchResponsesWith = () => new TimeoutException(
+                "Timeout executing nntp BODY command after 4 attempts."),
+            SingularException = _ => new TimeoutException(
+                "Timeout executing nntp BODY command after 4 attempts."),
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+            [
+                CreateProvider(primary, host: "a.example"),
+                CreateProvider(backup, host: "b.example", providerType: ProviderType.BackupOnly),
+            ],
+            metricsWriter: writer);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["segment"], onConnectionReadyAgain: null, CancellationToken.None);
+        Assert.Equal(
+            UsenetResponseType.ArticleRetrievedBodyFollows,
+            (await batch.Responses[0]).ResponseType);
+
+        Assert.Equal(0, primary.SingularRequests);
+        Assert.Equal(1, backup.SingularRequests);
+        Assert.Equal(1, writer.Stats.QueuedFailoverMisses);
+        Assert.Single(writer.SnapshotQueuedEvents(MetricsWriter.FailoverSaveEventKind));
+    }
+
+    [Fact]
+    public async Task DecodedBodyAsync_OpenPrimaryCircuit_UsesBackupOnly()
+    {
+        var openPrimary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        var healthyBackup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(openPrimary, host: "a.example", circuitBreaker: OpenBreaker("a.example")),
+            CreateProvider(healthyBackup, host: "b.example", providerType: ProviderType.BackupOnly),
+        ]);
+
+        var response = await client.DecodedBodyAsync("segment", CancellationToken.None);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.Equal(0, openPrimary.SingularRequests);
+        Assert.Equal(1, healthyBackup.SingularRequests);
+    }
+
+    [Fact]
     public async Task DecodedBodyAsync_CrossProviderRescue_RecordsFailoverMiss()
     {
         var writer = new MetricsWriter();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -10,11 +10,16 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
+[Collection(nameof(GlobalLoggerCollection))]
 public class StreamingTimeoutTests
 {
     [Fact]
@@ -604,6 +609,150 @@ public class StreamingTimeoutTests
     }
 
     [Fact]
+    public async Task MultiProvider_StreamingTimeout_FailsOverToBackup()
+    {
+        var primaryCreated = 0;
+        var backupCreated = 0;
+        var primaryPool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ =>
+            {
+                Interlocked.Increment(ref primaryCreated);
+                return ValueTask.FromResult<INntpClient>(new HangingNntpClient());
+            });
+        var backupPool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref backupCreated);
+                return ValueTask.FromResult<INntpClient>(
+                    new HealthyNntpClient(new Dictionary<string, byte[]>
+                    {
+                        ["seg"] = [1, 2, 3, 4],
+                    }));
+            });
+        var primary = new MultiConnectionNntpClient(
+            primaryPool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("news.primary.example"),
+            "news.primary.example",
+            priority: 0);
+        var backup = new MultiConnectionNntpClient(
+            backupPool,
+            ProviderType.BackupOnly,
+            new ProviderCircuitBreaker("news.backup.example"),
+            "news.backup.example",
+            priority: 1);
+        using var client = new MultiProviderNntpClient([primary, backup]);
+
+        using var cts = new CancellationTokenSource();
+        using var timeoutScope = cts.Token.SetContext(new StreamingTimeoutContext
+        {
+            PerSegmentTimeout = TimeSpan.FromMilliseconds(50),
+            MaxRetries = 1,
+        });
+
+        var response = await client.DecodedBodyAsync("seg", onConnectionReadyAgain: null, cts.Token);
+
+        Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseType);
+        Assert.Equal(2, primaryCreated);
+        Assert.Equal(1, backupCreated);
+        if (response.Stream != null)
+            await response.Stream.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task MultiProvider_PipelinedStreamingTimeout_FailsOverToBackup()
+    {
+        var primaryCreated = 0;
+        var backupCreated = 0;
+        var primaryPool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ =>
+            {
+                Interlocked.Increment(ref primaryCreated);
+                return ValueTask.FromResult<INntpClient>(new HangingPipelinedNntpClient());
+            });
+        var backupPool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref backupCreated);
+                return ValueTask.FromResult<INntpClient>(new HealthyPipelinedNntpClient());
+            });
+        var primary = new MultiConnectionNntpClient(
+            primaryPool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("news.primary.example"),
+            "news.primary.example",
+            priority: 0);
+        var backup = new MultiConnectionNntpClient(
+            backupPool,
+            ProviderType.BackupOnly,
+            new ProviderCircuitBreaker("news.backup.example"),
+            "news.backup.example",
+            priority: 1);
+        using var client = new MultiProviderNntpClient([primary, backup]);
+
+        using var cts = new CancellationTokenSource();
+        using var timeoutScope = cts.Token.SetContext(new StreamingTimeoutContext
+        {
+            PerSegmentTimeout = TimeSpan.FromMilliseconds(50),
+            MaxRetries = 1,
+        });
+
+        var batch = await client.DecodedBodiesAsync(
+            [new SegmentId("one")], onConnectionReadyAgain: null, cts.Token);
+        Assert.Equal(
+            UsenetResponseType.ArticleRetrievedBodyFollows,
+            (await batch.Responses[0]).ResponseType);
+        Assert.Equal(2, primaryCreated);
+        Assert.Equal(1, backupCreated);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_StreamingTimeoutExhausted_WarningIncludesProvider()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            using var pool = new ConnectionPool<INntpClient>(
+                maxConnections: 2,
+                _ => ValueTask.FromResult<INntpClient>(new HangingNntpClient()));
+            using var client = new MultiConnectionNntpClient(
+                pool,
+                ProviderType.Pooled,
+                new ProviderCircuitBreaker("news.verycheapprovider.com"),
+                "news.verycheapprovider.com");
+
+            using var cts = new CancellationTokenSource();
+            using var timeoutScope = cts.Token.SetContext(new StreamingTimeoutContext
+            {
+                PerSegmentTimeout = TimeSpan.FromMilliseconds(50),
+                MaxRetries = 0,
+            });
+
+            await Assert.ThrowsAsync<TimeoutException>(() =>
+                client.DecodedBodyAsync("seg", onConnectionReadyAgain: null, cts.Token));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        Assert.Contains(sink.Events, e =>
+            e.Level == LogEventLevel.Warning
+            && e.RenderMessage().Contains("news.verycheapprovider.com", StringComparison.Ordinal)
+            && e.RenderMessage().Contains("No retries left", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ConnectionPoolGate_CancelsWithinStreamingReadDeadline()
     {
         var created = 0;
@@ -835,6 +984,24 @@ public class StreamingTimeoutTests
             output.Write(Encoding.ASCII.GetBytes("\r\n"));
             output.Write(Encoding.ASCII.GetBytes($"=yend size={source.Length}\r\n"));
             return output.ToArray();
+        }
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
         }
     }
 


### PR DESCRIPTION
## Summary
- After a pipelined BODY streaming/read timeout exhausts same-provider retries, batch recovery now walks backups immediately instead of re-probing the exhausted primary (#723).
- Timeout “No retries left” warnings now include the provider hostname so logs show which host failed.
- Adds regression coverage for timeout → backup failover, open-circuit primary skipping, and provider-attributed warnings.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~StreamingTimeoutTests|FullyQualifiedName~MultiProviderNntpClientTests'`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Manual: stream with a slow/unresponsive primary + healthy backup; confirm backup is used after timeout and logs name the primary

Fixes #723