### PR TITLE
perf: background cache load, websocket coalescing, queue admission, sampled existence checks, and stream bridge cleanup

### DIFF
--- a/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
+++ b/backend/Api/Controllers/UpdateConfig/UpdateConfigController.cs
@@ -40,6 +40,7 @@ public class UpdateConfigController(DavDatabaseClient dbClient, ConfigManager co
         // background task. Run before webdav.pass hashing so validation sees the raw
         // submitted value.
         ConfigManager.ValidateConfigItems(request.ConfigItems);
+        configManager.ValidateQueueAdmissionSettings(request.ConfigItems);
 
         var configNames = request.ConfigItems.Select(x => x.ConfigName).ToHashSet();
         var existingItems = await dbClient.Ctx.ConfigItems

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -44,16 +44,51 @@ public class AddFileController(
 
     public async Task<AddFileResponse> AddFileAsync(AddFileRequest request)
     {
+        await using var sourceStream = request.NzbFileStream;
         var id = Guid.NewGuid();
         var category = StringUtil.EmptyToNull(request.Category)
                        ?? configManager.GetManualUploadCategory();
 
+        var replacesExisting = await dbClient.Ctx.QueueItems
+            .AnyAsync(
+                x => x.FileName == request.FileName && x.Category == category,
+                request.CancellationToken)
+            .ConfigureAwait(false);
+
+        IDisposable? admissionReservation = null;
+        if (!replacesExisting)
+        {
+            var maxItems = configManager.GetQueueMaxItems();
+            if (maxItems > 0)
+            {
+                var currentCount = await dbClient.Ctx.QueueItems
+                    .CountAsync(request.CancellationToken)
+                    .ConfigureAwait(false);
+                var resumeThreshold = configManager.GetQueueResumeThreshold();
+                admissionReservation = queueManager.TryReserveQueueSlot(
+                    currentCount, maxItems, resumeThreshold);
+                if (admissionReservation is null)
+                {
+                    Log.Warning(
+                        "Rejected NZB submission because the queue has {QueueCount} of {QueueLimit} items. " +
+                        "Admission resumes at or below {ResumeThreshold} items.",
+                        currentCount, maxItems, resumeThreshold);
+                    return new AddFileResponse
+                    {
+                        Status = false,
+                        Error = $"Queue is full ({currentCount} of {maxItems} items); " +
+                                $"submissions resume at or below {resumeThreshold}.",
+                    };
+                }
+            }
+        }
+
+        using var queueSlotReservation = admissionReservation;
         await ReplaceExistingQueueItemIfNeededAsync(request.FileName, category, request.CancellationToken)
             .ConfigureAwait(false);
         if (AfterDuplicatePreCheckHook is not null)
             await AfterDuplicatePreCheckHook().ConfigureAwait(false);
 
-        await using var sourceStream = request.NzbFileStream;
         QueueItem? queueItem;
         try
         {

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -23,7 +24,9 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private readonly MetricsWriter? _metricsWriter;
     private readonly ConcurrentDictionary<string, CacheEntry> _index = new();
     private readonly object _evictLock = new();
+    private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
     private long _currentBytes;
+    private int _catalogReady;
 
     private static readonly JsonSerializerOptions HeaderJsonOptions = new() { IncludeFields = true };
 
@@ -32,15 +35,32 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         string cacheDir,
         long maxBytes,
         ProviderUsageTracker? usageTracker = null,
-        MetricsWriter? metricsWriter = null) : base(inner)
+        MetricsWriter? metricsWriter = null)
+        : this(inner, cacheDir, maxBytes, usageTracker, metricsWriter, enumerateCacheFiles: null)
+    {
+    }
+
+    internal SegmentCacheNntpClient(
+        INntpClient inner,
+        string cacheDir,
+        long maxBytes,
+        ProviderUsageTracker? usageTracker,
+        MetricsWriter? metricsWriter,
+        Func<IEnumerable<string>>? enumerateCacheFiles) : base(inner)
     {
         _dir = cacheDir;
         _maxBytes = maxBytes;
         _usageTracker = usageTracker;
         _metricsWriter = metricsWriter;
         Directory.CreateDirectory(_dir);
-        LoadIndex();
+        _enumerateCacheFiles = enumerateCacheFiles
+                               ?? (() => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
+        CatalogLoadTask = Task.Run(LoadIndex);
     }
+
+    public bool IsCatalogReady => Volatile.Read(ref _catalogReady) != 0;
+    internal Task CatalogLoadTask { get; }
+    internal long CurrentBytes => Interlocked.Read(ref _currentBytes);
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId, CancellationToken ct)
     {
@@ -68,7 +88,9 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     public override async Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
         string segmentId, CancellationToken ct)
     {
-        if (MultiProviderNntpClient.AttributionContext.Value == null && _index.ContainsKey(Hash(segmentId)))
+        if (MultiProviderNntpClient.AttributionContext.Value == null
+            && IsCatalogReady
+            && _index.ContainsKey(Hash(segmentId)))
             return new UsenetExclusiveConnection(onConnectionReadyAgain: null);
         return await base.AcquireExclusiveConnectionAsync(segmentId, ct).ConfigureAwait(false);
     }
@@ -116,6 +138,8 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private bool TryServeFromCache(string id, out UsenetDecodedBodyResponse? response)
     {
         response = null;
+        if (!IsCatalogReady) return false;
+
         var hash = Hash(id);
         if (!_index.TryGetValue(hash, out var entry)) return false;
 
@@ -189,7 +213,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 
     private void EvictIfNeeded()
     {
-        if (_currentBytes <= _maxBytes) return;
+        if (Interlocked.Read(ref _currentBytes) <= _maxBytes) return;
         lock (_evictLock)
         {
             if (_currentBytes <= _maxBytes) return;
@@ -206,9 +230,10 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 
     private void LoadIndex()
     {
+        var stopwatch = Stopwatch.StartNew();
         try
         {
-            foreach (var file in Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories))
+            foreach (var file in _enumerateCacheFiles())
             {
                 if (file.EndsWith(".tmp", StringComparison.Ordinal))
                 {
@@ -219,20 +244,38 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 if (file.EndsWith(".h", StringComparison.Ordinal)) continue;
                 var info = new FileInfo(file);
                 if (!info.Exists) continue;
-                _index[Path.GetFileName(file)] = new CacheEntry
+                var entry = new CacheEntry
                 {
                     Size = info.Length,
                     LastAccessTicks = info.LastWriteTimeUtc.Ticks,
                 };
-                _currentBytes += info.Length;
+
+                lock (_evictLock)
+                {
+                    if (_index.TryAdd(Path.GetFileName(file), entry))
+                        _currentBytes += info.Length;
+                }
             }
         }
         catch (Exception e)
         {
             Log.Warning(e, "Segment cache: failed to scan {Dir}; starting empty.", _dir);
         }
-
-        EvictIfNeeded();
+        finally
+        {
+            try
+            {
+                EvictIfNeeded();
+            }
+            finally
+            {
+                Volatile.Write(ref _catalogReady, 1);
+                stopwatch.Stop();
+                Log.Information(
+                    "Segment cache catalog loaded: {Count} entries, {Size} bytes in {Elapsed}ms.",
+                    _index.Count, Interlocked.Read(ref _currentBytes), stopwatch.ElapsedMilliseconds);
+            }
+        }
     }
 
     private string BlobPath(string hash) => Path.Combine(_dir, hash[..2], hash);

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -14,6 +14,7 @@ public static class ConfigKeys
     public const string ApiCompletedDownloadsDir = "api.completed-downloads-dir";
     public const string ApiDownloadFileBlocklist = "api.download-file-blocklist";
     public const string ApiDuplicateNzbBehavior = "api.duplicate-nzb-behavior";
+    public const string ApiArticleExistenceCheckMode = "api.article-existence-check-mode";
     public const string ApiEnsureArticleExistenceCategories = "api.ensure-article-existence-categories";
     public const string ApiEnsureImportableVideo = "api.ensure-importable-video";
     public const string ApiIgnoreHistoryLimit = "api.ignore-history-limit";

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -44,6 +44,8 @@ public static class ConfigKeys
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";
     public const string UsenetMaxQueueConnections = "usenet.max-queue-connections";
     public const string UsenetMaxQueueConnectionsPreset = "usenet.max-queue-connections-preset";
+    public const string QueueMaxItems = "queue.max-items";
+    public const string QueueResumeThreshold = "queue.resume-threshold";
     public const string QueueWorkerCount = "queue.worker-count";
     public const string QueuePaused = "queue.paused";
     public const string QueueSpeedLimitKbps = "queue.speed-limit-kbps";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -274,6 +274,11 @@ public class ConfigManager
 
             switch (item.ConfigName)
             {
+                case ConfigKeys.QueueMaxItems:
+                case ConfigKeys.QueueResumeThreshold:
+                    RequireNonNegativeInt(item.ConfigName, value);
+                    break;
+
                 case ConfigKeys.UsenetMaxDownloadConnections:
                 case ConfigKeys.UsenetMaxQueueConnections:
                 case ConfigKeys.QueueWorkerCount:
@@ -405,6 +410,13 @@ public class ConfigManager
         {
             if (!long.TryParse(value, out _))
                 throw new ArgumentException($"Config value for '{key}' must be a whole number, but was '{value}'.");
+        }
+
+        static void RequireNonNegativeInt(string key, string value)
+        {
+            if (!int.TryParse(value, out var parsed) || parsed < 0)
+                throw new ArgumentException(
+                    $"Config value for '{key}' must be a non-negative whole number, but was '{value}'.");
         }
 
         static void RequireBool(string key, string value)
@@ -675,6 +687,48 @@ public class ConfigManager
         if (configured is null || !int.TryParse(configured, out var value))
             return 1;
         return Math.Clamp(value, 1, 4);
+    }
+
+    public int GetQueueMaxItems()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueueMaxItems));
+        return configured is not null && int.TryParse(configured, out var value)
+            ? Math.Max(0, value)
+            : 0;
+    }
+
+    public int GetQueueResumeThreshold()
+    {
+        var maxItems = GetQueueMaxItems();
+        if (maxItems == 0) return 0;
+
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueueResumeThreshold));
+        if (configured is null || !int.TryParse(configured, out var value) || value <= 0)
+            return maxItems;
+        return Math.Min(value, maxItems);
+    }
+
+    public void ValidateQueueAdmissionSettings(IEnumerable<ConfigItem> updates)
+    {
+        var patch = updates.ToDictionary(x => x.ConfigName, x => x.ConfigValue);
+        var maxItems = ParsePatchedValue(ConfigKeys.QueueMaxItems, GetQueueMaxItems());
+        var resumeThreshold = ParsePatchedValue(
+            ConfigKeys.QueueResumeThreshold,
+            GetQueueResumeThreshold());
+
+        if (maxItems > 0 && resumeThreshold > maxItems)
+            throw new ArgumentException(
+                $"Config value for '{ConfigKeys.QueueResumeThreshold}' must be less than or equal to " +
+                $"'{ConfigKeys.QueueMaxItems}'.");
+
+        return;
+
+        int ParsePatchedValue(string key, int fallback)
+        {
+            if (!patch.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw))
+                return fallback;
+            return int.TryParse(raw, out var parsed) ? parsed : fallback;
+        }
     }
 
     /// <summary>

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -382,6 +382,10 @@ public class ConfigManager
                     RequireOneOf(item.ConfigName, value, "standard", "enhanced", "deep", "complete");
                     break;
 
