### PR TITLE
feat(migration): simplify Altmount setup and clean up orphaned links

### DIFF
--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -46,9 +46,21 @@ public sealed class UsenetMigrationController(
         var categories = new List<AltmountCategory>();
         if (configPath is not null)
         {
-            var config = await AltmountConfigReader.ReadAsync(configPath, HttpContext.RequestAborted)
-                .ConfigureAwait(false);
+            AltmountConfigReader.AltmountSabConfig config;
+            try
+            {
+                config = await AltmountConfigReader
+                    .ReadAsync(configPath, HttpContext.RequestAborted)
+                    .ConfigureAwait(false);
+            }
+            catch (AltmountConfigException e)
+            {
+                throw new BadHttpRequestException(AltmountPathDetector.InvalidConfigReason, e);
+            }
+
             categories = config.Categories.ToList();
+            if (categories.Count == 0)
+                throw new BadHttpRequestException(AltmountPathDetector.NoCategoriesReason);
         }
 
         var transition = await store.ApplyConnectionAsync(
@@ -66,6 +78,34 @@ public sealed class UsenetMigrationController(
                 $"Cannot connect while migration operation '{transition.CurrentStatus}' is active.");
 
         return Ok(new { status = true, categoryCount = categories.Count, categories });
+    });
+
+    /// <summary>
+    /// Read-only probe sent as POST so container paths stay out of query strings,
+    /// access logs, browser history, and intermediary caches.
+    /// </summary>
+    [HttpPost("api/migration/altmount/detect")]
+    public Task<IActionResult> DetectPaths([FromBody] DetectPathsRequest request) => GuardedAsync(async () =>
+    {
+        if (request is null)
+        {
+            // GuardedAsync maps this client-input exception to the standard 400 response envelope.
+            throw new BadHttpRequestException("Request body is required.");
+        }
+
+        var detection = await AltmountPathDetector
+            .DetectAsync(request.Root, HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+        return Ok(new
+        {
+            status = true,
+            detection.Detected,
+            detection.Root,
+            detection.MetadataRoot,
+            detection.ConfigPath,
+            detection.StoreRoot,
+            detection.Reason,
+        });
     });
 
     // --- categories --------------------------------------------------------
@@ -1001,6 +1041,8 @@ public sealed record ConnectRequest(
     string? StoreRoot,
     int? MaxQueueDepth,
     int? SubmitWorkers);
+
+public sealed record DetectPathsRequest(string? Root);
 
 public sealed record CategoryMapRequest(List<CategoryMapEntry>? Mappings);
 

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -21,10 +21,9 @@ namespace NzbWebDAV.Api.Controllers.UsenetMigration;
 /// <see cref="UsenetMigrationRunner"/>, which reacts to Status changes. Progress
 /// is surfaced by polling <c>status</c>/<c>summary</c> rather than websockets.
 ///
-/// Symlink continuity (<c>symlinks/plan|apply</c>) is the optional Step 6: it
-/// runs against a completed migration and, like scan/run, is status-driven —
-/// <c>plan</c> flips Status to <c>linking</c> and <c>apply</c> (confirm-gated) to
-/// <c>applying</c>; the runner performs the work and returns to <c>linked</c>.
+/// Symlink continuity is the optional Step 6. Planning, applying rewrites, and
+/// removing orphaned links are status-driven; destructive actions are explicitly
+/// confirm-gated, and the runner returns completed work to <c>linked</c>.
 /// </summary>
 public sealed class UsenetMigrationController(
     UsenetMigrationStore store,
@@ -652,8 +651,8 @@ public sealed class UsenetMigrationController(
     [HttpPost("api/migration/altmount/symlinks/apply")]
     public Task<IActionResult> ApplySymlinks([FromBody] SymlinkApplyRequest request) => GuardedAsync(async () =>
     {
-        // Apply is the only Step 6 action that mutates the library, so require
-        // explicit confirmation and a reviewed plan.
+        // Rewrite apply mutates matched library links, so require explicit
+        // confirmation and a reviewed plan.
         if (request.Confirm != true)
             throw new BadHttpRequestException("Applying symlink rewrites requires explicit confirmation.");
 
@@ -690,6 +689,42 @@ public sealed class UsenetMigrationController(
         return Ok(new { status = true, state = "applying" });
     });
 
+    [HttpPost("api/migration/altmount/symlinks/orphans/remove")]
+    public Task<IActionResult> RemoveOrphanSymlinks(
+        [FromBody] SymlinkOrphanRemovalRequest request) => GuardedAsync(async () =>
+    {
+        if (request.Confirm != true)
+            throw new BadHttpRequestException("Removing orphaned symlinks requires explicit confirmation.");
+
+        var session = await store.GetSessionAsync(HttpContext.RequestAborted).ConfigureAwait(false);
+        if (session.Status is not "linked")
+            throw new BadHttpRequestException("Build and review a symlink plan before removing orphaned links.");
+        if (string.IsNullOrEmpty(session.SymlinkLibraryRoot)
+            || string.IsNullOrEmpty(session.SymlinkBackupDir))
+        {
+            throw new BadHttpRequestException(
+                "No library root or backup directory is configured; re-run the plan step.");
+        }
+
+        await using (var ctx = store.NewContext())
+        {
+            var orphans = await ctx.SymlinkRewrites.AsNoTracking()
+                .CountAsync(r => r.Status == "orphan", HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+            if (orphans == 0)
+                throw new BadHttpRequestException("The current plan has no orphaned symlinks to remove.");
+        }
+
+        var transition = await store.TryTransitionSessionAsync(
+                MigrationSessionTransition.StartOrphanRemoval, HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+        if (transition.Outcome != MigrationSessionTransitionOutcome.Applied)
+            throw new BadHttpRequestException(
+                $"Cannot remove orphaned symlinks while migration operation '{transition.CurrentStatus}' is active.");
+
+        return Ok(new { status = true, state = "removing_orphans" });
+    });
+
     [HttpDelete("api/migration/altmount/symlinks/operation")]
     public Task<IActionResult> CancelSymlinkOperation() => GuardedAsync(async () =>
     {
@@ -698,15 +733,16 @@ public sealed class UsenetMigrationController(
         {
             "linking" => MigrationSessionTransition.CancelLinkPlan,
             "applying" => MigrationSessionTransition.CancelApply,
+            "removing_orphans" => MigrationSessionTransition.CancelOrphanRemoval,
             _ => throw new BadHttpRequestException(
-                $"Only an active symlink plan or apply can be cancelled; current state is '{session.Status}'."),
+                $"Only an active symlink plan, apply, or orphan removal can be cancelled; current state is '{session.Status}'."),
         };
 
         var transition = await store.TryTransitionSessionAsync(transitionKind, HttpContext.RequestAborted)
             .ConfigureAwait(false);
         if (!transition.Succeeded)
             throw new BadHttpRequestException(
-                $"Only an active symlink plan or apply can be cancelled; current state is '{transition.CurrentStatus}'.");
+                $"Only an active symlink plan, apply, or orphan removal can be cancelled; current state is '{transition.CurrentStatus}'.");
 
         runner.InterruptStep6();
         return Ok(new { status = true, state = "linked" });
@@ -1057,6 +1093,8 @@ public sealed record ForgetMigrationDataRequest(bool? Confirm);
 public sealed record SymlinkPlanRequest(string? LibraryRoot, string? BackupDir);
 
 public sealed record SymlinkApplyRequest(bool? Confirm, bool? AcknowledgeUnreadable);
+
+public sealed record SymlinkOrphanRemovalRequest(bool? Confirm);
 
 public sealed record SymlinkRestoreRequest(string? FileName, bool? Confirm);
 

--- a/backend/Database/Models/UsenetMigration/UsenetMigrationEntities.cs
+++ b/backend/Database/Models/UsenetMigration/UsenetMigrationEntities.cs
@@ -28,7 +28,7 @@ public sealed class MigrationSessionState
     /// <summary>Root of the arr/Plex library whose symlinks point at Altmount.</summary>
     public string? SymlinkLibraryRoot { get; set; }
 
-    /// <summary>Where the wizard writes the restore tarball before rewriting.</summary>
+    /// <summary>Where the wizard writes restore tarballs before Step 6 mutations.</summary>
     public string? SymlinkBackupDir { get; set; }
 
     public int MaxQueueDepth { get; set; } = 20;
@@ -270,8 +270,8 @@ public sealed class MigratedFile
 /// <summary>
 /// One planned or applied symlink rewrite for Step 6.
 /// The plan is built dry-run (Status in rewrite|already-nzbdav|not-altmount|orphan),
-/// then apply flips matched rows to applied|failed. The wizard only ever retargets;
-/// it never deletes links or their targets.
+/// then apply flips matched rows to applied|failed. Optional orphan cleanup marks
+/// successfully removed link entries as removed; it never deletes their targets.
 /// </summary>
 public sealed class MigrationSymlinkRewrite
 {
@@ -286,7 +286,7 @@ public sealed class MigrationSymlinkRewrite
     /// <summary>Computed .ids/…/&lt;guid&gt; target; null until matched.</summary>
     public string? NewTarget { get; set; }
 
-    /// <summary>rewrite|already-nzbdav|not-altmount|orphan|unreadable|applied|failed.</summary>
+    /// <summary>rewrite|already-nzbdav|not-altmount|orphan|unreadable|applied|failed|removed.</summary>
     public string Status { get; set; } = "";
 
     /// <summary>relative-path|exact|unique-size|single-leaf-fallback; null when unmatched.</summary>

--- a/backend/UsenetMigration/MigrationSessionStateMachine.cs
+++ b/backend/UsenetMigration/MigrationSessionStateMachine.cs
@@ -17,6 +17,7 @@ internal static class MigrationSessionStatus
     internal const string Linking = "linking";
     internal const string Linked = "linked";
     internal const string Applying = "applying";
+    internal const string RemovingOrphans = "removing_orphans";
     internal const string Restoring = "restoring";
 
     internal static IReadOnlyList<string> All { get; } =
@@ -35,6 +36,7 @@ internal static class MigrationSessionStatus
         Linking,
         Linked,
         Applying,
+        RemovingOrphans,
         Restoring,
     ];
 }
@@ -65,6 +67,9 @@ internal enum MigrationSessionTransition
     StartApply,
     CompleteApply,
     CancelApply,
+    StartOrphanRemoval,
+    CompleteOrphanRemoval,
+    CancelOrphanRemoval,
     StartRestore,
     CompleteRestore,
 }
@@ -103,6 +108,7 @@ internal static class MigrationSessionStateMachine
         MigrationSessionStatus.Cancelling,
         MigrationSessionStatus.Linking,
         MigrationSessionStatus.Applying,
+        MigrationSessionStatus.RemovingOrphans,
         MigrationSessionStatus.Restoring,
     ];
 
@@ -188,6 +194,15 @@ internal static class MigrationSessionStateMachine
             MigrationSessionTransition.CancelApply => new(
                 MigrationSessionStatus.Linked,
                 [MigrationSessionStatus.Applying]),
+            MigrationSessionTransition.StartOrphanRemoval => new(
+                MigrationSessionStatus.RemovingOrphans,
+                [MigrationSessionStatus.Linked]),
+            MigrationSessionTransition.CompleteOrphanRemoval => new(
+                MigrationSessionStatus.Linked,
+                [MigrationSessionStatus.RemovingOrphans]),
+            MigrationSessionTransition.CancelOrphanRemoval => new(
+                MigrationSessionStatus.Linked,
+                [MigrationSessionStatus.RemovingOrphans]),
             MigrationSessionTransition.StartRestore => new(
                 MigrationSessionStatus.Restoring,
                 [MigrationSessionStatus.Linked]),

--- a/backend/UsenetMigration/Runner/UsenetMigrationRunner.cs
+++ b/backend/UsenetMigration/Runner/UsenetMigrationRunner.cs
@@ -38,6 +38,7 @@ public sealed class UsenetMigrationRunner : BackgroundService
     private readonly SubmissionReconciler _reconciler;
     private readonly SymlinkPlanner _symlinkPlanner;
     private readonly SymlinkRewriter _symlinkRewriter;
+    private readonly SymlinkOrphanRemover _symlinkOrphanRemover;
     private readonly SymlinkRestoreService _symlinkRestoreService;
     private readonly SubmissionOperationGate _scanGate = new();
     private readonly SubmissionOperationGate _submissionGate = new();
@@ -57,6 +58,7 @@ public sealed class UsenetMigrationRunner : BackgroundService
         _reconciler = new SubmissionReconciler(store);
         _symlinkPlanner = new SymlinkPlanner(store, configManager);
         _symlinkRewriter = new SymlinkRewriter(store, configManager);
+        _symlinkOrphanRemover = new SymlinkOrphanRemover(store);
         _symlinkRestoreService = new SymlinkRestoreService(store);
     }
 
@@ -74,6 +76,7 @@ public sealed class UsenetMigrationRunner : BackgroundService
     internal SubmissionReconciler ReconcilerForTests => _reconciler;
     internal SymlinkPlanner SymlinkPlannerForTests => _symlinkPlanner;
     internal SymlinkRewriter SymlinkRewriterForTests => _symlinkRewriter;
+    internal SymlinkOrphanRemover SymlinkOrphanRemoverForTests => _symlinkOrphanRemover;
     internal SymlinkRestoreService SymlinkRestoreServiceForTests => _symlinkRestoreService;
     internal Task TickOnceForTestsAsync(CancellationToken ct = default) => TickAsync(ct);
 
@@ -208,6 +211,7 @@ public sealed class UsenetMigrationRunner : BackgroundService
             case "linking":
                 await RunStep6OperationAsync(
                         "symlink plan",
+                        "linking",
                         token => _symlinkPlanner.PlanAsync(token),
                         MigrationSessionTransition.CompleteLinkPlan,
                         ct)
@@ -217,8 +221,19 @@ public sealed class UsenetMigrationRunner : BackgroundService
             case "applying":
                 await RunStep6OperationAsync(
                         "symlink apply",
+                        "applying",
                         token => _symlinkRewriter.ApplyAsync(token),
                         MigrationSessionTransition.CompleteApply,
+                        ct)
+                    .ConfigureAwait(false);
+                break;
+
+            case "removing_orphans":
+                await RunStep6OperationAsync(
+                        "orphan symlink removal",
+                        "removing_orphans",
+                        token => _symlinkOrphanRemover.RemoveAsync(token),
+                        MigrationSessionTransition.CompleteOrphanRemoval,
                         ct)
                     .ConfigureAwait(false);
                 break;
@@ -241,11 +256,20 @@ public sealed class UsenetMigrationRunner : BackgroundService
 
     private async Task RunStep6OperationAsync<T>(
         string operationName,
+        string requiredStatus,
         Func<CancellationToken, Task<T>> operation,
         MigrationSessionTransition completionTransition,
         CancellationToken ct)
     {
         using var linkOperation = _linkGate.Begin(ct);
+        // Cancellation or a competing request can move the durable state after
+        // TickAsync selected a case but before this operation boundary became active.
+        // Apply this guard to every Step 6 operation, including the existing plan
+        // and rewrite flows, so they receive the same race protection.
+        var session = await _store.GetSessionAsync(ct).ConfigureAwait(false);
+        if (session.Status != requiredStatus)
+            return;
+
         try
         {
             await operation(linkOperation.Token).ConfigureAwait(false);

--- a/backend/UsenetMigration/Source/AltmountConfigReader.cs
+++ b/backend/UsenetMigration/Source/AltmountConfigReader.cs
@@ -104,13 +104,20 @@ public static class AltmountConfigReader
             var raw = lines[i];
             if (IsBlankOrComment(raw)) continue;
             var indent = LeadingSpaces(raw);
-
-            // Dedent back to or past the categories key ends the sequence.
-            if (indent <= categoriesIndent) break;
-
             var trimmed = raw.Trim();
+            var isItemMarker = trimmed.StartsWith("- ", StringComparison.Ordinal) || trimmed == "-";
 
-            if (trimmed.StartsWith("- ", StringComparison.Ordinal) || trimmed == "-")
+            // YAML permits an "indentless sequence", where list markers align
+            // with their parent key. PyYAML emits that valid form by default,
+            // and DUMB can therefore persist `categories:` and `- name:` at the
+            // same indentation. A same-indent non-item is the next sabnzbd key.
+            if (indent < categoriesIndent
+                || (indent == categoriesIndent && !isItemMarker))
+            {
+                break;
+            }
+
+            if (isItemMarker)
             {
                 Flush();
                 haveItem = true;

--- a/backend/UsenetMigration/Source/AltmountPathDetector.cs
+++ b/backend/UsenetMigration/Source/AltmountPathDetector.cs
@@ -1,0 +1,102 @@
+namespace NzbWebDAV.UsenetMigration.Source;
+
+/// <summary>Three resolved inputs for the standard single-mount connection flow.</summary>
+/// <param name="StoreRoot">
+/// Intentionally mirrors <paramref name="Root"/> because the standard layout keeps
+/// <c>metadata/</c>, <c>config.yaml</c>, and <c>.nzbs/</c> below one directory. It remains
+/// explicit so the response maps directly to the three-path connection contract; Advanced
+/// mode may provide a different store root.
+/// </param>
+public sealed record AltmountPathDetection(
+    bool Detected,
+    string Root,
+    string MetadataRoot,
+    string ConfigPath,
+    string StoreRoot,
+    string? Reason);
+
+/// <summary>
+/// Resolves the standard single-mount Altmount layout used by the migration guide.
+/// Non-standard layouts remain available through the wizard's advanced fields.
+/// </summary>
+public static class AltmountPathDetector
+{
+    public const string DefaultRoot = "/altmount";
+    internal const string FailureReason =
+        "The selected directory does not match the standard Altmount layout.";
+    internal const string InvalidConfigReason =
+        "The Altmount config could not be read or parsed. Check the mount, file permissions, and YAML.";
+    internal const string NoCategoriesReason =
+        "The Altmount config does not contain any supported SABnzbd categories.";
+
+    public static async Task<AltmountPathDetection> DetectAsync(
+        string? root,
+        CancellationToken ct = default)
+    {
+        var requestedRoot = root is null ? DefaultRoot : root.Trim();
+        if (requestedRoot.Length == 0)
+            throw new ArgumentException("root cannot be empty.", nameof(root));
+        if (!Path.IsPathRooted(requestedRoot))
+            throw new ArgumentException("root must be an absolute path.", nameof(root));
+        if (HasNavigationSegment(requestedRoot))
+            throw new ArgumentException("root cannot contain '.' or '..' path segments.", nameof(root));
+
+        var storeRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(requestedRoot));
+        var fileSystemRoot = Path.GetPathRoot(storeRoot);
+        var pathComparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!string.IsNullOrEmpty(fileSystemRoot)
+            && string.Equals(storeRoot, fileSystemRoot, pathComparison))
+        {
+            throw new ArgumentException("root cannot be the filesystem root.", nameof(root));
+        }
+
+        var metadataRoot = Path.Combine(storeRoot, "metadata");
+        var configPath = Path.Combine(storeRoot, "config.yaml");
+
+        // This detector is reached through the API-key-guarded migration controller. A fixed
+        // prefix would break supported custom bind mounts, and Advanced Connect already accepts
+        // arbitrary container paths. These are three bounded metadata probes; .NET has no async
+        // Exists API, while Task.Run would merely move the same blocking work to another pool thread.
+        // The config itself is then read asynchronously so Basic mode verifies more than existence.
+        var rootExists = Directory.Exists(storeRoot);
+        var metadataExists = Directory.Exists(metadataRoot);
+        var configExists = File.Exists(configPath);
+        var layoutDetected = rootExists && metadataExists && configExists;
+
+        var detected = false;
+        string? reason;
+        if (!layoutDetected)
+        {
+            reason = FailureReason;
+        }
+        else
+        {
+            try
+            {
+                var config = await AltmountConfigReader.ReadAsync(configPath, ct).ConfigureAwait(false);
+                detected = config.Categories.Count > 0;
+                reason = detected ? null : NoCategoriesReason;
+            }
+            catch (AltmountConfigException)
+            {
+                reason = InvalidConfigReason;
+            }
+        }
+
+        return new AltmountPathDetection(
+            detected,
+            storeRoot,
+            metadataRoot,
+            configPath,
+            storeRoot,
+            reason);
+    }
+
+    private static bool HasNavigationSegment(string path) =>
+        path.Split(
+                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                StringSplitOptions.RemoveEmptyEntries)
+            .Any(segment => segment is "." or "..");
+}

--- a/backend/UsenetMigration/Symlinks/SymlinkBackup.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkBackup.cs
@@ -6,17 +6,23 @@ namespace NzbWebDAV.UsenetMigration.Symlinks;
 
 /// <summary>
 /// A restore <c>.tar.gz</c> whose single entry is a
-/// JSON manifest of the symlinks' pre-rewrite state (path → original Altmount target).
-/// The wizard writes this <b>before</b> any rewrite so the exact prior state can be
-/// replayed. A manifest (rather than raw symlink tar entries) keeps entry names safe
-/// and restore fully deterministic and testable.
+/// JSON manifest of symlinks' prior state (path → original Altmount target).
+/// The wizard writes this <b>before</b> any rewrite or orphan removal so the exact
+/// prior state can be replayed. A manifest (rather than raw symlink tar entries)
+/// keeps entry names safe and restore fully deterministic and testable.
 /// </summary>
 public static class SymlinkBackup
 {
     private const string ManifestEntryName = "symlinks.json";
     private const long MaxManifestBytes = 64L * 1024 * 1024;
 
-    public sealed record Entry(string Path, string Target, string? ReplacementTarget = null);
+    public const string OrphanRemovalOperation = "remove-orphan";
+
+    public sealed record Entry(
+        string Path,
+        string Target,
+        string? ReplacementTarget = null,
+        string? Operation = null);
 
     public static async Task WriteAsync(
         string backupFilePath, IReadOnlyList<Entry> entries, CancellationToken ct = default)

--- a/backend/UsenetMigration/Symlinks/SymlinkOps.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkOps.cs
@@ -3,8 +3,8 @@ using Serilog;
 namespace NzbWebDAV.UsenetMigration.Symlinks;
 
 /// <summary>
-/// The minimal filesystem surface needed to apply symlink rewrites while preserving
-/// backup-first, drift-guard, idempotency, and never-delete behavior.
+/// The minimal filesystem surface needed to rewrite, remove, and restore symlinks
+/// while preserving backup-first, drift-guard, and idempotency behavior.
 /// </summary>
 public interface ISymlinkOps
 {
@@ -23,6 +23,13 @@ public interface ISymlinkOps
     /// old link before rethrowing.
     /// </summary>
     void ReplaceSymlink(string libraryRoot, string path, string expectedOldTarget, string newTarget);
+
+    /// <summary>
+    /// Delete the symlink at <paramref name="path"/> only when its current target
+    /// still equals <paramref name="expectedTarget"/>. Removes only the link inode,
+    /// never its target, and refuses real files or directories.
+    /// </summary>
+    void DeleteSymlink(string libraryRoot, string path, string expectedTarget);
 
     /// <summary>
     /// Create a symlink at an entirely absent path. Refuses if anything already
@@ -155,6 +162,43 @@ public sealed class RealSymlinkOps : ISymlinkOps
 
         safePath = SymlinkPathGuard.RequireSafeParentChain(libraryRoot, safePath);
         File.CreateSymbolicLink(safePath, target);
+    }
+
+    public void DeleteSymlink(string libraryRoot, string path, string expectedTarget)
+    {
+        var safePath = SymlinkPathGuard.RequireSafeParentChain(libraryRoot, path);
+        // This first read classifies presence before the parent chain is checked
+        // again; current below is the authoritative target read after revalidation.
+        var existing = ReadLinkUnchecked(safePath);
+
+        // Match ReplaceSymlink's final parent and leaf checks so a path swap cannot
+        // turn an approved link deletion into removal of an unrelated filesystem entry.
+        safePath = SymlinkPathGuard.RequireSafeParentChain(libraryRoot, safePath);
+        if (existing is null)
+        {
+            if (File.Exists(safePath) || Directory.Exists(safePath))
+                throw new IOException($"Refusing to delete non-symlink at '{safePath}'.");
+            throw new IOException($"Refusing to delete '{safePath}' because no symlink is present.");
+        }
+
+        BeforeFinalLeafValidation?.Invoke(safePath);
+        var current = ReadLinkUnchecked(safePath);
+        if (current is null)
+        {
+            throw new IOException(
+                $"Refusing to delete '{safePath}' because it is no longer the expected symlink.");
+        }
+        if (!string.Equals(current, expectedTarget, SymlinkPathGuard.PathComparison))
+        {
+            throw new IOException(
+                $"Refusing to delete '{safePath}' because its symlink target changed during removal.");
+        }
+
+        var attrs = File.GetAttributes(safePath);
+        if ((attrs & FileAttributes.Directory) != 0)
+            Directory.Delete(safePath);
+        else
+            File.Delete(safePath);
     }
 
     private static string? ReadLinkUnchecked(string path)

--- a/backend/UsenetMigration/Symlinks/SymlinkOrphanRemover.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkOrphanRemover.cs
@@ -1,0 +1,177 @@
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace NzbWebDAV.UsenetMigration.Symlinks;
+
+public sealed class OrphanRemovalSummary
+{
+    public int Removed { get; init; }
+    public int Failed { get; init; }
+
+    /// <summary>Path of the restore tarball written before any deletion.</summary>
+    public string? BackupPath { get; init; }
+}
+
+/// <summary>
+/// Removes only links classified as orphaned by the current Step 6 plan. Every
+/// candidate is backed up and revalidated before its link inode is deleted; link
+/// targets, real files, unrelated links, and unreadable rows are never touched.
+/// </summary>
+public sealed class SymlinkOrphanRemover(UsenetMigrationStore store)
+{
+    internal ISymlinkOps Ops { get; set; } = RealSymlinkOps.Instance;
+    internal Func<DateTime> UtcNow { get; set; } = () => DateTime.UtcNow;
+    internal string ArchivePrefix { get; set; } = SymlinkRestoreService.OrphanRemovalArchivePrefix;
+
+    public async Task<OrphanRemovalSummary> RemoveAsync(CancellationToken ct = default)
+    {
+        var session = await store.GetSessionAsync(ct).ConfigureAwait(false);
+        if (session.Status is not "removing_orphans")
+        {
+            throw new InvalidOperationException(
+                "Removing orphaned symlinks requires an active orphan-removal operation.");
+        }
+        var libraryRoot = session.SymlinkLibraryRoot
+                          ?? throw new InvalidOperationException("Removing orphaned symlinks requires Library Root to be configured.");
+        var backupDir = session.SymlinkBackupDir
+                        ?? throw new InvalidOperationException("Removing orphaned symlinks requires SymlinkBackupDir to be set.");
+
+        await using var ctx = store.NewContext();
+        var rows = await ctx.SymlinkRewrites
+            .Where(r => r.Status == "orphan")
+            .OrderBy(r => r.SymlinkPath)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (rows.Count == 0)
+            return new OrphanRemovalSummary();
+
+        var candidates = new List<Database.Models.UsenetMigration.MigrationSymlinkRewrite>(rows.Count);
+        var failed = 0;
+        foreach (var row in rows)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var current = Ops.ReadLink(libraryRoot, row.SymlinkPath);
+                if (current is null)
+                {
+                    Fail(row, "No symlink is present; rebuild the plan before retrying removal.");
+                    failed++;
+                }
+                else if (!PathsEqual(current, row.OldTarget))
+                {
+                    Fail(row, $"Symlink target changed since planning (now '{current}'); left untouched.");
+                    failed++;
+                }
+                else
+                {
+                    candidates.Add(row);
+                }
+            }
+            catch (Exception e)
+            {
+                Fail(row, e.Message);
+                failed++;
+            }
+
+            row.UpdatedAt = UtcNow();
+        }
+
+        if (candidates.Count == 0)
+        {
+            await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+            return new OrphanRemovalSummary { Failed = failed };
+        }
+
+        // Intentionally back up every pre-validated candidate, not only links that
+        // are ultimately deleted. This safe superset guarantees that every possible
+        // mutation is recoverable before the first delete; restore treats an unchanged
+        // link as already restored and leaves a subsequently changed link untouched.
+        var backupPath = BuildBackupPath(backupDir, UtcNow(), ArchivePrefix);
+        var entries = candidates
+            .Select(r => new SymlinkBackup.Entry(
+                r.SymlinkPath,
+                r.OldTarget,
+                Operation: SymlinkBackup.OrphanRemovalOperation))
+            .ToList();
+        await SymlinkBackup.WriteAsync(backupPath, entries, ct).ConfigureAwait(false);
+
+        IReadOnlyList<SymlinkBackup.Entry> verified;
+        try
+        {
+            verified = await SymlinkBackup.ReadAsync(backupPath, ct).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is IOException or InvalidDataException or System.Text.Json.JsonException)
+        {
+            throw new InvalidDataException(
+                $"Orphan symlink backup at '{backupPath}' could not be verified after writing; removal aborted.", e);
+        }
+
+        if (verified.Count != entries.Count || !verified.SequenceEqual(entries))
+        {
+            throw new InvalidDataException(
+                $"Orphan symlink backup at '{backupPath}' did not match the requested removals; removal aborted.");
+        }
+
+        var removed = 0;
+        try
+        {
+            foreach (var row in candidates)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    Ops.DeleteSymlink(libraryRoot, row.SymlinkPath, row.OldTarget);
+                    row.Status = "removed";
+                    row.Error = null;
+                    removed++;
+                }
+                catch (Exception e)
+                {
+                    Fail(row, e.Message);
+                    failed++;
+                }
+
+                row.UpdatedAt = UtcNow();
+            }
+        }
+        finally
+        {
+            // Persist completed deletions even when the user cancels a large batch.
+            await ctx.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        Log.Information(
+            "Orphan symlink removal: {Removed} removed, {Failed} failed. Backup at {BackupPath}",
+            removed, failed, backupPath);
+
+        return new OrphanRemovalSummary
+        {
+            Removed = removed,
+            Failed = failed,
+            BackupPath = backupPath,
+        };
+    }
+
+    private static void Fail(Database.Models.UsenetMigration.MigrationSymlinkRewrite row, string error)
+    {
+        row.Status = "orphan";
+        row.Error = error;
+    }
+
+    private static string BuildBackupPath(string backupDir, DateTime createdAt, string archivePrefix)
+    {
+        var stem = $"{archivePrefix}{createdAt:yyyyMMdd-HHmmss}";
+        var path = Path.Combine(backupDir, $"{stem}.tar.gz");
+        for (var suffix = 2; File.Exists(path); suffix++)
+            path = Path.Combine(backupDir, $"{stem}-{suffix}.tar.gz");
+        return path;
+    }
+
+    private static bool PathsEqual(string a, string b) =>
+        string.Equals(
+            a.Replace('\\', '/').TrimEnd('/'),
+            b.Replace('\\', '/').TrimEnd('/'),
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+}

--- a/backend/UsenetMigration/Symlinks/SymlinkRestoreService.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkRestoreService.cs
@@ -10,6 +10,7 @@ public sealed record SymlinkBackupInfo(
     long SizeBytes,
     int EntryCount,
     int LegacyEntryCount,
+    string Kind,
     bool IsValid,
     string? Error);
 
@@ -23,20 +24,20 @@ public sealed class SymlinkRestoreSummary
     public int AlreadyRestored { get; init; }
     public int Failed { get; init; }
     public int Requeued { get; init; }
+    public int OrphansRestored { get; init; }
     public IReadOnlyList<SymlinkRestoreIssue> Issues { get; init; } = [];
 }
 
 /// <summary>
-/// Lists and restores the archives created before Step 6 rewrites. Restore is
-/// confined to the configured library and refuses links whose targets have
-/// changed since the archive was written.
+/// Lists and restores the archives created before Step 6 rewrites and orphan
+/// removals. Restore is confined to the configured library and refuses paths
+/// whose contents have changed since the archive was written.
 /// </summary>
 public sealed class SymlinkRestoreService(UsenetMigrationStore store)
 {
     internal const string DefaultArchivePrefix = "altmount-symlink-backup-";
+    internal const string OrphanRemovalArchivePrefix = "altmount-orphan-symlink-backup-";
 
-    /// <summary>Archive filename prefix; override for a future migration source with distinct archives.</summary>
-    internal string ArchivePrefix { get; set; } = DefaultArchivePrefix;
     internal const string ArchiveSuffix = ".tar.gz";
 
     internal ISymlinkOps Ops { get; set; } = RealSymlinkOps.Instance;
@@ -52,19 +53,28 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
             return [];
 
         var archives = new List<SymlinkBackupInfo>();
-        foreach (var path in Directory.EnumerateFiles(backupDir, $"{ArchivePrefix}*{ArchiveSuffix}"))
+        var archivePaths = Directory
+            .EnumerateFiles(backupDir, $"{DefaultArchivePrefix}*{ArchiveSuffix}")
+            .Concat(Directory.EnumerateFiles(
+                backupDir, $"{OrphanRemovalArchivePrefix}*{ArchiveSuffix}"));
+        foreach (var path in archivePaths)
         {
             ct.ThrowIfCancellationRequested();
             var fileName = Path.GetFileName(path);
+            if (!TryGetArchiveKind(fileName, out var fileKind))
+                continue;
             try
             {
                 var entries = await SymlinkBackup.ReadAsync(path, ct).ConfigureAwait(false);
+                var kind = ClassifyArchive(entries, fileKind, fileName);
                 archives.Add(new SymlinkBackupInfo(
                     fileName,
                     GetLastWriteTimeUtc(path),
                     GetFileLength(path),
                     entries.Count,
-                    entries.Count(e => string.IsNullOrWhiteSpace(e.ReplacementTarget)),
+                    entries.Count(e => string.IsNullOrWhiteSpace(e.ReplacementTarget)
+                                       && string.IsNullOrWhiteSpace(e.Operation)),
+                    kind,
                     true,
                     null));
             }
@@ -75,7 +85,8 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
                     path, e.Message);
                 Log.Debug(e, "Unreadable symlink restore archive {ArchivePath} failure stack", path);
                 archives.Add(new SymlinkBackupInfo(
-                    fileName, GetLastWriteTimeUtc(path), GetFileLength(path), 0, 0, false, e.Message));
+                    fileName, GetLastWriteTimeUtc(path), GetFileLength(path), 0, 0,
+                    fileKind, false, e.Message));
             }
         }
 
