### PR TITLE
feat(ui): let hosted providers set a support link for disabled features

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -42,22 +42,27 @@ Advanced reference for **process / container** wiring and **legacy Settings fall
 Hosted NzbDAV services can identify the service provider and mark selected
 navigation destinations as unavailable. Disabled destinations remain visible in
 the sidebar; selecting one explains that the feature is disabled by the provider
-and links to the provider's website. The provider attribution also
-appears in the page footer.
+and links to the provider's support page (or website). The provider attribution
+also appears in the page footer.
 
 Set `SERVICE_PROVIDER` to a JSON object on the frontend process:
 
 ```yaml
 environment:
   SERVICE_PROVIDER: >-
-    {"name":"ElfHosted","url":"https://elfhosted.com","disabledFeatures":["watchtower","search","settings.indexers","settings.profiles","settings.watchtower","settings.warden","settings.rclone"]}
+    {"name":"ElfHosted","url":"https://elfhosted.com","supportUrl":"https://docs.elfhosted.com","disabledFeatures":["watchtower","search","settings.indexers","settings.profiles","settings.watchtower","settings.warden","settings.rclone"]}
 ```
 
 The object requires:
 
 - `name`: service provider name shown in the dialog and footer
-- `url`: provider website using `http` or `https`
+- `url`: provider website using `http` or `https` (used in the footer link)
 - `disabledFeatures`: navigation identifiers to make unavailable
+
+Optional:
+
+- `supportUrl`: support page using `http` or `https`, used for the "Contact"
+  link in the disabled-feature dialog; falls back to `url` when omitted
 
 Top-level navigation identifiers are `overview`, `queue`, `watchdog`,
 `watchtower`, `explore`, `health`, `logs`, and `search`. `overview` cannot be

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,4 +7,4 @@ BACKEND_URL=http://localhost:5000
 FRONTEND_BACKEND_API_KEY=
 
 # Optional hosted-service branding and UI feature gating (JSON).
-# SERVICE_PROVIDER='{"name":"ElfHosted","url":"https://elfhosted.com","disabledFeatures":["watchtower","search","settings.indexers","settings.profiles","settings.watchtower","settings.warden","settings.rclone"]}'
+# SERVICE_PROVIDER='{"name":"ElfHosted","url":"https://elfhosted.com","supportUrl":"https://docs.elfhosted.com","disabledFeatures":["watchtower","search","settings.indexers","settings.profiles","settings.watchtower","settings.warden","settings.rclone"]}'

