### PR TITLE
feat(ui): let hosting providers disable specific features

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -35,6 +35,43 @@ Advanced reference for **process / container** wiring and **legacy Settings fall
 | `LOG_LEVEL` | `info` (prod) | Frontend log verbosity |
 | `VITE_ALLOWED_HOSTS` | unset | Dev/build host allowlist |
 | `NZBDAV_VERSION` / `NZBDAV_COMMIT_SHA` | image build | Version display |
+| `SERVICE_PROVIDER` | unset | Hosted-service branding and UI navigation feature gating |
+
+## `SERVICE_PROVIDER` [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+Hosted NzbDAV services can identify the service provider and mark selected
+navigation destinations as unavailable. Disabled destinations remain visible in
+the sidebar; selecting one explains that the provider does not support the
+feature and links to the provider's website. The provider attribution also
+appears in the page footer.
+
+Set `SERVICE_PROVIDER` to a JSON object on the frontend process:
+
+```yaml
+environment:
+  SERVICE_PROVIDER: >-
+    {"name":"ElfHosted","url":"https://elfhosted.com","disabledFeatures":["watchtower","search","settings.indexers","settings.profiles","settings.watchtower","settings.warden","settings.rclone"]}
+```
+
+The object requires:
+
+- `name`: service provider name shown in the dialog and footer
+- `url`: provider website using `http` or `https`
+- `disabledFeatures`: navigation identifiers to make unavailable
+
+Top-level navigation identifiers are `overview`, `queue`, `watchdog`,
+`watchtower`, `explore`, `health`, `logs`, and `search`. `overview` cannot be
+disabled — it is the app's landing page and the fallback destination when
+closing the "feature not available" dialog, so it always stays reachable.
+
+Settings navigation identifiers are `settings.usenet`, `settings.indexers`,
+`settings.profiles`, `settings.watchdog`, `settings.preflight`,
+`settings.watchtower`, `settings.warden`, `settings.sabnzbd`,
+`settings.webdav`, `settings.arrs`, `settings.repairs`, `settings.rclone`,
+`settings.maintenance`, `settings.backup`, and `settings.support`.
+
+This controls frontend presentation only. Providers must separately configure
+or restrict backend capabilities when enforcement is required.
 
 ## Backend (.NET)
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -41,8 +41,8 @@ Advanced reference for **process / container** wiring and **legacy Settings fall
 
 Hosted NzbDAV services can identify the service provider and mark selected
 navigation destinations as unavailable. Disabled destinations remain visible in
-the sidebar; selecting one explains that the provider does not support the
-feature and links to the provider's website. The provider attribution also
+the sidebar; selecting one explains that the feature is disabled by the provider
+and links to the provider's website. The provider attribution also
 appears in the page footer.
 
 Set `SERVICE_PROVIDER` to a JSON object on the frontend process:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,6 @@ NODE_ENV=development
 PORT=5173
 BACKEND_URL=http://localhost:5000
 FRONTEND_BACKEND_API_KEY=
+
+# Optional hosted-service branding and UI feature gating (JSON).
+# SERVICE_PROVIDER='{"name":"ElfHosted","url":"https://elfhosted.com","disabledFeatures":["watchtower","search","settings.indexers","settings.profiles","settings.watchtower","settings.warden","settings.rclone"]}'

--- a/frontend/app/auth/authorization.ts
+++ b/frontend/app/auth/authorization.ts
@@ -1,9 +1,11 @@
 import { useOutletContext } from "react-router";
 import type { UserRole } from "./authentication.server";
