### PR TITLE
perf(websocket): skip live-stat serialization when no browser client is subscribed

### DIFF
--- a/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
@@ -85,6 +85,9 @@ public class ConnectionPoolStats
         // so events arriving after the snapshot are never lost.
         Volatile.Write(ref _flushScheduled, 0);
 
+        if (!_websocketManager.HasSubscribers(WebsocketTopic.UsenetConnections))
+            return;
+
         lock (_lock)
         {
             // Publish while holding the same lock used by Deactivate(). SendMessage is

--- a/backend/Logging/LogBroadcaster.cs
+++ b/backend/Logging/LogBroadcaster.cs
@@ -55,8 +55,11 @@ public sealed class LogBroadcaster(
                     }
                 }
 
-                var payload = JsonSerializer.Serialize(new { entries = pending }, JsonOptions);
-                await websocketManager.SendMessage(WebsocketTopic.LogEntryAdded, payload).ConfigureAwait(false);
+                if (websocketManager.HasSubscribers(WebsocketTopic.LogEntryAdded))
+                {
+                    var payload = JsonSerializer.Serialize(new { entries = pending }, JsonOptions);
+                    await websocketManager.SendMessage(WebsocketTopic.LogEntryAdded, payload).ConfigureAwait(false);
+                }
                 pending.Clear();
             }
             catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered() || stoppingToken.IsCancellationRequested)

--- a/backend/Services/ActiveReadsBroadcaster.cs
+++ b/backend/Services/ActiveReadsBroadcaster.cs
@@ -76,6 +76,9 @@ public class ActiveReadsBroadcaster(
             });
         }
 
+        if (!websocketManager.HasSubscribers(WebsocketTopic.ActiveReads))
+            return;
+
         var entries = registry.Snapshot();
 
         // Common case: nothing active, nothing was active. Skip serialization entirely.