@@ -96,6 +107,8 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
         var entries = await SymlinkBackup.ReadAsync(archivePath, ct).ConfigureAwait(false);
         if (entries.Count == 0)
             throw new InvalidDataException("The selected archive does not contain any symlinks.");
+        TryGetArchiveKind(fileName, out var fileKind);
+        _ = ClassifyArchive(entries, fileKind, fileName);
 
         // Load plan rows then release the SQLite connection before filesystem work.
         // Holding an open context across CreateOrReplaceSymlink deadlocks callers that
@@ -112,7 +125,7 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
 
         var issues = new List<SymlinkRestoreIssue>();
         var seenPaths = new HashSet<string>(PathComparer);
-        var pendingRequeues = new List<(string Path, string OldTarget, string NewTarget)>();
+        var pendingPlanUpdates = new List<PendingPlanUpdate>();
         int restored = 0, alreadyRestored = 0;
 
         foreach (var entry in entries)
@@ -135,10 +148,14 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
             }
 
             var planRow = planRows.FirstOrDefault(r => PathsEqual(r.SymlinkPath, entry.Path));
-            var expectedReplacement = entry.ReplacementTarget
-                                      ?? (planRow is not null && PathsEqual(planRow.OldTarget, entry.Target)
-                                          ? planRow.NewTarget
-                                          : null);
+            var isOrphanRemoval = string.Equals(
+                entry.Operation, SymlinkBackup.OrphanRemovalOperation, StringComparison.Ordinal);
+            var expectedReplacement = isOrphanRemoval
+                ? null
+                : entry.ReplacementTarget
+                  ?? (planRow is not null && PathsEqual(planRow.OldTarget, entry.Target)
+                      ? planRow.NewTarget
+                      : null);
 
             try
             {
@@ -156,13 +173,20 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
 
                     Ops.CreateSymlink(libraryRoot, entry.Path, entry.Target);
                     restored++;
-                    TryQueueRequeue(pendingRequeues, entry, expectedReplacement);
+                    QueuePlanUpdate(pendingPlanUpdates, entry, expectedReplacement, isOrphanRemoval);
                     continue;
                 }
                 if (PathsEqual(current, entry.Target))
                 {
                     alreadyRestored++;
-                    TryQueueRequeue(pendingRequeues, entry, expectedReplacement);
+                    QueuePlanUpdate(pendingPlanUpdates, entry, expectedReplacement, isOrphanRemoval);
+                    continue;
+                }
+                if (isOrphanRemoval)
+                {
+                    issues.Add(new SymlinkRestoreIssue(
+                        entry.Path,
+                        $"A different symlink now exists at this path (target '{current}'); it was left untouched."));
                     continue;
                 }
                 if (string.IsNullOrWhiteSpace(expectedReplacement))
@@ -182,7 +206,7 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
 
                 Ops.ReplaceSymlink(libraryRoot, entry.Path, expectedReplacement, entry.Target);
                 restored++;
-                TryQueueRequeue(pendingRequeues, entry, expectedReplacement);
+                QueuePlanUpdate(pendingPlanUpdates, entry, expectedReplacement, isOrphanRemoval);
             }
             catch (Exception e)
             {
@@ -207,11 +231,12 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
         }
 
         var requeued = 0;