+import type { ServiceProviderConfig } from "~/utils/service-provider";
 
 export type AppOutletContext = {
   role: UserRole | null;
   isOidcEnabled: boolean;
+  serviceProvider: ServiceProviderConfig | null;
 };
 
 export function useIsReadOnly(): boolean {

--- a/frontend/app/components/service-provider-gate.tsx
+++ b/frontend/app/components/service-provider-gate.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { useLocation, useNavigate } from "react-router";
+import { parseSettingsTab } from "~/routes/settings/settings-tabs";
+import {
+  isNavRouteDisabled,
+  isSettingsTabDisabled,
+  type ServiceProviderConfig,
+} from "~/utils/service-provider";
+import { ServiceProviderNotice } from "./service-provider-notice";
+
+export type ServiceProviderGateProps = {
+  children: ReactNode;
+  serviceProvider: ServiceProviderConfig | null | undefined;
+};
+
+export function ServiceProviderGate({
+  children,
+  serviceProvider,
+}: ServiceProviderGateProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  if (!serviceProvider) {
+    return children;
+  }
+
+  const isSettingsRoute = location.pathname.startsWith("/settings");
+  const activeSettingsTab = parseSettingsTab(
+    new URLSearchParams(location.search).get("tab"),
+  );
+  const isDisabled = isSettingsRoute
+    ? isSettingsTabDisabled(serviceProvider, activeSettingsTab)
+    : isNavRouteDisabled(serviceProvider, location.pathname);
+
+  if (!isDisabled) {
+    return children;
+  }
+
+  return (
+    <ServiceProviderNotice
+      open
+      serviceProvider={serviceProvider}
+      onClose={() => navigate("/overview", { replace: true })}
+    />
+  );
+}

--- a/frontend/app/components/service-provider-notice.tsx
+++ b/frontend/app/components/service-provider-notice.tsx
@@ -1,0 +1,45 @@
+import { Button, Icon, Modal } from "~/components/ui";
+import type { ServiceProviderConfig } from "~/utils/service-provider";
+
+export type ServiceProviderNoticeProps = {
+  open: boolean;
+  serviceProvider: ServiceProviderConfig;
+  onClose: () => void;
+};
+
+export function ServiceProviderNotice({
+  open,
+  serviceProvider,
+  onClose,
+}: ServiceProviderNoticeProps) {
+  return (
+    <Modal
+      open={open}
+      title="Feature Not Available"
+      onClose={onClose}
+      className="max-w-lg"
+      footer={
+        <Button onClick={onClose}>
+          Close
+        </Button>
+      }
+    >
+      <div className="flex flex-col items-center gap-4 text-center">
+        <Icon name="info" className="!text-[52px] text-base-content/60" />
+        <p className="max-w-sm text-base-content/80">
+          This feature is disabled by your service provider:{" "}
+          <strong className="font-semibold text-base-content">{serviceProvider.name}</strong>.
+        </p>
+        <a
+          href={serviceProvider.url}
+          target="_blank"
+          rel="noreferrer"
+          className="link link-primary inline-flex items-center gap-1"
+        >
+          Contact {serviceProvider.name}
+          <Icon name="open_in_new" className="!text-[16px]" />
+        </a>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -22,15 +22,17 @@ import { getAppVersion } from "./utils/version.server";
 import { checkForUpdate } from "./utils/update-check.server";
 import { backendClient } from "./clients/backend-client.server";
 import { MigrationBoundary } from "./components/migration-progress";
+import { ServiceProviderGate } from "./components/service-provider-gate";
 import { StreamTracingBanner } from "./components/stream-tracing-banner";
 import { isOidcEnabled } from "../server/oidc.server";
+import { getServiceProvider } from "./utils/service-provider.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   // Single-fetch navigation/revalidation uses internal `.data` URLs
   // (e.g. /login.data), so strip that suffix before the layout check.
   let path = new URL(request.url).pathname.replace(/\.data$/, "");
   if (path === "/login" || path === "/onboarding") {
-    return { useLayout: false };
+    return { useLayout: false, serviceProvider: null };
   }
 
   const config = await backendClient.getConfig([
@@ -40,6 +42,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const version = await getAppVersion();
   const sessionUser = await getSessionUser(request);
+  const serviceProvider = getServiceProvider();
 
   return {
     useLayout: true,
@@ -54,6 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     ),
     isWatchdogEnabled:
       config.find(item => item.configName === "play.watchdog-enabled")?.configValue?.toLowerCase() !== "false",
+    serviceProvider,
   };
 }
 
@@ -132,6 +136,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
     isOidcEnabled,
     hasUsenetProviders,
     isWatchdogEnabled,
+    serviceProvider,
   } = loaderData;
   const location = useLocation();
   const navigation = useNavigation();
@@ -144,7 +149,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
   const showLoading = isNavigating && !(isCurrentExplorePage && isNextExplorePage);
   const hideShell =
     location.pathname === "/login" || location.pathname === "/onboarding";
-  const outlet = <Outlet context={{ role, isOidcEnabled }} />;
+  const outlet = <Outlet context={{ role, isOidcEnabled, serviceProvider }} />;
 
   if (useLayout && !hideShell) {
     return (
@@ -159,18 +164,26 @@ export default function App({ loaderData }: Route.ComponentProps) {
             hasUsenetProviders={hasUsenetProviders}
           />
         )}
-        bodyChild={showLoading ? <Loading /> : (
-          <>
-            <div className="px-4 pt-4 md:px-8">
-              <StreamTracingBanner isReadOnly={role === "readonly"} />
-            </div>
-            {outlet}
-          </>
-        )}
+        bodyChild={
+          <ServiceProviderGate serviceProvider={serviceProvider}>
+            {showLoading ? <Loading /> : (
+              <>
+                <div className="px-4 pt-4 md:px-8">
+                  <StreamTracingBanner isReadOnly={role === "readonly"} />
+                </div>
+                {outlet}
+              </>
+            )}
+          </ServiceProviderGate>
+        }
         leftNavChild={
           <LeftNavigation
-            isWatchdogEnabled={isWatchdogEnabled} />
-        } />
+            isWatchdogEnabled={isWatchdogEnabled}
+            serviceProvider={serviceProvider}
+          />
+        }
+        serviceProvider={serviceProvider}
+      />
     );
   }
 

