### PR TITLE
chore(usenet): measure whether concurrent playback would benefit from shared streams

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -27,6 +27,7 @@ public class GetWebdavItemController(
     ConfigManager configManager,
     ProviderUsageTracker providerUsageTracker,
     ActiveReadRegistry activeReadRegistry,
+    ConcurrentReadTracker concurrentReadTracker,
     CandidateNegativeCache negativeCache,
     StreamTraceBuffer streamTrace
 ) : ControllerBase
@@ -151,6 +152,10 @@ public class GetWebdavItemController(
         {
             HttpContext.Items["configManager"] = configManager;
             var request = new GetWebdavItemRequest(HttpContext);
+            using var concurrentReadScope = concurrentReadTracker.BeginRead(
+                request.Item,
+                request.SuffixLength.HasValue ? null : request.RangeStart ?? 0,
+                ResolveReadRegion(request));
             var sessionId = TrackReadSession(request.Item);
             HttpContext.Items["readSessionId"] = sessionId;
             using var scope = providerUsageTracker.BeginScope(sessionId);
@@ -170,6 +175,7 @@ public class GetWebdavItemController(
                 if (response == Stream.Null)
                     return;
                 var effectiveStart = (long)(HttpContext.Items["effectiveRangeStart"] ?? 0L);
+                concurrentReadScope.UpdateStart(effectiveStart);
                 var rangeEnd = HttpContext.Items["effectiveRangeEnd"] as long?;
                 traceRange = streamTrace.RangeOpen(
                     sessionId,
@@ -214,6 +220,15 @@ public class GetWebdavItemController(
         {
             Response.StatusCode = 401;
         }
+    }
+
+    private static ConcurrentReadRegion ResolveReadRegion(GetWebdavItemRequest request)
+    {
+        if (request.SuffixLength.HasValue) return ConcurrentReadRegion.SuffixRange;
+        if (!request.RangeStart.HasValue) return ConcurrentReadRegion.Full;
+        return request.RangeStart.Value == 0
+            ? ConcurrentReadRegion.StartRange
+            : ConcurrentReadRegion.OffsetRange;
     }
 
     private void FinishRange(

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -29,7 +29,8 @@ public class MultiProviderNntpClient(
     StreamTraceBuffer? streamTrace = null,
     ActiveReadRegistry? activeReadRegistry = null,
     ArticleMissNegativeCache? articleMissCache = null,
-    ConnectionPoolStats? connectionPoolStats = null
+    ConnectionPoolStats? connectionPoolStats = null,
+    ConcurrentReadTracker? concurrentReadTracker = null
 ) : NntpClient, INntpConnectionStats
 {
     /// <summary>
@@ -183,13 +184,32 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken
     )
     {
-        return await RunStreamingFromPoolWithBackup(
-            (provider, callback) =>
-                provider.DecodedBodyAsync(segmentId, callback, cancellationToken),
-            UsenetResponseType.ArticleRetrievedBodyFollows,
-            segmentId,
-            onConnectionReadyAgain,
-            cancellationToken).ConfigureAwait(false);
+        var fetchScope = concurrentReadTracker?.BeginSegmentFetch(segmentId);
+        try
+        {
+            return await RunStreamingFromPoolWithBackup(
+                (provider, callback) =>
+                    provider.DecodedBodyAsync(segmentId, callback, cancellationToken),
+                UsenetResponseType.ArticleRetrievedBodyFollows,
+                segmentId,
+                result =>
+                {
+                    try
+                    {
+                        InvokeCompletionCallback(onConnectionReadyAgain, result);
+                    }
+                    finally
+                    {
+                        fetchScope?.Dispose();
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            fetchScope?.Dispose();
+            throw;
+        }
     }
 
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync
@@ -199,82 +219,113 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken
     )
     {
-        ExceptionDispatchInfo? lastException = null;
-        var orderedProviders = SelectOrderedProviders(out var reserved);
-        using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
-        for (var providerIndex = 0; providerIndex < orderedProviders.Count; providerIndex++)
+        var fetchScopes = concurrentReadTracker is null
+            ? []
+            : segmentIds.Select(x => concurrentReadTracker.BeginSegmentFetch(x)).ToArray();
+
+        void CompleteBatchFetches(ArticleBodyResult result)
         {
-            var provider = orderedProviders[providerIndex];
-            var deferredCallback = new DeferredArticleBodyCallback();
             try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                var primaryBatch = await provider.DecodedBodiesAsync(
-                    segmentIds, deferredCallback.Invoke, cancellationToken).ConfigureAwait(false);
-                var coordinator = new BatchCallbackCoordinator(
-                    primaryBatch.Responses.Count, onConnectionReadyAgain);
-                deferredCallback.Activate(coordinator.CompleteTransfer);
-                var fallbackProviders = orderedProviders
-                    .Skip(providerIndex + 1)
-                    .ToArray();
-                var responses =
-                    new Task<UsenetDecodedBodyResponse>[primaryBatch.Responses.Count];
-                // Admission (start-order) is separate from transfer completion so segment
-                // N+1 can begin its fallback walk after N has admitted/started, without
-                // waiting for N's body stream to finish. Concurrent starts are bounded by
-                // _batchFallbackStartGate until each transfer's body callback fires.
-                Task previousFallbackAdmission = Task.CompletedTask;
-                for (var index = 0; index < responses.Length; index++)
-                {
-                    var fallbackAdmission = new TaskCompletionSource(
-                        TaskCreationOptions.RunContinuationsAsynchronously);
-                    responses[index] = ResolveBatchResponseAsync(
-                        primaryBatch.Responses[index],
-                        segmentIds[index],
-                        provider,
-                        fallbackProviders,
-                        previousFallbackAdmission,
-                        fallbackAdmission,
-                        coordinator,
-                        cancellationToken);
-                    previousFallbackAdmission = fallbackAdmission.Task;
-                }
-                return new UsenetDecodedBodyBatch { Responses = responses };
+                InvokeCompletionCallback(onConnectionReadyAgain, result);
             }
-            catch (NntpClientRetiredException)
+            finally
             {
-                // Every provider in this client belongs to the same retired generation.
-                // Do not walk the remaining disposed pools or record network failures.
-                deferredCallback.Discard();
-                InvokeCompletionCallback(
-                    onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
-                throw;
-            }
-            catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
-            {
-                // Invalid / permanently missing segment ids are invalid on every provider.
-                deferredCallback.Discard();
-                InvokeCompletionCallback(
-                    onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
-                throw;
-            }
-            catch (Exception e) when (!e.IsCancellationException(cancellationToken))
-            {
-                deferredCallback.Discard();
-                lastException = ExceptionDispatchInfo.Capture(e);
-            }
-            catch
-            {
-                deferredCallback.Discard();
-                InvokeCompletionCallback(
-                    onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
-                throw;
+                foreach (var fetchScope in fetchScopes)
+                    fetchScope.Dispose();
             }
         }
 
-        InvokeCompletionCallback(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
-        lastException?.Throw();
-        throw new Exception("There are no usenet providers configured.");
+        try
+        {
+            return await DecodedBodiesCoreAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            foreach (var fetchScope in fetchScopes)
+                fetchScope.Dispose();
+            throw;
+        }
+
+        async Task<UsenetDecodedBodyBatch> DecodedBodiesCoreAsync()
+        {
+            ExceptionDispatchInfo? lastException = null;
+            var orderedProviders = SelectOrderedProviders(out var reserved);
+            using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
+            for (var providerIndex = 0; providerIndex < orderedProviders.Count; providerIndex++)
+            {
+                var provider = orderedProviders[providerIndex];
+                var deferredCallback = new DeferredArticleBodyCallback();
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var primaryBatch = await provider.DecodedBodiesAsync(
+                        segmentIds, deferredCallback.Invoke, cancellationToken).ConfigureAwait(false);
+                    var coordinator = new BatchCallbackCoordinator(
+                    primaryBatch.Responses.Count, CompleteBatchFetches);
+                    deferredCallback.Activate(coordinator.CompleteTransfer);
+                    var fallbackProviders = orderedProviders
+                        .Skip(providerIndex + 1)
+                        .ToArray();
+                    var responses =
+                        new Task<UsenetDecodedBodyResponse>[primaryBatch.Responses.Count];
+                    // Admission (start-order) is separate from transfer completion so segment
+                    // N+1 can begin its fallback walk after N has admitted/started, without
+                    // waiting for N's body stream to finish. Concurrent starts are bounded by
+                    // _batchFallbackStartGate until each transfer's body callback fires.
+                    Task previousFallbackAdmission = Task.CompletedTask;
+                    for (var index = 0; index < responses.Length; index++)
+                    {
+                        var fallbackAdmission = new TaskCompletionSource(
+                            TaskCreationOptions.RunContinuationsAsynchronously);
+                        responses[index] = ResolveBatchResponseAsync(
+                            primaryBatch.Responses[index],
+                            segmentIds[index],
+                            provider,
+                            fallbackProviders,
+                            previousFallbackAdmission,
+                            fallbackAdmission,
+                            coordinator,
+                            cancellationToken);
+                        previousFallbackAdmission = fallbackAdmission.Task;
+                    }
+                    return new UsenetDecodedBodyBatch { Responses = responses };
+                }
+                catch (NntpClientRetiredException)
+                {
+                    // Every provider in this client belongs to the same retired generation.
+                    // Do not walk the remaining disposed pools or record network failures.
+                    deferredCallback.Discard();
+                    InvokeCompletionCallback(
+                        CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
+                    throw;
+                }
+                catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _))
+                {
+                    // Invalid / permanently missing segment ids are invalid on every provider.
+                    deferredCallback.Discard();
+                    InvokeCompletionCallback(
+                        CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
+                    throw;
+                }
+                catch (Exception e) when (!e.IsCancellationException(cancellationToken))
+                {
+                    deferredCallback.Discard();
+                    lastException = ExceptionDispatchInfo.Capture(e);
+                }
+                catch
+                {
+                    deferredCallback.Discard();
+                    InvokeCompletionCallback(
+                        CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
+                    throw;
+                }
+            }
+
+            InvokeCompletionCallback(CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
+            lastException?.Throw();
+            throw new Exception("There are no usenet providers configured.");
+        }
     }
 
     private async Task<UsenetDecodedBodyResponse> ResolveBatchResponseAsync(

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -26,10 +26,11 @@ public class UsenetStreamingClient : WrappingNntpClient
         StreamTraceBuffer streamTrace,
         ActiveReadRegistry activeReadRegistry,
         ArticleMissNegativeCache? articleMissCache = null,
-        ProviderLatencyTracker? latencyTracker = null)
+        ProviderLatencyTracker? latencyTracker = null,
+        ConcurrentReadTracker? concurrentReadTracker = null)
         : base(CreateDownloadingNntpClient(
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
-            streamTrace, activeReadRegistry, articleMissCache, latencyTracker))
+            streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker))
     {
         // when config changes, create a new MultiProviderClient to use instead.
         configManager.OnConfigChanged += (_, configEventArgs) =>
@@ -52,7 +53,8 @@ public class UsenetStreamingClient : WrappingNntpClient
                         // separate update (and must not touch the retired client).
                         var newUsenetClient = CreateDownloadingNntpClient(
                             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
-                            streamTrace, activeReadRegistry, articleMissCache, latencyTracker);
+                            streamTrace, activeReadRegistry, articleMissCache, latencyTracker,
+                            concurrentReadTracker);
                         ReplaceUnderlyingClient(newUsenetClient);
                         return;
                     }
@@ -81,12 +83,13 @@ public class UsenetStreamingClient : WrappingNntpClient
         StreamTraceBuffer streamTrace,
         ActiveReadRegistry activeReadRegistry,
         ArticleMissNegativeCache? articleMissCache,
-        ProviderLatencyTracker? latencyTracker
+        ProviderLatencyTracker? latencyTracker,
+        ConcurrentReadTracker? concurrentReadTracker
     )
     {
         var multiProviderClient = CreateMultiProviderClient(
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
-            streamTrace, activeReadRegistry, articleMissCache, latencyTracker);
+            streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker);
         var downloadingClient = new DownloadingNntpClient(multiProviderClient, configManager, latencyTracker);
         INntpClient inner = downloadingClient;
         if (configManager.IsSegmentCacheEnabled())
@@ -143,7 +146,8 @@ public class UsenetStreamingClient : WrappingNntpClient
         StreamTraceBuffer streamTrace,
         ActiveReadRegistry activeReadRegistry,
         ArticleMissNegativeCache? articleMissCache,
-        ProviderLatencyTracker? latencyTracker
+        ProviderLatencyTracker? latencyTracker,
+        ConcurrentReadTracker? concurrentReadTracker
     )
     {
         var providerConfig = configManager.GetUsenetProviderConfig();
@@ -174,7 +178,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             streamTrace: streamTrace,
             activeReadRegistry: activeReadRegistry,
             articleMissCache: articleMissCache,
-            connectionPoolStats: connectionPoolStats);
+            connectionPoolStats: connectionPoolStats,
+            concurrentReadTracker: concurrentReadTracker);
     }
 
     private static MultiConnectionNntpClient CreateProviderClient

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -222,6 +222,7 @@ public partial class Program
                 .AddSingleton<NzbWebDAV.Services.Benchmark.BenchmarkRunControl>()
                 .AddHostedService<LogBroadcaster>()
                 .AddSingleton<ActiveReadRegistry>()
+                .AddSingleton<ConcurrentReadTracker>()
                 .AddSingleton<StreamingReadinessCheck>()
                 .AddSingleton(_ => new RuntimeUsageTracker())
                 .AddHostedService<RuntimeUsageSampler>()

--- a/backend/Services/ConcurrentReadTracker.cs
+++ b/backend/Services/ConcurrentReadTracker.cs
@@ -1,0 +1,117 @@
+using System.Collections.Concurrent;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Tracks concurrent read sessions on the same content path to measure potential
+/// gains from shared streams or segment-fetch deduplication. This is instrumentation
+/// only — it does not alter streaming behavior.
+/// </summary>
+public sealed class ConcurrentReadTracker
+{
+    private readonly ConcurrentDictionary<string, PathState> _paths = new(StringComparer.Ordinal);
+    private long _overlapEvents;
+    private long _duplicateSegmentFetches;
+    private long _peakConcurrentReaders;
+
+    /// <summary>Number of times a new reader joined a path that already had active readers.</summary>
+    public long OverlapEvents => Interlocked.Read(ref _overlapEvents);
+
+    /// <summary>
+    /// Segment fetches that would have been deduplicatable if a shared stream existed
+    /// (same segment ID fetched while another reader on the same path was also active).
+    /// </summary>
+    public long DuplicateSegmentFetches => Interlocked.Read(ref _duplicateSegmentFetches);
+
+    /// <summary>Highest concurrent reader count observed on any single path.</summary>
+    public long PeakConcurrentReaders => Interlocked.Read(ref _peakConcurrentReaders);
+
+    /// <summary>Register a reader starting on a path. Returns a disposable scope.</summary>
+    public IDisposable BeginRead(string path)
+    {
+        var state = _paths.GetOrAdd(path, _ => new PathState());
+        var count = Interlocked.Increment(ref state.ActiveReaders);
+
+        if (count > 1)
+            Interlocked.Increment(ref _overlapEvents);
+
+        UpdatePeak(count);
+        return new ReadScope(this, path);
+    }
+
+    /// <summary>Record a segment fetch on a path that has concurrent readers.</summary>
+    public void RecordSegmentFetch(string path, string segmentId)
+    {
+        if (!_paths.TryGetValue(path, out var state)) return;
+        if (Volatile.Read(ref state.ActiveReaders) <= 1) return;
+
+        var seenSet = state.RecentSegments;
+        if (!seenSet.TryAdd(segmentId, Environment.TickCount64))
+        {
+            Interlocked.Increment(ref _duplicateSegmentFetches);
+        }
+
+        TrimOldSegments(seenSet);
+    }
+
+    /// <summary>Current snapshot for diagnostics/support packs.</summary>
+    public ConcurrentReadSnapshot Snapshot() => new(
+        OverlapEvents,
+        DuplicateSegmentFetches,
+        PeakConcurrentReaders,
+        _paths.Count(kv => Volatile.Read(ref kv.Value.ActiveReaders) > 1));
+
+    private void EndRead(string path)
+    {
+        if (!_paths.TryGetValue(path, out var state)) return;
+        var remaining = Interlocked.Decrement(ref state.ActiveReaders);
+        if (remaining <= 0)
+        {
+            state.RecentSegments.Clear();
+            _paths.TryRemove(path, out _);
+        }
+    }
+
+    private void UpdatePeak(long current)
+    {
+        while (true)
+        {
+            var peak = Interlocked.Read(ref _peakConcurrentReaders);
+            if (current <= peak) return;
+            if (Interlocked.CompareExchange(ref _peakConcurrentReaders, current, peak) == peak) return;
+        }
+    }
+
+    private static void TrimOldSegments(ConcurrentDictionary<string, long> segments)
+    {
+        if (segments.Count <= 256) return;
+        var cutoff = Environment.TickCount64 - 30_000;
+        foreach (var kv in segments)
+        {
+            if (kv.Value < cutoff)
+                segments.TryRemove(kv);
+        }
+    }
+
+    private sealed class PathState
+    {
+        public int ActiveReaders;
+        public readonly ConcurrentDictionary<string, long> RecentSegments = new(StringComparer.Ordinal);
+    }
+
+    private sealed class ReadScope(ConcurrentReadTracker tracker, string path) : IDisposable
+    {
+        private int _disposed;
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                tracker.EndRead(path);
+        }
+    }
+}
+
+public readonly record struct ConcurrentReadSnapshot(
+    long OverlapEvents,
+    long DuplicateSegmentFetches,
+    long PeakConcurrentReaders,
+    long CurrentOverlappingPaths);

--- a/backend/Services/ConcurrentReadTracker.cs
+++ b/backend/Services/ConcurrentReadTracker.cs
@@ -1,117 +1,312 @@
-using System.Collections.Concurrent;
-
 namespace NzbWebDAV.Services;
 
 /// <summary>
-/// Tracks concurrent read sessions on the same content path to measure potential
-/// gains from shared streams or segment-fetch deduplication. This is instrumentation
-/// only — it does not alter streaming behavior.
+/// Measures opportunities a hypothetical shared stream could serve. It does not
+/// alter streaming behavior: every overlapping request still uses a private stream.
 /// </summary>
-public sealed class ConcurrentReadTracker
+public sealed class ConcurrentReadTracker(TimeProvider? timeProvider = null)
 {
-    private readonly ConcurrentDictionary<string, PathState> _paths = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly Dictionary<string, PathState> _paths = new(StringComparer.Ordinal);
+    private readonly AsyncLocal<ReadContext?> _currentRead = new();
+    private long _nextReaderId;
+    private long _readerStarts;
     private long _overlapEvents;
-    private long _duplicateSegmentFetches;
+    private long _privateFallbacksNoRegistry;
+    private long _duplicateInFlightSegmentFetches;
     private long _peakConcurrentReaders;
+    private long _completedReads;
+    private long _totalReadLifetimeMs;
+    private long _maxReadLifetimeMs;
+    private long _startDistanceSamples;
+    private long _totalStartDistanceBytes;
+    private long _maxStartDistanceBytes;
+    private readonly long[] _regionStarts = new long[Enum.GetValues<ConcurrentReadRegion>().Length];
 
-    /// <summary>Number of times a new reader joined a path that already had active readers.</summary>
-    public long OverlapEvents => Interlocked.Read(ref _overlapEvents);
+    public ReadScope BeginRead(
+        string path,
+        long? startOffset,
+        ConcurrentReadRegion region)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (startOffset < 0)
+            throw new ArgumentOutOfRangeException(nameof(startOffset));
+        path = "/" + path.TrimStart('/');
+
+        var readerId = Interlocked.Increment(ref _nextReaderId);
+        var previous = _currentRead.Value;
+        var startedAt = _timeProvider.GetUtcNow();
+        lock (_gate)
+        {
+            if (!_paths.TryGetValue(path, out var state))
+            {
+                state = new PathState();
+                _paths.Add(path, state);
+            }
+
+            var overlaps = state.Readers.Count > 0;
+            var reader = new ReaderState(startOffset, overlaps);
+            state.Readers.Add(readerId, reader);
+            _readerStarts++;
+            _regionStarts[(int)region]++;
+
+            if (overlaps)
+            {
+                _overlapEvents++;
+                _privateFallbacksNoRegistry++;
+                RecordStartDistanceLocked(state, readerId, reader);
+            }
+
+            _peakConcurrentReaders = Math.Max(_peakConcurrentReaders, state.Readers.Count);
+        }
+
+        var context = new ReadContext(path, readerId);
+        _currentRead.Value = context;
+        return new ReadScope(this, context, previous, startedAt);
+    }
 
     /// <summary>
-    /// Segment fetches that would have been deduplicatable if a shared stream existed
-    /// (same segment ID fetched while another reader on the same path was also active).
+    /// Marks one logical segment transfer as in flight. A duplicate is counted only
+    /// when another reader for the same path is simultaneously fetching that segment.
     /// </summary>
-    public long DuplicateSegmentFetches => Interlocked.Read(ref _duplicateSegmentFetches);
-
-    /// <summary>Highest concurrent reader count observed on any single path.</summary>
-    public long PeakConcurrentReaders => Interlocked.Read(ref _peakConcurrentReaders);
-
-    /// <summary>Register a reader starting on a path. Returns a disposable scope.</summary>
-    public IDisposable BeginRead(string path)
+    public IDisposable BeginSegmentFetch(string segmentId)
     {
-        var state = _paths.GetOrAdd(path, _ => new PathState());
-        var count = Interlocked.Increment(ref state.ActiveReaders);
+        ArgumentException.ThrowIfNullOrWhiteSpace(segmentId);
+        var context = _currentRead.Value;
+        if (context is null) return NoopScope.Instance;
 
-        if (count > 1)
-            Interlocked.Increment(ref _overlapEvents);
-
-        UpdatePeak(count);
-        return new ReadScope(this, path);
-    }
-
-    /// <summary>Record a segment fetch on a path that has concurrent readers.</summary>
-    public void RecordSegmentFetch(string path, string segmentId)
-    {
-        if (!_paths.TryGetValue(path, out var state)) return;
-        if (Volatile.Read(ref state.ActiveReaders) <= 1) return;
-
-        var seenSet = state.RecentSegments;
-        if (!seenSet.TryAdd(segmentId, Environment.TickCount64))
+        lock (_gate)
         {
-            Interlocked.Increment(ref _duplicateSegmentFetches);
+            if (!_paths.TryGetValue(context.Path, out var state) ||
+                !state.Readers.ContainsKey(context.ReaderId))
+            {
+                return NoopScope.Instance;
+            }
+
+            if (!state.InFlightSegments.TryGetValue(segmentId, out var readers))
+            {
+                readers = [];
+                state.InFlightSegments.Add(segmentId, readers);
+            }
+
+            if (readers.Keys.Any(x => x != context.ReaderId))
+                _duplicateInFlightSegmentFetches++;
+
+            readers.TryGetValue(context.ReaderId, out var count);
+            readers[context.ReaderId] = count + 1;
         }
 
-        TrimOldSegments(seenSet);
+        return new SegmentFetchScope(this, context, segmentId);
     }
 
-    /// <summary>Current snapshot for diagnostics/support packs.</summary>
-    public ConcurrentReadSnapshot Snapshot() => new(
-        OverlapEvents,
-        DuplicateSegmentFetches,
-        PeakConcurrentReaders,
-        _paths.Count(kv => Volatile.Read(ref kv.Value.ActiveReaders) > 1));
-
-    private void EndRead(string path)
+    public ConcurrentReadSnapshot Snapshot()
     {
-        if (!_paths.TryGetValue(path, out var state)) return;
-        var remaining = Interlocked.Decrement(ref state.ActiveReaders);
-        if (remaining <= 0)
+        lock (_gate)
         {
-            state.RecentSegments.Clear();
-            _paths.TryRemove(path, out _);
-        }
-    }
-
-    private void UpdatePeak(long current)
-    {
-        while (true)
-        {
-            var peak = Interlocked.Read(ref _peakConcurrentReaders);
-            if (current <= peak) return;
-            if (Interlocked.CompareExchange(ref _peakConcurrentReaders, current, peak) == peak) return;
+            return new ConcurrentReadSnapshot(
+                _readerStarts,
+                _overlapEvents,
+                _privateFallbacksNoRegistry,
+                _duplicateInFlightSegmentFetches,
+                _peakConcurrentReaders,
+                _paths.Count(x => x.Value.Readers.Count > 1),
+                _paths.Sum(x => x.Value.InFlightSegments.Sum(
+                    segment => segment.Value.Values.Sum())),
+                _completedReads,
+                _totalReadLifetimeMs,
+                _maxReadLifetimeMs,
+                _startDistanceSamples,
+                _totalStartDistanceBytes,
+                _maxStartDistanceBytes,
+                _regionStarts[(int)ConcurrentReadRegion.Full],
+                _regionStarts[(int)ConcurrentReadRegion.StartRange],
+                _regionStarts[(int)ConcurrentReadRegion.OffsetRange],
+                _regionStarts[(int)ConcurrentReadRegion.SuffixRange]);
         }
     }
 
-    private static void TrimOldSegments(ConcurrentDictionary<string, long> segments)
+    private void UpdateStart(ReadContext context, long startOffset)
     {
-        if (segments.Count <= 256) return;
-        var cutoff = Environment.TickCount64 - 30_000;
-        foreach (var kv in segments)
+        ArgumentOutOfRangeException.ThrowIfNegative(startOffset);
+        lock (_gate)
         {
-            if (kv.Value < cutoff)
-                segments.TryRemove(kv);
+            if (!_paths.TryGetValue(context.Path, out var state) ||
+                !state.Readers.TryGetValue(context.ReaderId, out var reader))
+            {
+                return;
+            }
+
+            reader.StartOffset = startOffset;
+            RecordStartDistanceLocked(state, context.ReaderId, reader);
         }
     }
 
-    private sealed class PathState
+    private void RecordStartDistanceLocked(
+        PathState state,
+        long readerId,
+        ReaderState reader)
     {
-        public int ActiveReaders;
-        public readonly ConcurrentDictionary<string, long> RecentSegments = new(StringComparer.Ordinal);
+        if (!reader.JoinedOverlap ||
+            reader.DistanceRecorded ||
+            reader.StartOffset is not { } start)
+        {
+            return;
+        }
+
+        var otherStarts = state.Readers
+            .Where(x => x.Key != readerId && x.Value.StartOffset.HasValue)
+            .Select(x => x.Value.StartOffset!.Value)
+            .ToArray();
+        if (otherStarts.Length == 0) return;
+
+        var distance = otherStarts.Min(x => start >= x ? start - x : x - start);
+        reader.DistanceRecorded = true;
+        _startDistanceSamples++;
+        _totalStartDistanceBytes += distance;
+        _maxStartDistanceBytes = Math.Max(_maxStartDistanceBytes, distance);
     }
 
-    private sealed class ReadScope(ConcurrentReadTracker tracker, string path) : IDisposable
+    private void EndRead(ReadScope scope)
+    {
+        lock (_gate)
+        {
+            if (_paths.TryGetValue(scope.Context.Path, out var state))
+            {
+                state.Readers.Remove(scope.Context.ReaderId);
+                RemovePathIfIdleLocked(scope.Context.Path, state);
+            }
+
+            var elapsed = _timeProvider.GetUtcNow() - scope.StartedAt;
+            var elapsedMs = Math.Max(0, (long)elapsed.TotalMilliseconds);
+            _completedReads++;
+            _totalReadLifetimeMs += elapsedMs;
+            _maxReadLifetimeMs = Math.Max(_maxReadLifetimeMs, elapsedMs);
+        }
+    }
+
+    private void EndSegmentFetch(ReadContext context, string segmentId)
+    {
+        lock (_gate)
+        {
+            if (!_paths.TryGetValue(context.Path, out var state) ||
+                !state.InFlightSegments.TryGetValue(segmentId, out var readers) ||
+                !readers.TryGetValue(context.ReaderId, out var count))
+            {
+                return;
+            }
+
+            if (count == 1)
+                readers.Remove(context.ReaderId);
+            else
+                readers[context.ReaderId] = count - 1;
+            if (readers.Count == 0)
+                state.InFlightSegments.Remove(segmentId);
+            RemovePathIfIdleLocked(context.Path, state);
+        }
+    }
+
+    private void RemovePathIfIdleLocked(string path, PathState state)
+    {
+        if (state.Readers.Count == 0 && state.InFlightSegments.Count == 0)
+            _paths.Remove(path);
+    }
+
+    public sealed class ReadScope : IDisposable
+    {
+        private readonly ConcurrentReadTracker _tracker;
+        private readonly ReadContext? _previous;
+        private int _disposed;
+
+        internal ReadScope(
+            ConcurrentReadTracker tracker,
+            ReadContext context,
+            ReadContext? previous,
+            DateTimeOffset startedAt)
+        {
+            _tracker = tracker;
+            Context = context;
+            _previous = previous;
+            StartedAt = startedAt;
+        }
+
+        internal ReadContext Context { get; }
+        internal DateTimeOffset StartedAt { get; }
+
+        public void UpdateStart(long startOffset)
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+            _tracker.UpdateStart(Context, startOffset);
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            _tracker._currentRead.Value = _previous;
+            _tracker.EndRead(this);
+        }
+    }
+
+    private sealed class SegmentFetchScope(
+        ConcurrentReadTracker tracker,
+        ReadContext context,
+        string segmentId) : IDisposable
     {
         private int _disposed;
+
         public void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) == 0)
