### PR TITLE
fix(usenet): keep provider usage totals across restarts on env-only configs

### DIFF
--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
@@ -34,13 +37,12 @@ public static class UsenetProviderIdentity
         var assigned = EnsureProviderIds(providerConfig);
         if (!assigned) return;
 
-        // ENV-managed provider JSON is authoritative and must stay out of SQLite.
-        // IDs are normalized when the overlay loads; any remaining in-memory
-        // assignments above are kept until restart without persisting.
+        // ENV-managed provider JSON is authoritative and must stay out of SQLite. Ids are
+        // already assigned by the time this runs, so nothing here fires in practice.
         if (configManager.IsEnvironmentManaged(ConfigKeys.UsenetProviders))
         {
             Log.Information(
-                "Assigned ProviderId for {Count} ENV-managed usenet provider(s) in memory only.",
+                "Assigned ProviderId for {Count} ENV-managed usenet provider(s) without persisting.",
                 assignedCount);
             return;
         }
@@ -63,24 +65,79 @@ public static class UsenetProviderIdentity
         config.Providers.Count(provider => provider.ProviderId == Guid.Empty);
 
     /// <summary>
-    /// Assigns a Guid to every provider missing one. Returns true when any id was created.
+    /// Assigns an id to every provider missing one. Returns true when any id was created.
     /// </summary>
     public static bool EnsureProviderIds(UsenetProviderConfig config)
     {
+        var taken = config.Providers
+            .Where(provider => provider.ProviderId != Guid.Empty)
+            .Select(provider => provider.ProviderId)
+            .ToHashSet();
+
         var assigned = false;
         foreach (var provider in config.Providers)
         {
             if (provider.ProviderId != Guid.Empty) continue;
-            provider.ProviderId = Guid.NewGuid();
+            provider.ProviderId = AssignProviderId(provider, taken);
             assigned = true;
         }
         return assigned;
     }
 
     /// <summary>
+    /// Derives the id from the account instead of generating one, so a config that is never
+    /// written back still comes up with the same id. Host casing is folded to match how a
+    /// stored id is matched on save. The password is left out, so rotating it keeps the history.
+    /// </summary>
+    /// <param name="occurrence">
+    /// Separates repeated entries for one account. It sits ahead of the free-text fields, so a
+    /// newline inside a username cannot be read as a different occurrence.
+    /// </param>
+    internal static Guid DeriveProviderId(
+        UsenetProviderConfig.ConnectionDetails provider,
+        int occurrence = 0
+    )
+    {
+        // Nulls are guarded because a hand-edited row never passed through validation.
+        var canonical = string.Join('\n',
+            "nzbdav:usenet-provider",
+            occurrence.ToString(CultureInfo.InvariantCulture),
+            (provider.Host ?? "").ToLowerInvariant(),
+            provider.Port.ToString(CultureInfo.InvariantCulture),
+            provider.User ?? "");
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+        var bytes = hash[..16];
+        // Version 8 is the RFC 9562 slot for custom derivations, then the RFC 4122 variant.
+        bytes[6] = (byte)((bytes[6] & 0x0F) | 0x80);
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+        return new Guid(bytes, bigEndian: true);
+    }
+
+    /// <summary>
+    /// Gives a repeated account its own id rather than a shared counter. The loop is bounded,
+    /// and the random tail covers the case where every candidate was already taken.
+    /// </summary>
+    private static Guid AssignProviderId(
+        UsenetProviderConfig.ConnectionDetails provider,
+        HashSet<Guid> taken
+    )
+    {
+        for (var occurrence = 0; occurrence <= taken.Count; occurrence++)
+        {
+            var candidate = DeriveProviderId(provider, occurrence);
+            if (taken.Add(candidate)) return candidate;
+        }
+
+        var fallback = Guid.NewGuid();
+        taken.Add(fallback);
+        return fallback;
+    }
+
+    /// <summary>
     /// When saving usenet.providers, preserve ProviderIds from the stored config for
-    /// entries that omit them (match by Host+Port+User). Generates a new Guid when
-    /// no match exists. Mutates <paramref name="incoming"/> in place.
+    /// entries that omit them (match by Host+Port+User). Derives one when no match
+    /// exists. Mutates <paramref name="incoming"/> in place.
     /// </summary>
     public static void NormalizeProviderIdsOnSave(
         UsenetProviderConfig incoming,
@@ -89,6 +146,13 @@ public static class UsenetProviderIdentity
         var unusedExisting = existing?.Providers
             .Where(p => p.ProviderId != Guid.Empty)
             .ToList() ?? [];
+
+        // A stored id can be recovered further down the loop, so it is spoken for already.
+        var taken = incoming.Providers
+            .Where(p => p.ProviderId != Guid.Empty)
+            .Select(p => p.ProviderId)
+            .Concat(unusedExisting.Select(p => p.ProviderId))
+            .ToHashSet();
 
         foreach (var provider in incoming.Providers)
         {
@@ -106,7 +170,7 @@ public static class UsenetProviderIdentity
             }
             else
             {
-                provider.ProviderId = Guid.NewGuid();
+                provider.ProviderId = AssignProviderId(provider, taken);
             }
         }
     }

