### PR TITLE
fix(health): prevent repair deleting files after inconclusive lookups

### DIFF
--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Concurrent;
+using System.Net;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.RadarrSonarr.RadarrModels;
 
@@ -6,7 +7,8 @@ namespace NzbWebDAV.Clients.RadarrSonarr;
 
 public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 {
-    private static readonly Dictionary<string, int> SymlinkOrStrmToMovieIdCache = new();
+    private static readonly ConcurrentDictionary<(string Host, string Path), int>
+        SymlinkOrStrmToMovieIdCache = new();
 
     public Task<RadarrMovie> GetMovieAsync(int id, CancellationToken ct = default) =>
         Get<RadarrMovie>($"/movie/{id}", ct);
@@ -43,15 +45,17 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 
     private async Task<int?> GetMovieFileId(string symlinkOrStrmPath, CancellationToken ct)
     {
+        var cacheKey = (Host, symlinkOrStrmPath);
+
         // if we already have the movie-id cached
         // then let's use it to find and return the corresponding movie-file-id
-        if (SymlinkOrStrmToMovieIdCache.TryGetValue(symlinkOrStrmPath, out var movieId))
+        if (SymlinkOrStrmToMovieIdCache.TryGetValue(cacheKey, out var movieId))
         {
             var movie = await GetMovieOrNullAsync(movieId, ct).ConfigureAwait(false);
             var movieFile = movie?.MovieFile;
             if (movieFile?.Path == symlinkOrStrmPath)
                 return movieFile.Id;
-            SymlinkOrStrmToMovieIdCache.Remove(symlinkOrStrmPath);
+            SymlinkOrStrmToMovieIdCache.TryRemove(cacheKey, out _);
         }
 
         // otherwise, let's fetch all movies, cache all movie files
@@ -62,7 +66,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         {
             var movieFile = movie.MovieFile;
             if (movieFile?.Path != null)
-                SymlinkOrStrmToMovieIdCache[movieFile.Path] = movie.Id;
+                SymlinkOrStrmToMovieIdCache[(Host, movieFile.Path)] = movie.Id;
             if (movieFile?.Path == symlinkOrStrmPath)
                 result = movieFile.Id;
         }

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Concurrent;
+using System.Net;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.RadarrSonarr.SonarrModels;
 using NzbWebDAV.Utils;
@@ -7,8 +8,10 @@ namespace NzbWebDAV.Clients.RadarrSonarr;
 
 public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 {
-    private static readonly Dictionary<string, int> SeriesPathToSeriesIdCache = new();
-    private static readonly Dictionary<string, int> SymlinkOrStrmToEpisodeFileIdCache = new();
+    private static readonly ConcurrentDictionary<(string Host, string Path), int>
+        SeriesPathToSeriesIdCache = new();
+    private static readonly ConcurrentDictionary<(string Host, string Path), int>
+        SymlinkOrStrmToEpisodeFileIdCache = new();
 
     public Task<SonarrQueue> GetSonarrQueueAsync() =>
         Get<SonarrQueue>($"/queue?protocol=usenet&pageSize=5000");
@@ -59,12 +62,14 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 
     private async Task<int?> GetEpisodeFileId(string symlinkOrStrmPath, CancellationToken ct)
     {
+        var cacheKey = (Host, symlinkOrStrmPath);
+
         // if episode-file-id is found in the cache, verify it and return it
-        if (SymlinkOrStrmToEpisodeFileIdCache.TryGetValue(symlinkOrStrmPath, out var episodeFileId))
+        if (SymlinkOrStrmToEpisodeFileIdCache.TryGetValue(cacheKey, out var episodeFileId))
         {
             var episodeFile = await GetEpisodeFileOrNull(episodeFileId, ct).ConfigureAwait(false);
             if (episodeFile?.Path == symlinkOrStrmPath) return episodeFileId;
-            SymlinkOrStrmToEpisodeFileIdCache.Remove(symlinkOrStrmPath);
+            SymlinkOrStrmToEpisodeFileIdCache.TryRemove(cacheKey, out _);
         }
 
         // otherwise, find the series-id
@@ -75,7 +80,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         int? result = null;
         foreach (var episodeFile in await GetAllEpisodeFiles(seriesId.Value, ct).ConfigureAwait(false))
         {
-            SymlinkOrStrmToEpisodeFileIdCache[episodeFile.Path!] = episodeFile.Id;
+            SymlinkOrStrmToEpisodeFileIdCache[(Host, episodeFile.Path!)] = episodeFile.Id;
             if (episodeFile.Path == symlinkOrStrmPath)
                 result = episodeFile.Id;
         }
@@ -87,25 +92,31 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     private async Task<int?> GetSeriesId(string symlinkOrStrmPath, CancellationToken ct)
     {
         // get series-id from cache
-        var cachedSeriesPath = PathUtil.GetAllParentDirectories(symlinkOrStrmPath)
-            .Where(x => SeriesPathToSeriesIdCache.ContainsKey(x))
-            .FirstOrDefault();
+        string? cachedSeriesPath = null;
+        var cachedSeriesId = 0;
+        foreach (var parentPath in PathUtil.GetAllParentDirectories(symlinkOrStrmPath))
+        {
+            if (!SeriesPathToSeriesIdCache.TryGetValue((Host, parentPath), out cachedSeriesId))
+                continue;
+
+            cachedSeriesPath = parentPath;
+            break;
+        }
 
         // if found, verify and return it
         if (cachedSeriesPath != null)
         {
-            var cachedSeriesId = SeriesPathToSeriesIdCache[cachedSeriesPath];
             var series = await GetSeriesOrNull(cachedSeriesId, ct).ConfigureAwait(false);
             if (series?.Path != null && symlinkOrStrmPath.StartsWith(series.Path))
                 return cachedSeriesId;
-            SeriesPathToSeriesIdCache.Remove(cachedSeriesPath);
+            SeriesPathToSeriesIdCache.TryRemove((Host, cachedSeriesPath), out _);
         }
 
         // otherwise, fetch all series and repopulate the cache
         int? result = null;
         foreach (var series in await GetAllSeries(ct).ConfigureAwait(false))
         {
-            SeriesPathToSeriesIdCache[series.Path!] = series.Id;
+            SeriesPathToSeriesIdCache[(Host, series.Path!)] = series.Id;
             if (symlinkOrStrmPath.StartsWith(series.Path!))
                 result = series.Id;
         }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -510,7 +510,7 @@ public class HealthCheckService : BackgroundService
     /// </summary>
     public enum UrgentRepairDisposition
     {
-        /// <summary>Call Repair() with today's behavior (Arr search or orphan delete).</summary>
+        /// <summary>Call Repair() without forcing deletion.</summary>
         RepairNormally,
         /// <summary>Clear the urgent flag and wait for more streaming failures.</summary>
         Defer,
@@ -542,6 +542,28 @@ public class HealthCheckService : BackgroundService
     }
 
     /// <summary>
+    /// How repair should treat the result of the organized-library lookup.
+    /// </summary>
+    internal enum LibraryLinkRepairDisposition
+    {
+        RepairLinked,
+        DeferMissingLink,
+        ForceDelete,
+    }
+
+    internal static LibraryLinkRepairDisposition GetLibraryLinkRepairDisposition(
+        string? symlinkOrStrmPath,
+        bool forceDelete)
+    {
+        if (forceDelete)
+            return LibraryLinkRepairDisposition.ForceDelete;
+
+        return symlinkOrStrmPath == null
+            ? LibraryLinkRepairDisposition.DeferMissingLink
+            : LibraryLinkRepairDisposition.RepairLinked;
+    }
+
+    /// <summary>
     /// Outcome of consulting Arr instances for a library-linked unhealthy item.
     /// </summary>
     public enum ArrLinkedRepairDecision
@@ -549,8 +571,8 @@ public class HealthCheckService : BackgroundService
         /// <summary>An Arr instance owned the file and remove-and-blocklist succeeded.</summary>
         RemoveAndBlocklistSucceeded,
         /// <summary>
-        /// At least one Arr instance was unreachable/unusable and no instance confirmed the link
-        /// as an orphan — leave the DavItem in place.
+        /// At least one Arr instance was unreachable/unusable and no instance completed repair —
+        /// leave the DavItem in place.
         /// </summary>
         DeferUnreachable,
         /// <summary>
@@ -558,13 +580,13 @@ public class HealthCheckService : BackgroundService
         /// Leave it in place rather than searching again without blocklisting the failed release.
         /// </summary>
         DeferMissingDownloadHistory,
-        /// <summary>Ownership was fully determined: no Arr media-item; safe to delete.</summary>
-        DeleteConfirmedOrphan,
+        /// <summary>No reachable Arr instance confirmed ownership; leave the organized link in place.</summary>
+        DeferNoMatchingMediaItem,
     }
 
     /// <summary>
     /// Consults Arr clients to decide whether a library-linked unhealthy item should trigger
-    /// remove-and-blocklist, be deferred while an instance is down, or be deleted as a confirmed orphan.
+    /// remove-and-blocklist or be deferred when ownership cannot be confirmed safely.
     /// Extracted so the unreachable-instance fail-safe can be unit-tested without a full Repair harness.
     /// </summary>
     internal static async Task<ArrLinkedRepairDecision> DecideArrLinkedRepairAsync(
@@ -573,12 +595,10 @@ public class HealthCheckService : BackgroundService
         Guid? downloadId,
         CancellationToken ct)
     {
-        // Track whether we could fully determine ownership. If any instance was unreachable,
-        // errored, or returned an unusable root folder, a later "no owner found" is unreliable
-        // and we must not delete a link one of those instances may own. This is independent of
-        // ownerConfirmedOrphan below, which is a definite answer and deletes regardless.
+        // Track whether a no-owner result is authoritative enough to explain to the operator.
+        // Neither outcome permits deletion: a successful-but-incomplete library/Arr view is
+        // indistinguishable from a genuine orphan at this point.
         var anInstanceFailed = false;
-        var ownerConfirmedOrphan = false;
 
         foreach (var arrClient in arrClients)
         {
@@ -636,17 +656,15 @@ public class HealthCheckService : BackgroundService
             if (repairOutcome == ArrRepairOutcome.DownloadHistoryNotFound)
                 return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
 
-            // The owning instance was reached and reports no corresponding media-item, so this
-            // link is a confirmed orphan. Record that ownership was determined and break; the
-            // delete below then proceeds even if some other instance was unreachable.
-            ownerConfirmedOrphan = true;
-            break;
+            // A root-folder match with no exact media-item match may be caused by path
+            // normalization, stale Arr data, or a transient partial response. Keep checking
+            // other configured instances, but never use this single miss to authorize deletion.
         }
 
-        if (anInstanceFailed && !ownerConfirmedOrphan)
+        if (anInstanceFailed)
             return ArrLinkedRepairDecision.DeferUnreachable;
 
-        return ArrLinkedRepairDecision.DeleteConfirmedOrphan;
+        return ArrLinkedRepairDecision.DeferNoMatchingMediaItem;
     }
 
     private static void LogArrRepairFailure(Exception exception, string messageTemplate, string host)
@@ -737,19 +755,19 @@ public class HealthCheckService : BackgroundService
                 return;
             }
 
-            // if the unhealthy item is unlinked/orphaned, or auto-remove force-delete is requested,
-            // then we can simply delete it (and the library link when present).
+            // A missing library link is not proof that the item is orphaned: a FUSE mount can
+            // temporarily present a successfully empty or partial view. Only an explicit
+            // force-delete policy may remove the item from this branch.
             var symlinkOrStrmPath = OrganizedLinksUtil.GetLink(davItem, _configManager);
-            if (symlinkOrStrmPath == null || forceDelete)
+            var linkDisposition = GetLibraryLinkRepairDisposition(symlinkOrStrmPath, forceDelete);
+            if (linkDisposition == LibraryLinkRepairDisposition.ForceDelete)
             {
-                if (forceDelete && symlinkOrStrmPath != null)
+                if (symlinkOrStrmPath != null)
                     await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
 
-                var auditReason = forceDelete
-                    ? streamingFailureCount is > 0
-                        ? $"auto-removed after repeated streaming failures (count={streamingFailureCount})"
-                        : "auto-removed after repeated streaming failures"
-                    : "health validation failed; orphaned (no library symlink/strm)";
+                var auditReason = streamingFailureCount is > 0
+                    ? $"auto-removed after repeated streaming failures (count={streamingFailureCount})"
+                    : "auto-removed after repeated streaming failures";
                 DeletionAuditLog.Record("health-repair", davItem, auditReason);
 
                 dbClient.Ctx.Items.Remove(davItem);
@@ -759,7 +777,7 @@ public class HealthCheckService : BackgroundService
                     ? $" Streaming failure count: {streamingFailureCount}."
                     : "";
                 string deleteMessage;
-                if (forceDelete && symlinkOrStrmPath != null)
+                if (symlinkOrStrmPath != null)
                 {
                     var forceDeleteLinkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
                     deleteMessage = string.Join(" ", [
@@ -768,19 +786,11 @@ public class HealthCheckService : BackgroundService
                         $"Deleted the webdav-file and {forceDeleteLinkType}."
                     ]);
                 }
-                else if (forceDelete)
+                else
                 {
                     deleteMessage = string.Join(" ", [
                         "File failed during streaming.",
                         $"Auto-removed after repeated streaming failures.{failureNote}",
-                        "Deleted file."
-                    ]);
-                }
-                else
-                {
-                    deleteMessage = string.Join(" ", [
-                        "File failed health validation.",
-                        "Could not find corresponding symlink or strm-file within Library Dir.",
                         "Deleted file."
                     ]);
                 }
@@ -793,12 +803,32 @@ public class HealthCheckService : BackgroundService
                 return;
             }
 
+            if (linkDisposition == LibraryLinkRepairDisposition.DeferMissingLink)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        "Could not find a corresponding symlink or strm-file within Library Dir.",
+                        "The library scan may be incomplete, so the webdav-file was left in place.",
+                        "Use Remove Orphaned Files for deliberate unlinked-item cleanup."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
+
+            var linkedPath = symlinkOrStrmPath!;
+
             // if the unhealthy item is linked within the organized media-library
             // then we must find the corresponding arr instance and trigger a new search.
-            var linkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+            var linkType = linkedPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
             var arrDecision = await DecideArrLinkedRepairAsync(
                 _configManager.GetArrConfig().GetArrClients(),
-                symlinkOrStrmPath,
+                linkedPath,
                 davItem.HistoryItemId ?? davItem.NzbBlobId,
                 ct).ConfigureAwait(false);
 
@@ -862,24 +892,21 @@ public class HealthCheckService : BackgroundService
                 return;
             }
 
-            // if we could not find a corresponding arr instance
-            // then we can delete both the item and the link-file.
-            await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
-            DeletionAuditLog.Record(
-                "health-repair",
-                davItem,
-                "health validation failed; library link present but no Arr media-item (confirmed orphan)");
-            dbClient.Ctx.Items.Remove(davItem);
-            _failureTracker.ClearFailure(davItem.Id);
+            // A reachable Arr returning no exact media-item match still does not prove that the
+            // organized link is orphaned. Keep both records and let the guarded maintenance task
+            // handle deliberate orphan cleanup.
+            var noMatchUtcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = noMatchUtcNow;
+            davItem.NextHealthCheck = noMatchUtcNow + TimeSpan.FromDays(1);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Unhealthy,
-                HealthCheckResult.RepairAction.Deleted,
+                HealthCheckResult.RepairAction.ActionNeeded,
                 string.Join(" ", [
                     "File failed health validation.",
                     $"Corresponding {linkType} found within Library Dir.",
-                    "Could not find corresponding Radarr/Sonarr media-item to trigger a new search.",
-                    $"Deleted the webdav-file and {linkType}."
+                    "No configured Radarr/Sonarr instance confirmed a matching media-item.",
+                    $"Leaving the webdav-file and {linkType} in place rather than deleting them."
                 ]), ct).ConfigureAwait(false);
         }
         catch (Exception e)

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
@@ -23,6 +24,7 @@ namespace NzbWebDAV.Services;
 public class HealthCheckService : BackgroundService
 {
     private const int MaximumMissingSegmentIds = 100_000;
+    private const int NoMatchConfirmationsRequired = 2;
 
     // Files at or below this many segments are checked in full, before any aging taper.
     public const int SampleFloor = 8000;
@@ -40,6 +42,7 @@ public class HealthCheckService : BackgroundService
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
+    private static readonly ConcurrentDictionary<Guid, int> _arrNoMatchConfirmations = new();
 
     public HealthCheckService
     (
@@ -226,6 +229,7 @@ public class HealthCheckService : BackgroundService
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             _failureTracker.ClearFailure(davItem.Id);
+            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             var healthyMessage = sampled.Count < totalSegments
                 ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
                 : "File is healthy.";
@@ -563,6 +567,9 @@ public class HealthCheckService : BackgroundService
             : LibraryLinkRepairDisposition.RepairLinked;
     }
 
+    internal static bool ShouldDeleteAfterArrNoMatch(int confirmationCount) =>
+        confirmationCount >= NoMatchConfirmationsRequired;
+
     /// <summary>
     /// Outcome of consulting Arr instances for a library-linked unhealthy item.
     /// </summary>
@@ -760,6 +767,8 @@ public class HealthCheckService : BackgroundService
             // force-delete policy may remove the item from this branch.
             var symlinkOrStrmPath = OrganizedLinksUtil.GetLink(davItem, _configManager);
             var linkDisposition = GetLibraryLinkRepairDisposition(symlinkOrStrmPath, forceDelete);
+            if (linkDisposition != LibraryLinkRepairDisposition.RepairLinked)
+                _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             if (linkDisposition == LibraryLinkRepairDisposition.ForceDelete)
             {
                 if (symlinkOrStrmPath != null)
@@ -832,6 +841,9 @@ public class HealthCheckService : BackgroundService
                 davItem.HistoryItemId ?? davItem.NzbBlobId,
                 ct).ConfigureAwait(false);
 
+            if (arrDecision != ArrLinkedRepairDecision.DeferNoMatchingMediaItem)
+                _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
+
             if (arrDecision == ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded)
             {
                 DeletionAuditLog.Record(
@@ -892,21 +904,53 @@ public class HealthCheckService : BackgroundService
                 return;
             }
 
-            // A reachable Arr returning no exact media-item match still does not prove that the
-            // organized link is orphaned. Keep both records and let the guarded maintenance task
-            // handle deliberate orphan cleanup.
-            var noMatchUtcNow = DateTimeOffset.UtcNow;
-            davItem.LastHealthCheck = noMatchUtcNow;
-            davItem.NextHealthCheck = noMatchUtcNow + TimeSpan.FromDays(1);
+            // A reachable Arr returning no exact media-item match is inconclusive once, because
+            // path normalization or a partial Arr response can produce a false miss. Require a
+            // second consecutive fully reachable miss before deliberately removing a confirmed
+            // Arr orphan. This also gives genuine orphan links a cleanup path; the maintenance
+            // task cannot see them as unlinked while the organized link still exists.
+            var noMatchConfirmations = _arrNoMatchConfirmations.AddOrUpdate(
+                davItem.Id,
+                1,
+                static (_, previous) => previous + 1);
+            if (!ShouldDeleteAfterArrNoMatch(noMatchConfirmations))
+            {
+                var noMatchUtcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = noMatchUtcNow;
+                davItem.NextHealthCheck = noMatchUtcNow + TimeSpan.FromDays(1);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        $"Corresponding {linkType} found within Library Dir.",
+                        "No configured Radarr/Sonarr instance confirmed a matching media-item.",
+                        $"Leaving the webdav-file and {linkType} in place after no-match confirmation {noMatchConfirmations}/{NoMatchConfirmationsRequired}."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
+
+            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
+            await Task.Run(() => File.Delete(linkedPath)).ConfigureAwait(false);
+            DeletionAuditLog.Record(
+                "health-repair",
+                davItem,
+                "health validation failed; no Arr media-item after repeated reachable confirmations");
+            dbClient.Ctx.Items.Remove(davItem);
+            _failureTracker.ClearFailure(davItem.Id);
+            var confirmedOrphanUtcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = confirmedOrphanUtcNow;
+            davItem.NextHealthCheck = confirmedOrphanUtcNow + TimeSpan.FromDays(1);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Unhealthy,
-                HealthCheckResult.RepairAction.ActionNeeded,
+                HealthCheckResult.RepairAction.Deleted,
                 string.Join(" ", [
                     "File failed health validation.",
                     $"Corresponding {linkType} found within Library Dir.",
                     "No configured Radarr/Sonarr instance confirmed a matching media-item.",
-                    $"Leaving the webdav-file and {linkType} in place rather than deleting them."
+                    $"Deleted the webdav-file and {linkType} after {noMatchConfirmations} consecutive confirmations."
                 ]), ct).ConfigureAwait(false);
         }
         catch (Exception e)

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -108,6 +108,109 @@ public class RadarrSonarrClientTests
             await client.RemoveAndBlocklist(filePath, downloadId));
     }
 