-                tracker.EndRead(path);
+                tracker.EndSegmentFetch(context, segmentId);
         }
+    }
+
+    private sealed class NoopScope : IDisposable
+    {
+        public static NoopScope Instance { get; } = new();
+        public void Dispose() { }
+    }
+
+    internal sealed record ReadContext(string Path, long ReaderId);
+
+    private sealed class PathState
+    {
+        public Dictionary<long, ReaderState> Readers { get; } = [];
+        public Dictionary<string, Dictionary<long, int>> InFlightSegments { get; } =
+            new(StringComparer.Ordinal);
+    }
+
+    private sealed class ReaderState(long? startOffset, bool joinedOverlap)
+    {
+        public long? StartOffset { get; set; } = startOffset;
+        public bool JoinedOverlap { get; } = joinedOverlap;
+        public bool DistanceRecorded { get; set; }
     }
 }
 
+public enum ConcurrentReadRegion
+{
+    Full,
+    StartRange,
+    OffsetRange,
+    SuffixRange,
+}
+
 public readonly record struct ConcurrentReadSnapshot(
+    long ReaderStarts,
     long OverlapEvents,
-    long DuplicateSegmentFetches,
+    long PrivateFallbacksNoRegistry,
+    long DuplicateInFlightSegmentFetches,
     long PeakConcurrentReaders,
-    long CurrentOverlappingPaths);
+    long CurrentOverlappingPaths,
+    long CurrentInFlightSegmentFetches,
+    long CompletedReads,
+    long TotalReadLifetimeMs,
+    long MaxReadLifetimeMs,
+    long StartDistanceSamples,
+    long TotalStartDistanceBytes,
+    long MaxStartDistanceBytes,
+    long FullReads,
+    long StartRangeReads,
+    long OffsetRangeReads,
+    long SuffixRangeReads);

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -29,7 +29,8 @@ public sealed class SupportPackService(
     ArticleMissNegativeCache articleMissCache,
     InFlightArticleBudget inFlightArticleBudget,
     StreamTraceBuffer streamTraceBuffer,
-    RuntimeUsageTracker runtimeUsage)
+    RuntimeUsageTracker runtimeUsage,
+    ConcurrentReadTracker? concurrentReadTracker = null)
 {
     private const long MinuteMs = 60_000;
     private const long HourMs = 60 * MinuteMs;
@@ -256,6 +257,7 @@ public sealed class SupportPackService(
         var uptime = ProcessUptime();
         var streamTracing = streamTraceBuffer.GetStatus();
         var usage = runtimeUsage.Snapshot();
+        var concurrentReads = concurrentReadTracker?.Snapshot() ?? default;
         var cpu = await BuildCpuDiagnosticsAsync(usage, uptime, cancellationToken).ConfigureAwait(false);
 
         return new
@@ -277,6 +279,25 @@ public sealed class SupportPackService(
                 inFlightArticleBytes = inFlightArticleBudget.LeasedBytes,
                 inFlightArticleBudgetBytes = inFlightArticleBudget.CapBytes,
                 inFlightArticleThrottleEvents = inFlightArticleBudget.ThrottleEvents,
+                concurrentReadStarts = concurrentReads.ReaderStarts,
+                concurrentReadOverlapEvents = concurrentReads.OverlapEvents,
+                concurrentReadPrivateFallbacksNoRegistry = concurrentReads.PrivateFallbacksNoRegistry,
+                concurrentReadDuplicateInFlightSegmentFetches =
+                    concurrentReads.DuplicateInFlightSegmentFetches,
+                concurrentReadPeakReadersPerPath = concurrentReads.PeakConcurrentReaders,
+                concurrentReadCurrentOverlappingPaths = concurrentReads.CurrentOverlappingPaths,
+                concurrentReadCurrentInFlightSegmentFetches =
+                    concurrentReads.CurrentInFlightSegmentFetches,
+                concurrentReadCompleted = concurrentReads.CompletedReads,
+                concurrentReadTotalLifetimeMs = concurrentReads.TotalReadLifetimeMs,
+                concurrentReadMaxLifetimeMs = concurrentReads.MaxReadLifetimeMs,
+                concurrentReadStartDistanceSamples = concurrentReads.StartDistanceSamples,
+                concurrentReadTotalStartDistanceBytes = concurrentReads.TotalStartDistanceBytes,
+                concurrentReadMaxStartDistanceBytes = concurrentReads.MaxStartDistanceBytes,
+                concurrentReadFullStarts = concurrentReads.FullReads,
+                concurrentReadStartRangeStarts = concurrentReads.StartRangeReads,
+                concurrentReadOffsetRangeStarts = concurrentReads.OffsetRangeReads,
+                concurrentReadSuffixRangeStarts = concurrentReads.SuffixRangeReads,
                 timeZone = TimeZoneInfo.Local.Id,
             },
             runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -34,6 +34,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
     private readonly ConfigManager _configManager;
     private readonly ProviderUsageTracker _providerUsageTracker;
     private readonly ActiveReadRegistry _activeReadRegistry;
+    private readonly ConcurrentReadTracker _concurrentReadTracker;
     private readonly StreamTraceBuffer _streamTrace;
     private readonly StreamingFailureTracker _failureTracker;
 
@@ -42,6 +43,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         ConfigManager configManager,
         ProviderUsageTracker providerUsageTracker,
         ActiveReadRegistry activeReadRegistry,
+        ConcurrentReadTracker concurrentReadTracker,
         StreamTraceBuffer streamTrace,
         StreamingFailureTracker failureTracker)
     {
@@ -49,6 +51,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         _configManager = configManager;
         _providerUsageTracker = providerUsageTracker;
         _activeReadRegistry = activeReadRegistry;
+        _concurrentReadTracker = concurrentReadTracker;
         _streamTrace = streamTrace;
         _failureTracker = failureTracker;
     }
@@ -129,6 +132,14 @@ public class GetAndHeadHandlerPatch : IRequestHandler
             response.SetStatus(DavStatusCode.NotFound);
             return true;
         }
