### PR TITLE
chore(streams): evaluate a byte-bounded pool for segment buffers

### DIFF
--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -12,6 +12,64 @@ using UsenetSharp.Streams;
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
 [MemoryDiagnoser]
+public class SegmentBufferPoolBenchmarks
+{
+    private const int SegmentSize = 768 * 1024;
+    private const int ConcurrentStreams = 8;
+    private const int SegmentsPerStream = 20;
+    private byte[] _payload = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _payload = new byte[SegmentSize];
+        new Random(42).NextBytes(_payload);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task ArrayPoolShared()
+    {
+        PooledBufferStream.Pool = SharedArrayPoolAdapter.Instance;
+        await DrainSegments();
+    }
+
+    [Benchmark]
+    public async Task SegmentBufferPool_128MB()
+    {
+        PooledBufferStream.Pool = new SegmentBufferPool(128 * 1024 * 1024);
+        await DrainSegments();
+    }
+
+    [Benchmark]
+    public async Task SegmentBufferPool_64MB()
+    {
+        PooledBufferStream.Pool = new SegmentBufferPool(64 * 1024 * 1024);
+        await DrainSegments();
+    }
+
+    private async Task DrainSegments()
+    {
+        var tasks = Enumerable.Range(0, ConcurrentStreams).Select(async _ =>
+        {
+            for (var i = 0; i < SegmentsPerStream; i++)
+            {
+                await using var buffer = new PooledBufferStream(SegmentSize);
+                await buffer.WriteAsync(_payload);
+                buffer.Position = 0;
+                await buffer.CopyToAsync(Stream.Null);
+            }
+        });
+        await Task.WhenAll(tasks);
+    }
+
+    [IterationCleanup]
+    public void Cleanup()
+    {
+        PooledBufferStream.Pool = SharedArrayPoolAdapter.Instance;
+    }
+}
+
+[MemoryDiagnoser]
 public class YencDecodeBenchmarks
 {
     private byte[] _decoded = null!;

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -46,27 +46,28 @@ public class SegmentBufferPoolBenchmarks
 
     private long DrainSegments(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
     {
+        if (ConcurrentStreams == 1)
+            return DrainStream(pool, diagnostics);
+
+        long totalBytesRead = 0;
+        Parallel.For(0, ConcurrentStreams, _ =>
+        {
+            var bytesRead = DrainStream(pool, diagnostics);
+            Interlocked.Add(ref totalBytesRead, bytesRead);
+        });
+        return totalBytesRead;
+    }
+
+    private long DrainStream(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
+    {
         long bytesRead = 0;
         for (var segment = 0; segment < SegmentsPerStream; segment++)
         {
-            var buffers = Enumerable.Range(0, ConcurrentStreams)
-                .Select(_ => new PooledBufferStream(SegmentSize, pool, diagnostics))
-                .ToArray();
-            try
-            {
-                foreach (var buffer in buffers)
-                {
-                    buffer.Write(_payload);
-                    buffer.Position = 0;
-                    buffer.CopyTo(Stream.Null);
-                    bytesRead += buffer.Length;
-                }
-            }
-            finally
-            {
-                foreach (var buffer in buffers)
-                    buffer.Dispose();
-            }
+            using var buffer = new PooledBufferStream(SegmentSize, pool, diagnostics);
+            buffer.Write(_payload);
+            buffer.Position = 0;
+            buffer.CopyTo(Stream.Null);
+            bytesRead += buffer.Length;
         }
         return bytesRead;
     }

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -14,58 +14,61 @@ BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 [MemoryDiagnoser]
 public class SegmentBufferPoolBenchmarks
 {
-    private const int SegmentSize = 768 * 1024;
-    private const int ConcurrentStreams = 8;
     private const int SegmentsPerStream = 20;
     private byte[] _payload = null!;
+    private SegmentBufferPool _segmentPool = null!;
+    private BufferPoolDiagnostics _sharedDiagnostics = null!;
+    private BufferPoolDiagnostics _segmentDiagnostics = null!;
+
+    [Params(700_000, 750_000, 800_000)]
+    public int SegmentSize { get; set; }
+
+    [Params(1, 8)]
+    public int ConcurrentStreams { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
         _payload = new byte[SegmentSize];
         new Random(42).NextBytes(_payload);
+        _segmentPool = new SegmentBufferPool(128 * 1024 * 1024);
+        _sharedDiagnostics = new BufferPoolDiagnostics();
+        _segmentDiagnostics = new BufferPoolDiagnostics();
     }
 
     [Benchmark(Baseline = true)]
-    public async Task ArrayPoolShared()
-    {
-        PooledBufferStream.Pool = SharedArrayPoolAdapter.Instance;
-        await DrainSegments();
-    }
+    public long ArrayPoolShared() =>
+        DrainSegments(SharedArrayPoolAdapter.Instance, _sharedDiagnostics);
 
     [Benchmark]
-    public async Task SegmentBufferPool_128MB()
-    {
-        PooledBufferStream.Pool = new SegmentBufferPool(128 * 1024 * 1024);
-        await DrainSegments();
-    }
+    public long SegmentBufferPool_128MB() =>
+        DrainSegments(_segmentPool, _segmentDiagnostics);
 
-    [Benchmark]
-    public async Task SegmentBufferPool_64MB()
+    private long DrainSegments(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
     {
-        PooledBufferStream.Pool = new SegmentBufferPool(64 * 1024 * 1024);
-        await DrainSegments();
-    }
-
-    private async Task DrainSegments()
-    {
-        var tasks = Enumerable.Range(0, ConcurrentStreams).Select(async _ =>
+        long bytesRead = 0;
+        for (var segment = 0; segment < SegmentsPerStream; segment++)
         {
-            for (var i = 0; i < SegmentsPerStream; i++)
+            var buffers = Enumerable.Range(0, ConcurrentStreams)
+                .Select(_ => new PooledBufferStream(SegmentSize, pool, diagnostics))
+                .ToArray();
+            try
             {
-                await using var buffer = new PooledBufferStream(SegmentSize);
-                await buffer.WriteAsync(_payload);
-                buffer.Position = 0;
-                await buffer.CopyToAsync(Stream.Null);
+                foreach (var buffer in buffers)
+                {
+                    buffer.Write(_payload);
+                    buffer.Position = 0;
+                    buffer.CopyTo(Stream.Null);
+                    bytesRead += buffer.Length;
+                }
             }
-        });
-        await Task.WhenAll(tasks);
-    }
-
-    [IterationCleanup]
-    public void Cleanup()
-    {
-        PooledBufferStream.Pool = SharedArrayPoolAdapter.Instance;
+            finally
+            {
+                foreach (var buffer in buffers)
+                    buffer.Dispose();
+            }
+        }
+        return bytesRead;
     }
 }
 

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -256,6 +256,7 @@ public sealed class SupportPackService(
         var uptime = ProcessUptime();
         var streamTracing = streamTraceBuffer.GetStatus();
         var usage = runtimeUsage.Snapshot();
+        var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
         var cpu = await BuildCpuDiagnosticsAsync(usage, uptime, cancellationToken).ConfigureAwait(false);
 
         return new
@@ -277,6 +278,13 @@ public sealed class SupportPackService(
                 inFlightArticleBytes = inFlightArticleBudget.LeasedBytes,
                 inFlightArticleBudgetBytes = inFlightArticleBudget.CapBytes,
                 inFlightArticleThrottleEvents = inFlightArticleBudget.ThrottleEvents,
+                segmentBufferRents = bufferPool.Rents,
+                segmentBufferReturns = bufferPool.Returns,
+                segmentBufferGrowths = bufferPool.Growths,
+                segmentBufferCheckedOutBytes = bufferPool.CheckedOutBytes,
+                segmentBufferRequestedBytes = bufferPool.RequestedBytes,
+                segmentBufferRentedBytes = bufferPool.RentedBytes,
+                segmentBufferBucketWasteBytes = bufferPool.BucketWasteBytes,
                 timeZone = TimeZoneInfo.Local.Id,
             },
             runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),

--- a/backend/Streams/BufferPoolDiagnostics.cs
+++ b/backend/Streams/BufferPoolDiagnostics.cs
@@ -1,67 +1,61 @@
 namespace NzbWebDAV.Streams;
 
 /// <summary>
-/// Process-wide counters tracking <see cref="PooledBufferStream"/> rent/return
-/// behavior for the active <see cref="ISegmentBufferPool"/> implementation.
-/// Thread-safe; intended for support packs and live diagnostics, not hot-path gating.
+/// Thread-safe counters tracking <see cref="PooledBufferStream"/> ownership and
+/// bucket rounding. The shared instance describes production traffic; tests and
+/// benchmarks can inject isolated instances.
 /// </summary>
-public static class BufferPoolDiagnostics
+public sealed class BufferPoolDiagnostics
 {
-    private static long _rents;
-    private static long _returns;
-    private static long _growths;
-    private static long _activeBytes;
-    private static long _wastedBytes;
+    public static BufferPoolDiagnostics Shared { get; } = new();
 
-    public static long Rents => Interlocked.Read(ref _rents);
-    public static long Returns => Interlocked.Read(ref _returns);
-    public static long Growths => Interlocked.Read(ref _growths);
-    public static long ActiveBytes => Interlocked.Read(ref _activeBytes);
+    private long _rents;
+    private long _returns;
+    private long _growths;
+    private long _checkedOutBytes;
+    private long _requestedBytes;
+    private long _rentedBytes;
+    private long _bucketWasteBytes;
 
-    /// <summary>
-    /// Cumulative bytes wasted to bucket rounding (rented capacity − requested capacity).
-    /// </summary>
-    public static long WastedBytes => Interlocked.Read(ref _wastedBytes);
-
-    internal static void RecordRent(int requested, int actualCapacity)
+    internal void RecordRent(int requested, int actualCapacity)
     {
         Interlocked.Increment(ref _rents);
-        Interlocked.Add(ref _activeBytes, actualCapacity);
+        Interlocked.Add(ref _checkedOutBytes, actualCapacity);
+        Interlocked.Add(ref _requestedBytes, requested);
+        Interlocked.Add(ref _rentedBytes, actualCapacity);
         if (actualCapacity > requested)
-            Interlocked.Add(ref _wastedBytes, actualCapacity - requested);
+            Interlocked.Add(ref _bucketWasteBytes, actualCapacity - requested);
     }
 
-    internal static void RecordReturn(int capacity)
+    internal void RecordReturn(int capacity)
     {
         Interlocked.Increment(ref _returns);
-        Interlocked.Add(ref _activeBytes, -capacity);
+        Interlocked.Add(ref _checkedOutBytes, -capacity);
     }
 
-    internal static void RecordGrowth(int oldCapacity, int newCapacity)
+    internal void RecordGrowth(int requested, int oldCapacity, int newCapacity)
     {
         Interlocked.Increment(ref _growths);
-        Interlocked.Add(ref _activeBytes, newCapacity - oldCapacity);
-        if (newCapacity > oldCapacity)
-            Interlocked.Add(ref _wastedBytes, newCapacity - oldCapacity);
+        RecordRent(requested, newCapacity);
+        if (oldCapacity > 0)
+            RecordReturn(oldCapacity);
     }
 
-    /// <summary>Snapshot for serialization into support packs or websocket stats.</summary>
-    public static BufferPoolSnapshot Snapshot() => new(
-        Rents, Returns, Growths, ActiveBytes, WastedBytes);
-
-    internal static void Reset()
-    {
-        Interlocked.Exchange(ref _rents, 0);
-        Interlocked.Exchange(ref _returns, 0);
-        Interlocked.Exchange(ref _growths, 0);
-        Interlocked.Exchange(ref _activeBytes, 0);
-        Interlocked.Exchange(ref _wastedBytes, 0);
-    }
+    public BufferPoolSnapshot Snapshot() => new(
+        Interlocked.Read(ref _rents),
+        Interlocked.Read(ref _returns),
+        Interlocked.Read(ref _growths),
+        Interlocked.Read(ref _checkedOutBytes),
+        Interlocked.Read(ref _requestedBytes),
+        Interlocked.Read(ref _rentedBytes),
+        Interlocked.Read(ref _bucketWasteBytes));
 }
 
 public readonly record struct BufferPoolSnapshot(
     long Rents,
     long Returns,
     long Growths,
-    long ActiveBytes,
-    long WastedBytes);
+    long CheckedOutBytes,
+    long RequestedBytes,
+    long RentedBytes,
+    long BucketWasteBytes);

--- a/backend/Streams/BufferPoolDiagnostics.cs
+++ b/backend/Streams/BufferPoolDiagnostics.cs
@@ -1,0 +1,67 @@
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Process-wide counters tracking <see cref="PooledBufferStream"/> rent/return
+/// behavior for the active <see cref="ISegmentBufferPool"/> implementation.
+/// Thread-safe; intended for support packs and live diagnostics, not hot-path gating.
+/// </summary>
+public static class BufferPoolDiagnostics
+{
+    private static long _rents;
+    private static long _returns;
+    private static long _growths;
+    private static long _activeBytes;
+    private static long _wastedBytes;
+
+    public static long Rents => Interlocked.Read(ref _rents);
+    public static long Returns => Interlocked.Read(ref _returns);
+    public static long Growths => Interlocked.Read(ref _growths);
+    public static long ActiveBytes => Interlocked.Read(ref _activeBytes);
+
+    /// <summary>
+    /// Cumulative bytes wasted to bucket rounding (rented capacity − requested capacity).
+    /// </summary>
+    public static long WastedBytes => Interlocked.Read(ref _wastedBytes);
+
+    internal static void RecordRent(int requested, int actualCapacity)
+    {
+        Interlocked.Increment(ref _rents);
+        Interlocked.Add(ref _activeBytes, actualCapacity);
+        if (actualCapacity > requested)
+            Interlocked.Add(ref _wastedBytes, actualCapacity - requested);
+    }
+
+    internal static void RecordReturn(int capacity)
+    {
+        Interlocked.Increment(ref _returns);
+        Interlocked.Add(ref _activeBytes, -capacity);
+    }
+
+    internal static void RecordGrowth(int oldCapacity, int newCapacity)
+    {
+        Interlocked.Increment(ref _growths);
+        Interlocked.Add(ref _activeBytes, newCapacity - oldCapacity);
+        if (newCapacity > oldCapacity)
+            Interlocked.Add(ref _wastedBytes, newCapacity - oldCapacity);
+    }
+
+    /// <summary>Snapshot for serialization into support packs or websocket stats.</summary>
+    public static BufferPoolSnapshot Snapshot() => new(
+        Rents, Returns, Growths, ActiveBytes, WastedBytes);
+
+    internal static void Reset()
+    {
+        Interlocked.Exchange(ref _rents, 0);
+        Interlocked.Exchange(ref _returns, 0);
+        Interlocked.Exchange(ref _growths, 0);
+        Interlocked.Exchange(ref _activeBytes, 0);
+        Interlocked.Exchange(ref _wastedBytes, 0);
+    }
+}
+
+public readonly record struct BufferPoolSnapshot(
+    long Rents,
+    long Returns,
+    long Growths,
+    long ActiveBytes,
+    long WastedBytes);

--- a/backend/Streams/ISegmentBufferPool.cs
+++ b/backend/Streams/ISegmentBufferPool.cs
@@ -12,10 +12,4 @@ public interface ISegmentBufferPool
 
     /// <summary>Return a previously rented buffer.</summary>
     void Return(byte[] buffer);
-
-    /// <summary>Approximate bytes held idle in the pool (not rented out).</summary>
-    long IdleBytes { get; }
-
-    /// <summary>Number of distinct size classes with at least one idle buffer.</summary>
-    int ActiveSizeClasses { get; }
 }

--- a/backend/Streams/ISegmentBufferPool.cs
+++ b/backend/Streams/ISegmentBufferPool.cs
@@ -1,0 +1,21 @@
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Abstracts segment buffer allocation so <see cref="PooledBufferStream"/> can use
+/// either the BCL <see cref="System.Buffers.ArrayPool{T}"/> or a custom byte-bounded
+/// pool without changing consumers.
+/// </summary>
+public interface ISegmentBufferPool
+{
+    /// <summary>Rent a buffer of at least <paramref name="minimumLength"/> bytes.</summary>
+    byte[] Rent(int minimumLength);
+
+    /// <summary>Return a previously rented buffer.</summary>
+    void Return(byte[] buffer);
+
+    /// <summary>Approximate bytes held idle in the pool (not rented out).</summary>
+    long IdleBytes { get; }
+
+    /// <summary>Number of distinct size classes with at least one idle buffer.</summary>
+    int ActiveSizeClasses { get; }
+}

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -1,5 +1,3 @@
-using System.Buffers;
-
 namespace NzbWebDAV.Streams;
 
 /// <summary>
@@ -9,27 +7,28 @@ namespace NzbWebDAV.Streams;
 /// </summary>
 public sealed class PooledBufferStream : Stream
 {
-    /// <summary>
-    /// Process-wide pool used by all <see cref="PooledBufferStream"/> instances.
-    /// Defaults to <see cref="SharedArrayPoolAdapter"/> (BCL behavior). Replace at
-    /// startup to use <see cref="SegmentBufferPool"/> or a test double.
-    /// </summary>
-    public static ISegmentBufferPool Pool { get; set; } = SharedArrayPoolAdapter.Instance;
-
+    private readonly ISegmentBufferPool _pool;
+    private readonly BufferPoolDiagnostics _diagnostics;
     private byte[]? _buffer;
     private int _length;
     private int _position;
     private bool _disposed;
 
-    public PooledBufferStream(int capacityHint)
+    public PooledBufferStream(
+        int capacityHint,
+        ISegmentBufferPool? pool = null,
+        BufferPoolDiagnostics? diagnostics = null)
     {
         if (capacityHint < 0)
             throw new ArgumentOutOfRangeException(nameof(capacityHint));
 
+        _pool = pool ?? SharedArrayPoolAdapter.Instance;
+        _diagnostics = diagnostics ?? BufferPoolDiagnostics.Shared;
+
         if (capacityHint > 0)
         {
-            _buffer = Pool.Rent(capacityHint);
-            BufferPoolDiagnostics.RecordRent(capacityHint, _buffer.Length);
+            _buffer = RentBuffer(capacityHint);
+            _diagnostics.RecordRent(capacityHint, _buffer.Length);
         }
         else
         {
@@ -196,14 +195,14 @@ public sealed class PooledBufferStream : Stream
         var current = _buffer!;
         if (required <= current.Length) return;
 
-        var next = Pool.Rent(required);
-        BufferPoolDiagnostics.RecordGrowth(current.Length, next.Length);
+        var next = RentBuffer(required);
         if (_length > 0)
             current.AsSpan(0, _length).CopyTo(next);
 
         if (current.Length > 0)
-            Pool.Return(current);
+            _pool.Return(current);
 
+        _diagnostics.RecordGrowth(required, current.Length, next.Length);
         _buffer = next;
     }
 
@@ -212,12 +211,23 @@ public sealed class PooledBufferStream : Stream
         var buffer = Interlocked.Exchange(ref _buffer, null);
         if (buffer is { Length: > 0 })
         {
-            BufferPoolDiagnostics.RecordReturn(buffer.Length);
-            Pool.Return(buffer);
+            _diagnostics.RecordReturn(buffer.Length);
+            _pool.Return(buffer);
         }
 
         _length = 0;
         _position = 0;
+    }
+
+    private byte[] RentBuffer(int minimumLength)
+    {
+        var buffer = _pool.Rent(minimumLength);
+        if (buffer.Length >= minimumLength) return buffer;
+
+        if (buffer.Length > 0)
+            _pool.Return(buffer);
+        throw new InvalidOperationException(
+            $"Segment buffer pool returned {buffer.Length} bytes for a {minimumLength}-byte request.");
     }
 
     private void ThrowIfDisposed()

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -3,12 +3,19 @@ using System.Buffers;
 namespace NzbWebDAV.Streams;
 
 /// <summary>
-/// Seekable read/write stream over an <see cref="ArrayPool{T}"/>-rented array.
+/// Seekable read/write stream over an <see cref="ISegmentBufferPool"/>-rented array.
 /// Logical <see cref="Length"/> is independent of rented capacity so lease accounting
 /// and segment alignment stay on decoded byte counts, not pool bucket sizes.
 /// </summary>
 public sealed class PooledBufferStream : Stream
 {
+    /// <summary>
+    /// Process-wide pool used by all <see cref="PooledBufferStream"/> instances.
+    /// Defaults to <see cref="SharedArrayPoolAdapter"/> (BCL behavior). Replace at
+    /// startup to use <see cref="SegmentBufferPool"/> or a test double.
+    /// </summary>
+    public static ISegmentBufferPool Pool { get; set; } = SharedArrayPoolAdapter.Instance;
+
     private byte[]? _buffer;
     private int _length;
     private int _position;
@@ -19,9 +26,15 @@ public sealed class PooledBufferStream : Stream
         if (capacityHint < 0)
             throw new ArgumentOutOfRangeException(nameof(capacityHint));
 
-        _buffer = capacityHint > 0
-            ? ArrayPool<byte>.Shared.Rent(capacityHint)
-            : [];
+        if (capacityHint > 0)
+        {
+            _buffer = Pool.Rent(capacityHint);
+            BufferPoolDiagnostics.RecordRent(capacityHint, _buffer.Length);
+        }
+        else
+        {
+            _buffer = [];
+        }
     }
 
     public override bool CanRead => !_disposed;
@@ -154,8 +167,6 @@ public sealed class PooledBufferStream : Stream
         if (newLength > _length)
         {
             EnsureCapacity(newLength);
-            // Rented arrays are dirty; MemoryStream would zero here and AlignDrainedSegment
-            // depends on that guarantee when padding short bodies.
             _buffer.AsSpan(_length, newLength - _length).Clear();
         }
 
@@ -185,14 +196,13 @@ public sealed class PooledBufferStream : Stream
         var current = _buffer!;
         if (required <= current.Length) return;
 
-        // Rent exactly what is needed so a small overshoot of a good hint does not
-        // jump the Shared pool's 1 MiB bucket and lose pooling.
-        var next = ArrayPool<byte>.Shared.Rent(required);
+        var next = Pool.Rent(required);
+        BufferPoolDiagnostics.RecordGrowth(current.Length, next.Length);
         if (_length > 0)
             current.AsSpan(0, _length).CopyTo(next);
 
         if (current.Length > 0)
-            ArrayPool<byte>.Shared.Return(current);
+            Pool.Return(current);
 
         _buffer = next;
     }
@@ -201,7 +211,10 @@ public sealed class PooledBufferStream : Stream
     {
         var buffer = Interlocked.Exchange(ref _buffer, null);
         if (buffer is { Length: > 0 })
-            ArrayPool<byte>.Shared.Return(buffer);
+        {
+            BufferPoolDiagnostics.RecordReturn(buffer.Length);
+            Pool.Return(buffer);
+        }
 
         _length = 0;
         _position = 0;

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -1,0 +1,80 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Byte-bounded buffer pool with 256 KiB size classes designed for Usenet segment
+/// drains (~750 KiB typical). Reduces bucket waste versus <see cref="System.Buffers.ArrayPool{T}.Shared"/>
+/// power-of-two buckets while bounding total idle retention in bytes.
+/// </summary>
+public sealed class SegmentBufferPool : ISegmentBufferPool
+{
+    private const int SizeClassGranularity = 256 * 1024;
+    private const int MaxBuffersPerClass = 64;
+
+    private readonly long _maxIdleBytes;
+    private readonly ConcurrentDictionary<int, ConcurrentBag<byte[]>> _buckets = new();
+    private long _idleBytes;
+    private long _trimTimestamp;
+
+    /// <param name="maxIdleBytes">
+    /// Maximum bytes to retain idle across all size classes. When exceeded, the oldest
+    /// class with the most waste is trimmed on the next return.
+    /// </param>
+    public SegmentBufferPool(long maxIdleBytes)
+    {
+        _maxIdleBytes = Math.Max(SizeClassGranularity, maxIdleBytes);
+    }
+
+    public long IdleBytes => Interlocked.Read(ref _idleBytes);
+    public int ActiveSizeClasses => _buckets.Count(kv => !kv.Value.IsEmpty);
+
+    public byte[] Rent(int minimumLength)
+    {
+        if (minimumLength <= 0) return [];
+
+        var sizeClass = RoundToSizeClass(minimumLength);
+        if (_buckets.TryGetValue(sizeClass, out var bag) && bag.TryTake(out var buffer))
+        {
+            Interlocked.Add(ref _idleBytes, -buffer.Length);
+            return buffer;
+        }
+
+        return new byte[sizeClass];
+    }
+
+    public void Return(byte[] buffer)
+    {
+        if (buffer.Length == 0) return;
+
+        var sizeClass = buffer.Length;
+        var bag = _buckets.GetOrAdd(sizeClass, _ => new ConcurrentBag<byte[]>());
+
+        if (bag.Count >= MaxBuffersPerClass)
+            return;
+
+        bag.Add(buffer);
+        var idle = Interlocked.Add(ref _idleBytes, buffer.Length);
+
+        if (idle > _maxIdleBytes)
+            TrimExcess();
+    }
+
+    private void TrimExcess()
+    {
+        var now = Stopwatch.GetTimestamp();
+        var last = Interlocked.Read(ref _trimTimestamp);
+        if (Stopwatch.GetElapsedTime(last, now) < TimeSpan.FromSeconds(1)) return;
+        if (Interlocked.CompareExchange(ref _trimTimestamp, now, last) != last) return;
+
+        foreach (var (_, bag) in _buckets)
+        {
+            while (Interlocked.Read(ref _idleBytes) > _maxIdleBytes && bag.TryTake(out var evicted))
+                Interlocked.Add(ref _idleBytes, -evicted.Length);
+        }
+    }
+
+    internal static int RoundToSizeClass(int size) =>
+        ((size + SizeClassGranularity - 1) / SizeClassGranularity) * SizeClassGranularity;
+}

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -1,80 +1,215 @@
-using System.Collections.Concurrent;
-using System.Diagnostics;
-
 namespace NzbWebDAV.Streams;
 
 /// <summary>
-/// Byte-bounded buffer pool with 256 KiB size classes designed for Usenet segment
-/// drains (~750 KiB typical). Reduces bucket waste versus <see cref="System.Buffers.ArrayPool{T}.Shared"/>
-/// power-of-two buckets while bounding total idle retention in bytes.
+/// Evaluation pool for Usenet segment drains. Uses 256 KiB size classes, strictly
+/// bounds idle retention, reclaims across classes, and expires stale buffers.
 /// </summary>
 public sealed class SegmentBufferPool : ISegmentBufferPool
 {
-    private const int SizeClassGranularity = 256 * 1024;
-    private const int MaxBuffersPerClass = 64;
+    internal const int SizeClassGranularity = 256 * 1024;
+    private const int DefaultMaxBuffersPerClass = 64;
+    private static readonly TimeSpan DefaultStaleAfter = TimeSpan.FromMinutes(2);
 
+    private readonly object _gate = new();
     private readonly long _maxIdleBytes;
-    private readonly ConcurrentDictionary<int, ConcurrentBag<byte[]>> _buckets = new();
+    private readonly int _maxBuffersPerClass;
+    private readonly TimeSpan _staleAfter;
+    private readonly TimeProvider _timeProvider;
+    private readonly Dictionary<int, Queue<IdleBuffer>> _buckets = [];
+    private readonly HashSet<byte[]> _checkedOut = new(ReferenceEqualityComparer.Instance);
+
     private long _idleBytes;
-    private long _trimTimestamp;
+    private long _trimmedBytes;
+    private long _rentCount;
+    private long _returnCount;
+    private long _reuseCount;
+    private long _allocationCount;
 
-    /// <param name="maxIdleBytes">
-    /// Maximum bytes to retain idle across all size classes. When exceeded, the oldest
-    /// class with the most waste is trimmed on the next return.
-    /// </param>
-    public SegmentBufferPool(long maxIdleBytes)
+    public SegmentBufferPool(
+        long maxIdleBytes,
+        TimeSpan? staleAfter = null,
+        int maxBuffersPerClass = DefaultMaxBuffersPerClass,
+        TimeProvider? timeProvider = null)
     {
-        _maxIdleBytes = Math.Max(SizeClassGranularity, maxIdleBytes);
-    }
+        ArgumentOutOfRangeException.ThrowIfNegative(maxIdleBytes);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxBuffersPerClass, 1);
 
-    public long IdleBytes => Interlocked.Read(ref _idleBytes);
-    public int ActiveSizeClasses => _buckets.Count(kv => !kv.Value.IsEmpty);
+        _maxIdleBytes = maxIdleBytes;
+        _maxBuffersPerClass = maxBuffersPerClass;
+        _staleAfter = staleAfter ?? DefaultStaleAfter;
+        if (_staleAfter < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(staleAfter));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
 
     public byte[] Rent(int minimumLength)
     {
-        if (minimumLength <= 0) return [];
+        if (minimumLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(minimumLength));
+        if (minimumLength == 0) return [];
+        if (minimumLength > Array.MaxLength)
+            throw new ArgumentOutOfRangeException(nameof(minimumLength));
 
         var sizeClass = RoundToSizeClass(minimumLength);
-        if (_buckets.TryGetValue(sizeClass, out var bag) && bag.TryTake(out var buffer))
+        var now = _timeProvider.GetUtcNow();
+
+        lock (_gate)
         {
-            Interlocked.Add(ref _idleBytes, -buffer.Length);
-            return buffer;
+            TrimStaleLocked(now);
+            if (_buckets.TryGetValue(sizeClass, out var bucket) && bucket.Count > 0)
+            {
+                var idle = bucket.Dequeue();
+                _idleBytes -= idle.Buffer.Length;
+                if (bucket.Count == 0)
+                    _buckets.Remove(sizeClass);
+                _checkedOut.Add(idle.Buffer);
+                _rentCount++;
+                _reuseCount++;
+                return idle.Buffer;
+            }
         }
 
-        return new byte[sizeClass];
+        var allocated = new byte[sizeClass];
+        lock (_gate)
+        {
+            _checkedOut.Add(allocated);
+            _rentCount++;
+            _allocationCount++;
+        }
+        return allocated;
     }
 
     public void Return(byte[] buffer)
     {
+        ArgumentNullException.ThrowIfNull(buffer);
         if (buffer.Length == 0) return;
 
-        var sizeClass = buffer.Length;
-        var bag = _buckets.GetOrAdd(sizeClass, _ => new ConcurrentBag<byte[]>());
-
-        if (bag.Count >= MaxBuffersPerClass)
-            return;
-
-        bag.Add(buffer);
-        var idle = Interlocked.Add(ref _idleBytes, buffer.Length);
-
-        if (idle > _maxIdleBytes)
-            TrimExcess();
-    }
-
-    private void TrimExcess()
-    {
-        var now = Stopwatch.GetTimestamp();
-        var last = Interlocked.Read(ref _trimTimestamp);
-        if (Stopwatch.GetElapsedTime(last, now) < TimeSpan.FromSeconds(1)) return;
-        if (Interlocked.CompareExchange(ref _trimTimestamp, now, last) != last) return;
-
-        foreach (var (_, bag) in _buckets)
+        var now = _timeProvider.GetUtcNow();
+        lock (_gate)
         {
-            while (Interlocked.Read(ref _idleBytes) > _maxIdleBytes && bag.TryTake(out var evicted))
-                Interlocked.Add(ref _idleBytes, -evicted.Length);
+            if (!_checkedOut.Remove(buffer))
+                throw new InvalidOperationException(
+                    "The segment buffer was not rented from this pool or was already returned.");
+
+            _returnCount++;
+            TrimStaleLocked(now);
+
+            if (buffer.Length > _maxIdleBytes)
+            {
+                _trimmedBytes += buffer.Length;
+                return;
+            }
+
+            if (_buckets.TryGetValue(buffer.Length, out var existingBucket) &&
+                existingBucket.Count >= _maxBuffersPerClass)
+            {
+                _trimmedBytes += buffer.Length;
+                return;
+            }
+
+            ReclaimForLocked(buffer.Length);
+            if (_idleBytes + buffer.Length > _maxIdleBytes)
+            {
+                _trimmedBytes += buffer.Length;
+                return;
+            }
+
+            var bucket = GetOrCreateBucketLocked(buffer.Length);
+            bucket.Enqueue(new IdleBuffer(buffer, now));
+            _idleBytes += buffer.Length;
         }
     }
 
-    internal static int RoundToSizeClass(int size) =>
-        ((size + SizeClassGranularity - 1) / SizeClassGranularity) * SizeClassGranularity;
+    public SegmentBufferPoolSnapshot Snapshot()
+    {
+        lock (_gate)
+        {
+            var classes = _buckets
+                .OrderBy(x => x.Key)
+                .Select(x => new SegmentBufferPoolClassSnapshot(
+                    x.Key, x.Value.Count, (long)x.Key * x.Value.Count))
+                .ToArray();
+            return new SegmentBufferPoolSnapshot(
+                _idleBytes,
+                _trimmedBytes,
+                _checkedOut.Sum(x => (long)x.Length),
+                _rentCount,
+                _returnCount,
+                _reuseCount,
+                _allocationCount,
+                classes);
+        }
+    }
+
+    internal static int RoundToSizeClass(int size)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(size, Array.MaxLength);
+
+        var rounded = ((long)size + SizeClassGranularity - 1)
+                      / SizeClassGranularity
+                      * SizeClassGranularity;
+        return rounded <= Array.MaxLength ? (int)rounded : size;
+    }
+
+    private Queue<IdleBuffer> GetOrCreateBucketLocked(int sizeClass)
+    {
+        if (_buckets.TryGetValue(sizeClass, out var bucket)) return bucket;
+        bucket = new Queue<IdleBuffer>();
+        _buckets.Add(sizeClass, bucket);
+        return bucket;
+    }
+
+    private void ReclaimForLocked(int incomingBytes)
+    {
+        while (_idleBytes + incomingBytes > _maxIdleBytes)
+        {
+            var oldest = _buckets
+                .Where(x => x.Value.Count > 0)
+                .OrderBy(x => x.Value.Peek().ReturnedAt)
+                .FirstOrDefault();
+            if (oldest.Value is null) return;
+
+            var evicted = oldest.Value.Dequeue();
+            _idleBytes -= evicted.Buffer.Length;
+            _trimmedBytes += evicted.Buffer.Length;
+            if (oldest.Value.Count == 0)
+                _buckets.Remove(oldest.Key);
+        }
+    }
+
+    private void TrimStaleLocked(DateTimeOffset now)
+    {
+        if (_buckets.Count == 0) return;
+        var cutoff = now - _staleAfter;
+        foreach (var (sizeClass, bucket) in _buckets.ToArray())
+        {
+            while (bucket.Count > 0 && bucket.Peek().ReturnedAt <= cutoff)
+            {
+                var evicted = bucket.Dequeue();
+                _idleBytes -= evicted.Buffer.Length;
+                _trimmedBytes += evicted.Buffer.Length;
+            }
+
+            if (bucket.Count == 0)
+                _buckets.Remove(sizeClass);
+        }
+    }
+
+    private sealed record IdleBuffer(byte[] Buffer, DateTimeOffset ReturnedAt);
 }
