### PR TITLE
chore(ci): improve CI efficiency and test coverage gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,14 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Publish backend for linux-musl-x64
         run: |
           dotnet publish backend/NzbWebDAV.csproj \
@@ -164,3 +172,58 @@ jobs:
             -w /app \
             mcr.microsoft.com/dotnet/aspnet:10.0-alpine \
             sh -c 'apk add --no-cache libc6-compat >/dev/null && ./NzbWebDAV --yenc-self-test'
+
+  docker-runtime-smoke:
+    name: Docker runtime image smoke build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect runtime image changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            Dockerfile \
+            .dockerignore \
+            entrypoint.sh \
+            backend/NzbWebDAV.csproj \
+            backend/nuget.config \
+            frontend/package.json \
+            frontend/package-lock.json; then
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              exit "$status"
+            fi
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.build == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker runtime image
+        if: steps.changes.outputs.build == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64
+          build-args: |
+            NZBDAV_VERSION=ci
+            NZBDAV_COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+            REPO_URL=https://github.com/${{ github.repository }}
+
+      - name: Skip unchanged runtime image
+        if: steps.changes.outputs.build != 'true'
+        run: echo "No runtime image inputs changed; smoke build skipped."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,15 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Cache NuGet packages
+        if: matrix.language == 'csharp'
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Set up Node.js
         if: matrix.language == 'javascript-typescript'
         uses: actions/setup-node@v7.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.x"
+          cache: pip
+          cache-dependency-path: docs-requirements.txt
 
       - name: Install documentation dependencies
         run: pip install -r docs-requirements.txt

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -28,7 +28,14 @@ public sealed class DavDatabaseContext : DbContext
     public static string ConfigPath => EnvironmentUtil.GetEnvironmentVariable("CONFIG_PATH") ?? "/config";
     public static string DatabaseFilePath => Path.Join(ConfigPath, "db.sqlite");
 
