### PR TITLE
fix(nntp): return the connection when a body is left unread

### DIFF
--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -267,6 +267,11 @@ public abstract class NntpClient : INntpClient
         if (segmentIds.Count == 0) yield break;
 
         depth = Math.Max(1, depth);
+
+        // Download priority and the streaming deadline are keyed by token identity, so a plain
+        // linked token silently drops both. Scoped to the enumeration because the reader
+        // outlives a single batch iteration.
+        using var batchCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         for (var batchStart = 0; batchStart < segmentIds.Count; batchStart += depth)
         {
             var batchSize = Math.Min(depth, segmentIds.Count - batchStart);
@@ -275,12 +280,70 @@ public abstract class NntpClient : INntpClient
                 batchIds[index] = segmentIds[batchStart + index];
 
             var batch = await DecodedBodiesAsync(
-                batchIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
-            for (var index = 0; index < batch.Responses.Count; index++)
+                batchIds, onConnectionReadyAgain: null, batchCts.Token).ConfigureAwait(false);
+            var position = 0;
+            try
             {
-                var segmentId = segmentIds[batchStart + index];
-                yield return await MapPipelinedBodyResultAsync(
-                    batch.Responses[index], segmentId, cancellationToken).ConfigureAwait(false);
+                for (; position < batch.Responses.Count; position++)
+                {
+                    var segmentId = segmentIds[batchStart + position];
+                    yield return await MapPipelinedBodyResultAsync(
+                        batch.Responses[position], segmentId, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // A fully drained batch belongs to the consumer, and cancelling would tear
+                // down streams it still holds.
+                if (position < batch.Responses.Count)
+                {
+                    try
+                    {
+                        await batchCts.CancelAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        // Releasing the bodies matters more than the cancellation succeeding.
+                        Log.Debug(e, "Failed to cancel an abandoned pipelined BODY batch");
+                    }
+
+                    await ReleaseRemainingBodiesAsync(batch.Responses, position).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases an abandoned batch from the response the loop stopped on, which the consumer
+    /// may or may not have received. The batch shares one connection that is returned only
+    /// once every response is read. Cancel first, or awaiting a response drives the fetch the
+    /// consumer walked away from.
+    /// </summary>
+    private static async Task ReleaseRemainingBodiesAsync
+    (
+        IReadOnlyList<Task<UsenetDecodedBodyResponse>> responses,
+        int startIndex
+    )
+    {
+        for (var index = startIndex; index < responses.Count; index++)
+        {
+            try
+            {
+                var response = await responses[index].ConfigureAwait(false);
+                if (response.Stream != null)
+                    await response.Stream.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: cancelling the batch faults every response still in flight.
+            }
+            catch (UsenetArticleNotFoundException)
+            {
+                // Expected: a definitive miss is the usual reason a consumer stops early.
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e, "Failed to release abandoned pipelined BODY response");
             }
         }
     }

--- a/backend/Streams/CountingYencStream.cs
+++ b/backend/Streams/CountingYencStream.cs
@@ -21,6 +21,7 @@ public sealed class CountingYencStream : YencStream
     private readonly ActiveReadRegistry? _activeReadRegistry;
     private long _bytes;
     private long _activeReadTicks;
+    private int _recorded;
 
     public CountingYencStream(
         YencStream inner,
@@ -54,9 +55,11 @@ public sealed class CountingYencStream : YencStream
 
     protected override void Dispose(bool disposing)
     {
+        // Teardown releases a body the consumer may have released already, and the sample
+        // feeds a provider-selection average, so record it once regardless.
         if (disposing)
         {
-            if (_bytes > 0 && _activeReadTicks > 0)
+            if (_bytes > 0 && _activeReadTicks > 0 && Interlocked.Exchange(ref _recorded, 1) == 0)
             {
                 var activeMs = _activeReadTicks * 1000.0 / Stopwatch.Frequency;
                 _tracker.RecordSegmentThroughput(_providerKey, _bytes, activeMs);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
@@ -1,0 +1,441 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Extensions;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class NntpClientPipelinedTeardownTests
+{
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_AbandonedMidBatch_DisposesUnreadBodies()
+    {
+        var client = new ScriptedBatchClient();
+
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           ["a@example", "b@example", "c@example", "d@example"],
+                           depth: 4,
+                           CancellationToken.None))
+        {
+            Assert.True(result.Found);
+            break;
+        }
+
+        // Every body in the open batch shares one connection, and a later response cannot
+        // complete until the earlier stream is released, so teardown has to release the one
+        // it just handed out as well.
+        Assert.True(client.Streams[0].Disposed);
+        Assert.True(client.Streams[1].Disposed);
+        Assert.True(client.Streams[2].Disposed);
+        Assert.True(client.Streams[3].Disposed);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_FullyEnumerated_LeavesBodiesToTheConsumer()
+    {
+        var client = new ScriptedBatchClient();
+
+        var results = new List<PipelinedBodyResult>();
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           ["a@example", "b@example", "c@example"],
+                           depth: 3,
+                           CancellationToken.None))
+        {
+            results.Add(result);
+        }
+
+        Assert.Equal(3, results.Count);
+        Assert.All(client.Streams, stream => Assert.False(stream.Disposed));
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_AbandonedAcrossBatches_OnlyDisposesTheOpenBatch()
+    {
+        var client = new ScriptedBatchClient();
+
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           ["a@example", "b@example", "c@example", "d@example"],
+                           depth: 2,
+                           CancellationToken.None))
+        {
+            Assert.True(result.Found);
+            if (client.Streams.Count == 4) break;
+        }
+
+        // The first batch was fully consumed before the second was requested, so its bodies
+        // stay with the consumer. Only the batch still open at teardown is released.
+        Assert.False(client.Streams[0].Disposed);
+        Assert.False(client.Streams[1].Disposed);
+        Assert.True(client.Streams[2].Disposed);
+        Assert.True(client.Streams[3].Disposed);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_ConsumerAlreadyReleasedCurrentBody_ReleasesItAgain()
+    {
+        var client = new ScriptedBatchClient();
+
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           ["a@example", "b@example"],
+                           depth: 2,
+                           CancellationToken.None))
+        {
+            // What every real consumer does: release the body inside the loop, then stop.
+            if (result.Stream != null)
+                await result.Stream.DisposeAsync();
+            break;
+        }
+
+        // Teardown cannot tell whether the consumer already released it, so bodies have to
+        // tolerate a repeat dispose.
+        Assert.Equal(2, client.Streams[0].DisposeCount);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_Abandoned_CancelsTheBatchInsteadOfAwaitingIt()
+    {
+        // Remaining responses never complete on their own. Teardown must cancel the batch
+        // rather than wait on work the consumer walked away from.
+        var client = new CancelToCompleteBatchClient(count: 3);
+
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                               ["a@example", "b@example", "c@example"],
+                               depth: 3,
+                               CancellationToken.None))
+            {
+                Assert.True(result.Found);
+                break;
+            }
+        });
+
+        var finished = await Task.WhenAny(enumeration, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.True(
+            ReferenceEquals(finished, enumeration),
+            "Teardown waited on responses instead of cancelling the abandoned batch.");
+        await enumeration;
+        Assert.True(client.BatchTokenCancelled);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_AbandonedWithoutDrainingCurrent_StillCompletesTeardown()
+    {
+        // Models the library contract: a later response cannot complete until the earlier
+        // stream is drained. Teardown must not wait on a response gated behind a stream the
+        // consumer still owns, or disposing the enumerator deadlocks.
+        var client = new BackpressuredBatchClient(count: 3);
+
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                               ["a@example", "b@example", "c@example"],
+                               depth: 3,
+                               CancellationToken.None))
+            {
+                Assert.True(result.Found);
+                break;
+            }
+        });
+
+        var finished = await Task.WhenAny(enumeration, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.True(
+            ReferenceEquals(finished, enumeration),
+            "Disposing the enumerator blocked waiting on a response gated behind an undrained stream.");
+        await enumeration;
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_CarriesTokenContextIntoTheBatch()
+    {
+        // Download priority and the streaming deadline are resolved by token identity, so a
+        // batch token that does not carry them silently downgrades every pipelined fetch.
+        using var callerCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(
+            CancellationToken.None);
+        using var scope = callerCts.Token.SetContext(new DownloadPriorityContext
+        {
+            Priority = SemaphorePriority.High,
+        });
+
+        var client = new ScriptedBatchClient();
+        await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                           ["a@example"], depth: 1, callerCts.Token))
+        {
+            Assert.True(result.Found);
+            break;
+        }
+
+        // Resolved at the moment the batch is issued, which is when the connection pool
+        // reads it in production.
+        Assert.Equal(SemaphorePriority.High, client.BatchPriority);
+    }
+
+    private sealed class TrackingYencStream : YencStream
+    {
+        public TrackingYencStream() : base(new MemoryStream([], writable: false))
+        {
+        }
+
+        public int DisposeCount { get; private set; }
+
+        public bool Disposed => DisposeCount > 0;
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Every response after the first completes only when the batch is cancelled, standing
+    /// in for a fetch that is still outstanding.
+    /// </summary>
+    private sealed class CancelToCompleteBatchClient(int count) : NntpClient
+    {
+        private CancellationToken _batchToken;
+
+        public bool BatchTokenCancelled => _batchToken.IsCancellationRequested;
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            _batchToken = cancellationToken;
+
+            var responses = new List<Task<UsenetDecodedBodyResponse>>();
+            for (var index = 0; index < count; index++)
+            {
+                if (index == 0)
+                {
+                    responses.Add(Task.FromResult(new UsenetDecodedBodyResponse
+                    {
+                        SegmentId = segmentIds[index].ToString(),
+                        ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                        ResponseMessage = "222 first",
+                        Stream = new YencStream(new MemoryStream([], writable: false)),
+                    }));
+                    continue;
+                }
+
+                var pending = new TaskCompletionSource<UsenetDecodedBodyResponse>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                cancellationToken.Register(() => pending.TrySetCanceled(cancellationToken));
+                responses.Add(pending.Task);
+            }
+
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Response N+1 completes only once stream N has been disposed, which is the ordering
+    /// UsenetDecodedBodyBatch documents and enforces through pipe backpressure.
+    /// </summary>
+    private sealed class BackpressuredBatchClient(int count) : NntpClient
+    {
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var gates = new List<TaskCompletionSource>();
+            for (var index = 0; index < count; index++)
+                gates.Add(new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+
+            var responses = new List<Task<UsenetDecodedBodyResponse>>();
+            for (var index = 0; index < count; index++)
+            {
+                var position = index;
+                var stream = new GatedYencStream(gates[position]);
+                var response = new UsenetDecodedBodyResponse
+                {
+                    SegmentId = segmentIds[position].ToString(),
+                    ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                    ResponseMessage = "222 gated",
+                    Stream = stream,
+                };
+
+                responses.Add(position == 0
+                    ? Task.FromResult(response)
+                    : gates[position - 1].Task.ContinueWith(
+                        _ => response, TaskScheduler.Default));
+            }
+
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class GatedYencStream(TaskCompletionSource gate)
+        : YencStream(new MemoryStream([], writable: false))
+    {
+        protected override void Dispose(bool disposing)
+        {
+            gate.TrySetResult();
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class ScriptedBatchClient : NntpClient
+    {
+        public List<TrackingYencStream> Streams { get; } = [];
+
+        public SemaphorePriority? BatchPriority { get; private set; }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BatchPriority = cancellationToken.GetContext<DownloadPriorityContext>()?.Priority;
+            var responses = new List<Task<UsenetDecodedBodyResponse>>();
+            foreach (var segmentId in segmentIds)
+            {
+                var stream = new TrackingYencStream();
+                Streams.Add(stream);
+                responses.Add(Task.FromResult(new UsenetDecodedBodyResponse
+                {
+                    SegmentId = segmentId.ToString(),
+                    ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                    ResponseMessage = $"222 <{segmentId}>",
+                    Stream = stream,
+                }));
+            }
+
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/StreamHelperTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/StreamHelperTests.cs
@@ -97,6 +97,30 @@ public class StreamHelperTests
     }
 
     [Fact]
+    public async Task CountingYencStream_DisposedTwice_RecordsOneThroughputSample()
+    {
+        var tracker = new ProviderBytesTracker();
+        var stream = new CountingYencStream(
+            new CachedYencStream(Header(partSize: 3), new TrackingMemoryStream([1, 2, 3])),
+            tracker,
+            "provider");
+
+        Assert.Equal(3, await stream.ReadAsync(new byte[8]));
+        stream.Dispose();
+        Assert.True(tracker.GetBytesPerMs("provider") > 0, "the first dispose should record a sample");
+
+        // Another body for the same provider moves the average. Without it the replay is
+        // harmless, since re-applying a sample the average already sits on is a no-op.
+        tracker.RecordSegmentThroughput("provider", 1_000_000, 1);
+        var afterSecondSample = tracker.GetBytesPerMs("provider");
+
+        // Replaying the stale sample now would drag provider selection backwards.
+        stream.Dispose();
+
+        Assert.Equal(afterSecondSample, tracker.GetBytesPerMs("provider"));
+    }
+
+    [Fact]
     public void CountingYencStream_DisposesInnerStream()
     {
         var innerBytes = new TrackingMemoryStream([1]);


### PR DESCRIPTION
When nzbdav pulls a group of articles down a single connection and something goes wrong partway through, like hitting a corrupt article, it gives up on the rest without cleaning up after itself. That connection never gets handed back, so it's stuck for good, and enough of those and you're out of connections until you restart the container. This makes it let go of the rest of the group on the way out so the connection comes back. Only happens with pipelining turned on.