--- a/frontend/app/routes/_index/components/left-navigation/left-navigation.tsx
+++ b/frontend/app/routes/_index/components/left-navigation/left-navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useNavigate, useNavigation } from "react-router";
+import { Link, useLocation, useNavigation } from "react-router";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { Icon } from "~/components/ui";
@@ -35,7 +35,6 @@ export function LeftNavigation({
     serviceProvider,
 }: LeftNavigationProps) {
     const location = useLocation();
-    const navigate = useNavigate();
     const navigation = useNavigation();
     const pathname = navigation.location?.pathname ?? location.pathname;
     const search = navigation.location?.search ?? location.search;
@@ -63,9 +62,11 @@ export function LeftNavigation({
         { target: "/search", icon: "search", label: "Search", featureId: "search" },
     ];
 
+    // Sidebar clicks open the notice without navigating away from the current
+    // page, so Close only dismisses the dialog. Deep-link gates use replace to
+    // /overview instead (see ServiceProviderGate / Settings).
     const closeProviderNotice = () => {
         setProviderNoticeOpen(false);
-        navigate("/overview");
     };
 
     return (
@@ -79,6 +80,7 @@ export function LeftNavigation({
                             icon={item.icon}
                             pathname={pathname}
                             disabled={isFeatureDisabled(serviceProvider, item.featureId)}
+                            providerName={serviceProvider?.name}
                             onDisabledClick={() => setProviderNoticeOpen(true)}
                         >
                             {item.label}
@@ -109,6 +111,7 @@ export function LeftNavigation({
                             icon={item.icon}
                             activeTab={activeSettingsTab}
                             disabled={isSettingsTabDisabled(serviceProvider, item.id)}
+                            providerName={serviceProvider?.name}
                             onDisabledClick={() => setProviderNoticeOpen(true)}
                         >
                             {item.label}
@@ -133,6 +136,7 @@ function Item({
     children,
     pathname,
     disabled,
+    providerName,
     onDisabledClick,
 }: {
     target: string;
@@ -140,6 +144,7 @@ function Item({
     children: React.ReactNode;
     pathname: string;
     disabled: boolean;
+    providerName?: string;
     onDisabledClick: () => void;
 }) {
     const isSelected = pathname.startsWith(target);
@@ -155,6 +160,11 @@ function Item({
                 <button
                     type="button"
                     aria-disabled="true"
+                    aria-label={
+                        typeof children === "string"
+                            ? `${children} (disabled by ${providerName ?? "your service provider"})`
+                            : undefined
+                    }
                     className="opacity-50"
                     onClick={onDisabledClick}
                 >
@@ -179,6 +189,7 @@ function SettingsItem({
     activeTab,
     children,
     disabled,
+    providerName,
     onDisabledClick,
 }: {
     tab: SettingsTab;
@@ -186,6 +197,7 @@ function SettingsItem({
     activeTab: SettingsTab | null;
     children: React.ReactNode;
     disabled: boolean;
+    providerName?: string;
     onDisabledClick: () => void;
 }) {
     const isSelected = activeTab === tab;
@@ -201,6 +213,11 @@ function SettingsItem({
                 <button
                     type="button"
                     aria-disabled="true"
+                    aria-label={
+                        typeof children === "string"
+                            ? `${children} (disabled by ${providerName ?? "your service provider"})`
+                            : undefined
+                    }
                     className="text-sm opacity-50"
                     onClick={onDisabledClick}
                 >

--- a/frontend/app/routes/_index/components/left-navigation/left-navigation.tsx
+++ b/frontend/app/routes/_index/components/left-navigation/left-navigation.tsx
@@ -1,30 +1,41 @@
-import { Link, useLocation, useNavigation } from "react-router";
+import { Link, useLocation, useNavigate, useNavigation } from "react-router";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { Icon } from "~/components/ui";
+import { ServiceProviderNotice } from "~/components/service-provider-notice";
 import {
     SETTINGS_TAB_GROUPS,
     parseSettingsTab,
     settingsPath,
     type SettingsTab,
 } from "~/routes/settings/settings-tabs";
+import {
+    isFeatureDisabled,
+    isSettingsTabDisabled,
+    type NavFeatureId,
+    type ServiceProviderConfig,
+} from "~/utils/service-provider";
 
 export type LeftNavigationProps = {
     isWatchdogEnabled?: boolean,
+    serviceProvider?: ServiceProviderConfig | null,
 }
 
 type NavItem = {
     target: string;
     icon: string;
     label: string;
+    featureId: NavFeatureId;
 };
 
 const SETTINGS_ITEMS = SETTINGS_TAB_GROUPS.flatMap((group) => group.items);
 
 export function LeftNavigation({
     isWatchdogEnabled,
+    serviceProvider,
 }: LeftNavigationProps) {
     const location = useLocation();
+    const navigate = useNavigate();
     const navigation = useNavigation();
     const pathname = navigation.location?.pathname ?? location.pathname;
     const search = navigation.location?.search ?? location.search;
@@ -34,22 +45,28 @@ export function LeftNavigation({
         : null;
 
     const [settingsOpen, setSettingsOpen] = useState(isSettingsRoute);
+    const [providerNoticeOpen, setProviderNoticeOpen] = useState(false);
     useEffect(() => {
         if (isSettingsRoute) setSettingsOpen(true);
     }, [isSettingsRoute]);
 
     const items: NavItem[] = [
-        { target: "/overview", icon: "dashboard", label: "Overview" },
-        { target: "/queue", icon: "list_alt", label: "Queue" },
+        { target: "/overview", icon: "dashboard", label: "Overview", featureId: "overview" },
+        { target: "/queue", icon: "list_alt", label: "Queue", featureId: "queue" },
         ...(isWatchdogEnabled
-            ? [{ target: "/watchdog", icon: "monitor_heart", label: "Watchdog" }]
+            ? [{ target: "/watchdog", icon: "monitor_heart", label: "Watchdog", featureId: "watchdog" as const }]
             : []),
-        { target: "/watchtower", icon: "cell_tower", label: "Watchtower" },
-        { target: "/explore", icon: "folder_open", label: "Files" },
-        { target: "/health", icon: "health_and_safety", label: "Health" },
-        { target: "/logs", icon: "description", label: "Logs" },
-        { target: "/search", icon: "search", label: "Search" },
+        { target: "/watchtower", icon: "cell_tower", label: "Watchtower", featureId: "watchtower" },
+        { target: "/explore", icon: "folder_open", label: "Files", featureId: "explore" },
+        { target: "/health", icon: "health_and_safety", label: "Health", featureId: "health" },
+        { target: "/logs", icon: "description", label: "Logs", featureId: "logs" },
+        { target: "/search", icon: "search", label: "Search", featureId: "search" },
     ];
+
+    const closeProviderNotice = () => {
+        setProviderNoticeOpen(false);
+        navigate("/overview");
+    };
 
     return (
         <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto p-4 text-base-content">
@@ -61,6 +78,8 @@ export function LeftNavigation({
                             target={item.target}
                             icon={item.icon}
                             pathname={pathname}
+                            disabled={isFeatureDisabled(serviceProvider, item.featureId)}
+                            onDisabledClick={() => setProviderNoticeOpen(true)}
                         >
                             {item.label}
                         </Item>
@@ -89,12 +108,21 @@ export function LeftNavigation({
                             tab={item.id}
                             icon={item.icon}
                             activeTab={activeSettingsTab}
+                            disabled={isSettingsTabDisabled(serviceProvider, item.id)}
+                            onDisabledClick={() => setProviderNoticeOpen(true)}
                         >
                             {item.label}
                         </SettingsItem>
                     ))}
                 </ul>
             </nav>
+            {serviceProvider && (
+                <ServiceProviderNotice
+                    open={providerNoticeOpen}
+                    serviceProvider={serviceProvider}
+                    onClose={closeProviderNotice}
+                />
+            )}
         </div>
     );
 }
@@ -104,23 +132,43 @@ function Item({
     icon,
     children,
     pathname,
+    disabled,
+    onDisabledClick,
 }: {
     target: string;
     icon: string;
     children: React.ReactNode;
     pathname: string;
+    disabled: boolean;
+    onDisabledClick: () => void;
 }) {
     const isSelected = pathname.startsWith(target);
+    const content = (
+        <>
+            <Icon name={icon} filled={isSelected} className="!text-[22px]" />
+            <span className="flex-1 text-left">{children}</span>
+        </>
+    );
     return (
         <li>
-            <Link
-                to={target}
-                aria-current={isSelected ? "page" : undefined}
-                className={isSelected ? "menu-active" : undefined}
-            >
-                <Icon name={icon} filled={isSelected} className="!text-[22px]" />
-                <span className="flex-1 text-left">{children}</span>
-            </Link>
+            {disabled ? (
+                <button
+                    type="button"
+                    aria-disabled="true"
+                    className="opacity-50"
+                    onClick={onDisabledClick}
+                >
+                    {content}
+                </button>
+            ) : (
+                <Link
+                    to={target}
+                    aria-current={isSelected ? "page" : undefined}
+                    className={isSelected ? "menu-active" : undefined}
+                >
+                    {content}
+                </Link>
+            )}
         </li>
     );
 }
@@ -130,23 +178,43 @@ function SettingsItem({
     icon,
     activeTab,
     children,
+    disabled,
+    onDisabledClick,
 }: {
     tab: SettingsTab;
     icon: string;
     activeTab: SettingsTab | null;
     children: React.ReactNode;
+    disabled: boolean;
+    onDisabledClick: () => void;
 }) {
     const isSelected = activeTab === tab;
+    const content = (
+        <>
+            <Icon name={icon} filled={isSelected} className="!text-[18px]" />
+            <span className="flex-1 text-left">{children}</span>
+        </>
+    );
     return (
         <li className="ms-3 border-s border-base-content/10 ps-1">
-            <Link
-                to={settingsPath(tab)}
-                aria-current={isSelected ? "page" : undefined}
-                className={`text-sm ${isSelected ? "menu-active" : ""}`}
-            >
-                <Icon name={icon} filled={isSelected} className="!text-[18px]" />
-                <span className="flex-1 text-left">{children}</span>
-            </Link>
+            {disabled ? (
+                <button
+                    type="button"
+                    aria-disabled="true"
+                    className="text-sm opacity-50"
+                    onClick={onDisabledClick}
+                >
+                    {content}
+                </button>
+            ) : (
+                <Link
+                    to={settingsPath(tab)}
+                    aria-current={isSelected ? "page" : undefined}
+                    className={`text-sm ${isSelected ? "menu-active" : ""}`}
+                >
+                    {content}
+                </Link>
+            )}
         </li>
     );
 }

--- a/frontend/app/routes/_index/components/page-layout/page-layout.tsx
+++ b/frontend/app/routes/_index/components/page-layout/page-layout.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useId, useState } from "react";
 import { useNavigation } from "react-router";
+import type { ServiceProviderConfig } from "~/utils/service-provider";
 
 export type PageLayoutProps = {
     topNavComponent: (props: RequiredTopNavProps) => React.ReactNode,
     leftNavChild: React.ReactNode,
     bodyChild: React.ReactNode,
+    serviceProvider?: ServiceProviderConfig | null,
 }
 
 export type RequiredTopNavProps = {
@@ -47,7 +49,37 @@ export function PageLayout(props: PageLayoutProps) {
                 />
                 <div className="drawer-content flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
                     <main className="yes-scrollbar relative h-full min-h-0 min-w-0 overflow-y-auto bg-base-300">
-                        {props.bodyChild}
+                        <div className="flex min-h-full flex-col">
+                            <div className="min-h-0 flex-1">
+                                {props.bodyChild}
+                            </div>
+                            {props.serviceProvider?.name && (
+                                <footer className="footer sm:footer-horizontal footer-center border-t border-base-content/10 bg-base-300 px-4 py-4 text-xs text-base-content/50">
+                                    <aside>
+                                        <p>
+                                            This installation of{" "}
+                                            <a
+                                                href="https://nzbdav.com"
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="link link-hover font-semibold"
+                                            >
+                                                NzbDAV
+                                            </a>{" "}
+                                            is provided by{" "}
+                                            <a
+                                                href={props.serviceProvider.url}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="link link-hover font-semibold"
+                                            >
+                                                {props.serviceProvider.name}
+                                            </a>.
+                                        </p>
+                                    </aside>
+                                </footer>
+                            )}
+                        </div>
                     </main>
                 </div>
                 <div className="drawer-side z-50 lg:!h-full lg:!max-h-full">

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -19,12 +19,14 @@ import { isWardenSettingsUpdated, WardenSettings } from "./warden/warden";
 import { isRcloneSettingsUpdated, RcloneSettings } from "./rclone/rclone";
 import { SupportSettings } from "./support/support";
 import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from "react";
-import { useBlocker, useOutletContext, useSearchParams } from "react-router";
+import { useBlocker, useNavigate, useOutletContext, useSearchParams } from "react-router";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
+import { ServiceProviderNotice } from "~/components/service-provider-notice";
 import { getAppVersion } from "~/utils/version.server";
-import { parseSettingsTab, getSettingsTabItem } from "./settings-tabs";
+import { parseSettingsTab, getSettingsTabItem, type SettingsTab } from "./settings-tabs";
 import { Icon } from "~/components/ui";
-import type { UserRole } from "~/auth/authentication.server";
+import type { AppOutletContext } from "~/auth/authorization";
+import { isSettingsTabDisabled } from "~/utils/service-provider";
 
 const defaultConfig = {
     "general.base-url": "",
@@ -175,8 +177,27 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export default function Settings(props: Route.ComponentProps) {
+    const { serviceProvider } = useOutletContext<AppOutletContext>();
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const activeTab = parseSettingsTab(searchParams.get("tab"));
+
+    // The root-level ServiceProviderGate (app/components/service-provider-gate.tsx)
+    // already intercepts disabled settings tabs before this route renders. This
+    // guard is defense-in-depth in case Settings is ever rendered outside that
+    // wrapper (e.g. a future layout change or isolated test).
+    if (serviceProvider && isSettingsTabDisabled(serviceProvider, activeTab)) {
+        return (
+            <ServiceProviderNotice
+                open
+                serviceProvider={serviceProvider}
+                onClose={() => navigate("/overview", { replace: true })}
+            />
+        );
+    }
+
     return (
-        <Body {...props.loaderData} />
+        <Body {...props.loaderData} activeTab={activeTab} />
     );
 }
 
@@ -184,13 +205,13 @@ type BodyProps = {
     config: Record<string, string>,
     managedEnv: ManagedEnvMap,
     appVersion: string,
+    activeTab: SettingsTab,
 };
 
 function Body(props: BodyProps) {
-    const { role } = useOutletContext<{ role: UserRole | null }>();
+    const { role } = useOutletContext<AppOutletContext>();
     const isReadOnly = role === "readonly";
-    const [searchParams] = useSearchParams();
-    const activeTab = parseSettingsTab(searchParams.get("tab"));
+    const activeTab = props.activeTab;
     const activeTabItem = getSettingsTabItem(activeTab);
     const [config, setConfig] = useState(props.config);
     const [newConfig, setNewConfigState] = useState(config);

--- a/frontend/app/utils/service-provider.server.test.ts
+++ b/frontend/app/utils/service-provider.server.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
+}));
+
+vi.mock("../../server/logger", () => ({
+  logger: {
+    warn: warnMock,
+  },
+}));
+
+import {
+  getServiceProvider,
+  resetServiceProviderCache,
+} from "./service-provider.server";
+
+const originalServiceProvider = process.env.SERVICE_PROVIDER;
+
+beforeEach(() => {
+  delete process.env.SERVICE_PROVIDER;
+  resetServiceProviderCache();
+  warnMock.mockReset();
+});
+
+afterEach(() => {
+  if (originalServiceProvider === undefined) {
+    delete process.env.SERVICE_PROVIDER;
+  } else {
+    process.env.SERVICE_PROVIDER = originalServiceProvider;
+  }
+  resetServiceProviderCache();
+});
+
+describe("getServiceProvider", () => {
+  it("returns null when SERVICE_PROVIDER is unset", () => {
+    expect(getServiceProvider()).toBeNull();
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("parses and normalizes a valid configuration", () => {
+    process.env.SERVICE_PROVIDER = JSON.stringify({
+      name: " ElfHosted ",
+      url: "https://elfhosted.com",
+      disabledFeatures: ["search", "settings.rclone", "search"],
+    });
+
+    expect(getServiceProvider()).toEqual({
+      name: "ElfHosted",
+      url: "https://elfhosted.com/",
+      disabledFeatures: ["search", "settings.rclone"],
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores unknown feature identifiers without discarding the provider", () => {
+    process.env.SERVICE_PROVIDER = JSON.stringify({
+      name: "Example Hosting",
+      url: "https://example.com",
+      disabledFeatures: ["search", "future-feature"],
+    });
+
+    expect(getServiceProvider()?.disabledFeatures).toEqual(["search"]);
+    expect(warnMock).toHaveBeenCalledWith(
+      "SERVICE_PROVIDER contains unknown disabled feature identifiers; ignoring: future-feature",
+    );
+  });
+
+  it("rejects disabling overview so the fallback landing page always stays reachable", () => {
+    process.env.SERVICE_PROVIDER = JSON.stringify({
+      name: "Example Hosting",
+      url: "https://example.com",
+      disabledFeatures: ["overview", "search"],
+    });
+
+    expect(getServiceProvider()?.disabledFeatures).toEqual(["search"]);
+    expect(warnMock).toHaveBeenCalledWith(
+      'SERVICE_PROVIDER cannot disable "overview" because it is the fallback landing page; ignoring.',
+    );
+  });
+
+  it.each([
+    ["malformed JSON", "{"],
+    ["missing name", JSON.stringify({ url: "https://example.com", disabledFeatures: [] })],
+    ["unsafe URL", JSON.stringify({ name: "Example", url: "javascript:alert(1)", disabledFeatures: [] })],
+    ["invalid feature list", JSON.stringify({ name: "Example", url: "https://example.com", disabledFeatures: "search" })],
+  ])("ignores %s", (_description, rawValue) => {
+    process.env.SERVICE_PROVIDER = rawValue;
+
+    expect(getServiceProvider()).toBeNull();
+    expect(warnMock).toHaveBeenCalledOnce();
+    expect(warnMock.mock.calls[0][0]).toContain(
+      "SERVICE_PROVIDER is invalid and will be ignored. Reason:",
+    );
+  });
+
+  it("caches parsing and warnings for an unchanged value", () => {
+    process.env.SERVICE_PROVIDER = "{";
+
+    expect(getServiceProvider()).toBeNull();
+    expect(getServiceProvider()).toBeNull();
+    expect(warnMock).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/utils/service-provider.server.ts
+++ b/frontend/app/utils/service-provider.server.ts
@@ -1,0 +1,108 @@
+import { logger } from "../../server/logger";
+import {
+  isNavFeatureId,
+  NON_DISABLEABLE_FEATURE_ID,
+  type NavFeatureId,
+  type ServiceProviderConfig,
+} from "./service-provider";
+
+type ParsedServiceProvider = {
+  config: ServiceProviderConfig;
+  ignoredFeatures: string[];
+  rejectedFeatures: string[];
+};
+
+let cachedRawValue: string | undefined;
+let cachedConfig: ServiceProviderConfig | null = null;
+
+function parseUrl(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error('"url" must be a non-empty string');
+  }
+
+  const url = new URL(value.trim());
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error('"url" must use http or https');
+  }
+
+  return url.toString();
+}
+
+function parseConfig(rawValue: string): ParsedServiceProvider {
+  const value: unknown = JSON.parse(rawValue);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("the value must be a JSON object");
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.name !== "string" || !candidate.name.trim()) {
+    throw new Error('"name" must be a non-empty string');
+  }
+  if (
+    !Array.isArray(candidate.disabledFeatures)
+    || !candidate.disabledFeatures.every((feature) => typeof feature === "string")
+  ) {
+    throw new Error('"disabledFeatures" must be an array of strings');
+  }
+
+  const disabledFeatures: NavFeatureId[] = [];
+  const ignoredFeatures: string[] = [];
+  const rejectedFeatures: string[] = [];
+  for (const feature of new Set(candidate.disabledFeatures)) {
+    if (feature === NON_DISABLEABLE_FEATURE_ID) {
+      rejectedFeatures.push(feature);
+    } else if (isNavFeatureId(feature)) {
+      disabledFeatures.push(feature);
+    } else {
+      ignoredFeatures.push(feature);
+    }
+  }
+
+  return {
+    config: {
+      name: candidate.name.trim(),
+      url: parseUrl(candidate.url),
+      disabledFeatures,
+    },
+    ignoredFeatures,
+    rejectedFeatures,
+  };
+}
+
+export function getServiceProvider(): ServiceProviderConfig | null {
+  const rawValue = process.env.SERVICE_PROVIDER?.trim();
+  if (rawValue === cachedRawValue) {
+    return cachedConfig;
+  }
+
+  cachedRawValue = rawValue;
+  cachedConfig = null;
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const { config, ignoredFeatures, rejectedFeatures } = parseConfig(rawValue);
+    cachedConfig = config;
+    if (rejectedFeatures.length > 0) {
+      logger.warn(
+        `SERVICE_PROVIDER cannot disable "${NON_DISABLEABLE_FEATURE_ID}" because it is the fallback landing page; ignoring.`,
+      );
+    }
+    if (ignoredFeatures.length > 0) {
+      logger.warn(
+        `SERVICE_PROVIDER contains unknown disabled feature identifiers; ignoring: ${ignoredFeatures.join(", ")}`,
+      );
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logger.warn(`SERVICE_PROVIDER is invalid and will be ignored. Reason: ${reason}`);
+  }
+
+  return cachedConfig;
+}
+
+export function resetServiceProviderCache(): void {
+  cachedRawValue = undefined;
+  cachedConfig = null;
+}

--- a/frontend/app/utils/service-provider.test.ts
+++ b/frontend/app/utils/service-provider.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  isFeatureDisabled,
+  isNavFeatureId,
+  isNavRouteDisabled,
+  isSettingsTabDisabled,
+  type ServiceProviderConfig,
+} from "./service-provider";
+
+function configWith(disabledFeatures: ServiceProviderConfig["disabledFeatures"]): ServiceProviderConfig {
+  return { name: "ElfHosted", url: "https://elfhosted.com", disabledFeatures };
+}
+
+describe("isNavFeatureId", () => {
+  it.each(["overview", "watchtower", "search", "settings.rclone"])(
+    "accepts known identifier %s",
+    (value) => {
+      expect(isNavFeatureId(value)).toBe(true);
+    },
+  );
+
+  it.each(["", "watchtower ", "Watchtower", "unknown-feature"])(
+    "rejects unknown identifier %s",
+    (value) => {
+      expect(isNavFeatureId(value)).toBe(false);
+    },
+  );
+});
+
+describe("isFeatureDisabled", () => {
+  it("returns false when config is null or undefined", () => {
+    expect(isFeatureDisabled(null, "search")).toBe(false);
+    expect(isFeatureDisabled(undefined, "search")).toBe(false);
+  });
+
+  it("returns false when the feature is not in disabledFeatures", () => {
+    expect(isFeatureDisabled(configWith(["watchtower"]), "search")).toBe(false);
+  });
+
+  it("returns true when the feature is in disabledFeatures", () => {
+    expect(isFeatureDisabled(configWith(["watchtower", "search"]), "search")).toBe(true);
+  });
+});
+
+describe("isSettingsTabDisabled", () => {
+  it("checks the settings.<tab> namespaced identifier", () => {
+    const config = configWith(["settings.rclone"]);
+    expect(isSettingsTabDisabled(config, "rclone")).toBe(true);
+    expect(isSettingsTabDisabled(config, "usenet")).toBe(false);
+  });
+
+  it("does not confuse a settings tab with a same-named top-level route", () => {
+    const config = configWith(["watchtower"]);
+    expect(isSettingsTabDisabled(config, "watchtower")).toBe(false);
+  });
+
+  it("returns false when config is null", () => {
+    expect(isSettingsTabDisabled(null, "rclone")).toBe(false);
+  });
+});
+
+describe("isNavRouteDisabled", () => {
+  it("checks the first path segment against disabledFeatures", () => {
+    const config = configWith(["watchtower"]);
+    expect(isNavRouteDisabled(config, "/watchtower")).toBe(true);
+    expect(isNavRouteDisabled(config, "/watchtower/foo")).toBe(true);
+    expect(isNavRouteDisabled(config, "/queue")).toBe(false);
+  });
+
+  it("does not confuse a top-level route with a same-named settings tab", () => {
+    const config = configWith(["settings.watchtower"]);
+    expect(isNavRouteDisabled(config, "/watchtower")).toBe(false);
+  });
+
+  it("returns false for the root path", () => {
+    expect(isNavRouteDisabled(configWith(["overview"]), "/")).toBe(false);
+  });
+
+  it("returns false when config is null", () => {
+    expect(isNavRouteDisabled(null, "/watchtower")).toBe(false);
+  });
+});

--- a/frontend/app/utils/service-provider.ts
+++ b/frontend/app/utils/service-provider.ts
@@ -1,0 +1,70 @@
+import type { SettingsTab } from "~/routes/settings/settings-tabs";
+
+export const NAV_FEATURE_IDS = [
+  "overview",
+  "queue",
+  "watchdog",
+  "watchtower",
+  "explore",
+  "health",
+  "logs",
+  "search",
+  "settings.usenet",
+  "settings.indexers",
+  "settings.profiles",
+  "settings.watchdog",
+  "settings.preflight",
+  "settings.watchtower",
+  "settings.warden",
+  "settings.sabnzbd",
+  "settings.webdav",
+  "settings.arrs",
+  "settings.repairs",
+  "settings.rclone",
+  "settings.maintenance",
+  "settings.backup",
+  "settings.support",
+] as const;
+
+export type NavFeatureId = (typeof NAV_FEATURE_IDS)[number];
+
+export type ServiceProviderConfig = {
+  name: string;
+  url: string;
+  disabledFeatures: NavFeatureId[];
+};
+
+const NAV_FEATURE_ID_SET = new Set<string>(NAV_FEATURE_IDS);
+
+export function isNavFeatureId(value: string): value is NavFeatureId {
+  return NAV_FEATURE_ID_SET.has(value);
+}
+
+/**
+ * Overview is the app's landing page and the fallback destination used when
+ * closing the "feature not available" notice. It must always stay reachable,
+ * so it cannot be disabled even though it's a valid nav feature identifier.
+ */
+export const NON_DISABLEABLE_FEATURE_ID = "overview" satisfies NavFeatureId;
+
+export function isFeatureDisabled(
+  config: ServiceProviderConfig | null | undefined,
+  featureId: string,
+): boolean {
+  return config?.disabledFeatures.includes(featureId as NavFeatureId) ?? false;
+}
+
+export function isSettingsTabDisabled(
+  config: ServiceProviderConfig | null | undefined,
+  tab: SettingsTab,
+): boolean {
+  return isFeatureDisabled(config, `settings.${tab}`);
+}
+
+export function isNavRouteDisabled(
+  config: ServiceProviderConfig | null | undefined,
+  pathname: string,
+): boolean {
+  const featureId = pathname.split("/").filter(Boolean)[0];
+  return featureId ? isFeatureDisabled(config, featureId) : false;
+}


### PR DESCRIPTION
## Summary
- Hosting providers (e.g. ElfHosted) can now hide specific nav items and settings tabs from their customers via a `SERVICE_PROVIDER` environment variable (name, URL, and a list of disabled feature identifiers).
- Disabled nav items/settings tabs render muted and, when clicked (or reached via direct URL), show a modal explaining the feature is disabled by the provider, with a link to contact them. The `overview` page can never be disabled, since it's the app's landing page and fallback destination.
- When configured, a footer note attributes the installation to the provider (linking to them) and to nzbdav.com.
- Documented the new `SERVICE_PROVIDER` environment variable (since 0.10.0) and added a commented example to `.env.example`.

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build && npm run build:server`
- [x] `cd frontend && npm test` (342 passing, including new coverage for config parsing/helpers)
- [x] `cd frontend && npm run lint` (no new warnings/errors)
- [x] Manually verified in a local preview: disabled nav items show the modal with updated "disabled by" copy, direct navigation to a disabled route shows the same modal, the footer renders provider attribution, and setting `overview` as disabled is rejected (with a warning) instead of causing a redirect loop.