+
+public readonly record struct SegmentBufferPoolSnapshot(
+    long IdleBytes,
+    long TrimmedBytes,
+    long CheckedOutBytes,
+    long RentCount,
+    long ReturnCount,
+    long ReuseCount,
+    long AllocationCount,
+    IReadOnlyList<SegmentBufferPoolClassSnapshot> SizeClasses);
+
+public readonly record struct SegmentBufferPoolClassSnapshot(
+    int BufferSize,
+    int BufferCount,
+    long IdleBytes);

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -60,8 +60,6 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
             {
                 var idle = bucket.Dequeue();
                 _idleBytes -= idle.Buffer.Length;
-                if (bucket.Count == 0)
-                    _buckets.Remove(sizeClass);
                 _checkedOut.Add(idle.Buffer);
                 _rentCount++;
                 _reuseCount++;
@@ -125,6 +123,7 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
         lock (_gate)
         {
             var classes = _buckets
+                .Where(x => x.Value.Count > 0)
                 .OrderBy(x => x.Key)
                 .Select(x => new SegmentBufferPoolClassSnapshot(
                     x.Key, x.Value.Count, (long)x.Key * x.Value.Count))
@@ -164,17 +163,21 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
     {
         while (_idleBytes + incomingBytes > _maxIdleBytes)
         {
-            var oldest = _buckets
-                .Where(x => x.Value.Count > 0)
-                .OrderBy(x => x.Value.Peek().ReturnedAt)
-                .FirstOrDefault();
-            if (oldest.Value is null) return;
+            Queue<IdleBuffer>? oldest = null;
+            foreach (var bucket in _buckets.Values)
+            {
+                if (bucket.Count == 0) continue;
+                if (oldest is null ||
+                    bucket.Peek().ReturnedAt < oldest.Peek().ReturnedAt)
+                {
+                    oldest = bucket;
+                }
+            }
 
-            var evicted = oldest.Value.Dequeue();
+            if (oldest is null) return;
+            var evicted = oldest.Dequeue();
             _idleBytes -= evicted.Buffer.Length;
             _trimmedBytes += evicted.Buffer.Length;
-            if (oldest.Value.Count == 0)
-                _buckets.Remove(oldest.Key);
         }
     }
 
@@ -182,7 +185,7 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
     {
         if (_buckets.Count == 0) return;
         var cutoff = now - _staleAfter;
-        foreach (var (sizeClass, bucket) in _buckets.ToArray())
+        foreach (var bucket in _buckets.Values)
         {
             while (bucket.Count > 0 && bucket.Peek().ReturnedAt <= cutoff)
             {
@@ -190,13 +193,10 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
                 _idleBytes -= evicted.Buffer.Length;
                 _trimmedBytes += evicted.Buffer.Length;
             }
-
-            if (bucket.Count == 0)
-                _buckets.Remove(sizeClass);
         }
     }
 
-    private sealed record IdleBuffer(byte[] Buffer, DateTimeOffset ReturnedAt);
+    private readonly record struct IdleBuffer(byte[] Buffer, DateTimeOffset ReturnedAt);
 }
 
 public readonly record struct SegmentBufferPoolSnapshot(

--- a/backend/Streams/SharedArrayPoolAdapter.cs
+++ b/backend/Streams/SharedArrayPoolAdapter.cs
@@ -12,7 +12,4 @@ public sealed class SharedArrayPoolAdapter : ISegmentBufferPool
 
     public byte[] Rent(int minimumLength) => ArrayPool<byte>.Shared.Rent(minimumLength);
     public void Return(byte[] buffer) => ArrayPool<byte>.Shared.Return(buffer);
-
-    public long IdleBytes => 0;
-    public int ActiveSizeClasses => 0;
 }

--- a/backend/Streams/SharedArrayPoolAdapter.cs
+++ b/backend/Streams/SharedArrayPoolAdapter.cs
@@ -1,0 +1,18 @@
+using System.Buffers;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Default <see cref="ISegmentBufferPool"/> wrapping <see cref="ArrayPool{T}.Shared"/>.
+/// Used as the production baseline for comparison with <see cref="SegmentBufferPool"/>.
+/// </summary>
+public sealed class SharedArrayPoolAdapter : ISegmentBufferPool
+{
+    public static readonly SharedArrayPoolAdapter Instance = new();
+
+    public byte[] Rent(int minimumLength) => ArrayPool<byte>.Shared.Rent(minimumLength);
+    public void Return(byte[] buffer) => ArrayPool<byte>.Shared.Return(buffer);
+
+    public long IdleBytes => 0;
+    public int ActiveSizeClasses => 0;
+}

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -1,0 +1,138 @@
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class SegmentBufferPoolTests
+{
+    [Theory]
+    [InlineData(1, 256 * 1024)]
+    [InlineData(256 * 1024, 256 * 1024)]
+    [InlineData(256 * 1024 + 1, 512 * 1024)]
+    [InlineData(750_000, 768 * 1024)]
+    [InlineData(1024 * 1024, 1024 * 1024)]
+    public void RoundToSizeClass_AlignsToBoundary(int input, int expected)
+    {
+        Assert.Equal(expected, SegmentBufferPool.RoundToSizeClass(input));
+    }
+
+    [Fact]
+    public void Rent_ReturnsBufferOfAtLeastRequestedSize()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
+        var buffer = pool.Rent(700_000);
+        Assert.True(buffer.Length >= 700_000);
+        pool.Return(buffer);
+    }
+
+    [Fact]
+    public void Return_ThenRent_ReusesBuffer()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
+        var first = pool.Rent(500_000);
+        pool.Return(first);
+
+        var second = pool.Rent(500_000);
+        Assert.Same(first, second);
+        pool.Return(second);
+    }
+
+    [Fact]
+    public void IdleBytes_ReflectsRetainedBuffers()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
+        Assert.Equal(0, pool.IdleBytes);
+
+        var buffer = pool.Rent(750_000);
+        Assert.Equal(0, pool.IdleBytes);
+
+        pool.Return(buffer);
+        Assert.Equal(buffer.Length, pool.IdleBytes);
+    }
+
+    [Fact]
+    public void Rent_ZeroLength_ReturnsEmptyArray()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
+        var buffer = pool.Rent(0);
+        Assert.Empty(buffer);
+    }
+
+    [Fact]
+    public void Return_EmptyArray_IsNoOp()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
+        pool.Return([]);
+        Assert.Equal(0, pool.IdleBytes);
+    }
+
+    [Fact]
+    public void MaxBuffersPerClass_PreventsUnboundedRetention()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 256 * 1024 * 1024L);
+        var buffers = Enumerable.Range(0, 100)
+            .Select(_ => pool.Rent(256 * 1024))
+            .ToList();
+
+        foreach (var b in buffers) pool.Return(b);
+
+        // Pool caps at 64 buffers per class; excess is silently dropped.
+        Assert.True(pool.IdleBytes <= 64 * 256 * 1024);
+    }
+}
+
+public class BufferPoolDiagnosticsTests
+{
+    [Fact]
+    public void RentAndReturn_UpdatesCounters()
+    {
+        BufferPoolDiagnostics.Reset();
+        using var stream = new PooledBufferStream(1024);
+        Assert.Equal(1, BufferPoolDiagnostics.Rents);
+        Assert.True(BufferPoolDiagnostics.ActiveBytes > 0);
+
+        stream.Dispose();
+        Assert.Equal(1, BufferPoolDiagnostics.Returns);
+    }
+
+    [Fact]
+    public void Growth_TrackedSeparately()
+    {
+        BufferPoolDiagnostics.Reset();
+        using var stream = new PooledBufferStream(16);
+        stream.Write(new byte[1024]);
+        Assert.True(BufferPoolDiagnostics.Growths >= 1);
+    }
+
+    [Fact]
+    public void Snapshot_CapturesCurrentState()
+    {
+        BufferPoolDiagnostics.Reset();
+        using var stream = new PooledBufferStream(512);
+        var snap = BufferPoolDiagnostics.Snapshot();
+        Assert.Equal(1, snap.Rents);
+        Assert.True(snap.ActiveBytes > 0);
+    }
+}
+
+public class PooledBufferStreamPoolSwapTests
+{
+    [Fact]
+    public async Task CustomPool_IsUsedForRentAndReturn()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
+        var previous = PooledBufferStream.Pool;
+        PooledBufferStream.Pool = pool;
+
+        try
+        {
+            await using var stream = new PooledBufferStream(750_000);
+            await stream.WriteAsync(new byte[750_000]);
+        }
+        finally
+        {
+            PooledBufferStream.Pool = previous;
+        }
+
+        Assert.True(pool.IdleBytes > 0);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -10,129 +10,212 @@ public class SegmentBufferPoolTests
     [InlineData(256 * 1024 + 1, 512 * 1024)]
     [InlineData(750_000, 768 * 1024)]
     [InlineData(1024 * 1024, 1024 * 1024)]
-    public void RoundToSizeClass_AlignsToBoundary(int input, int expected)
-    {
+    public void RoundToSizeClass_AlignsToBoundary(int input, int expected) =>
         Assert.Equal(expected, SegmentBufferPool.RoundToSizeClass(input));
+
+    [Fact]
+    public void Return_StrictlyEnforcesIdleByteCap()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 512 * 1024);
+        var buffers = Enumerable.Range(0, 3)
+            .Select(_ => pool.Rent(256 * 1024))
+            .ToArray();
+
+        foreach (var buffer in buffers)
+            pool.Return(buffer);
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(512 * 1024, snapshot.IdleBytes);
+        Assert.Equal(256 * 1024, snapshot.TrimmedBytes);
+        Assert.Equal(2, snapshot.SizeClasses.Single().BufferCount);
     }
 
     [Fact]
