### PR TITLE
fix(usenet): prevent unreachable providers from stalling concurrent requests

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -187,6 +187,36 @@ public class ProviderCircuitBreaker
         }
     }
 
+    /// <summary>
+    /// Records a connection-establishment failure. Unlike command failures, one failed
+    /// connect is enough to trip because concurrent retries would otherwise consume the
+    /// provider's connection capacity while it is unreachable.
+    /// </summary>
+    public void RecordConnectionFailure(string? reason = null)
+    {
+        lock (_lock)
+        {
+            var now = Environment.TickCount64;
+
+            // Ignore failures already in flight when the provider first tripped.
+            if (_trippedUntilMs > 0 && now < _trippedUntilMs)
+                return;
+
+            var wasHalfOpen = Volatile.Read(ref _halfOpenProbeInFlight) == 1
+                              || _trippedUntilMs > 0;
+            Volatile.Write(ref _halfOpenProbeInFlight, 0);
+            Volatile.Write(ref _probeStartedMs, 0);
+            Interlocked.Increment(ref _failureCount);
+
+            var failureReason = wasHalfOpen
+                ? "half-open connection failure"
+                : "connection failure";
+            Trip(now, reason is null
+                ? failureReason
+                : $"{failureReason} ({reason})");
+        }
+    }
+
     public void RecordFailure(string? reason = null)
     {
         lock (_lock)

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -439,7 +439,7 @@ public class MultiConnectionNntpClient(
             }
             catch (Exception e)
             {
-                circuitBreaker.RecordFailure($"get-connection-{e.GetType().Name}");
+                circuitBreaker.RecordConnectionFailure($"get-connection-{e.GetType().Name}");
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
                 if (retryCount > 0)
@@ -547,8 +547,8 @@ public class MultiConnectionNntpClient(
             {
                 deferredCallback.Discard();
                 var wasReused = connectionLock?.WasReused ?? false;
-                // stat, head, and date do not feed the circuit breaker. The success path
-                // already skips them so a failure recorded here would never be reset.
+                // STAT, HEAD, and DATE failures do not feed a closed circuit because their
+                // successes intentionally do not reset its BODY failure sampling window.
                 if (!wasReused && IsBodyCommand(name))
                     circuitBreaker.RecordFailure($"cmd-setup-{name}-{e.GetType().Name}");
                 LogException(() => connectionLock?.Replace());
@@ -568,6 +568,12 @@ public class MultiConnectionNntpClient(
                     retryCount--;
                     continue;
                 }
+
+                // A non-BODY command selected while the provider was half-open is a
+                // recovery probe. Once its retries are exhausted, release the probe slot
+                // and reopen the circuit instead of leaving it claimed until timeout.
+                if (!IsBodyCommand(name) && circuitBreaker.IsLatched)
+                    circuitBreaker.RecordFailure($"cmd-{name}-{e.GetType().Name}");
 
                 e.LogWarningKnownOrStack(
                     "Error executing nntp {Command} command for provider {Provider}.", name, providerName);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
@@ -51,6 +51,46 @@ public class ProviderCircuitBreakerConnectionFailureTests
     }
 
     [Fact]
+    public async Task MultiProvider_ConcurrentRequestsAfterConnectionFailure_UseHealthyFallback()
+    {
+        var primaryAttempts = 0;
+        var primaryBreaker = new ProviderCircuitBreaker("unreachable");
+        using var primaryPool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref primaryAttempts);
+                throw new IOException("Primary provider is unreachable.");
+            });
+        using var backupPool = new ConnectionPool<INntpClient>(
+            maxConnections: 8,
+            _ => ValueTask.FromResult<INntpClient>(new SuccessfulStatClient()));
+        using var primary = new MultiConnectionNntpClient(
+            primaryPool,
+            ProviderType.Pooled,
+            primaryBreaker,
+            "unreachable");
+        using var backup = new MultiConnectionNntpClient(
+            backupPool,
+            ProviderType.BackupOnly,
+            new ProviderCircuitBreaker("healthy-backup"),
+            "healthy-backup");
+        using var client = new MultiProviderNntpClient([primary, backup]);
+
+        var firstResponse = await client.StatAsync("first", CancellationToken.None);
+        Assert.True(firstResponse.ArticleExists);
+        Assert.Equal(2, primaryAttempts);
+        Assert.Equal(ProviderCircuitState.Open, primaryBreaker.GetSnapshot().State);
+
+        var responses = await Task.WhenAll(
+            Enumerable.Range(0, 32)
+                .Select(i => client.StatAsync($"concurrent-{i}", CancellationToken.None)));
+
+        Assert.All(responses, response => Assert.True(response.ArticleExists));
+        Assert.Equal(2, primaryAttempts);
+    }
+
+    [Fact]
     public void RecordConnectionFailure_OnClosedCircuit_UsesExistingCooldownLadder()
     {
         var transitions = new List<ProviderCircuitTransition>();
@@ -163,6 +203,63 @@ public class ProviderCircuitBreakerConnectionFailureTests
         public override Task<UsenetStatResponse> StatAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>
             throw new IOException("Provider disconnected during STAT.");
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class SuccessfulStatClient : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = (int)UsenetResponseType.ArticleExists,
+                ResponseMessage = $"223 0 0 <{segmentId}>",
+                ArticleExists = true,
+            });
 
         public override Task<UsenetHeadResponse> HeadAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