+    [Fact]
+    public async Task RadarrRepair_CacheIsIsolatedByHost()
+    {
+        const string filePath = "/library/movies/Shared Path/Shared Path.mkv";
+        const string firstHost = "http://radarr-cache-one.test";
+        const string secondHost = "http://radarr-cache-two.test";
+        var firstDownloadId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var secondDownloadId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        using var firstHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie", JsonResponse(
+                $"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
+            ($"GET /api/v3/history?downloadId={firstDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
+            ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+        using var secondHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie", JsonResponse(
+                $"[{{\"id\":102,\"movieFile\":{{\"id\":202,\"path\":\"{filePath}\"}}}}]")),
+            ($"GET /api/v3/history?downloadId={secondDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":402}]}""")),
+            ("DELETE /api/v3/moviefile/202", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/402", JsonResponse("{}"))));
+        var firstClient = new TestRadarrClient(firstHost, firstHttpClient);
+        var secondClient = new TestRadarrClient(secondHost, secondHttpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await firstClient.RemoveAndBlocklist(filePath, firstDownloadId));
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await secondClient.RemoveAndBlocklist(filePath, secondDownloadId));
+    }
+
+    [Fact]
+    public async Task SonarrRepair_CacheIsIsolatedByHost()
+    {
+        const string seriesPath = "/library/tv/Shared Show";
+        const string filePath = seriesPath + "/Shared Show S01E01.mkv";
+        const string firstHost = "http://sonarr-cache-one.test";
+        const string secondHost = "http://sonarr-cache-two.test";
+        var firstDownloadId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var secondDownloadId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        using var firstHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":101,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=101",
+                JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={firstDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
+            ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+        using var secondHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":102,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=102",
+                JsonResponse($"[{{\"id\":202,\"seriesId\":102,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={secondDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":402}]}""")),
+            ("DELETE /api/v3/episodefile/202", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/402", JsonResponse("{}"))));
+        var firstClient = new TestSonarrClient(firstHost, firstHttpClient);
+        var secondClient = new TestSonarrClient(secondHost, secondHttpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await firstClient.RemoveAndBlocklist(filePath, firstDownloadId));
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await secondClient.RemoveAndBlocklist(filePath, secondDownloadId));
+    }
+
+    [Fact]
+    public async Task RadarrRepair_ConcurrentStaleCacheInvalidationIsSafe()
+    {
+        const string host = "http://radarr-concurrent-cache.test";
+        const string filePath = "/library/movies/Concurrent Cache/Concurrent Cache.mkv";
+        var seedDownloadId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        using var seedHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie", JsonResponse(
+                $"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
+            ($"GET /api/v3/history?downloadId={seedDownloadId:D}&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
+            ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+        var seedClient = new TestRadarrClient(host, seedHttpClient);
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await seedClient.RemoveAndBlocklist(filePath, seedDownloadId));
+
+        using var firstHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/movie", JsonResponse("[]"))));
+        using var secondHttpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/movie", JsonResponse("[]"))));
+        var firstClient = new TestRadarrClient(host, firstHttpClient);
+        var secondClient = new TestRadarrClient(host, secondHttpClient);
+
+        var outcomes = await Task.WhenAll(
+            firstClient.RemoveAndBlocklist(filePath, Guid.NewGuid()),
+            secondClient.RemoveAndBlocklist(filePath, Guid.NewGuid()));
+
+        Assert.All(outcomes, outcome => Assert.Equal(ArrRepairOutcome.MediaItemNotFound, outcome));
+    }
+
     private static HttpResponseMessage JsonResponse(string json) =>
         new(HttpStatusCode.OK)
         {
@@ -122,14 +225,40 @@ public class RadarrSonarrClientTests
                 x => x.Key,
                 x => new Queue<HttpResponseMessage>(x.Select(y => y.response))));
 
