### PR TITLE
fix(ui): move logout link to avatar object in header, prep for #99

### DIFF
--- a/frontend/app/auth/authentication.server.test.ts
+++ b/frontend/app/auth/authentication.server.test.ts
@@ -50,9 +50,19 @@ describe("authentication sessions", () => {
     const cookie = getSetCookie(loginResult);
 
     expect(authenticateMock).toHaveBeenCalledWith("alice", "secret");
-    await expect(authentication.isAuthenticated(new Request("http://localhost/", {
+    const authenticatedRequest = new Request("http://localhost/", {
       headers: { Cookie: cookie },
-    }))).resolves.toBe(true);
+    });
+    await expect(authentication.isAuthenticated(authenticatedRequest)).resolves.toBe(true);
+    await expect(authentication.getSessionUser(authenticatedRequest)).resolves.toEqual({
+      username: "alice",
+    });
+  });
+
+  it("returns null session user when unauthenticated", async () => {
+    await expect(
+      authentication.getSessionUser(new Request("http://localhost/")),
+    ).resolves.toBeNull();
   });
 
   it("rejects missing or invalid credentials", async () => {

--- a/frontend/app/auth/authentication.server.ts
+++ b/frontend/app/auth/authentication.server.ts
@@ -7,7 +7,7 @@ import type { IncomingMessage } from "http";
 
 export const IS_FRONTEND_AUTH_DISABLED = process.env.DISABLE_FRONTEND_AUTH === 'true';
 
-type User = {
+export type User = {
   username: string;
 };
 
@@ -76,13 +76,21 @@ export async function isAuthenticated(request: Request | IncomingMessage): Promi
   if (IS_FRONTEND_AUTH_DISABLED) return true;
 
   // Otherwise, check session storage
+  return (await getSessionUser(request)) !== null;
+}
+
+export async function getSessionUser(request: Request | IncomingMessage): Promise<User | null> {
+  if (IS_FRONTEND_AUTH_DISABLED) return null;
+
   const cookieHeader = request instanceof Request
     ? request.headers.get("cookie")
     : request.headers.cookie;
-  if (!cookieHeader) return false;
+  if (!cookieHeader) return null;
+
   const session = await sessionStorage.getSession(cookieHeader);
-  const user = session.get("user");
-  return !!user;
+  const user = session.get("user") as User | undefined;
+  if (!user?.username) return null;
+  return { username: user.username };
 }
 
 export async function login(request: Request): Promise<ResponseInit> {

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -13,7 +13,7 @@ import {
 
 import "./app.css";
 import type { Route } from "./+types/root";
-import { IS_FRONTEND_AUTH_DISABLED } from "~/auth/authentication.server";
+import { getSessionUser, IS_FRONTEND_AUTH_DISABLED } from "~/auth/authentication.server";
 import { TopNavigation } from "./routes/_index/components/top-navigation/top-navigation";
 import { LeftNavigation } from "./routes/_index/components/left-navigation/left-navigation";
 import { PageLayout } from "./routes/_index/components/page-layout/page-layout";
@@ -38,12 +38,14 @@ export async function loader({ request }: Route.LoaderArgs) {
   ]);
 
   const version = await getAppVersion();
+  const sessionUser = await getSessionUser(request);
 
   return {
     useLayout: true,
     version,
     updateAvailable: await checkForUpdate(version),
     isFrontendAuthDisabled: IS_FRONTEND_AUTH_DISABLED,
+    username: sessionUser?.username ?? null,
     hasUsenetProviders: hasConfiguredUsenetProviders(
       config.find(item => item.configName === "usenet.providers")?.configValue
     ),
@@ -122,6 +124,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
     version,
     updateAvailable,
     isFrontendAuthDisabled,
+    username,
     hasUsenetProviders,
     isWatchdogEnabled,
   } = loaderData;
@@ -146,6 +149,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
             version={version}
             updateAvailable={updateAvailable}
             isFrontendAuthDisabled={isFrontendAuthDisabled}
+            username={username}
             hasUsenetProviders={hasUsenetProviders}
           />
         )}

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -9,6 +9,7 @@ export type TopNavigationProps = RequiredTopNavProps & {
   version?: string,
   updateAvailable?: UpdateAvailable | null,
   isFrontendAuthDisabled?: boolean,
+  username?: string | null,
   hasUsenetProviders?: boolean,
 };
 
@@ -19,12 +20,15 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
     version,
     updateAvailable,
     isFrontendAuthDisabled,
+    username,
     hasUsenetProviders,
   } = props;
   const navigate = useNavigate();
   const displayVersion = version || "unknown";
   const hasUpdate = Boolean(updateAvailable);
   const channelLabel = isComparableVersion(version) ? "Stable" : "Dev";
+  const showUserMenu = !isFrontendAuthDisabled && Boolean(username);
+  const initial = username?.trim().charAt(0).toUpperCase() || "?";
 
   return (
     <>
@@ -88,11 +92,6 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
               )}
             </button>
           </div>
-          {!isFrontendAuthDisabled && (
-            <Form method="post" action="/logout" id="top-nav-logout" className="hidden">
-              <input name="confirm" value="true" type="hidden" />
-            </Form>
-          )}
           <ul
             tabIndex={0}
             className="dropdown-content menu z-50 mt-2 w-64 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
@@ -153,19 +152,41 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
                 Changelog
               </a>
             </li>
-            {!isFrontendAuthDisabled && (
-              <>
-                <li />
-                <li>
-                  <button type="submit" form="top-nav-logout">
-                    <Icon name="logout" className="!text-[18px]" />
-                    Logout
-                  </button>
-                </li>
-              </>
-            )}
           </ul>
         </div>
+        {showUserMenu && (
+          <div className="dropdown dropdown-end">
+            <Form method="post" action="/logout" id="top-nav-logout" className="hidden">
+              <input name="confirm" value="true" type="hidden" />
+            </Form>
+            <button
+              type="button"
+              tabIndex={0}
+              className="btn btn-ghost btn-circle btn-sm"
+              aria-label="User menu"
+            >
+              <div className="avatar avatar-placeholder">
+                <div className="w-8 rounded-full bg-neutral text-neutral-content">
+                  <span className="text-xs">{initial}</span>
+                </div>
+              </div>
+            </button>
+            <ul
+              tabIndex={0}
+              className="dropdown-content menu z-50 mt-2 w-56 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
+            >
+              <li className="menu-title">
+                <span>{username}</span>
+              </li>
+              <li>
+                <button type="submit" form="top-nav-logout">
+                  <Icon name="logout" className="!text-[18px]" />
+                  Logout
+                </button>
+              </li>
+            </ul>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- Adds a far-right avatar in the top header for the logged-in user (initials from username)
- Moves Logout out of the update/version dropdown into the avatar menu
- Exposes the session username from the root loader via `getSessionUser`

## Test plan
- [ ] Log in and confirm an initials avatar appears to the right of the update/version control
- [ ] Open the avatar menu and confirm it shows the username and Logout
- [ ] Confirm Logout still signs out and redirects to `/login`
- [ ] Confirm the update/version dropdown no longer includes Logout
- [ ] With `DISABLE_FRONTEND_AUTH=true`, confirm the avatar is hidden