--- a/backend/Services/Metrics/LiveStatsBroadcaster.cs
+++ b/backend/Services/Metrics/LiveStatsBroadcaster.cs
@@ -63,6 +63,9 @@ public class LiveStatsBroadcaster(
 
     private async Task BroadcastAsync()
     {
+        if (!websocketManager.HasSubscribers(WebsocketTopic.LiveStats))
+            return;
+
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var sinceMs = nowMs - WindowMs;
 

--- a/backend/Services/StreamTrace/StreamTraceStatusBroadcaster.cs
+++ b/backend/Services/StreamTrace/StreamTraceStatusBroadcaster.cs
@@ -30,9 +30,8 @@ public sealed class StreamTraceStatusBroadcaster(WebsocketManager websocketManag
             _lastPayload = payload;
         }
 
-        if (!websocketManager.HasSubscribers(WebsocketTopic.StreamTracing))
-            return;
-
+        // SendMessage records the latest state before applying its subscriber gate,
+        // so a later subscriber receives the transition that happened while idle.
         await websocketManager.SendMessage(WebsocketTopic.StreamTracing, payload).ConfigureAwait(false);
     }
 

--- a/backend/Services/StreamTrace/StreamTraceStatusBroadcaster.cs
+++ b/backend/Services/StreamTrace/StreamTraceStatusBroadcaster.cs
@@ -30,6 +30,9 @@ public sealed class StreamTraceStatusBroadcaster(WebsocketManager websocketManag
             _lastPayload = payload;
         }
 
+        if (!websocketManager.HasSubscribers(WebsocketTopic.StreamTracing))
+            return;
+
         await websocketManager.SendMessage(WebsocketTopic.StreamTracing, payload).ConfigureAwait(false);
     }
 

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -138,6 +138,8 @@ public class WebsocketManager
     private async Task ReceiveSubscriptions(SocketSession session)
     {
         var buffer = new byte[MaxSubscriptionMessageSize];
+        using var messageBuffer = new MemoryStream(MaxSubscriptionMessageSize);
+        var discardCurrentMessage = false;
         try
         {
             while (true)
@@ -152,11 +154,37 @@ public class WebsocketManager
                     return;
                 }
 
-                if (result.MessageType != WebSocketMessageType.Text || !result.EndOfMessage)
-                    continue;
+                if (result.MessageType != WebSocketMessageType.Text)
+                {
+                    discardCurrentMessage = true;
+                }
+                else if (!discardCurrentMessage)
+                {
+                    if (messageBuffer.Length + result.Count > MaxSubscriptionMessageSize)
+                    {
+                        discardCurrentMessage = true;
+                        messageBuffer.SetLength(0);
+                        Log.Debug(
+                            "Ignoring websocket subscription message larger than {MaxBytes} bytes",
+                            MaxSubscriptionMessageSize);
+                    }
+                    else
+                    {
+                        messageBuffer.Write(buffer, 0, result.Count);
+                    }
+                }
 
-                var text = Encoding.UTF8.GetString(buffer, 0, result.Count);
-                ProcessSubscriptionMessage(session, text);
+                if (!result.EndOfMessage) continue;
+
+                if (!discardCurrentMessage)
+                {
+                    var text = Encoding.UTF8.GetString(
+                        messageBuffer.GetBuffer(), 0, checked((int)messageBuffer.Length));
+                    ProcessSubscriptionMessage(session, text);
+                }
+
+                messageBuffer.SetLength(0);
+                discardCurrentMessage = false;
             }
         }
         catch (OperationCanceledException)

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -1,6 +1,8 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Extensions;
@@ -12,10 +14,23 @@ namespace NzbWebDAV.Websocket;
 public class WebsocketManager
 {
     private const int EventQueueCapacity = 64;
+    private const int MaxSubscriptionMessageSize = 4096;
     private static readonly TimeSpan SendTimeout = TimeSpan.FromSeconds(30);
 
     private readonly Dictionary<WebSocket, SocketSession> _sessions = new();
     private readonly Dictionary<WebsocketTopic, string> _lastMessage = new();
+    private readonly ConcurrentDictionary<WebsocketTopic, int> _subscriberCounts = new();
+    private long _skippedPublishes;
+
+    /// <summary>
+    /// Whether at least one downstream browser client is subscribed to the given topic.
+    /// Publishers should check this before performing expensive work (DB queries, serialization).
+    /// </summary>
+    public bool HasSubscribers(WebsocketTopic topic) =>
+        _subscriberCounts.TryGetValue(topic, out var count) && count > 0;
+
+    /// <summary>Total number of publish calls skipped due to zero subscribers.</summary>
+    public long SkippedPublishes => Interlocked.Read(ref _skippedPublishes);
 
     public async Task HandleRoute(HttpContext context)
     {
@@ -39,8 +54,7 @@ public class WebsocketManager
 
             try
             {
-                // wait for the socket to disconnect
-                await WaitForDisconnected(webSocket).ConfigureAwait(false);
+                await ReceiveSubscriptions(session).ConfigureAwait(false);
             }
             finally
             {
@@ -70,6 +84,12 @@ public class WebsocketManager
         lock (_sessions) sessions = _sessions.Values.ToList();
         if (sessions.Count == 0) return Task.CompletedTask;
 
+        if (!HasSubscribers(topic))
+        {
+            Interlocked.Increment(ref _skippedPublishes);
+            return Task.CompletedTask;
+        }
+
         var bytes = SerializeMessage(topic, message);
         foreach (var session in sessions)
             session.TryEnqueue(topic, bytes);
@@ -89,6 +109,16 @@ public class WebsocketManager
         return () => RemoveSocket(session);
     }
 
+    internal void SimulateSubscribe(WebsocketTopic topic)
+    {
+        _subscriberCounts.AddOrUpdate(topic, 1, (_, c) => c + 1);
+    }
+
+    internal void SimulateUnsubscribe(WebsocketTopic topic)
+    {
+        _subscriberCounts.AddOrUpdate(topic, 0, (_, c) => Math.Max(0, c - 1));
+    }
+
     /// <summary>
     /// Ensure a websocket sends a valid api key.
     /// </summary>
@@ -101,30 +131,98 @@ public class WebsocketManager
     }
 
     /// <summary>
-    /// Ignore all messages from the websocket and
-    /// wait for it to disconnect.
+    /// Receive frames from the connected relay, parsing subscription messages. Waits until
+    /// the socket disconnects or the application shuts down. Malformed messages are logged
+    /// and tolerated — the connection is never dropped over a parse error.
     /// </summary>
-    /// <param name="socket">The websocket to wait for disconnect.</param>
-    private static async Task WaitForDisconnected(WebSocket socket)
+    private async Task ReceiveSubscriptions(SocketSession session)
     {
+        var buffer = new byte[MaxSubscriptionMessageSize];
         try
         {
-            var buffer = new byte[1024];
-            WebSocketReceiveResult? result = null;
-            while (result is not { CloseStatus: not null })
-                result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), SigtermUtil.GetCancellationToken()).ConfigureAwait(false);
-            await socket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
+            while (true)
+            {
+                var result = await session.Socket.ReceiveAsync(
+                    new ArraySegment<byte>(buffer), SigtermUtil.GetCancellationToken()).ConfigureAwait(false);
+
+                if (result.CloseStatus is not null)
+                {
+                    await session.Socket.CloseAsync(
+                        result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
+                    return;
+                }
+
+                if (result.MessageType != WebSocketMessageType.Text || !result.EndOfMessage)
+                    continue;
+
+                var text = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                ProcessSubscriptionMessage(session, text);
+            }
         }
         catch (OperationCanceledException)
         {
-            // Application is shutting down - send a proper close frame
-            if (socket.State == WebSocketState.Open)
-                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server shutting down", CancellationToken.None).ConfigureAwait(false);
+            if (session.Socket.State == WebSocketState.Open)
+                await session.Socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server shutting down", CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e)
         {
             Log.Warning(e, "Websocket receive loop failed");
         }
+    }
+
+    private void ProcessSubscriptionMessage(SocketSession session, string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("sub", out var subArray) && subArray.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in subArray.EnumerateArray())
+                {
+                    var name = element.GetString();
+                    if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null)
+                    {
+                        if (session.AddSubscription(topic))
+                        {
+                            _subscriberCounts.AddOrUpdate(topic, 1, (_, c) => c + 1);
+                            ReplayStateForNewSubscription(session, topic);
+                        }
+                    }
+                }
+            }
+
+            if (root.TryGetProperty("unsub", out var unsubArray) && unsubArray.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in unsubArray.EnumerateArray())
+                {
+                    var name = element.GetString();
+                    if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null)
+                    {
+                        if (session.RemoveSubscription(topic))
+                            _subscriberCounts.AddOrUpdate(topic, 0, (_, c) => Math.Max(0, c - 1));
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            Log.Debug("Ignoring malformed subscription message from websocket client");
+        }
+    }
+
+    private void ReplayStateForNewSubscription(SocketSession session, WebsocketTopic topic)
+    {
+        if (topic.Type != WebsocketTopic.TopicType.State) return;
+
+        string? lastMsg;
+        lock (_lastMessage)
+        {
+            if (!_lastMessage.TryGetValue(topic, out lastMsg)) return;
+        }
+
+        session.TryEnqueue(topic, SerializeMessage(topic, lastMsg));
     }
 
     private SocketSession AddSocket(WebSocket socket, bool replayState = false)