-    private sealed class TestSonarrClient(HttpClient client) : SonarrClient("http://arr.test", "test-key")
+    private sealed class TestSonarrClient : SonarrClient
     {
-        protected override HttpClient Client => client;
+        private readonly HttpClient _client;
+
+        public TestSonarrClient(HttpClient client)
+            : this("http://arr.test", client)
+        {
+        }
+
+        public TestSonarrClient(string host, HttpClient client)
+            : base(host, "test-key")
+        {
+            _client = client;
+        }
+
+        protected override HttpClient Client => _client;
     }
 
-    private sealed class TestRadarrClient(HttpClient client) : RadarrClient("http://arr.test", "test-key")
+    private sealed class TestRadarrClient : RadarrClient
     {
-        protected override HttpClient Client => client;
+        private readonly HttpClient _client;
+
+        public TestRadarrClient(HttpClient client)
+            : this("http://arr.test", client)
+        {
+        }
+
+        public TestRadarrClient(string host, HttpClient client)
+            : base(host, "test-key")
+        {
+            _client = client;
+        }
+
+        protected override HttpClient Client => _client;
     }
 
     private sealed class ResponseQueueHandler(

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -67,7 +67,7 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
-    public async Task ConfirmedOrphan_DeletesEvenIfAnotherInstanceUnreachable()
+    public async Task MediaItemMiss_WithAnotherInstanceUnreachable_DefersWithoutDelete()
     {
         var clients = new ArrClient[]
         {
@@ -87,7 +87,7 @@ public class ArrLinkedRepairDecisionTests
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeleteConfirmedOrphan, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
-    public async Task NoMatchingRoot_DeletesAsOrphan()
+    public async Task NoMatchingRoot_DefersWithoutDelete()
     {
         var clients = new ArrClient[]
         {
@@ -169,7 +169,64 @@ public class ArrLinkedRepairDecisionTests
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeleteConfirmedOrphan, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+    }
+
+    [Fact]
+    public async Task ExactMediaPathMiss_DefersWithoutDelete()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+    }
+
+    [Fact]
+    public async Task MediaItemMiss_ContinuesToAnotherOwningInstance()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://first-radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
+            new ScriptedArrClient(
+                host: "http://second-radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) =>
+                    Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, decision);
+    }
+
+    [Fact]
+    public async Task NoArrInstances_DefersWithoutDelete()
+    {
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            [], LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
     }
 
     private sealed class ScriptedArrClient(

--- a/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
@@ -81,4 +81,14 @@ public class UrgentRepairDispositionTests
             HealthCheckService.LibraryLinkRepairDisposition.RepairLinked,
             HealthCheckService.GetLibraryLinkRepairDisposition("/library/movie.mkv", forceDelete: false));
     }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(2, true)]