+                case ConfigKeys.ApiArticleExistenceCheckMode:
+                    RequireOneOf(item.ConfigName, value, "full", "sampled");
+                    break;
+
                 case ConfigKeys.UsenetMaxQueueConnectionsPreset:
                     RequireOneOf(item.ConfigName, value, "low", "medium", "high", "max");
                     break;
@@ -932,6 +936,12 @@ public class ConfigManager
             .Select(x => x.ToLower())
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .ToHashSet();
+    }
+
+    public string GetArticleExistenceCheckMode()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiArticleExistenceCheckMode));
+        return configured?.ToLowerInvariant() == "sampled" ? "sampled" : "full";
     }
 
     public bool IsPlaybackWatchdogEnabled()

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -72,6 +72,17 @@ public class QueueItemProcessor(
     private const int MaxProviderRetryAttempts = 20;
     private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(15);
 
+    internal static List<string> SelectArticlesForExistenceCheck(
+        IEnumerable<IReadOnlyList<string>> segmentsByFile,
+        string mode)
+    {
+        var files = segmentsByFile.ToList();
+        return mode == "sampled"
+            ? files.SelectMany(segments =>
+                HealthCheckService.SampleSegments(segments.ToList())).ToList()
+            : files.SelectMany(segments => segments).ToList();
+    }
+
     private static TimeSpan GetProviderRetryBackoff(int attempt)
     {
         var seconds = Math.Min(60d, 10d * Math.Pow(2, attempt - 1));
@@ -366,10 +377,21 @@ public class QueueItemProcessor(
         var healthCheckCategories = configManager.GetEnsureArticleExistenceCategories();
         if (healthCheckCategories.Contains(queueItem.Category.ToLower()))
         {
-            var articlesToCheck = fileInfos
+            var segmentsByFile = fileInfos
                 .Where(x => x.IsRar || FilenameUtil.IsImportantFileType(x.FileName))
-                .SelectMany(x => x.NzbFile.GetSegmentIds())
+                .Select(x => (IReadOnlyList<string>)x.NzbFile.GetSegmentIds().ToList())
                 .ToList();
+            var totalArticles = segmentsByFile.Sum(x => x.Count);
+            var checkMode = configManager.GetArticleExistenceCheckMode();
+            var articlesToCheck = SelectArticlesForExistenceCheck(segmentsByFile, checkMode);
+            if (checkMode == "sampled")
+            {
+                Log.Information(
+                    "Article existence check sampled {SampledCount}/{TotalCount} segments across {FileCount} files " +
+                    "for queue item {QueueItemId}.",
+                    articlesToCheck.Count, totalArticles, segmentsByFile.Count, queueItem.Id);
+            }
+
             var part3Progress = progress
                 .Offset(100)
                 .ToPercentage(articlesToCheck.Count);

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -22,6 +22,7 @@ public class QueueManager : IDisposable
     private readonly CancellationTokenSource? _cancellationTokenSource;
     private readonly SemaphoreSlim _stateLock = new(1, 1);
     private readonly SemaphoreSlim _finalizeLock = new(1, 1);
+    private readonly Lock _admissionLock = new();
     private readonly ConfigManager _configManager;
     private readonly WebsocketManager _websocketManager;
     private readonly ProviderUsageTracker _providerUsageTracker;
@@ -34,6 +35,8 @@ public class QueueManager : IDisposable
     private int _loopStarted;
     private Task? _coordinatorTask;
     private Guid? _primaryId;
+    private int _pendingAdmissions;
+    private bool _admissionPaused;
 
     // Overridable in tests so persistent-failure / idle-sleep behaviour can be
     // exercised without a real database.
@@ -99,6 +102,57 @@ public class QueueManager : IDisposable
 
     /// <summary>True while any NZB queue item is actively processing.</summary>
     public bool HasActiveQueueItems => !_inProgress.IsEmpty;
+
+    internal IDisposable? TryReserveQueueSlot(
+        int persistedCount,
+        int maxItems,
+        int resumeThreshold)
+    {
+        if (maxItems <= 0) return new QueueAdmissionReservation(static () => { });
+
+        lock (_admissionLock)
+        {
+            var effectiveCount = (long)Math.Max(0, persistedCount) + _pendingAdmissions;
+            var effectiveResumeThreshold = resumeThreshold <= 0
+                ? maxItems
+                : Math.Min(resumeThreshold, maxItems);
+
+            if (_admissionPaused)
+            {
+                if (effectiveCount > effectiveResumeThreshold)
+                    return null;
+                _admissionPaused = false;
+            }
+
+            if (effectiveCount >= maxItems)
+            {
+                _admissionPaused = true;
+                return null;
+            }
+
+            _pendingAdmissions++;
+            return new QueueAdmissionReservation(ReleaseQueueSlotReservation);
+        }
+    }
+
+    private void ReleaseQueueSlotReservation()
+    {
+        lock (_admissionLock)
+        {
+            if (_pendingAdmissions > 0)
+                _pendingAdmissions--;
+        }
+    }
+
+    private sealed class QueueAdmissionReservation(Action release) : IDisposable
+    {
+        private Action? _release = release;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _release, null)?.Invoke();
+        }
+    }
 
     /// <summary>
     /// Immutable snapshot of every in-flight queue item and its progress.

--- a/backend/Streams/AesDecoderStream.cs
+++ b/backend/Streams/AesDecoderStream.cs
@@ -1,10 +1,11 @@
 ﻿using System.Security.Cryptography;
 using System.Runtime.InteropServices;
 using NzbWebDAV.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams
 {
-    internal sealed class AesDecoderStream : Stream
+    internal sealed class AesDecoderStream : FastReadOnlyStream
     {
         private readonly Stream _mStream;
         private Aes _aes; // keep Aes alive for transform lifetime
@@ -86,18 +87,11 @@ namespace NzbWebDAV.Streams
         public override bool CanRead => true;
         public override bool CanSeek => true;
 
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
-        }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("AesDecoderStream supports asynchronous reads only.");
 
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken ct)
-        {
-            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
-            if (offset < 0 || count < 0 || offset + count > buffer.Length) throw new ArgumentOutOfRangeException();
-
-            return await ReadAsync(buffer.AsMemory(offset, count), ct).ConfigureAwait(false);
-        }
+        public override int Read(Span<byte> buffer) =>
+            throw new NotSupportedException("AesDecoderStream supports asynchronous reads only.");
 
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer,
             CancellationToken ct = default)

--- a/backend/Streams/CancellableStream.cs
+++ b/backend/Streams/CancellableStream.cs
@@ -32,6 +32,9 @@ public class CancellableStream(Stream innerStream, CancellationToken token) : Fa
     public override int Read(byte[] buffer, int offset, int count)
     {
         CheckDisposed();
+        // SharpCompress exposes synchronous RAR/7z header readers. Those readers run
+        // inside Task.Run in RarUtil/SevenZipUtil, and this bridge preserves the
+        // operation token until the library offers an async header-enumeration path.
         return ReadAsync(buffer, offset, count, token)
             .GetAwaiter()
             .GetResult();
@@ -40,6 +43,8 @@ public class CancellableStream(Stream innerStream, CancellationToken token) : Fa
     public override int Read(Span<byte> buffer)
     {
         CheckDisposed();
+        // Keep the construction token here too; FastReadOnlyStream's fallback uses
+        // CancellationToken.None and would make synchronous archive scans uncancellable.
         var array = ArrayPool<byte>.Shared.Rent(buffer.Length);
         try
         {

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -4,10 +4,14 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using Serilog;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
 
-public class DavMultipartFileStream : Stream
+// Nested RAR expansion still passes this stream to SharpCompress's synchronous
+// header reader. FastReadOnlyStream centralizes that compatibility fallback while
+// WebDAV GET/range handlers use the Memory<byte> async path below.
+public class DavMultipartFileStream : FastReadOnlyStream
 {
     private readonly DavMultipartFile _mpf;
     private readonly INntpClient _usenetClient;
@@ -83,15 +87,12 @@ public class DavMultipartFileStream : Stream
         _innerStream?.Flush();
     }
 
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-        return ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
-    }
-
-    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
     {
         _innerStream ??= await GetFileStreamAsync(_position, cancellationToken).ConfigureAwait(false);
-        var read = await _innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        var read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         _position += read;
         return read;
     }

--- a/backend/Streams/MultipartFileStream.cs
+++ b/backend/Streams/MultipartFileStream.cs
@@ -20,11 +20,6 @@ public class MultipartFileStream(MultipartFile multipartFile, INntpClient usenet
         set => Seek(value, SeekOrigin.Begin);
     }
 
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-        return ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
-    }
-
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
         if (buffer.Length == 0) return 0;

--- a/backend/WebDav/DatabaseStoreCategoryWatchFolder.cs
+++ b/backend/WebDav/DatabaseStoreCategoryWatchFolder.cs
@@ -62,6 +62,9 @@ public class DatabaseStoreCategoryWatchFolder(
             CancellationToken = request.CancellationToken
         };
         var response = await controller.AddFileAsync(addFileRequest).ConfigureAwait(false);
+        if (!response.Status)
+            return new StoreItemResult(DavStatusCode.InsufficientStorage);
+
         var queueItem = dbClient.Ctx.ChangeTracker
             .Entries<QueueItem>()
             .Select(x => x.Entity)

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -91,8 +91,9 @@ public class WebsocketManager
         }
 
         var bytes = SerializeMessage(topic, message);
+        var messageKey = GetMessageKey(topic, message);
         foreach (var session in sessions)
-            session.TryEnqueue(topic, bytes);
+            session.TryEnqueue(topic, messageKey, bytes);
 
         return Task.CompletedTask;
     }
