### PR TITLE
fix(nntp): initialize rapidyenc dispatch before concurrent Usenet work

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -375,10 +375,14 @@ public partial class Program
     /// </summary>
     private static void RunYencNativeSelfTest()
     {
-        Log.Information("Running yEnc native self-test (rapidyenc {Version:X})",
-            RapidYencSharp.Version.GetVersion());
         try
         {
+            RapidYencSharp.YencEncoder.EnsureInitialized();
+            RapidYencSharp.YencDecoder.EnsureInitialized();
+            RapidYencSharp.Crc32.EnsureInitialized();
+            Log.Information("Running yEnc native self-test (rapidyenc {Version:X})",
+                RapidYencSharp.Version.GetVersion());
+
             ReadOnlySpan<byte> sample = "nzbdav rapidyenc startup self-test"u8;
             var encoded = RapidYencSharp.YencEncoder.Encode(sample);
             var decoded = RapidYencSharp.YencDecoder.Decode(encoded);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -375,6 +375,8 @@ public partial class Program
     /// </summary>
     private static void RunYencNativeSelfTest()
     {
+        // Log before native init so a hard crash during dispatch setup still leaves a breadcrumb.
+        Log.Information("Initializing yEnc native dispatch (rapidyenc)");
         try
         {
             RapidYencSharp.YencEncoder.EnsureInitialized();

--- a/libs/UsenetSharp/Clients/UsenetClient.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.cs
@@ -1,10 +1,20 @@
 using System.IO.Pipelines;
+using RapidYencSharp;
 
 namespace UsenetSharp.Clients;
 
 public partial class UsenetClient : IUsenetClient, IDisposable, IAsyncDisposable
 {
     private int _disposeState;
+
+    static UsenetClient()
+    {
+        // Native *_init mutates global dispatch state and is not thread-safe across
+        // subsystems. Serialize encode/decode/CRC init before any concurrent first use.
+        YencEncoder.EnsureInitialized();
+        YencDecoder.EnsureInitialized();
+        Crc32.EnsureInitialized();
+    }
 
     public UsenetClient()
         : this(new UsenetClientOptions(), TimeProvider.System)


### PR DESCRIPTION
## Summary
- initialize rapidyenc encode, decode, and CRC dispatch serially at UsenetClient type load and again during the backend yEnc self-test
- log before native init so a hard crash during dispatch setup still leaves an operator-visible breadcrumb
- keep initialization failures inside the self-test's operator-facing fatal error path

## Context for #42
Issue #42 asked for receive-buffer decode/CRC pipelining. Current UsenetSharp already decodes ~64 KiB reassembled chunks and chains CRC before reuse. A direct socket-buffer prototype was tested at 32/64/128 KiB but did not pass the shipping gate, so that restructure was not shipped:

- 256 KiB, 64 KiB buffer: baseline 390.4 µs / 8.69 KB; prototype 445.3 µs / 13.73 KB
- 1 MiB, 64 KiB buffer: baseline 1.411 ms / 18.43 KB; prototype 1.401 ms / 37.4 KB

This PR only lands the independent startup-init hardening from that investigation. Refs #42.

## Test plan
- [x] `RAPIDYENC_LIBRARY_PATH=... dotnet run --project backend/NzbWebDAV.csproj -c Release -- --yenc-self-test`
- [x] `RAPIDYENC_LIBRARY_PATH=... dotnet test tests/UsenetSharp.Tests/UsenetSharp.Tests.csproj -c Release --filter "TestCategory!=Integration"` (227 passed)
- [x] Earlier full `NzbWebDAV.Tests` run on the init change (1511 passed, 3 skipped)