+
+        var path = request.GetUri().AbsolutePath;
+        using var concurrentReadScope = isHeadRequest
+            ? null
+            : _concurrentReadTracker.BeginRead(
+                path,
+                range?.Start ?? (range is null ? 0 : null),
+                ResolveReadRegion(range));
 
         // ETag might be used for a conditional request
         string? etag = null;
@@ -234,13 +245,14 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                 // HEAD method doesn't require the actual item data
                 if (!isHeadRequest)
                 {
+                    concurrentReadScope!.UpdateStart(copyStart);
+
                     // Cap segment prefetch at the range end (open-ended ranges leave budget null).
                     if (copyEnd.HasValue)
                         RangeContext.SetReadBudget(copyEnd.Value - copyStart + 1);
                     else
                         RangeContext.SetReadBudget(null);
 
-                    var path = request.GetUri().AbsolutePath;
                     var userAgent = request.Headers.UserAgent.ToString();
                     var clientIp = httpContext.Connection.RemoteIpAddress?.ToString();
                     var clientKey = $"{clientIp}|{userAgent}";
@@ -297,6 +309,15 @@ public class GetAndHeadHandlerPatch : IRequestHandler
             }
         }
         return true;
+    }
+
+    private static ConcurrentReadRegion ResolveReadRegion(NWebDav.Server.Helpers.Range? range)
+    {
+        if (range is null) return ConcurrentReadRegion.Full;
+        if (!range.Start.HasValue) return ConcurrentReadRegion.SuffixRange;
+        return range.Start.Value == 0
+            ? ConcurrentReadRegion.StartRange
+            : ConcurrentReadRegion.OffsetRange;
     }
 
     internal static bool ClearStreamingFailureAfterCompletedRead(

--- a/tests/NzbWebDAV.Tests/Services/ConcurrentReadTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ConcurrentReadTrackerTests.cs
@@ -1,0 +1,99 @@
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class ConcurrentReadTrackerTests
+{
+    [Fact]
+    public void SingleReader_NoOverlapDetected()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using (tracker.BeginRead("/content/movie.mkv")) { }
+
+        Assert.Equal(0, tracker.OverlapEvents);
+        Assert.Equal(1, tracker.PeakConcurrentReaders);
+    }
+
+    [Fact]
+    public void TwoConcurrentReaders_RecordsOverlap()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader1 = tracker.BeginRead("/content/movie.mkv");
+        using var reader2 = tracker.BeginRead("/content/movie.mkv");
+
+        Assert.Equal(1, tracker.OverlapEvents);
+        Assert.Equal(2, tracker.PeakConcurrentReaders);
+    }
+
+    [Fact]
+    public void DifferentPaths_NoOverlap()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader1 = tracker.BeginRead("/content/movie1.mkv");
+        using var reader2 = tracker.BeginRead("/content/movie2.mkv");
+
+        Assert.Equal(0, tracker.OverlapEvents);
+    }
+
+    [Fact]
+    public void DuplicateSegmentFetch_DetectedWhenConcurrent()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader1 = tracker.BeginRead("/content/movie.mkv");
+        using var reader2 = tracker.BeginRead("/content/movie.mkv");
+
+        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
+        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
+
+        Assert.Equal(1, tracker.DuplicateSegmentFetches);
+    }
+
+    [Fact]
+    public void DuplicateSegmentFetch_NotDetectedWithSingleReader()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader1 = tracker.BeginRead("/content/movie.mkv");
+
+        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
+        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
+
+        Assert.Equal(0, tracker.DuplicateSegmentFetches);
+    }
+
+    [Fact]
+    public void EndRead_CleansUpState()
+    {
+        var tracker = new ConcurrentReadTracker();
+        var reader = tracker.BeginRead("/content/movie.mkv");
+        reader.Dispose();
+
+        var snapshot = tracker.Snapshot();
+        Assert.Equal(0, snapshot.CurrentOverlappingPaths);
+    }
+
+    [Fact]
+    public void Snapshot_ReflectsLiveState()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader1 = tracker.BeginRead("/content/a.mkv");
+        using var reader2 = tracker.BeginRead("/content/a.mkv");
+        using var reader3 = tracker.BeginRead("/content/b.mkv");
+
+        var snapshot = tracker.Snapshot();
+        Assert.Equal(1, snapshot.OverlapEvents);
+        Assert.Equal(2, snapshot.PeakConcurrentReaders);
+        Assert.Equal(1, snapshot.CurrentOverlappingPaths);
+    }
+
+    [Fact]
+    public void ThreeConcurrentReaders_TracksIncreasingPeak()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var r1 = tracker.BeginRead("/content/movie.mkv");
+        using var r2 = tracker.BeginRead("/content/movie.mkv");
+        using var r3 = tracker.BeginRead("/content/movie.mkv");
+
+        Assert.Equal(3, tracker.PeakConcurrentReaders);
+        Assert.Equal(2, tracker.OverlapEvents);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/ConcurrentReadTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ConcurrentReadTrackerTests.cs
@@ -1,99 +1,195 @@
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Services;
+using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Services;
 
 public class ConcurrentReadTrackerTests
 {
     [Fact]
-    public void SingleReader_NoOverlapDetected()
+    public void OverlappingRanges_RecordPrivateFallbackAndStartDistance()
     {
         var tracker = new ConcurrentReadTracker();
-        using (tracker.BeginRead("/content/movie.mkv")) { }
-
-        Assert.Equal(0, tracker.OverlapEvents);
-        Assert.Equal(1, tracker.PeakConcurrentReaders);
-    }
-
-    [Fact]
-    public void TwoConcurrentReaders_RecordsOverlap()
-    {
-        var tracker = new ConcurrentReadTracker();
-        using var reader1 = tracker.BeginRead("/content/movie.mkv");
-        using var reader2 = tracker.BeginRead("/content/movie.mkv");
-
-        Assert.Equal(1, tracker.OverlapEvents);
-        Assert.Equal(2, tracker.PeakConcurrentReaders);
-    }
-
-    [Fact]
-    public void DifferentPaths_NoOverlap()
-    {
-        var tracker = new ConcurrentReadTracker();
-        using var reader1 = tracker.BeginRead("/content/movie1.mkv");
-        using var reader2 = tracker.BeginRead("/content/movie2.mkv");
-
-        Assert.Equal(0, tracker.OverlapEvents);
-    }
-
-    [Fact]
-    public void DuplicateSegmentFetch_DetectedWhenConcurrent()
-    {
-        var tracker = new ConcurrentReadTracker();
-        using var reader1 = tracker.BeginRead("/content/movie.mkv");
-        using var reader2 = tracker.BeginRead("/content/movie.mkv");
-
-        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
-        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
-
-        Assert.Equal(1, tracker.DuplicateSegmentFetches);
-    }
-
-    [Fact]
-    public void DuplicateSegmentFetch_NotDetectedWithSingleReader()
-    {
-        var tracker = new ConcurrentReadTracker();
-        using var reader1 = tracker.BeginRead("/content/movie.mkv");
-
-        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
-        tracker.RecordSegmentFetch("/content/movie.mkv", "seg-42");
-
-        Assert.Equal(0, tracker.DuplicateSegmentFetches);
-    }
-
-    [Fact]
-    public void EndRead_CleansUpState()
-    {
-        var tracker = new ConcurrentReadTracker();
-        var reader = tracker.BeginRead("/content/movie.mkv");
-        reader.Dispose();
+        using var first = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.StartRange);
+        using var second = tracker.BeginRead(
+            "/content/movie.mkv", 5_000_000_000, ConcurrentReadRegion.OffsetRange);
 
         var snapshot = tracker.Snapshot();
+
+        Assert.Equal(2, snapshot.ReaderStarts);
+        Assert.Equal(1, snapshot.OverlapEvents);
+        Assert.Equal(1, snapshot.PrivateFallbacksNoRegistry);
+        Assert.Equal(2, snapshot.PeakConcurrentReaders);
+        Assert.Equal(1, snapshot.CurrentOverlappingPaths);
+        Assert.Equal(1, snapshot.StartDistanceSamples);
+        Assert.Equal(5_000_000_000, snapshot.TotalStartDistanceBytes);
+        Assert.Equal(5_000_000_000, snapshot.MaxStartDistanceBytes);
+    }
+
+    [Fact]
+    public void SuffixRange_UpdateStartRecordsResolvedDistance()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var first = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.StartRange);
+        using var suffix = tracker.BeginRead(
+            "/content/movie.mkv", null, ConcurrentReadRegion.SuffixRange);
+        Assert.Equal(0, tracker.Snapshot().StartDistanceSamples);
+
+        suffix.UpdateStart(10_000_000_000);
+
+        var snapshot = tracker.Snapshot();
+        Assert.Equal(1, snapshot.StartDistanceSamples);
+        Assert.Equal(10_000_000_000, snapshot.MaxStartDistanceBytes);
+    }
+
+    [Fact]
+    public void DifferentPaths_DoNotOverlap()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var first = tracker.BeginRead("/content/a.mkv", 0, ConcurrentReadRegion.Full);
+        using var second = tracker.BeginRead("/content/b.mkv", 0, ConcurrentReadRegion.Full);
+
+        Assert.Equal(0, tracker.Snapshot().OverlapEvents);
+    }
+
+    [Fact]
+    public void SimultaneousSameSegmentFetchesByDifferentReaders_CountAsDuplicate()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var firstReader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        using var firstFetch = tracker.BeginSegmentFetch("segment-42");
+        using var secondReader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        using var secondFetch = tracker.BeginSegmentFetch("segment-42");
+
+        Assert.Equal(1, tracker.Snapshot().DuplicateInFlightSegmentFetches);
+    }
+
+    [Fact]
+    public void SequentialOrSameReaderFetches_DoNotCountAsDuplicates()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+
+        using (tracker.BeginSegmentFetch("segment-42")) { }
+        using (tracker.BeginSegmentFetch("segment-42")) { }
+        using var firstConcurrent = tracker.BeginSegmentFetch("segment-43");
+        using var secondConcurrent = tracker.BeginSegmentFetch("segment-43");
+
+        Assert.Equal(0, tracker.Snapshot().DuplicateInFlightSegmentFetches);
+    }
+
+    [Fact]
+    public void FetchOutsideReadContext_IsIgnored()
+    {
+        var tracker = new ConcurrentReadTracker();
+
+        using var fetch = tracker.BeginSegmentFetch("segment-42");
+
+        Assert.Equal(default, tracker.Snapshot());
+    }
+
+    [Fact]
+    public async Task MultiProviderSetupFailure_ClosesTrackedFetchScope()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using var reader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        var segmentId = (SegmentId)"segment-42";
+        string segmentKey = segmentId;
+        using var existingFetch = tracker.BeginSegmentFetch(segmentKey);
+        using var secondReader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        using var client = new MultiProviderNntpClient(
+            [],
+            concurrentReadTracker: tracker);
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.DecodedBodyAsync(
+            segmentId,
+            onConnectionReadyAgain: null,
+            CancellationToken.None));
+
+        var snapshot = tracker.Snapshot();
+        Assert.Equal(1, snapshot.DuplicateInFlightSegmentFetches);
+        Assert.Equal(1, snapshot.CurrentInFlightSegmentFetches);
+    }
+
+    [Fact]
+    public async Task MultiProviderBatchSetupFailure_ClosesEveryTrackedFetchScope()
+    {
+        var tracker = new ConcurrentReadTracker();
+        var firstId = (SegmentId)"segment-1";
+        var secondId = (SegmentId)"segment-2";
+        string firstKey = firstId;
+        string secondKey = secondId;
+        using var firstReader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        using var firstFetch = tracker.BeginSegmentFetch(firstKey);
+        using var secondFetch = tracker.BeginSegmentFetch(secondKey);
+        using var secondReader = tracker.BeginRead(
+            "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        using var client = new MultiProviderNntpClient(
+            [],
+            concurrentReadTracker: tracker);
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.DecodedBodiesAsync(
+            [firstId, secondId],
+            onConnectionReadyAgain: null,
+            CancellationToken.None));
+
+        var snapshot = tracker.Snapshot();
+        Assert.Equal(2, snapshot.DuplicateInFlightSegmentFetches);
+        Assert.Equal(2, snapshot.CurrentInFlightSegmentFetches);
+    }
+
+    [Fact]
+    public void Snapshot_TracksRegionsAndCompletedLifetime()
+    {
+        var clock = new ManualTimeProvider();
+        var tracker = new ConcurrentReadTracker(clock);
+        var full = tracker.BeginRead("/full", 0, ConcurrentReadRegion.Full);
+        clock.Advance(TimeSpan.FromSeconds(2));
+        full.Dispose();
+        using var start = tracker.BeginRead("/start", 0, ConcurrentReadRegion.StartRange);
+        using var offset = tracker.BeginRead("/offset", 100, ConcurrentReadRegion.OffsetRange);
+        using var suffix = tracker.BeginRead("/suffix", null, ConcurrentReadRegion.SuffixRange);
+
+        var snapshot = tracker.Snapshot();
+
+        Assert.Equal(1, snapshot.CompletedReads);
+        Assert.Equal(2_000, snapshot.TotalReadLifetimeMs);
+        Assert.Equal(2_000, snapshot.MaxReadLifetimeMs);
+        Assert.Equal(1, snapshot.FullReads);
+        Assert.Equal(1, snapshot.StartRangeReads);
+        Assert.Equal(1, snapshot.OffsetRangeReads);
+        Assert.Equal(1, snapshot.SuffixRangeReads);
+    }
+
+    [Fact]
+    public void ParallelBeginAndEnd_LeavesNoLivePaths()
+    {
+        var tracker = new ConcurrentReadTracker();
+
+        Parallel.For(0, 1_000, _ =>
+        {
+            using var read = tracker.BeginRead(
+                "/content/movie.mkv", 0, ConcurrentReadRegion.Full);
+        });
+
+        var snapshot = tracker.Snapshot();
+        Assert.Equal(1_000, snapshot.ReaderStarts);
+        Assert.Equal(1_000, snapshot.CompletedReads);
         Assert.Equal(0, snapshot.CurrentOverlappingPaths);
     }
 