@@ -250,7 +251,7 @@ public class WebsocketManager
             if (!_lastMessage.TryGetValue(topic, out lastMsg)) return;
         }
 
-        session.TryEnqueue(topic, SerializeMessage(topic, lastMsg));
+        session.TryEnqueue(topic, GetMessageKey(topic, lastMsg), SerializeMessage(topic, lastMsg));
     }
 
     private SocketSession AddSocket(WebSocket socket, bool replayState = false)
@@ -272,7 +273,10 @@ public class WebsocketManager
 
             foreach (var message in _lastMessage)
                 if (message.Key.Type == WebsocketTopic.TopicType.State)
-                    session.TryEnqueue(message.Key, SerializeMessage(message.Key, message.Value));
+                    session.TryEnqueue(
+                        message.Key,
+                        GetMessageKey(message.Key, message.Value),
+                        SerializeMessage(message.Key, message.Value));
         }
 
         return session;
@@ -401,6 +405,13 @@ public class WebsocketManager
         return new ArraySegment<byte>(Encoding.UTF8.GetBytes(topicMessage.ToJson()));
     }
 
+    private static string? GetMessageKey(WebsocketTopic topic, string message)
+    {
+        if (!topic.IsKeyed) return null;
+        var separator = message.IndexOf('|');
+        return separator > 0 ? message[..separator] : null;
+    }
+
     private sealed class TopicMessage(WebsocketTopic topic, string message)
     {
         public string Topic { get; } = topic.Name;
@@ -411,6 +422,7 @@ public class WebsocketManager
     {
         private readonly object _stateLock = new();
         private readonly Dictionary<WebsocketTopic, ArraySegment<byte>> _pendingState = new();
+        private readonly Dictionary<(WebsocketTopic Topic, string Key), ArraySegment<byte>> _pendingKeyedState = new();
         private readonly Channel<ArraySegment<byte>> _eventMessages;
         private readonly Channel<bool> _workSignal =
             Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
@@ -465,7 +477,7 @@ public class WebsocketManager
             }
         }
 