--- a/docs/configuration/headless.md
+++ b/docs/configuration/headless.md
@@ -175,7 +175,7 @@ services:
 
     Use **PascalCase** property names exactly as the Settings UI persists them (`Providers`, `Type`, `Host`, `RadarrInstances`, `Indexers`, `Profiles`, …). camelCase or misspelled keys abort startup with an error naming the JSON path of the offending property, so a typo cannot leave you with empty or partial configuration.
 
-    Provider `Type` for **Pool Connections** is `1` (`0` = Disabled, `2` = BackupAndStats, `3` = BackupOnly — see [Usenet](usenet.md)). Omit `ProviderId` in ENV JSON — NzbDAV preserves matching SQLite ids by host/port/user, or assigns new ones. Pure ENV-only first installs (no matching SQLite row) get new IDs each restart until a SQLite match exists, so metrics keys may drift.
+    Provider `Type` for **Pool Connections** is `1` (`0` = Disabled, `2` = BackupAndStats, `3` = BackupOnly — see [Usenet](usenet.md)). Omit `ProviderId` in ENV JSON — NzbDAV preserves matching SQLite ids by host/port/user, and otherwise derives one from host, port and user, so a pure ENV-only install keeps the same ids across restarts.
 
     Passwords containing `"`, `\`, or `$` can break JSON after Compose substitution; prefer `.env` values without those characters or inject secrets outside inline JSON.
 

--- a/tests/NzbWebDAV.Tests/Config/ConfigEnvironmentOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigEnvironmentOverlayTests.cs
@@ -161,6 +161,17 @@ public class ConfigEnvironmentOverlayTests
         Assert.True(overlay.TryGetValue(ConfigKeys.UsenetProviders, out var normalized));
         var parsed = JsonSerializer.Deserialize<UsenetProviderConfig>(normalized)!;
         Assert.NotEqual(Guid.Empty, parsed.Providers[0].ProviderId);
+
+        // The same env JSON on the next start has to land on the same id, or per-provider
+        // usage totals begin again from zero on every boot.
+        var restarted = ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__USENET__PROVIDERS"] = incoming,
+        });
+
+        Assert.True(restarted.TryGetValue(ConfigKeys.UsenetProviders, out var afterRestart));
+        var parsedAgain = JsonSerializer.Deserialize<UsenetProviderConfig>(afterRestart)!;
+        Assert.Equal(parsed.Providers[0].ProviderId, parsedAgain.Providers[0].ProviderId);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Config/UsenetProviderIdentityTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/UsenetProviderIdentityTests.cs
@@ -1,0 +1,169 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class UsenetProviderIdentityTests
+{
+    [Fact]
+    public void DeriveProviderId_MatchesAPinnedValue()
+    {
+        // Env-only installs depend on this value never moving.
+        Assert.Equal(
+            Guid.Parse("a71c51df-fed5-85cc-9fe3-7fa3866d6724"),
+            UsenetProviderIdentity.DeriveProviderId(MakeProvider("news.example.com", "alice")));
+    }
+
+    [Fact]
+    public void EnsureProviderIds_AssignsTheSameIdOnEveryStart()
+    {
+        var first = MakeConfig(MakeProvider("news.example.com", "alice"));
+        var second = MakeConfig(MakeProvider("news.example.com", "alice"));
+
+        Assert.True(UsenetProviderIdentity.EnsureProviderIds(first));
+        Assert.True(UsenetProviderIdentity.EnsureProviderIds(second));
+
+        Assert.NotEqual(Guid.Empty, first.Providers[0].ProviderId);
+        Assert.Equal(first.Providers[0].ProviderId, second.Providers[0].ProviderId);
+    }
+
+    [Fact]
+    public void EnsureProviderIds_KeepsTwoAccountsOnOneHostApart()
+    {
+        var config = MakeConfig(
+            MakeProvider("news.example.com", "alice"),
+            MakeProvider("news.example.com", "bob"));
+
+        UsenetProviderIdentity.EnsureProviderIds(config);
+
+        Assert.Equal(
+            UsenetProviderIdentity.DeriveProviderId(MakeProvider("news.example.com", "alice")),
+            config.Providers[0].ProviderId);
+        Assert.Equal(
+            UsenetProviderIdentity.DeriveProviderId(MakeProvider("news.example.com", "bob")),
+            config.Providers[1].ProviderId);
+    }
+
+    [Fact]
+    public void EnsureProviderIds_GivesRepeatedAccountsStableDistinctIds()
+    {
+        var first = MakeConfig(
+            MakeProvider("news.example.com", "alice"),
+            MakeProvider("news.example.com", "alice"));
+        var second = MakeConfig(
+            MakeProvider("news.example.com", "alice"),
+            MakeProvider("news.example.com", "alice"));
+
+        UsenetProviderIdentity.EnsureProviderIds(first);
+        UsenetProviderIdentity.EnsureProviderIds(second);
+
+        Assert.Equal(
+            UsenetProviderIdentity.DeriveProviderId(MakeProvider("news.example.com", "alice")),
+            first.Providers[0].ProviderId);
+        Assert.NotEqual(first.Providers[0].ProviderId, first.Providers[1].ProviderId);
+        Assert.Equal(first.Providers[0].ProviderId, second.Providers[0].ProviderId);
+        Assert.Equal(first.Providers[1].ProviderId, second.Providers[1].ProviderId);
+    }
+
+    [Fact]
+    public void DeriveProviderId_FoldsHostCaseButNotUserCase()
+    {
+        var lowerHost = MakeProvider("news.example.com", "alice");
+        var upperHost = MakeProvider("NEWS.EXAMPLE.COM", "alice");
+        var upperUser = MakeProvider("news.example.com", "Alice");
+        var otherPort = MakeProvider("news.example.com", "alice", port: 119);
+
+        Assert.Equal(
+            UsenetProviderIdentity.DeriveProviderId(lowerHost),
+            UsenetProviderIdentity.DeriveProviderId(upperHost));
+        Assert.NotEqual(
+            UsenetProviderIdentity.DeriveProviderId(lowerHost),
+            UsenetProviderIdentity.DeriveProviderId(upperUser));
+        Assert.NotEqual(
+            UsenetProviderIdentity.DeriveProviderId(lowerHost),
+            UsenetProviderIdentity.DeriveProviderId(otherPort));
+    }
+
+    [Fact]
+    public void DeriveProviderId_IgnoresThePassword()
+    {
+        var before = MakeProvider("news.example.com", "alice");
+        var after = MakeProvider("news.example.com", "alice");
+        after.Pass = "rotated";
+
+        Assert.Equal(
+            UsenetProviderIdentity.DeriveProviderId(before),
+            UsenetProviderIdentity.DeriveProviderId(after));
+    }
+
+    [Fact]
+    public void NormalizeProviderIdsOnSave_DerivesWhenNothingStoredMatches()
+    {
+        var incoming = MakeConfig(MakeProvider("news.example.com", "alice"));
+        UsenetProviderIdentity.NormalizeProviderIdsOnSave(incoming, existing: null);
+
+        Assert.Equal(
+            UsenetProviderIdentity.DeriveProviderId(MakeProvider("news.example.com", "alice")),
+            incoming.Providers[0].ProviderId);
+    }
+
+    [Fact]
+    public void NormalizeProviderIdsOnSave_DoesNotHandOutAnIdItWillLaterRecover()
+    {
+        // The stored entry holds the id a new entry at its old host would derive.
+        var renamed = MakeProvider("old.example.com", "alice");
+        renamed.ProviderId = UsenetProviderIdentity.DeriveProviderId(
+            MakeProvider("new.example.com", "alice"));
+
+        var incoming = MakeConfig(
+            MakeProvider("new.example.com", "alice"),
+            MakeProvider("old.example.com", "alice"));
+        UsenetProviderIdentity.NormalizeProviderIdsOnSave(incoming, MakeConfig(renamed));
+
+        Assert.Equal(renamed.ProviderId, incoming.Providers[1].ProviderId);
+        Assert.NotEqual(incoming.Providers[0].ProviderId, incoming.Providers[1].ProviderId);
+    }
+
+    [Fact]
+    public void DeriveProviderId_SeparatesAnOccurrenceFromAUsernameThatLooksLikeOne()
+    {
+        Assert.NotEqual(
+            UsenetProviderIdentity.DeriveProviderId(
+                MakeProvider("news.example.com", "alice"), occurrence: 1),
+            UsenetProviderIdentity.DeriveProviderId(
+                MakeProvider("news.example.com", "alice\n1")));
+    }
+
+    [Fact]
+    public void DeriveProviderId_SurvivesAMissingHost()
+    {
+        var provider = MakeProvider("news.example.com", "alice");
+        provider.Host = null!;
+
+        Assert.NotEqual(Guid.Empty, UsenetProviderIdentity.DeriveProviderId(provider));
+    }
+
+    private static UsenetProviderConfig MakeConfig(
+        params UsenetProviderConfig.ConnectionDetails[] providers)
+    {
+        return new UsenetProviderConfig { Providers = [.. providers] };
+    }
+
+    private static UsenetProviderConfig.ConnectionDetails MakeProvider(
+        string host,
+        string user,
+        int port = 563
+    )
+    {
+        return new UsenetProviderConfig.ConnectionDetails
+        {
+            Type = ProviderType.Pooled,
+            Host = host,
+            Port = port,
+            UseSsl = true,
+            User = user,
+            Pass = "pass",
+            MaxConnections = 10,
+        };
+    }
+}


### PR DESCRIPTION
If you configure providers through the environment variable and don't write a ProviderId in yourself, nzbdav invents a new one at every start and won't save it, so totals reset on every restart and a byte limit on a block account isn't tracked correctly. This derives a stable ID from host, port and username instead, the same three fields the code already compares when recovering a stored ID. Passwords stay out, so rotating one keeps your history.