### PR TITLE
feat(auth): sign in with OIDC and mapped access roles

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -16,7 +16,7 @@ For **authoritative headless** configuration of those same Settings keys via `NZ
 -   **Playback & automation** — [Watchdog](watchdog.md) · [Preflight](preflight.md) · [Watchtower](watchtower.md) · [Warden](warden.md)
 -   **Integrations** — [SABnzbd](sabnzbd.md) · [WebDAV](webdav.md) · [Radarr/Sonarr](arrs.md) · [Rclone](rclone.md)
 -   **System** — [Repairs](repairs.md) · [Maintenance](maintenance.md) · [Backup](backup.md) · [Support](support.md)
--   **Headless / ops** — [Headless ENV config](headless.md) · [Environment variables](environment-variables.md)
+-   **Headless / ops** — [OIDC / SSO](oidc.md) · [Headless ENV config](headless.md) · [Environment variables](environment-variables.md)
 
 </div>
 

--- a/docs/configuration/oidc.md
+++ b/docs/configuration/oidc.md
@@ -1,0 +1,153 @@
+# OIDC / SSO [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+NzbDAV can authenticate browser sessions with any standards-compliant OpenID
+Connect (OIDC) provider, including Authentik, Authelia, and Keycloak. OIDC is
+disabled by default and does not change WebDAV Basic authentication or API-key
+authentication.
+
+OIDC users are not written to the NzbDAV database. A successful identity
+provider login creates the same signed frontend session used by local login,
+using a configured ID-token claim as the displayed username.
+
+## Enable OIDC
+
+Register NzbDAV as a confidential OIDC client in your identity provider, then
+set these variables on the NzbDAV container:
+
+```yaml
+environment:
+  OIDC_ISSUER: https://auth.example.com/application/o/nzbdav/
+  OIDC_CLIENT_ID: nzbdav
+  OIDC_CLIENT_SECRET: replace-with-your-client-secret
+  OIDC_REDIRECT_URI: https://nzbdav.example.com/auth/oidc/callback
+```
+
+Restart NzbDAV after changing OIDC variables. The login page will show both
+local credentials and **Sign in with SSO**.
+
+`OIDC_ISSUER`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` must all be set.
+Missing any required value leaves OIDC disabled so local login remains
+available.
+
+!!! tip "Set the redirect URI explicitly"
+
+    `OIDC_REDIRECT_URI` falls back to the configured SABnzbd **Base URL**, then
+    to the incoming request origin. An explicit public HTTPS URL avoids
+    reverse-proxy host or scheme mismatches. Register the exact same URI in the
+    identity provider.
+
+## Environment variable reference
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `OIDC_ISSUER` | Yes | — | OIDC issuer identifier. NzbDAV discovers provider metadata from this issuer. |
+| `OIDC_CLIENT_ID` | Yes | — | Confidential client identifier registered with the provider. |
+| `OIDC_CLIENT_SECRET` | Yes | — | Confidential client secret. Keep it out of logs and source control. |
+| `OIDC_REDIRECT_URI` | Recommended | `general.base-url`, then incoming request origin, plus `/auth/oidc/callback` | Public callback URI registered with the provider. |
+| `OIDC_SCOPES` | No | `openid profile email` | Space-separated scopes requested during login. Must include `openid`. |
+| `OIDC_USERNAME_CLAIM` | No | `preferred_username` | ID-token claim used as the displayed username. NzbDAV falls back to `preferred_username`, `email`, then `sub`. |
+| `OIDC_ADMIN_CLAIM` | No | — | Claim inspected to decide whether the session is admin or read-only. If omitted, all OIDC users are admins. |
+| `OIDC_ADMIN_CLAIM_VALUE` | With `OIDC_ADMIN_CLAIM` | — | Exact string or array member that grants the admin role. If the claim is configured without a value, all OIDC users are read-only. |
+
+These are frontend process variables, not `NZBDAV_CONFIG__...` settings. They
+are read when the frontend starts and are not stored in SQLite or displayed in
+the Settings UI.
+
+## Map admin and read-only roles
+
+To grant admin access only to members of an identity-provider group:
+
+```yaml
+environment:
+  OIDC_ADMIN_CLAIM: groups
+  OIDC_ADMIN_CLAIM_VALUE: nzbdav-admins
+```
+
+NzbDAV accepts either a string claim or an array claim. A matching value grants
+`admin`; every other authenticated OIDC user receives `readonly`.
+
+!!! warning "Read-only is a UI role"
+
+    In 0.10.0, read-only sessions can view the dashboard and settings but
+    mutation controls are disabled or hidden. This is not backend API
+    authorization: the frontend still uses its shared backend API key for
+    authenticated sessions. Restrict access at the identity provider and do
+    not treat the read-only role as a security boundary.
+
+Local username/password sessions remain admins. OIDC role mapping does not
+change WebDAV credentials, SABnzbd API keys, or other machine-client access.
+
+## Identity provider setup
+
+### Authentik
+
+1. Create an OAuth2/OpenID Provider and a linked application.
+2. Use a confidential client and the Authorization Code flow.
+3. Add the exact NzbDAV callback URI as a strict redirect URI.
+4. Include `openid`, `profile`, and `email` scopes.
+5. To map roles, expose group membership in the ID token and configure
+   `OIDC_ADMIN_CLAIM=groups`.
+6. Use the provider's issuer URL for `OIDC_ISSUER`; do not use only its
+   authorization endpoint.
+
+### Authelia
+
+1. Add NzbDAV under `identity_providers.oidc.clients` as a confidential client.
+2. Register the exact callback URI and enable the Authorization Code flow.
+3. Allow the `openid`, `profile`, and `email` scopes.
+4. Configure the groups claim when using group-based role mapping.
+5. Set `OIDC_ISSUER` to Authelia's published issuer URL.
+
+### Keycloak
+
+1. Create a client with OpenID Connect, client authentication enabled, and the
+   Standard Flow enabled.
+2. Add the exact callback URI to **Valid redirect URIs**.
+3. Copy the client secret from the client's credentials.
+4. Add a group-membership or role mapper to the ID token when using role
+   mapping. Set its token claim name to the value used by
+   `OIDC_ADMIN_CLAIM`.
+5. Use the realm issuer URL, such as
+   `https://keycloak.example.com/realms/media`.
+
+## First run and local login
+
+When OIDC is enabled, NzbDAV skips local-account onboarding. The first
+successful OIDC login creates a session directly without creating an
+`Accounts` row. Local login remains visible and works if a local admin account
+already exists.
+
+Application logout clears the NzbDAV session only. It does not currently end
+the identity-provider session, so selecting SSO again may sign in immediately.
+
+## Troubleshooting
+
+### The SSO button is missing
+
+Confirm all three required variables are non-empty and restart the container.
+The logs identify missing variable names without printing their values.
+
+### Redirect URI mismatch
+
+The callback URI is case-sensitive and must match exactly in NzbDAV and the
+identity provider, including scheme, host, port, path, and any trailing slash.
+Prefer setting `OIDC_REDIRECT_URI` explicitly when NzbDAV is behind a reverse
+proxy.
+
+### SSO returns to the login page
+
+Check the frontend logs for the single-line `OIDC sign-in failed` warning.
+Common causes are an incorrect issuer or client secret, an expired login flow,
+or an identity provider that did not return ID-token claims.
+
+### The wrong username is displayed
+
+Set `OIDC_USERNAME_CLAIM` to a string-valued ID-token claim exposed by the
+provider. If that claim is absent or empty, NzbDAV tries
+`preferred_username`, `email`, and `sub` in that order.
+
+### Every user is read-only
+
+Verify that both `OIDC_ADMIN_CLAIM` and `OIDC_ADMIN_CLAIM_VALUE` are set, and
+that the selected claim is included in the ID token. Claim names and values are
+case-sensitive.