-        public bool TryEnqueue(WebsocketTopic topic, ArraySegment<byte> message)
+        public bool TryEnqueue(WebsocketTopic topic, string? messageKey, ArraySegment<byte> message)
         {
             if (Volatile.Read(ref _stopped) != 0) return false;
 
@@ -474,7 +486,10 @@ public class WebsocketManager
                 lock (_stateLock)
                 {
                     if (_stopped != 0) return false;
-                    _pendingState[topic] = message;
+                    if (topic.IsKeyed && messageKey is not null)
+                        _pendingKeyedState[(topic, messageKey)] = message;
+                    else
+                        _pendingState[topic] = message;
                 }
             }
             else if (!_eventMessages.Writer.TryWrite(message))
@@ -496,8 +511,12 @@ public class WebsocketManager
         {
             lock (_stateLock)
             {
-                var messages = _pendingState.Values.ToList();
+                var messages = new List<ArraySegment<byte>>(
+                    _pendingState.Count + _pendingKeyedState.Count);
+                messages.AddRange(_pendingState.Values);
+                messages.AddRange(_pendingKeyedState.Values);
                 _pendingState.Clear();
+                _pendingKeyedState.Clear();
                 return messages;
             }
         }

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -12,11 +12,11 @@ public class WebsocketTopic
     public static readonly WebsocketTopic RenameWindowsInvalidPathsProgress = new("rwip", TopicType.State);
     public static readonly WebsocketTopic StrmToSymlinksTaskProgress = new("st2sy", TopicType.State);
     public static readonly WebsocketTopic RecreateStrmTaskProgress = new("rstm", TopicType.State);
-    public static readonly WebsocketTopic QueueItemStatus = new("qs", TopicType.State);
-    public static readonly WebsocketTopic QueueItemProgress = new("qp", TopicType.State);
-    public static readonly WebsocketTopic QueueItemProviders = new("qpv", TopicType.State);
-    public static readonly WebsocketTopic HealthItemStatus = new("hs", TopicType.State);
-    public static readonly WebsocketTopic HealthItemProgress = new("hp", TopicType.State);
+    public static readonly WebsocketTopic QueueItemStatus = new("qs", TopicType.State, isKeyed: true);
+    public static readonly WebsocketTopic QueueItemProgress = new("qp", TopicType.State, isKeyed: true);
+    public static readonly WebsocketTopic QueueItemProviders = new("qpv", TopicType.State, isKeyed: true);
+    public static readonly WebsocketTopic HealthItemStatus = new("hs", TopicType.State, isKeyed: true);
+    public static readonly WebsocketTopic HealthItemProgress = new("hp", TopicType.State, isKeyed: true);
     public static readonly WebsocketTopic LiveStats = new("ls", TopicType.State);
     public static readonly WebsocketTopic BenchmarkProgress = new("bench", TopicType.State);
     public static readonly WebsocketTopic StreamTracing = new("strt", TopicType.State);
@@ -38,11 +38,13 @@ public class WebsocketTopic
 
     public readonly string Name;
     public readonly TopicType Type;
+    public readonly bool IsKeyed;
 
-    private WebsocketTopic(string name, TopicType type)
+    private WebsocketTopic(string name, TopicType type, bool isKeyed = false)
     {
         Name = name;
         Type = type;
+        IsKeyed = isKeyed;
         ByName[name] = this;
     }
 

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -24,6 +24,7 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Fail downloads without video | `api.ensure-importable-video` | on | Reject non-video NZBs |
 | Fail when non-video missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-video by default | |
 | Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category; may be slow |
+| Article health check mode | `api.article-existence-check-mode` | `full` | Full or per-file sampled verification |
 | Maximum queued jobs | `queue.max-items` | `0` (unlimited) | Reject new submissions at this queue depth |
 | Queue resume threshold | `queue.resume-threshold` | `0` (same as maximum) | Resume admission at or below this depth |
 | Always send full History | `api.ignore-history-limit` | on | Ignore client history limit |
