### PR TITLE
fix(health): stop endless re-grab loops when imports succeed before repair

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -69,7 +69,10 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             });
 
             if (context.Items["DavItem"] is DavItem davItem)
+            {
+                RecordMissingArticleForFailFast(davItem, notFound.SegmentId);
                 ScheduleRepair(davItem.Id);
+            }
 
             AbortStartedResponse(context);
         }
@@ -305,6 +308,19 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
+    }
+
+    /// <summary>
+    /// Streaming is the only check that reaches freshly imported (history-linked) items, so a
+    /// missing article discovered mid-stream must feed the step-0 queue precheck. Otherwise a
+    /// re-grab of the same broken release imports cleanly again and loops through repair
+    /// forever (issue #732). Failing the re-grab pre-import lets Arr blocklist it properly.
+    /// </summary>
+    internal static void RecordMissingArticleForFailFast(DavItem davItem, string segmentId)
+    {
+        if (!FilenameUtil.IsImportantFileType(davItem.Name))
+            return;
+        HealthCheckService.AddMissingSegmentIds([segmentId]);
     }
 
     private static void AbortStartedResponse(HttpContext context)

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -152,6 +152,15 @@ public class QueueItemProcessor(
         // it to the history as a failed job.
         catch (Exception e)
         {
+            // Remember definitively missing articles so retries of this item and re-grabs
+            // of the same release fail in milliseconds at the step-0 precheck instead of
+            // re-verifying every article across all providers (issue #732).
+            if (e.TryGetCausingException<UsenetArticleNotFoundException>(out var articleNotFound) &&
+                articleNotFound is not null)
+            {
+                HealthCheckService.AddMissingSegmentIds([articleNotFound.SegmentId]);
+            }
+
             try
             {
                 await MarkQueueItemCompleted(startTime, error: e.Message).ConfigureAwait(false);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -26,6 +26,13 @@ public class HealthCheckService : BackgroundService
     private const int MaximumMissingSegmentIds = 100_000;
     private const int NoMatchConfirmationsRequired = 2;
 
+    // Repeated remove-and-blocklist repairs for the same library path in a short window indicate
+    // a replacement loop (Arr keeps re-grabbing a release repair keeps rejecting, issue #732).
+    // After the limit is hit, further repairs at that path are deferred instead of deleting again.
+    internal const int RepairRecurrenceLimit = 3;
+    internal static readonly TimeSpan RepairRecurrenceWindow = TimeSpan.FromHours(6);
+    private const int MaximumTrackedRepairPaths = 10_000;
+
     // Files at or below this many segments are checked in full, before any aging taper.
     public const int SampleFloor = 8000;
 
@@ -43,6 +50,7 @@ public class HealthCheckService : BackgroundService
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
     private static readonly ConcurrentDictionary<Guid, int> _arrNoMatchConfirmations = new();
+    private static readonly ConcurrentDictionary<string, List<DateTimeOffset>> _recentRepairRemovalsByPath = new();
 
     public HealthCheckService
     (
@@ -571,6 +579,51 @@ public class HealthCheckService : BackgroundService
         confirmationCount >= NoMatchConfirmationsRequired;
 
     /// <summary>
+    /// True when the linked library path has already had <see cref="RepairRecurrenceLimit"/>
+    /// downloads removed by repair within <see cref="RepairRecurrenceWindow"/>. The path is the
+    /// stable identity across replacement cycles: each re-grab creates a new DavItem, but Arr
+    /// imports it to the same library location.
+    /// </summary>
+    internal static bool IsRepairRateLimited(string linkedPath, DateTimeOffset utcNow)
+    {
+        if (!_recentRepairRemovalsByPath.TryGetValue(linkedPath, out var removals))
+            return false;
+        lock (removals)
+        {
+            removals.RemoveAll(x => utcNow - x >= RepairRecurrenceWindow);
+            return removals.Count >= RepairRecurrenceLimit;
+        }
+    }
+
+    internal static void RecordRepairRemoval(string linkedPath, DateTimeOffset utcNow)
+    {
+        var removals = _recentRepairRemovalsByPath.GetOrAdd(linkedPath, _ => []);
+        lock (removals)
+        {
+            removals.RemoveAll(x => utcNow - x >= RepairRecurrenceWindow);
+            removals.Add(utcNow);
+        }
+
+        if (_recentRepairRemovalsByPath.Count <= MaximumTrackedRepairPaths)
+            return;
+
+        // Best-effort prune of fully stale paths; a concurrent add racing a TryRemove can at
+        // worst drop one timestamp, which only makes the rate limiter marginally more lenient.
+        foreach (var entry in _recentRepairRemovalsByPath)
+        {
+            bool stale;
+            lock (entry.Value)
+            {
+                entry.Value.RemoveAll(x => utcNow - x >= RepairRecurrenceWindow);
+                stale = entry.Value.Count == 0;
+            }
+
+            if (stale)
+                _recentRepairRemovalsByPath.TryRemove(entry.Key, out _);
+        }
+    }
+
+    /// <summary>
     /// Outcome of consulting Arr instances for a library-linked unhealthy item.
     /// </summary>
     public enum ArrLinkedRepairDecision
@@ -831,10 +884,38 @@ public class HealthCheckService : BackgroundService
             }
 
             var linkedPath = symlinkOrStrmPath!;
+            var linkType = linkedPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+
+            // Rate-limit repairs per library path: when Arr keeps re-importing broken
+            // replacements to the same location, deleting again only fuels the loop.
+            if (IsRepairRateLimited(linkedPath, DateTimeOffset.UtcNow))
+            {
+                Log.Warning(
+                    "Health-check repair rate limit reached for {LinkedPath}: " +
+                    "{RemovalCount} downloads already removed within {WindowHours} hours. " +
+                    "Leaving the file in place to break the replacement loop.",
+                    linkedPath,
+                    RepairRecurrenceLimit,
+                    RepairRecurrenceWindow.TotalHours);
+                var deferUntil = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = deferUntil;
+                davItem.NextHealthCheck = deferUntil + TimeSpan.FromDays(1);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        $"Repair already removed {RepairRecurrenceLimit} downloads for this library path",
+                        $"within the last {RepairRecurrenceWindow.TotalHours:0} hours,",
+                        "which indicates a replacement loop.",
+                        "Leaving the file in place rather than triggering another replacement."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
 
             // if the unhealthy item is linked within the organized media-library
             // then we must find the corresponding arr instance and trigger a new search.
-            var linkType = linkedPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
             var arrDecision = await DecideArrLinkedRepairAsync(
                 _configManager.GetArrConfig().GetArrClients(),
                 linkedPath,
@@ -846,6 +927,7 @@ public class HealthCheckService : BackgroundService
 
             if (arrDecision == ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded)
             {
+                RecordRepairRemoval(linkedPath, DateTimeOffset.UtcNow);
                 DeletionAuditLog.Record(
                     "health-repair",
                     davItem,

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -33,6 +33,11 @@ public class HealthCheckService : BackgroundService
     internal static readonly TimeSpan RepairRecurrenceWindow = TimeSpan.FromHours(6);
     private const int MaximumTrackedRepairPaths = 10_000;
 
+    // How many of a rejected release's segment ids to seed into the fail-fast cache.
+    // Bounded so a single large release cannot evict the whole FIFO cache; the queue
+    // precheck fails on any overlap, so a prefix is sufficient to reject a re-grab.
+    internal const int RejectedReleaseSeedSegments = 200;
+
     // Files at or below this many segments are checked in full, before any aging taper.
     public const int SampleFloor = 8000;
 
@@ -886,13 +891,13 @@ public class HealthCheckService : BackgroundService
             var linkedPath = symlinkOrStrmPath!;
             var linkType = linkedPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
 
-            // Rate-limit repairs per library path: when Arr keeps re-importing broken
+            // Rate-limit repairs per library file: when Arr keeps re-importing broken
             // replacements to the same location, deleting again only fuels the loop.
             if (IsRepairRateLimited(linkedPath, DateTimeOffset.UtcNow))
             {
                 Log.Warning(
-                    "Health-check repair rate limit reached for {LinkedPath}: " +
-                    "{RemovalCount} downloads already removed within {WindowHours} hours. " +
+                    "Health-check repair rate limit reached for library file {LinkedPath}: " +
+                    "{RemovalCount} downloads already removed for this file within {WindowHours} hours. " +
                     "Leaving the file in place to break the replacement loop.",
                     linkedPath,
                     RepairRecurrenceLimit,
@@ -906,7 +911,7 @@ public class HealthCheckService : BackgroundService
                     HealthCheckResult.RepairAction.ActionNeeded,
                     string.Join(" ", [
                         "File failed health validation.",
-                        $"Repair already removed {RepairRecurrenceLimit} downloads for this library path",
+                        $"Repair already removed {RepairRecurrenceLimit} downloads for this library file",
                         $"within the last {RepairRecurrenceWindow.TotalHours:0} hours,",
                         "which indicates a replacement loop.",
                         "Leaving the file in place rather than triggering another replacement."
@@ -928,6 +933,7 @@ public class HealthCheckService : BackgroundService
             if (arrDecision == ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded)
             {
                 RecordRepairRemoval(linkedPath, DateTimeOffset.UtcNow);
+                await SeedRejectedReleaseSegmentsAsync(davItem, dbClient, ct).ConfigureAwait(false);
                 DeletionAuditLog.Record(
                     "health-repair",
                     davItem,
@@ -1083,6 +1089,44 @@ public class HealthCheckService : BackgroundService
         );
         return result;
     }
+
+    /// <summary>
+    /// Seeds the fail-fast cache with the segment ids of a release that repair just rejected
+    /// via remove-and-blocklist. The cache semantically holds "segments of rejected releases"
+    /// here: a corrupt-archive or truncated-stream rejection can have every article present,
+    /// but a re-grab of the same release carries identical message-ids, so failing it at the
+    /// queue step-0 precheck — pre-import, where Arr blocklisting works — is the intended
+    /// outcome regardless of which failure type triggered the repair (issue #732).
+    /// </summary>
+    private async Task SeedRejectedReleaseSegmentsAsync(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        CancellationToken ct)
+    {
+        try
+        {
+            var segments = await GetAllSegments(davItem, dbClient, ct).ConfigureAwait(false);
+            AddMissingSegmentIds(SelectRejectedReleaseSeedSegments(segments));
+        }
+        catch (Exception e) when (!e.IsCancellationException(ct))
+        {
+            // A missing blob must not abort the repair; the release is already
+            // blocklisted in Arr, we only lose the pre-import fail-fast.
+            Log.Warning(
+                "Could not seed the fail-fast cache with segments of rejected release {Path}. " +
+                "A re-grab of the same release may import once more before failing. Reason: {Reason}",
+                davItem.Path, e.Message);
+            Log.Debug(e, "Rejected-release cache seeding failure stack for {Path}", davItem.Path);
+        }
+    }
+
+    /// <summary>
+    /// Selects the bounded prefix of a rejected release's segment ids to seed into the cache.
+    /// </summary>
+    internal static List<string> SelectRejectedReleaseSeedSegments(List<string> segments) =>
+        segments.Count <= RejectedReleaseSeedSegments
+            ? segments
+            : segments.Take(RejectedReleaseSeedSegments).ToList();
 
     public static void AddMissingSegmentIds(IEnumerable<string> segmentIds)
     {

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -38,13 +38,15 @@ import successfully before any health check runs. Marking an already-imported do
 not reliably blocklist it, so *Arr could re-grab the identical release and loop. Two safeguards
 break that cycle:
 
-- **Fail re-grabs before import.** Articles found missing during streaming are remembered, so a
-  re-grabbed NZB containing them fails within milliseconds while still in the download queue.
-  *Arr sees a failed download before import, blocklists the release, and moves on to a different
-  one. The memory is in-process and resets on restart; a loop that survives a restart is stopped
-  again after one extra cycle.
-- **Per-path repair rate limit.** After repair has removed 3 downloads for the same library path
-  within 6 hours, further repairs at that path are deferred for a day and surfaced as
-  **Action needed** in the health screen instead of triggering another replacement.
+- **Fail re-grabs before import.** Releases rejected by repair are remembered: when repair removes
+  a broken download and marks it failed, the release's article ids are recorded (as are articles
+  found definitively missing while downloading or streaming). A re-grabbed NZB containing any of
+  them fails within milliseconds while still in the download queue. *Arr sees a failed download
+  before import, blocklists the release, and moves on to a different one. The memory is in-process
+  and resets on restart; a loop that survives a restart is stopped again after one extra cycle.
+- **Per-file repair rate limit.** After repair has removed 3 downloads for the same library file
+  (the same episode or movie file path — not the whole series or folder) within 6 hours, further
+  repairs for that file are deferred for a day and surfaced as **Action needed** in the health
+  screen instead of triggering another replacement.
 
 [Health and repairs](../operations/health-repairs.md)

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -31,4 +31,20 @@ Successful full-file playback and a successful background health check reset the
 count. The count resets when NzbDAV restarts, so it is intentionally not a durable replacement for
 health checks.
 
+## Replacement-loop protection [since 0.9.4](https://github.com/nzbdav/nzbdav/releases/tag/v0.9.4){ .nzbdav-since }
+
+When *Arr imports a download instantly (for example over an rclone mount), a broken release can
+import successfully before any health check runs. Marking an already-imported download failed does
+not reliably blocklist it, so *Arr could re-grab the identical release and loop. Two safeguards
+break that cycle:
+
+- **Fail re-grabs before import.** Articles found missing during streaming are remembered, so a
+  re-grabbed NZB containing them fails within milliseconds while still in the download queue.
+  *Arr sees a failed download before import, blocklists the release, and moves on to a different
+  one. The memory is in-process and resets on restart; a loop that survives a restart is stopped
+  again after one extra cycle.
+- **Per-path repair rate limit.** After repair has removed 3 downloads for the same library path
+  within 6 hours, further repairs at that path are deferred for a day and surfaced as
+  **Action needed** in the health screen instead of triggering another replacement.
+
 [Health and repairs](../operations/health-repairs.md)

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -254,6 +254,45 @@ public class ExceptionMiddlewareTests
         Assert.Contains("aborted after headers", logged.RenderMessage(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task MissingArticleWithDavItem_RecordsSegmentForQueueFailFast()
+    {
+        // Re-grabs of the same release must fail the step-0 queue precheck pre-import
+        // instead of importing again and looping through repair (issue #732).
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetArticleNotFoundException(segmentId));
+
+        await middleware.InvokeAsync(context);
+
+        var ex = Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+        Assert.Equal(segmentId, ex.SegmentId);
+    }
+
+    [Fact]
+    public void RecordMissingArticleForFailFast_IgnoresUnimportantFileTypes()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var id = Guid.NewGuid();
+        var davItem = new DavItem
+        {
+            Id = id,
+            IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+            CreatedAt = DateTime.UtcNow,
+            Name = "release.nfo",
+            Path = "/content/release.nfo",
+            Type = DavItem.ItemType.UsenetFile,
+        };
+
+        ExceptionMiddleware.RecordMissingArticleForFailFast(davItem, segmentId);
+
+        // Must not throw — unimportant files never enter the fail-fast cache.
+        HealthCheckService.CheckCachedMissingSegmentIds([segmentId]);
+    }
+
     [Theory]
     [InlineData(0, 1, true)]
     [InlineData(3, 2, false)]

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckRejectedReleaseSeedTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckRejectedReleaseSeedTests.cs
@@ -1,0 +1,50 @@
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class HealthCheckRejectedReleaseSeedTests
+{
+    private static List<string> NewSegmentIds(int count) =>
+        Enumerable.Range(0, count).Select(_ => $"<{Guid.NewGuid():N}@test>").ToList();
+
+    [Fact]
+    public void SmallRelease_SeedsAllSegments()
+    {
+        var segments = NewSegmentIds(HealthCheckService.RejectedReleaseSeedSegments - 1);
+
+        var seed = HealthCheckService.SelectRejectedReleaseSeedSegments(segments);
+
+        Assert.Equal(segments, seed);
+    }
+
+    [Fact]
+    public void LargeRelease_SeedIsBoundedToPrefix()
+    {
+        var segments = NewSegmentIds(HealthCheckService.RejectedReleaseSeedSegments * 3);
+
+        var seed = HealthCheckService.SelectRejectedReleaseSeedSegments(segments);
+
+        Assert.Equal(HealthCheckService.RejectedReleaseSeedSegments, seed.Count);
+        Assert.Equal(segments.Take(HealthCheckService.RejectedReleaseSeedSegments), seed);
+    }
+
+    [Fact]
+    public void SeededSegments_FailTheQueuePrecheck()
+    {
+        // A re-grab of a rejected release carries identical message-ids, so any overlap
+        // between the seed and the incoming NZB must throw at the step-0 precheck.
+        var segments = NewSegmentIds(HealthCheckService.RejectedReleaseSeedSegments + 50);
+
+        HealthCheckService.AddMissingSegmentIds(
+            HealthCheckService.SelectRejectedReleaseSeedSegments(segments));
+
+        var ex = Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds(segments));
+        Assert.Equal(segments[0], ex.SegmentId);
+
+        // Segments beyond the bounded prefix are not seeded — the cache stays bounded.
+        HealthCheckService.CheckCachedMissingSegmentIds(
+            segments.Skip(HealthCheckService.RejectedReleaseSeedSegments));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckRepairRateLimitTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckRepairRateLimitTests.cs
@@ -1,0 +1,67 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class HealthCheckRepairRateLimitTests
+{
+    // The tracker is a shared static with no reset API, so every test uses a unique path.
+    private static string NewPath() => $"/media/tv/Show/Season 01/{Guid.NewGuid():N}.mkv";
+
+    [Fact]
+    public void UnknownPath_IsNotRateLimited()
+    {
+        Assert.False(HealthCheckService.IsRepairRateLimited(NewPath(), DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void RemovalsBelowLimit_AreNotRateLimited()
+    {
+        var path = NewPath();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < HealthCheckService.RepairRecurrenceLimit - 1; i++)
+            HealthCheckService.RecordRepairRemoval(path, now);
+
+        Assert.False(HealthCheckService.IsRepairRateLimited(path, now));
+    }
+
+    [Fact]
+    public void RemovalsAtLimit_AreRateLimited()
+    {
+        var path = NewPath();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < HealthCheckService.RepairRecurrenceLimit; i++)
+            HealthCheckService.RecordRepairRemoval(path, now);
+
+        Assert.True(HealthCheckService.IsRepairRateLimited(path, now));
+    }
+
+    [Fact]
+    public void RemovalsOutsideWindow_AreForgotten()
+    {
+        var path = NewPath();
+        var start = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < HealthCheckService.RepairRecurrenceLimit; i++)
+            HealthCheckService.RecordRepairRemoval(path, start);
+
+        Assert.True(HealthCheckService.IsRepairRateLimited(path, start));
+        Assert.False(HealthCheckService.IsRepairRateLimited(
+            path, start + HealthCheckService.RepairRecurrenceWindow));
+    }
+
+    [Fact]
+    public void RateLimitIsPerPath()
+    {
+        var limitedPath = NewPath();
+        var otherPath = NewPath();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < HealthCheckService.RepairRecurrenceLimit; i++)
+            HealthCheckService.RecordRepairRemoval(limitedPath, now);
+
+        Assert.True(HealthCheckService.IsRepairRateLimited(limitedPath, now));
+        Assert.False(HealthCheckService.IsRepairRateLimited(otherPath, now));
+    }
+}


### PR DESCRIPTION
## Summary
- Broken releases now fail **before** *Arr imports them — the point where failed-download blocklisting actually works — terminating the instant-import repair loop from #732, where post-import mark-as-failed never blocklisted and the identical release was re-grabbed every ~20 seconds. Three recording paths feed the queue's step-0 fail-fast cache:
  - **Rejection-time seeding (primary):** when repair removes a download and marks it failed, the release's segment ids are cached, so the identical re-grab fails in milliseconds regardless of which failure type (missing article, corrupt archive, truncated stream) triggered the repair. Mid-file missing articles are zero-filled during streaming and never surface as exceptions, so this is the path that covers the reported scenario.
  - Definitive missing-article failures during queue processing are recorded.
  - Missing articles that do surface as streaming exceptions are recorded (fastest path for first-segment playback failures).
- As a backstop, repairs are rate-limited **per library file** (the episode/movie file path, not the folder): after 3 removals for the same file within 6 hours, further repairs for it are deferred for a day and surfaced as **Action needed** instead of fueling another replacement search.
- Documents both safeguards in the repairs guide.

Fixes #732

## Test plan
- [x] New regression tests: rejected-release seed selection (bounded prefix, precheck overlap), streaming missing-article recording (important vs unimportant file types), and the per-file rate limit (below/at limit, window expiry, per-file isolation)
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 1402 passed, 0 failed
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release` — no new warnings
- [x] `zensical build --clean --strict`
- [x] Live validation by the reporter on the `loop-fix` image ([run details](https://github.com/nzbdav/nzbdav/issues/732#issuecomment-5144238020)): loop terminated, 16/16 episodes completed, blocklist grew via the pre-import path, no item exceeded 3 removals