### PR TITLE
feat(health): report when streaming is unable to make progress

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
@@ -172,7 +173,10 @@ class Program
             builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = maxRequestBodySize);
             builder.Host.UseSerilog();
             builder.Services.AddControllers();
-            builder.Services.AddHealthChecks();
+            builder.Services.AddHealthChecks()
+                .AddCheck<StreamingReadinessCheck>(
+                    "streaming_readiness",
+                    tags: ["ready"]);
             builder.Services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
@@ -211,6 +215,7 @@ class Program
                 .AddSingleton<NzbWebDAV.Services.Benchmark.BenchmarkRunControl>()
                 .AddHostedService<LogBroadcaster>()
                 .AddSingleton<ActiveReadRegistry>()
+                .AddSingleton<StreamingReadinessCheck>()
                 .AddSingleton(_ => new RuntimeUsageTracker())
                 .AddHostedService<RuntimeUsageSampler>()
                 .AddSingleton<ProviderUsageTracker>(sp =>
@@ -309,7 +314,14 @@ class Program
             app.UseForwardedHeaders();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
-            app.MapHealthChecks("/health");
+            app.MapHealthChecks("/health", new HealthCheckOptions
+            {
+                Predicate = check => !check.Tags.Contains("ready"),
+            });
+            app.MapHealthChecks("/ready", new HealthCheckOptions
+            {
+                Predicate = check => check.Tags.Contains("ready"),
+            });
             app.Map("/ws", websocketManager.HandleRoute);
             app.MapControllers();
             app.UseWebdavBasicAuthentication();

--- a/backend/Services/StreamingReadinessCheck.cs
+++ b/backend/Services/StreamingReadinessCheck.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Services;
+
+public sealed class StreamingReadinessCheck : IHealthCheck
+{
+    internal static readonly TimeSpan DwellTime = TimeSpan.FromSeconds(30);
+    private const double SaturationThreshold = 0.9;
+
+    private readonly InFlightArticleBudget _budget;
+    private readonly ActiveReadRegistry _activeReads;
+    private readonly TimeProvider _timeProvider;
+    private long _stuckSinceUtcTicks;
+
+    public StreamingReadinessCheck(
+        InFlightArticleBudget budget,
+        ActiveReadRegistry activeReads)
+        : this(budget, activeReads, TimeProvider.System)
+    {
+    }
+
+    internal StreamingReadinessCheck(
+        InFlightArticleBudget budget,
+        ActiveReadRegistry activeReads,
+        TimeProvider timeProvider)
+    {
+        _budget = budget;
+        _activeReads = activeReads;
+        _timeProvider = timeProvider;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var leasedBytes = _budget.LeasedBytes;
+        var capBytes = _budget.CapBytes;
+        var activeReadCount = _activeReads.Count;
+        var isSaturated = leasedBytes > 0
+            && leasedBytes >= capBytes * SaturationThreshold;
+
+        if (!isSaturated || activeReadCount > 0)
+        {
+            Interlocked.Exchange(ref _stuckSinceUtcTicks, 0);
+            return Task.FromResult(HealthCheckResult.Healthy());
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var stuckSinceUtcTicks = Interlocked.Read(ref _stuckSinceUtcTicks);
+        if (stuckSinceUtcTicks == 0)
+        {
+            stuckSinceUtcTicks = Interlocked.CompareExchange(
+                ref _stuckSinceUtcTicks,
+                now.UtcTicks,
+                0);
+            if (stuckSinceUtcTicks == 0)
+                stuckSinceUtcTicks = now.UtcTicks;
+        }
+
+        var stuckFor = now - new DateTimeOffset(stuckSinceUtcTicks, TimeSpan.Zero);
+        if (stuckFor < DwellTime)
+            return Task.FromResult(HealthCheckResult.Healthy());
+
+        var description =
+            $"Streaming is stuck: article memory has remained saturated with no active reads " +
+            $"for {stuckFor.TotalSeconds:F0}s (leased {leasedBytes} of {capBytes} bytes).";
+        var data = new Dictionary<string, object>
+        {
+            ["leasedBytes"] = leasedBytes,
+            ["capBytes"] = capBytes,
+            ["activeReads"] = activeReadCount,
+            ["stuckForSeconds"] = stuckFor.TotalSeconds,
+        };
+
+        return Task.FromResult(HealthCheckResult.Unhealthy(description, data: data));
+    }
+}

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -6,6 +6,28 @@
 - Ensure `CONFIG_PATH` (`/config`) is writable by `PUID`/`PGID`.
 - Frontend `/healthz` should pass during long migrations; backend `/health` must eventually succeed.
 
+## Streaming readiness (`/ready`) [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+The backend readiness endpoint reports whether NzbDAV can make progress on new streams. It returns
+`503 Service Unavailable` when Article RAM remains at least 90% leased with no active reads for 30
+seconds. A high Article RAM value while reads are active is normal backpressure and remains ready.
+
+`/ready` is separate from the cheap liveness endpoints (`/health` on the backend and `/healthz` on
+the frontend). The default container healthcheck stays on `/healthz`, so temporary streaming load
+does not trigger restarts. To opt into readiness for routing or monitoring, probe the backend port:
+
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "curl -fsSL http://localhost:8080/ready > /dev/null || exit 1"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+  start_period: 60s
+```
+
+Use `/ready` as a restart trigger only if restarting a streaming-wedged container is the intended
+policy. This check detects a stuck in-flight article budget; it does not test provider connectivity.
+
 ## WebDAV or playback fails
 
 - Confirm WebDAV username/password.

--- a/tests/NzbWebDAV.Tests/Services/StreamingReadinessCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamingReadinessCheckTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NzbWebDAV.Services;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class StreamingReadinessCheckTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_LowBudgetWithNoReads_IsHealthy()
+    {
+        var budget = new InFlightArticleBudget(100);
+        using var lease = await budget.LeaseAsync(89, CancellationToken.None);
+        var check = CreateCheck(budget);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_SaturatedBudgetWithActiveRead_IsHealthy()
+    {
+        var budget = new InFlightArticleBudget(100);
+        using var lease = await budget.LeaseAsync(90, CancellationToken.None);
+        var activeReads = new ActiveReadRegistry();
+        activeReads.GetOrCreate("/view/movie.mkv", "client", "movie.mkv", 100);
+        var check = CreateCheck(budget, activeReads);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_StuckConditionWithinDwellTime_IsHealthy()
+    {
+        var budget = new InFlightArticleBudget(100);
+        using var lease = await budget.LeaseAsync(90, CancellationToken.None);
+        var time = new TestTimeProvider();
+        var check = CreateCheck(budget, timeProvider: time);
+
+        var initial = await check.CheckHealthAsync(new HealthCheckContext());
+        time.Advance(StreamingReadinessCheck.DwellTime - TimeSpan.FromMilliseconds(1));
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, initial.Status);
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_StuckConditionPastDwellTime_IsUnhealthy()
+    {
+        var budget = new InFlightArticleBudget(100);
+        using var lease = await budget.LeaseAsync(90, CancellationToken.None);
+        var time = new TestTimeProvider();
+        var check = CreateCheck(budget, timeProvider: time);
+
+        await check.CheckHealthAsync(new HealthCheckContext());
+        time.Advance(StreamingReadinessCheck.DwellTime);
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("leased 90 of 100 bytes", result.Description);
+        Assert.Equal(90L, result.Data["leasedBytes"]);
+        Assert.Equal(0, result.Data["activeReads"]);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenStuckConditionClears_ResetsDwellTime()
+    {
+        var budget = new InFlightArticleBudget(100);
+        var lease = await budget.LeaseAsync(90, CancellationToken.None);
+        var time = new TestTimeProvider();
+        var check = CreateCheck(budget, timeProvider: time);
+
+        await check.CheckHealthAsync(new HealthCheckContext());
+        time.Advance(StreamingReadinessCheck.DwellTime);
+        var unhealthy = await check.CheckHealthAsync(new HealthCheckContext());
+
+        lease.Dispose();
+        var recovered = await check.CheckHealthAsync(new HealthCheckContext());
+
+        using var nextLease = await budget.LeaseAsync(90, CancellationToken.None);
+        var restartedDwell = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, unhealthy.Status);
+        Assert.Equal(HealthStatus.Healthy, recovered.Status);
+        Assert.Equal(HealthStatus.Healthy, restartedDwell.Status);
+    }
+
+    private static StreamingReadinessCheck CreateCheck(
+        InFlightArticleBudget budget,
+        ActiveReadRegistry? activeReads = null,
+        TimeProvider? timeProvider = null) =>
+        new(
+            budget,
+            activeReads ?? new ActiveReadRegistry(),
+            timeProvider ?? new TestTimeProvider());
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = new(2026, 8, 2, 12, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan elapsed) => _utcNow += elapsed;
+    }
+}


### PR DESCRIPTION
## Summary
- add a backend `/ready` probe that returns 503 after Article RAM stays at least 90% leased with no active reads for 30 seconds
- preserve `/health` and frontend `/healthz` as load-independent liveness probes
- document optional orchestrator use with a `since 0.10.0` marker

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `zensical build --clean --strict`

Closes #670