@@ -50,3 +51,17 @@ not increase queue depth.
 For reference, see the
 [SABnzbd API response format](https://sabnzbd.org/wiki/advanced/api) and
 [Sonarr's SABnzbd response handling](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs).
+
+## Sampled article checks [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+Categories selected under `api.ensure-article-existence-categories` use a full
+article check by default, preserving existing behavior. Set
+`api.article-existence-check-mode` to `sampled` to check the first and last
+segments plus an evenly spaced selection of middle segments in each important
+file. Sampling is applied per file so every file's tail is covered; this catches
+common truncated or partially removed releases without a full STAT sweep.
+
+Small files (currently up to roughly 8,000 segments) are still checked in full.
+The sampled mode uses the same standard-depth selection as background health
+checks. It is a screen rather than a guarantee: urgent repair remains the
+backstop if an article disappears later or STAT succeeds while BODY fails.

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -24,9 +24,29 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Fail downloads without video | `api.ensure-importable-video` | on | Reject non-video NZBs |
 | Fail when non-video missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-video by default | |
 | Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category; may be slow |
+| Maximum queued jobs | `queue.max-items` | `0` (unlimited) | Reject new submissions at this queue depth |
+| Queue resume threshold | `queue.resume-threshold` | `0` (same as maximum) | Resume admission at or below this depth |
 | Always send full History | `api.ignore-history-limit` | on | Ignore client history limit |
 | Save backup copies of incoming NZBs | `api.nzb-backup-enabled` | off | On-disk `*.nzb` copies |
 | Backup location | `api.nzb-backup-location` | — | By category |
 | Keep NZB backups (days) | `api.nzb-backup-retention-days` | `30` | `0` = forever |
 
 [Import strategies](../guides/import-strategies.md)
+
+## Queue admission control [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+Set `queue.max-items` to prevent a large automatic *Arr search from adding an
+unbounded number of NZBs at once. At the limit, NzbDAV returns the standard
+SAB-compatible `{"status": false, "error": "..."}` response without storing the
+NZB. Sonarr and Radarr treat this as a temporarily unavailable download client
+and keep automatic-search releases pending for a later retry.
+
+`queue.resume-threshold` adds hysteresis: after the queue reaches the maximum,
+new submissions remain blocked until queue depth falls to this value. Set it to
+`0` to resume as soon as the queue falls below the maximum. Duplicate
+submissions that replace an already queued item remain allowed because they do
+not increase queue depth.
+
+For reference, see the
+[SABnzbd API response format](https://sabnzbd.org/wiki/advanced/api) and
+[Sonarr's SABnzbd response handling](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs).

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -36,6 +36,7 @@ const defaultConfig = {
     "api.ensure-importable-video": "true",
     "api.skip-non-video-on-missing-articles": "true",
     "api.ensure-article-existence-categories": "",
+    "api.article-existence-check-mode": "full",
     "api.ignore-history-limit": "true",
     "api.download-file-blocklist": "*.nfo, *.par2, *.sfv, *sample.mkv, *unpack.mkv, *.unpack.mp4",
     "api.duplicate-nzb-behavior": "increment",

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -49,6 +49,8 @@ const defaultConfig = {
     "usenet.max-download-connections-per-stream": "false",
     "usenet.max-download-connections-per-stream-preset": "high",
     "usenet.max-queue-connections": "",
+    "queue.max-items": "0",
+    "queue.resume-threshold": "0",
     "queue.worker-count": "1",
     "usenet.streaming-priority": "80",
     "usenet.streaming-segment-timeout-seconds": "8",

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -310,13 +310,38 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                     <span>{`Perform article health check during downloads`}</span>
                 </label>
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="ensure-article-existence-help">
-                    Whether to check for the existence of all articles within an NZB during queue processing. This process may be slow.
+                    Check article availability in the selected categories before mounting the NZB.
                 </p>
                 <MultiCheckboxInput
                     options={ensureArticleExistanceSetting.categories}
                     value={config["api.ensure-article-existence-categories"] ?? ""}
                     onChange={value => setNewConfig({ ...config, "api.ensure-article-existence-categories": value })}
                 />
+            </div>
+            </ManagedSetting>
+            <ManagedSetting configKey="api.article-existence-check-mode">
+            <div className="ml-4 mt-4 space-y-2 border-l border-base-content/10 pl-4">
+                <label className="block text-sm font-medium text-base-content" htmlFor="article-existence-check-mode-input">
+                    Article health check mode
+                </label>
+                <Select
+                    className="w-full"
+                    id="article-existence-check-mode-input"
+                    aria-describedby="article-existence-check-mode-help"
+                    value={config["api.article-existence-check-mode"] ?? "full"}
+                    disabled={ensureArticleExistanceSetting.areNoneSelected}
+                    onChange={e => setNewConfig({
+                        ...config,
+                        "api.article-existence-check-mode": e.target.value
+                    })}
+                >
+                    <option value="full">Full — check every segment</option>
+                    <option value="sampled">Sampled — first, last, and evenly spaced segments per file</option>
+                </Select>
+                <p className="text-[11px] leading-relaxed text-base-content/45" id="article-existence-check-mode-help">
+                    Sampled mode reduces import time for large files while still detecting common truncated
+                    or partially removed releases. Files below the sampling threshold are checked in full.
+                </p>
             </div>
             </ManagedSetting>
             <hr />
@@ -447,6 +472,7 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
         || config["api.ensure-importable-video"] !== newConfig["api.ensure-importable-video"]
         || config["api.skip-non-video-on-missing-articles"] !== newConfig["api.skip-non-video-on-missing-articles"]
         || config["api.ensure-article-existence-categories"] !== newConfig["api.ensure-article-existence-categories"]
+        || config["api.article-existence-check-mode"] !== newConfig["api.article-existence-check-mode"]
         || config["api.ignore-history-limit"] !== newConfig["api.ignore-history-limit"]
         || config["api.duplicate-nzb-behavior"] !== newConfig["api.duplicate-nzb-behavior"]
         || config["api.download-file-blocklist"] !== newConfig["api.download-file-blocklist"]

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -21,6 +21,9 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
 
     const ensureArticleExistanceSetting =
         useEnsureArticleExistanceSetting(config, setNewConfig);
+    const queueMaxItems = parseNonNegativeInteger(config["queue.max-items"]);
+    const queueResumeThreshold = parseNonNegativeInteger(config["queue.resume-threshold"]);
+    const queueAdmissionValid = isValidQueueAdmission(config);
 
     return (
         <SettingsPage>
@@ -75,6 +78,54 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="manual-category-help">
                     The category to use for manual uploads through the Queue page on the UI.
                 </p>
+            </div>
+            </ManagedSetting>
+            <hr />
+            <ManagedSetting configKeys={["queue.max-items", "queue.resume-threshold"]}>
+            <div className="space-y-4">
+                <div className="space-y-2">
+                    <label className="block text-sm font-medium text-base-content" htmlFor="queue-max-items-input">
+                        Maximum queued jobs
+                    </label>
+                    <Input
+                        className={`w-full ${queueAdmissionValid ? "" : "input-error"}`}
+                        type="number"
+                        min={0}
+                        step={1}
+                        id="queue-max-items-input"
+                        aria-describedby="queue-max-items-help"
+                        aria-invalid={!queueAdmissionValid}
+                        value={config["queue.max-items"] ?? "0"}
+                        onChange={e => setNewConfig({ ...config, "queue.max-items": e.target.value })} />
+                    <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-max-items-help">
+                        Reject new SAB submissions when this many jobs are queued. Radarr and Sonarr keep
+                        rejected grabs pending and retry later. Use <code>0</code> for no limit.
+                    </p>
+                </div>
+                <div className="space-y-2">
+                    <label className="block text-sm font-medium text-base-content" htmlFor="queue-resume-threshold-input">
+                        Resume threshold
+                    </label>
+                    <Input
+                        className={`w-full ${queueAdmissionValid ? "" : "input-error"}`}
+                        type="number"
+                        min={0}
+                        max={queueMaxItems ?? undefined}
+                        step={1}
+                        id="queue-resume-threshold-input"
+                        aria-describedby="queue-resume-threshold-help"
+                        aria-invalid={!queueAdmissionValid}
+                        value={config["queue.resume-threshold"] ?? "0"}
+                        disabled={queueMaxItems === 0}
+                        onChange={e => setNewConfig({ ...config, "queue.resume-threshold": e.target.value })} />
+                    <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-resume-threshold-help">
+                        After the limit is reached, accept submissions again at or below this queue depth.
+                        Use <code>0</code> to resume immediately below the maximum.
+                        {queueResumeThreshold !== null && queueMaxItems !== null && queueResumeThreshold > queueMaxItems
+                            ? " The threshold cannot exceed the maximum."
+                            : ""}
+                    </p>
+                </div>
             </div>
             </ManagedSetting>
             <hr />
@@ -390,6 +441,8 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
     return config["api.key"] !== newConfig["api.key"]
         || config["api.categories"] !== newConfig["api.categories"]
         || config["api.manual-category"] !== newConfig["api.manual-category"]
+        || config["queue.max-items"] !== newConfig["queue.max-items"]
+        || config["queue.resume-threshold"] !== newConfig["queue.resume-threshold"]
         || config["rclone.mount-dir"] !== newConfig["rclone.mount-dir"]
         || config["api.ensure-importable-video"] !== newConfig["api.ensure-importable-video"]
         || config["api.skip-non-video-on-missing-articles"] !== newConfig["api.skip-non-video-on-missing-articles"]
@@ -409,7 +462,8 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
 
 export function isSabnzbdSettingsValid(newConfig: Record<string, string>) {
     return isValidCategories(newConfig["api.categories"])
-        && isValidNzbBackupLocation(newConfig);
+        && isValidNzbBackupLocation(newConfig)
+        && isValidQueueAdmission(newConfig);
 }
 
 export function generateNewApiKey(): string {
@@ -425,6 +479,20 @@ function isValidCategories(categories: string): boolean {
 function isValidNzbBackupLocation(config: Record<string, string>) {
     return config["api.nzb-backup-enabled"] !== "true"
         || !!config["api.nzb-backup-location"]?.trim();
+}
+
+function isValidQueueAdmission(config: Record<string, string>) {
+    const maxItems = parseNonNegativeInteger(config["queue.max-items"]);
+    const resumeThreshold = parseNonNegativeInteger(config["queue.resume-threshold"]);
+    if (maxItems === null || resumeThreshold === null) return false;
+    return maxItems === 0 || resumeThreshold === 0 || resumeThreshold <= maxItems;
+}
+
+function parseNonNegativeInteger(value: string | undefined): number | null {
+    if (value === undefined || value.trim() === "") return 0;
+    if (!/^\d+$/.test(value)) return null;
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 function isAlphaNumericWithDashes(input: string): boolean {

--- a/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
@@ -173,6 +173,63 @@ public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AddFileAsync_RejectsAtLimit_AndResumesAtThreshold()
+    {
+        ConfigureAdmission(maxItems: 2, resumeThreshold: 1);
+        await SeedQueueItem("first.nzb", "tv");
+        await SeedQueueItem("second.nzb", "tv");
+
+        var rejected = await CreateController().AddFileAsync(CreateRequest("third.nzb", "tv"));
+
+        Assert.False(rejected.Status);
+        Assert.Empty(rejected.NzoIds);
+        Assert.Contains("Queue is full", rejected.Error);
+        Assert.Equal(2, await _context.QueueItems.CountAsync());
+
+        var first = await _context.QueueItems.SingleAsync(x => x.FileName == "first.nzb");
+        _context.QueueItems.Remove(first);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var accepted = await CreateController().AddFileAsync(CreateRequest("third.nzb", "tv"));
+
+        Assert.True(accepted.Status);
+        Assert.Single(accepted.NzoIds);
+        Assert.Equal(2, await _context.QueueItems.CountAsync());
+    }
+
+    [Fact]
+    public async Task AddFileAsync_AllowsDuplicateReplacementWhileQueueIsFull()
+    {
+        ConfigureAdmission(maxItems: 2, resumeThreshold: 1);
+        await SeedQueueItem("replace-me.nzb", "tv");
+        await SeedQueueItem("other.nzb", "tv");
+
+        var response = await CreateController()
+            .AddFileAsync(CreateRequest("replace-me.nzb", "tv"));
+
+        Assert.True(response.Status);
+        Assert.Single(response.NzoIds);
+        Assert.Equal(2, await _context.QueueItems.CountAsync());
+        Assert.Single(await _context.QueueItems
+            .Where(x => x.FileName == "replace-me.nzb" && x.Category == "tv")
+            .ToListAsync());
+    }
+
+    [Fact]
+    public void QueueAdmission_AccountsForConcurrentPendingReservations()
+    {
+        using var first = _queueManager.TryReserveQueueSlot(
+            persistedCount: 0, maxItems: 1, resumeThreshold: 1);
+
+        var second = _queueManager.TryReserveQueueSlot(
+            persistedCount: 0, maxItems: 1, resumeThreshold: 1);
+
+        Assert.NotNull(first);
+        Assert.Null(second);
+    }
+
+    [Fact]
     public void IsCategoryFileNameUniqueViolation_DetectsSqliteConstraintMessage()
     {
         var sqlite = new Microsoft.Data.Sqlite.SqliteException(
@@ -194,6 +251,43 @@ public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
             FreshContextFactory = () => new DavDatabaseContext(_options),
         };
         return controller;
+    }
+
+    private void ConfigureAdmission(int maxItems, int resumeThreshold)
+    {
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.QueueMaxItems,
+                ConfigValue = maxItems.ToString(),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.QueueResumeThreshold,
+                ConfigValue = resumeThreshold.ToString(),
+            },
+        ]);
+    }
+
+    private async Task SeedQueueItem(string fileName, string category)
+    {
+        var id = Guid.NewGuid();
+        _context.QueueItems.Add(new QueueItem
+        {
+            Id = id,
+            CreatedAt = DateTime.UtcNow,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            NzbFileSize = 10,
+            TotalSegmentBytes = 10,
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        });
+        _context.NzbNames.Add(new NzbName { Id = id, FileName = fileName });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
     }
 
     private static AddFileRequest CreateRequest(string fileName, string category)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -1,0 +1,143 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class SegmentCacheNntpClientTests
+{
+    [Fact]
+    public async Task CatalogHydration_DoesNotBlockConstruction_AndServesEntriesAfterLoad()
+    {
+        var cacheDir = Path.Combine(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        var loadStarted = new ManualResetEventSlim();
+        var allowLoad = new ManualResetEventSlim();
+        const string segmentId = "segment-1";
+        byte[] content = "cached-content"u8.ToArray();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>
+            {
+                [segmentId] = content,
+            }, useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: () =>
+                {
+                    loadStarted.Set();
+                    allowLoad.Wait();
+                    return Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories);
+                });
+
+            Assert.True(loadStarted.Wait(TimeSpan.FromSeconds(5)));
+            Assert.False(client.IsCatalogReady);
+
+            var beforeHydration = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            beforeHydration.Stream?.Dispose();
+            Assert.Equal(1, inner.BodyRequestCount);
+
+            allowLoad.Set();
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(client.IsCatalogReady);
+
+            var afterHydration = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(1, inner.BodyRequestCount);
+            Assert.NotNull(afterHydration.Stream);
+
+            await using var output = new MemoryStream();
+            await afterHydration.Stream.CopyToAsync(output);
+            Assert.Equal(content, output.ToArray());
+        }
+        finally
+        {
+            allowLoad.Set();
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+            loadStarted.Dispose();
+            allowLoad.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CatalogHydration_DoesNotDoubleCountEntryFinalizedDuringLoad()
+    {
+        var cacheDir = Path.Combine(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        var loadStarted = new ManualResetEventSlim();
+        var allowLoad = new ManualResetEventSlim();
+        const string segmentId = "segment-written-during-load";
+        byte[] content = "new-cache-content"u8.ToArray();
+
+        try
+        {
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>
+            {
+                [segmentId] = content,
+            }, useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: () =>
+                {
+                    loadStarted.Set();
+                    allowLoad.Wait();
+                    return Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories);
+                });
+
+            Assert.True(loadStarted.Wait(TimeSpan.FromSeconds(5)));
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.NotNull(response.Stream);
+            await response.Stream.CopyToAsync(Stream.Null);
+            response.Stream.Dispose();
+            Assert.Equal(content.Length, client.CurrentBytes);
+
+            allowLoad.Set();
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(content.Length, client.CurrentBytes);
+        }
+        finally
+        {
+            allowLoad.Set();
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+            loadStarted.Dispose();
+            allowLoad.Dispose();
+        }
+    }
+
+    private static void WriteCacheEntry(string cacheDir, string segmentId, byte[] content)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
+        var directory = Path.Combine(cacheDir, hash[..2]);
+        Directory.CreateDirectory(directory);
+        File.WriteAllBytes(Path.Combine(directory, hash), content);
+
+        var header = new UsenetYencHeader
+        {
+            FileName = "fake.bin",
+            FileSize = content.Length,
+            LineLength = 128,
+            PartNumber = 1,
+            PartOffset = 0,
+            PartSize = content.Length,
+            TotalParts = 1,
+        };
+        File.WriteAllText(
+            Path.Combine(directory, hash) + ".h",
+            JsonSerializer.Serialize(header, new JsonSerializerOptions { IncludeFields = true }));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ArticleExistenceCheckModeConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ArticleExistenceCheckModeConfigTests.cs
@@ -1,0 +1,37 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class ArticleExistenceCheckModeConfigTests
+{
+    [Theory]
+    [InlineData("full", "full")]
+    [InlineData("SAMPLED", "sampled")]
+    public void ConfiguredMode_IsValidatedAndResolved(string configured, string expected)
+    {
+        var item = new ConfigItem
+        {
+            ConfigName = ConfigKeys.ApiArticleExistenceCheckMode,
+            ConfigValue = configured,
+        };
+        ConfigManager.ValidateConfigItems([item]);
+        var config = new ConfigManager();
+        config.UpdateValues([item]);
+
+        Assert.Equal(expected, config.GetArticleExistenceCheckMode());
+    }
+
+    [Fact]
+    public void UnknownMode_IsRejected()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiArticleExistenceCheckMode,
+                ConfigValue = "partial",
+            },
+        ]));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/QueueAdmissionConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/QueueAdmissionConfigTests.cs
@@ -1,0 +1,61 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class QueueAdmissionConfigTests
+{
+    [Fact]
+    public void ResumeThreshold_ZeroUsesConfiguredMaximum()
+    {
+        var config = CreateConfig(maxItems: 50, resumeThreshold: 0);
+
+        Assert.Equal(50, config.GetQueueMaxItems());
+        Assert.Equal(50, config.GetQueueResumeThreshold());
+    }
+
+    [Fact]
+    public void ValidateQueueAdmissionSettings_RejectsThresholdAboveMaximum()
+    {
+        var config = new ConfigManager();
+        var items = new List<ConfigItem>
+        {
+            new() { ConfigName = ConfigKeys.QueueMaxItems, ConfigValue = "50" },
+            new() { ConfigName = ConfigKeys.QueueResumeThreshold, ConfigValue = "51" },
+        };
+
+        ConfigManager.ValidateConfigItems(items);
+        Assert.Throws<ArgumentException>(() => config.ValidateQueueAdmissionSettings(items));
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("1.5")]
+    [InlineData("many")]
+    public void ValidateConfigItems_RejectsInvalidAdmissionCounts(string value)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.QueueMaxItems, ConfigValue = value },
+        ]));
+    }
+
+    private static ConfigManager CreateConfig(int maxItems, int resumeThreshold)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.QueueMaxItems,
+                ConfigValue = maxItems.ToString(),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.QueueResumeThreshold,
+                ConfigValue = resumeThreshold.ToString(),
+            },
+        ]);
+        return config;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueArticleExistenceSelectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueArticleExistenceSelectionTests.cs
@@ -1,0 +1,61 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Tests.Fakes;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public sealed class QueueArticleExistenceSelectionTests
+{
+    [Fact]
+    public void SampledMode_IncludesFirstAndLastSegmentOfEveryFile()
+    {
+        var files = Enumerable.Range(0, 3)
+            .Select(file => Segments($"file-{file}", 20_000))
+            .Cast<IReadOnlyList<string>>()
+            .ToList();
+
+        var sampled = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "sampled");
+
+        Assert.True(sampled.Count < files.Sum(x => x.Count));
+        for (var file = 0; file < files.Count; file++)
+        {
+            Assert.Contains($"file-{file}-0", sampled);
+            Assert.Contains($"file-{file}-19999", sampled);
+        }
+    }
+
+    [Fact]
+    public void FullMode_PreservesEverySegment()
+    {
+        IReadOnlyList<string>[] files =
+        [
+            Segments("first", 10),
+            Segments("second", 15),
+        ];
+
+        var selected = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "full");
+
+        Assert.Equal(files.SelectMany(x => x), selected);
+    }
+
+    [Fact]
+    public async Task SampledMode_MissingLastSegmentFailsExistenceCheck()
+    {
+        var file = Segments("video", 20_000);
+        var selected = QueueItemProcessor.SelectArticlesForExistenceCheck([file], "sampled");
+        var available = selected
+            .Where(x => x != file[^1])
+            .ToDictionary(x => x, _ => Array.Empty<byte>());
+        var client = new FakeNntpClient(available);
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            ArticleExistenceChecker.CheckAsync(
+                client, selected, concurrency: 8, progress: null, CancellationToken.None));
+
+        Assert.Equal(file[^1], exception.SegmentId);
+    }
+
+    private static List<string> Segments(string prefix, int count) =>
+        Enumerable.Range(0, count).Select(i => $"{prefix}-{i}").ToList();
+}

