### PR TITLE
fix(ui): selection ticks, swallowed clicks, and a hidden menu in the file browser

### DIFF
--- a/frontend/app/routes/explore/dropdown-options/dropdown-options.tsx
+++ b/frontend/app/routes/explore/dropdown-options/dropdown-options.tsx
@@ -44,7 +44,7 @@ export function DropdownOptions({ className, style, isOpen = true, options, onCl
                         <a
                             href={option.linkTo}
                             className={option.variant === "danger" ? "text-error" : undefined}
-                            onClick={() => option.onSelect?.()}
+                            onClick={() => { option.onSelect?.(); onClose?.(); }}
                         >
                             {option.option}
                         </a>
@@ -52,7 +52,7 @@ export function DropdownOptions({ className, style, isOpen = true, options, onCl
                         <button
                             type="button"
                             className={option.variant === "danger" ? "text-error" : undefined}
-                            onClick={() => option.onSelect?.()}
+                            onClick={() => { option.onSelect?.(); onClose?.(); }}
                         >
                             {option.option}
                         </button>

--- a/frontend/app/routes/explore/dropdown-options/dropdown-options.tsx
+++ b/frontend/app/routes/explore/dropdown-options/dropdown-options.tsx
@@ -23,7 +23,6 @@ export function DropdownOptions({ className, style, isOpen = true, options, onCl
 
         function handleClick(e: MouseEvent) {
             if (ref.current && !ref.current.contains(e.target as Node)) {
-                e.preventDefault();
                 onClose?.();
             }
         }

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -550,11 +550,7 @@ function CheckCell(props: { name: string, checked: boolean, onToggle: (name: str
         >
             <Checkbox
                 checked={props.checked}
-                onClick={e => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    props.onToggle(props.name, e.shiftKey);
-                }}
+                onChange={e => props.onToggle(props.name, e.nativeEvent instanceof MouseEvent && e.nativeEvent.shiftKey)}
                 onKeyDown={e => {
                     if (e.key === " " || e.key === "Enter") {
                         e.preventDefault();

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -323,7 +323,7 @@ function Body(props: ExplorePageData) {
                 />
             )}
             {!showSkeleton && visibleItems.length > 0 &&
-                <div className="flex flex-col overflow-hidden rounded-lg border border-base-content/10 divide-y divide-base-content/10">
+                <div className="flex flex-col rounded-lg border border-base-content/10 divide-y divide-base-content/10">
                     {visibleItems.filter(x => x.isDirectory).map((x, index) => {
                         const checked = selected.has(x.name);
                         return (
@@ -662,6 +662,7 @@ function isDeletable(parentDirectories: string[]): boolean {
 function getClassName(item: DirectoryItem | ExploreFile, isSelected: boolean) {
     return classNames([
         "relative flex bg-base-200 transition-colors duration-100",
+        "first:rounded-t-lg last:rounded-b-lg",
         "has-[a:hover]:bg-base-100 has-[a:active]:bg-base-300",
         "[@media(hover:hover)]:has-[a:hover]:cursor-pointer",
         item.name.startsWith(".") && "opacity-50",


### PR DESCRIPTION
Fixes these UI bugs on the Files section:
- The row you just clicked showed no checkmark, even though it was selected and counted.
- Clicking outside an open item menu closed it but swallowed that click, so the thing you clicked needed a second click.
- Selecting an option didn't close the menu, most visibly leaving it open behind the Remove confirm modal.
- An open menu was invisible on the last row of a listing, so on a single-file folder it couldn't be seen at all.