@@ -1,0 +1,204 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ProviderCircuitBreakerConnectionFailureTests
+{
+    [Fact]
+    public void RecordConnectionFailure_OnClosedCircuit_TripsImmediately()
+    {
+        var breaker = new ProviderCircuitBreaker("unreachable");
+
+        breaker.RecordConnectionFailure("connect-timeout");
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.Equal(1, snapshot.FailureCount);
+        Assert.Equal(1, snapshot.TripCount);
+        Assert.Contains("connection failure", snapshot.LastFailureReason);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_ConnectionFailureTripsImmediately()
+    {
+        var attempts = 0;
+        var breaker = new ProviderCircuitBreaker("unreachable");
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new IOException("Provider is unreachable.");
+            });
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            breaker,
+            "unreachable");
+
+        await Assert.ThrowsAsync<IOException>(
+            () => client.StatAsync("segment", CancellationToken.None));
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(2, attempts);
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.Equal(1, snapshot.FailureCount);
+        Assert.Equal(1, snapshot.TripCount);
+    }
+
+    [Fact]
+    public void RecordConnectionFailure_OnClosedCircuit_UsesExistingCooldownLadder()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("cooldown", transitions.Add);
+
+        breaker.RecordConnectionFailure();
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped);
+        breaker.RecordConnectionFailure();
+
+        var openTransitions = transitions
+            .Where(x => x.State == ProviderCircuitTransitionState.Open)
+            .ToList();
+        Assert.Equal(2, openTransitions.Count);
+        Assert.Equal(TimeSpan.FromSeconds(60), openTransitions[0].Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(120), openTransitions[1].Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(240), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void RecordConnectionFailure_WhileLatched_IsIgnored()
+    {
+        var breaker = new ProviderCircuitBreaker("latched");
+        breaker.RecordConnectionFailure("first");
+        var trippedUntil = breaker.TrippedUntilMs;
+        var cooldown = breaker.CurrentCooldown;
+
+        Parallel.For(0, 32, _ => breaker.RecordConnectionFailure("concurrent"));
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.Equal(1, snapshot.FailureCount);
+        Assert.Equal(1, snapshot.TripCount);
+        Assert.Equal(trippedUntil, breaker.TrippedUntilMs);
+        Assert.Equal(cooldown, breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void RecordConnectionFailure_WhileHalfOpen_RetripsAndReleasesProbe()
+    {
+        var breaker = new ProviderCircuitBreaker("half-open");
+        breaker.RecordConnectionFailure();
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped);
+
+        breaker.RecordConnectionFailure("still-unreachable");
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(TimeSpan.FromSeconds(240), breaker.CurrentCooldown);
+
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped);
+    }
+
+    [Fact]
+    public void RecordConnectionFailure_AfterRecovery_TripsAgainFromInitialCooldown()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("recovered", transitions.Add);
+        breaker.RecordConnectionFailure();
+        breaker.RecordSuccess();
+
+        breaker.RecordConnectionFailure();
+
+        var openTransitions = transitions
+            .Where(x => x.State == ProviderCircuitTransitionState.Open)
+            .ToList();
+        Assert.Equal(2, openTransitions.Count);
+        Assert.All(openTransitions, transition =>
+            Assert.Equal(TimeSpan.FromSeconds(60), transition.Cooldown));
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public async Task NonBodyFailure_WhileLatched_ReleasesProbeSlot()
+    {
+        var breaker = new ProviderCircuitBreaker("stat-probe");
+        breaker.RecordConnectionFailure();
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped);
+
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ => ValueTask.FromResult<INntpClient>(new FailingStatClient()));
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            breaker,
+            "stat-probe");
+
+        await Assert.ThrowsAsync<IOException>(
+            () => client.StatAsync("segment", CancellationToken.None));
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        breaker.ExpireCooldownForTests();
+        Assert.False(breaker.IsTripped);
+    }
+
+    private sealed class FailingStatClient : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new IOException("Provider disconnected during STAT.");
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- trip a provider immediately when connection establishment fails so later concurrent work can fall back without waiting for the normal failure window
- release half-open recovery state when STAT, HEAD, or DATE retries are exhausted
- cover connection failures, cooldown progression, recovery, non-BODY probe failures, and concurrent requests using a healthy fallback after a provider trips

This is a targeted circuit-breaker improvement related to #763. It does not implement a latency-probe gate because current NzbDAV has no periodic provider latency-probe path.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~ProviderCircuitBreakerConnectionFailureTests`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`