--- a/tests/NzbWebDAV.Tests/Streams/AesDecoderStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/AesDecoderStreamTests.cs
@@ -21,6 +21,20 @@ public class AesDecoderStreamTests
         Assert.Equal(plaintext.Length, stream.Position);
     }
 
+    [Fact]
+    public void Read_RejectsSynchronousWebDavReads()
+    {
+        var plaintext = Enumerable.Range(0, 16).Select(index => (byte)index).ToArray();
+        var (ciphertext, parameters) = Encrypt(plaintext);
+        using var stream = new AesDecoderStream(
+            new MemoryStream(ciphertext), parameters);
+
+        Assert.Throws<NotSupportedException>(
+            () => stream.Read(new byte[16], 0, 16));
+        Assert.Throws<NotSupportedException>(
+            () => stream.Read(new Span<byte>(new byte[16])));
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(1)]

--- a/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
@@ -207,4 +207,16 @@ public class BasicStreamTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             async () => await stream.ReadAsync(new byte[1]));
     }
+
+    [Fact]
+    public void CancellableStream_SynchronousArchiveReadHonorsConstructionToken()
+    {
+        using var cts = new CancellationTokenSource();
+        using var stream = new CancellableStream(
+            new MemoryStream(new byte[] { 1, 2, 3 }), cts.Token);
+        cts.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(
+            () => stream.Read(new byte[1], 0, 1));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -51,6 +51,32 @@ public class DavMultipartFileStreamTests
     }
 
     [Fact]