-        if (pendingRequeues.Count > 0)
+        var orphansRestored = 0;
+        if (pendingPlanUpdates.Count > 0)
         {
             await using var ctx = store.NewContext();
             var rows = await ctx.SymlinkRewrites.ToListAsync(ct).ConfigureAwait(false);
-            foreach (var pending in pendingRequeues)
+            foreach (var pending in pendingPlanUpdates)
             {
                 var row = rows.FirstOrDefault(r => PathsEqual(r.SymlinkPath, pending.Path));
                 if (row is null)
@@ -226,10 +251,13 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
 
                 row.OldTarget = pending.OldTarget;
                 row.NewTarget = pending.NewTarget;
-                row.Status = "rewrite";
+                row.Status = pending.Status;
                 row.Error = null;
                 row.UpdatedAt = DateTime.UtcNow;
-                requeued++;
+                if (pending.Status == "orphan")
+                    orphansRestored++;
+                else
+                    requeued++;
             }
 
             await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
@@ -247,6 +275,7 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
             AlreadyRestored = alreadyRestored,
             Failed = issues.Count,
             Requeued = requeued,
+            OrphansRestored = orphansRestored,
             Issues = issues,
         };
     }
@@ -255,8 +284,7 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
     {
         if (string.IsNullOrWhiteSpace(fileName)
             || !string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal)
-            || !fileName.StartsWith(DefaultArchivePrefix, StringComparison.Ordinal)
-            || !fileName.EndsWith(ArchiveSuffix, StringComparison.Ordinal))
+            || !TryGetArchiveKind(fileName, out _))
             throw new InvalidDataException("The selected symlink restore archive name is invalid.");
 
         var root = Path.GetFullPath(backupDir);
@@ -275,16 +303,75 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
                && !relative.StartsWith($"..{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal);
     }
 
-    private static bool TryQueueRequeue(
-        List<(string Path, string OldTarget, string NewTarget)> pending,
+    private static void QueuePlanUpdate(
+        List<PendingPlanUpdate> pending,
         SymlinkBackup.Entry entry,
-        string? replacementTarget)
+        string? replacementTarget,
+        bool isOrphanRemoval)
     {
-        if (string.IsNullOrWhiteSpace(replacementTarget))
-            return false;
-        pending.Add((entry.Path, entry.Target, replacementTarget));
-        return true;
+        if (isOrphanRemoval)
+        {
+            pending.Add(new PendingPlanUpdate(entry.Path, entry.Target, null, "orphan"));
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(replacementTarget))
+            pending.Add(new PendingPlanUpdate(entry.Path, entry.Target, replacementTarget, "rewrite"));
     }
+
+    private static string ClassifyArchive(
+        IReadOnlyList<SymlinkBackup.Entry> entries,
+        string fileKind,
+        string fileName)
+    {
+        if (entries.Any(e => !string.IsNullOrWhiteSpace(e.Operation)
+                             && !string.Equals(
+                                 e.Operation,
+                                 SymlinkBackup.OrphanRemovalOperation,
+                                 StringComparison.Ordinal)))
+        {
+            throw new InvalidDataException(
+                $"The archive '{fileName}' contains an unsupported symlink operation.");
+        }
+        var hasOrphanEntries = entries.Any(e => string.Equals(
+            e.Operation, SymlinkBackup.OrphanRemovalOperation, StringComparison.Ordinal));
+        var hasOtherEntries = entries.Any(e => !string.Equals(
+            e.Operation, SymlinkBackup.OrphanRemovalOperation, StringComparison.Ordinal));
+        if (hasOrphanEntries && hasOtherEntries)
+            throw new InvalidDataException(
+                $"The archive '{fileName}' mixes rewrite and orphan-removal entries.");
+        if (fileKind == "orphan-removal" && !hasOrphanEntries)
+            throw new InvalidDataException(
+                $"The orphan-removal archive '{fileName}' does not contain orphan-removal entries.");
+        if (fileKind == "rewrite" && hasOrphanEntries)
+            throw new InvalidDataException(
+                $"The rewrite archive '{fileName}' contains orphan-removal entries.");
+        return fileKind;
+    }
+
+    private static bool TryGetArchiveKind(string fileName, out string kind)
+    {
+        kind = "";
+        if (!fileName.EndsWith(ArchiveSuffix, StringComparison.Ordinal))
+            return false;
+        if (fileName.StartsWith(OrphanRemovalArchivePrefix, StringComparison.Ordinal))
+        {
+            kind = "orphan-removal";
+            return true;
+        }
+        if (fileName.StartsWith(DefaultArchivePrefix, StringComparison.Ordinal))
+        {
+            kind = "rewrite";
+            return true;
+        }
+        return false;
+    }
+
+    private sealed record PendingPlanUpdate(
+        string Path,
+        string OldTarget,
+        string? NewTarget,
+        string Status);
 
     private static readonly StringComparer PathComparer = OperatingSystem.IsWindows()
         ? StringComparer.OrdinalIgnoreCase

--- a/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
@@ -16,15 +16,14 @@ public sealed class RewriteSummary
 }
 
 /// <summary>
-/// Applies the Step 6 plan. It is the only component that mutates the arr/Plex
-/// library, and it does so with three guarantees:
+/// Applies the Step 6 rewrite plan. It retargets matched links with three guarantees:
 /// <list type="number">
 /// <item><b>Backup first.</b> A restore tarball of every to-be-changed symlink's prior
 ///   state is written before the first rewrite.</item>
 /// <item><b>Retarget only, never delete.</b> Each rewrite replaces a symlink's target
 ///   via <see cref="ISymlinkOps"/>, which removes only the link inode; migrated content
 ///   and any real (non-symlink) file are never touched. Orphan / not-altmount /
-///   already-nzbdav rows are never loaded, so they are untouched by construction.</item>
+///   already-nzbdav rows are never loaded, so they are untouched by rewrite apply.</item>
 /// <item><b>Drift-guarded and idempotent.</b> A row is rewritten only if the on-disk
 ///   target still equals the planned <c>OldTarget</c>; a symlink already pointing at
 ///   <c>NewTarget</c> is a no-op success, so re-running apply is safe.</item>

--- a/docs/guides/altmount-migration.md
+++ b/docs/guides/altmount-migration.md
@@ -44,7 +44,7 @@ services:
 3. **Scan** — NzbDAV groups metadata by store, verifies the referenced `.nzbz` data, estimates fetch cost, and checks whether the release is already present.
 4. **Review** — inspect red/amber findings, exclusions, filename changes, and collisions. Blocking collisions must be resolved before the run can start.
 5. **Run** — the wizard reconstructs NZBs and submits them through NzbDAV's normal import pipeline. Progress survives restarts. Pause or cancel stops before the next submission; an individual submission already crossing the queue boundary is allowed to finish and is recorded safely.
-6. **Links (optional)** — build a dry-run plan for library symlinks that still target Altmount. Review every status before applying. NzbDAV writes a restore archive first, changes symlinks only, and leaves real files, unmatched links, and drifted links untouched.
+6. **Links (optional)** — build a dry-run plan for library symlinks that still target Altmount. Review every status before applying. NzbDAV writes a restore archive first, changes symlinks only, and leaves real files, unmatched links, and drifted links untouched. If you want a clean break from Altmount, you can separately remove links classified as `orphan`; that action writes its own restore archive first.
 
 The wizard can be reset after work reaches a non-active state. Resetting clears the current scan and plan but retains completed migration mappings so later symlink scans can identify releases imported in earlier runs.
 
@@ -52,7 +52,7 @@ The wizard can be reset after work reaches a non-active state. Resetting clears 
 
 Set **Library Root** to the media library containing the links. **Backup Directory** defaults to `/config/migration-backups` (do not place it on the AltMount mount you are about to decommission). Apply and restore are confined to the Library Root and reject symlinked or reparse-point parent directories. If a link target changes after planning, the drift guard leaves it untouched.
 
-Pause *Arr import automation while Apply runs — a rename race with Sonarr/Radarr during rewrite can leave a drifted link. Restored (and rewritten) symlinks are owned by the NzbDAV process user.
+Pause *Arr import automation while Apply or orphan removal runs — a rename race with Sonarr/Radarr can leave a drifted link. Restored (and rewritten) symlinks are owned by the NzbDAV process user.
 
 You can download a **shell script** of rewrite rows to run on the host (or any container where the library paths are visible). That path does not update the wizard status table; in-container Apply with the restore archive remains the recommended path when the library is mounted.
 
@@ -67,8 +67,17 @@ The dry-run plan classifies every symlink found during the library walk:
 | `not-altmount` | Does not correlate to scanned Altmount content and is left unchanged. |
 | `applied` | Successfully repointed to NzbDAV. |
 | `failed` | A verified rewrite was attempted but could not be completed. |
+| `removed` | An orphaned Altmount symlink was removed after its original target was backed up. |
 
-Use **Restore previous rewrite** to select a generated archive. Restore verifies that each link still points to the replacement recorded by that archive before restoring its original target.
+Use **Restore Symlinks** to select a generated archive. Rewrite restores verify that each link still points to the recorded NzbDAV replacement; orphan-removal restores require the path to remain absent. Both restore the original Altmount target without overwriting changed library entries.
+
+### Remove orphaned Altmount links
+
+After reviewing the plan, **Remove orphaned links** can delete only the library symlink entries classified as `orphan`. It does not delete the files those links point to, remove Altmount or NzbDAV data, touch real files, or act on `unreadable` and unrelated links. Each link target is checked again immediately before removal, and a separately labelled orphan-removal archive is written and verified before the first link is deleted.
+
+This cleanup does **not** ask Sonarr or Radarr to search for replacements. After removing orphaned links, run **Refresh & Scan** for each affected series or movie (or trigger the corresponding refresh job) so the Arr application detects the deleted paths and marks those files as missing. You can then initiate or schedule re-grabs according to your Arr configuration.
+
+Orphan-removal archives appear in the same **Restore Symlinks** control as rewrite archives. Restoring one recreates an absent link with its original Altmount target, but never overwrites a real file, directory, or differently targeted symlink that now occupies that path.
 
 ## Troubleshooting
 
@@ -81,6 +90,7 @@ Use **Restore previous rewrite** to select a generated archive. Restore verifies
 | Start migration is disabled | Resolve blocking collisions, map or exclude every category, and successfully refresh the review tables. |
 | Reset is disabled | Cancel active work and wait for the session to reach a non-active state. A paused run is still active. |
 | A symlink is `orphan`, `unreadable`, or `failed` | Review its match/target details. The wizard will not guess or overwrite a link that cannot be verified safely. |
+| Removed links are still shown as present in Sonarr or Radarr | Run the relevant **Refresh & Scan** or refresh job so the Arr detects the missing paths before starting re-grabs. |
 | Many releases show `evicted` or `failed` after restoring a database backup | The migration ledger is ahead of the restored main database. Use Reset (or Forget migration data), then re-scan; releases that already imported are re-detected and not resubmitted. |
 
 ## Extending to other sources

--- a/docs/guides/altmount-migration.md
+++ b/docs/guides/altmount-migration.md
@@ -19,7 +19,7 @@ Altmount does **not** have to be running for this process.
 
 - Configure and test the Usenet providers NzbDAV will use.
 - Create the destination NzbDAV categories expected by Radarr and Sonarr.
-- Mount **exactly one** new path into the NzbDAV container: the AltMount data directory, read-only (for example `- /host/path/altmount:/altmount:ro`). Values entered in the wizard are **container paths**, not host paths.
+- Mount **exactly one** new path into the NzbDAV container: the AltMount data directory, read-only (for example `- /host/path/altmount:/altmount:ro`). Basic mode automatically detects this recommended `/altmount` layout. Values entered in the wizard are **container paths**, not host paths.
 - **No rclone configuration changes** are required for any part of the migration.
 - Locate the metadata tree containing `.meta` files and the store tree containing `.nzbs/*.nzbz` files (often under the same AltMount data mount).
 - Keep Altmount's `config.yaml` available if you want its SABnzbd category list discovered automatically.
@@ -39,7 +39,7 @@ services:
 
 ## Run the wizard
 
-1. **Connect** — enter the metadata root. Add `config.yaml` when available and the store root when recorded store paths are not directly readable. **Submit Workers** controls how many imports may cross the queue boundary concurrently; keep it at `1` unless you have a specific reason to increase it. **Max Queue Depth** limits how many imports NzbDAV queues at once.
+1. **Connect** — Basic mode checks `/altmount` automatically and resolves `/altmount/metadata`, `/altmount/config.yaml`, and `/altmount` as the store root. If you mounted the same directory somewhere else, enter that one container path and select **Detect paths**. Use **Advanced mode** when metadata, `config.yaml`, and the store tree are mounted separately or do not follow that layout. Advanced mode also exposes **Submit Workers** and **Max Queue Depth**; keep Submit Workers at `1` unless you have a specific reason to increase it.
 2. **Categories** — map every discovered Altmount category to an existing NzbDAV category, or exclude it.
 3. **Scan** — NzbDAV groups metadata by store, verifies the referenced `.nzbz` data, estimates fetch cost, and checks whether the release is already present.
 4. **Review** — inspect red/amber findings, exclusions, filename changes, and collisions. Blocking collisions must be resolved before the run can start.
@@ -74,6 +74,7 @@ Use **Restore previous rewrite** to select a generated archive. Restore verifies
 
 | Symptom | Check |
 |---------|-------|
+| Basic mode cannot detect Altmount | Confirm the entered container directory contains `metadata/` and `config.yaml`. If the paths are split or `config.yaml` is unavailable, use Advanced mode. |
 | No categories discovered | Supply Altmount's `config.yaml`, or continue to Scan so categories can be discovered from stores. |
 | `store_missing` | Mount the `.nzbs` tree and set **Altmount Store Root** to the directory that contains `.nzbs`. |
 | A release is already migrated | It is not resubmitted; retained provenance can still be used for symlink matching. |

--- a/docs/guides/altmount-migration.md
+++ b/docs/guides/altmount-migration.md
@@ -8,8 +8,7 @@ The guided migration under **Settings → System → Migration (experimental)** 
 
 Both legacy raw-protobuf metadata and Altmount v3-prefixed `.meta` formats are supported, including v3 stores. The wizard follows each file's recorded `store_ref`; **Altmount Store Root** can remap its `.nzbs/...` suffix when the library was copied from another host or mounted at a different container path. Pre-v0.3.0 (v1) releases without a store are migrated from the original NZB when it still exists on disk (including `.nzb.gz` under `.nzbs/`).
 
-WARNING: "Back up and keep Altmount data available"
-
+!!! warning "Back up and keep Altmount data available"
 
     Back up both applications before beginning. Mount the Altmount metadata, config, and store paths read-only when possible, and keep the old service available until migrated releases play correctly from NzbDAV. The optional symlink step needs write access to the media library and a writable backup directory.
 
@@ -18,12 +17,12 @@ WARNING: "Back up and keep Altmount data available"
 Altmount does **not** have to be running for this process.
 
 - Configure and test the Usenet providers NzbDAV will use.
-- Create the destination NzbDAV categories expected by Radarr and Sonarr.
+- Create one or more dedicated, migration-only NzbDAV categories that Radarr and Sonarr do not monitor. Do not reuse the categories configured on their normal NzbDAV download clients.
 - Mount **exactly one** new path into the NzbDAV container: the AltMount data directory, read-only (for example `- /host/path/altmount:/altmount:ro`). Basic mode automatically detects this recommended `/altmount` layout. Values entered in the wizard are **container paths**, not host paths.
 - **No rclone configuration changes** are required for any part of the migration.
 - Locate the metadata tree containing `.meta` files and the store tree containing `.nzbs/*.nzbz` files (often under the same AltMount data mount).
-- Keep Altmount's `config.yaml` available if you want its SABnzbd category list discovered automatically.
-- The optional Links step needs the media library mounted **only** for in-container Apply. Prefer downloading the shell script to rewrite links on the host when you do not want a library volume in NzbDAV. Symlink backup archives default to `/config/migration-backups` (no extra volume).
+- Keep Altmount's `config.yaml` available if you want its SABnzbd category list discovered automatically. Basic mode requires this file to be readable, valid, and contain at least one supported category.
+- The optional Links step needs the media library mounted read-write for in-container Apply, orphan removal, or restore. Prefer downloading the shell script when you only need to perform rewrites on the host and do not want a library volume in NzbDAV. Symlink backup archives default to `/config/migration-backups` (no extra volume).
 
 Example compose fragment for the one-mount default:
 
@@ -33,14 +32,43 @@ services:
     volumes:
       - /host/path/config:/config
       - /host/path/altmount:/altmount:ro