--- a/frontend/app/components/service-provider-notice.tsx
+++ b/frontend/app/components/service-provider-notice.tsx
@@ -31,7 +31,7 @@ export function ServiceProviderNotice({
           <strong className="font-semibold text-base-content">{serviceProvider.name}</strong>.
         </p>
         <a
-          href={serviceProvider.url}
+          href={serviceProvider.supportUrl ?? serviceProvider.url}
           target="_blank"
           rel="noreferrer"
           className="link link-primary inline-flex items-center gap-1"

--- a/frontend/app/routes/_index/components/page-layout/page-layout.tsx
+++ b/frontend/app/routes/_index/components/page-layout/page-layout.tsx
@@ -66,7 +66,7 @@ export function PageLayout(props: PageLayoutProps) {
                                             >
                                                 NzbDAV
                                             </a>{" "}
-                                            is provided by{" "}
+                                            is powered by{" "}
                                             <a
                                                 href={props.serviceProvider.url}
                                                 target="_blank"

--- a/frontend/app/utils/service-provider.server.test.ts
+++ b/frontend/app/utils/service-provider.server.test.ts
@@ -53,6 +53,38 @@ describe("getServiceProvider", () => {
     expect(warnMock).not.toHaveBeenCalled();
   });
 
+  it("parses an optional supportUrl when provided", () => {
+    process.env.SERVICE_PROVIDER = JSON.stringify({
+      name: "ElfHosted",
+      url: "https://elfhosted.com",
+      supportUrl: "https://support.elfhosted.com/help",
+      disabledFeatures: [],
+    });
+
+    expect(getServiceProvider()).toEqual({
+      name: "ElfHosted",
+      url: "https://elfhosted.com/",
+      supportUrl: "https://support.elfhosted.com/help",
+      disabledFeatures: [],
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("omits supportUrl when it is not provided", () => {
+    process.env.SERVICE_PROVIDER = JSON.stringify({
+      name: "ElfHosted",
+      url: "https://elfhosted.com",
+      disabledFeatures: [],
+    });
+
+    expect(getServiceProvider()).toEqual({
+      name: "ElfHosted",
+      url: "https://elfhosted.com/",
+      disabledFeatures: [],
+    });
+    expect(getServiceProvider()).not.toHaveProperty("supportUrl");
+  });
+
   it("ignores unknown feature identifiers without discarding the provider", () => {
     process.env.SERVICE_PROVIDER = JSON.stringify({
       name: "Example Hosting",
@@ -83,6 +115,7 @@ describe("getServiceProvider", () => {
     ["malformed JSON", "{"],
     ["missing name", JSON.stringify({ url: "https://example.com", disabledFeatures: [] })],
     ["unsafe URL", JSON.stringify({ name: "Example", url: "javascript:alert(1)", disabledFeatures: [] })],
+    ["unsafe supportUrl", JSON.stringify({ name: "Example", url: "https://example.com", supportUrl: "javascript:alert(1)", disabledFeatures: [] })],
     ["invalid feature list", JSON.stringify({ name: "Example", url: "https://example.com", disabledFeatures: "search" })],
   ])("ignores %s", (_description, rawValue) => {
     process.env.SERVICE_PROVIDER = rawValue;

--- a/frontend/app/utils/service-provider.server.ts
+++ b/frontend/app/utils/service-provider.server.ts
@@ -15,14 +15,14 @@ type ParsedServiceProvider = {
 let cachedRawValue: string | undefined;
 let cachedConfig: ServiceProviderConfig | null = null;
 
-function parseUrl(value: unknown): string {
+function parseUrl(value: unknown, fieldName = "url"): string {
   if (typeof value !== "string" || !value.trim()) {
-    throw new Error('"url" must be a non-empty string');
+    throw new Error(`"${fieldName}" must be a non-empty string`);
   }
 
   const url = new URL(value.trim());
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error('"url" must use http or https');
+    throw new Error(`"${fieldName}" must use http or https`);
   }
 
   return url.toString();
@@ -62,6 +62,9 @@ function parseConfig(rawValue: string): ParsedServiceProvider {
     config: {
       name: candidate.name.trim(),
       url: parseUrl(candidate.url),
+      ...(candidate.supportUrl !== undefined
+        ? { supportUrl: parseUrl(candidate.supportUrl, "supportUrl") }
+        : {}),
       disabledFeatures,
     },
     ignoredFeatures,

--- a/frontend/app/utils/service-provider.ts
+++ b/frontend/app/utils/service-provider.ts
@@ -31,6 +31,7 @@ export type NavFeatureId = (typeof NAV_FEATURE_IDS)[number];
 export type ServiceProviderConfig = {
   name: string;
   url: string;
+  supportUrl?: string;
   disabledFeatures: NavFeatureId[];
 };
 


### PR DESCRIPTION
## Summary
- Change the optional service-provider footer from "is provided by" to "is powered by".
- Add optional `supportUrl` to the `SERVICE_PROVIDER` JSON config for the disabled-feature dialog's "Contact" link (falls back to `url`).
- Document the new property in env docs and `.env.example`.

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test -- --run app/utils/service-provider.server.test.ts app/utils/service-provider.test.ts`
- [ ] Manually set `SERVICE_PROVIDER` with and without `supportUrl`, confirm footer wording and Contact link targets