+    public void Read_PreservesSynchronousArchiveParserCompatibility()
+    {
+        var volumeBytes = Enumerable.Range(0, 16).Select(x => (byte)x).ToArray();
+        using var client = new FakeNntpClient(new Dictionary<string, byte[]>
+        {
+            ["segment"] = volumeBytes,
+        }, useCachedYencStreams: true);
+        var multipart = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(0, 8),
+            fileRange: LongRange.FromStartAndSize(4, 12));
+        using var stream = new DavMultipartFileStream(
+            multipart,
+            client,
+            articleBufferSize: 0,
+            resolver: null,
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv");
+
+        var buffer = new byte[12];
+        var bytesRead = stream.Read(buffer, 0, buffer.Length);
+
+        Assert.Equal(buffer.Length, bytesRead);
+        Assert.Equal(volumeBytes[4..], buffer);
+    }
+
+    [Fact]
     public async Task ReadAsync_InvalidSegmentRangeThrowsKnownSeekError()
     {
         using var client = new FakeNntpClient(new Dictionary<string, byte[]>());

--- a/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
@@ -76,6 +76,56 @@ public class WebsocketManagerTests
     }
 
     [Fact]
+    public async Task KeyedStateMessages_CoalesceToLatestValuePerItem()
+    {
+        var manager = new WebsocketManager();
+        manager.SimulateSubscribe(WebsocketTopic.LiveStats);
+        manager.SimulateSubscribe(WebsocketTopic.QueueItemProgress);
+        manager.SimulateSubscribe(WebsocketTopic.HealthItemProgress);
+        using var socket = new TestWebSocket(blockSends: true);
+        var detach = manager.AttachAuthenticatedSocketForTests(socket);
+
+        try
+        {
+            await manager.SendMessage(WebsocketTopic.LiveStats, "blocked");
+            await socket.SendStarted.WaitAsync(TimeSpan.FromSeconds(1));
+
+            await manager.SendMessage(WebsocketTopic.QueueItemProgress, "queue-a|10");
+            await manager.SendMessage(WebsocketTopic.QueueItemProgress, "queue-b|20");
+            await manager.SendMessage(WebsocketTopic.QueueItemProgress, "queue-a|90");
+            await manager.SendMessage(WebsocketTopic.QueueItemProgress, "queue-b|100");
+            await manager.SendMessage(WebsocketTopic.HealthItemProgress, "health-a|25");
+            await manager.SendMessage(WebsocketTopic.HealthItemProgress, "health-b|50");
+            await manager.SendMessage(WebsocketTopic.HealthItemProgress, "health-a|done");
+            await manager.SendMessage(WebsocketTopic.HealthItemProgress, "health-b|done");
+
+            socket.ReleaseSends();
+            await WaitUntil(() => socket.Messages.Count == 5);
+
+            var messages = socket.Messages.Select(Parse).ToList();
+            Assert.Equal(
+                ["queue-a|90", "queue-b|100"],
+                messages
+                    .Where(x => x.Topic == WebsocketTopic.QueueItemProgress.Name)
+                    .Select(x => x.Message)
+                    .Order());
+            Assert.Equal(
+                ["health-a|done", "health-b|done"],
+                messages
+                    .Where(x => x.Topic == WebsocketTopic.HealthItemProgress.Name)
+                    .Select(x => x.Message)
+                    .Order());
+        }
+        finally
+        {
+            manager.SimulateUnsubscribe(WebsocketTopic.LiveStats);
+            manager.SimulateUnsubscribe(WebsocketTopic.QueueItemProgress);
+            manager.SimulateUnsubscribe(WebsocketTopic.HealthItemProgress);
+            await detach();
+        }
+    }
+
+    [Fact]
     public async Task EventQueueOverflow_DropsOldestEventsAndKeepsSocketConnected()
     {
         var manager = new WebsocketManager();


### PR DESCRIPTION
## Summary
- hydrate the segment-cache catalog off the startup path and preserve per-item queue/health websocket updates under backpressure
- add configurable queue admission hysteresis and per-file sampled article existence checks, including settings UI and operator documentation
- make WebDAV decryption async-only while retaining the cancellation-aware synchronous bridge required by SharpCompress archive parsing

Closes #465
Closes #464
Closes #426
Closes #169
Part of #317

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore` (1500 passed, 14 skipped)
- [x] `cd frontend && npm run typecheck && npm run build && npm test && npm run lint`
- [x] `zensical build --clean --strict`