### PR TITLE
chore(ci): match Discord release announcement formatting

### DIFF
--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -52,7 +52,6 @@ jobs:
           SHA: ${{ github.sha }}
           PREVIOUS_SHA: ${{ needs.tag-dev.outputs.previous_sha }}
           REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           if [ -z "${DISCORD_DEVELOPMENT_WEBHOOK_URL}" ]; then
@@ -61,15 +60,22 @@ jobs:
           fi
 
           SHORT_SHA="${SHA:0:7}"
-          ANNOUNCEMENT_BODY=$(printf '**Dev image refreshed**\n`ghcr.io/%s:dev` and git tag `dev` now point to `%s`.\nRun: %s' "${REPO}" "${SHORT_SHA}" "${RUN_URL}")
-
+          BASE_LABEL="Changes since last dev build"
           if [ -n "${PREVIOUS_SHA}" ] && [ "${PREVIOUS_SHA}" != "${SHA}" ]; then
             CHANGELOG=$(gh api "repos/${REPO}/compare/${PREVIOUS_SHA}...${SHA}" \
-              --jq '.commits[] | "• " + (.commit.message | split("\n")[0] | sub(" \\(#[0-9]+\\)$"; ""))')
-            if [ -n "${CHANGELOG}" ]; then
-              ANNOUNCEMENT_BODY=$(printf '%s\n\n**Changes since previous :dev:**\n%s' "${ANNOUNCEMENT_BODY}" "${CHANGELOG}")
-            fi
+              --jq '.commits[] | "- " + (.commit.message | split("\n")[0] | sub(" \\(#[0-9]+\\)$"; "")) + " ([" + .sha[0:7] + "](" + .html_url + "))"')
+          elif [ "${PREVIOUS_SHA}" = "${SHA}" ]; then
+            CHANGELOG="- (no new commits since last dev build)"
+          else
+            BASE_LABEL="Initial dev build"
+            CHANGELOG=$(printf -- '- Current commit ([%s](https://github.com/%s/commit/%s))' "${SHORT_SHA}" "${REPO}" "${SHA}")
           fi
+          if [ -z "${CHANGELOG}" ]; then
+            CHANGELOG="- (no new commits since last dev build)"
+          fi
+
+          ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `dev-%s`)\n%s\n%s' \
+            "${SHORT_SHA}" "${BASE_LABEL}" "${CHANGELOG}")
 
           MAX_LEN=1900
           if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then
@@ -78,5 +84,5 @@ jobs:
 
           ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
           curl --fail-with-body -sS -H "Content-Type: application/json" \
-            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4, \"allowed_mentions\": {\"parse\": []}}" \
             "$DISCORD_DEVELOPMENT_WEBHOOK_URL"

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -63,12 +63,12 @@ jobs:
           BASE_LABEL="Changes since last dev build"
           if [ -n "${PREVIOUS_SHA}" ] && [ "${PREVIOUS_SHA}" != "${SHA}" ]; then
             CHANGELOG=$(gh api "repos/${REPO}/compare/${PREVIOUS_SHA}...${SHA}" \
-              --jq '.commits[] | "- " + (.commit.message | split("\n")[0] | sub(" \\(#[0-9]+\\)$"; "")) + " ([" + .sha[0:7] + "](" + .html_url + "))"')
+              --jq '.commits[] | "- " + (.commit.message | split("\n")[0] | sub(" \\(#[0-9]+\\)$"; ""))')
           elif [ "${PREVIOUS_SHA}" = "${SHA}" ]; then
             CHANGELOG="- (no new commits since last dev build)"
           else
             BASE_LABEL="Initial dev build"
-            CHANGELOG=$(printf -- '- Current commit ([%s](https://github.com/%s/commit/%s))' "${SHORT_SHA}" "${REPO}" "${SHA}")
+            CHANGELOG="- No previous dev build to compare"
           fi
           if [ -z "${CHANGELOG}" ]; then
             CHANGELOG="- (no new commits since last dev build)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,10 @@ jobs:
             }
             seen { print }
           ' CHANGELOG.md)
+          RELEASE_NOTES=$(printf '%s\n' "${RELEASE_NOTES}" | sed -E \
+            -e 's/ \(\[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)\)//g' \
+            -e 's/ \(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[^)]+\)\)//g' \
+            -e 's/, closes \[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)//g')
 
           ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**%s' "${VERSION}" "${RELEASE_NOTES}")
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,6 @@ jobs:
         env:
           DISCORD_ANNOUNCEMENTS_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
           VERSION: ${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ -z "${DISCORD_ANNOUNCEMENTS_WEBHOOK_URL}" ]; then
@@ -164,28 +163,15 @@ jobs:
             seen { print }
           ' CHANGELOG.md)
 
-          # Discord-friendly notes: drop markdown noise and per-commit parentheticals.
-          RELEASE_NOTES=$(printf '%s\n' "${RELEASE_NOTES}" | sed -E \
-            -e 's/^### //' \
-            -e 's/^\* \*\*([^*]+):\*\* /\1: /' \
-            -e 's/^\* //' \
-            -e 's/ \(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[^)]+\)\)//g' \
-            -e 's/ \(\[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)\)//g' \
-            -e 's/, closes \[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)//g' \
-            | awk 'NF { blank=0; print; next } !blank++')
+          ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**%s' "${VERSION}" "${RELEASE_NOTES}")
 
-          RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
-          HEADER=$(printf '**New Release: v%s**' "${VERSION}")
-          # Discord content limit is 2000; keep a single message and prefer the release URL.
+          # Discord content is limited to 2000 characters.
           MAX_LEN=1900
-          overhead=$((${#HEADER} + ${#RELEASE_URL} + 2))
-          max_notes=$((MAX_LEN - overhead))
-          if [ "${#RELEASE_NOTES}" -gt "${max_notes}" ]; then
-            RELEASE_NOTES="${RELEASE_NOTES:0:$((max_notes - 3))}..."
+          if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then
+            ANNOUNCEMENT_BODY="${ANNOUNCEMENT_BODY:0:$((MAX_LEN - 3))}..."
           fi
-          ANNOUNCEMENT_BODY=$(printf '%s\n%s\n%s' "${HEADER}" "${RELEASE_NOTES}" "${RELEASE_URL}")
 
           ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
           curl --fail-with-body -sS -H "Content-Type: application/json" \
-            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4, \"allowed_mentions\": {\"parse\": []}}" \
             "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- format stable release posts with the DUMB-style release header and raw release-please notes
- format `:dev` refresh posts with a dev version and linked commit list
- disable Discord mentions while retaining embed suppression and message-length guards

## Test plan
- [x] Parse edited workflows as YAML
- [x] Render and validate representative stable and development Discord payloads
- [x] Confirm payloads stay under 2,000 characters and disable mentions
- [x] Run `git diff --check`