### PR TITLE
fix(build): allow DUMB to compile NzbDAV after updating from main

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -28,6 +28,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\libs\SharpCompress\SharpCompress.csproj" />
+      <ProjectReference Include="..\libs\RapidYencSharp\RapidYencSharp.csproj" />
       <ProjectReference Include="..\libs\UsenetSharp\UsenetSharp.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- declare the backend's direct RapidYencSharp dependency explicitly
- avoid relying on UsenetSharp to expose transitive compile references during DUMB incremental builds

## Test plan
- [x] Publish with `DisableTransitiveProjectReferences=true`
- [x] Confirm RapidYencSharp is copied to publish output
- [x] Run `NzbWebDAV --yenc-self-test` from that output