-    private static readonly Lazy<DbContextOptions<DavDatabaseContext>> Options = new(() =>
+    private static Lazy<DbContextOptions<DavDatabaseContext>> Options = CreateOptions();
+
+    internal static void ResetOptionsForTests()
+    {
+        Options = CreateOptions();
+    }
+
+    private static Lazy<DbContextOptions<DavDatabaseContext>> CreateOptions() => new(() =>
         new DbContextOptionsBuilder<DavDatabaseContext>()
             .UseSqlite(new SqliteConnectionStringBuilder
             {

--- a/backend/Database/MetricsDbContext.cs
+++ b/backend/Database/MetricsDbContext.cs
@@ -17,7 +17,14 @@ public sealed class MetricsDbContext : DbContext
 {
     public static string DatabaseFilePath => Path.Join(DavDatabaseContext.ConfigPath, "metrics.sqlite");
 
-    private static readonly Lazy<DbContextOptions<MetricsDbContext>> Options = new(() =>
+    private static Lazy<DbContextOptions<MetricsDbContext>> Options = CreateOptions();
+
+    internal static void ResetOptionsForTests()
+    {
+        Options = CreateOptions();
+    }
+
+    private static Lazy<DbContextOptions<MetricsDbContext>> CreateOptions() => new(() =>
         new DbContextOptionsBuilder<MetricsDbContext>()
             .UseSqlite($"Data Source={DatabaseFilePath}")
             .AddInterceptors(new SqliteMetricsPragmas())

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Api.SabControllers;
@@ -34,7 +35,7 @@ using Serilog.Templates.Themes;
 
 namespace NzbWebDAV;
 
-class Program
+public partial class Program
 {
     static async Task Main(string[] args)
     {
@@ -151,7 +152,13 @@ class Program
                 return;
             }
 
-            RunYencNativeSelfTest();
+            // WebApplicationFactory runs from the test output directory, where the
+            // backend's published rapidyenc native asset is not present.
+            if (!string.Equals(
+                    EnvironmentUtil.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+                    "Testing",
+                    StringComparison.OrdinalIgnoreCase))
+                RunYencNativeSelfTest();
 
             // Assign stable ProviderIds (persisting if needed) before the streaming
             // client is built. Cheap and non-fatal; the heavy legacy-metrics remap
@@ -314,7 +321,10 @@ class Program
             app.MapControllers();
             app.UseWebdavBasicAuthentication();
             app.UseNWebDav();
-            app.Lifetime.ApplicationStopping.Register(SigtermUtil.Cancel);
+            // TestServer hosts share a process, so stopping one must not trip the
+            // process-wide SIGTERM token used by later integration tests.
+            if (!app.Environment.IsEnvironment("Testing"))
+                app.Lifetime.ApplicationStopping.Register(SigtermUtil.Cancel);
             // Remap legacy host-keyed metrics rows onto ProviderIds after the app is
             // serving. This can rewrite a lot of rows on old databases and must never
             // delay the /health endpoint: blocking startup on it caused a container

--- a/frontend/app/routes/health/route.test.ts
+++ b/frontend/app/routes/health/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loader } from "./route";
+
+const {
+  getConfigMock,
+  getHealthCheckHistoryMock,
+  getHealthCheckQueueMock,
+} = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+  getHealthCheckHistoryMock: vi.fn(),
+  getHealthCheckQueueMock: vi.fn(),
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    getConfig: getConfigMock,
+    getHealthCheckHistory: getHealthCheckHistoryMock,
+    getHealthCheckQueue: getHealthCheckQueueMock,
+  },
+}));
+
+vi.mock("./components/health-table/health-table", () => ({
+  HealthTable: vi.fn(),
+}));
+
+vi.mock("./components/health-stats/health-stats", () => ({
+  HealthStats: vi.fn(),
+}));
+
+vi.mock("~/utils/shared-websocket", () => ({
+  useWebsocketTopics: vi.fn(),
+}));
+
+vi.mock("~/components/ui", () => ({
+  Alert: vi.fn(),
+  Icon: vi.fn(),
+}));
+
+vi.mock("./health-queue-state", () => ({
+  completeHealthCheck: vi.fn(),
+}));
+
+describe("health route loader", () => {
+  beforeEach(() => {
+    getConfigMock.mockReset();
+    getHealthCheckHistoryMock.mockReset();
+    getHealthCheckQueueMock.mockReset();
+  });
+
+  it("combines the health queue, history, and enabled setting", async () => {
+    const queueItems = [{ id: "queue-1", name: "Example" }];
+    const historyStats = [{ result: 0, repairStatus: 0, count: 4 }];
+    const historyItems = [{ id: "history-1", path: "/view/example.mkv" }];
+    getHealthCheckQueueMock.mockResolvedValueOnce({
+      uncheckedCount: 12,
+      items: queueItems,
+    });
+    getHealthCheckHistoryMock.mockResolvedValueOnce({
+      stats: historyStats,
+      items: historyItems,
+    });
+    getConfigMock.mockResolvedValueOnce([
+      { configName: "repair.enable", configValue: "TRUE" },
+    ]);
+
+    await expect(loader()).resolves.toEqual({
+      uncheckedCount: 12,
+      queueItems,
+      historyStats,
+      historyItems,
+      isEnabled: true,
+    });
+    expect(getHealthCheckQueueMock).toHaveBeenCalledWith(30);
+    expect(getHealthCheckHistoryMock).toHaveBeenCalledOnce();
+    expect(getConfigMock).toHaveBeenCalledWith(["repair.enable"]);
+  });
+
+  it("reports health checks disabled when the setting is absent or false", async () => {
+    getHealthCheckQueueMock.mockResolvedValue({
+      uncheckedCount: 0,
+      items: [],
+    });
+    getHealthCheckHistoryMock.mockResolvedValue({
+      stats: [],
+      items: [],
+    });
+    getConfigMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { configName: "repair.enable", configValue: "false" },
+      ]);
+
+    await expect(loader()).resolves.toMatchObject({ isEnabled: false });
+    await expect(loader()).resolves.toMatchObject({ isEnabled: false });
+  });
+
+  it("surfaces backend failures instead of returning partial health data", async () => {
+    getHealthCheckQueueMock.mockRejectedValueOnce(new Error("queue unavailable"));
+    getHealthCheckHistoryMock.mockResolvedValueOnce({ stats: [], items: [] });
+    getConfigMock.mockResolvedValueOnce([]);
+
+    await expect(loader()).rejects.toThrow("queue unavailable");
+  });
+});

--- a/frontend/app/routes/queue/route.test.ts
+++ b/frontend/app/routes/queue/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loader } from "./route";
+
+const { getConfigMock, getHistoryMock, getQueueMock } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+  getHistoryMock: vi.fn(),
+  getQueueMock: vi.fn(),
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    getConfig: getConfigMock,
+    getHistory: getHistoryMock,
+    getQueue: getQueueMock,
+  },
+}));
+
+vi.mock("./components/history-table/history-table", () => ({
+  HistoryTable: vi.fn(),
+}));
+
+vi.mock("./components/queue-table/queue-table", () => ({
+  QueueTable: vi.fn(),
+}));
+
+vi.mock("./controllers/events-controller", () => ({
+  useHistoryEvents: vi.fn(),
+  useQueueEvents: vi.fn(),
+}));
+
+vi.mock("./controllers/websocket-controller", () => ({
+  useQueueHistoryWebsocket: vi.fn(),
+}));
+
+vi.mock("./controllers/nzb-upload-controller", () => ({
+  useUploadController: vi.fn(),
+}));
+
+vi.mock("./controllers/dropzone-controller", () => ({
+  useQueueDropzone: vi.fn(),
+}));
+
+vi.mock("~/components/ui", () => ({
+  Alert: vi.fn(),
+}));
+
+vi.mock("~/auth/authorization", () => ({
+  useIsReadOnly: vi.fn(),
+}));
+
+function loaderRequest(search = ""): Parameters<typeof loader>[0] {
+  return {
+    request: new Request(`http://localhost/queue${search}`),
+  } as Parameters<typeof loader>[0];
+}
+
+describe("queue route loader", () => {
+  beforeEach(() => {
+    getConfigMock.mockReset();
+    getHistoryMock.mockReset();
+    getQueueMock.mockReset();
+  });
+
+  it("loads the requested queue and history pages with configured categories", async () => {
+    const queueSlots = [{ nzo_id: "queue-1" }];
+    const historySlots = [{ nzo_id: "history-1" }];
+    getQueueMock.mockResolvedValueOnce({ slots: queueSlots, noofslots: 30 });
+    getHistoryMock.mockResolvedValueOnce({ slots: historySlots, noofslots: 700 });
+    getConfigMock.mockResolvedValueOnce([
+      { configName: "api.categories", configValue: "tv, movies" },
+      { configName: "api.manual-category", configValue: "anime" },
+    ]);
+
+    const result = await loader(loaderRequest("?qp=2&hp=3&qps=25&hps=250"));
+
+    expect(getQueueMock).toHaveBeenCalledWith(25, 25);
+    expect(getHistoryMock).toHaveBeenCalledWith(250, 500);
+    expect(getConfigMock).toHaveBeenCalledWith([
+      "api.categories",
+      "api.manual-category",
+    ]);
+    expect(result).toEqual({
+      queueSlots,
+      historySlots,
+      totalQueueCount: 30,
+      totalHistoryCount: 700,
+      categories: ["anime", "tv", "movies"],
+      manualCategory: "anime",
+      queuePage: 2,
+      historyPage: 3,
+      queuePageSize: 25,
+      historyPageSize: 250,
+    });
+  });
+
+  it("normalizes invalid pagination and uses safe response defaults", async () => {
+    getQueueMock.mockResolvedValueOnce(null);
+    getHistoryMock.mockResolvedValueOnce(undefined);
+    getConfigMock.mockResolvedValueOnce([]);
+
+    const result = await loader(loaderRequest("?qp=0&hp=invalid&qps=10&hps=999"));
+
+    expect(getQueueMock).toHaveBeenCalledWith(100, 0);
+    expect(getHistoryMock).toHaveBeenCalledWith(100, 0);
+    expect(result).toMatchObject({
+      queueSlots: [],
+      historySlots: [],
+      totalQueueCount: 0,
+      totalHistoryCount: 0,
+      categories: ["uncategorized", "audio", "software", "tv", "movies"],
+      manualCategory: "uncategorized",
+      queuePage: 1,
+      historyPage: 1,
+      queuePageSize: 100,
+      historyPageSize: 100,
+    });
+  });
+
+  it("surfaces backend failures instead of returning partial queue data", async () => {
+    getQueueMock.mockRejectedValueOnce(new Error("queue unavailable"));
+    getHistoryMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getConfigMock.mockResolvedValueOnce([]);
+
+    await expect(loader(loaderRequest())).rejects.toThrow("queue unavailable");
+  });
+});