-    [Fact]
-    public void Snapshot_ReflectsLiveState()
+    private sealed class ManualTimeProvider : TimeProvider
     {
-        var tracker = new ConcurrentReadTracker();
-        using var reader1 = tracker.BeginRead("/content/a.mkv");
-        using var reader2 = tracker.BeginRead("/content/a.mkv");
-        using var reader3 = tracker.BeginRead("/content/b.mkv");
-
-        var snapshot = tracker.Snapshot();
-        Assert.Equal(1, snapshot.OverlapEvents);
-        Assert.Equal(2, snapshot.PeakConcurrentReaders);
-        Assert.Equal(1, snapshot.CurrentOverlappingPaths);
-    }
-
-    [Fact]
-    public void ThreeConcurrentReaders_TracksIncreasingPeak()
-    {
-        var tracker = new ConcurrentReadTracker();
-        using var r1 = tracker.BeginRead("/content/movie.mkv");
-        using var r2 = tracker.BeginRead("/content/movie.mkv");
-        using var r3 = tracker.BeginRead("/content/movie.mkv");
-
-        Assert.Equal(3, tracker.PeakConcurrentReaders);
-        Assert.Equal(2, tracker.OverlapEvents);
+        private DateTimeOffset _now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan duration) => _now += duration;
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -144,6 +144,35 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_ReportsConcurrentReadAuditCounters()
+    {
+        var tracker = new ConcurrentReadTracker();
+        using (var first = tracker.BeginRead("/movie.mkv", 0, ConcurrentReadRegion.StartRange))
+        using (var firstFetch = tracker.BeginSegmentFetch("segment-1"))
+        using (var second = tracker.BeginRead("/movie.mkv", 1_000_000, ConcurrentReadRegion.OffsetRange))
+        using (var secondFetch = tracker.BeginSegmentFetch("segment-1"))
+        {
+            Assert.Equal(1, tracker.Snapshot().DuplicateInFlightSegmentFetches);
+        }
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            concurrentReadTracker: tracker);
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var runtime = environment.RootElement.GetProperty("runtime");
+        Assert.Equal(2, runtime.GetProperty("concurrentReadStarts").GetInt64());
+        Assert.Equal(1, runtime.GetProperty("concurrentReadOverlapEvents").GetInt64());
+        Assert.Equal(
+            1,
+            runtime.GetProperty("concurrentReadDuplicateInFlightSegmentFetches").GetInt64());
+        Assert.Equal(
+            1_000_000,
+            runtime.GetProperty("concurrentReadMaxStartDistanceBytes").GetInt64());
+    }
+
+    [Fact]
     public async Task Pack_ReportsPeakCpuAttributedToPlaybackRatherThanOnlyAnIdleSnapshot()
     {
         // Packs are collected after the symptom has passed, so an instantaneous sample
@@ -354,14 +383,21 @@ public sealed class SupportPackContentsTests : IDisposable
     private static Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,
         WarningLogBuffer warningBuffer,
-        RuntimeUsageTracker? runtimeUsage = null) =>
-        ReadPackEntriesAsync(logBuffer, warningBuffer, new StreamTraceBuffer(100, enabled: false), runtimeUsage);
+        RuntimeUsageTracker? runtimeUsage = null,
+        ConcurrentReadTracker? concurrentReadTracker = null) =>
+        ReadPackEntriesAsync(
+            logBuffer,
+            warningBuffer,
+            new StreamTraceBuffer(100, enabled: false),
+            runtimeUsage,
+            concurrentReadTracker);
 
     private static async Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,
         WarningLogBuffer warningBuffer,
         StreamTraceBuffer streamTraceBuffer,