-      # Optional — only for in-container Step 6 Apply:
+      # Optional — for in-container Step 6 Apply, orphan removal, or restore:
       # - /host/path/media:/data/media
 ```
 
+## Connect modes and detected paths
+
+**Basic mode** is the default. When Step 1 opens, it checks a previously saved standard-layout directory or `/altmount` on a new migration. Detection verifies more than the path names: the data directory and `metadata/` directory must exist, `config.yaml` must be readable and parseable, and the config must contain at least one supported SABnzbd category. **Connect** remains disabled until those checks pass.
+
+The single data-directory field expands as follows:
+
+| Altmount Data Directory | Metadata Root | `config.yaml` | Store Root |
+|-------------------------|---------------|---------------|------------|
+| `/altmount` | `/altmount/metadata` | `/altmount/config.yaml` | `/altmount` |
+| `/altmount-data/config` | `/altmount-data/config/metadata` | `/altmount-data/config/config.yaml` | `/altmount-data/config` |
+
+Enter an absolute **container path** and select **Detect paths** when you use a custom mount. The path cannot be the container filesystem root or contain `.` or `..` navigation segments. The Store Root intentionally matches the selected data directory in Basic mode; Scan later verifies the `.nzbs/` store data referenced by the metadata.
+
+!!! note "DUMB-managed installations"
+
+    Category lists written by DUMB-managed Altmount installations are supported, including valid YAML lists whose `- name:` markers align with `categories:`. Map the complete Altmount data directory into the NzbDAV container, then enter that container path in Basic mode.
+
+Use **Advanced mode** when metadata, `config.yaml`, and the store are split across mounts or do not follow the single-directory layout. It preserves the three manual path fields from the original wizard and exposes **Submit Workers** and **Max Queue Depth**. Metadata Root is required; `config.yaml` and Store Root are optional. If you omit `config.yaml`, categories can still be discovered from the store during Scan.
+
+## Choose dedicated migration categories
+
+Create a new NzbDAV category for migration imports, or one per media type/source category when you want separate rollback boundaries. Names such as `altmount-migration-movies` and `altmount-migration-tv` make their purpose clear. Map each included Altmount category to one of these dedicated categories, and exclude anything you do not intend to migrate.
+
+!!! warning "Do not reuse an Arr-monitored category"
+
+    Reusing a category already configured in Sonarr or Radarr is strongly discouraged. During migration, that Arr can observe and act on the wizard's queue and history entries, which may trigger imports, renames, retries, or other automation while the migration is still running. Avoiding that interference otherwise requires stopping the Arr or disabling NzbDAV as its download client.
+
+NzbDAV places each imported release under `/content/<target-category>/<release>`. A migration-only category therefore also creates a clean rollback boundary: all content introduced by the migration is isolated beneath a known category directory. If migration imports share a production category with unrelated NzbDAV content, there is no safe category-wide cleanup when reversing the migration.
+
 ## Run the wizard
 
-1. **Connect** — Basic mode checks `/altmount` automatically and resolves `/altmount/metadata`, `/altmount/config.yaml`, and `/altmount` as the store root. If you mounted the same directory somewhere else, enter that one container path and select **Detect paths**. Use **Advanced mode** when metadata, `config.yaml`, and the store tree are mounted separately or do not follow that layout. Advanced mode also exposes **Submit Workers** and **Max Queue Depth**; keep Submit Workers at `1` unless you have a specific reason to increase it.
-2. **Categories** — map every discovered Altmount category to an existing NzbDAV category, or exclude it.
+1. **Connect** — use Basic mode to detect the standard single-directory layout described above, or switch to Advanced mode to enter each path manually. Keep Submit Workers at `1` unless you have a specific reason to increase it.
+2. **Categories** — map every included Altmount category to a dedicated migration-only NzbDAV category, or exclude it. Do not select a category monitored by Sonarr or Radarr.
 3. **Scan** — NzbDAV groups metadata by store, verifies the referenced `.nzbz` data, estimates fetch cost, and checks whether the release is already present.
 4. **Review** — inspect red/amber findings, exclusions, filename changes, and collisions. Blocking collisions must be resolved before the run can start.
 5. **Run** — the wizard reconstructs NZBs and submits them through NzbDAV's normal import pipeline. Progress survives restarts. Pause or cancel stops before the next submission; an individual submission already crossing the queue boundary is allowed to finish and is recorded safely.
@@ -52,7 +80,7 @@ The wizard can be reset after work reaches a non-active state. Resetting clears 
 
 Set **Library Root** to the media library containing the links. **Backup Directory** defaults to `/config/migration-backups` (do not place it on the AltMount mount you are about to decommission). Apply and restore are confined to the Library Root and reject symlinked or reparse-point parent directories. If a link target changes after planning, the drift guard leaves it untouched.
 
-Pause *Arr import automation while Apply or orphan removal runs — a rename race with Sonarr/Radarr can leave a drifted link. Restored (and rewritten) symlinks are owned by the NzbDAV process user.
+Pause *Arr import automation while Apply, orphan removal, or restore runs — a rename race with Sonarr/Radarr can leave a drifted link. Restored (and rewritten) symlinks are owned by the NzbDAV process user.
 
 You can download a **shell script** of rewrite rows to run on the host (or any container where the library paths are visible). That path does not update the wizard status table; in-container Apply with the restore archive remains the recommended path when the library is mounted.
 
@@ -73,7 +101,9 @@ Use **Restore Symlinks** to select a generated archive. Rewrite restores verify 
 
 ### Remove orphaned Altmount links
 
-After reviewing the plan, **Remove orphaned links** can delete only the library symlink entries classified as `orphan`. It does not delete the files those links point to, remove Altmount or NzbDAV data, touch real files, or act on `unreadable` and unrelated links. Each link target is checked again immediately before removal, and a separately labelled orphan-removal archive is written and verified before the first link is deleted.
+After reviewing the plan, **Remove orphaned links** can delete only the library symlink entries classified as `orphan`. The button shows the current orphan count and requires a separate acknowledgement before removal begins. It does not delete the files those links point to, remove Altmount or NzbDAV data, touch real files, or act on `unreadable` and unrelated links. Each link target is checked again immediately before removal, and a separately labelled orphan-removal archive is written and verified before the first link is deleted.
+
+You can cancel an active removal. Links removed before cancellation remain recorded as `removed`, while untouched or drifted links remain available for review or retry. The verified archive intentionally covers every pre-validated candidate, so any link that was removed before cancellation remains recoverable.
 
 This cleanup does **not** ask Sonarr or Radarr to search for replacements. After removing orphaned links, run **Refresh & Scan** for each affected series or movie (or trigger the corresponding refresh job) so the Arr application detects the deleted paths and marks those files as missing. You can then initiate or schedule re-grabs according to your Arr configuration.
 
@@ -83,8 +113,8 @@ Orphan-removal archives appear in the same **Restore Symlinks** control as rewri
 
 | Symptom | Check |
 |---------|-------|
-| Basic mode cannot detect Altmount | Confirm the entered container directory contains `metadata/` and `config.yaml`. If the paths are split or `config.yaml` is unavailable, use Advanced mode. |
-| No categories discovered | Supply Altmount's `config.yaml`, or continue to Scan so categories can be discovered from stores. |
+| Basic mode cannot detect Altmount | Confirm the absolute container directory contains `metadata/` and a readable, valid `config.yaml` with at least one SABnzbd category. Basic mode rejects the filesystem root and paths containing `.` or `..`. If the paths are split or `config.yaml` is unavailable, use Advanced mode. |
+| No categories discovered | In Basic mode, check the `sabnzbd.categories` block in `config.yaml`; inline flow-style lists such as `categories: [...]` are not supported. In Advanced mode, omit an unusable config and continue to Scan so categories can be discovered from stores. |
 | `store_missing` | Mount the `.nzbs` tree and set **Altmount Store Root** to the directory that contains `.nzbs`. |
 | A release is already migrated | It is not resubmitted; retained provenance can still be used for symlink matching. |
 | Start migration is disabled | Resolve blocking collisions, map or exclude every category, and successfully refresh the review tables. |
@@ -92,6 +122,24 @@ Orphan-removal archives appear in the same **Restore Symlinks** control as rewri
 | A symlink is `orphan`, `unreadable`, or `failed` | Review its match/target details. The wizard will not guess or overwrite a link that cannot be verified safely. |
 | Removed links are still shown as present in Sonarr or Radarr | Run the relevant **Refresh & Scan** or refresh job so the Arr detects the missing paths before starting re-grabs. |
 | Many releases show `evicted` or `failed` after restoring a database backup | The migration ledger is ahead of the restored main database. Use Reset (or Forget migration data), then re-scan; releases that already imported are re-detected and not resubmitted. |
+
+## Reverse the migration
+
+A complete reversal is safest when the migration used dedicated categories containing no unrelated NzbDAV releases. Do not begin cleanup until Altmount is available again and you have the rewrite and orphan-removal archives created during Step 6.
+
+1. **Stop migration and library automation.** Cancel or finish any active wizard operation, then pause Sonarr/Radarr imports, refresh jobs, and media-server scans. Do not let another process rename or replace library entries during restore.
+2. **Make Altmount available.** Start Altmount if needed and confirm its container mounts and original link targets are accessible. Restoring links to an unavailable Altmount instance will leave the library unusable.
+3. **Restore removed and rewritten links.** In Step 6, use **Restore Symlinks** for every orphan-removal archive whose links you want back, then restore the rewrite archive created before Apply. Missing orphan links are recreated with their original targets, and rewritten links are pointed back to Altmount. Restore refuses to overwrite real files, directories, or links changed since migration; resolve every reported issue before proceeding.
+4. **Verify the restored library.** Inspect representative symlinks, confirm they point to Altmount again, and test playback through the original path. Do not delete the NzbDAV copies until this verification succeeds.
+5. **Delete only the isolated migration content.** Temporarily disable **Settings → WebDAV → Enforce Read-Only**, open **Explore → content → `<migration-category>`**, and delete every release folder underneath that dedicated category. Repeat for each migration-only category, then immediately re-enable **Enforce Read-Only**.
+6. **Refresh the applications.** Run **Refresh & Scan** in each affected Arr and refresh the media server. Confirm the restored files are present and no migrated NzbDAV paths remain in use before resuming automation.
+7. **Remove migration bookkeeping last.** After the rollback is verified, open **Manage Migration Data** in the wizard and select **Forget all migration records**. This removes the saved migration provenance and plan but does not delete WebDAV content, SAB history, symlinks, or backup archives. Keep the archives until you are satisfied that the rollback is complete.
+
+!!! danger "Keep deletion scoped to the migration category"
+
+    Never delete `/content` itself, and never bulk-delete a category that also contains normal NzbDAV releases. If an existing production category was reused, identify and remove the migrated release folders individually; the category no longer provides a safe rollback boundary. Deleting folders from Explore is recursive and cannot be undone by the symlink restore archive.
+
+Deleting the release folders does not remove their SAB history entries. After the library and content rollback is verified, you may separately remove the migration-category history entries and remove the temporary categories from NzbDAV settings if you no longer need them.
 
 ## Extending to other sources
 

--- a/frontend/app/routes/settings/migration/altmount/altmount-migration.tsx
+++ b/frontend/app/routes/settings/migration/altmount/altmount-migration.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, Badge, Spinner, Tooltip } from "~/components/ui/feedback";
 import { Button } from "~/components/ui/button";
-import { Input, Select } from "~/components/ui/form";
+import { Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { SettingsIntro } from "~/components/ui";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { Modal } from "~/components/ui/modal";
 import {
+    type AltmountPathDetection,
     type CategoryMapRow,
     type CollisionGroup,
     type ConnectForm,
@@ -19,14 +20,19 @@ import {
     type SymlinkBackupInfo,
     type SymlinkPlanForm,
     type SymlinkRow,
+    DEFAULT_ALTMOUNT_ROOT,
     canConnectMigration,
     canEditCategoryMappings,
     canEditReleaseSelection,
     canResetMigration,
     canStartScanMigration,
+    connectFormWithDetectedPaths,
+    connectFormWithStatusPaths,
     hasScanData,
+    inferStandardAltmountRoot,
     isMigrationWorkActive,
     loadTableLatest,
+    requestAltmountPathDetection,
     useAltmountMigration,
 } from "./use-altmount-migration";
 
@@ -188,6 +194,13 @@ type Hook = ReturnType<typeof useAltmountMigration>;
 
 function ConnectStep({ m }: { m: Hook }) {
     const roots = m.status?.roots;
+    const [advancedMode, setAdvancedMode] = useState(false);
+    const [basicRoot, setBasicRoot] = useState(DEFAULT_ALTMOUNT_ROOT);
+    const [detection, setDetection] = useState<AltmountPathDetection | null>(null);
+    const [detectionError, setDetectionError] = useState<string | null>(null);
+    const [detecting, setDetecting] = useState(false);
+    const detectionGeneration = useRef(0);
+    const initialDetectionStarted = useRef(false);
     const [form, setForm] = useState<ConnectForm>({
         metadataRoot: roots?.altmountMetadataRoot ?? "",
         configPath: roots?.altmountConfigPath ?? "",
@@ -195,6 +208,53 @@ function ConnectStep({ m }: { m: Hook }) {
         maxQueueDepth: m.status?.maxQueueDepth ?? 20,
         submitWorkers: m.status?.submitWorkers ?? 1,
     });
+
+    const detectPaths = useCallback(async (candidateRoot: string) => {
+        const generation = ++detectionGeneration.current;
+        setDetecting(true);
+        setDetection(null);
+        setDetectionError(null);
+        try {
+            const result = await requestAltmountPathDetection(candidateRoot);
+            if (generation !== detectionGeneration.current) return;
+            setDetection(result);
+            setBasicRoot(result.root);
+            if (result.detected)
+                setForm((current) => connectFormWithDetectedPaths(current, result));
+        } catch (error) {
+            if (generation !== detectionGeneration.current) return;
+            setDetectionError(error instanceof Error ? error.message : String(error));
+        } finally {
+            if (generation === detectionGeneration.current) setDetecting(false);
+        }
+    }, []);
+
+    useEffect(() => () => {
+        detectionGeneration.current++;
+    }, []);
+
+    // Wait for status so saved standard-layout paths take precedence over the default.
+    useEffect(() => {
+        if (!m.status || initialDetectionStarted.current) return;
+        initialDetectionStarted.current = true;
+
+        const savedRoot = inferStandardAltmountRoot(m.status.roots);
+        const hasSavedPaths = Boolean(
+            m.status.roots.altmountMetadataRoot
+            || m.status.roots.altmountConfigPath
+            || m.status.roots.altmountStoreRoot,
+        );
+        if (hasSavedPaths && !savedRoot) {
+            setDetectionError(
+                "Your saved paths use a non-standard layout. Enter a standard Altmount data directory below, or turn on Advanced mode to keep editing them.",
+            );
+            return;
+        }
+
+        const candidateRoot = savedRoot ?? DEFAULT_ALTMOUNT_ROOT;
+        setBasicRoot(candidateRoot);
+        void detectPaths(candidateRoot);
+    }, [m.status, detectPaths]);
 
     // Sync once the initial status loads.
     useEffect(() => {
@@ -210,53 +270,150 @@ function ConnectStep({ m }: { m: Hook }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [m.status?.sessionStatus]);
 
-    const canSubmit = form.metadataRoot.trim().length > 0
+    const canSubmit = (advancedMode
+        ? form.metadataRoot.trim().length > 0
+        : detection?.detected === true)
         && canConnectMigration(m.status?.sessionStatus)
         && m.busy !== "connect";
 
+    const toggleAdvancedMode = (enabled: boolean) => {
+        setAdvancedMode(enabled);
+        if (enabled && detecting) {
+            detectionGeneration.current++;
+            setDetecting(false);
+        }
+    };
+
+    const connect = () => {
+        const values = !advancedMode && detection?.detected
+            ? connectFormWithDetectedPaths(form, detection)
+            : form;
+        void m.connect(values);
+    };
+
     return (
-        <Section icon="link" title="Connect to Altmount" subtitle="Point NzbDAV at the Altmount config volume it can read.">
+        <Section icon="link" title="Connect to Altmount" subtitle="Detect the recommended single-mount layout, or configure each path manually.">
             <div className="space-y-4">
-                <PathField
-                    label="Altmount Metadata Root"
-                    required
-                    help="Directory containing Altmount's .meta files (the virtual-file metadata tree)."
-                    value={form.metadataRoot}
-                    onChange={(v) => setForm({ ...form, metadataRoot: v })}
-                />
-                <PathField
-                    label="Path to Altmount config.yaml"
-                    help="Altmount config file — read to discover SABnzbd categories. Optional but recommended."
-                    value={form.configPath}
-                    onChange={(v) => setForm({ ...form, configPath: v })}
-                />
-                <PathField
-                    label="Altmount Store Root"
-                    help="Directory holding the .nzbs/ store tree. Used to locate stores when the recorded path differs."
-                    value={form.storeRoot}
-                    onChange={(v) => setForm({ ...form, storeRoot: v })}
-                />
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                    <NumberField
-                        label="Max Queue Depth"
-                        help="Upper bound on releases queued into NzbDAV at once."
-                        value={form.maxQueueDepth}
-                        min={1}
-                        max={500}
-                        onChange={(v) => setForm({ ...form, maxQueueDepth: v })}
-                    />
-                    <NumberField
-                        label="Submit Workers"
-                        help="Recommended to keep at 1 — concurrent submissions can trip queue-key eviction."
-                        value={form.submitWorkers}
-                        min={1}
-                        max={16}
-                        onChange={(v) => setForm({ ...form, submitWorkers: v })}
+                <div className="flex justify-end">
+                    <Toggle
+                        id="altmount-connect-advanced"
+                        className="cursor-pointer gap-2"
+                        checked={advancedMode}
+                        onChange={(event) => toggleAdvancedMode(event.target.checked)}
+                        label={<span className="text-sm font-medium text-base-content">Advanced mode</span>}
                     />
                 </div>
 
+                {advancedMode ? (
+                    <>
+                        <PathField
+                            label="Altmount Metadata Root"
+                            required
+                            help="Directory containing Altmount's .meta files (the virtual-file metadata tree)."
+                            value={form.metadataRoot}
+                            onChange={(v) => setForm({ ...form, metadataRoot: v })}
+                        />
+                        <PathField
+                            label="Path to Altmount config.yaml"
+                            help="Altmount config file — read to discover SABnzbd categories. Optional but recommended."
+                            value={form.configPath}
+                            onChange={(v) => setForm({ ...form, configPath: v })}
+                        />
+                        <PathField
+                            label="Altmount Store Root"
+                            help="Directory holding the .nzbs/ store tree. Used to locate stores when the recorded path differs."
+                            value={form.storeRoot}
+                            onChange={(v) => setForm({ ...form, storeRoot: v })}
+                        />
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <NumberField
+                                label="Max Queue Depth"
+                                help="Upper bound on releases queued into NzbDAV at once."
+                                value={form.maxQueueDepth}
+                                min={1}
+                                max={500}
+                                onChange={(v) => setForm({ ...form, maxQueueDepth: v })}
+                            />
+                            <NumberField
+                                label="Submit Workers"
+                                help="Recommended to keep at 1 — concurrent submissions can trip queue-key eviction."
+                                value={form.submitWorkers}
+                                min={1}
+                                max={16}
+                                onChange={(v) => setForm({ ...form, submitWorkers: v })}
+                            />
+                        </div>
+                    </>
+                ) : detecting ? (
+                    <div className="flex items-center gap-3 rounded-lg border border-base-content/10 bg-base-200/30 p-4 text-sm text-base-content/65">
+                        <Spinner className="h-4 w-4" />
+                        <span>
+                            Checking the Altmount layout at <span className="font-mono">{basicRoot}</span>
+                        </span>
+                    </div>
+                ) : detection?.detected ? (
+                    <div className="space-y-3 rounded-lg border border-success/25 bg-success/5 p-4">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                            <div className="flex items-center gap-2 text-sm font-medium text-success">
+                                <Icon name="check_circle" className="!text-[20px]" />
+                                Altmount paths detected
+                            </div>
+                            <Button
+                                variant="ghost"
+                                size="xsmall"
+                                onClick={() => {
+                                    detectionGeneration.current++;
+                                    setDetecting(false);
+                                    setDetection(null);
+                                    setDetectionError(null);
+                                    setForm((current) =>
+                                        connectFormWithStatusPaths(current, m.status?.roots));
+                                }}
+                            >
+                                Change directory
+                            </Button>
+                        </div>
+                        <dl className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-[auto_1fr]">
+                            <dt className="text-base-content/50">Metadata root</dt>
+                            <dd className="break-all font-mono text-base-content">{detection.metadataRoot}</dd>
+                            <dt className="text-base-content/50">config.yaml</dt>
+                            <dd className="break-all font-mono text-base-content">{detection.configPath}</dd>
+                            <dt className="text-base-content/50">Store root</dt>
+                            <dd className="break-all font-mono text-base-content">{detection.storeRoot}</dd>
+                        </dl>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {(detection?.reason || detectionError) && (
+                            <Alert className="alert-soft text-sm" variant="warning">
+                                <Icon name="warning" className="!text-[18px]" />
+                                {detection?.reason || detectionError}
+                            </Alert>
+                        )}
+                        <PathField
+                            label="Altmount Data Directory"
+                            required
+                            help="Container path containing Altmount's metadata/ directory and config.yaml. The store root will use this same directory."
+                            value={basicRoot}
+                            onChange={(value) => {
+                                setBasicRoot(value);
+                                setDetection(null);
+                                setDetectionError(null);
+                            }}
+                        />
+                        <Button
+                            variant="outline"
+                            disabled={!basicRoot.trim()}
+                            onClick={() => void detectPaths(basicRoot)}
+                        >
+                            <Icon name="search" className="!text-[18px]" />
+                            Detect paths
+                        </Button>
+                    </div>
+                )}
+
                 <div className="flex items-center gap-3">
-                    <Button variant="primary" disabled={!canSubmit} onClick={() => void m.connect(form)}>
+                    <Button variant="primary" disabled={!canSubmit} onClick={connect}>
                         {m.busy === "connect" ? <Spinner className="h-4 w-4" /> : <Icon name="link" className="!text-[18px]" />}
                         Connect
                     </Button>

--- a/frontend/app/routes/settings/migration/altmount/altmount-migration.tsx
+++ b/frontend/app/routes/settings/migration/altmount/altmount-migration.tsx
@@ -57,6 +57,7 @@ const SYMLINK_STATUS_HELP: Record<string, string> = {
     "not-altmount": "Does not point to Altmount and will be left unchanged.",
     applied: "Successfully repointed to NzbDAV.",
     failed: "A rewrite was attempted but could not be completed.",
+    removed: "The orphaned Altmount symlink was removed after its original target was backed up.",
 };
 
 const SYMLINK_STATUS_LABELS: Record<string, string> = {
@@ -67,6 +68,7 @@ const SYMLINK_STATUS_LABELS: Record<string, string> = {
     "not-altmount": "Other",
     applied: "Applied",
     failed: "Failed",
+    removed: "Removed",
 };
 
 const MATCH_METHODS: Record<string, { label: string; help: string }> = {
@@ -95,7 +97,7 @@ const MATCH_METHODS: Record<string, { label: string; help: string }> = {
 /** True once the migration has finished, so the optional Links step is available. */
 function canLinkStep(status: SessionStatus | undefined): boolean {
     return status === "complete" || status === "linking" || status === "linked"
-        || status === "applying" || status === "restoring";
+        || status === "applying" || status === "removing_orphans" || status === "restoring";
 }
 
 function stepForStatus(status: SessionStatus | undefined): number {
@@ -111,10 +113,11 @@ function stepForStatus(status: SessionStatus | undefined): number {
         case "complete":
         case "cancelled": return 4;
         // Step 6 is opt-in: it does not auto-advance from "complete", but once the
-        // user enters it the linking/applying/linked statuses live on the Links step.
+        // user enters it, all Step 6 operation statuses live on the Links step.
         case "linking":
         case "linked":
         case "applying":
+        case "removing_orphans":
         case "restoring": return LINK_STEP;
         default: return 0; // idle
     }
@@ -1013,10 +1016,11 @@ function SymlinkStep({ m }: { m: Hook }) {
 
     const linking = status === "linking";
     const applying = status === "applying";
+    const removingOrphans = status === "removing_orphans";
     const restoring = status === "restoring";
     const linked = status === "linked";
     const busyPlan = m.busy === "symlink-plan";
-    const step6Active = linking || applying || restoring || m.busy !== null;
+    const step6Active = linking || applying || removingOrphans || restoring || m.busy !== null;
     const canPlan = form.libraryRoot.trim().length > 0 && !step6Active;
 
     return (
@@ -1029,7 +1033,7 @@ function SymlinkStep({ m }: { m: Hook }) {
                 <Alert className="alert-soft mb-4 text-sm" variant="info">
                     <Icon name="info" className="!text-[18px]" />
                     This is the only step that changes your media library. A restore tarball is written before any
-                    rewrite, orphans are left pointing at Altmount, and real files are never touched.
+                    rewrite or optional orphan removal, and real files and symlink targets are never touched.
                 </Alert>
 
                 <div className="space-y-4">
@@ -1054,7 +1058,7 @@ function SymlinkStep({ m }: { m: Hook }) {
                             {(busyPlan || linking) ? <Spinner className="h-4 w-4" /> : <Icon name="search" className="!text-[18px]" />}
                             {linked ? "Rebuild plan" : "Build plan"}
                         </Button>
-                        {(linking || applying) && (
+                        {(linking || applying || removingOrphans) && (
                             <Button
                                 variant="outline"
                                 size="small"
@@ -1067,6 +1071,7 @@ function SymlinkStep({ m }: { m: Hook }) {
                         )}
                         {linking && <span className="text-xs text-base-content/60">Scanning the library and matching symlinks… updates automatically.</span>}
                         {applying && <span className="flex items-center gap-2 text-xs text-base-content/60"><Spinner className="h-4 w-4" /> Applying rewrites…</span>}
+                        {removingOrphans && <span className="flex items-center gap-2 text-xs text-base-content/60"><Spinner className="h-4 w-4" /> Removing orphaned Altmount symlinks…</span>}
                         {restoring && <span className="flex items-center gap-2 text-xs text-base-content/60"><Spinner className="h-4 w-4" /> Restoring symlinks…</span>}
                     </div>
                 </div>
@@ -1085,6 +1090,7 @@ function SymlinkResults({ m }: { m: Hook }) {
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [confirmApply, setConfirmApply] = useState(false);
+    const [confirmOrphanRemoval, setConfirmOrphanRemoval] = useState(false);
     const loadGeneration = useRef(0);
 
     useEffect(() => {
@@ -1112,10 +1118,13 @@ function SymlinkResults({ m }: { m: Hook }) {
 
     const counts = data.counts;
     const rewrites = counts["rewrite"] ?? 0;
+    const orphans = counts["orphan"] ?? 0;
     const unreadable = counts["unreadable"] ?? 0;
     const applied = counts["applied"] ?? 0;
+    const removed = counts["removed"] ?? 0;
     const failed = counts["failed"] ?? 0;
     const canApply = !loading && loadError === null && rewrites > 0 && m.busy === null;
+    const canRemoveOrphans = !loading && loadError === null && orphans > 0 && m.busy === null;
     const pages = Math.max(1, Math.ceil(data.total / filters.pageSize));
 
     const doApply = (acknowledgeUnreadable?: boolean) => {
@@ -1123,8 +1132,13 @@ function SymlinkResults({ m }: { m: Hook }) {
         void m.applySymlinks(acknowledgeUnreadable === true);
     };
 
+    const doRemoveOrphans = () => {
+        setConfirmOrphanRemoval(false);
+        void m.removeOrphanSymlinks();
+    };
+
     return (
-        <Section icon="rule" title="Rewrite plan" subtitle="Review before applying. Only 'rewrite' rows change; the rest are informational.">
+        <Section icon="rule" title="Symlink plan" subtitle="Review first. Rewrites and optional orphan cleanup are separate confirmed actions.">
             {loadError && (
                 <Alert className="alert-soft mb-4 text-sm" variant="danger">
                     <Icon name="error" className="!text-[18px]" />
@@ -1133,13 +1147,14 @@ function SymlinkResults({ m }: { m: Hook }) {
                 </Alert>
             )}
 
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-8">
                 <StatTile label="Rewrite" value={rewrites} tone="success" help={SYMLINK_STATUS_HELP.rewrite} />
-                <StatTile label="Orphan" value={counts["orphan"] ?? 0} tone={(counts["orphan"] ?? 0) > 0 ? "warning" : undefined} help={SYMLINK_STATUS_HELP.orphan} />
+                <StatTile label="Orphan" value={orphans} tone={orphans > 0 ? "warning" : undefined} help={SYMLINK_STATUS_HELP.orphan} />
                 {unreadable > 0 && <StatTile label="Unreadable" value={unreadable} tone="error" help={SYMLINK_STATUS_HELP.unreadable} />}
                 <StatTile label="NzbDAV" value={counts["already-nzbdav"] ?? 0} help={SYMLINK_STATUS_HELP["already-nzbdav"]} />
                 <StatTile label="Other" value={counts["not-altmount"] ?? 0} help={SYMLINK_STATUS_HELP["not-altmount"]} />
                 <StatTile label="Applied" value={applied} tone={applied > 0 ? "success" : undefined} help={SYMLINK_STATUS_HELP.applied} />
+                <StatTile label="Removed" value={removed} tone={removed > 0 ? "warning" : undefined} help={SYMLINK_STATUS_HELP.removed} />
                 <StatTile label="Failed" value={failed} tone={failed > 0 ? "error" : undefined} help={SYMLINK_STATUS_HELP.failed} />
             </div>
 
@@ -1147,6 +1162,10 @@ function SymlinkResults({ m }: { m: Hook }) {
                 <Button variant="primary" disabled={!canApply} onClick={() => setConfirmApply(true)}>
                     {m.busy === "symlink-apply" ? <Spinner className="h-4 w-4" /> : <Icon name="published_with_changes" className="!text-[18px]" />}
                     Apply {rewrites} rewrite(s)
+                </Button>
+                <Button variant="danger" disabled={!canRemoveOrphans} onClick={() => setConfirmOrphanRemoval(true)}>
+                    {m.busy === "symlink-orphan-remove" ? <Spinner className="h-4 w-4" /> : <Icon name="link_off" className="!text-[18px]" />}
+                    Remove {orphans} orphaned link(s)
                 </Button>
                 {!loading && !loadError && rewrites === 0 && applied === 0 && (
                     unreadable > 0
@@ -1157,6 +1176,11 @@ function SymlinkResults({ m }: { m: Hook }) {
                     <span className="text-xs text-success">
                         {applied} symlink(s) rewritten. A restore tarball is in your backup directory.
                         {unreadable > 0 && <span className="ml-1 text-error">{unreadable} unreadable symlink(s) remain unchanged.</span>}
+                    </span>
+                )}
+                {removed > 0 && (
+                    <span className="text-xs text-warning">
+                        {removed} orphaned symlink(s) removed. Use the restore archive if you need to recreate them.
                     </span>
                 )}
             </div>
@@ -1175,6 +1199,7 @@ function SymlinkResults({ m }: { m: Hook }) {
                     <option value="not-altmount">Other</option>
                     <option value="applied">Applied</option>
                     <option value="failed">Failed</option>
+                    <option value="removed">Removed</option>
                 </Select>
                 <Input
                     className="input-sm w-56"
@@ -1259,6 +1284,32 @@ function SymlinkResults({ m }: { m: Hook }) {
                 onCancel={() => setConfirmApply(false)}
                 onConfirm={doApply}
             />
+
+            <ConfirmModal
+                show={confirmOrphanRemoval}
+                title="Remove orphaned Altmount symlinks"
+                message={
+                    <>
+                        This deletes {orphans} symlink entry(s) from your media library, so those paths will appear
+                        missing to Sonarr, Radarr, Plex, and other applications. It does not delete files stored by
+                        Altmount or NzbDAV, and it does not tell your Arr applications to search or re-grab them.
+                        A verified restore archive is written first, and only links still pointing to the Altmount
+                        target recorded by this plan are removed. Real files, changed links, unreadable links, and
+                        target data remain untouched.
+                        <span className="mt-2 block font-semibold">
+                            After removal, run a Refresh &amp; Scan job in each affected Arr application so it detects
+                            the deleted links and marks those files as missing before you initiate or schedule re-grabs.
+                        </span>
+                    </>
+                }
+                checkboxMessage="I understand these library paths will remain missing until my Arr applications re-grab them or I restore the backup"
+                requireCheckbox
+                errorMessage="This cleanup is optional. Cancel if you need to keep Altmount serving any unmatched files."
+                cancelText="Cancel"
+                confirmText="Remove orphaned links"
+                onCancel={() => setConfirmOrphanRemoval(false)}
+                onConfirm={doRemoveOrphans}
+            />
         </Section>
     );
 }
@@ -1312,7 +1363,8 @@ function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => vo
                 <div className="min-w-0 flex-1">
                     <h3 className="text-sm font-semibold">Restore Symlinks</h3>
                     <p className="mt-1 text-xs text-base-content/60">
-                        Roll back a previous rewrite using its archive. Links changed since that rewrite are left untouched.
+                        Roll back a previous rewrite or recreate links removed by orphan cleanup. Real files and changed
+                        links are left untouched.
                     </p>
 
                     <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -1325,7 +1377,7 @@ function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => vo
                             {backups.length === 0 && <option value="">No restore archives found</option>}
                             {backups.map((backup) => (
                                 <option key={backup.fileName} value={backup.fileName} disabled={!backup.isValid}>
-                                    {new Date(backup.createdAt).toLocaleString()} — {backup.entryCount} link(s){backup.isValid ? "" : " — unreadable"}
+                                    {backup.kind === "orphan-removal" ? "Orphan removal" : "Rewrite"} — {new Date(backup.createdAt).toLocaleString()} — {backup.entryCount} link(s){backup.isValid ? "" : " — unreadable"}
                                 </option>
                             ))}
                         </Select>
@@ -1346,6 +1398,7 @@ function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => vo
                     {archive && (
                         <div className="mt-2 text-[11px] text-base-content/50">
                             <span className="font-mono">{archive.fileName}</span> · {formatBytes(archive.sizeBytes)}
+                            <span className="ml-2">{archive.kind === "orphan-removal" ? "orphan-removal backup" : "rewrite backup"}</span>
                             {archive.legacyEntryCount > 0 && (
                                 <span className="ml-2 text-warning">
                                     {archive.legacyEntryCount} older-format link(s) require the current rewrite plan for verification.
@@ -1361,6 +1414,7 @@ function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => vo
                             <div>
                                 Restored {result.restored}; already restored {result.alreadyRestored}; failed {result.failed}.
                                 {result.requeued > 0 && ` ${result.requeued} link(s) are ready to rewrite again.`}
+                                {result.orphansRestored > 0 && ` ${result.orphansRestored} orphaned link(s) were returned to the plan.`}
                                 {result.issues.length > 0 && (
                                     <ul className="mt-2 list-disc space-y-1 pl-4">
                                         {result.issues.map((issue, index) => (
@@ -1380,11 +1434,18 @@ function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => vo
                 show={confirm}
                 title="Restore symlinks"
                 message={
-                    <>
-                        Restore {archive?.entryCount ?? 0} symlink(s) from <span className="font-mono">{archive?.fileName}</span>?
-                        Only links still pointing at their recorded NzbDAV targets will be changed. Real files, link targets,
-                        and links changed after the rewrite are never overwritten.
-                    </>
+                    archive?.kind === "orphan-removal" ? (
+                        <>
+                            Recreate {archive.entryCount} symlink(s) removed by orphan cleanup from <span className="font-mono">{archive.fileName}</span>?
+                            Only absent paths are recreated. Real files, directories, and differently targeted links are never overwritten.
+                        </>
+                    ) : (
+                        <>
+                            Restore {archive?.entryCount ?? 0} symlink(s) from <span className="font-mono">{archive?.fileName}</span>?
+                            Links still pointing at their recorded NzbDAV targets are restored, and missing links can be recreated.
+                            Real files, link targets, and links changed after the rewrite are never overwritten.
+                        </>
+                    )
                 }
                 cancelText="Cancel"
                 confirmText="Restore"
@@ -1449,6 +1510,7 @@ function SymlinkStatusBadge({ status }: { status: string }) {
     const cls = status === "rewrite" ? "badge-info"
         : status === "applied" ? "badge-success"
         : status === "failed" || status === "unreadable" ? "badge-error"
+        : status === "removed" ? "badge-warning"
         : status === "orphan" ? "badge-warning"
         : "badge-ghost";
     const badge = <Badge className={`badge-sm ${cls} badge-soft cursor-help`}>{SYMLINK_STATUS_LABELS[status] ?? status}</Badge>;

--- a/frontend/app/routes/settings/migration/altmount/use-altmount-migration.test.ts
+++ b/frontend/app/routes/settings/migration/altmount/use-altmount-migration.test.ts
@@ -6,14 +6,161 @@ import {
     canEditReleaseSelection,
     canResetMigration,
     canStartScanMigration,
+    connectFormWithDetectedPaths,
+    connectFormWithStatusPaths,
     hasScanData,
+    inferStandardAltmountRoot,
     isMigrationWorkActive,
     loadTableLatest,
     loadTableRetainingLastGood,
+    requestAltmountPathDetection,
     requestSymlinkApply,
     runUiMutation,
     type SessionStatus,
 } from "./use-altmount-migration";
+
+describe("requestAltmountPathDetection", () => {
+    it("asks the backend to inspect the trimmed container path", async () => {
+        const originalFetch = globalThis.fetch;
+        const response = {
+            detected: true,
+            root: "/altmount-data/config",
+            metadataRoot: "/altmount-data/config/metadata",
+            configPath: "/altmount-data/config/config.yaml",
+            storeRoot: "/altmount-data/config",
+            reason: null,
+        };
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify(response), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        globalThis.fetch = fetchMock;
+        try {
+            await expect(requestAltmountPathDetection("  /altmount-data/config  "))
+                .resolves.toEqual(response);
+
+            expect(fetchMock).toHaveBeenCalledOnce();
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe("/api/migration/altmount/detect");
+            expect(init?.method).toBe("POST");
+            expect(JSON.parse(String(init?.body))).toEqual({ root: "/altmount-data/config" });
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it("sends an explicit null root when requesting default detection", async () => {
+        const originalFetch = globalThis.fetch;
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify({
+                detected: false,
+                root: "/altmount",
+                metadataRoot: "/altmount/metadata",
+                configPath: "/altmount/config.yaml",
+                storeRoot: "/altmount",
+                reason: "The selected directory does not match the standard Altmount layout.",
+            }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        globalThis.fetch = fetchMock;
+        try {
+            await requestAltmountPathDetection();
+
+            const [, init] = fetchMock.mock.calls[0];
+            expect(JSON.parse(String(init?.body))).toEqual({ root: null });
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+describe("standard Altmount path helpers", () => {
+    it("recognizes saved paths that share the basic-mode layout", () => {
+        expect(inferStandardAltmountRoot({
+            altmountMetadataRoot: "/altmount-data/config/metadata/",
+            altmountConfigPath: "/altmount-data/config/config.yaml",
+            altmountStoreRoot: "/altmount-data/config/",
+        })).toBe("/altmount-data/config");
+
+        expect(inferStandardAltmountRoot({
+            altmountMetadataRoot: String.raw`C:\altmount\metadata`,
+            altmountConfigPath: String.raw`C:\altmount\config.yaml`,
+            altmountStoreRoot: String.raw`C:\altmount`,
+        })).toBe(String.raw`C:\altmount`);
+    });
+
+    it("rejects split or incomplete advanced-mode paths", () => {
+        expect(inferStandardAltmountRoot({
+            altmountMetadataRoot: "/metadata",
+            altmountConfigPath: "/config/config.yaml",
+            altmountStoreRoot: "/stores",
+        })).toBeNull();
+        expect(inferStandardAltmountRoot({
+            altmountMetadataRoot: "/altmount/metadata",
+            altmountConfigPath: null,
+            altmountStoreRoot: "/altmount",
+        })).toBeNull();
+    });
+
+    it("applies detected paths without resetting queue tuning", () => {
+        expect(connectFormWithDetectedPaths(
+            {
+                metadataRoot: "/old/metadata",
+                configPath: "/old/config.yaml",
+                storeRoot: "/old",
+                maxQueueDepth: 73,
+                submitWorkers: 4,
+            },
+            {
+                detected: true,
+                root: "/altmount-data/config",
+                metadataRoot: "/altmount-data/config/metadata",
+                configPath: "/altmount-data/config/config.yaml",
+                storeRoot: "/altmount-data/config",
+                reason: null,
+            },
+        )).toEqual({
+            metadataRoot: "/altmount-data/config/metadata",
+            configPath: "/altmount-data/config/config.yaml",
+            storeRoot: "/altmount-data/config",
+            maxQueueDepth: 73,
+            submitWorkers: 4,
+        });
+    });
+
+    it("restores status paths without resetting queue tuning", () => {
+        const form = {
+            metadataRoot: "/detected/metadata",
+            configPath: "/detected/config.yaml",
+            storeRoot: "/detected",
+            maxQueueDepth: 73,
+            submitWorkers: 4,
+        };
+
+        expect(connectFormWithStatusPaths(form, {
+            altmountMetadataRoot: "/saved/metadata",
+            altmountConfigPath: "/saved/config.yaml",
+            altmountStoreRoot: "/saved",
+        })).toEqual({
+            metadataRoot: "/saved/metadata",
+            configPath: "/saved/config.yaml",
+            storeRoot: "/saved",
+            maxQueueDepth: 73,
+            submitWorkers: 4,
+        });
+        expect(connectFormWithStatusPaths(form, undefined)).toEqual({
+            metadataRoot: "",
+            configPath: "",
+            storeRoot: "",
+            maxQueueDepth: 73,
+            submitWorkers: 4,
+        });
+    });
+});
 
 describe("requestSymlinkApply", () => {
     it.each([

--- a/frontend/app/routes/settings/migration/altmount/use-altmount-migration.test.ts
+++ b/frontend/app/routes/settings/migration/altmount/use-altmount-migration.test.ts
@@ -14,6 +14,7 @@ import {
     loadTableLatest,
     loadTableRetainingLastGood,
     requestAltmountPathDetection,
+    requestOrphanSymlinkRemoval,
     requestSymlinkApply,
     runUiMutation,
     type SessionStatus,
@@ -192,6 +193,30 @@ describe("requestSymlinkApply", () => {
     });
 });
 
+describe("requestOrphanSymlinkRemoval", () => {
+    it("requires explicit confirmation in the removal request", async () => {
+        const originalFetch = globalThis.fetch;
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify({ status: true }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        globalThis.fetch = fetchMock;
+        try {
+            await requestOrphanSymlinkRemoval();
+
+            expect(fetchMock).toHaveBeenCalledOnce();
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe("/api/migration/altmount/symlinks/orphans/remove");
+            expect(init?.method).toBe("POST");
+            expect(JSON.parse(String(init?.body))).toEqual({ confirm: true });
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
 describe("beginLatestRequest", () => {
     it("invalidates older request tickets when a newer refresh starts", () => {
         const generation = { current: 0 };
@@ -213,7 +238,7 @@ describe("beginLatestRequest", () => {
 });
 
 describe("isMigrationWorkActive", () => {
-    it.each<SessionStatus>(["scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "restoring"])(
+    it.each<SessionStatus>(["scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "removing_orphans", "restoring"])(
         "blocks destructive wizard actions while status is %s",
         (status) => expect(isMigrationWorkActive(status)).toBe(true),
     );
@@ -229,7 +254,7 @@ describe("isMigrationWorkActive", () => {
 });
 
 describe("canResetMigration", () => {
-    it.each<SessionStatus>(["scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "restoring"])(
+    it.each<SessionStatus>(["scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "removing_orphans", "restoring"])(
         "blocks Reset Wizard while status is %s",
         (status) => expect(canResetMigration(status, null)).toBe(false),
     );
@@ -247,7 +272,7 @@ describe("review mutation state guards", () => {
         (status) => expect(canConnectMigration(status)).toBe(true),
     );
 
-    it.each<SessionStatus>(["scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "restoring"])(
+    it.each<SessionStatus>(["scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "removing_orphans", "restoring"])(
         "blocks Connect during active state %s",
         (status) => expect(canConnectMigration(status)).toBe(false),
     );
@@ -257,7 +282,7 @@ describe("review mutation state guards", () => {
         (status) => expect(canStartScanMigration(status)).toBe(true),
     );
 
-    it.each<SessionStatus>(["idle", "scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "restoring"])(
+    it.each<SessionStatus>(["idle", "scanning", "scan_cancelling", "running", "paused", "cancelling", "linking", "applying", "removing_orphans", "restoring"])(
         "blocks Scan from illegal state %s",
         (status) => expect(canStartScanMigration(status)).toBe(false),
     );
@@ -267,7 +292,7 @@ describe("review mutation state guards", () => {
         (status) => expect(canEditCategoryMappings(status)).toBe(true),
     );
 
-    it.each<SessionStatus>(["idle", "scanning", "scan_cancelling", "running", "paused", "cancelling", "complete", "cancelled", "linking", "linked", "applying", "restoring"])(
+    it.each<SessionStatus>(["idle", "scanning", "scan_cancelling", "running", "paused", "cancelling", "complete", "cancelled", "linking", "linked", "applying", "removing_orphans", "restoring"])(
         "locks category mapping edits while status is %s",
         (status) => expect(canEditCategoryMappings(status)).toBe(false),
     );
@@ -275,7 +300,7 @@ describe("review mutation state guards", () => {
     it("allows release selection edits only for a completed scan", () => {
         const statuses: (SessionStatus | undefined)[] = [
             undefined, "idle", "connected", "mapped", "scanning", "scan_cancelling", "running", "paused", "cancelling",
-            "complete", "cancelled", "linking", "linked", "applying", "restoring",
+            "complete", "cancelled", "linking", "linked", "applying", "removing_orphans", "restoring",
         ];
         expect(canEditReleaseSelection("scanned")).toBe(true);
         statuses.forEach((status) => expect(canEditReleaseSelection(status)).toBe(false));
@@ -285,7 +310,7 @@ describe("review mutation state guards", () => {
 describe("hasScanData", () => {
     it.each<SessionStatus>([
         "scanned", "running", "paused", "cancelling", "complete", "cancelled",
-        "linking", "linked", "applying", "restoring",
+        "linking", "linked", "applying", "removing_orphans", "restoring",
     ])("reports scan data available for status %s", (status) => {
         expect(hasScanData(status)).toBe(true);
     });

--- a/frontend/app/routes/settings/migration/altmount/use-altmount-migration.ts
+++ b/frontend/app/routes/settings/migration/altmount/use-altmount-migration.ts
@@ -18,12 +18,14 @@ export type SessionStatus =
     | "linking"
     | "linked"
     | "applying"
+    | "removing_orphans"
     | "restoring";
 
 export function isMigrationWorkActive(status: SessionStatus | undefined): boolean {
     return status === "scanning" || status === "scan_cancelling"
         || status === "running" || status === "paused" || status === "cancelling"
-        || status === "linking" || status === "applying" || status === "restoring";
+        || status === "linking" || status === "applying" || status === "removing_orphans"
+        || status === "restoring";
 }
 
 export function canConnectMigration(status: SessionStatus | undefined): boolean {
@@ -59,6 +61,7 @@ export function hasScanData(status: SessionStatus | undefined): boolean {
         || status === "linking"
         || status === "linked"
         || status === "applying"
+        || status === "removing_orphans"
         || status === "restoring";
 }
 
@@ -203,6 +206,7 @@ export type SymlinkBackupInfo = {
     sizeBytes: number;
     entryCount: number;
     legacyEntryCount: number;
+    kind: "rewrite" | "orphan-removal";
     isValid: boolean;
     error?: string | null;
 };
@@ -216,6 +220,7 @@ export type SymlinkRestoreSummary = {
     alreadyRestored: number;
     failed: number;
     requeued: number;
+    orphansRestored: number;
     issues: SymlinkRestoreIssue[];
 };
 
@@ -319,6 +324,13 @@ export async function requestSymlinkApply(acknowledgeUnreadable = false): Promis
     await apiJson(
         `${BASE}/symlinks/apply`,
         jsonInit("POST", { confirm: true, acknowledgeUnreadable }),
+    );
+}
+
+export async function requestOrphanSymlinkRemoval(): Promise<void> {
+    await apiJson(
+        `${BASE}/symlinks/orphans/remove`,
+        jsonInit("POST", { confirm: true }),
     );
 }
 
@@ -432,7 +444,7 @@ export function useAltmountMigration() {
         void loadCategories();
     }, [refresh, loadCategories]);
 
-    // Poll while background work is in progress (scan, run, or Step 6 link/apply).
+    // Poll while background work is in progress (scan, run, or a Step 6 operation).
     const sessionStatus = status?.sessionStatus;
     const previousSessionStatus = useRef<SessionStatus | undefined>(undefined);
     useEffect(() => {
@@ -585,6 +597,11 @@ export function useAltmountMigration() {
         await refresh();
     }), [withBusy, refresh]);
 
+    const removeOrphanSymlinks = useCallback(() => withBusy("symlink-orphan-remove", async () => {
+        await requestOrphanSymlinkRemoval();
+        await refresh();
+    }), [withBusy, refresh]);
+
     const loadSymlinkBackups = useCallback(async (): Promise<SymlinkBackupInfo[]> => {
         const data = await apiJson<{ backups: SymlinkBackupInfo[] }>(`${BASE}/symlinks/backups`);
         return data.backups;
@@ -647,6 +664,7 @@ export function useAltmountMigration() {
         cancelSymlinkOperation,
         loadSymlinks,
         applySymlinks,
+        removeOrphanSymlinks,
         loadSymlinkBackups,
         restoreSymlinks,
         symlinkCsvHref,
@@ -681,6 +699,7 @@ export function useAltmountMigration() {
         cancelSymlinkOperation,
         loadSymlinks,
         applySymlinks,
+        removeOrphanSymlinks,
         loadSymlinkBackups,
         restoreSymlinks,
         symlinkCsvHref,

--- a/frontend/app/routes/settings/migration/altmount/use-altmount-migration.ts
+++ b/frontend/app/routes/settings/migration/altmount/use-altmount-migration.ts
@@ -227,6 +227,61 @@ export type ConnectForm = {
     submitWorkers: number;
 };
 
+export type AltmountPathDetection = {
+    detected: boolean;
+    root: string;
+    metadataRoot: string;
+    configPath: string;
+    storeRoot: string;
+    reason?: string | null;
+};
+
+export const DEFAULT_ALTMOUNT_ROOT = "/altmount";
+
+// Production runs in Linux, but a directly hosted development backend can persist
+// Windows paths. Normalize both separators when recognizing those saved sessions.
+function comparablePath(path: string): string {
+    return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+/** Returns the shared root when saved paths use the standard single-mount layout. */
+export function inferStandardAltmountRoot(roots: StatusResponse["roots"] | undefined): string | null {
+    const metadataRoot = roots?.altmountMetadataRoot?.trim();
+    const configPath = roots?.altmountConfigPath?.trim();
+    const storeRoot = roots?.altmountStoreRoot?.trim();
+    if (!metadataRoot || !configPath || !storeRoot) return null;
+
+    const comparableRoot = comparablePath(storeRoot);
+    if (!comparableRoot) return null;
+    if (comparablePath(metadataRoot) !== `${comparableRoot}/metadata`) return null;
+    if (comparablePath(configPath) !== `${comparableRoot}/config.yaml`) return null;
+    return storeRoot.replace(/[\\/]+$/, "");
+}
+
+export function connectFormWithDetectedPaths(
+    form: ConnectForm,
+    detection: AltmountPathDetection,
+): ConnectForm {
+    return {
+        ...form,
+        metadataRoot: detection.metadataRoot,
+        configPath: detection.configPath,
+        storeRoot: detection.storeRoot,
+    };
+}
+
+export function connectFormWithStatusPaths(
+    form: ConnectForm,
+    roots: StatusResponse["roots"] | undefined,
+): ConnectForm {
+    return {
+        ...form,
+        metadataRoot: roots?.altmountMetadataRoot ?? "",
+        configPath: roots?.altmountConfigPath ?? "",
+        storeRoot: roots?.altmountStoreRoot ?? "",
+    };
+}
+
 export type ReleaseFilters = {
     page: number;
     pageSize: number;
@@ -264,6 +319,13 @@ export async function requestSymlinkApply(acknowledgeUnreadable = false): Promis
     await apiJson(
         `${BASE}/symlinks/apply`,
         jsonInit("POST", { confirm: true, acknowledgeUnreadable }),
+    );
+}
+
+export async function requestAltmountPathDetection(root?: string): Promise<AltmountPathDetection> {
+    return apiJson<AltmountPathDetection>(
+        `${BASE}/detect`,
+        jsonInit("POST", { root: root?.trim() || null }),
     );
 }
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/AltmountConfigReaderTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/AltmountConfigReaderTests.cs
@@ -59,6 +59,52 @@ public class AltmountConfigReaderTests
     }
 
     [Fact]
+    public void Parse_AcceptsDumbStyleIndentlessCategories()
+    {
+        var cfg = AltmountConfigReader.Parse(new[]
+        {
+            "sabnzbd:",
+            "  enabled: true",
+            "  complete_dir: '/'",
+            "  categories:",
+            "  - name: 'movies'",
+            "    order: 1",
+            "    priority: -100",
+            "    dir: 'movies'",
+            "    type: 'radarr'",
+            "  - name: 'tv'",
+            "    order: 2",
+            "    dir: 'tv'",
+            "    type: 'sonarr'",
+            "  fallback_host: ''",
+        });
+
+        Assert.Equal(2, cfg.Categories.Count);
+        Assert.Equal("movies", cfg.Categories[0].Name);
+        Assert.Equal("radarr", cfg.Categories[0].Type);
+        Assert.Equal(-100, cfg.Categories[0].Priority);
+        Assert.Equal("tv", cfg.Categories[1].Name);
+        Assert.Equal("sonarr", cfg.Categories[1].Type);
+    }
+
+    [Fact]
+    public void Parse_StopsIndentlessCategoriesAtNextSabnzbdKey()
+    {
+        var cfg = AltmountConfigReader.Parse(new[]
+        {
+            "sabnzbd:",
+            "  categories:",
+            "  - name: 'movies'",
+            "    dir: 'movies'",
+            "  fallback_host: 'http://sabnzbd:8080'",
+            "  - name: 'not-a-category'",
+        });
+
+        var category = Assert.Single(cfg.Categories);
+        Assert.Equal("movies", category.Name);
+    }
+
+    [Fact]
     public void Parse_NoSabnzbdBlock_ReturnsEmpty()
     {
         var cfg = AltmountConfigReader.Parse(new[] { "webdav:", "  port: 8080" });

--- a/tests/NzbWebDAV.Tests/UsenetMigration/AltmountPathDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/AltmountPathDetectorTests.cs
@@ -1,0 +1,168 @@
+using NzbWebDAV.UsenetMigration.Source;
+
+namespace NzbWebDAV.Tests.UsenetMigration;
+
+public sealed class AltmountPathDetectorTests
+{
+    [Fact]
+    public async Task Detect_ResolvesStandardLayoutFromCustomRoot()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-detect-");
+        try
+        {
+            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            var configPath = Path.Combine(root.FullName, "config.yaml");
+            await File.WriteAllTextAsync(
+                configPath,
+                "sabnzbd:\n  categories:\n  - name: 'movies'\n    dir: 'movies'\n");
+
+            var result = await AltmountPathDetector.DetectAsync(
+                root.FullName + Path.DirectorySeparatorChar);
+
+            Assert.True(result.Detected);
+            Assert.Null(result.Reason);
+            Assert.Equal(Path.TrimEndingDirectorySeparator(root.FullName), result.Root);
+            Assert.Equal(metadataRoot.FullName, result.MetadataRoot);
+            Assert.Equal(configPath, result.ConfigPath);
+            Assert.Equal(result.Root, result.StoreRoot);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Detect_ReportsMissingRoot()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            $"missing-altmig-detect-{Guid.NewGuid():N}");
+
+        var result = await AltmountPathDetector.DetectAsync(root);
+
+        Assert.False(result.Detected);
+        Assert.Equal(AltmountPathDetector.FailureReason, result.Reason);
+        Assert.DoesNotContain(root, result.Reason);
+        Assert.Equal(Path.Combine(Path.GetFullPath(root), "metadata"), result.MetadataRoot);
+        Assert.Equal(Path.Combine(Path.GetFullPath(root), "config.yaml"), result.ConfigPath);
+        Assert.Equal(Path.GetFullPath(root), result.StoreRoot);
+    }
+
+    [Fact]
+    public async Task Detect_DoesNotReportWhichStandardLayoutEntryIsMissing()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-detect-");
+        try
+        {
+            var result = await AltmountPathDetector.DetectAsync(root.FullName);
+
+            Assert.False(result.Detected);
+            Assert.Equal(AltmountPathDetector.FailureReason, result.Reason);
+            Assert.DoesNotContain(root.FullName, result.Reason);
+            Assert.DoesNotContain("metadata", result.Reason, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("config", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Detect_RequiresConfigAlongsideExistingMetadata()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-detect-");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+
+            var result = await AltmountPathDetector.DetectAsync(root.FullName);
+
+            Assert.False(result.Detected);
+            Assert.Equal(AltmountPathDetector.FailureReason, result.Reason);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("../../../../etc")]
+    public async Task Detect_RejectsBlankOrRelativeRoots(string root)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => AltmountPathDetector.DetectAsync(root));
+    }
+
+    [Fact]
+    public async Task Detect_RejectsNavigationSegmentsBeforeCanonicalization()
+    {
+        var parent = Path.Combine(Path.GetTempPath(), $"altmig-parent-{Guid.NewGuid():N}");
+        var withParentTraversal = Path.Combine(parent, "child", "..", "altmount");
+        var withCurrentTraversal = Path.Combine(parent, ".", "altmount");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => AltmountPathDetector.DetectAsync(withParentTraversal));
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => AltmountPathDetector.DetectAsync(withCurrentTraversal));
+    }
+
+    [Fact]
+    public async Task Detect_RejectsFilesystemRoot()
+    {
+        var fileSystemRoot = Path.GetPathRoot(Path.GetFullPath(Path.GetTempPath()));
+
+        Assert.False(string.IsNullOrEmpty(fileSystemRoot));
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => AltmountPathDetector.DetectAsync(fileSystemRoot));
+    }
+
+    [Fact]
+    public async Task Detect_ReportsReadableConfigWithoutCategories()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-detect-");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            await File.WriteAllTextAsync(
+                Path.Combine(root.FullName, "config.yaml"),
+                "sabnzbd:\n  categories:\n");
+
+            var result = await AltmountPathDetector.DetectAsync(root.FullName);
+
+            Assert.False(result.Detected);
+            Assert.Equal(AltmountPathDetector.NoCategoriesReason, result.Reason);
+            Assert.DoesNotContain(root.FullName, result.Reason);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Detect_ReportsUnsupportedConfigWithoutEchoingPath()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-detect-");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            await File.WriteAllTextAsync(
+                Path.Combine(root.FullName, "config.yaml"),
+                "sabnzbd:\n  categories: [{ name: 'movies' }]\n");
+
+            var result = await AltmountPathDetector.DetectAsync(root.FullName);
+
+            Assert.False(result.Detected);
+            Assert.Equal(AltmountPathDetector.InvalidConfigReason, result.Reason);
+            Assert.DoesNotContain(root.FullName, result.Reason);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/UsenetMigration/MigrationRunStateTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/MigrationRunStateTests.cs
@@ -19,6 +19,7 @@ public class MigrationRunStateTests
     [InlineData("cancelling", false)]
     [InlineData("linking", false)]
     [InlineData("applying", false)]
+    [InlineData("removing_orphans", false)]
     [InlineData("restoring", false)]
     public void Connect_IsAllowedOnlyFromRestingStates(string status, bool expected) =>
         Assert.Equal(expected, UsenetMigrationController.CanConnect(status));
@@ -75,6 +76,7 @@ public class MigrationRunStateTests
     [InlineData("scan_cancelling", false)]
     [InlineData("linking", false)]
     [InlineData("applying", false)]
+    [InlineData("removing_orphans", false)]
     [InlineData("restoring", false)]
     [InlineData("complete", true)]
     [InlineData("cancelled", true)]
@@ -113,6 +115,7 @@ public class MigrationRunStateTests
     [InlineData("scan_cancelling", true)]
     [InlineData("linking", true)]
     [InlineData("applying", true)]
+    [InlineData("removing_orphans", true)]
     [InlineData("restoring", true)]
     [InlineData("idle", false)]
     [InlineData("connected", false)]

--- a/tests/NzbWebDAV.Tests/UsenetMigration/MigrationSessionStateMachineTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/MigrationSessionStateMachineTests.cs
@@ -32,6 +32,9 @@ public sealed class MigrationSessionStateMachineTests
             [MigrationSessionTransition.StartApply] = new("applying", "linked"),
             [MigrationSessionTransition.CompleteApply] = new("linked", "applying"),
             [MigrationSessionTransition.CancelApply] = new("linked", "applying"),
+            [MigrationSessionTransition.StartOrphanRemoval] = new("removing_orphans", "linked"),
+            [MigrationSessionTransition.CompleteOrphanRemoval] = new("linked", "removing_orphans"),
+            [MigrationSessionTransition.CancelOrphanRemoval] = new("linked", "removing_orphans"),
             [MigrationSessionTransition.StartRestore] = new("restoring", "linked"),
             [MigrationSessionTransition.CompleteRestore] = new("linked", "restoring"),
         };
@@ -71,6 +74,7 @@ public sealed class MigrationSessionStateMachineTests
     [InlineData("cancelling", true)]
     [InlineData("linking", true)]
     [InlineData("applying", true)]
+    [InlineData("removing_orphans", true)]
     [InlineData("restoring", true)]
     [InlineData("idle", false)]
     [InlineData("connected", false)]
@@ -195,11 +199,13 @@ public sealed class MigrationSessionStateMachineTests
         var results = await Task.WhenAll(
             h.Store.TryTransitionSessionAsync(MigrationSessionTransition.StartLinkPlan),
             h.Store.TryTransitionSessionAsync(MigrationSessionTransition.StartApply),
+            h.Store.TryTransitionSessionAsync(MigrationSessionTransition.StartOrphanRemoval),
             h.Store.TryTransitionSessionAsync(MigrationSessionTransition.StartRestore));
 
         Assert.Single(results, r => r.Outcome == MigrationSessionTransitionOutcome.Applied);
-        Assert.Equal(2, results.Count(r => r.Outcome == MigrationSessionTransitionOutcome.Rejected));
-        Assert.Contains((await h.Store.GetSessionAsync()).Status, new[] { "linking", "applying", "restoring" });
+        Assert.Equal(3, results.Count(r => r.Outcome == MigrationSessionTransitionOutcome.Rejected));
+        Assert.Contains((await h.Store.GetSessionAsync()).Status,
+            new[] { "linking", "applying", "removing_orphans", "restoring" });
     }
 
     private sealed record ExpectedRule(string TargetStatus, params string[] SourceStatuses);

--- a/tests/NzbWebDAV.Tests/UsenetMigration/Step6LifecycleTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/Step6LifecycleTests.cs
@@ -34,6 +34,11 @@ public sealed class Step6LifecycleTests
             currentTarget = target;
         }
 
+        public void DeleteSymlink(string libraryRoot, string candidatePath, string expectedTarget)
+        {
+            currentTarget = null!;
+        }
+
         public void CreateSymlink(string libraryRoot, string candidatePath, string target)
         {
             currentTarget = target;
@@ -367,6 +372,115 @@ public sealed class Step6LifecycleTests
             Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", previousApiKey);
             Environment.SetEnvironmentVariable("CONFIG_PATH", previousConfig);
             configDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task RemoveOrphans_RequiresConfirmationAndClaimsBackgroundOperation()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var library = Directory.CreateTempSubdirectory("altmig-library-");
+        var backups = Directory.CreateTempSubdirectory("altmig-backups-");
+        await h.Store.UpdateSessionAsync(s =>
+        {
+            s.Status = "linked";
+            s.SymlinkLibraryRoot = library.FullName;
+            s.SymlinkBackupDir = backups.FullName;
+        });
+        await using (var migration = h.Mig())
+        {
+            migration.SymlinkRewrites.Add(new MigrationSymlinkRewrite
+            {
+                SymlinkPath = Path.Combine(library.FullName, "orphan.mkv"),
+                OldTarget = "/mnt/altmount/orphan.mkv",
+                Status = "orphan",
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await migration.SaveChangesAsync();
+        }
+
+        const string apiKey = "step6-orphan-removal-key";
+        var previousApiKey = Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", apiKey);
+        try
+        {
+            var config = new ConfigManager();
+            using var queueManager = CreateQueueManager();
+            var runner = new UsenetMigrationRunner(
+                h.Store, queueManager, config, new WebsocketManager());
+            using var services = new ServiceCollection()
+                .AddSingleton(config)
+                .AddSingleton(h.Store)
+                .BuildServiceProvider();
+            var httpContext = new DefaultHttpContext { RequestServices = services };
+            httpContext.Request.Headers["x-api-key"] = apiKey;
+            var controller = new UsenetMigrationController(h.Store, runner)
+            {
+                ControllerContext = new ControllerContext { HttpContext = httpContext },
+            };
+
+            var rejected = Assert.IsType<BadRequestObjectResult>(
+                await controller.RemoveOrphanSymlinks(new SymlinkOrphanRemovalRequest(null)));
+            Assert.Contains("explicit confirmation", Assert.IsType<BaseApiResponse>(rejected.Value).Error!);
+            Assert.Equal("linked", (await h.Store.GetSessionAsync()).Status);
+
+            Assert.IsType<OkObjectResult>(
+                await controller.RemoveOrphanSymlinks(new SymlinkOrphanRemovalRequest(true)));
+            Assert.Equal("removing_orphans", (await h.Store.GetSessionAsync()).Status);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", previousApiKey);
+            library.Delete(recursive: true);
+            backups.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Runner_OrphanRemovalCompletesAndReturnsToLinked()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var library = Directory.CreateTempSubdirectory("altmig-library-");
+        var backups = Directory.CreateTempSubdirectory("altmig-backups-");
+        var link = Path.Combine(library.FullName, "orphan.mkv");
+        const string target = "/mnt/altmount/orphan.mkv";
+        await h.Store.UpdateSessionAsync(s =>
+        {
+            s.Status = "removing_orphans";
+            s.SymlinkLibraryRoot = library.FullName;
+            s.SymlinkBackupDir = backups.FullName;
+        });
+        await using (var migration = h.Mig())
+        {
+            migration.SymlinkRewrites.Add(new MigrationSymlinkRewrite
+            {
+                SymlinkPath = link,
+                OldTarget = target,
+                Status = "orphan",
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await migration.SaveChangesAsync();
+        }
+
+        try
+        {
+            using var queueManager = CreateQueueManager();
+            var runner = new UsenetMigrationRunner(
+                h.Store, queueManager, new ConfigManager(), new WebsocketManager());
+            runner.SymlinkOrphanRemoverForTests.Ops = new TestSymlinkOps(link, target);
+
+            await runner.TickOnceForTestsAsync();
+
+            Assert.Equal("linked", (await h.Store.GetSessionAsync()).Status);
+            await using var verify = h.Mig();
+            Assert.Equal("removed", (await verify.SymlinkRewrites.SingleAsync()).Status);
+            Assert.Single(Directory.EnumerateFiles(
+                backups.FullName, "altmount-orphan-symlink-backup-*.tar.gz"));
+        }
+        finally
+        {
+            library.Delete(recursive: true);
+            backups.Delete(recursive: true);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkOrphanRemoverTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkOrphanRemoverTests.cs
@@ -1,0 +1,344 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database.Models.UsenetMigration;
+using NzbWebDAV.UsenetMigration.Symlinks;
+
+namespace NzbWebDAV.Tests.UsenetMigration;
+
+public sealed class SymlinkOrphanRemoverTests
+{
+    private sealed class FakeSymlinkOps : ISymlinkOps
+    {
+        public readonly Dictionary<string, string> Links = new(StringComparer.Ordinal);
+        public int DeleteCalls { get; private set; }
+        public Action<int>? AfterDelete { get; init; }
+
+        public string? ReadLink(string libraryRoot, string path) => Links.GetValueOrDefault(path);
+
+        public void ReplaceSymlink(string libraryRoot, string path, string expectedOldTarget, string newTarget) =>
+            throw new NotSupportedException();
+
+        public void DeleteSymlink(string libraryRoot, string path, string expectedTarget)
+        {
+            if (!Links.TryGetValue(path, out var current)
+                || !string.Equals(current, expectedTarget, StringComparison.Ordinal))
+            {
+                throw new IOException("Target changed during removal.");
+            }
+
+            Links.Remove(path);
+            DeleteCalls++;
+            AfterDelete?.Invoke(DeleteCalls);
+        }
+
+        public void CreateSymlink(string libraryRoot, string path, string target) =>
+            throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Remove_RejectsUnexpectedSessionStatus()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        await h.Store.UpdateSessionAsync(s => s.Status = "linked");
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => new SymlinkOrphanRemover(h.Store).RemoveAsync());
+
+        Assert.Contains("active orphan-removal operation", error.Message);
+    }
+
+    [Fact]
+    public async Task Remove_BackupsAndDeletesOnlyCurrentOrphanRows()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
+        var backups = Directory.CreateTempSubdirectory("altmig-orphan-backups-");
+        var orphan = Path.Combine(library.FullName, "orphan.mkv");
+        var rewrite = Path.Combine(library.FullName, "rewrite.mkv");
+        const string orphanTarget = "/mnt/altmount/orphan.mkv";
+        const string rewriteTarget = "/mnt/altmount/rewrite.mkv";
+        var ops = new FakeSymlinkOps
+        {
+            Links =
+            {
+                [orphan] = orphanTarget,
+                [rewrite] = rewriteTarget,
+            },
+        };
+
+        try
+        {
+            await ConfigureSessionAsync(h, library.FullName, backups.FullName);
+            await SeedPlanAsync(h,
+                Row(orphan, orphanTarget, "orphan"),
+                Row(rewrite, rewriteTarget, "rewrite"),
+                Row(Path.Combine(library.FullName, "unreadable.mkv"), "", "unreadable"));
+
+            var remover = new SymlinkOrphanRemover(h.Store)
+            {
+                Ops = ops,
+                UtcNow = () => new DateTime(2026, 8, 2, 12, 34, 56, DateTimeKind.Utc),
+            };
+            var result = await remover.RemoveAsync();
+
+            Assert.Equal(1, result.Removed);
+            Assert.Equal(0, result.Failed);
+            Assert.Equal(1, ops.DeleteCalls);
+            Assert.DoesNotContain(orphan, ops.Links.Keys);
+            Assert.Equal(rewriteTarget, ops.Links[rewrite]);
+            Assert.Equal(
+                Path.Combine(backups.FullName, "altmount-orphan-symlink-backup-20260802-123456.tar.gz"),
+                result.BackupPath);
+
+            var entries = await SymlinkBackup.ReadAsync(result.BackupPath!);
+            var entry = Assert.Single(entries);
+            Assert.Equal(orphan, entry.Path);
+            Assert.Equal(orphanTarget, entry.Target);
+            Assert.Equal(SymlinkBackup.OrphanRemovalOperation, entry.Operation);
+
+            await using var verify = h.Mig();
+            Assert.Equal("removed", (await verify.SymlinkRewrites.SingleAsync(r => r.SymlinkPath == orphan)).Status);
+            Assert.Equal("rewrite", (await verify.SymlinkRewrites.SingleAsync(r => r.SymlinkPath == rewrite)).Status);
+        }
+        finally
+        {
+            library.Delete(recursive: true);
+            backups.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Remove_BackupFailureAbortsBeforeAnyDeletion()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
+        var backupPathThatIsAFile = Path.GetTempFileName();
+        var orphan = Path.Combine(library.FullName, "orphan.mkv");
+        const string target = "/mnt/altmount/orphan.mkv";
+        var ops = new FakeSymlinkOps { Links = { [orphan] = target } };
+
+        try
+        {
+            await ConfigureSessionAsync(h, library.FullName, backupPathThatIsAFile);
+            await SeedPlanAsync(h, Row(orphan, target, "orphan"));
+
+            var remover = new SymlinkOrphanRemover(h.Store) { Ops = ops };
+            await Assert.ThrowsAnyAsync<IOException>(() => remover.RemoveAsync());
+
+            Assert.Equal(0, ops.DeleteCalls);
+            Assert.Equal(target, ops.Links[orphan]);
+            await using var verify = h.Mig();
+            Assert.Equal("orphan", (await verify.SymlinkRewrites.SingleAsync()).Status);
+        }
+        finally
+        {
+            library.Delete(recursive: true);
+            File.Delete(backupPathThatIsAFile);
+        }
+    }
+
+    [Fact]
+    public async Task Remove_DriftedLinkIsLeftUntouchedAndRetryable()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
+        var backups = Directory.CreateTempSubdirectory("altmig-orphan-backups-");
+        var orphan = Path.Combine(library.FullName, "orphan.mkv");
+        const string planned = "/mnt/altmount/original.mkv";
+        const string current = "/mnt/elsewhere/replaced.mkv";
+        var ops = new FakeSymlinkOps { Links = { [orphan] = current } };
+
+        try
+        {
+            await ConfigureSessionAsync(h, library.FullName, backups.FullName);
+            await SeedPlanAsync(h, Row(orphan, planned, "orphan"));
+
+            var result = await new SymlinkOrphanRemover(h.Store) { Ops = ops }.RemoveAsync();
+
+            Assert.Equal(0, result.Removed);
+            Assert.Equal(1, result.Failed);
+            Assert.Null(result.BackupPath);
+            Assert.Equal(current, ops.Links[orphan]);
+            await using var verify = h.Mig();
+            var row = await verify.SymlinkRewrites.SingleAsync();
+            Assert.Equal("orphan", row.Status);
+            Assert.Contains("changed since planning", row.Error);
+        }
+        finally
+        {
+            library.Delete(recursive: true);
+            backups.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Remove_CancellationPersistsCompletedDeletesAndBacksUpWholeBatch()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
+        var backups = Directory.CreateTempSubdirectory("altmig-orphan-backups-");
+        var first = Path.Combine(library.FullName, "a.mkv");
+        var second = Path.Combine(library.FullName, "b.mkv");
+        using var cancel = new CancellationTokenSource();
+        var ops = new FakeSymlinkOps
+        {
+            Links =
+            {
+                [first] = "/mnt/altmount/a.mkv",
+                [second] = "/mnt/altmount/b.mkv",
+            },
+            AfterDelete = count =>
+            {
+                if (count == 1) cancel.Cancel();
+            },
+        };
+
+        try
+        {
+            await ConfigureSessionAsync(h, library.FullName, backups.FullName);
+            await SeedPlanAsync(h,
+                Row(first, "/mnt/altmount/a.mkv", "orphan"),
+                Row(second, "/mnt/altmount/b.mkv", "orphan"));
+
+            var remover = new SymlinkOrphanRemover(h.Store)
+            {
+                Ops = ops,
+                UtcNow = () => new DateTime(2026, 8, 2, 13, 0, 0, DateTimeKind.Utc),
+            };
+            await Assert.ThrowsAsync<OperationCanceledException>(() => remover.RemoveAsync(cancel.Token));
+
+            Assert.Equal(1, ops.DeleteCalls);
+            Assert.False(ops.Links.ContainsKey(first));
+            Assert.True(ops.Links.ContainsKey(second));
+            var archive = Path.Combine(
+                backups.FullName, "altmount-orphan-symlink-backup-20260802-130000.tar.gz");
+            Assert.Equal(2, (await SymlinkBackup.ReadAsync(archive)).Count);
+
+            await using var verify = h.Mig();
+            Assert.Equal("removed", (await verify.SymlinkRewrites.SingleAsync(r => r.SymlinkPath == first)).Status);
+            Assert.Equal("orphan", (await verify.SymlinkRewrites.SingleAsync(r => r.SymlinkPath == second)).Status);
+        }
+        finally
+        {
+            library.Delete(recursive: true);
+            backups.Delete(recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public void RealOps_DeleteRemovesOnlyTheSymlinkAndPreservesItsTarget()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Creating symlinks may require Windows developer mode.");
+        var root = Directory.CreateTempSubdirectory("altmig-real-delete-");
+        var target = Path.Combine(root.FullName, "target.mkv");
+        var link = Path.Combine(root.FullName, "link.mkv");
+        File.WriteAllText(target, "precious content");
+        File.CreateSymbolicLink(link, target);
+
+        try
+        {
+            RealSymlinkOps.Instance.DeleteSymlink(root.FullName, link, target);
+
+            Assert.False(File.Exists(link));
+            Assert.Equal("precious content", File.ReadAllText(target));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RealOps_DeleteRefusesRealFile()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-real-delete-");
+        var path = Path.Combine(root.FullName, "real.mkv");
+        File.WriteAllText(path, "precious content");
+
+        try
+        {
+            var error = Assert.Throws<IOException>(() =>
+                RealSymlinkOps.Instance.DeleteSymlink(root.FullName, path, "/mnt/altmount/real.mkv"));
+            Assert.Contains("non-symlink", error.Message);
+            Assert.Equal("precious content", File.ReadAllText(path));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public void RealOps_DeleteLeafSwapLeavesReplacementFileUntouched()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Creating symlinks may require Windows developer mode.");
+        var root = Directory.CreateTempSubdirectory("altmig-delete-race-");
+        var link = Path.Combine(root.FullName, "movie.mkv");
+        const string target = "/mnt/altmount/movie.mkv";
+        File.CreateSymbolicLink(link, target);
+
+        try
+        {
+            var ops = new RealSymlinkOps
+            {
+                BeforeFinalLeafValidation = path =>
+                {
+                    File.Delete(path);
+                    File.WriteAllText(path, "replacement content");
+                },
+            };
+
+            var error = Assert.Throws<IOException>(() =>
+                ops.DeleteSymlink(root.FullName, link, target));
+
+            Assert.Contains("no longer the expected symlink", error.Message);
+            Assert.Equal("replacement content", File.ReadAllText(link));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RealOps_DeleteRejectsPathOutsideLibraryRoot()
+    {
+        var root = Directory.CreateTempSubdirectory("altmig-delete-root-");
+        var outside = Path.Combine(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}.mkv");
+        try
+        {
+            var error = Assert.Throws<IOException>(() =>
+                RealSymlinkOps.Instance.DeleteSymlink(root.FullName, outside, "/mnt/altmount/movie.mkv"));
+            Assert.Contains("outside the configured Library Root", error.Message);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    private static async Task ConfigureSessionAsync(
+        MigrationTestHarness h,
+        string libraryRoot,
+        string backupDir) =>
+        await h.Store.UpdateSessionAsync(s =>
+        {
+            s.Status = "removing_orphans";
+            s.SymlinkLibraryRoot = libraryRoot;
+            s.SymlinkBackupDir = backupDir;
+        });
+
+    private static async Task SeedPlanAsync(MigrationTestHarness h, params MigrationSymlinkRewrite[] rows)
+    {
+        await using var ctx = h.Mig();
+        ctx.SymlinkRewrites.AddRange(rows);
+        await ctx.SaveChangesAsync();
+    }
+
+    private static MigrationSymlinkRewrite Row(string path, string target, string status) => new()
+    {
+        SymlinkPath = path,
+        OldTarget = target,
+        Status = status,
+        UpdatedAt = DateTime.UtcNow,
+    };
+}

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRestoreServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRestoreServiceTests.cs
@@ -20,6 +20,14 @@ public class SymlinkRestoreServiceTests
             Links[path] = newTarget;
         }
 
+        public void DeleteSymlink(string libraryRoot, string path, string expectedTarget)
+        {
+            if (!Links.TryGetValue(path, out var current)
+                || !string.Equals(current, expectedTarget, StringComparison.Ordinal))
+                throw new IOException($"Refusing to delete '{path}' because its symlink target changed during removal.");
+            Links.Remove(path);
+        }
+
         public void CreateSymlink(string libraryRoot, string path, string target)
         {
             if (Links.ContainsKey(path))
@@ -207,8 +215,131 @@ public class SymlinkRestoreServiceTests
         Directory.Delete(root, recursive: true);
     }
 
+    [Fact]
+    public async Task Restore_OrphanRemovalArchiveRecreatesMissingLinkAndRestoresPlanStatus()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var root = Directory.CreateTempSubdirectory("altmig-library-");
+        var backupDir = Directory.CreateTempSubdirectory("altmig-backups-");
+        var link = Path.Combine(root.FullName, "orphan.mkv");
+        const string target = "/mnt/altmount/orphan.mkv";
+        var archiveName = "altmount-orphan-symlink-backup-20260720-120005.tar.gz";
+        try
+        {
+            await h.Store.UpdateSessionAsync(s =>
+            {
+                s.Status = "linked";
+                s.SymlinkLibraryRoot = root.FullName;
+                s.SymlinkBackupDir = backupDir.FullName;
+            });
+            await using (var migration = h.Mig())
+            {
+                migration.SymlinkRewrites.Add(new MigrationSymlinkRewrite
+                {
+                    SymlinkPath = link,
+                    OldTarget = target,
+                    Status = "removed",
+                    UpdatedAt = DateTime.UtcNow,
+                });
+                await migration.SaveChangesAsync();
+            }
+            await SymlinkBackup.WriteAsync(
+                Path.Combine(backupDir.FullName, archiveName),
+                [new SymlinkBackup.Entry(
+                    link,
+                    target,
+                    Operation: SymlinkBackup.OrphanRemovalOperation)]);
+            var ops = new FakeSymlinkOps();
+
+            var result = await new SymlinkRestoreService(h.Store) { Ops = ops }
+                .RestoreAsync(archiveName);
+
+            Assert.Equal(1, result.Restored);
+            Assert.Equal(1, result.OrphansRestored);
+            Assert.Equal(0, result.Requeued);
+            Assert.Equal(target, ops.Links[link]);
+            await using var verify = h.Mig();
+            var row = await verify.SymlinkRewrites.SingleAsync();
+            Assert.Equal("orphan", row.Status);
+            Assert.Null(row.NewTarget);
+        }
+        finally
+        {
+            backupDir.Delete(recursive: true);
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task List_LabelsRewriteAndOrphanRemovalArchives()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var backupDir = Directory.CreateTempSubdirectory("altmig-backups-");
+        try
+        {
+            await h.Store.UpdateSessionAsync(s => s.SymlinkBackupDir = backupDir.FullName);
+            await SymlinkBackup.WriteAsync(
+                Path.Combine(backupDir.FullName, "altmount-symlink-backup-20260720-120006.tar.gz"),
+                [new SymlinkBackup.Entry("/lib/rewrite.mkv", "/alt/rewrite.mkv", "/nzbdav/rewrite.mkv")]);
+            await SymlinkBackup.WriteAsync(
+                Path.Combine(backupDir.FullName, "altmount-orphan-symlink-backup-20260720-120007.tar.gz"),
+                [new SymlinkBackup.Entry(
+                    "/lib/orphan.mkv",
+                    "/alt/orphan.mkv",
+                    Operation: SymlinkBackup.OrphanRemovalOperation)]);
+
+            var backups = await new SymlinkRestoreService(h.Store).ListAsync();
+
+            Assert.Equal("rewrite", backups.Single(b => b.FileName.Contains("120006")).Kind);
+            var orphan = backups.Single(b => b.FileName.Contains("120007"));
+            Assert.Equal("orphan-removal", orphan.Kind);
+            Assert.Equal(0, orphan.LegacyEntryCount);
+        }
+        finally
+        {
+            backupDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task List_InvalidArchiveErrorNamesTheArchive()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var backupDir = Directory.CreateTempSubdirectory("altmig-backups-");
+        const string archiveName = "altmount-symlink-backup-20260720-120009.tar.gz";
+        try
+        {
+            await h.Store.UpdateSessionAsync(s => s.SymlinkBackupDir = backupDir.FullName);
+            await SymlinkBackup.WriteAsync(
+                Path.Combine(backupDir.FullName, archiveName),
+                [new SymlinkBackup.Entry(
+                    "/lib/orphan.mkv",
+                    "/alt/orphan.mkv",
+                    Operation: SymlinkBackup.OrphanRemovalOperation)]);
+
+            var backup = Assert.Single(await new SymlinkRestoreService(h.Store).ListAsync());
+
+            Assert.False(backup.IsValid);
+            Assert.Contains(archiveName, backup.Error);
+        }
+        finally
+        {
+            backupDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveArchivePath_AcceptsOrphanRemovalArchive()
+    {
+        const string name = "altmount-orphan-symlink-backup-20260720-120008.tar.gz";
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), name)),
+            SymlinkRestoreService.ResolveArchivePath(Path.GetTempPath(), name));
+    }
+
     [Theory]
     [InlineData("../altmount-symlink-backup-20260720.tar.gz")]
+    [InlineData("../altmount-orphan-symlink-backup-20260720.tar.gz")]
     [InlineData("other.tar.gz")]
     [InlineData("")]
     public void ResolveArchivePath_RejectsUntrustedNames(string fileName)

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRewriterTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRewriterTests.cs
@@ -28,6 +28,14 @@ public class SymlinkRewriterTests
             Links[path] = newTarget;
         }
 
+        public void DeleteSymlink(string libraryRoot, string path, string expectedTarget)
+        {
+            if (!Links.TryGetValue(path, out var current)
+                || !string.Equals(current, expectedTarget, StringComparison.Ordinal))
+                throw new IOException($"Refusing to delete '{path}' because its symlink target changed during removal.");
+            Links.Remove(path);
+        }
+
         public void CreateSymlink(string libraryRoot, string path, string target)
         {
             if (Links.ContainsKey(path))

--- a/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationControllerAuthTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationControllerAuthTests.cs
@@ -15,6 +15,7 @@ using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Tests.Database;
 using NzbWebDAV.UsenetMigration;
 using NzbWebDAV.UsenetMigration.Runner;
+using NzbWebDAV.UsenetMigration.Source;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.UsenetMigration;
@@ -22,6 +23,186 @@ namespace NzbWebDAV.Tests.UsenetMigration;
 [Collection(nameof(ConfigPathCollection))]
 public sealed class UsenetMigrationControllerAuthTests
 {
+    [Fact]
+    public async Task DetectPaths_RequiresBodyButAllowsExplicitDefaultRoot()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        using var queueManager = CreateQueueManager();
+        var runner = new UsenetMigrationRunner(
+            h.Store, queueManager, new ConfigManager(), new WebsocketManager());
+
+        const string apiKey = "migration-detect-contract-key";
+        var previousApiKey = Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", apiKey);
+        try
+        {
+            var config = new ConfigManager();
+            using var services = new ServiceCollection()
+                .AddSingleton(config)
+                .AddSingleton(h.Store)
+                .BuildServiceProvider();
+            var httpContext = new DefaultHttpContext { RequestServices = services };
+            httpContext.Request.Headers["x-api-key"] = apiKey;
+            var controller = new UsenetMigrationController(h.Store, runner)
+            {
+                ControllerContext = new ControllerContext { HttpContext = httpContext },
+            };
+
+            var missingBody = await controller.DetectPaths(null!);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(missingBody);
+            var error = Assert.IsType<BaseApiResponse>(badRequest.Value);
+            Assert.Equal("Request body is required.", error.Error);
+
+            var explicitDefault = await controller.DetectPaths(new DetectPathsRequest(null));
+
+            var ok = Assert.IsType<OkObjectResult>(explicitDefault);
+            var json = JsonSerializer.Serialize(
+                ok.Value,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            using var document = JsonDocument.Parse(json);
+            Assert.Equal(
+                new[] { "status", "detected", "root", "metadataRoot", "configPath", "storeRoot", "reason" },
+                document.RootElement.EnumerateObject().Select(property => property.Name));
+            var expectedRoot = Path.TrimEndingDirectorySeparator(
+                Path.GetFullPath(AltmountPathDetector.DefaultRoot));
+            Assert.Equal(expectedRoot, document.RootElement.GetProperty("root").GetString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", previousApiKey);
+        }
+    }
+
+    [Fact]
+    public async Task Connect_SeedsCategoriesFromDumbStyleConfig()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var root = Directory.CreateTempSubdirectory("altmig-connect-");
+        try
+        {
+            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            var configPath = Path.Combine(root.FullName, "config.yaml");
+            await File.WriteAllTextAsync(configPath, string.Join('\n',
+            [
+                "sabnzbd:",
+                "  complete_dir: '/'",
+                "  categories:",
+                "  - name: 'movies'",
+                "    dir: 'movies'",
+                "    type: 'radarr'",
+                "  - name: 'tv'",
+                "    dir: 'tv'",
+                "    type: 'sonarr'",
+            ]));
+
+            await WithAuthorizedControllerAsync(h, async controller =>
+            {
+                var result = await controller.Connect(new ConnectRequest(
+                    metadataRoot.FullName, configPath, root.FullName, 20, 1));
+
+                Assert.IsType<OkObjectResult>(result);
+            });
+
+            var categories = await h.Store.GetCategoryMapAsync();
+            Assert.Equal(new[] { "movies", "tv" },
+                categories.Select(category => category.AltmountCategory));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Connect_RejectsSuppliedConfigWithoutCategories()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var root = Directory.CreateTempSubdirectory("altmig-connect-");
+        try
+        {
+            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            var configPath = Path.Combine(root.FullName, "config.yaml");
+            await File.WriteAllTextAsync(configPath, "sabnzbd:\n  categories:\n");
+
+            await WithAuthorizedControllerAsync(h, async controller =>
+            {
+                var result = await controller.Connect(new ConnectRequest(
+                    metadataRoot.FullName, configPath, root.FullName, 20, 1));
+
+                var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+                var response = Assert.IsType<BaseApiResponse>(badRequest.Value);
+                Assert.Equal(AltmountPathDetector.NoCategoriesReason, response.Error);
+            });
+
+            var session = await h.Store.GetSessionAsync();
+            Assert.Equal("idle", session.Status);
+            Assert.Empty(await h.Store.GetCategoryMapAsync());
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Connect_RejectsUnsupportedConfigWithoutEchoingPath()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var root = Directory.CreateTempSubdirectory("altmig-connect-");
+        try
+        {
+            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            var configPath = Path.Combine(root.FullName, "config.yaml");
+            await File.WriteAllTextAsync(
+                configPath,
+                "sabnzbd:\n  categories: [{ name: 'movies' }]\n");
+
+            await WithAuthorizedControllerAsync(h, async controller =>
+            {
+                var result = await controller.Connect(new ConnectRequest(
+                    metadataRoot.FullName, configPath, root.FullName, 20, 1));
+
+                var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+                var response = Assert.IsType<BaseApiResponse>(badRequest.Value);
+                Assert.Equal(AltmountPathDetector.InvalidConfigReason, response.Error);
+                Assert.DoesNotContain(root.FullName, response.Error);
+            });
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Connect_AllowsAdvancedConnectionWithoutConfigPath()
+    {
+        await using var h = await MigrationTestHarness.CreateAsync();
+        var root = Directory.CreateTempSubdirectory("altmig-connect-");
+        try
+        {
+            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+
+            await WithAuthorizedControllerAsync(h, async controller =>
+            {
+                var result = await controller.Connect(new ConnectRequest(
+                    metadataRoot.FullName, null, root.FullName, 20, 1));
+
+                Assert.IsType<OkObjectResult>(result);
+            });
+
+            var session = await h.Store.GetSessionAsync();
+            Assert.Equal("connected", session.Status);
+            Assert.Null(session.AltmountConfigPath);
+            Assert.Empty(await h.Store.GetCategoryMapAsync());
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
     [Fact]
     public async Task EveryHttpAction_RejectsMissingApiKeyWith401()
     {
@@ -144,6 +325,38 @@ public sealed class UsenetMigrationControllerAuthTests
         }
 
         throw new InvalidOperationException("Could not locate the repository root from the test output directory.");
+    }
+
+    private static async Task WithAuthorizedControllerAsync(
+        MigrationTestHarness harness,
+        Func<UsenetMigrationController, Task> test)
+    {
+        const string apiKey = "migration-connect-contract-key";
+        var previousApiKey = Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", apiKey);
+        try
+        {
+            using var queueManager = CreateQueueManager();
+            var config = new ConfigManager();
+            var runner = new UsenetMigrationRunner(
+                harness.Store, queueManager, config, new WebsocketManager());
+            using var services = new ServiceCollection()
+                .AddSingleton(config)
+                .AddSingleton(harness.Store)
+                .BuildServiceProvider();
+            var httpContext = new DefaultHttpContext { RequestServices = services };
+            httpContext.Request.Headers["x-api-key"] = apiKey;
+            var controller = new UsenetMigrationController(harness.Store, runner)
+            {
+                ControllerContext = new ControllerContext { HttpContext = httpContext },
+            };
+
+            await test(controller);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", previousApiKey);
+        }
     }
 
     private static QueueManager CreateQueueManager()


### PR DESCRIPTION
## Summary

This PR improves both the beginning and the final cleanup stage of the Altmount migration wizard.

- Simplifies Step 1 with automatic path detection for standard and custom Altmount mounts.
- Adds an optional Step 6 action for safely removing and restoring orphaned Altmount symlinks.

## Simplified Altmount connection

Step 1 now defaults to a Basic mode that automatically derives and validates:

- Altmount metadata root
- `config.yaml` path
- Altmount store root

The recommended `/altmount` layout is detected automatically. Users with a custom mount location can provide its root directory in a single field.

Advanced mode preserves the existing three-field configuration for nonstandard layouts.

The connection flow also:

- Confirms that `config.yaml` can be opened and parsed.
- Verifies that categories are present before continuing.
- Supports category YAML generated by DUMB-managed Altmount installations.
- Restricts path probing to safe container paths and avoids exposing resolved filesystem paths in errors.

## Optional orphaned-link cleanup

Step 6 now offers a separately confirmed action to remove symlinks classified as `orphan`.

Before removing anything, NzbDAV:

- Revalidates the active migration state and each link’s recorded target.
- Writes and verifies a dedicated orphan-removal backup archive.
- Confines changes to the configured library root.
- Refuses to modify real files, directories, unreadable links, changed links, or symlink targets.
- Records completed removals so interrupted operations can be retried safely.

Orphan-removal archives appear in the existing Restore Symlinks interface. Restoration recreates only absent links and never overwrites a real file, directory, or differently targeted symlink.

The confirmation dialog and documentation explain that Sonarr and Radarr will not automatically search for replacements. Users are instructed to run Refresh & Scan afterward so removed paths are detected and marked as missing before re-grabs begin.

## Compatibility

- Advanced Step 1 behavior remains available.
- Existing rewrite backup archives remain supported.
- No database migration is introduced.
- Orphan cleanup is entirely optional.

## Documentation improvements

The Altmount migration guide has been expanded to reflect the updated wizard and provide a safer end-to-end workflow.

- Documents Basic mode path detection, custom mount roots, Advanced mode, and DUMB-generated category YAML compatibility.
- Strongly recommends dedicated migration-only NzbDAV categories instead of categories monitored by Sonarr or Radarr.
- Explains how isolated categories prevent Arr interference and create a safe rollback boundary under `/content/<migration-category>`.
- Documents the confirmation, backup, cancellation, restoration, and Arr Refresh & Scan requirements for orphaned-link cleanup.
- Corrects the read-write media-library mount requirements for Apply, orphan removal, and restore.
- Adds a complete migration reversal procedure covering restoration of rewritten and removed symlinks, playback verification, safely deleting isolated migration content, refreshing applications, and removing migration bookkeeping last.
- Includes explicit warnings against deleting `/content` or bulk-deleting categories containing unrelated NzbDAV releases.

## Validation

- Frontend typecheck passed.
- Frontend build passed.
- All 403 frontend tests passed.
- Frontend lint completed with no errors.
- 445 focused migration backend tests passed; 2 Windows symlink tests were platform-skipped.
- Full backend run passed 2,135 tests; the remaining 22 failures are pre-existing Windows-specific path, symlink-privilege, and SQLite cleanup issues.
- A DUMB-hosted test installation successfully completed automatic connection and category discovery.