### PR TITLE
fix(health): prevent endless Arr searches for broken releases

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -18,7 +18,10 @@ public class ArrClient(string host, string apiKey)
     public Task<ArrApiInfoResponse> GetApiInfo(CancellationToken ct = default) =>
         GetRoot<ArrApiInfoResponse>($"/api", ct);
 
-    public virtual Task<bool> RemoveAndSearch(string symlinkOrStrmPath) =>
+    public virtual Task<ArrRepairOutcome> RemoveAndBlocklist(
+        string symlinkOrStrmPath,
+        Guid downloadId,
+        CancellationToken ct = default) =>
         throw new InvalidOperationException();
 
     public virtual Task<List<ArrRootFolder>> GetRootFolders() =>
@@ -52,6 +55,19 @@ public class ArrClient(string host, string apiKey)
 
     public Task<ArrCommand> CommandAsync(object command, CancellationToken ct = default) =>
         Post<ArrCommand>($"/command", command, ct);
+
+    protected async Task<int?> GetHistoryRecordId(Guid downloadId, CancellationToken ct = default)
+    {
+        var history = await Get<ArrHistory>(
+            $"/history?downloadId={downloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+            ct).ConfigureAwait(false);
+        return history.Records.FirstOrDefault()?.Id;
+    }
+
+    protected async Task MarkHistoryFailed(int historyId, CancellationToken ct = default)
+    {
+        _ = await Post<object>($"/history/failed/{historyId}", new { }, ct).ConfigureAwait(false);
+    }
 
     protected Task<T> Get<T>(string path, CancellationToken ct = default) =>
         GetRoot<T>($"{BasePath}{path}", ct);

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+
+public class ArrHistory
+{
+    [JsonPropertyName("records")]
+    public List<ArrHistoryRecord> Records { get; set; } = [];
+}
+
+public class ArrHistoryRecord
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+}

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrRepairOutcome.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrRepairOutcome.cs
@@ -1,0 +1,8 @@
+namespace NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+
+public enum ArrRepairOutcome
+{
+    RemoveAndBlocklistSucceeded,
+    MediaItemNotFound,
+    DownloadHistoryNotFound,
+}

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -8,61 +8,63 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 {
     private static readonly Dictionary<string, int> SymlinkOrStrmToMovieIdCache = new();
 
-    public Task<RadarrMovie> GetMovieAsync(int id) =>
-        Get<RadarrMovie>($"/movie/{id}");
+    public Task<RadarrMovie> GetMovieAsync(int id, CancellationToken ct = default) =>
+        Get<RadarrMovie>($"/movie/{id}", ct);
 
-    private Task<RadarrMovie?> GetMovieOrNullAsync(int id) =>
-        GetOrNull<RadarrMovie>($"/movie/{id}");
+    private Task<RadarrMovie?> GetMovieOrNullAsync(int id, CancellationToken ct = default) =>
+        GetOrNull<RadarrMovie>($"/movie/{id}", ct);
 
-    public Task<List<RadarrMovie>> GetMoviesAsync() =>
-        Get<List<RadarrMovie>>($"/movie");
+    public Task<List<RadarrMovie>> GetMoviesAsync(CancellationToken ct = default) =>
+        Get<List<RadarrMovie>>($"/movie", ct);
 
     public Task<RadarrQueue> GetRadarrQueueAsync() =>
         Get<RadarrQueue>($"/queue?protocol=usenet&pageSize=5000");
 
-    public Task<HttpStatusCode> DeleteMovieFile(int id) =>
-        Delete($"/moviefile/{id}");
+    public Task<HttpStatusCode> DeleteMovieFile(int id, CancellationToken ct = default) =>
+        Delete($"/moviefile/{id}", ct: ct);
 
-    public Task<ArrCommand> SearchMovieAsync(int id) =>
-        CommandAsync(new { name = "MoviesSearch", movieIds = new List<int> { id } });
-
-
-    public override async Task<bool> RemoveAndSearch(string symlinkOrStrmPath)
+    public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
+        string symlinkOrStrmPath,
+        Guid downloadId,
+        CancellationToken ct = default)
     {
-        var mediaIds = await GetMediaIds(symlinkOrStrmPath);
-        if (mediaIds == null) return false;
+        var movieFileId = await GetMovieFileId(symlinkOrStrmPath, ct).ConfigureAwait(false);
+        if (movieFileId == null) return ArrRepairOutcome.MediaItemNotFound;
 
-        if (await DeleteMovieFile(mediaIds.Value.movieFileId) != HttpStatusCode.OK)
+        var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
+        if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
+
+        if (await DeleteMovieFile(movieFileId.Value, ct).ConfigureAwait(false) != HttpStatusCode.OK)
             throw new Exception($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
 
-        await SearchMovieAsync(mediaIds.Value.movieId);
-        return true;
+        await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+        return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
     }
 
-    private async Task<(int movieFileId, int movieId)?> GetMediaIds(string symlinkOrStrmPath)
+    private async Task<int?> GetMovieFileId(string symlinkOrStrmPath, CancellationToken ct)
     {
         // if we already have the movie-id cached
         // then let's use it to find and return the corresponding movie-file-id
         if (SymlinkOrStrmToMovieIdCache.TryGetValue(symlinkOrStrmPath, out var movieId))
         {
-            var movie = await GetMovieOrNullAsync(movieId);
+            var movie = await GetMovieOrNullAsync(movieId, ct).ConfigureAwait(false);
             var movieFile = movie?.MovieFile;
             if (movieFile?.Path == symlinkOrStrmPath)
-                return (movieFile.Id!, movieId);
+                return movieFile.Id;
             SymlinkOrStrmToMovieIdCache.Remove(symlinkOrStrmPath);
         }
 
         // otherwise, let's fetch all movies, cache all movie files
         // and return the matching movie-id and movie-file-id
-        var allMovies = await GetMoviesAsync();
-        (int movieFileId, int movieId)? result = null;
+        var allMovies = await GetMoviesAsync(ct).ConfigureAwait(false);
+        int? result = null;
         foreach (var movie in allMovies)
         {
             var movieFile = movie.MovieFile;
             if (movieFile?.Path != null)
                 SymlinkOrStrmToMovieIdCache[movieFile.Path] = movie.Id;
             if (movieFile?.Path == symlinkOrStrmPath)
-                result = (movieFile.Id!, movie.Id);
+                result = movieFile.Id;
         }
 
         return result;

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -13,80 +13,67 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public Task<SonarrQueue> GetSonarrQueueAsync() =>
         Get<SonarrQueue>($"/queue?protocol=usenet&pageSize=5000");
 
-    public Task<List<SonarrSeries>> GetAllSeries() =>
-        Get<List<SonarrSeries>>($"/series");
+    public Task<List<SonarrSeries>> GetAllSeries(CancellationToken ct = default) =>
+        Get<List<SonarrSeries>>($"/series", ct);
 
-    public Task<SonarrSeries> GetSeries(int seriesId) =>
-        Get<SonarrSeries>($"/series/{seriesId}");
+    public Task<SonarrSeries> GetSeries(int seriesId, CancellationToken ct = default) =>
+        Get<SonarrSeries>($"/series/{seriesId}", ct);
 
-    private Task<SonarrSeries?> GetSeriesOrNull(int seriesId) =>
-        GetOrNull<SonarrSeries>($"/series/{seriesId}");
+    private Task<SonarrSeries?> GetSeriesOrNull(int seriesId, CancellationToken ct = default) =>
+        GetOrNull<SonarrSeries>($"/series/{seriesId}", ct);
 
-    public Task<SonarrEpisodeFile> GetEpisodeFile(int episodeFileId) =>
-        Get<SonarrEpisodeFile>($"/episodefile/{episodeFileId}");
+    public Task<SonarrEpisodeFile> GetEpisodeFile(int episodeFileId, CancellationToken ct = default) =>
+        Get<SonarrEpisodeFile>($"/episodefile/{episodeFileId}", ct);
 
-    private Task<SonarrEpisodeFile?> GetEpisodeFileOrNull(int episodeFileId) =>
-        GetOrNull<SonarrEpisodeFile>($"/episodefile/{episodeFileId}");
+    private Task<SonarrEpisodeFile?> GetEpisodeFileOrNull(int episodeFileId, CancellationToken ct = default) =>
+        GetOrNull<SonarrEpisodeFile>($"/episodefile/{episodeFileId}", ct);
 
-    public Task<List<SonarrEpisodeFile>> GetAllEpisodeFiles(int seriesId) =>
-        Get<List<SonarrEpisodeFile>>($"/episodefile?seriesId={seriesId}");
+    public Task<List<SonarrEpisodeFile>> GetAllEpisodeFiles(int seriesId, CancellationToken ct = default) =>
+        Get<List<SonarrEpisodeFile>>($"/episodefile?seriesId={seriesId}", ct);
 
-    public Task<List<SonarrEpisode>> GetEpisodesFromEpisodeFileId(int episodeFileId) =>
-        Get<List<SonarrEpisode>>($"/episode?episodeFileId={episodeFileId}");
+    public Task<List<SonarrEpisode>> GetEpisodesFromEpisodeFileId(
+        int episodeFileId,
+        CancellationToken ct = default) =>
+        Get<List<SonarrEpisode>>($"/episode?episodeFileId={episodeFileId}", ct);
 
-    public Task<HttpStatusCode> DeleteEpisodeFile(int episodeFileId) =>
-        Delete($"/episodefile/{episodeFileId}");
+    public Task<HttpStatusCode> DeleteEpisodeFile(int episodeFileId, CancellationToken ct = default) =>
+        Delete($"/episodefile/{episodeFileId}", ct: ct);
 
-    public Task<ArrCommand> SearchEpisodesAsync(List<int> episodeIds) =>
-        CommandAsync(new { name = "EpisodeSearch", episodeIds });
-
-    public override async Task<bool> RemoveAndSearch(string symlinkOrStrmPath)
+    public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
+        string symlinkOrStrmPath,
+        Guid downloadId,
+        CancellationToken ct = default)
     {
-        // get episode-file-id and episode-ids
-        var mediaIds = await GetMediaIds(symlinkOrStrmPath);
-        if (mediaIds == null) return false;
+        var episodeFileId = await GetEpisodeFileId(symlinkOrStrmPath, ct).ConfigureAwait(false);
+        if (episodeFileId == null) return ArrRepairOutcome.MediaItemNotFound;
 
-        // delete the episode-file
-        if (await DeleteEpisodeFile(mediaIds.Value.episodeFileId) != HttpStatusCode.OK)
+        var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
+        if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
+
+        if (await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false) != HttpStatusCode.OK)
             throw new Exception($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
 
-        // trigger a new search for each episode
-        await SearchEpisodesAsync(mediaIds.Value.episodeIds);
-        return true;
+        await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+        return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
     }
 
-    private async Task<(int episodeFileId, List<int> episodeIds)?> GetMediaIds(string symlinkOrStrmPath)
-    {
-        // get episode-file-id
-        var episodeFileId = await GetEpisodeFileId(symlinkOrStrmPath);
-        if (episodeFileId == null) return null;
-
-        // get episode-ids
-        var episodes = await GetEpisodesFromEpisodeFileId(episodeFileId.Value);
-        var episodeIds = episodes.Select(x => x.Id).ToList();
-        if (episodeIds.Count == 0) return null;
-
-        // return
-        return (episodeFileId.Value, episodeIds);
-    }
-
-    private async Task<int?> GetEpisodeFileId(string symlinkOrStrmPath)
+    private async Task<int?> GetEpisodeFileId(string symlinkOrStrmPath, CancellationToken ct)
     {
         // if episode-file-id is found in the cache, verify it and return it
         if (SymlinkOrStrmToEpisodeFileIdCache.TryGetValue(symlinkOrStrmPath, out var episodeFileId))
         {
-            var episodeFile = await GetEpisodeFileOrNull(episodeFileId);
+            var episodeFile = await GetEpisodeFileOrNull(episodeFileId, ct).ConfigureAwait(false);
             if (episodeFile?.Path == symlinkOrStrmPath) return episodeFileId;
             SymlinkOrStrmToEpisodeFileIdCache.Remove(symlinkOrStrmPath);
         }
 
         // otherwise, find the series-id
-        var seriesId = await GetSeriesId(symlinkOrStrmPath);
+        var seriesId = await GetSeriesId(symlinkOrStrmPath, ct).ConfigureAwait(false);
         if (seriesId == null) return null;
 
         // then use it to find all episode-files and repopulate the cache
         int? result = null;
-        foreach (var episodeFile in await GetAllEpisodeFiles(seriesId.Value))
+        foreach (var episodeFile in await GetAllEpisodeFiles(seriesId.Value, ct).ConfigureAwait(false))
         {
             SymlinkOrStrmToEpisodeFileIdCache[episodeFile.Path!] = episodeFile.Id;
             if (episodeFile.Path == symlinkOrStrmPath)
@@ -97,7 +84,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         return result;
     }
 
-    private async Task<int?> GetSeriesId(string symlinkOrStrmPath)
+    private async Task<int?> GetSeriesId(string symlinkOrStrmPath, CancellationToken ct)
     {
         // get series-id from cache
         var cachedSeriesPath = PathUtil.GetAllParentDirectories(symlinkOrStrmPath)
@@ -108,7 +95,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         if (cachedSeriesPath != null)
         {
             var cachedSeriesId = SeriesPathToSeriesIdCache[cachedSeriesPath];
-            var series = await GetSeriesOrNull(cachedSeriesId);
+            var series = await GetSeriesOrNull(cachedSeriesId, ct).ConfigureAwait(false);
             if (series?.Path != null && symlinkOrStrmPath.StartsWith(series.Path))
                 return cachedSeriesId;
             SeriesPathToSeriesIdCache.Remove(cachedSeriesPath);
@@ -116,7 +103,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 
         // otherwise, fetch all series and repopulate the cache
         int? result = null;
-        foreach (var series in await GetAllSeries())
+        foreach (var series in await GetAllSeries(ct).ConfigureAwait(false))
         {
             SeriesPathToSeriesIdCache[series.Path!] = series.Id;
             if (symlinkOrStrmPath.StartsWith(series.Path!))

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1438,8 +1438,8 @@ public class ConfigManager
     }
 
     /// <summary>
-    /// When true (default), library-linked items use *Arr remove-and-search at the failure
-    /// threshold. When false, linked items are force-deleted after the threshold as well.
+    /// When true (default), library-linked items are removed and blocklisted through *Arr at the
+    /// failure threshold. When false, linked items are force-deleted after the threshold as well.
     /// </summary>
     public bool IsAutoRemoveUnlinkedOnly()
     {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -546,25 +546,31 @@ public class HealthCheckService : BackgroundService
     /// </summary>
     public enum ArrLinkedRepairDecision
     {
-        /// <summary>An Arr instance owned the file and remove-and-search succeeded.</summary>
-        RemoveAndSearchSucceeded,
+        /// <summary>An Arr instance owned the file and remove-and-blocklist succeeded.</summary>
+        RemoveAndBlocklistSucceeded,
         /// <summary>
         /// At least one Arr instance was unreachable/unusable and no instance confirmed the link
         /// as an orphan — leave the DavItem in place.
         /// </summary>
         DeferUnreachable,
+        /// <summary>
+        /// The Arr media item exists, but its original download history cannot be identified.
+        /// Leave it in place rather than searching again without blocklisting the failed release.
+        /// </summary>
+        DeferMissingDownloadHistory,
         /// <summary>Ownership was fully determined: no Arr media-item; safe to delete.</summary>
         DeleteConfirmedOrphan,
     }
 
     /// <summary>
     /// Consults Arr clients to decide whether a library-linked unhealthy item should trigger
-    /// remove-and-search, be deferred while an instance is down, or be deleted as a confirmed orphan.
+    /// remove-and-blocklist, be deferred while an instance is down, or be deleted as a confirmed orphan.
     /// Extracted so the unreachable-instance fail-safe can be unit-tested without a full Repair harness.
     /// </summary>
     internal static async Task<ArrLinkedRepairDecision> DecideArrLinkedRepairAsync(
         IEnumerable<ArrClient> arrClients,
         string symlinkOrStrmPath,
+        Guid? downloadId,
         CancellationToken ct)
     {
         // Track whether we could fully determine ownership. If any instance was unreachable,
@@ -603,23 +609,32 @@ public class HealthCheckService : BackgroundService
                 continue;
             }
 
-            bool removedAndSearched;
+            if (downloadId == null)
+                return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
+
+            ArrRepairOutcome repairOutcome;
             try
             {
-                removedAndSearched = await arrClient.RemoveAndSearch(symlinkOrStrmPath).ConfigureAwait(false);
+                repairOutcome = await arrClient.RemoveAndBlocklist(
+                    symlinkOrStrmPath,
+                    downloadId.Value,
+                    ct).ConfigureAwait(false);
             }
             catch (Exception e)
             {
                 anInstanceFailed = true;
                 LogArrRepairFailure(
                     e,
-                    "Health-check repair: remove-and-search failed on {Host}",
+                    "Health-check repair: remove-and-blocklist failed on {Host}",
                     arrClient.Host);
                 continue;
             }
 
-            if (removedAndSearched)
-                return ArrLinkedRepairDecision.RemoveAndSearchSucceeded;
+            if (repairOutcome == ArrRepairOutcome.RemoveAndBlocklistSucceeded)
+                return ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded;
+
+            if (repairOutcome == ArrRepairOutcome.DownloadHistoryNotFound)
+                return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
 
             // The owning instance was reached and reports no corresponding media-item, so this
             // link is a confirmed orphan. Record that ownership was determined and break; the
@@ -784,14 +799,15 @@ public class HealthCheckService : BackgroundService
             var arrDecision = await DecideArrLinkedRepairAsync(
                 _configManager.GetArrConfig().GetArrClients(),
                 symlinkOrStrmPath,
+                davItem.HistoryItemId ?? davItem.NzbBlobId,
                 ct).ConfigureAwait(false);
 
-            if (arrDecision == ArrLinkedRepairDecision.RemoveAndSearchSucceeded)
+            if (arrDecision == ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded)
             {
                 DeletionAuditLog.Record(
                     "health-repair",
                     davItem,
-                    "health validation failed; Arr remove-and-search triggered");
+                    "health validation failed; Arr media removed and original download blocklisted");
                 dbClient.Ctx.Items.Remove(davItem);
                 _failureTracker.ClearFailure(davItem.Id);
                 await RecordHealthResult(
@@ -801,7 +817,26 @@ public class HealthCheckService : BackgroundService
                     string.Join(" ", [
                         "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir.",
-                        "Triggered new Arr search."
+                        "Removed the Arr media file and blocklisted its original download.",
+                        "Arr will apply its configured failed-download redownload policy."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
+
+            if (arrDecision == ArrLinkedRepairDecision.DeferMissingDownloadHistory)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        $"Corresponding {linkType} and Arr media item found,",
+                        "but the original Arr download history could not be identified.",
+                        "Leaving the file in place rather than searching again without blocklisting the failed release."
                     ]), ct).ConfigureAwait(false);
                 return;
             }

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -16,14 +16,16 @@ Background health monitoring and replacement of unhealthy library items.
 | Health Check Depth | `repair.healthcheck-depth` | `standard` | standard / enhanced / deep / complete |
 | Check older releases less thoroughly [since 0.8.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.0){ .nzbdav-since } | `repair.healthcheck-aging` | off | Aging taper |
 | Repair After Streaming Failures | `repair.auto-remove-after-failures` | `0` | Consecutive streaming failures before urgent repair; `0` = immediate repair |
-| Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items use *Arr remove-and-search instead of force-delete |
+| Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items are removed and blocklisted through *Arr instead of force-deleted |
 | Library Directory | `media.library-dir` | empty | Organized media path in container |
 
 `repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
 articles and corrupt archives. With a value greater than `0`, NzbDAV waits for that many
-consecutive failures before it starts an urgent repair. At the threshold, linked library items
-trigger *Arr remove-and-search when **Auto-remove unlinked files only** is enabled; unlinked files
-are removed. Disable that option to force-delete linked items at the threshold.
+consecutive failures before it starts an urgent repair. At the threshold, linked library items are
+removed and their original downloads are marked failed in *Arr when **Auto-remove unlinked files
+only** is enabled. *Arr blocklists those releases and applies its configured failed-download
+redownload policy. Unlinked files are removed. Disable that option to force-delete linked items at
+the threshold.
 
 Successful full-file playback and a successful background health check reset the in-memory failure
 count. The count resets when NzbDAV restarts, so it is intentionally not a durable replacement for

--- a/docs/operations/deletion-audit.md
+++ b/docs/operations/deletion-audit.md
@@ -6,7 +6,7 @@ Mounted content under `/content` can vanish for several independent reasons. “
 |-------|---------|--------------|
 | History delete with delete-files | Admin UI, or `del_completed_files=1` | Mounted items for that history row are deleted |
 | Cascading child sweep | Deleted directory | Children removed in background |
-| Health repair | Repairs + missing articles | Orphans/blocklisted deleted; linked may *Arr remove-and-search |
+| Health repair | Repairs + missing articles | Orphans/blocklisted files are deleted; linked releases are removed and blocklisted through *Arr |
 | Remove Orphaned Files | Manual/scheduled | Deletes files with **no** library symlink/STRM (safety abort if too few links) |
 | History retention | Retention days > 0 | Prunes history with `deleteFiles: false` — mounts stay, lose history link |
 | Manual delete | WebDAV DELETE / admin API | Explicit user action |

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -153,13 +153,13 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     onChange={e => setNewConfig({ ...config, "repair.auto-remove-after-failures": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-after-failures-help">
                     Wait for this many consecutive streaming playback failures before urgent repair starts. Linked library
-                    items then use Radarr/Sonarr remove-and-search; unlinked items are removed. Set to 0 for immediate
-                    repair (default).
+                    items are removed and blocklisted through Radarr/Sonarr, which then applies its failed-download
+                    redownload policy. Unlinked items are removed. Set to 0 for immediate repair (default).
                 </p>
             </div>
             </ManagedSetting>
             <ManagedSetting configKey="repair.auto-remove-unlinked-only">
-            <Tooltip content="When enabled (default), library-linked files still use Radarr/Sonarr remove-and-search. Disable to force-delete linked files after the failure threshold.">
+            <Tooltip content="When enabled (default), library-linked releases are removed and blocklisted through Radarr/Sonarr. Disable to force-delete linked files after the failure threshold.">
                 <Toggle
                     id="auto-remove-unlinked-only-checkbox"
                     className="cursor-pointer gap-2 p-0"

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -1,51 +1,111 @@
 using System.Net;
 using System.Text;
 using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 
 namespace NzbWebDAV.Tests.Clients;
 
 public class RadarrSonarrClientTests
 {
     [Fact]
-    public async Task SonarrStaleCachedEpisodeAndSeries_ReturnsFalseAfter404()
+    public async Task SonarrRepair_BlocklistsHistoryWithoutDirectSearch()
     {
         const string seriesPath = "/library/tv/Stale Show";
         const string filePath = seriesPath + "/Stale Show S01E01.mkv";
+        var downloadId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         using var httpClient = new HttpClient(CreateHandler(
             ("GET /api/v3/series", JsonResponse("""[{"id":101,"path":"/library/tv/Stale Show"}]""")),
             ("GET /api/v3/episodefile?seriesId=101", JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
-            ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
             ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("""{"id":1}""", Encoding.UTF8, "application/json"),
-            }),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("GET /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/series/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/series", JsonResponse("[]"))));
         var client = new TestSonarrClient(httpClient);
 
-        Assert.True(await client.RemoveAndSearch(filePath));
-        Assert.False(await client.RemoveAndSearch(filePath));
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+        Assert.Equal(
+            ArrRepairOutcome.MediaItemNotFound,
+            await client.RemoveAndBlocklist(filePath, downloadId));
     }
 
     [Fact]
-    public async Task RadarrStaleCachedMovie_ReturnsFalseAfter404()
+    public async Task RadarrRepair_BlocklistsHistoryWithoutDirectSearch()
     {
         const string filePath = "/library/movies/Stale Movie/Stale Movie.mkv";
+        var downloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         using var httpClient = new HttpClient(CreateHandler(
             ("GET /api/v3/movie", JsonResponse($"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
             ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("""{"id":1}""", Encoding.UTF8, "application/json"),
-            }),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/movie", JsonResponse("[]"))));
         var client = new TestRadarrClient(httpClient);
 
-        Assert.True(await client.RemoveAndSearch(filePath));
-        Assert.False(await client.RemoveAndSearch(filePath));
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+        Assert.Equal(
+            ArrRepairOutcome.MediaItemNotFound,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+    }
+
+    [Fact]
+    public async Task SonarrRepair_TwoReplacementDownloadsAreEachBlocklistedOnce()
+    {
+        const string seriesPath = "/library/tv/Loop Show";
+        const string filePath = seriesPath + "/Loop Show S01E01.mkv";
+        var firstDownloadId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var secondDownloadId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":103,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=103",
+                JsonResponse($"[{{\"id\":203,\"seriesId\":103,\"path\":\"{filePath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=103",
+                JsonResponse($"[{{\"id\":204,\"seriesId\":103,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={firstDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":403}]}""")),
+            ($"GET /api/v3/history?downloadId={secondDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":404}]}""")),
+            ("DELETE /api/v3/episodefile/203", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/204", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/403", JsonResponse("{}")),
+            ("POST /api/v3/history/failed/404", JsonResponse("{}")),
+            ("GET /api/v3/episodefile/203", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/series/103", JsonResponse($"{{\"id\":103,\"path\":\"{seriesPath}\"}}"))));
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, firstDownloadId));
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, secondDownloadId));
+    }
+
+    [Fact]
+    public async Task SonarrRepair_MissingHistoryDoesNotDeleteMedia()
+    {
+        const string seriesPath = "/library/tv/No History Show";
+        const string filePath = seriesPath + "/No History Show S01E01.mkv";
+        var downloadId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":102,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=102",
+                JsonResponse($"[{{\"id\":202,\"seriesId\":102,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[]}"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.DownloadHistoryNotFound,
+            await client.RemoveAndBlocklist(filePath, downloadId));
     }
 
     private static HttpResponseMessage JsonResponse(string json) =>

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -7,6 +7,7 @@ namespace NzbWebDAV.Tests.Services;
 public class ArrLinkedRepairDecisionTests
 {
     private const string LibraryPath = "/media/movies/Some Movie (2020)/Some Movie (2020).mkv";
+    private static readonly Guid DownloadId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
     [Fact]
     public async Task UnreachableRootFolders_DefersWithoutDelete()
@@ -16,17 +17,17 @@ public class ArrLinkedRepairDecisionTests
             new ScriptedArrClient(
                 host: "http://unreachable",
                 rootFolders: () => throw new HttpRequestException("connection refused"),
-                removeAndSearch: _ => Task.FromResult(false)),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, CancellationToken.None);
+            clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
     }
 
     [Fact]
-    public async Task RemoveAndSearchThrows_DefersWithoutDelete()
+    public async Task RemoveAndBlocklistThrows_DefersWithoutDelete()
     {
         var clients = new ArrClient[]
         {
@@ -36,11 +37,11 @@ public class ArrLinkedRepairDecisionTests
                 {
                     new() { Path = "/media/movies" },
                 }),
-                removeAndSearch: _ => throw new HttpRequestException("timeout")),
+                removeAndBlocklist: (_, _) => throw new HttpRequestException("timeout")),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, CancellationToken.None);
+            clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
     }
@@ -56,11 +57,11 @@ public class ArrLinkedRepairDecisionTests
                 {
                     new() { Path = "" },
                 }),
-                removeAndSearch: _ => Task.FromResult(false)),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, CancellationToken.None);
+            clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
     }
@@ -73,24 +74,24 @@ public class ArrLinkedRepairDecisionTests
             new ScriptedArrClient(
                 host: "http://unreachable",
                 rootFolders: () => throw new HttpRequestException("down"),
-                removeAndSearch: _ => Task.FromResult(false)),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
             new ScriptedArrClient(
                 host: "http://radarr",
                 rootFolders: () => Task.FromResult(new List<ArrRootFolder>
                 {
                     new() { Path = "/media/movies" },
                 }),
-                removeAndSearch: _ => Task.FromResult(false)),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, CancellationToken.None);
+            clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeleteConfirmedOrphan, decision);
     }
 
     [Fact]
-    public async Task RemoveAndSearchSucceeded_ReturnsRemoveAndSearch()
+    public async Task RemoveAndBlocklistSucceeded_ReturnsRemoveAndBlocklist()
     {
         var clients = new ArrClient[]
         {
@@ -100,13 +101,55 @@ public class ArrLinkedRepairDecisionTests
                 {
                     new() { Path = "/media/movies" },
                 }),
-                removeAndSearch: _ => Task.FromResult(true)),
+                removeAndBlocklist: (_, _) =>
+                    Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded)),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, CancellationToken.None);
+            clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndSearchSucceeded, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, decision);
+    }
+
+    [Fact]
+    public async Task MissingDownloadIdentity_DefersWithoutCallingArrRepair()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, null, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadHistory, decision);
+    }
+
+    [Fact]
+    public async Task MissingDownloadHistory_DefersWithoutDelete()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) =>
+                    Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadHistory, decision);
     }
 
     [Fact]
@@ -120,11 +163,11 @@ public class ArrLinkedRepairDecisionTests
                 {
                     new() { Path = "/media/tv" },
                 }),
-                removeAndSearch: _ => Task.FromResult(false)),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, CancellationToken.None);
+            clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeleteConfirmedOrphan, decision);
     }
@@ -132,11 +175,14 @@ public class ArrLinkedRepairDecisionTests
     private sealed class ScriptedArrClient(
         string host,
         Func<Task<List<ArrRootFolder>>> rootFolders,
-        Func<string, Task<bool>> removeAndSearch) : ArrClient(host, "test-key")
+        Func<string, Guid, Task<ArrRepairOutcome>> removeAndBlocklist) : ArrClient(host, "test-key")
     {
         public override Task<List<ArrRootFolder>> GetRootFolders() => rootFolders();
 
-        public override Task<bool> RemoveAndSearch(string symlinkOrStrmPath) =>
-            removeAndSearch(symlinkOrStrmPath);
+        public override Task<ArrRepairOutcome> RemoveAndBlocklist(
+            string symlinkOrStrmPath,
+            Guid downloadId,
+            CancellationToken ct = default) =>
+            removeAndBlocklist(symlinkOrStrmPath, downloadId);
     }
 }


### PR DESCRIPTION
## Summary
- mark unhealthy Sonarr/Radarr downloads failed so each rejected release is blocklisted before Arr applies its redownload policy
- defer linked repairs when the original download identity or Arr history cannot be resolved, preventing unblocked replacement loops
- update repair guidance and add regression coverage for repeated Sonarr replacements and both Arr clients

Closes #724

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~RadarrSonarrClientTests|FullyQualifiedName~ArrLinkedRepairDecisionTests\"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `cd frontend && npm run typecheck && npm run build && npm test -- --run`
- [x] `zensical build --clean --strict`