-        RuntimeUsageTracker? runtimeUsage = null)
+        RuntimeUsageTracker? runtimeUsage = null,
+        ConcurrentReadTracker? concurrentReadTracker = null)
     {
         var configManager = new ConfigManager();
         var websocketManager = new WebsocketManager();
@@ -385,7 +421,8 @@ public sealed class SupportPackContentsTests : IDisposable
             new ArticleMissNegativeCache(configManager),
             new InFlightArticleBudget(64 * 1024 * 1024),
             streamTraceBuffer,
-            runtimeUsage ?? new RuntimeUsageTracker());
+            runtimeUsage ?? new RuntimeUsageTracker(),
+            concurrentReadTracker);
 
         using var memory = new MemoryStream();
         await service.WriteAsync(memory, CancellationToken.None);


### PR DESCRIPTION
## Summary

- Confirms NzbDAV currently has no shared-stream registry: overlapping reads always create private stream pipelines, so the sibling fork's single-anchor attachment limitation does not map directly to this architecture
- Wires a singleton `ConcurrentReadTracker` into both WebDAV read entry points and the single/batch NNTP BODY lifecycle
- Measures reader region, start-offset distance, overlap count, private fallbacks, reader lifetime, peak readers per path, and only truly simultaneous same-segment fetches by different readers
- Publishes the cumulative audit counters in `environment.json` support packs
- Keeps streaming behavior unchanged; this PR measures whether a future shared-stream or in-flight-fetch deduplication feature is justified