-    public void Rent_ReturnsBufferOfAtLeastRequestedSize()
+    public void Return_ReclaimsOldestBuffersAcrossSizeClasses()
     {
-        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
-        var buffer = pool.Rent(700_000);
-        Assert.True(buffer.Length >= 700_000);
-        pool.Return(buffer);
+        var pool = new SegmentBufferPool(maxIdleBytes: 768 * 1024);
+        var small = pool.Rent(256 * 1024);
+        var medium = pool.Rent(512 * 1024);
+        var large = pool.Rent(768 * 1024);
+        pool.Return(small);
+        pool.Return(medium);
+
+        pool.Return(large);
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(768 * 1024, snapshot.IdleBytes);
+        Assert.Equal(768 * 1024, snapshot.TrimmedBytes);
+        Assert.Single(snapshot.SizeClasses);
+        Assert.Equal(768 * 1024, snapshot.SizeClasses[0].BufferSize);
     }
 
     [Fact]
-    public void Return_ThenRent_ReusesBuffer()
+    public void Rent_TrimsStaleBuffersBeforeReuse()
     {
-        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
-        var first = pool.Rent(500_000);
+        var clock = new ManualTimeProvider();
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 4 * 1024 * 1024,
+            staleAfter: TimeSpan.FromMinutes(1),
+            timeProvider: clock);
+        var first = pool.Rent(750_000);
         pool.Return(first);
