### PR TITLE
feat(ui): compare per-provider download speeds on Overview

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -21,12 +21,14 @@ public class GetOverviewStatsController(
     ConfigManager configManager,
     IndexerHitTracker hitTracker,
     UsenetStreamingClient usenetStreamingClient,
-    InFlightArticleBudget inFlightArticleBudget
+    InFlightArticleBudget inFlightArticleBudget,
+    ProviderBytesTracker providerBytesTracker
 ) : BaseApiController
 {
     private const long OneMinute = 60_000;
     private const long OneHour = 60 * OneMinute;
     private const long OneDay = 24 * OneHour;
+    private static readonly TimeSpan LiveSpeedMaxAge = TimeSpan.FromMinutes(1);
 
     // Log-scale latency buckets in milliseconds. Last bucket is a catch-all up to int.MaxValue.
     private static readonly int[] LatencyBucketEdges =
@@ -351,6 +353,7 @@ public class GetOverviewStatsController(
             providers,
             usenetStreamingClient.GetProviderCircuitSnapshots(),
             labelsByMetricsKey);
+        ApplyLiveSpeedFallback(providers);
         var circuitEvents = await circuitEventsTask.ConfigureAwait(false);
         ApplyOutageSparks(
             providers,
@@ -772,6 +775,8 @@ public class GetOverviewStatsController(
                 acc.Spark[idx] += m.Articles;
                 acc.ErrorSpark[idx] += m.Errors;
                 acc.RetrySpark[idx] += m.Retries;
+                acc.BytesSpark[idx] += m.BytesFetched;
+                acc.DurationSpark[idx] += m.SumDurationMs;
             }
             byProvider[m.Provider] = acc;
         }
@@ -789,6 +794,8 @@ public class GetOverviewStatsController(
                     BytesFetched = kv.Value.Bytes,
                     Errors = kv.Value.Errors,
                     Retries = kv.Value.Retries,
+                    SpeedMbPerSec = CalculateSpeedMbPerSec(kv.Value.Bytes, kv.Value.SumDurationMs),
+                    SpeedSpark = BuildSpeedSpark(kv.Value.BytesSpark, kv.Value.DurationSpark),
                     // SumDurationMs is Ok-only from rollup; divide by Ok count, not all attempts.
                     AvgDurationMs = okArticles > 0 ? (double)kv.Value.SumDurationMs / okArticles : 0,
                     ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
@@ -831,6 +838,8 @@ public class GetOverviewStatsController(
                 acc.Spark[idx] += (long)h.Articles;
                 acc.ErrorSpark[idx] += (long)h.Errors;
                 acc.RetrySpark[idx] += (long)h.Retries;
+                acc.BytesSpark[idx] += (long)h.BytesFetched;
+                acc.DurationSpark[idx] += (long)h.SumDurationMs;
             }
             byProvider[host] = acc;
         }
@@ -848,6 +857,8 @@ public class GetOverviewStatsController(
                     BytesFetched = kv.Value.Bytes,
                     Errors = kv.Value.Errors,
                     Retries = kv.Value.Retries,
+                    SpeedMbPerSec = CalculateSpeedMbPerSec(kv.Value.Bytes, kv.Value.SumDurationMs),
+                    SpeedSpark = BuildSpeedSpark(kv.Value.BytesSpark, kv.Value.DurationSpark),
                     AvgDurationMs = okArticles > 0 ? (double)kv.Value.SumDurationMs / okArticles : 0,
                     ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
                     Spark = kv.Value.Spark.ToList(),
@@ -859,17 +870,44 @@ public class GetOverviewStatsController(
             .ToList();
     }
 
+    private void ApplyLiveSpeedFallback(IEnumerable<GetOverviewStatsResponse.ProviderRow> providers)
+    {
+        foreach (var provider in providers)
+        {
+            if (provider.SpeedMbPerSec is not null) continue;
+            var bytesPerMs = providerBytesTracker.GetRecentBytesPerMs(provider.Provider, LiveSpeedMaxAge);
+            if (bytesPerMs > 0)
+                provider.SpeedMbPerSec = bytesPerMs * 1000 / 1_000_000;
+        }
+    }
+
+    private static double? CalculateSpeedMbPerSec(long bytes, long durationMs) =>
+        bytes > 0 && durationMs > 0
+            ? bytes * 1000d / durationMs / 1_000_000d
+            : null;
+
+    private static List<double> BuildSpeedSpark(
+        IReadOnlyList<long> bytes,
+        IReadOnlyList<long> durations) =>
+        bytes.Select((value, index) =>
+                CalculateSpeedMbPerSec(value, durations[index]) ?? 0)
+            .ToList();
+
     private sealed class ProviderAccumulator
     {
         public long Articles, Misses, Errors, Retries, SumDurationMs, Bytes;
         public readonly long[] Spark;
         public readonly long[] ErrorSpark;
         public readonly long[] RetrySpark;
+        public readonly long[] BytesSpark;
+        public readonly long[] DurationSpark;
         public ProviderAccumulator(int n)
         {
             Spark = new long[n];
             ErrorSpark = new long[n];
             RetrySpark = new long[n];
+            BytesSpark = new long[n];
+            DurationSpark = new long[n];
         }
     }
 

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -268,7 +268,12 @@ public class GetOverviewStatsController(
                 hours.Select(h => (h.Hour, h.Articles, h.Misses, h.Errors, h.BytesFetched)),
                 sessions.Select(s => (s.EndedAt, s.BytesServed)),
                 bucketSize);
-            providers = BuildProvidersFromHourly(hours, windowStart, bucketSize, nowMs, labelsByMetricsKey);
+            providers = BuildProvidersFromHourly(
+                hours.Select(h => (h.Hour, h.Provider, h.Articles, h.BytesFetched, h.Misses, h.Errors, h.Retries, h.SumDurationMs)),
+                windowStart,
+                bucketSize,
+                nowMs,
+                labelsByMetricsKey);
             totalArticles = hours.Sum(h => h.Articles);
             totalMisses = hours.Sum(h => h.Misses);
             totalErrors = hours.Sum(h => h.Errors);
@@ -808,8 +813,8 @@ public class GetOverviewStatsController(
             .ToList();
     }
 
-    private static List<GetOverviewStatsResponse.ProviderRow> BuildProvidersFromHourly(
-        IEnumerable<dynamic> hours,
+    internal static List<GetOverviewStatsResponse.ProviderRow> BuildProvidersFromHourly(
+        IEnumerable<(long Hour, string Provider, long Articles, long BytesFetched, long Misses, long Errors, long Retries, long SumDurationMs)> hours,
         long windowStart,
         long bucketSize,
         long nowMs,
@@ -823,23 +828,23 @@ public class GetOverviewStatsController(
         var byProvider = new Dictionary<string, ProviderAccumulator>();
         foreach (var h in hours)
         {
-            string host = h.Provider;
+            var host = h.Provider;
             if (!byProvider.TryGetValue(host, out var acc))
                 acc = new ProviderAccumulator(sparkBuckets);
-            acc.Articles += (long)h.Articles;
-            acc.Misses += (long)h.Misses;
-            acc.Errors += (long)h.Errors;
-            acc.Retries += (long)h.Retries;
-            acc.SumDurationMs += (long)h.SumDurationMs;
-            acc.Bytes += (long)h.BytesFetched;
-            var idx = (int)(((long)h.Hour - sparkStart) / sparkSize);
+            acc.Articles += h.Articles;
+            acc.Misses += h.Misses;
+            acc.Errors += h.Errors;
+            acc.Retries += h.Retries;
+            acc.SumDurationMs += h.SumDurationMs;
+            acc.Bytes += h.BytesFetched;
+            var idx = (int)((h.Hour - sparkStart) / sparkSize);
             if (idx >= 0 && idx < sparkBuckets)
             {
-                acc.Spark[idx] += (long)h.Articles;
-                acc.ErrorSpark[idx] += (long)h.Errors;
-                acc.RetrySpark[idx] += (long)h.Retries;
-                acc.BytesSpark[idx] += (long)h.BytesFetched;
-                acc.DurationSpark[idx] += (long)h.SumDurationMs;
+                acc.Spark[idx] += h.Articles;
+                acc.ErrorSpark[idx] += h.Errors;
+                acc.RetrySpark[idx] += h.Retries;
+                acc.BytesSpark[idx] += h.BytesFetched;
+                acc.DurationSpark[idx] += h.SumDurationMs;
             }
             byProvider[host] = acc;
         }

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -68,6 +68,9 @@ public class GetOverviewStatsResponse
         public long BytesFetched { get; init; }
         public long Errors { get; init; }
         public long Retries { get; init; }
+        /// <summary>Decimal megabytes fetched per second over the selected window.</summary>
+        public double? SpeedMbPerSec { get; set; }
+        public List<double> SpeedSpark { get; init; } = new();
         /// <summary>
         /// Mean duration of successful (Ok) fetches only. Includes connection-pool wait
         /// inside the provider call; not pure wire RTT. Misses/errors are excluded.

--- a/backend/Services/Metrics/ProviderBytesTracker.cs
+++ b/backend/Services/Metrics/ProviderBytesTracker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace NzbWebDAV.Services.Metrics;
 
@@ -23,6 +24,7 @@ public sealed class ProviderBytesTracker
     private long _lifetimeAll;
 
     private readonly ConcurrentDictionary<string, double> _bytesPerMs = new();
+    private readonly ConcurrentDictionary<string, long> _speedRecordedAt = new();
     private const double SpeedEwmaAlpha = 0.3;
 
     public void Add(string providerKey, long bytes)
@@ -62,12 +64,23 @@ public sealed class ProviderBytesTracker
         if (string.IsNullOrEmpty(providerKey) || bytes <= 0 || activeMs <= 0) return;
         var sample = bytes / activeMs;
         _bytesPerMs.AddOrUpdate(providerKey, sample, (_, prev) => prev + SpeedEwmaAlpha * (sample - prev));
+        _speedRecordedAt[providerKey] = Stopwatch.GetTimestamp();
     }
 
     public double GetBytesPerMs(string providerKey)
     {
         if (string.IsNullOrEmpty(providerKey)) return 0;
         return _bytesPerMs.TryGetValue(providerKey, out var v) ? v : 0;
+    }
+
+    public double GetRecentBytesPerMs(string providerKey, TimeSpan maxAge)
+    {
+        if (maxAge <= TimeSpan.Zero ||
+            !_speedRecordedAt.TryGetValue(providerKey, out var recordedAt))
+            return 0;
+
+        var elapsed = Stopwatch.GetElapsedTime(recordedAt);
+        return elapsed <= maxAge ? GetBytesPerMs(providerKey) : 0;
     }
 
     /// <summary>

--- a/backend/Services/Metrics/ProviderBytesTracker.cs
+++ b/backend/Services/Metrics/ProviderBytesTracker.cs
@@ -25,7 +25,17 @@ public sealed class ProviderBytesTracker
 
     private readonly ConcurrentDictionary<string, double> _bytesPerMs = new();
     private readonly ConcurrentDictionary<string, long> _speedRecordedAt = new();
+    private readonly Func<long> _timestampProvider;
     private const double SpeedEwmaAlpha = 0.3;
+
+    public ProviderBytesTracker() : this(Stopwatch.GetTimestamp)
+    {
+    }
+
+    internal ProviderBytesTracker(Func<long> timestampProvider)
+    {
+        _timestampProvider = timestampProvider;
+    }
 
     public void Add(string providerKey, long bytes)
     {
@@ -64,7 +74,7 @@ public sealed class ProviderBytesTracker
         if (string.IsNullOrEmpty(providerKey) || bytes <= 0 || activeMs <= 0) return;
         var sample = bytes / activeMs;
         _bytesPerMs.AddOrUpdate(providerKey, sample, (_, prev) => prev + SpeedEwmaAlpha * (sample - prev));
-        _speedRecordedAt[providerKey] = Stopwatch.GetTimestamp();
+        _speedRecordedAt[providerKey] = _timestampProvider();
     }
 
     public double GetBytesPerMs(string providerKey)
@@ -79,7 +89,7 @@ public sealed class ProviderBytesTracker
             !_speedRecordedAt.TryGetValue(providerKey, out var recordedAt))
             return 0;
 
-        var elapsed = Stopwatch.GetElapsedTime(recordedAt);
+        var elapsed = Stopwatch.GetElapsedTime(recordedAt, _timestampProvider());
         return elapsed <= maxAge ? GetBytesPerMs(providerKey) : 0;
     }
 

--- a/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
+++ b/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
@@ -26,6 +26,8 @@ internal static class ProviderCircuitOverviewEnricher
                     BytesFetched = existing.BytesFetched,
                     Errors = existing.Errors,
                     Retries = existing.Retries,
+                    SpeedMbPerSec = existing.SpeedMbPerSec,
+                    SpeedSpark = existing.SpeedSpark,
                     AvgDurationMs = existing.AvgDurationMs,
                     ErrorRate = existing.ErrorRate,
                     Spark = existing.Spark,

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -744,6 +744,8 @@ export type ProviderRow = {
     bytesFetched: number,
     errors: number,
     retries: number,
+    speedMbPerSec?: number | null,
+    speedSpark?: number[],
     avgDurationMs: number,
     errorRate: number,
     spark: number[],

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -1,6 +1,35 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { OutageBuckets, Sparkline } from "./provider-scoreboard";
+import type { ProviderRow } from "~/clients/backend-client.server";
+import { OutageBuckets, ProviderScoreboard, Sparkline } from "./provider-scoreboard";
+
+const provider = (speedMbPerSec: number | null): ProviderRow => ({
+    provider: "provider-1",
+    articles: 10,
+    bytesFetched: 1_000_000,
+    errors: 0,
+    retries: 0,
+    speedMbPerSec,
+    speedSpark: speedMbPerSec == null ? [] : [speedMbPerSec],
+    avgDurationMs: 100,
+    errorRate: 0,
+    spark: [10],
+});
+
+describe("ProviderScoreboard", () => {
+    it("shows sustained speed and an em dash when speed is unavailable", () => {
+        const active = renderToStaticMarkup(
+            <ProviderScoreboard providers={[provider(12.34)]} window="1h" />,
+        );
+        const idle = renderToStaticMarkup(
+            <ProviderScoreboard providers={[provider(null)]} window="1h" />,
+        );
+
+        expect(active).toContain(">MB/s<");
+        expect(active).toContain(">12.3<");
+        expect(idle).toContain(">—<");
+    });
+});
 
 describe("OutageBuckets", () => {
     it("keeps a brief trip inside its single time bucket", () => {

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -27,6 +27,7 @@ describe("ProviderScoreboard", () => {
 
         expect(active).toContain(">MB/s<");
         expect(active).toContain(">12.3<");
+        expect(active).toContain("not wall-clock aggregate bandwidth");
         expect(idle).toContain(">—<");
     });
 });

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -9,6 +9,7 @@ export type ProviderScoreboardProps = {
 export function ProviderScoreboard({ providers, window }: ProviderScoreboardProps) {
     const total = providers.reduce((s, p) => s + p.articles, 0);
     const outageHelp = `Circuit-open time per ${outageIntervalLabel(window)} interval on a fixed 0–100% scale. Brief trips use a minimum-height tick.`;
+    const speedHelp = "Historical average: bytes fetched divided by summed successful fetch durations over the selected window. Durations include connection-pool wait and overlap across concurrent fetches, so this is not wall-clock aggregate bandwidth. Use the provider benchmark for line-rate calibration.";
 
     return (
         <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
@@ -39,7 +40,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                     <th>Share</th>
                                     <th
                                         className="w-[120px]"
-                                        title="Sustained download throughput (bytes fetched / successful fetch duration) over the selected window. Fetch duration includes connection-pool wait.">
+                                        title={speedHelp}>
                                         MB/s
                                     </th>
                                     <th className="w-[120px]">Errors</th>
@@ -82,7 +83,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                             <td>
                                                 <ShareBar share={share} />
                                             </td>
-                                            <td title="Sustained download throughput over the selected window">
+                                            <td title={speedHelp}>
                                                 <div className="flex flex-col gap-0.5">
                                                     <Sparkline values={p.speedSpark ?? []} tone="success" />
                                                     <div className="font-mono text-[11px] tabular-nums text-base-content/60">

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -1,5 +1,5 @@
 import type { OverviewWindow, ProviderCircuitState, ProviderRow } from "~/clients/backend-client.server";
-import { formatBytes, formatNumber, formatPercent } from "../../utils/format";
+import { formatBytes, formatNumber, formatPercent, formatSpeed } from "../../utils/format";
 
 export type ProviderScoreboardProps = {
     providers: ProviderRow[],
@@ -24,7 +24,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                     <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
                 ) : (
                     <div className="overflow-x-auto">
-                        <table className="table table-sm min-w-[680px]">
+                        <table className="table table-sm min-w-[800px]">
                             <thead>
                                 <tr>
                                     <th>Provider</th>
@@ -37,6 +37,11 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                     <th>Articles</th>
                                     <th>Read</th>
                                     <th>Share</th>
+                                    <th
+                                        className="w-[120px]"
+                                        title="Sustained download throughput (bytes fetched / successful fetch duration) over the selected window. Fetch duration includes connection-pool wait.">
+                                        MB/s
+                                    </th>
                                     <th className="w-[120px]">Errors</th>
                                     <th className="w-[120px]">Retries</th>
                                     <th
@@ -76,6 +81,14 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                                             <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>
                                             <td>
                                                 <ShareBar share={share} />
+                                            </td>
+                                            <td title="Sustained download throughput over the selected window">
+                                                <div className="flex flex-col gap-0.5">
+                                                    <Sparkline values={p.speedSpark ?? []} tone="success" />
+                                                    <div className="font-mono text-[11px] tabular-nums text-base-content/60">
+                                                        {formatSpeed(p.speedMbPerSec)}
+                                                    </div>
+                                                </div>
                                             </td>
                                             <td>
                                                 <div className="flex flex-col gap-0.5">

--- a/frontend/app/routes/overview/utils/format.ts
+++ b/frontend/app/routes/overview/utils/format.ts
@@ -9,6 +9,10 @@ export function formatBytes(bytes: number): string {
     return v >= 100 ? `${v.toFixed(0)} ${units[i]}` : `${v.toFixed(1)} ${units[i]}`;
 }
 
+export function formatSpeed(mbPerSec: number | null | undefined): string {
+    return mbPerSec == null || !isFinite(mbPerSec) ? "—" : mbPerSec.toFixed(1);
+}
+
 export function formatNumber(n: number): string {
     return n.toLocaleString();
 }

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
@@ -99,6 +99,30 @@ public class GetOverviewStatsProviderFilterTests
     }
 
     [Fact]
+    public void BuildProvidersFromMinutes_ComputesAggregateAndBucketSpeeds()
+    {
+        var windowStart = 1_700_000_000_000L;
+        var minutes = new[]
+        {
+            (windowStart, ConfiguredKey, 10L, 2_000_000L, 0L, 0L, 0L, 1_000L),
+            (windowStart + 60_000, ConfiguredKey, 10L, 1_000_000L, 0L, 0L, 0L, 1_000L),
+        };
+
+        var rows = GetOverviewStatsController.BuildProvidersFromMinutes(
+            minutes,
+            windowStart,
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour,
+            Labels);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(1.5, row.SpeedMbPerSec);
+        Assert.Equal(60, row.SpeedSpark.Count);
+        Assert.Equal(2.0, row.SpeedSpark[0]);
+        Assert.Equal(1.0, row.SpeedSpark[1]);
+        Assert.Equal(0.0, row.SpeedSpark[2]);
+    }
+
+    [Fact]
     public void BuildFailover_OmitsDeletedProvidersFromListsButKeepsAggregateTotals()
     {
         var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderFilterTests.cs
@@ -123,6 +123,33 @@ public class GetOverviewStatsProviderFilterTests
     }
 
     [Fact]
+    public void BuildProvidersFromHourly_ComputesDailySpeedBuckets()
+    {
+        const long oneHour = 3_600_000;
+        const long oneDay = 86_400_000;
+        var windowStart = 1_700_000_000_000L - (1_700_000_000_000L % oneDay);
+        var hours = new[]
+        {
+            (windowStart, ConfiguredKey, 10L, 2_000_000L, 0L, 0L, 0L, 1_000L),
+            (windowStart + oneDay, ConfiguredKey, 10L, 1_000_000L, 0L, 0L, 0L, 1_000L),
+        };
+
+        var rows = GetOverviewStatsController.BuildProvidersFromHourly(
+            hours,
+            windowStart,
+            oneHour,
+            windowStart + (2 * oneDay),
+            Labels);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(1.5, row.SpeedMbPerSec);
+        Assert.Equal(3, row.SpeedSpark.Count);
+        Assert.Equal(2.0, row.SpeedSpark[0]);
+        Assert.Equal(1.0, row.SpeedSpark[1]);
+        Assert.Equal(0.0, row.SpeedSpark[2]);
+    }
+
+    [Fact]
     public void BuildFailover_OmitsDeletedProvidersFromListsButKeepsAggregateTotals()
     {
         var at = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderBytesTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderBytesTrackerTests.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+public class ProviderBytesTrackerTests
+{
+    [Fact]
+    public void GetRecentBytesPerMs_ExpiresUiFallbackWithoutClearingSchedulerEstimate()
+    {
+        long timestamp = 1;
+        var tracker = new ProviderBytesTracker(() => timestamp);
+        tracker.RecordSegmentThroughput("primary", 1_000_000, 1_000);
+
+        Assert.Equal(1_000d, tracker.GetRecentBytesPerMs("primary", TimeSpan.FromSeconds(1)));
+
+        timestamp += Stopwatch.Frequency * 2;
+
+        Assert.Equal(0, tracker.GetRecentBytesPerMs("primary", TimeSpan.FromSeconds(1)));
+        Assert.Equal(1_000d, tracker.GetBytesPerMs("primary"));
+    }
+}


### PR DESCRIPTION
## Summary
- expose per-provider MB/s and speed history from existing overview rollups
- fall back to the recent live EWMA before rollups are available, with stale values suppressed
- add an MB/s sparkline and idle-state em dash to the provider scoreboard

Closes #259

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm test`