--- a/frontend/app/auth/auth-middleware.server.test.ts
+++ b/frontend/app/auth/auth-middleware.server.test.ts
@@ -30,6 +30,8 @@ describe("authMiddleware", () => {
     "/login.data",
     "/onboarding",
     "/onboarding.data",
+    "/auth/oidc/login",
+    "/auth/oidc/callback",
     "/__manifest",
   ])("allows public path %s without auth", async (path) => {
     const next = vi.fn();

--- a/frontend/app/auth/auth-middleware.server.ts
+++ b/frontend/app/auth/auth-middleware.server.ts
@@ -9,6 +9,8 @@ const PUBLIC_PATHS = [
   "/login.data",
   "/onboarding",
   "/onboarding.data",
+  "/auth/oidc/login",
+  "/auth/oidc/callback",
 ];
 
 export async function authMiddleware(

--- a/frontend/app/auth/authentication.server.test.ts
+++ b/frontend/app/auth/authentication.server.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionResponseInit } from "./authentication.server";
 
 const { authenticateMock } = vi.hoisted(() => ({
   authenticateMock: vi.fn(),
@@ -30,7 +31,7 @@ function formRequest(username?: string, password?: string): Request {
   return new Request("http://localhost/login", { method: "POST", body });
 }
 
-function getSetCookie(responseInit: ResponseInit): string {
+function getSetCookie(responseInit: SessionResponseInit): string {
   const cookie = new Headers(responseInit.headers).get("Set-Cookie");
   if (!cookie) throw new Error("Expected a Set-Cookie header");
   return cookie;
@@ -56,6 +57,7 @@ describe("authentication sessions", () => {
     await expect(authentication.isAuthenticated(authenticatedRequest)).resolves.toBe(true);
     await expect(authentication.getSessionUser(authenticatedRequest)).resolves.toEqual({
       username: "alice",
+      role: "admin",
     });
   });
 
@@ -93,6 +95,43 @@ describe("authentication sessions", () => {
     await expect(authentication.isAuthenticated(new Request("http://localhost/", {
       headers: { Cookie: loggedOutCookie },
     }))).resolves.toBe(false);
+  });
+
+  it("stores OIDC users and clears the temporary flow state", async () => {
+    const flowResult = await authentication.setOidcFlowState(
+      new Request("http://localhost/auth/oidc/login"),
+      {
+        codeVerifier: "verifier",
+        nonce: "nonce",
+        redirectUri: "https://nzbdav.example.com/auth/oidc/callback",
+        state: "state",
+      },
+    );
+    const flowRequest = new Request("http://localhost/auth/oidc/callback", {
+      headers: { Cookie: getSetCookie(flowResult) },
+    });
+
+    await expect(authentication.getOidcFlowState(flowRequest)).resolves.toEqual({
+      codeVerifier: "verifier",
+      nonce: "nonce",
+      redirectUri: "https://nzbdav.example.com/auth/oidc/callback",
+      state: "state",
+    });
+
+    const loginResult = await authentication.setSessionUser(
+      flowRequest,
+      "reader",
+      "readonly",
+    );
+    const authenticatedRequest = new Request("http://localhost/", {
+      headers: { Cookie: getSetCookie(loginResult) },
+    });
+
+    await expect(authentication.getSessionUser(authenticatedRequest)).resolves.toEqual({
+      username: "reader",
+      role: "readonly",
+    });
+    await expect(authentication.getOidcFlowState(authenticatedRequest)).resolves.toBeNull();
   });
 
   it("accepts authentication cookies on Request objects", async () => {

--- a/frontend/app/auth/authentication.server.ts
+++ b/frontend/app/auth/authentication.server.ts
@@ -7,8 +7,24 @@ import type { IncomingMessage } from "http";
 
 export const IS_FRONTEND_AUTH_DISABLED = process.env.DISABLE_FRONTEND_AUTH === 'true';
 
+export type UserRole = "admin" | "readonly";
+
 export type User = {
   username: string;
+  role: UserRole;
+};
+
+export type OidcFlowState = {
+  codeVerifier: string;
+  nonce: string;
+  redirectUri: string;
+  state: string;
+};
+
+export type SessionResponseInit = {
+  headers: {
+    "Set-Cookie": string;
+  };
 };
 
 const oneYear = 60 * 60 * 24 * 365; // seconds
@@ -52,6 +68,8 @@ function resolveSessionKey(): string {
 
 const sessionKey = resolveSessionKey();
 const sessionMaxAge = resolveSessionMaxAgeSeconds();
+const oidcConfigured = ["OIDC_ISSUER", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET"]
+  .every((name) => Boolean(process.env[name]?.trim()));
 const secureCookiesExplicit = process.env.SECURE_COOKIES !== undefined && process.env.SECURE_COOKIES !== "";
 if (!secureCookiesExplicit && !IS_FRONTEND_AUTH_DISABLED) {
   console.warn(
@@ -64,7 +82,8 @@ const sessionStorage = createCookieSessionStorage({
     name: "__session",
     httpOnly: true,
     path: "/",
-    sameSite: "strict",
+    // OIDC callbacks are top-level cross-site navigations, which require Lax.
+    sameSite: oidcConfigured ? "lax" : "strict",
     secrets: [sessionKey],
     secure: ["true", "yes"].includes(process?.env?.SECURE_COOKIES || ""),
     maxAge: sessionMaxAge,
@@ -82,33 +101,70 @@ export async function isAuthenticated(request: Request | IncomingMessage): Promi
 export async function getSessionUser(request: Request | IncomingMessage): Promise<User | null> {
   if (IS_FRONTEND_AUTH_DISABLED) return null;
 
-  const cookieHeader = request instanceof Request
-    ? request.headers.get("cookie")
-    : request.headers.cookie;
+  const cookieHeader = getCookieHeader(request);
   if (!cookieHeader) return null;
 
   const session = await sessionStorage.getSession(cookieHeader);
   const user = session.get("user") as User | undefined;
   if (!user?.username) return null;
-  return { username: user.username };
+  return {
+    username: user.username,
+    role: user.role === "readonly" ? "readonly" : "admin",
+  };
 }
 
-export async function login(request: Request): Promise<ResponseInit> {
-  let user = await authenticate(request);
-  let session = await sessionStorage.getSession(request.headers.get("cookie"));
+export async function login(request: Request): Promise<SessionResponseInit> {
+  const user = await authenticate(request);
+  const session = await sessionStorage.getSession(request.headers.get("cookie"));
   session.set("user", user);
   return { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } };
 }
 
-export async function logout(request: Request): Promise<ResponseInit> {
-  let session = await sessionStorage.getSession(request.headers.get("cookie"));
+export async function logout(request: Request | IncomingMessage): Promise<SessionResponseInit> {
+  const session = await sessionStorage.getSession(getCookieHeader(request));
   session.unset("user");
   return { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } };
 }
 
-export async function setSessionUser(request: Request, username: string): Promise<ResponseInit> {
-  let session = await sessionStorage.getSession(request.headers.get("cookie"));
-  session.set("user", { username: username })
+export async function setSessionUser(
+  request: Request | IncomingMessage,
+  username: string,
+  role: UserRole = "admin",
+): Promise<SessionResponseInit> {
+  const session = await sessionStorage.getSession(getCookieHeader(request));
+  session.set("user", { username, role });
+  session.unset("oidcFlow");
+  return { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } };
+}
+
+export async function setOidcFlowState(
+  request: Request | IncomingMessage,
+  oidcFlow: OidcFlowState,
+): Promise<SessionResponseInit> {
+  const session = await sessionStorage.getSession(getCookieHeader(request));
+  session.set("oidcFlow", oidcFlow);
+  return { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } };
+}
+
+export async function getOidcFlowState(
+  request: Request | IncomingMessage,
+): Promise<OidcFlowState | null> {
+  const session = await sessionStorage.getSession(getCookieHeader(request));
+  const oidcFlow = session.get("oidcFlow") as OidcFlowState | undefined;
+  if (
+    !oidcFlow?.codeVerifier
+    || !oidcFlow.nonce
+    || !oidcFlow.redirectUri
+    || !oidcFlow.state
+  ) return null;
+  return oidcFlow;
+}
+
+export async function clearOidcFlowState(
+  request: Request | IncomingMessage,
+): Promise<SessionResponseInit> {
+  const session = await sessionStorage.getSession(getCookieHeader(request));
+  session.unset("oidcFlow");
   return { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } };
 }
 
@@ -117,6 +173,14 @@ async function authenticate(request: Request): Promise<User> {
   const username = formData.get("username")?.toString();
   const password = formData.get("password")?.toString();
   if (!username || !password) throw new Error("username and password required");
-  if (await backendClient.authenticate(username, password)) return { username: username };
+  if (await backendClient.authenticate(username, password)) {
+    return { username, role: "admin" };
+  }
   throw new Error("Invalid credentials");
+}
+
+function getCookieHeader(request: Request | IncomingMessage): string | null | undefined {
+  return request instanceof Request
+    ? request.headers.get("cookie")
+    : request.headers.cookie;
 }

--- a/frontend/app/auth/authorization.ts
+++ b/frontend/app/auth/authorization.ts
@@ -1,0 +1,11 @@
+import { useOutletContext } from "react-router";
+import type { UserRole } from "./authentication.server";
+
+export type AppOutletContext = {
+  role: UserRole | null;
+  isOidcEnabled: boolean;
+};
+
+export function useIsReadOnly(): boolean {
+  return useOutletContext<AppOutletContext>().role === "readonly";
+}

--- a/frontend/app/components/stream-tracing-banner.tsx
+++ b/frontend/app/components/stream-tracing-banner.tsx
@@ -21,7 +21,7 @@ function formatRemaining(expiresAtUnixMs: number, nowMs: number): string {
     return `${totalMinutes}m left`;
 }
 
-export function StreamTracingBanner() {
+export function StreamTracingBanner({ isReadOnly = false }: { isReadOnly?: boolean }) {
     const [status, setStatus] = useState<StreamTracingStatus | null>(null);
     const [now, setNow] = useState(() => Date.now());
     const [busy, setBusy] = useState(false);
@@ -79,7 +79,7 @@ export function StreamTracingBanner() {
                     Tracing uses RAM only and resets on restart.
                 </span>
             </div>
-            <Button
+            {!isReadOnly && <Button
                 variant="ghost"
                 size="small"
                 className="shrink-0 text-warning-content hover:bg-warning-content/10"
@@ -87,7 +87,7 @@ export function StreamTracingBanner() {
                 onClick={() => void turnOff()}
             >
                 Turn off
-            </Button>
+            </Button>}
         </Alert>
     );
 }

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -23,6 +23,7 @@ import { checkForUpdate } from "./utils/update-check.server";
 import { backendClient } from "./clients/backend-client.server";
 import { MigrationBoundary } from "./components/migration-progress";
 import { StreamTracingBanner } from "./components/stream-tracing-banner";
+import { isOidcEnabled } from "../server/oidc.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   // Single-fetch navigation/revalidation uses internal `.data` URLs
@@ -46,6 +47,8 @@ export async function loader({ request }: Route.LoaderArgs) {
     updateAvailable: await checkForUpdate(version),
     isFrontendAuthDisabled: IS_FRONTEND_AUTH_DISABLED,
     username: sessionUser?.username ?? null,
+    role: sessionUser?.role ?? null,
+    isOidcEnabled: isOidcEnabled(),
     hasUsenetProviders: hasConfiguredUsenetProviders(
       config.find(item => item.configName === "usenet.providers")?.configValue
     ),
@@ -125,6 +128,8 @@ export default function App({ loaderData }: Route.ComponentProps) {
     updateAvailable,
     isFrontendAuthDisabled,
     username,
+    role,
+    isOidcEnabled,
     hasUsenetProviders,
     isWatchdogEnabled,
   } = loaderData;
@@ -139,6 +144,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
   const showLoading = isNavigating && !(isCurrentExplorePage && isNextExplorePage);
   const hideShell =
     location.pathname === "/login" || location.pathname === "/onboarding";
+  const outlet = <Outlet context={{ role, isOidcEnabled }} />;
 
   if (useLayout && !hideShell) {
     return (
@@ -156,9 +162,9 @@ export default function App({ loaderData }: Route.ComponentProps) {
         bodyChild={showLoading ? <Loading /> : (
           <>
             <div className="px-4 pt-4 md:px-8">
-              <StreamTracingBanner />
+              <StreamTracingBanner isReadOnly={role === "readonly"} />
             </div>
-            <Outlet />
+            {outlet}
           </>
         )}
         leftNavChild={
@@ -168,7 +174,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
     );
   }
 
-  return <Outlet />;
+  return outlet;
 }
 
 // Root ErrorBoundary catches loader/component throws that aren't handled closer

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -16,6 +16,7 @@ import { ItemMenu } from "./item-menu/item-menu";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { classNames } from "~/utils/styling";
 import { Icon, Checkbox, Button } from "~/components/ui";
+import { useIsReadOnly } from "~/auth/authorization";
 
 const ITEM_MENU_CLASS =
     "flex select-none items-center self-stretch rounded-r-lg px-5 py-[15px]";
@@ -79,6 +80,7 @@ export default function Explore({ loaderData }: Route.ComponentProps) {
 }
 
 function Body(props: ExplorePageData) {
+    const isReadOnly = useIsReadOnly();
     const location = useLocation();
     const navigation = useNavigation();
     const revalidator = useRevalidator();
@@ -88,7 +90,7 @@ function Body(props: ExplorePageData) {
     const parentDirectories = isNavigating
         ? getParentDirectories(getWebdavPathDecoded(navigation.location!.pathname))
         : props.parentDirectories;
-    const canDelete = isDeletable(parentDirectories);
+    const canDelete = !isReadOnly && isDeletable(parentDirectories);
 
     const [query, setQuery] = useState("");
     const [sortKey, setSortKey] = useState<SortKey>("name");

--- a/frontend/app/routes/login/route.tsx
+++ b/frontend/app/routes/login/route.tsx
@@ -2,26 +2,35 @@ import type { Route } from "./+types/route";
 import { isAuthenticated, login } from "~/auth/authentication.server";
 import { Form, redirect, useNavigation } from "react-router";
 import { backendClient } from "~/clients/backend-client.server";
-import { Alert, Button, Input, Spinner } from "~/components/ui";
+import { Alert, Button, Icon, Input, Spinner } from "~/components/ui";
+import { isOidcEnabled } from "../../../server/oidc.server";
 
 type LoginPageData = {
-    loginError: string
+    loginError: string | null;
+    isOidcEnabled: boolean;
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
     if (await isAuthenticated(request)) return redirect("/");
 
-    const isOnboarding = await backendClient.isOnboarding();
-    if (isOnboarding) return redirect("/onboarding");
+    const oidcEnabled = isOidcEnabled();
+    if (!oidcEnabled) {
+        const isOnboarding = await backendClient.isOnboarding();
+        if (isOnboarding) return redirect("/onboarding");
+    }
 
-    return { loginError: null };
+    const error = new URL(request.url).searchParams.get("error");
+    return {
+        loginError: getOidcErrorMessage(error),
+        isOidcEnabled: oidcEnabled,
+    } satisfies LoginPageData;
 }
 
 export default function Index({ loaderData, actionData }: Route.ComponentProps) {
     const navigation = useNavigation();
     const isLoading = navigation.state == "submitting";
-    const pageData = actionData || loaderData;
-    const showError = !!pageData.loginError;
+    const loginError = actionData?.loginError ?? loaderData.loginError;
+    const showError = !!loginError;
     const submitButtonDisabled = isLoading;
     const submitButtonText = isLoading ? "Logging in..." : "Login";
 
@@ -41,7 +50,7 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                             </div>
                         </div>
 
-                        {showError && <Alert variant="danger">{pageData.loginError}</Alert>}
+                        {showError && <Alert variant="danger">{loginError}</Alert>}
 
                         <fieldset className="fieldset space-y-3">
                             <label className="floating-label">
@@ -77,11 +86,36 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                             {isLoading && <Spinner />}
                             {submitButtonText}
                         </Button>
+
+                        {loaderData.isOidcEnabled && (
+                            <>
+                                <div className="divider my-0 text-xs uppercase text-base-content/50">
+                                    or
+                                </div>
+                                <a
+                                    className="btn btn-outline w-full gap-2"
+                                    href="/auth/oidc/login"
+                                >
+                                    <Icon name="login" className="!text-[18px]" />
+                                    Sign in with SSO
+                                </a>
+                            </>
+                        )}
                     </div>
                 </Form>
             </div>
         </main>
     );
+}
+
+function getOidcErrorMessage(error: string | null): string | null {
+    if (error === "oidc_not_configured") {
+        return "OIDC sign-in is not configured. Use your local account instead.";
+    }
+    if (error === "oidc_failed") {
+        return "SSO sign-in failed. Try again or use your local account.";
+    }
+    return null;
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -11,6 +11,7 @@ import { Pagination } from "../pagination/pagination"
 import { DropdownOptions } from "~/routes/explore/dropdown-options/dropdown-options"
 import { ExportNzb, Remove } from "~/routes/explore/item-menu/item-menu"
 import { canRetryHistorySlot, retryHistoryItem, shouldAcceptRetryClick } from "./history-retry"
+import { useIsReadOnly } from "~/auth/authorization"
 
 export type HistoryTableProps = {
     historySlots: PresentationHistorySlot[],
@@ -41,6 +42,7 @@ export function HistoryTable({
     onIsRemovingChanged,
     onRemoved,
 }: HistoryTableProps) {
+    const isReadOnly = useIsReadOnly();
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
     const selectedCount = historySlots.filter(x => !!x.isSelected).length;
     const headerCheckboxState: TriCheckboxState = selectedCount === 0 ? 'none' : selectedCount === historySlots.length ? 'all' : 'some';
@@ -84,7 +86,7 @@ export function HistoryTable({
     const sectionTitle = (
         <div className="flex items-center gap-2.5">
             <h2 className="text-xl font-semibold text-base-content">History</h2>
-            {headerCheckboxState !== 'none' &&
+            {!isReadOnly && headerCheckboxState !== 'none' &&
                 <ActionButton type="delete" onClick={onRemove} />
             }
         </div>
@@ -110,7 +112,13 @@ export function HistoryTable({
             title={sectionTitle}
             badgeText={totalHistoryCount > 0 ? String(totalHistoryCount) : undefined}
         >
-            <PageTable headerCheckboxState={headerCheckboxState} onHeaderCheckboxChange={onSelectAll} footer={footer} showCompleted>
+            <PageTable
+                headerCheckboxState={headerCheckboxState}
+                onHeaderCheckboxChange={onSelectAll}
+                footer={footer}
+                showCompleted
+                selectable={!isReadOnly}
+            >
                 {historySlots.map(slot =>
                     <HistoryRow
                         key={slot.nzo_id}
@@ -142,6 +150,7 @@ type HistoryRowProps = {
 }
 
 export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onRemoved }: HistoryRowProps) {
+    const isReadOnly = useIsReadOnly();
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
     const [isRetrying, setIsRetrying] = useState(false);
@@ -224,6 +233,7 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                     </div>
                 }
                 onRowSelectionChanged={isSelected => onIsSelectedChanged(slot.nzo_id, isSelected)}
+                selectable={!isReadOnly}
                 indexer={slot.indexer}
                 providers={slot.providers}
             />
@@ -250,6 +260,7 @@ export function Actions({
     onRemove: () => void,
     onRetry?: () => void,
 }) {
+    const isReadOnly = useIsReadOnly();
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
     const folderLink = getExploreContentLink(slot.storage, slot.category);
@@ -280,7 +291,7 @@ export function Actions({
 
     return (
         <>
-            {showRetry &&
+            {!isReadOnly && showRetry &&
                 <ActionButton
                     type="retry"
                     disabled={!!slot.isRemoving || isRetrying}
@@ -295,7 +306,7 @@ export function Actions({
             {(isFolderDisabled || !folderLink) &&
                 <ActionButton type="explore" disabled />
             }
-            <div className="relative">
+            {(!isReadOnly || !!nzbDownloadUrl) && <div className="relative">
                 <ActionButton
                     type="menu"
                     disabled={!!slot.isRemoving || isRetrying}
@@ -307,9 +318,11 @@ export function Actions({
                     onClose={() => setIsMenuOpen(false)}
                     options={[
                         !!nzbDownloadUrl ? { option: <ExportNzb />, linkTo: nzbDownloadUrl } : undefined,
-                        { option: <Remove />, onSelect: onRemoveSelected, variant: "danger" },
+                        !isReadOnly
+                            ? { option: <Remove />, onSelect: onRemoveSelected, variant: "danger" }
+                            : undefined,
                     ]} />
-            </div>
+            </div>}
         </>
     );
 }

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -18,18 +18,19 @@ export type PageTableProps = {
     onHeaderCheckboxChange: (isChecked: boolean) => void,
     footer?: ReactNode,
     showCompleted?: boolean,
+    selectable?: boolean,
 }
 
-export function PageTable({ children, headerCheckboxState, onHeaderCheckboxChange, footer, showCompleted }: PageTableProps) {
+export function PageTable({ children, headerCheckboxState, onHeaderCheckboxChange, footer, showCompleted, selectable = true }: PageTableProps) {
     return (
         <div className="-mx-4 overflow-x-auto sm:-mx-6">
             <table className="table table-zebra table-sm mb-0 w-full min-w-0 text-base-content min-[900px]:min-w-[880px]">
                 <thead>
                     <tr className="border-base-content/10 [&_th]:bg-base-200 [&_th]:text-base-content/70">
                         <th className="min-[900px]:w-1/2 w-auto py-4 pl-0 text-left text-xs font-semibold uppercase tracking-wide">
-                            <TriCheckbox state={headerCheckboxState} onChange={onHeaderCheckboxChange}>
-                                Name
-                            </TriCheckbox>
+                            {selectable
+                                ? <TriCheckbox state={headerCheckboxState} onChange={onHeaderCheckboxChange}>Name</TriCheckbox>
+                                : "Name"}
                         </th>
                         <th className={desktopHeaderClass}>Category</th>
                         <th className={desktopHeaderClass}>Indexer</th>
@@ -68,7 +69,8 @@ export type PageRowProps = {
     actions: ReactNode,
     indexer?: string | null,
     providers?: ProviderUsage[] | null,
-    onRowSelectionChanged: (isSelected: boolean) => void
+    onRowSelectionChanged: (isSelected: boolean) => void,
+    selectable?: boolean,
 }
 export function PageRow(props: PageRowProps) {
     const nameContent = props.nameHref
@@ -79,21 +81,15 @@ export function PageRow(props: PageRowProps) {
     return (
         <tr className={`${props.isRemoving ? "opacity-20" : ""} ${props.isUploading ? "bg-primary/5 [&+tr]:border-t-[3px] [&+tr]:border-base-300" : ""}`}>
             <td className="max-w-[200px] whitespace-nowrap py-3 pl-0 pr-1 text-left align-middle min-[900px]:max-w-[200px] max-[899px]:max-w-none max-[899px]:whitespace-normal">
-                <TriCheckbox state={props.isSelected} onChange={props.onRowSelectionChanged}>
+                {props.selectable === false ? (
+                    <>
+                        <Truncate>{nameContent}</Truncate>
+                        <MobileRowDetails {...props} completedLabel={completedLabel} />
+                    </>
+                ) : <TriCheckbox state={props.isSelected} onChange={props.onRowSelectionChanged}>
                     <Truncate>{nameContent}</Truncate>
-                    <div className="block min-[900px]:hidden">
-                        <div className="mb-1 mt-1 flex flex-wrap gap-2.5">
-                            <StatusBadge status={props.status} percentage={props.percentage} error={props.error} />
-                            <CategoryBadge category={props.category} />
-                            {props.indexer && <IndexerBadge indexer={props.indexer} />}
-                            {props.providers && props.providers.length > 0 && <ProvidersBadge providers={props.providers} />}
-                        </div>
-                        <div className="font-mono text-xs text-base-content/60">{formatFileSize(props.fileSizeBytes)}</div>
-                        {props.showCompleted && completedLabel &&
-                            <div className="font-mono text-xs text-base-content/60" title={completedLabel.full}>{completedLabel.short}</div>
-                        }
-                    </div>
-                </TriCheckbox>
+                    <MobileRowDetails {...props} completedLabel={completedLabel} />
+                </TriCheckbox>}
             </td>
             <td className={desktopCellClass}>
                 <CategoryBadge category={props.category} />
@@ -123,6 +119,25 @@ export function PageRow(props: PageRowProps) {
                 </div>
             </td>
         </tr>
+    );
+}
+
+function MobileRowDetails(
+    props: PageRowProps & { completedLabel: ReturnType<typeof formatCompleted> },
+) {
+    return (
+        <div className="block min-[900px]:hidden">
+            <div className="mb-1 mt-1 flex flex-wrap gap-2.5">
+                <StatusBadge status={props.status} percentage={props.percentage} error={props.error} />
+                <CategoryBadge category={props.category} />
+                {props.indexer && <IndexerBadge indexer={props.indexer} />}
+                {props.providers && props.providers.length > 0 && <ProvidersBadge providers={props.providers} />}
+            </div>
+            <div className="font-mono text-xs text-base-content/60">{formatFileSize(props.fileSizeBytes)}</div>
+            {props.showCompleted && props.completedLabel &&
+                <div className="font-mono text-xs text-base-content/60" title={props.completedLabel.full}>{props.completedLabel.short}</div>
+            }
+        </div>
     );
 }
 

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -9,6 +9,7 @@ import { Pagination } from "../pagination/pagination"
 import { EmptyQueue } from "../empty-queue/empty-queue"
 import { SimpleDropdown } from "../simple-dropdown/simple-dropdown"
 import { Tooltip } from "~/components/ui"
+import { useIsReadOnly } from "~/auth/authorization"
 
 export type QueueTableProps = {
     queueSlots: PresentationQueueSlot[],
@@ -66,6 +67,7 @@ export function QueueTable({
     onMovedToTop,
     onUploadClicked,
 }: QueueTableProps) {
+    const isReadOnly = useIsReadOnly();
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
     const selectedCount = queueSlots.filter(x => !!x.isSelected).length;
     const headerCheckboxState: TriCheckboxState = selectedCount === 0 ? 'none' : selectedCount === queueSlots.length ? 'all' : 'some';
@@ -144,18 +146,21 @@ export function QueueTable({
 
 
     // view
-    const categoryDropdown = useMemo(() => (
+    const categoryDropdown = useMemo(() => isReadOnly ? null : (
         <Tooltip content="Choose the category for manual nzb uploads.">
             <SimpleDropdown options={categories} valueRef={manualCategoryRef} />
         </Tooltip>
-    ), [categories]);
+    ), [categories, isReadOnly, manualCategoryRef]);
 
     const sectionTitle = (
         <div className="flex items-center gap-2.5">
-            <h2 className="cursor-pointer text-xl font-semibold text-base-content" onClick={onUploadClicked}>
+            <h2
+                className={`${isReadOnly ? "" : "cursor-pointer"} text-xl font-semibold text-base-content`}
+                onClick={isReadOnly ? undefined : onUploadClicked}
+            >
                 Queue
             </h2>
-            {headerCheckboxState !== 'none' &&
+            {!isReadOnly && headerCheckboxState !== 'none' &&
                 <>
                     {selectedMovableIds.length > 0 &&
                         <Tooltip content="Move selected to top of queue">
@@ -199,9 +204,14 @@ export function QueueTable({
             badgeText={totalQueueCount > 0 ? String(totalQueueCount) : undefined}
         >
             {queueSlots?.length == 0 ? (
-                <EmptyQueue onUploadClicked={onUploadClicked} />
+                <EmptyQueue onUploadClicked={isReadOnly ? undefined : onUploadClicked} />
             ) : (
-                <PageTable headerCheckboxState={headerCheckboxState} onHeaderCheckboxChange={onSelectAll} footer={footer}>
+                <PageTable
+                    headerCheckboxState={headerCheckboxState}
+                    onHeaderCheckboxChange={onSelectAll}
+                    footer={footer}
+                    selectable={!isReadOnly}
+                >
                     {queueSlots.map(slot =>
                         <QueueRow
                             key={slot.nzo_id}
@@ -234,6 +244,7 @@ type QueueRowProps = {
 }
 
 export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, onRemoved, onMovedToTop }: QueueRowProps) => {
+    const isReadOnly = useIsReadOnly();
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
     const [isMoving, setIsMoving] = useState(false);
@@ -296,7 +307,7 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                 status={slot.status}
                 percentage={slot.true_percentage}
                 fileSizeBytes={Number(slot.mb) * 1024 * 1024}
-                actions={
+                actions={isReadOnly ? null : (
                     <div className="flex items-center justify-center gap-1">
                         {!slot.isUploading &&
                             <Tooltip content="Move to top">
@@ -309,8 +320,9 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                         }
                         <ActionButton type="delete" disabled={!!slot.isRemoving || isActivelyUploading} onClick={onRemove} />
                     </div>
-                }
+                )}
                 onRowSelectionChanged={isSelected => onIsSelectedChanged(slot.nzo_id, isSelected)}
+                selectable={!isReadOnly}
                 error={slot.error}
                 indexer={slot.indexer}
                 providers={slot.providers}

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -9,6 +9,7 @@ import { useQueueHistoryWebsocket } from "./controllers/websocket-controller";
 import { useUploadController } from "./controllers/nzb-upload-controller";
 import { useQueueDropzone } from "./controllers/dropzone-controller";
 import { Alert } from "~/components/ui";
+import { useIsReadOnly } from "~/auth/authorization";
 
 export const PAGE_SIZE_OPTIONS = [25, 50, 100, 250] as const;
 const DEFAULT_PAGE_SIZE = 100;
@@ -60,6 +61,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export default function Queue(props: Route.ComponentProps) {
+    const isReadOnly = useIsReadOnly();
     const { queuePageSize, historyPageSize, queuePage, historyPage } = props.loaderData;
     const [queueSlots, setQueueSlots] = useState<PresentationQueueSlot[]>(props.loaderData.queueSlots);
     const [historySlots, setHistorySlots] = useState<PresentationHistorySlot[]>(props.loaderData.historySlots);
@@ -142,9 +144,9 @@ export default function Queue(props: Route.ComponentProps) {
 
             {/* queue */}
             <div className="min-h-[413.9px] min-[450px]:min-h-[382.9px]">
-                <div className="relative" {...dropzone.getRootProps()}>
+                <div className="relative" {...(isReadOnly ? {} : dropzone.getRootProps())}>
                     {dropzone.isDragActive && <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded border-2 border-dashed border-primary bg-primary/10" />}
-                    <input {...dropzone.getInputProps()} />
+                    {!isReadOnly && <input {...dropzone.getInputProps()} />}
                     <QueueTable
                         queueSlots={combinedQueueSlots}
                         totalQueueCount={totalQueueCount + uploadingFiles.length}
@@ -161,7 +163,7 @@ export default function Queue(props: Route.ComponentProps) {
                         onIsRemovingChanged={queueEvents.onRemovingQueueSlots}
                         onRemoved={queueEvents.onRemoveQueueSlots}
                         onMovedToTop={queueEvents.onMoveQueueSlotsToTop}
-                        onUploadClicked={dropzone.open}
+                        onUploadClicked={isReadOnly ? undefined : dropzone.open}
                     />
                 </div>
             </div>

--- a/frontend/app/routes/search/route.tsx
+++ b/frontend/app/routes/search/route.tsx
@@ -3,6 +3,7 @@ import { Form, useFetcher, useNavigation } from "react-router";
 import { backendClient, type SearchIndexersResponse } from "~/clients/backend-client.server";
 import { Badge, Button, Input, Spinner } from "~/components/ui";
 import { formatFileSize } from "~/utils/file-size";
+import { useIsReadOnly } from "~/auth/authorization";
 
 export async function loader({ request }: Route.LoaderArgs) {
     const url = new URL(request.url);
@@ -92,6 +93,7 @@ export default function Search({ loaderData }: Route.ComponentProps) {
 }
 
 function ResultRow({ result }: { result: { indexer: string; title: string; nzbUrl: string; size: number; posted: string | null } }) {
+    const isReadOnly = useIsReadOnly();
     const fetcher = useFetcher<typeof action>();
     const submitting = fetcher.state !== "idle";
     const done = fetcher.data?.ok === true;
@@ -106,7 +108,7 @@ function ResultRow({ result }: { result: { indexer: string; title: string; nzbUr
                     {result.posted && ` · ${new Date(result.posted).toLocaleDateString()}`}
                 </div>
             </div>
-            <fetcher.Form method="post">
+            {!isReadOnly && <fetcher.Form method="post">
                 <input type="hidden" name="nzbUrl" value={result.nzbUrl} />
                 <input type="hidden" name="nzbName" value={result.title} />
                 <Button
@@ -122,7 +124,7 @@ function ResultRow({ result }: { result: { indexer: string; title: string; nzbUr
                         : failed ? "Failed"
                         : "Mount"}
                 </Button>
-            </fetcher.Form>
+            </fetcher.Form>}
         </li>
     );
 }

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -19,11 +19,12 @@ import { isWardenSettingsUpdated, WardenSettings } from "./warden/warden";
 import { isRcloneSettingsUpdated, RcloneSettings } from "./rclone/rclone";
 import { SupportSettings } from "./support/support";
 import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from "react";
-import { useBlocker, useSearchParams } from "react-router";
+import { useBlocker, useOutletContext, useSearchParams } from "react-router";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { getAppVersion } from "~/utils/version.server";
 import { parseSettingsTab, getSettingsTabItem } from "./settings-tabs";
 import { Icon } from "~/components/ui";
+import type { UserRole } from "~/auth/authentication.server";
 
 const defaultConfig = {
     "general.base-url": "",
@@ -186,6 +187,8 @@ type BodyProps = {
 };
 
 function Body(props: BodyProps) {
+    const { role } = useOutletContext<{ role: UserRole | null }>();
+    const isReadOnly = role === "readonly";
     const [searchParams] = useSearchParams();
     const activeTab = parseSettingsTab(searchParams.get("tab"));
     const activeTabItem = getSettingsTabItem(activeTab);
@@ -333,6 +336,12 @@ function Body(props: BodyProps) {
                         </span>
                     </Alert>
                 )}
+                {isReadOnly && (
+                    <Alert variant="info" className="mb-6 text-sm">
+                        You are signed in with read-only access. Settings and maintenance actions are disabled.
+                    </Alert>
+                )}
+                <fieldset className="contents" disabled={isReadOnly}>
                 {activeTab === "usenet" && (
                     <UsenetSettings
                         config={newConfig}
@@ -354,6 +363,7 @@ function Body(props: BodyProps) {
                 {activeTab === "maintenance" && <Maintenance savedConfig={config} config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "backup" && <BackupSettings config={newConfig} setNewConfig={setNewConfig} />}
                 {activeTab === "support" && <SupportSettings />}
+                </fieldset>
             </SettingsPanel>
 
             {saveError && (
@@ -361,7 +371,7 @@ function Body(props: BodyProps) {
                     {saveError}
                 </Alert>
             )}
-            {(activeTab !== "support" || isUpdated) && <div className="sticky bottom-0 z-10 -mx-4 flex flex-wrap justify-end gap-2 border-t border-base-content/10 bg-base-300/95 px-4 py-3 backdrop-blur md:-mx-8 md:px-8">
+            {!isReadOnly && (activeTab !== "support" || isUpdated) && <div className="sticky bottom-0 z-10 -mx-4 flex flex-wrap justify-end gap-2 border-t border-base-content/10 bg-base-300/95 px-4 py-3 backdrop-blur md:-mx-8 md:px-8">
                 {isUpdated && <Button
                     className="min-w-28"
                     variant="outline"

--- a/frontend/app/routes/watchdog/route.tsx
+++ b/frontend/app/routes/watchdog/route.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { backendClient, type WatchdogEntry, type WatchdogOutcome } from "~/clients/backend-client.server";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { Alert, Badge, Icon } from "~/components/ui";
+import { useIsReadOnly } from "~/auth/authorization";
 
 const POLL_INTERVAL_MS = 3000;
 
@@ -31,6 +32,7 @@ const FILTER_OPTIONS: { key: FilterKey, label: string }[] = [
 ];
 
 export default function Watchdog({ loaderData }: Route.ComponentProps) {
+    const isReadOnly = useIsReadOnly();
     const [attempts, setAttempts] = useState<WatchdogEntry[]>(loaderData.entries);
     const [autoRefresh, setAutoRefresh] = useState(true);
     const [filter, setFilter] = useState<FilterKey>("all");
@@ -131,7 +133,7 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
                                 />
                                 Refresh
                             </button>
-                            <button
+                            {!isReadOnly && <button
                                 type="button"
                                 className="btn btn-sm btn-error join-item gap-2"
                                 onClick={() => setShowClearConfirm(true)}
@@ -139,7 +141,7 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
                                 title="Permanently delete all watchdog entries.">
                                 <Icon name="delete" className="!text-[16px]" />
                                 {clearing ? "Clearing…" : "Clear log"}
-                            </button>
+                            </button>}
                         </div>
                     </div>
 

--- a/frontend/app/routes/watchtower/route.tsx
+++ b/frontend/app/routes/watchtower/route.tsx
@@ -5,6 +5,7 @@ import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { Alert, Badge, Button, Icon, NativeForm as Form } from "~/components/ui";
 import { Checkbox } from "~/components/ui/form";
 import { backendClient, type WatchtowerData, type WatchtowerItem, type WatchtowerSource } from "~/clients/backend-client.server";
+import { useIsReadOnly } from "~/auth/authorization";
 
 const POLL_INTERVAL_MS = 5000;
 const PAGE_SIZE = 100;
@@ -55,6 +56,7 @@ export async function action({ request }: Route.ActionArgs) {
 type PendingRemove = "bulk" | "filter";
 
 export default function Watchtower({ loaderData }: Route.ComponentProps) {
+    const isReadOnly = useIsReadOnly();
     const addFetcher = useFetcher<typeof action>();
     const discoverFetcher = useFetcher<typeof action>();
     const bulkFetcher = useFetcher<typeof action>();
@@ -317,7 +319,7 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
         : `Remove ${selectedItems.size} item${selectedItems.size === 1 ? "" : "s"} from Watchtower?`;
 
     return (
-        <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-4 py-4 text-sm text-base-content/70 md:px-8">
+        <div className={`mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-4 py-4 text-sm text-base-content/70 md:px-8 ${isReadOnly ? "[&_form]:hidden" : ""}`}>
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
                     <h2 className="text-xl font-semibold tracking-tight text-base-content">Watchtower</h2>
@@ -549,7 +551,7 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
                                     type="button"
                                     size="xsmall"
                                     variant="danger"
-                                    disabled={filterBusy}
+                                    disabled={filterBusy || isReadOnly}
                                     onClick={() => setPendingRemove("filter")}
                                 >
                                     <Icon name="delete" className="!text-[16px]" />
@@ -576,7 +578,7 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
                                     type="button"
                                     size="xsmall"
                                     variant="danger"
-                                    disabled={bulkBusy}
+                                    disabled={bulkBusy || isReadOnly}
                                     onClick={() => setPendingRemove("bulk")}
                                 >
                                     <Icon name="delete" className="!text-[16px]" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "isbot": "^5.1.0",
         "material-symbols": "^0.45.9",
         "mime-types": "^3.0.2",
+        "openid-client": "^6.8.4",
         "picocolors": "^1.1.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -4028,6 +4029,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.7.tgz",
+      "integrity": "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4571,6 +4581,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4625,6 +4644,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "isbot": "^5.1.0",
     "material-symbols": "^0.45.9",
     "mime-types": "^3.0.2",
+    "openid-client": "^6.8.4",
     "picocolors": "^1.1.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -16,6 +16,7 @@ import {
 import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
 import { backendProxyTimeoutOptions } from "./backend-proxy-options";
 import { handleBackendProxyResponse } from "./backend-proxy-response";
+import { oidcRouter } from "./oidc-routes";
 
 export const app = express();
 app.disable("x-powered-by");
@@ -77,11 +78,15 @@ const forwardToBackend = createProxyMiddleware({
   },
 });
 
-const credentialPaths = new Set([
+const credentialPostPaths = new Set([
   "/login",
   "/login.data",
   "/onboarding",
   "/onboarding.data",
+]);
+const oidcGetPaths = new Set([
+  "/auth/oidc/login",
+  "/auth/oidc/callback",
 ]);
 const credentialRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -96,10 +101,15 @@ const credentialRateLimiter = rateLimit({
     return remoteAddress ? ipKeyGenerator(remoteAddress) : "unknown";
   },
   skip: (req) => {
-    if (req.method.toUpperCase() !== "POST") return true;
     // Malformed encoding is not a credential path; must not throw (see #217).
     const decodedPath = safeDecodePath(req.path);
-    return decodedPath === null || !credentialPaths.has(decodedPath);
+    if (decodedPath === null) return true;
+
+    const method = req.method.toUpperCase();
+    return !(
+      (method === "POST" && credentialPostPaths.has(decodedPath))
+      || (method === "GET" && oidcGetPaths.has(decodedPath))
+    );
   },
   handler: (req, res, _next, options) => {
     logger.warn(
@@ -119,6 +129,9 @@ app.use(async (req, res, next) => {
 
 // Limit credential attempts without throttling WebDAV, API, or regular UI traffic.
 app.use(credentialRateLimiter);
+
+// OIDC endpoints must remain public so the provider can complete the callback.
+app.use(oidcRouter);
 
 // Require authentication for all React Router routes
 app.use(authMiddleware);

--- a/frontend/server/oidc-routes.integration.test.ts
+++ b/frontend/server/oidc-routes.integration.test.ts
@@ -1,0 +1,294 @@
+import http from "node:http";
+import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import type { Request, Response } from "express";
+import * as oidc from "openid-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getOidcFlowState: vi.fn(),
+  setSessionUser: vi.fn(),
+  clearOidcFlowState: vi.fn(),
+  getOidcConfiguration: vi.fn(),
+}));
+
+vi.mock("~/auth/authentication.server", () => ({
+  getOidcFlowState: mocks.getOidcFlowState,
+  setSessionUser: mocks.setSessionUser,
+  clearOidcFlowState: mocks.clearOidcFlowState,
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    getConfig: vi.fn(),
+  },
+}));
+
+vi.mock("./oidc.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./oidc.server")>();
+  return {
+    ...actual,
+    getOidcConfiguration: mocks.getOidcConfiguration,
+    isOidcEnabled: () => true,
+  };
+});
+
+vi.mock("./logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { oidcCallbackHandler } from "./oidc-routes";
+
+const CLIENT_ID = "nzbdav";
+const CLIENT_SECRET = "secret";
+const REDIRECT_URI = "https://nzbdav.example.com/auth/oidc/callback";
+const FLOW = {
+  codeVerifier: "fixture-code-verifier",
+  nonce: "fixture-nonce",
+  redirectUri: REDIRECT_URI,
+  state: "fixture-state",
+};
+const OIDC_ENV_NAMES = [
+  "OIDC_ISSUER",
+  "OIDC_CLIENT_ID",
+  "OIDC_CLIENT_SECRET",
+  "OIDC_USERNAME_CLAIM",
+  "OIDC_ADMIN_CLAIM",
+  "OIDC_ADMIN_CLAIM_VALUE",
+] as const;
+
+type OidcFixture = {
+  configuration: oidc.Configuration;
+  server: http.Server;
+  tokenRequest: () => URLSearchParams | undefined;
+};
+
+const originalOidcEnv = Object.fromEntries(
+  OIDC_ENV_NAMES.map((name) => [name, process.env[name]]),
+);
+const servers: http.Server[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.OIDC_ISSUER = "https://fixture.invalid";
+  process.env.OIDC_CLIENT_ID = CLIENT_ID;
+  process.env.OIDC_CLIENT_SECRET = CLIENT_SECRET;
+  process.env.OIDC_USERNAME_CLAIM = "preferred_username";
+  process.env.OIDC_ADMIN_CLAIM = "groups";
+  process.env.OIDC_ADMIN_CLAIM_VALUE = "nzbdav-admins";
+  mocks.getOidcFlowState.mockResolvedValue(FLOW);
+  mocks.setSessionUser.mockResolvedValue({
+    headers: { "Set-Cookie": "__session=user" },
+  });
+  mocks.clearOidcFlowState.mockResolvedValue({
+    headers: { "Set-Cookie": "__session=cleared" },
+  });
+});
+
+afterEach(async () => {
+  for (const name of OIDC_ENV_NAMES) {
+    const value = originalOidcEnv[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  await Promise.all(servers.splice(0).map(closeServer));
+});
+
+describe("OIDC callback integration", () => {
+  it("discovers the provider, validates its ID token, and creates a session", async () => {
+    const fixture = await startOidcFixture();
+    mocks.getOidcConfiguration.mockResolvedValue(fixture.configuration);
+    const req = mockRequest(
+      "/auth/oidc/callback?code=fixture-code&state=fixture-state",
+    );
+    const res = mockResponse();
+
+    await oidcCallbackHandler(req, res);
+
+    expect(fixture.tokenRequest()).toEqual(expect.any(URLSearchParams));
+    expect(fixture.tokenRequest()?.get("client_id")).toBe(CLIENT_ID);
+    expect(fixture.tokenRequest()?.get("client_secret")).toBe(CLIENT_SECRET);
+    expect(fixture.tokenRequest()?.get("code")).toBe("fixture-code");
+    expect(fixture.tokenRequest()?.get("code_verifier")).toBe(FLOW.codeVerifier);
+    expect(fixture.tokenRequest()?.get("redirect_uri")).toBe(REDIRECT_URI);
+    expect(mocks.setSessionUser).toHaveBeenCalledWith(req, "alice", "admin");
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", "__session=user");
+    expect(res.redirect).toHaveBeenCalledWith(302, "/");
+  });
+
+  it("rejects an ID token not signed by the discovered provider key", async () => {
+    const fixture = await startOidcFixture(false);
+    mocks.getOidcConfiguration.mockResolvedValue(fixture.configuration);
+    const req = mockRequest(
+      "/auth/oidc/callback?code=fixture-code&state=fixture-state",
+    );
+    const res = mockResponse();
+
+    await oidcCallbackHandler(req, res);
+
+    expect(mocks.setSessionUser).not.toHaveBeenCalled();
+    expect(mocks.clearOidcFlowState).toHaveBeenCalledWith(req);
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", "__session=cleared");
+    expect(res.redirect).toHaveBeenCalledWith(302, "/login?error=oidc_failed");
+  });
+});
+
+async function startOidcFixture(trustedSignature = true): Promise<OidcFixture> {
+  const trustedKeys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const untrustedKeys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const signingKey = trustedSignature ? trustedKeys.privateKey : untrustedKeys.privateKey;
+  const publicJwk = {
+    ...trustedKeys.publicKey.export({ format: "jwk" }),
+    alg: "RS256",
+    kid: "fixture-key",
+    use: "sig",
+  };
+  let issuer = "";
+  let lastTokenRequest: URLSearchParams | undefined;
+
+  const server = http.createServer((req, res) => {
+    if (req.url === "/.well-known/openid-configuration") {
+      sendJson(res, {
+        issuer,
+        authorization_endpoint: `${issuer}/authorize`,
+        token_endpoint: `${issuer}/token`,
+        jwks_uri: `${issuer}/jwks`,
+        response_types_supported: ["code"],
+        subject_types_supported: ["public"],
+        id_token_signing_alg_values_supported: ["RS256"],
+        token_endpoint_auth_methods_supported: ["client_secret_post"],
+        code_challenge_methods_supported: ["S256"],
+      });
+      return;
+    }
+
+    if (req.url === "/jwks") {
+      sendJson(res, { keys: [publicJwk] });
+      return;
+    }
+
+    if (req.url === "/token" && req.method === "POST") {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        lastTokenRequest = new URLSearchParams(body);
+        const now = Math.floor(Date.now() / 1000);
+        sendJson(res, {
+          access_token: "fixture-access-token",
+          token_type: "Bearer",
+          expires_in: 300,
+          id_token: signJwt(
+            {
+              iss: issuer,
+              sub: "fixture-user",
+              aud: CLIENT_ID,
+              iat: now,
+              exp: now + 300,
+              nonce: FLOW.nonce,
+              preferred_username: "alice",
+              groups: ["nzbdav-admins"],
+            },
+            signingKey,
+          ),
+        });
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+  servers.push(server);
+
+  const port = await listen(server);
+  issuer = `http://127.0.0.1:${port}`;
+  const configuration = await oidc.discovery(
+    new URL(issuer),
+    CLIENT_ID,
+    CLIENT_SECRET,
+    undefined,
+    {
+      execute: [
+        oidc.allowInsecureRequests,
+        oidc.enableNonRepudiationChecks,
+      ],
+    },
+  );
+
+  return {
+    configuration,
+    server,
+    tokenRequest: () => lastTokenRequest,
+  };
+}
+
+function signJwt(claims: Record<string, unknown>, privateKey: KeyObject): string {
+  const header = encodeJson({ alg: "RS256", kid: "fixture-key", typ: "JWT" });
+  const payload = encodeJson(claims);
+  const signingInput = `${header}.${payload}`;
+  const signature = sign("RSA-SHA256", Buffer.from(signingInput), privateKey);
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+function encodeJson(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function sendJson(res: http.ServerResponse, value: unknown): void {
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+  });
+  res.end(JSON.stringify(value));
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo | null;
+      if (!address) {
+        reject(new Error("OIDC fixture has no address"));
+        return;
+      }
+      resolve(address.port);
+    });
+    server.on("error", reject);
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function mockRequest(originalUrl: string): Request {
+  return {
+    protocol: "https",
+    originalUrl,
+    get: vi.fn((name: string) => name === "host" ? "nzbdav.example.com" : undefined),
+  } as unknown as Request;
+}
+
+function mockResponse(): Response & {
+  redirect: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+} {
+  return {
+    redirect: vi.fn(),
+    setHeader: vi.fn(),
+  } as unknown as Response & {
+    redirect: ReturnType<typeof vi.fn>;
+    setHeader: ReturnType<typeof vi.fn>;
+  };
+}

--- a/frontend/server/oidc-routes.test.ts
+++ b/frontend/server/oidc-routes.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+
+const mocks = vi.hoisted(() => ({
+  randomPKCECodeVerifier: vi.fn(() => "verifier"),
+  calculatePKCECodeChallenge: vi.fn(async () => "challenge"),
+  randomNonce: vi.fn(() => "nonce"),
+  randomState: vi.fn(() => "state"),
+  buildAuthorizationUrl: vi.fn(() => new URL("https://identity.example.com/authorize")),
+  authorizationCodeGrant: vi.fn(),
+  setOidcFlowState: vi.fn(),
+  getOidcFlowState: vi.fn(),
+  setSessionUser: vi.fn(),
+  clearOidcFlowState: vi.fn(),
+  getOidcConfiguration: vi.fn(),
+  getOidcSettings: vi.fn(),
+  isOidcEnabled: vi.fn(),
+  resolveOidcRole: vi.fn(),
+  resolveOidcUsername: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock("openid-client", () => ({
+  randomPKCECodeVerifier: mocks.randomPKCECodeVerifier,
+  calculatePKCECodeChallenge: mocks.calculatePKCECodeChallenge,
+  randomNonce: mocks.randomNonce,
+  randomState: mocks.randomState,
+  buildAuthorizationUrl: mocks.buildAuthorizationUrl,
+  authorizationCodeGrant: mocks.authorizationCodeGrant,
+}));
+
+vi.mock("~/auth/authentication.server", () => ({
+  setOidcFlowState: mocks.setOidcFlowState,
+  getOidcFlowState: mocks.getOidcFlowState,
+  setSessionUser: mocks.setSessionUser,
+  clearOidcFlowState: mocks.clearOidcFlowState,
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    getConfig: mocks.getConfig,
+  },
+}));
+
+vi.mock("./oidc.server", () => ({
+  getOidcConfiguration: mocks.getOidcConfiguration,
+  getOidcSettings: mocks.getOidcSettings,
+  isOidcEnabled: mocks.isOidcEnabled,
+  resolveOidcRole: mocks.resolveOidcRole,
+  resolveOidcUsername: mocks.resolveOidcUsername,
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { oidcCallbackHandler, oidcLoginHandler } from "./oidc-routes";
+
+function mockRequest(originalUrl: string): Request {
+  return {
+    protocol: "https",
+    originalUrl,
+    get: vi.fn((name: string) => name === "host" ? "nzbdav.example.com" : undefined),
+  } as unknown as Request;
+}
+
+function mockResponse(): Response & {
+  redirect: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+} {
+  return {
+    redirect: vi.fn(),
+    setHeader: vi.fn(),
+  } as unknown as Response & {
+    redirect: ReturnType<typeof vi.fn>;
+    setHeader: ReturnType<typeof vi.fn>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isOidcEnabled.mockReturnValue(true);
+  mocks.getOidcConfiguration.mockResolvedValue({});
+  mocks.getOidcSettings.mockReturnValue({
+    issuer: "https://identity.example.com",
+    clientId: "nzbdav",
+    clientSecret: "secret",
+    scopes: "openid profile email",
+    usernameClaim: "preferred_username",
+  });
+  mocks.getConfig.mockResolvedValue([]);
+  mocks.setOidcFlowState.mockResolvedValue({
+    headers: { "Set-Cookie": "__session=flow" },
+  });
+  mocks.clearOidcFlowState.mockResolvedValue({
+    headers: { "Set-Cookie": "__session=cleared" },
+  });
+});
+
+describe("OIDC Express routes", () => {
+  it("starts an authorization-code flow with PKCE and state", async () => {
+    const req = mockRequest("/auth/oidc/login");
+    const res = mockResponse();
+
+    await oidcLoginHandler(req, res);
+
+    expect(mocks.setOidcFlowState).toHaveBeenCalledWith(req, {
+      codeVerifier: "verifier",
+      nonce: "nonce",
+      redirectUri: "https://nzbdav.example.com/auth/oidc/callback",
+      state: "state",
+    });
+    expect(mocks.buildAuthorizationUrl).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        redirect_uri: "https://nzbdav.example.com/auth/oidc/callback",
+        code_challenge: "challenge",
+        code_challenge_method: "S256",
+        nonce: "nonce",
+        state: "state",
+      }),
+    );
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", "__session=flow");
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      "https://identity.example.com/authorize",
+    );
+  });
+
+  it("exchanges the callback and creates a role-aware session", async () => {
+    const req = mockRequest("/auth/oidc/callback?code=code&state=state");
+    const res = mockResponse();
+    mocks.getOidcFlowState.mockResolvedValue({
+      codeVerifier: "verifier",
+      nonce: "nonce",
+      redirectUri: "https://nzbdav.example.com/auth/oidc/callback",
+      state: "state",
+    });
+    mocks.authorizationCodeGrant.mockResolvedValue({
+      claims: () => ({ preferred_username: "alice", groups: ["admins"] }),
+    });
+    mocks.resolveOidcUsername.mockReturnValue("alice");
+    mocks.resolveOidcRole.mockReturnValue("admin");
+    mocks.setSessionUser.mockResolvedValue({
+      headers: { "Set-Cookie": "__session=user" },
+    });
+
+    await oidcCallbackHandler(req, res);
+
+    expect(mocks.authorizationCodeGrant).toHaveBeenCalledWith(
+      {},
+      new URL("https://nzbdav.example.com/auth/oidc/callback?code=code&state=state"),
+      {
+        pkceCodeVerifier: "verifier",
+        expectedNonce: "nonce",
+        expectedState: "state",
+      },
+    );
+    expect(mocks.setSessionUser).toHaveBeenCalledWith(req, "alice", "admin");
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", "__session=user");
+    expect(res.redirect).toHaveBeenCalledWith(302, "/");
+  });
+
+  it("clears failed callback state and returns to login", async () => {
+    const req = mockRequest("/auth/oidc/callback?error=access_denied");
+    const res = mockResponse();
+    mocks.getOidcFlowState.mockResolvedValue(null);
+
+    await oidcCallbackHandler(req, res);
+
+    expect(mocks.clearOidcFlowState).toHaveBeenCalledWith(req);
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", "__session=cleared");
+    expect(res.redirect).toHaveBeenCalledWith(302, "/login?error=oidc_failed");
+  });
+});

--- a/frontend/server/oidc-routes.ts
+++ b/frontend/server/oidc-routes.ts
@@ -1,0 +1,144 @@
+import { Router, type Request, type Response } from "express";
+import * as oidc from "openid-client";
+import {
+  clearOidcFlowState,
+  getOidcFlowState,
+  setOidcFlowState,
+  setSessionUser,
+  type SessionResponseInit,
+} from "~/auth/authentication.server";
+import {
+  getOidcConfiguration,
+  getOidcSettings,
+  isOidcEnabled,
+  resolveOidcRole,
+  resolveOidcUsername,
+} from "./oidc.server";
+import { logger } from "./logger";
+import { backendClient } from "~/clients/backend-client.server";
+
+export const oidcRouter = Router();
+
+oidcRouter.get("/auth/oidc/login", oidcLoginHandler);
+oidcRouter.get("/auth/oidc/callback", oidcCallbackHandler);
+
+export async function oidcLoginHandler(req: Request, res: Response): Promise<void> {
+  if (!isOidcEnabled()) {
+    res.redirect(302, "/login?error=oidc_not_configured");
+    return;
+  }
+
+  try {
+    const configuration = await getOidcConfiguration();
+    const settings = getOidcSettings();
+    const codeVerifier = oidc.randomPKCECodeVerifier();
+    const codeChallenge = await oidc.calculatePKCECodeChallenge(codeVerifier);
+    const nonce = oidc.randomNonce();
+    const state = oidc.randomState();
+    const redirectUri = await resolveRedirectUri(req);
+    const session = await setOidcFlowState(req, {
+      codeVerifier,
+      nonce,
+      redirectUri,
+      state,
+    });
+
+    applySetCookie(res, session);
+    const authorizationUrl = oidc.buildAuthorizationUrl(configuration, {
+      redirect_uri: redirectUri,
+      scope: settings.scopes,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+      nonce,
+      state,
+    });
+    res.redirect(302, authorizationUrl.href);
+  } catch (error) {
+    logOidcFailure("Could not start OIDC sign-in", error);
+    res.redirect(302, "/login?error=oidc_failed");
+  }
+}
+
+export async function oidcCallbackHandler(req: Request, res: Response): Promise<void> {
+  if (!isOidcEnabled()) {
+    res.redirect(302, "/login?error=oidc_not_configured");
+    return;
+  }
+
+  try {
+    const flow = await getOidcFlowState(req);
+    if (!flow) {
+      throw new Error("OIDC sign-in state is missing or expired");
+    }
+
+    const configuration = await getOidcConfiguration();
+    const tokens = await oidc.authorizationCodeGrant(
+      configuration,
+      buildCallbackUrl(req, flow.redirectUri),
+      {
+        pkceCodeVerifier: flow.codeVerifier,
+        expectedNonce: flow.nonce,
+        expectedState: flow.state,
+      },
+    );
+    const claims = tokens.claims();
+    if (!claims) {
+      throw new Error("OIDC provider did not return ID token claims");
+    }
+
+    const username = resolveOidcUsername(claims);
+    const role = resolveOidcRole(claims);
+    const session = await setSessionUser(req, username, role);
+
+    applySetCookie(res, session);
+    logger.info(`OIDC sign-in succeeded for ${username} with ${role} role`);
+    res.redirect(302, "/");
+  } catch (error) {
+    logOidcFailure("OIDC sign-in failed", error);
+    const session = await clearOidcFlowState(req);
+    applySetCookie(res, session);
+    res.redirect(302, "/login?error=oidc_failed");
+  }
+}
+
+async function resolveRedirectUri(req: Request): Promise<string> {
+  const configured = getOidcSettings().redirectUri;
+  if (configured) return new URL(configured).href;
+
+  try {
+    const config = await backendClient.getConfig(["general.base-url"]);
+    const baseUrl = config.find((item) => item.configName === "general.base-url")
+      ?.configValue
+      ?.trim();
+    if (baseUrl) {
+      return new URL(
+        "auth/oidc/callback",
+        baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`,
+      ).href;
+    }
+  } catch (error) {
+    logger.debug("Could not read general.base-url for OIDC callback", error);
+  }
+
+  const host = req.get("host");
+  if (!host) throw new Error("Unable to determine OIDC callback host");
+  return new URL("/auth/oidc/callback", `${req.protocol}://${host}`).href;
+}
+
+function buildCallbackUrl(req: Request, redirectUri: string): URL {
+  const callbackUrl = new URL(redirectUri);
+  const queryIndex = req.originalUrl.indexOf("?");
+  callbackUrl.search = queryIndex === -1 ? "" : req.originalUrl.slice(queryIndex);
+  return callbackUrl;
+}
+
+function applySetCookie(res: Response, responseInit: SessionResponseInit): void {
+  const setCookie = new Headers(responseInit.headers).get("Set-Cookie");
+  if (setCookie) res.setHeader("Set-Cookie", setCookie);
+}
+
+function logOidcFailure(message: string, error: unknown): void {
+  const reason = error instanceof Error ? error.message : String(error);
+  logger.warn(`${message}. Reason: ${reason}`);
+  if (error instanceof Error) logger.debug(`${message} stack`, error);
+}

--- a/frontend/server/oidc.server.test.ts
+++ b/frontend/server/oidc.server.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./logger", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+import {
+  getOidcSettings,
+  isOidcEnabled,
+  resolveOidcRole,
+  resolveOidcUsername,
+} from "./oidc.server";
+
+const requiredEnvironment = {
+  OIDC_ISSUER: "https://identity.example.com",
+  OIDC_CLIENT_ID: "nzbdav",
+  OIDC_CLIENT_SECRET: "secret",
+};
+
+beforeEach(() => {
+  for (const name of [
+    "OIDC_ISSUER",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_REDIRECT_URI",
+    "OIDC_SCOPES",
+    "OIDC_USERNAME_CLAIM",
+    "OIDC_ADMIN_CLAIM",
+    "OIDC_ADMIN_CLAIM_VALUE",
+  ]) {
+    vi.stubEnv(name, "");
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function enableOidc(): void {
+  for (const [name, value] of Object.entries(requiredEnvironment)) {
+    vi.stubEnv(name, value);
+  }
+}
+
+describe("OIDC configuration", () => {
+  it("is disabled unless all required variables are configured", () => {
+    expect(isOidcEnabled()).toBe(false);
+
+    vi.stubEnv("OIDC_ISSUER", requiredEnvironment.OIDC_ISSUER);
+    expect(isOidcEnabled()).toBe(false);
+
+    enableOidc();
+    expect(isOidcEnabled()).toBe(true);
+  });
+
+  it("uses secure defaults for optional settings", () => {
+    enableOidc();
+
+    expect(getOidcSettings()).toEqual({
+      issuer: requiredEnvironment.OIDC_ISSUER,
+      clientId: requiredEnvironment.OIDC_CLIENT_ID,
+      clientSecret: requiredEnvironment.OIDC_CLIENT_SECRET,
+      redirectUri: undefined,
+      scopes: "openid profile email",
+      usernameClaim: "preferred_username",
+      adminClaim: undefined,
+      adminClaimValue: undefined,
+    });
+  });
+
+  it("resolves the configured username claim with standard fallbacks", () => {
+    enableOidc();
+    vi.stubEnv("OIDC_USERNAME_CLAIM", "nickname");
+
+    expect(resolveOidcUsername({ nickname: "alice", email: "alice@example.com" }))
+      .toBe("alice");
+    expect(resolveOidcUsername({ email: "alice@example.com" }))
+      .toBe("alice@example.com");
+    expect(() => resolveOidcUsername({ name: "Alice" }))
+      .toThrow("does not contain a usable username claim");
+  });
+
+  it("maps matching string and array claims to admin", () => {
+    enableOidc();
+    vi.stubEnv("OIDC_ADMIN_CLAIM", "groups");
+    vi.stubEnv("OIDC_ADMIN_CLAIM_VALUE", "nzbdav-admins");
+
+    expect(resolveOidcRole({ groups: "nzbdav-admins" })).toBe("admin");
+    expect(resolveOidcRole({ groups: ["users", "nzbdav-admins"] })).toBe("admin");
+    expect(resolveOidcRole({ groups: ["users"] })).toBe("readonly");
+  });
+
+  it("defaults to admin only when role mapping is not configured", () => {
+    enableOidc();
+    expect(resolveOidcRole({})).toBe("admin");
+
+    vi.stubEnv("OIDC_ADMIN_CLAIM", "groups");
+    expect(resolveOidcRole({ groups: ["nzbdav-admins"] })).toBe("readonly");
+  });
+});

--- a/frontend/server/oidc.server.ts
+++ b/frontend/server/oidc.server.ts
@@ -1,0 +1,107 @@
+import * as oidc from "openid-client";
+import type { UserRole } from "~/auth/authentication.server";
+import { logger } from "./logger";
+
+export type OidcClaims = Record<string, unknown>;
+
+export type OidcSettings = {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri?: string;
+  scopes: string;
+  usernameClaim: string;
+  adminClaim?: string;
+  adminClaimValue?: string;
+};
+
+const REQUIRED_ENV_VARS = [
+  "OIDC_ISSUER",
+  "OIDC_CLIENT_ID",
+  "OIDC_CLIENT_SECRET",
+] as const;
+
+let discoveryPromise: Promise<oidc.Configuration> | undefined;
+let partialConfigWarningLogged = false;
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+export function isOidcEnabled(): boolean {
+  const configured = REQUIRED_ENV_VARS.filter((name) => readEnv(name) !== undefined);
+  if (configured.length === 0) return false;
+
+  if (configured.length !== REQUIRED_ENV_VARS.length) {
+    if (!partialConfigWarningLogged) {
+      const missing = REQUIRED_ENV_VARS.filter((name) => !readEnv(name));
+      logger.warn(
+        `OIDC is disabled because required environment variables are missing: ${missing.join(", ")}`,
+      );
+      partialConfigWarningLogged = true;
+    }
+    return false;
+  }
+
+  return true;
+}
+
+export function getOidcSettings(): OidcSettings {
+  if (!isOidcEnabled()) {
+    throw new Error("OIDC is not configured");
+  }
+
+  return {
+    issuer: readEnv("OIDC_ISSUER")!,
+    clientId: readEnv("OIDC_CLIENT_ID")!,
+    clientSecret: readEnv("OIDC_CLIENT_SECRET")!,
+    redirectUri: readEnv("OIDC_REDIRECT_URI"),
+    scopes: readEnv("OIDC_SCOPES") ?? "openid profile email",
+    usernameClaim: readEnv("OIDC_USERNAME_CLAIM") ?? "preferred_username",
+    adminClaim: readEnv("OIDC_ADMIN_CLAIM"),
+    adminClaimValue: readEnv("OIDC_ADMIN_CLAIM_VALUE"),
+  };
+}
+
+export async function getOidcConfiguration(): Promise<oidc.Configuration> {
+  const settings = getOidcSettings();
+  discoveryPromise ??= oidc.discovery(
+    new URL(settings.issuer),
+    settings.clientId,
+    settings.clientSecret,
+  ).catch((error: unknown) => {
+    discoveryPromise = undefined;
+    throw error;
+  });
+  return discoveryPromise;
+}
+
+export function resolveOidcUsername(claims: OidcClaims): string {
+  const configuredClaim = getOidcSettings().usernameClaim;
+  const candidates = [configuredClaim, "preferred_username", "email", "sub"];
+
+  for (const claimName of new Set(candidates)) {
+    const value = claims[claimName];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  throw new Error("OIDC identity does not contain a usable username claim");
+}
+
+export function resolveOidcRole(claims: OidcClaims): UserRole {
+  const { adminClaim, adminClaimValue } = getOidcSettings();
+  if (!adminClaim) return "admin";
+  if (!adminClaimValue) return "readonly";
+
+  const value = claims[adminClaim];
+  if (typeof value === "string") {
+    return value === adminClaimValue ? "admin" : "readonly";
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => item === adminClaimValue) ? "admin" : "readonly";
+  }
+  return "readonly";
+}

--- a/frontend/server/oidc.server.ts
+++ b/frontend/server/oidc.server.ts
@@ -70,6 +70,8 @@ export async function getOidcConfiguration(): Promise<oidc.Configuration> {
     new URL(settings.issuer),
     settings.clientId,
     settings.clientSecret,
+    undefined,
+    { execute: [oidc.enableNonRepudiationChecks] },
   ).catch((error: unknown) => {
     discoveryPromise = undefined;
     throw error;

--- a/zensical.toml
+++ b/zensical.toml
@@ -53,6 +53,7 @@ nav = [
     { "Warden" = "configuration/warden.md" },
     { "SABnzbd" = "configuration/sabnzbd.md" },
     { "WebDAV" = "configuration/webdav.md" },
+    { "OIDC / SSO" = "configuration/oidc.md" },
     { "Radarr/Sonarr" = "configuration/arrs.md" },
     { "Rclone" = "configuration/rclone.md" },
     { "Repairs" = "configuration/repairs.md" },


### PR DESCRIPTION
## Summary
- add optional OIDC Authorization Code login with PKCE, nonce validation, environment-only configuration, and no local account provisioning
- map identity-provider claims to admin or read-only frontend sessions while keeping local login available
- verify provider-signed ID tokens against discovered keys and document setup as available since 0.10.0

Closes #99.

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm test`
- [x] integration fixture covers discovery, token exchange, valid ID-token acceptance, and invalid signature rejection
- [x] `cd frontend && npm run lint`
- [x] `zensical build --clean --strict`
- [x] visually verify the login page with OIDC enabled

## Notes
- Read-only is intentionally UI-level gating in this first release; it is not a backend API authorization boundary.
- OIDC identities create frontend sessions directly and are not provisioned as local account records.