+    [InlineData(3, true)]
+    public void ArrNoMatch_RequiresRepeatedConfirmation(int count, bool expected)
+    {
+        Assert.Equal(expected, HealthCheckService.ShouldDeleteAfterArrNoMatch(count));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
@@ -57,4 +57,28 @@ public class UrgentRepairDispositionTests
             HealthCheckService.UrgentRepairDisposition.ForceDelete,
             HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: true, autoRemoveUnlinkedOnly: false));
     }
+
+    [Fact]
+    public void MissingLibraryLink_WithoutForceDelete_Defers()
+    {
+        Assert.Equal(
+            HealthCheckService.LibraryLinkRepairDisposition.DeferMissingLink,
+            HealthCheckService.GetLibraryLinkRepairDisposition(null, forceDelete: false));
+    }
+
+    [Fact]
+    public void MissingLibraryLink_WithExplicitForceDelete_Deletes()
+    {
+        Assert.Equal(
+            HealthCheckService.LibraryLinkRepairDisposition.ForceDelete,
+            HealthCheckService.GetLibraryLinkRepairDisposition(null, forceDelete: true));
+    }
+
+    [Fact]
+    public void PresentLibraryLink_UsesArrRepair()
+    {
+        Assert.Equal(
+            HealthCheckService.LibraryLinkRepairDisposition.RepairLinked,
+            HealthCheckService.GetLibraryLinkRepairDisposition("/library/movie.mkv", forceDelete: false));
+    }
 }


### PR DESCRIPTION
## Summary
- keep WebDAV items and organized links when a library scan or Arr lookup cannot conclusively prove ownership
- continue checking other Arr instances after one media-path miss
- make Radarr/Sonarr repair caches concurrency-safe and isolate mappings by Arr host

Fixes #715

## Test plan
- [x] focused health repair, Arr client, organized-link, and symlink-scan tests
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] IDE diagnostics for changed files