+        clock.Advance(TimeSpan.FromMinutes(2));
 
-        var second = pool.Rent(500_000);
-        Assert.Same(first, second);
+        var second = pool.Rent(750_000);
+
+        Assert.NotSame(first, second);
+        Assert.Equal(first.Length, pool.Snapshot().TrimmedBytes);
         pool.Return(second);
     }
 
     [Fact]
-    public void IdleBytes_ReflectsRetainedBuffers()
+    public void Return_EnforcesPerClassLimit()
     {
-        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
-        Assert.Equal(0, pool.IdleBytes);
-
-        var buffer = pool.Rent(750_000);
-        Assert.Equal(0, pool.IdleBytes);
-
-        pool.Return(buffer);
-        Assert.Equal(buffer.Length, pool.IdleBytes);
-    }
-
-    [Fact]
-    public void Rent_ZeroLength_ReturnsEmptyArray()
-    {
-        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
-        var buffer = pool.Rent(0);
-        Assert.Empty(buffer);
-    }
-
-    [Fact]
-    public void Return_EmptyArray_IsNoOp()
-    {
-        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
-        pool.Return([]);
-        Assert.Equal(0, pool.IdleBytes);
-    }
-
-    [Fact]
-    public void MaxBuffersPerClass_PreventsUnboundedRetention()
-    {
-        var pool = new SegmentBufferPool(maxIdleBytes: 256 * 1024 * 1024L);
-        var buffers = Enumerable.Range(0, 100)
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 16 * 1024 * 1024,
+            maxBuffersPerClass: 2);
+        var buffers = Enumerable.Range(0, 3)
             .Select(_ => pool.Rent(256 * 1024))