@@ -206,6 +304,9 @@ public class WebsocketManager
             if (_sessions.TryGetValue(session.Socket, out var current) && ReferenceEquals(current, session))
                 _sessions.Remove(session.Socket);
         }
+
+        foreach (var topic in session.TakeAllSubscriptions())
+            _subscriberCounts.AddOrUpdate(topic, 0, (_, c) => Math.Max(0, c - 1));
 
         session.Stop();
         await session.DrainTask.ConfigureAwait(false);
@@ -292,6 +393,7 @@ public class WebsocketManager
             });
         private readonly CancellationTokenSource _cancellation =
             CancellationTokenSource.CreateLinkedTokenSource(SigtermUtil.GetCancellationToken());
+        private readonly HashSet<WebsocketTopic> _subscriptions = new();
         private long _droppedEventMessageCount;
         private long _lastDroppedEventWarningTimestamp;
         private int _stopped;
@@ -312,6 +414,28 @@ public class WebsocketManager
         public WebSocket Socket { get; }
         public CancellationToken CancellationToken => _cancellation.Token;
         public Task DrainTask { get; set; } = Task.CompletedTask;
+
+        public bool AddSubscription(WebsocketTopic topic)
+        {
+            lock (_stateLock)
+                return _subscriptions.Add(topic);
+        }
+
+        public bool RemoveSubscription(WebsocketTopic topic)
+        {
+            lock (_stateLock)
+                return _subscriptions.Remove(topic);
+        }
+
+        public List<WebsocketTopic> TakeAllSubscriptions()
+        {
+            lock (_stateLock)
+            {
+                var topics = _subscriptions.ToList();
+                _subscriptions.Clear();
+                return topics;
+            }
+        }
 
         public bool TryEnqueue(WebsocketTopic topic, ArraySegment<byte> message)
         {

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -2,6 +2,8 @@
 
 public class WebsocketTopic
 {
+    private static readonly Dictionary<string, WebsocketTopic> ByName = new(StringComparer.Ordinal);
+
     // Stateful topics
     public static readonly WebsocketTopic UsenetConnections = new("cxs", TopicType.State);
     public static readonly WebsocketTopic ActiveReads = new("ar", TopicType.State);
@@ -33,8 +35,6 @@ public class WebsocketTopic
     // Database backup / restore progress
     public static readonly WebsocketTopic DatabaseBackupTaskProgress = new("dbbk", TopicType.State);
     public static readonly WebsocketTopic DatabaseRestoreTaskProgress = new("dbrs", TopicType.State);
-
-    private static readonly Dictionary<string, WebsocketTopic> ByName = new(StringComparer.Ordinal);
 
     public readonly string Name;
     public readonly TopicType Type;

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -34,6 +34,8 @@ public class WebsocketTopic
     public static readonly WebsocketTopic DatabaseBackupTaskProgress = new("dbbk", TopicType.State);
     public static readonly WebsocketTopic DatabaseRestoreTaskProgress = new("dbrs", TopicType.State);
 
+    private static readonly Dictionary<string, WebsocketTopic> ByName = new(StringComparer.Ordinal);
+
     public readonly string Name;
     public readonly TopicType Type;
 
@@ -41,7 +43,11 @@ public class WebsocketTopic
     {
         Name = name;
         Type = type;
+        ByName[name] = this;
     }
+
+    public static bool TryGetByName(string name, out WebsocketTopic? topic) =>
+        ByName.TryGetValue(name, out topic);
 
     public enum TopicType
     {

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -8,6 +8,7 @@ import {
     nextBackendReconnectDelayMs,
     parseSubscriptionTopics,
     sendToBrowserClient,
+    UpstreamSubscriptionForwarder,
 } from "./websocket.server";
 
 describe("parseSubscriptionTopics", () => {
@@ -75,6 +76,88 @@ describe("nextBackendReconnectDelayMs", () => {
 
     it("uses full jitter so a zero draw yields zero delay", () => {
         expect(nextBackendReconnectDelayMs(3, () => 0)).toBe(0);
+    });
+});
+
+describe("UpstreamSubscriptionForwarder", () => {
+    function createMockSocket() {
+        const sent: string[] = [];
+        return {
+            socket: {
+                readyState: WebSocket.OPEN,
+                send: (data: string) => sent.push(data),
+            } as unknown as WebSocket,
+            sent,
+        };
+    }
+
+    it("sends sub when a topic gains its first subscriber", () => {
+        const subscriptions = new Map<string, Set<WebSocket>>();
+        const forwarder = new UpstreamSubscriptionForwarder(subscriptions);
+        const { socket, sent } = createMockSocket();
+        forwarder.setBackendSocket(socket);
+
+        subscriptions.set("ls", new Set([{} as WebSocket]));
+        forwarder.syncAfterBrowserChange([]);
+
+        expect(sent).toHaveLength(1);
+        expect(JSON.parse(sent[0])).toEqual({ sub: ["ls"] });
+    });
+
+    it("sends unsub when a topic loses its last subscriber", () => {
+        const subscriptions = new Map<string, Set<WebSocket>>();
+        subscriptions.set("ls", new Set([{} as WebSocket]));
+        const forwarder = new UpstreamSubscriptionForwarder(subscriptions);
+        const { socket, sent } = createMockSocket();
+        forwarder.setBackendSocket(socket);
+        forwarder.sendFullSubscriptionSet();
+        sent.length = 0;
+
+        subscriptions.get("ls")!.clear();
+        forwarder.syncAfterBrowserChange(["ls"]);
+
+        expect(sent).toHaveLength(1);
+        expect(JSON.parse(sent[0])).toEqual({ unsub: ["ls"] });
+    });
+
+    it("sends full subscription set on reconnect", () => {
+        const subscriptions = new Map<string, Set<WebSocket>>();
+        subscriptions.set("ls", new Set([{} as WebSocket]));
+        subscriptions.set("cxs", new Set([{} as WebSocket]));
+        const forwarder = new UpstreamSubscriptionForwarder(subscriptions);
+        const { socket, sent } = createMockSocket();
+        forwarder.setBackendSocket(socket);
+
+        forwarder.sendFullSubscriptionSet();
+
+        expect(sent).toHaveLength(1);
+        const parsed = JSON.parse(sent[0]);
+        expect(parsed.sub.sort()).toEqual(["cxs", "ls"]);
+    });
+
+    it("does not send when backend socket is not connected", () => {
+        const subscriptions = new Map<string, Set<WebSocket>>();
+        subscriptions.set("ls", new Set([{} as WebSocket]));
+        const forwarder = new UpstreamSubscriptionForwarder(subscriptions);
+
+        forwarder.syncAfterBrowserChange([]);
+        // No error, just no-op
+    });
+
+    it("does not send redundant sub/unsub messages", () => {
+        const subscriptions = new Map<string, Set<WebSocket>>();
+        subscriptions.set("ls", new Set([{} as WebSocket]));
+        const forwarder = new UpstreamSubscriptionForwarder(subscriptions);
+        const { socket, sent } = createMockSocket();
+        forwarder.setBackendSocket(socket);
+        forwarder.sendFullSubscriptionSet();
+        sent.length = 0;
+
+        // Add a second subscriber to "ls" — topic was already active, no message needed
+        subscriptions.get("ls")!.add({} as WebSocket);
+        forwarder.syncAfterBrowserChange([]);
+
+        expect(sent).toHaveLength(0);
     });
 });
 

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -98,7 +98,7 @@ describe("UpstreamSubscriptionForwarder", () => {
         forwarder.setBackendSocket(socket);
 
         subscriptions.set("ls", new Set([{} as WebSocket]));
-        forwarder.syncAfterBrowserChange([]);
+        forwarder.syncAfterBrowserChange();
 
         expect(sent).toHaveLength(1);
         expect(JSON.parse(sent[0])).toEqual({ sub: ["ls"] });
@@ -114,7 +114,7 @@ describe("UpstreamSubscriptionForwarder", () => {
         sent.length = 0;
 
         subscriptions.get("ls")!.clear();
-        forwarder.syncAfterBrowserChange(["ls"]);
+        forwarder.syncAfterBrowserChange();
 
         expect(sent).toHaveLength(1);
         expect(JSON.parse(sent[0])).toEqual({ unsub: ["ls"] });
@@ -140,7 +140,7 @@ describe("UpstreamSubscriptionForwarder", () => {
         subscriptions.set("ls", new Set([{} as WebSocket]));
         const forwarder = new UpstreamSubscriptionForwarder(subscriptions);
 
-        forwarder.syncAfterBrowserChange([]);
+        forwarder.syncAfterBrowserChange();
         // No error, just no-op
     });
 
@@ -155,7 +155,7 @@ describe("UpstreamSubscriptionForwarder", () => {
 
         // Add a second subscriber to "ls" — topic was already active, no message needed
         subscriptions.get("ls")!.add({} as WebSocket);
-        forwarder.syncAfterBrowserChange([]);
+        forwarder.syncAfterBrowserChange();
 
         expect(sent).toHaveLength(0);
     });

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -123,7 +123,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
                 }
             }
 
-            upstreamSubscriptions.syncAfterBrowserChange(previous ? Object.keys(previous) : []);
+            upstreamSubscriptions.syncAfterBrowserChange();
         };
 
         ws.onmessage = (event: WebSocket.MessageEvent) => {
@@ -144,7 +144,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
                     const topicSubscriptions = subscriptions.get(topic);
                     if (topicSubscriptions) topicSubscriptions.delete(ws);
                 }
-                upstreamSubscriptions.syncAfterBrowserChange(Object.keys(topics));
+                upstreamSubscriptions.syncAfterBrowserChange();
             }
             if (authenticated) {
                 logger.info(
@@ -310,7 +310,7 @@ export class UpstreamSubscriptionForwarder {
     }
 
     /** Called after any browser subscribe/unsubscribe to diff and forward changes. */
-    syncAfterBrowserChange(previousTopics: string[]): void {
+    syncAfterBrowserChange(): void {
         if (!this._backendSocket || this._backendSocket.readyState !== WebSocket.OPEN) return;
 
         const currentActive = this._getActiveTopics();

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -64,7 +64,12 @@ function initializeWebsocketServer(wss: WebSocketServer) {
     const websockets = new Map<TrackedSocket, Record<string, TopicKind>>();
     const subscriptions = new Map<string, Set<TrackedSocket>>();
     const lastMessage = new Map<string, string>();
-    initializeWebsocketClient(subscriptions, lastMessage);
+
+    // Tracks which topics have at least one browser subscriber, and forwards
+    // aggregate changes upstream to the backend so it can skip serialization
+    // for topics with zero listeners.
+    const upstreamSubscriptions = new UpstreamSubscriptionForwarder(subscriptions);
+    initializeWebsocketClient(subscriptions, lastMessage, upstreamSubscriptions);
 
     const heartbeat = setInterval(() => {
         for (const client of wss.clients) {
@@ -117,6 +122,8 @@ function initializeWebsocketServer(wss: WebSocketServer) {
                     if (messageToSend) sendToBrowserClient(ws, messageToSend);
                 }
             }
+
+            upstreamSubscriptions.syncAfterBrowserChange(previous ? Object.keys(previous) : []);
         };
 
         ws.onmessage = (event: WebSocket.MessageEvent) => {
@@ -137,6 +144,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
                     const topicSubscriptions = subscriptions.get(topic);
                     if (topicSubscriptions) topicSubscriptions.delete(ws);
                 }
+                upstreamSubscriptions.syncAfterBrowserChange(Object.keys(topics));
             }
             if (authenticated) {
                 logger.info(
@@ -166,7 +174,11 @@ function initializeWebsocketServer(wss: WebSocketServer) {
     });
 }
 
-export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSocket>>, lastMessage: Map<string, string>) {
+export function initializeWebsocketClient(
+    subscriptions: Map<string, Set<WebSocket>>,
+    lastMessage: Map<string, string>,
+    upstreamForwarder?: UpstreamSubscriptionForwarder,
+) {
     let reconnectTimeout: NodeJS.Timeout | null = null;
     let connected = false;
     let connectionFailures = 0;
@@ -220,6 +232,11 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
             }
 
             socket.send(Buffer.from(process.env.FRONTEND_BACKEND_API_KEY!, "utf-8"), { binary: false });
+
+            if (upstreamForwarder) {
+                upstreamForwarder.setBackendSocket(socket);
+                upstreamForwarder.sendFullSubscriptionSet();
+            }
         };
 
         socket.onmessage = (event: WebSocket.MessageEvent) => {
@@ -248,6 +265,7 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
             // mass browser reconnect (see #515).
             const wasConnected = connected;
             connected = false;
+            if (upstreamForwarder) upstreamForwarder.setBackendSocket(null);
             const retryDelayMs = nextBackendReconnectDelayMs(connectionFailures);
             if (wasConnected) {
                 logConnectionFailure(
@@ -270,6 +288,70 @@ export function initializeWebsocketClient(subscriptions: Map<string, Set<WebSock
     }
 
     connect();
+}
+
+/**
+ * Forwards the aggregate set of browser-subscribed topics upstream to the backend
+ * so the backend can skip serialization for topics nobody is listening to. Only sends
+ * a diff when the set of topics with >0 subscribers actually changes.
+ */
+export class UpstreamSubscriptionForwarder {
+    private _backendSocket: WebSocket | null = null;
+    private _lastSentTopics = new Set<string>();
+    private readonly _subscriptions: Map<string, Set<WebSocket>>;
+
+    constructor(subscriptions: Map<string, Set<WebSocket>>) {
+        this._subscriptions = subscriptions;
+    }
+
+    setBackendSocket(socket: WebSocket | null): void {
+        this._backendSocket = socket;
+        if (!socket) this._lastSentTopics.clear();
+    }
+
+    /** Called after any browser subscribe/unsubscribe to diff and forward changes. */
+    syncAfterBrowserChange(previousTopics: string[]): void {
+        if (!this._backendSocket || this._backendSocket.readyState !== WebSocket.OPEN) return;
+
+        const currentActive = this._getActiveTopics();
+        const toSub: string[] = [];
+        const toUnsub: string[] = [];
+
+        for (const topic of currentActive) {
+            if (!this._lastSentTopics.has(topic)) toSub.push(topic);
+        }
+        for (const topic of this._lastSentTopics) {
+            if (!currentActive.has(topic)) toUnsub.push(topic);
+        }
+
+        if (toSub.length > 0) {
+            this._backendSocket.send(JSON.stringify({ sub: toSub }));
+        }
+        if (toUnsub.length > 0) {
+            this._backendSocket.send(JSON.stringify({ unsub: toUnsub }));
+        }
+
+        this._lastSentTopics = currentActive;
+    }
+
+    /** Resend the full subscription set on reconnect. */
+    sendFullSubscriptionSet(): void {
+        if (!this._backendSocket || this._backendSocket.readyState !== WebSocket.OPEN) return;
+
+        const active = this._getActiveTopics();
+        if (active.size > 0) {
+            this._backendSocket.send(JSON.stringify({ sub: [...active] }));
+        }
+        this._lastSentTopics = active;
+    }
+
+    private _getActiveTopics(): Set<string> {
+        const active = new Set<string>();
+        for (const [topic, subs] of this._subscriptions) {
+            if (subs.size > 0) active.add(topic);
+        }
+        return active;
+    }
 }
 
 function getBackendWebsocketUrl() {

--- a/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
@@ -11,6 +11,7 @@ public class WebsocketManagerTests
     public async Task SendMessage_DoesNotLetSlowSocketBlockFastSocket()
     {
         var manager = new WebsocketManager();
+        manager.SimulateSubscribe(WebsocketTopic.LiveStats);
         using var slowSocket = new TestWebSocket(blockSends: true);
         using var fastSocket = new TestWebSocket();
         var detachSlow = manager.AttachAuthenticatedSocketForTests(slowSocket);
@@ -29,6 +30,7 @@ public class WebsocketManagerTests
         }
         finally
         {
+            manager.SimulateUnsubscribe(WebsocketTopic.LiveStats);
             await detachSlow();
             await detachFast();
         }
@@ -38,6 +40,8 @@ public class WebsocketManagerTests
     public async Task StateMessages_CoalescePerTopic()
     {
         var manager = new WebsocketManager();
+        manager.SimulateSubscribe(WebsocketTopic.LiveStats);
+        manager.SimulateSubscribe(WebsocketTopic.UsenetConnections);
         using var socket = new TestWebSocket(blockSends: true);
         var detach = manager.AttachAuthenticatedSocketForTests(socket);
 
@@ -64,6 +68,8 @@ public class WebsocketManagerTests
         }
         finally
         {
+            manager.SimulateUnsubscribe(WebsocketTopic.LiveStats);
+            manager.SimulateUnsubscribe(WebsocketTopic.UsenetConnections);
             await detach();
         }
     }
@@ -72,6 +78,8 @@ public class WebsocketManagerTests
     public async Task EventQueueOverflow_DropsOldestEventsAndKeepsSocketConnected()
     {
         var manager = new WebsocketManager();
+        manager.SimulateSubscribe(WebsocketTopic.LiveStats);
+        manager.SimulateSubscribe(WebsocketTopic.QueueItemAdded);
         using var socket = new TestWebSocket(blockSends: true);
         var detach = manager.AttachAuthenticatedSocketForTests(socket);
 
@@ -96,6 +104,8 @@ public class WebsocketManagerTests
         }
         finally
         {
+            manager.SimulateUnsubscribe(WebsocketTopic.LiveStats);
+            manager.SimulateUnsubscribe(WebsocketTopic.QueueItemAdded);
             await detach();
         }
     }
@@ -111,9 +121,103 @@ public class WebsocketManagerTests
     }
 
     [Fact]
+    public async Task SendMessage_SkipsSerializationWhenNoTopicSubscribers()
+    {
+        var manager = new WebsocketManager();
+        using var socket = new TestWebSocket();
+        var detach = manager.AttachAuthenticatedSocketForTests(socket);
+
+        try
+        {
+            await manager.SendMessage(WebsocketTopic.LiveStats, "nobody-listening");
+            await Task.Delay(100);
+
+            Assert.Empty(socket.Messages);
+            Assert.Equal("nobody-listening", manager.PeekLastMessage(WebsocketTopic.LiveStats));
+            Assert.True(manager.SkippedPublishes > 0);
+        }
+        finally
+        {
+            await detach();
+        }
+    }
+
+    [Fact]
+    public async Task SendMessage_DeliversWhenTopicHasSubscribers()
+    {
+        var manager = new WebsocketManager();
+        using var socket = new TestWebSocket();
+        var detach = manager.AttachAuthenticatedSocketForTests(socket);
+        manager.SimulateSubscribe(WebsocketTopic.LiveStats);
+
+        try
+        {
+            await manager.SendMessage(WebsocketTopic.LiveStats, "with-subscriber");
+            await WaitUntil(() => socket.Messages.Count == 1);
+
+            var msg = Parse(socket.Messages.Single());
+            Assert.Equal("with-subscriber", msg.Message);
+        }
+        finally
+        {
+            manager.SimulateUnsubscribe(WebsocketTopic.LiveStats);
+            await detach();
+        }
+    }
+
+    [Fact]
+    public void HasSubscribers_IncrementAndDecrement()
+    {
+        var manager = new WebsocketManager();
+
+        Assert.False(manager.HasSubscribers(WebsocketTopic.ActiveReads));
+
+        manager.SimulateSubscribe(WebsocketTopic.ActiveReads);
+        Assert.True(manager.HasSubscribers(WebsocketTopic.ActiveReads));
+
+        manager.SimulateSubscribe(WebsocketTopic.ActiveReads);
+        Assert.True(manager.HasSubscribers(WebsocketTopic.ActiveReads));
+
+        manager.SimulateUnsubscribe(WebsocketTopic.ActiveReads);
+        Assert.True(manager.HasSubscribers(WebsocketTopic.ActiveReads));
+
+        manager.SimulateUnsubscribe(WebsocketTopic.ActiveReads);
+        Assert.False(manager.HasSubscribers(WebsocketTopic.ActiveReads));
+    }
+
+    [Fact]
+    public async Task StateTopicReplay_ServesLastMessage_EvenWhenSkippedSerialize()
+    {
+        var manager = new WebsocketManager();
+
+        // Send a message with no subscribers — skips serialization but updates _lastMessage
+        await manager.SendMessage(WebsocketTopic.LiveStats, "stale-value");
+        Assert.Equal("stale-value", manager.PeekLastMessage(WebsocketTopic.LiveStats));
+
+        // Now attach a socket with replayState — should still get the stale value
+        using var socket = new TestWebSocket();
+        var detach = manager.AttachAuthenticatedSocketForTests(socket, replayState: true);
+
+        try
+        {
+            await WaitUntil(() => socket.Messages.Count == 1);
+
+            var replay = Parse(socket.Messages.Single());
+            Assert.Equal(WebsocketTopic.LiveStats.Name, replay.Topic);
+            Assert.Equal("stale-value", replay.Message);
+        }
+        finally
+        {
+            await detach();
+        }
+    }
+
+    [Fact]
     public async Task NewSocket_ReplaysLatestStateButNotEvents()
     {
         var manager = new WebsocketManager();
+        manager.SimulateSubscribe(WebsocketTopic.LiveStats);
+        manager.SimulateSubscribe(WebsocketTopic.QueueItemAdded);
         await manager.SendMessage(WebsocketTopic.LiveStats, "latest");
         await manager.SendMessage(WebsocketTopic.QueueItemAdded, "old-event");
         using var socket = new TestWebSocket();
@@ -129,6 +233,8 @@ public class WebsocketManagerTests
         }
         finally
         {
+            manager.SimulateUnsubscribe(WebsocketTopic.LiveStats);
+            manager.SimulateUnsubscribe(WebsocketTopic.QueueItemAdded);
             await detach();
         }
     }

--- a/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
@@ -1,6 +1,7 @@
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Websocket;
@@ -205,6 +206,31 @@ public class WebsocketManagerTests
             var replay = Parse(socket.Messages.Single());
             Assert.Equal(WebsocketTopic.LiveStats.Name, replay.Topic);
             Assert.Equal("stale-value", replay.Message);
+        }
+        finally
+        {
+            await detach();
+        }
+    }
+
+    [Fact]
+    public async Task StreamTraceStatusTransitionWhileIdle_ReplaysToLateSubscriber()
+    {
+        var manager = new WebsocketManager();
+        var broadcaster = new StreamTraceStatusBroadcaster(manager);
+
+        await broadcaster.BroadcastAsync("""{"enabled":false}""");
+
+        using var socket = new TestWebSocket();
+        var detach = manager.AttachAuthenticatedSocketForTests(socket, replayState: true);
+
+        try
+        {
+            await WaitUntil(() => socket.Messages.Count == 1);
+
+            var replay = Parse(socket.Messages.Single());
+            Assert.Equal(WebsocketTopic.StreamTracing.Name, replay.Topic);
+            Assert.Equal("""{"enabled":false}""", replay.Message);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Adds per-topic subscription tracking to `WebsocketManager` so it knows which topics have active browser listeners
- Frontend relay forwards aggregate subscription changes upstream (`{\"sub\":[...]}` / `{\"unsub\":[...]}`) when the set of active topics changes
- `SendMessage` skips serialization and enqueue when `HasSubscribers(topic)` is false while still preserving `_lastMessage` for state replay
- Accepts fragmented subscription messages up to the 4 KiB protocol limit and safely discards oversized or non-text messages
- Guards expensive publishers at the point of their costly work:
  - `LiveStatsBroadcaster` (ls): skips DB queries + JSON every 5s
  - `ActiveReadsBroadcaster` (ar): skips registry snapshot + JSON every 1s (prune still runs)
  - `ConnectionPoolStats` (cxs): skips message construction per 200ms burst
  - `LogBroadcaster` (log): drains channel but skips JSON serialization every 100ms
  - `StreamTraceStatusBroadcaster` (strt): records idle transitions through `SendMessage`, which preserves replay state before applying the shared subscriber gate

## Test plan

- [x] Backend websocket tests: serialization skip, subscriber lifecycle, delivery, state replay, and idle stream-trace transition replay
- [x] Frontend relay tests: subscribe on first listener, unsubscribe on last listener, reconnect resend, and no redundant messages
- [x] Full backend test suite
- [x] Full frontend test suite
- [ ] Manual: open a browser and verify live stats update; close all tabs and verify publisher work drops; reopen and verify state resumes immediately

Closes #768