--- a/frontend/app/routes/settings.update/route.test.ts
+++ b/frontend/app/routes/settings.update/route.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { action } from "./route";
+
+const { updateConfigMock } = vi.hoisted(() => ({
+  updateConfigMock: vi.fn(),
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    updateConfig: updateConfigMock,
+  },
+}));
+
+function configRequest(config: string): Request {
+  const formData = new FormData();
+  formData.set("config", config);
+  return new Request("http://localhost/settings/update", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+describe("settings.update route action", () => {
+  beforeEach(() => {
+    updateConfigMock.mockReset();
+  });
+
+  it("updates every submitted setting and returns the saved values", async () => {
+    updateConfigMock.mockResolvedValueOnce(true);
+    const request = configRequest(JSON.stringify({
+      "repair.enable": "true",
+      "api.manual-category": "movies",
+    }));
+
+    const result = await action({ request } as Parameters<typeof action>[0]);
+
+    expect(updateConfigMock).toHaveBeenCalledWith([
+      { configName: "repair.enable", configValue: "true" },
+      { configName: "api.manual-category", configValue: "movies" },
+    ]);
+    expect(result).toEqual({
+      config: {
+        "repair.enable": "true",
+        "api.manual-category": "movies",
+      },
+    });
+  });
+
+  it("rejects malformed configuration without updating the backend", async () => {
+    const request = configRequest("{not-json");
+
+    await expect(
+      action({ request } as Parameters<typeof action>[0]),
+    ).rejects.toBeInstanceOf(SyntaxError);
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces backend update failures", async () => {
+    updateConfigMock.mockRejectedValueOnce(new Error("backend unavailable"));
+    const request = configRequest(JSON.stringify({ "repair.enable": "false" }));
+
+    await expect(
+      action({ request } as Parameters<typeof action>[0]),
+    ).rejects.toThrow("backend unavailable");
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       reportsDirectory: "./coverage",
+      thresholds: {
+        branches: 50,
+        functions: 49,
+        lines: 58,
+        statements: 56,
+      },
     },
   },
 });

--- a/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Text.Json;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class HttpPipelineIntegrationTests(NzbDavWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task AdminApi_RejectsMissingKeyAndAcceptsFrontendKey()
+    {
+        using var client = factory.CreateClient();
+
+        using var rejected = await client.GetAsync("/api/is-onboarding");
+        Assert.Equal(HttpStatusCode.Unauthorized, rejected.StatusCode);
+        using var rejectedJson = await JsonDocument.ParseAsync(
+            await rejected.Content.ReadAsStreamAsync());
+        Assert.False(rejectedJson.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal("API Key Required", rejectedJson.RootElement.GetProperty("error").GetString());
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/is-onboarding");
+        request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+        using var accepted = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, accepted.StatusCode);
+        using var acceptedJson = await JsonDocument.ParseAsync(
+            await accepted.Content.ReadAsStreamAsync());
+        Assert.True(acceptedJson.RootElement.GetProperty("status").GetBoolean());
+        Assert.True(acceptedJson.RootElement.GetProperty("isOnboarding").GetBoolean());
+    }
+
+    [Fact]
+    public async Task HealthEndpoint_IsAvailableWithoutAuthentication()
+    {
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Healthy", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task SabVersionEndpoint_MatchesUnauthenticatedCompatibilityRoute()
+    {
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api?mode=version&output=json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        Assert.True(json.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal("4.5.1", json.RootElement.GetProperty("version").GetString());
+    }
+}

--- a/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
+++ b/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">

--- a/tests/NzbWebDAV.Tests/TestUtils/HttpIntegrationCollection.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/HttpIntegrationCollection.cs
@@ -1,0 +1,9 @@
+namespace NzbWebDAV.Tests.TestUtils;
+
+/// <summary>
+/// Serializes the real application host because it mutates process-wide environment
+/// variables and database option caches.
+/// </summary>
+[CollectionDefinition(nameof(HttpIntegrationCollection), DisableParallelization = true)]
+public sealed class HttpIntegrationCollection
+    : ICollectionFixture<NzbDavWebApplicationFactory>;

--- a/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
@@ -1,0 +1,126 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public const string ApiKey = "integration-api-key";
+    public const string WebDavUser = "integration-user";
+    public const string WebDavPassword = "integration-password";
+
+    private readonly string _configPath =
+        Path.Combine(Path.GetTempPath(), $"nzbdav-http-tests-{Guid.NewGuid():N}");
+    private readonly Dictionary<string, string?> _previousEnvironment = new();
+    private int _disposed;
+
+    public NzbDavWebApplicationFactory()
+    {
+        Directory.CreateDirectory(_configPath);
+        SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
+        SetEnvironmentVariable("CONFIG_PATH", _configPath);
+        SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", ApiKey);
+        SetEnvironmentVariable("WEBDAV_USER", WebDavUser);
+        SetEnvironmentVariable("WEBDAV_PASSWORD", WebDavPassword);
+        SetEnvironmentVariable("DISABLE_WEBDAV_AUTH", null);
+        SetEnvironmentVariable("LOG_LEVEL", "Warning");
+        ResetDefaultDatabaseOptions();
+        InitializeDatabases();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+    }
+
+    public HttpRequestMessage CreateWebDavRequest(HttpMethod method, string path, string? depth = null)
+    {
+        var request = new HttpRequestMessage(method, path);
+        var credentials = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{WebDavUser}:{WebDavPassword}"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        if (depth is not null)
+            request.Headers.TryAddWithoutValidation("Depth", depth);
+        return request;
+    }
+
+    public async Task AddDavItemsAsync(params DavItem[] items)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DavDatabaseContext>();
+        context.Items.AddRange(items);
+        await context.SaveChangesAsync();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        try
+        {
+            base.Dispose(disposing);
+        }
+        finally
+        {
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                SqliteConnection.ClearAllPools();
+                foreach (var variable in _previousEnvironment)
+                    Environment.SetEnvironmentVariable(variable.Key, variable.Value);
+                ResetDefaultDatabaseOptions();
+
+                try
+                {
+                    Directory.Delete(_configPath, recursive: true);
+                }
+                catch
+                {
+                    // Best-effort cleanup for transient SQLite file handles.
+                }
+            }
+        }
+    }
+
+    private void SetEnvironmentVariable(string name, string? value)
+    {
+        _previousEnvironment[name] = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    private void InitializeDatabases()
+    {
+        var databaseOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={Path.Combine(_configPath, "db.sqlite")}")
+            .AddInterceptors(new SqliteMainDbPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        using var databaseContext = new DavDatabaseContext(databaseOptions);
+        databaseContext.Database.Migrate();
+
+        var metricsOptions = new DbContextOptionsBuilder<MetricsDbContext>()
+            .UseSqlite($"Data Source={Path.Combine(_configPath, "metrics.sqlite")}")
+            .AddInterceptors(new SqliteMetricsPragmas())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        using var metricsContext = new MetricsDbContext(metricsOptions);
+        metricsContext.Database.Migrate();
+    }
+
+    private static void ResetDefaultDatabaseOptions()
+    {
+        DavDatabaseContext.ResetOptionsForTests();
+        MetricsDbContext.ResetOptionsForTests();
+    }
+}

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Xml.Linq;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactory factory)
+{
+    private static readonly HttpMethod PropFind = new("PROPFIND");
+
+    [Fact]
+    public async Task PropFindRoot_RequiresBasicAuthenticationAndListsCoreMounts()
+    {
+        using var client = factory.CreateClient();
+        using var rejectedRequest = new HttpRequestMessage(PropFind, "/");
+        rejectedRequest.Headers.TryAddWithoutValidation("Depth", "1");
+
+        using var rejected = await client.SendAsync(rejectedRequest);
+        Assert.Equal(HttpStatusCode.Unauthorized, rejected.StatusCode);
+
+        using var acceptedRequest = factory.CreateWebDavRequest(PropFind, "/", depth: "1");
+        using var accepted = await client.SendAsync(acceptedRequest);
+        Assert.Equal((HttpStatusCode)207, accepted.StatusCode);
+
+        var hrefs = await ReadHrefsAsync(accepted);
+        Assert.Contains(hrefs, href => href.EndsWith("/nzbs", StringComparison.Ordinal));
+        Assert.Contains(hrefs, href => href.EndsWith("/content", StringComparison.Ordinal));
+        Assert.Contains(hrefs, href => href.EndsWith("/completed-symlinks", StringComparison.Ordinal));
+        Assert.Contains(hrefs, href => href.EndsWith("/.ids", StringComparison.Ordinal));
+        Assert.Contains(hrefs, href => href.EndsWith("/README", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PropFindNestedPersistedCollection_ResolvesAndListsChildren()
+    {
+        var library = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "integration-library",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+        var title = DavItem.New(
+            Guid.NewGuid(),
+            library,
+            "deterministic-title",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+        await factory.AddDavItemsAsync(library, title);
+
+        using var client = factory.CreateClient();
+        using var request = factory.CreateWebDavRequest(
+            PropFind,
+            "/content/integration-library",
+            depth: "1");
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal((HttpStatusCode)207, response.StatusCode);
+        var hrefs = await ReadHrefsAsync(response);
+        Assert.Contains(
+            hrefs,
+            href => href.EndsWith(
+                "/content/integration-library/deterministic-title",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task HeadReadme_ReturnsDeterministicEmbeddedFileMetadata()
+    {
+        using var client = factory.CreateClient();
+        using var request = factory.CreateWebDavRequest(HttpMethod.Head, "/README");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Content.Headers.ContentLength > 0);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    private static async Task<string[]> ReadHrefsAsync(HttpResponseMessage response)
+    {
+        var document = await XDocument.LoadAsync(
+            await response.Content.ReadAsStreamAsync(),
+            LoadOptions.None,
+            CancellationToken.None);
+        return document
+            .Descendants()
+            .Where(element => element.Name.LocalName == "href")
+            .Select(element => Uri.UnescapeDataString(element.Value))
+            .ToArray();
+    }
+}


### PR DESCRIPTION
## Summary
- cache NuGet and documentation dependencies, and conditionally smoke-build changed container inputs
- enforce measured frontend coverage baselines and test health, queue, and settings route data flows
- add isolated real-host backend tests for API authentication, health, SAB compatibility, and SQLite-backed WebDAV routing

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `dotnet format whitespace --verify-no-changes --folder backend`
- [x] `dotnet format whitespace --verify-no-changes --folder tests`
- [x] `cd frontend && npm run test:coverage`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build && npm run build:server`
- [x] parse all workflow YAML files