-            .ToList();
+            .ToArray();
 
-        foreach (var b in buffers) pool.Return(b);
+        foreach (var buffer in buffers)
+            pool.Return(buffer);
 
-        // Pool caps at 64 buffers per class; excess is silently dropped.
-        Assert.True(pool.IdleBytes <= 64 * 256 * 1024);
+        var snapshot = pool.Snapshot();
+        Assert.Equal(2 * 256 * 1024, snapshot.IdleBytes);
+        Assert.Equal(256 * 1024, snapshot.TrimmedBytes);
+    }
+
+    [Fact]
+    public void Return_RejectsForeignOrDuplicateBuffers()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);
+        var buffer = pool.Rent(256 * 1024);
+        pool.Return(buffer);
+
+        Assert.Throws<InvalidOperationException>(() => pool.Return(buffer));
+        Assert.Throws<InvalidOperationException>(() => pool.Return(new byte[256 * 1024]));
+    }
+
+    [Fact]
+    public void Snapshot_AccountsForCheckedOutAndReusedBytes()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        var first = pool.Rent(750_000);
+        Assert.Equal(first.Length, pool.Snapshot().CheckedOutBytes);
+        pool.Return(first);
+
+        var second = pool.Rent(750_000);
+        var snapshot = pool.Snapshot();
+
+        Assert.Same(first, second);
+        Assert.Equal(2, snapshot.RentCount);
+        Assert.Equal(1, snapshot.ReturnCount);
+        Assert.Equal(1, snapshot.ReuseCount);
+        Assert.Equal(1, snapshot.AllocationCount);
+        pool.Return(second);
+    }
+
+    [Fact]
+    public void TypicalSegment_UsesLessCapacityThanSharedArrayPoolBucket()
+    {
+        const int requested = 750_000;
+        var custom = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        var customBuffer = custom.Rent(requested);
+        var sharedBuffer = SharedArrayPoolAdapter.Instance.Rent(requested);
+
+        try
+        {
+            Assert.Equal(768 * 1024, customBuffer.Length);
+            Assert.True(sharedBuffer.Length >= customBuffer.Length);
+        }
+        finally
+        {
+            custom.Return(customBuffer);
+            SharedArrayPoolAdapter.Instance.Return(sharedBuffer);
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan duration) => _now += duration;
     }
 }
 
 public class BufferPoolDiagnosticsTests
 {
     [Fact]
-    public void RentAndReturn_UpdatesCounters()
+    public void GrowthAndDispose_KeepOwnershipAndWasteAccountingBalanced()
     {
-        BufferPoolDiagnostics.Reset();
-        using var stream = new PooledBufferStream(1024);
-        Assert.Equal(1, BufferPoolDiagnostics.Rents);
-        Assert.True(BufferPoolDiagnostics.ActiveBytes > 0);
+        var diagnostics = new BufferPoolDiagnostics();
+        var pool = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        var stream = new PooledBufferStream(750_000, pool, diagnostics);
+
+        var initial = diagnostics.Snapshot();
+        Assert.Equal(1, initial.Rents);
+        Assert.Equal(0, initial.Returns);
+        Assert.Equal(768 * 1024, initial.CheckedOutBytes);
+        Assert.Equal(750_000, initial.RequestedBytes);
+        Assert.Equal(768 * 1024 - 750_000, initial.BucketWasteBytes);
+
+        stream.Write(new byte[900_000]);
+        var grown = diagnostics.Snapshot();
+        Assert.Equal(2, grown.Rents);
+        Assert.Equal(1, grown.Returns);
+        Assert.Equal(1, grown.Growths);
+        Assert.Equal(1024 * 1024, grown.CheckedOutBytes);
 
         stream.Dispose();
-        Assert.Equal(1, BufferPoolDiagnostics.Returns);
+        var disposed = diagnostics.Snapshot();
+        Assert.Equal(2, disposed.Returns);
+        Assert.Equal(0, disposed.CheckedOutBytes);
     }
 
     [Fact]
-    public void Growth_TrackedSeparately()
+    public void PooledBufferStream_ReturnsToThePoolThatRentedIt()
     {
-        BufferPoolDiagnostics.Reset();
-        using var stream = new PooledBufferStream(16);
-        stream.Write(new byte[1024]);
-        Assert.True(BufferPoolDiagnostics.Growths >= 1);
+        var pool = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        using (var stream = new PooledBufferStream(750_000, pool))
+            stream.Write(new byte[900_000]);
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(0, snapshot.CheckedOutBytes);
+        Assert.Equal(2, snapshot.ReturnCount);
     }
 
     [Fact]
-    public void Snapshot_CapturesCurrentState()
+    public void GrowthFromEmpty_DoesNotRecordAFalseReturn()
     {
-        BufferPoolDiagnostics.Reset();
-        using var stream = new PooledBufferStream(512);
-        var snap = BufferPoolDiagnostics.Snapshot();
-        Assert.Equal(1, snap.Rents);
-        Assert.True(snap.ActiveBytes > 0);
+        var diagnostics = new BufferPoolDiagnostics();
+        using var stream = new PooledBufferStream(
+            0,
+            SharedArrayPoolAdapter.Instance,
+            diagnostics);
+
+        stream.WriteByte(1);
+
+        var snapshot = diagnostics.Snapshot();
+        Assert.Equal(1, snapshot.Rents);
+        Assert.Equal(0, snapshot.Returns);
+        Assert.Equal(1, snapshot.Growths);
     }
-}
 
