### PR TITLE
fix(usenet): body-mode playback verification no longer leaks provider connections

### DIFF
--- a/backend/Services/PlaybackFastVerifier.cs
+++ b/backend/Services/PlaybackFastVerifier.cs
@@ -125,9 +125,26 @@ public class PlaybackFastVerifier
         if (mode == "body")
         {
             var resp = await _usenetClient.DecodedBodyAsync(messageId, ct).ConfigureAwait(false);
-            return resp.ResponseType == UsenetResponseType.ArticleRetrievedBodyFollows
+            var verdict = resp.ResponseType == UsenetResponseType.ArticleRetrievedBodyFollows
                 ? Verdict.Available
                 : Verdict.Dead;
+
+            // The response code decides the verdict, but the body still arrives, and an unread
+            // one holds the connection for the life of the process. Releasing it must not be
+            // able to turn a verified article into a failure.
+            if (resp.Stream != null)
+            {
+                try
+                {
+                    await resp.Stream.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Log.Debug(e, "Failed to release verified article body for {SegmentId}", messageId);
+                }
+            }
+
+            return verdict;
         }
 
         var stat = await _usenetClient.StatAsync(messageId, ct).ConfigureAwait(false);

--- a/tests/NzbWebDAV.Tests/Services/PlaybackFastVerifierBodyReleaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/PlaybackFastVerifierBodyReleaseTests.cs
@@ -1,0 +1,129 @@
+using System.Text;
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Websocket;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class PlaybackFastVerifierBodyReleaseTests
+{
+    [Fact]
+    public async Task VerifyAsync_BodyMode_ReleasesTheProbedBody()
+    {
+        var stream = new TrackingYencStream();
+        var verifier = new PlaybackFastVerifier(BuildClient(stream));
+
+        var outcome = await verifier.VerifyAsync(
+            Nzb(), "body", sampleCount: 1, CancellationToken.None);
+
+        Assert.Equal(PlaybackFastVerifier.Verdict.Available, outcome.Verdict);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_BodyMode_FailedReleaseKeepsTheVerdict()
+    {
+        var stream = new ThrowOnDisposeYencStream();
+        var verifier = new PlaybackFastVerifier(BuildClient(stream));
+
+        var outcome = await verifier.VerifyAsync(
+            Nzb(), "body", sampleCount: 1, CancellationToken.None);
+
+        // The response code already said the article is there. Failing to hand the body back
+        // must not turn that into a failure.
+        Assert.Equal(PlaybackFastVerifier.Verdict.Available, outcome.Verdict);
+    }
+
+    private static ScriptedBodyClient BuildClient(YencStream stream)
+    {
+        var configManager = new ConfigManager();
+        configManager.UpdateValues([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        return new ScriptedBodyClient(
+            stream,
+            configManager,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+    }
+
+    private static MemoryStream Nzb()
+    {
+        var nzb = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+              <file subject="test">
+                <groups><group>alt.binaries.test</group></groups>
+                <segments>
+                  <segment bytes="100" number="1">seg@example.com</segment>
+                </segments>
+              </file>
+            </nzb>
+            """;
+        return new MemoryStream(Encoding.UTF8.GetBytes(nzb));
+    }
+
+    private sealed class ScriptedBodyClient(
+        YencStream stream,
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        ProviderUsageTracker usageTracker,
+        MetricsWriter metricsWriter,
+        ProviderBytesTracker bytesTracker,
+        StreamTraceBuffer streamTrace,
+        ActiveReadRegistry activeReadRegistry) : UsenetStreamingClient(
+        configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
+        streamTrace, activeReadRegistry)
+    {
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = $"222 <{segmentId}>",
+                Stream = stream,
+            });
+    }
+
+    private sealed class TrackingYencStream : YencStream
+    {
+        public TrackingYencStream() : base(new MemoryStream([], writable: false))
+        {
+        }
+
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class ThrowOnDisposeYencStream : YencStream
+    {
+        public ThrowOnDisposeYencStream() : base(new MemoryStream([], writable: false))
+        {
+        }
+
+        protected override void Dispose(bool disposing) =>
+            throw new IOException("connection reset while releasing the body");
+    }
+}


### PR DESCRIPTION
Found this bug while looking into something else. With `play.verify-mode=body`, PlaybackFastVerifier fetches the article and reads only the response code, so the decoded body is never released and the connection behind the probe stays out for the life of the process. The verdict is now computed before the body is released, and the release is guarded so a failure returning it cannot turn a verified article into a failed one.