## Audit decision

Do not introduce a `SharedStreamRegistry` without production evidence. NzbDAV has no existing shared entry that can be pinned to the wrong region, and adding one would introduce cancellation, lifecycle, memory-bound, and connection-ordering risk. Support packs now provide the evidence needed to scope a follow-up if multi-user installations show meaningful overlap and duplicate in-flight BODY fetches.

## Corrections from review

- Replaced the unwired prototype with production wiring
- Replaced the 30-second "recent segment" heuristic with exact in-flight scopes keyed by path, reader, and segment ID
- Serialized path lifecycle updates to eliminate begin/end removal races
- Kept BODY scopes alive through the existing completion callbacks, including setup failures and batch completion
- Added resolved suffix offsets, region counters, distance metrics, reader lifetime, and support-pack coverage

## Test plan

- [x] Same-path overlap, private fallback, and multi-gigabyte start-distance accounting
- [x] Full/start/offset/suffix region classification and resolved suffix offsets
- [x] Simultaneous cross-reader duplicate fetch detection
- [x] No false positives for sequential or same-reader fetches
- [x] Single and batch NNTP setup failures close every instrumentation scope
- [x] Parallel reader begin/end leaves no live state
- [x] Support pack exports audit counters
- [x] Full backend suite: 1456 passed, 14 platform skips

Closes #769