-public class PooledBufferStreamPoolSwapTests
-{
     [Fact]
-    public async Task CustomPool_IsUsedForRentAndReturn()
+    public void PooledBufferStream_RejectsUndersizedPoolRent()
     {
-        var pool = new SegmentBufferPool(maxIdleBytes: 64 * 1024 * 1024);
-        var previous = PooledBufferStream.Pool;
-        PooledBufferStream.Pool = pool;
+        var pool = new UndersizedPool();
 
-        try
-        {
-            await using var stream = new PooledBufferStream(750_000);
-            await stream.WriteAsync(new byte[750_000]);
-        }
-        finally
-        {
-            PooledBufferStream.Pool = previous;
-        }
+        Assert.Throws<InvalidOperationException>(
+            () => new PooledBufferStream(1024, pool));
+        Assert.Equal(1, pool.ReturnCount);
+    }
 
-        Assert.True(pool.IdleBytes > 0);
+    private sealed class UndersizedPool : ISegmentBufferPool
+    {
+        public int ReturnCount { get; private set; }
+        public byte[] Rent(int minimumLength) => new byte[minimumLength - 1];
+        public void Return(byte[] buffer) => ReturnCount++;
     }
 }


### PR DESCRIPTION
## Summary

- Adds exact production diagnostics for `PooledBufferStream` rents, returns, growth, checked-out capacity, requested capacity, rented capacity, and cumulative bucket waste
- Exports those counters in support-pack `environment.json`
- Adds a benchmark/test-only `SegmentBufferPool` prototype with 256 KiB classes, a strict idle-byte cap, stale trimming, cross-class reclamation, exact ownership checks, and per-class snapshots
- Keeps `ArrayPool<byte>.Shared` as the production default; there is intentionally no operator setting for the custom pool

