### PR TITLE
fix(ui): restore spacing between overview widgets

### DIFF
--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -363,7 +363,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
             )}
 
             <div className="flex min-w-0 flex-col items-stretch gap-4 xl:flex-row">
-                <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 flex-1 flex-col gap-4">
                     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
                         <SortableContext items={visibleOrder} strategy={verticalListSortingStrategy}>
                             {visibleOrder.map(id => {


### PR DESCRIPTION
## Summary
- restore the dashboard stack gap lost when the Right now rail wrapper was added

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test -- --run "app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx" "app/routes/overview/utils/has-configured-indexers.test.ts"`