### PR TITLE
fix(health): complete initial scans without progress resetting

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -161,10 +161,12 @@ public class HealthCheckService : BackgroundService
 
     public static IOrderedQueryable<DavItem> GetHealthCheckQueueItems(DavDatabaseClient dbClient)
     {
-        // Non-null NextHealthCheck first (includes urgent UnixEpoch from dynamic repair),
-        // then ascending NextHealthCheck, then newest releases.
+        // Playback-triggered urgent repairs stay first. Never-checked files come next so
+        // routine rechecks cannot starve the initial scan.
         return GetHealthCheckQueueItemsQuery(dbClient)
-            .OrderBy(x => x.NextHealthCheck == null ? 1 : 0)
+            .OrderBy(x =>
+                x.NextHealthCheck == DateTimeOffset.UnixEpoch ? 0 :
+                x.NextHealthCheck == null ? 1 : 2)
             .ThenBy(x => x.NextHealthCheck)
             .ThenByDescending(x => x.ReleaseDate)
             .ThenBy(x => x.Id);

--- a/frontend/app/routes/health/health-queue-state.test.ts
+++ b/frontend/app/routes/health/health-queue-state.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { HealthCheckQueueItem } from "~/clients/backend-client.server";
+import { completeHealthCheck, type HealthQueueState } from "./health-queue-state";
+
+function queueItem(id: string, nextHealthCheck: string | null): HealthCheckQueueItem {
+    return {
+        id,
+        name: `${id}.mkv`,
+        path: `/content/${id}.mkv`,
+        releaseDate: null,
+        lastHealthCheck: null,
+        nextHealthCheck,
+        progress: 0,
+    };
+}
+
+describe("completeHealthCheck", () => {
+    it("decrements the pending count for a never-checked item", () => {
+        const state: HealthQueueState = {
+            items: [queueItem("initial", null)],
+            uncheckedCount: 10,
+        };
+
+        expect(completeHealthCheck(state, "initial")).toEqual({
+            items: [],
+            uncheckedCount: 9,
+        });
+    });
+
+    it("does not decrement the pending count for a recheck", () => {
+        const state: HealthQueueState = {
+            items: [queueItem("recheck", "2026-07-31T12:00:00Z")],
+            uncheckedCount: 10,
+        };
+
+        expect(completeHealthCheck(state, "recheck")).toEqual({
+            items: [],
+            uncheckedCount: 10,
+        });
+    });
+
+    it("ignores duplicate or unknown completion events", () => {
+        const state: HealthQueueState = {
+            items: [queueItem("other", null)],
+            uncheckedCount: 10,
+        };
+
+        expect(completeHealthCheck(state, "missing")).toBe(state);
+    });
+
+    it("never decrements the pending count below zero", () => {
+        const state: HealthQueueState = {
+            items: [queueItem("initial", null)],
+            uncheckedCount: 0,
+        };
+
+        expect(completeHealthCheck(state, "initial").uncheckedCount).toBe(0);
+    });
+});

--- a/frontend/app/routes/health/health-queue-state.ts
+++ b/frontend/app/routes/health/health-queue-state.ts
@@ -1,0 +1,21 @@
+import type { HealthCheckQueueItem } from "~/clients/backend-client.server";
+
+export type HealthQueueState = {
+    items: HealthCheckQueueItem[],
+    uncheckedCount: number,
+}
+
+export function completeHealthCheck(
+    state: HealthQueueState,
+    davItemId: string,
+): HealthQueueState {
+    const completedItem = state.items.find(item => item.id === davItemId);
+    if (!completedItem) return state;
+
+    return {
+        items: state.items.filter(item => item.id !== davItemId),
+        uncheckedCount: completedItem.nextHealthCheck === null
+            ? Math.max(0, state.uncheckedCount - 1)
+            : state.uncheckedCount,
+    };
+}

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -5,6 +5,8 @@ import { HealthStats } from "./components/health-stats/health-stats";
 import { useCallback, useEffect, useState } from "react";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
 import { Alert, Icon } from "~/components/ui";
+import type { HealthCheckQueueResponse } from "~/clients/backend-client.server";
+import { completeHealthCheck, type HealthQueueState } from "./health-queue-state";
 
 const topicNames = {
     healthItemStatus: 'hs',
@@ -38,8 +40,11 @@ export async function loader() {
 export default function Health({ loaderData }: Route.ComponentProps) {
     const { isEnabled } = loaderData;
     const [historyStats, setHistoryStats] = useState(loaderData.historyStats);
-    const [queueItems, setQueueItems] = useState(loaderData.queueItems);
-    const [uncheckedCount, setUncheckedCount] = useState(loaderData.uncheckedCount);
+    const [queueState, setQueueState] = useState<HealthQueueState>({
+        items: loaderData.queueItems,
+        uncheckedCount: loaderData.uncheckedCount,
+    });
+    const { items: queueItems, uncheckedCount } = queueState;
 
     // effects
     useEffect(() => {
@@ -47,19 +52,20 @@ export default function Health({ loaderData }: Route.ComponentProps) {
         const refetchData = async () => {
             const response = await fetch('/api/get-health-check-queue?pageSize=30');
             if (response.ok) {
-                const healthCheckQueue = await response.json();
-                setQueueItems(healthCheckQueue.items);
-                setUncheckedCount(healthCheckQueue.uncheckedCount);
+                const healthCheckQueue: HealthCheckQueueResponse = await response.json();
+                setQueueState({
+                    items: healthCheckQueue.items,
+                    uncheckedCount: healthCheckQueue.uncheckedCount,
+                });
             }
         };
         refetchData();
-    }, [queueItems, setQueueItems])
+    }, [queueItems, setQueueState])
 
     // events
     const onHealthItemStatus = useCallback(async (message: string) => {
         const [davItemId, healthResult, repairAction] = message.split('|');
-        setQueueItems(x => x.filter(item => item.id !== davItemId));
-        setUncheckedCount(x => x - 1);
+        setQueueState(x => completeHealthCheck(x, davItemId));
         setHistoryStats(x => {
             const healthResultNum = Number(healthResult);
             const repairActionNum = Number(repairAction);
@@ -89,22 +95,25 @@ export default function Health({ loaderData }: Route.ComponentProps) {
             // if an update occurred, return the modified array
             return newStats;
         });
-    }, [setQueueItems, setHistoryStats]);
+    }, [setQueueState, setHistoryStats]);
 
     const onHealthItemProgress = useCallback((message: string) => {
         const [davItemId, progress] = message.split('|');
         if (progress === "done") return;
-        setQueueItems(queueItems => {
-            const index = queueItems.findIndex(x => x.id === davItemId);
-            if (index === -1) return queueItems;
-            return queueItems
-                .filter((_, i) => i >= index)
-                .map(item => item.id === davItemId
-                    ? { ...item, progress: Number(progress) }
-                    : item
-                )
+        setQueueState(queueState => {
+            const index = queueState.items.findIndex(x => x.id === davItemId);
+            if (index === -1) return queueState;
+            return {
+                ...queueState,
+                items: queueState.items
+                    .filter((_, i) => i >= index)
+                    .map(item => item.id === davItemId
+                        ? { ...item, progress: Number(progress) }
+                        : item
+                    ),
+            };
         });
-    }, [setQueueItems]);
+    }, [setQueueState]);
 
     // websocket
     const onWebsocketMessage = useCallback((topic: string, message: string) => {

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -65,15 +65,16 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task OrderedQuery_PlacesUrgentHistoryLinkedItemAheadOfScheduledItem()
+    public async Task OrderedQuery_PrioritizesUrgentThenUncheckedThenScheduledItems()
     {
         var historyId = Guid.NewGuid();
-        var scheduledAt = DateTimeOffset.UtcNow.AddHours(2);
+        var scheduledAt = DateTimeOffset.UtcNow.AddHours(-2);
 
         var historyLinkedUrgent = NewUsenetFile("urgent-first.mkv", historyId, DateTimeOffset.UnixEpoch);
-        var unlinkedScheduled = NewUsenetFile("scheduled-second.mkv", null, scheduledAt);
+        var uncheckedItem = NewUsenetFile("unchecked-second.mkv", null, nextHealthCheck: null);
+        var unlinkedScheduled = NewUsenetFile("scheduled-third.mkv", null, scheduledAt);
 
-        _context.Items.AddRange(historyLinkedUrgent, unlinkedScheduled);
+        _context.Items.AddRange(historyLinkedUrgent, uncheckedItem, unlinkedScheduled);
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
@@ -82,11 +83,14 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
             .ToListAsync();
 
         Assert.Equal(
-            [historyLinkedUrgent.Id, unlinkedScheduled.Id],
+            [historyLinkedUrgent.Id, uncheckedItem.Id, unlinkedScheduled.Id],
             orderedIds);
     }
 
-    private static DavItem NewUsenetFile(string name, Guid? historyItemId, DateTimeOffset nextHealthCheck)
+    private static DavItem NewUsenetFile(
+        string name,
+        Guid? historyItemId,
+        DateTimeOffset? nextHealthCheck)
     {
         var item = DavItem.New(
             Guid.NewGuid(),


### PR DESCRIPTION
## Summary
- keep the live pending count tied to unchecked queue items instead of decrementing for every re-check
- prioritize urgent repairs, then never-checked files, so routine re-checks cannot starve the initial scan
- cover live counter updates and queue ordering with frontend and backend regression tests

Fixes #738

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint` (existing warning baseline only)
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run build`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`