## Evaluation result

Short BenchmarkDotNet runs on an Apple M4 Pro tested 700,000, 750,000, and 800,000-byte segments with one and eight genuinely concurrent streams (20 segments each):

- Managed allocations were equal between implementations after removing custom-pool bookkeeping allocations
- The custom pool's throughput ranged from 2% faster to 4% slower; at eight concurrent streams it was 2–4% slower in all three size cases
- 700,000 and 750,000-byte requests use a 786,432-byte custom bucket instead of the shared pool's 1,048,576-byte bucket (25% less checked-out capacity)
- 800,000-byte requests use 1,048,576 bytes in both pools, so there is no capacity benefit above the 768 KiB class boundary

The measured result does not justify replacing the mature shared pool globally. Keep `ArrayPool<byte>.Shared` in production and use the new support-pack bucket-waste counters to determine whether real installations have enough sub-768 KiB traffic to justify a configurable dedicated pool later.

## Corrections from review

- Removed unsafe process-wide pool mutation; every stream captures the pool that owns its buffers
- Enforced the idle-byte cap synchronously instead of leaving it over budget behind a one-second throttle
- Added stale and cross-class reclamation, strict per-class limits, and foreign/double-return detection
- Corrected growth/waste accounting and made test diagnostics instance-scoped to avoid parallel-test races
- Added overflow-safe size rounding and undersized-rent validation
- Reworked the benchmark to reuse pools, test representative size boundaries, and execute parallel playback workers
- Removed hot-path custom-pool metadata allocations

## Test plan

- [x] Size-class boundaries and shared-pool capacity comparison
- [x] Strict byte cap, cross-class reclamation, stale expiry, and per-class cap
- [x] Exact checked-out/reuse/trim accounting and duplicate-return rejection
- [x] Stream growth, empty growth, owner return, and undersized-rent handling
- [x] Support-pack diagnostics integration
- [x] Full backend suite: 1461 passed, 14 platform skips
- [x] Benchmark project build and 12-case short benchmark run

Closes #759