### PR TITLE
feat(usenet): prevent playback desync and add experimental container-aware gap fill

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -80,7 +80,8 @@ public interface INntpClient : IDisposable
         CancellationToken ct,
         bool usePipelinedBodyRequests = true,
         string? fileName = null,
-        InFlightArticleBudget? inFlightArticleBudget = null);
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false);
 
     NzbFileStream GetFileStream(
         NzbFile nzbFile,
@@ -88,7 +89,8 @@ public interface INntpClient : IDisposable
         int articleBufferSize,
         bool usePipelinedBodyRequests = true,
         string? fileName = null,
-        InFlightArticleBudget? inFlightArticleBudget = null);
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false);
 
     NzbFileStream GetFileStream(
         string[] segmentIds,
@@ -98,7 +100,8 @@ public interface INntpClient : IDisposable
         bool usePipelinedBodyRequests = true,
         string? fileName = null,
         string[][]? segmentFallbacks = null,
-        InFlightArticleBudget? inFlightArticleBudget = null);
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -140,7 +140,8 @@ public abstract class NntpClient : INntpClient
         CancellationToken ct,
         bool usePipelinedBodyRequests = true,
         string? fileName = null,
-        InFlightArticleBudget? inFlightArticleBudget = null)
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false)
     {
         var segmentIds = nzbFile.GetSegmentIds();
         var fileSize = await GetFileSizeAsync(nzbFile, ct).ConfigureAwait(false);
@@ -153,7 +154,8 @@ public abstract class NntpClient : INntpClient
             usePipelinedBodyRequests,
             ResolveFileName(fileName, nzbFile),
             nzbFile.GetSegmentFallbackIds(),
-            inFlightArticleBudget);
+            inFlightArticleBudget,
+            useContainerAwareFill);
     }
 
     public virtual NzbFileStream GetFileStream(
@@ -162,7 +164,8 @@ public abstract class NntpClient : INntpClient
         int articleBufferSize,
         bool usePipelinedBodyRequests = true,
         string? fileName = null,
-        InFlightArticleBudget? inFlightArticleBudget = null)
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false)
     {
         return new NzbFileStream(
             nzbFile.GetSegmentIds(),
@@ -173,7 +176,8 @@ public abstract class NntpClient : INntpClient
             usePipelinedBodyRequests,
             ResolveFileName(fileName, nzbFile),
             nzbFile.GetSegmentFallbackIds(),
-            inFlightArticleBudget
+            inFlightArticleBudget,
+            useContainerAwareFill
         );
     }
 
@@ -185,7 +189,8 @@ public abstract class NntpClient : INntpClient
         bool usePipelinedBodyRequests = true,
         string? fileName = null,
         string[][]? segmentFallbacks = null,
-        InFlightArticleBudget? inFlightArticleBudget = null)
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false)
     {
         return new NzbFileStream(
             segmentIds,
@@ -196,7 +201,8 @@ public abstract class NntpClient : INntpClient
             usePipelinedBodyRequests,
             fileName,
             segmentFallbacks,
-            inFlightArticleBudget);
+            inFlightArticleBudget,
+            useContainerAwareFill);
     }
 
     private static string? ResolveFileName(string? fileName, NzbFile nzbFile)

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -37,6 +37,7 @@ public static class ConfigKeys
     public const string UsenetArticleBufferSize = "usenet.article-buffer-size";
     public const string UsenetArticleMissCacheTtlSeconds = "usenet.article-miss-cache-ttl-seconds";
     public const string UsenetArticleMissCacheMaxEntries = "usenet.article-miss-cache-max-entries";
+    public const string UsenetContainerAwareFill = "usenet.container-aware-fill";
     public const string UsenetInFlightArticleBudgetMb = "usenet.in-flight-article-budget-mb";
     public const string UsenetCascadeEnabled = "usenet.cascade.enabled";
     public const string UsenetCascadeRetryPrimaryOnMiss = "usenet.cascade.retry-primary-on-miss";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -355,6 +355,7 @@ public class ConfigManager
                 case ConfigKeys.UsenetPipeliningEnabled:
                 case ConfigKeys.UsenetCascadeEnabled:
                 case ConfigKeys.UsenetCascadeRetryPrimaryOnMiss:
+                case ConfigKeys.UsenetContainerAwareFill:
                 case ConfigKeys.UsenetPipelinedBodyRequests:
                 case ConfigKeys.UsenetSegmentCacheEnabled:
                 case ConfigKeys.PlayWatchdogEnabled:
@@ -853,6 +854,13 @@ public class ConfigManager
         var configValue = StringUtil.EmptyToNull(
             GetConfigValue(ConfigKeys.UsenetPipelinedBodyRequests));
         return configValue == null || bool.Parse(configValue);
+    }
+
+    public bool IsContainerAwareFillEnabled()
+    {
+        var configValue = StringUtil.EmptyToNull(
+            GetConfigValue(ConfigKeys.UsenetContainerAwareFill));
+        return configValue != null && bool.Parse(configValue);
     }
 
     public bool IsSegmentCacheEnabled()

--- a/backend/Exceptions/TransientSegmentExhaustionException.cs
+++ b/backend/Exceptions/TransientSegmentExhaustionException.cs
@@ -1,0 +1,4 @@
+namespace NzbWebDAV.Exceptions;
+
+public class TransientSegmentExhaustionException(string message, Exception? innerException = null)
+    : RetryableDownloadException(message, innerException);

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -253,9 +253,13 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             // reserve full stack traces for unexpected failures.
             var isKnown = IsKnownDownloadException(e, out var knownError);
             var reason = isKnown ? knownError : e.GetType().Name;
-            // Data that was never posted completely is a repairable state of the item,
-            // not a fault in serving it, so it warns rather than errors.
-            var knownLevel = isIncompleteData ? LogEventLevel.Warning : LogEventLevel.Error;
+            // Transient segment exhaustion (all retries spent, player will retry the range)
+            // and incomplete multipart data are expected operational conditions, so they
+            // warn rather than error. Other retryable failures (e.g. unknown-length
+            // segments that need repair) stay at Error.
+            var knownLevel = isIncompleteData || e is TransientSegmentExhaustionException
+                ? LogEventLevel.Warning
+                : LogEventLevel.Error;
             var dedupeKey = $"{filePath}|{seekPosition}|{reason}";
             LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
             {

--- a/backend/Streams/ContainerAwareFillStream.cs
+++ b/backend/Streams/ContainerAwareFillStream.cs
@@ -9,7 +9,6 @@ internal sealed class ContainerAwareFillStream : Stream
 {
     private enum FillFormat
     {
-        Matroska,
         TransportStream188,
         TransportStream192,
     }
@@ -35,8 +34,6 @@ internal sealed class ContainerAwareFillStream : Stream
         var extension = Path.GetExtension(fileName)?.ToLowerInvariant() ?? string.Empty;
         return extension switch
         {
-            ".mkv" or ".mk3d" or ".webm" when length >= 2 =>
-                new ContainerAwareFillStream(length, fileOffset ?? 0, FillFormat.Matroska),
             ".ts" when fileOffset is >= 0 =>
                 new ContainerAwareFillStream(length, fileOffset.Value, FillFormat.TransportStream188),
             ".m2ts" or ".mts" when fileOffset is >= 0 =>
@@ -91,9 +88,6 @@ internal sealed class ContainerAwareFillStream : Stream
         var destination = buffer[..toRead];
         switch (_format)
         {
-            case FillFormat.Matroska:
-                FillMatroska(destination);
-                break;
             case FillFormat.TransportStream188:
                 FillTransportStream(destination, packetSize: 188, transportHeaderOffset: 0);
                 break;
@@ -148,31 +142,6 @@ internal sealed class ContainerAwareFillStream : Stream
     {
         _disposed = true;
         base.Dispose(disposing);
-    }
-
-    private void FillMatroska(Span<byte> destination)
-    {
-        // Tile the gap with valid global Void elements rather than one large Void.
-        // A gap usually begins inside a Block, so dense element boundaries give an
-        // EBML parser another resync target after it abandons the damaged Block.
-        var oddLength = (_length & 1) != 0;
-        for (var i = 0; i < destination.Length; i++)
-        {
-            var position = _position + i;
-            if (oddLength && position < 3)
-            {
-                destination[i] = position switch
-                {
-                    0 => 0xEC, // Void element ID
-                    1 => 0x81, // one-byte payload
-                    _ => 0x00,
-                };
-                continue;
-            }
-
-            var pairPosition = oddLength ? position - 3 : position;
-            destination[i] = (pairPosition & 1) == 0 ? (byte)0xEC : (byte)0x80;
-        }
     }
 
     private void FillTransportStream(

--- a/backend/Streams/ContainerAwareFillStream.cs
+++ b/backend/Streams/ContainerAwareFillStream.cs
@@ -149,7 +149,7 @@ internal sealed class ContainerAwareFillStream : Stream
         int packetSize,
         int transportHeaderOffset)
     {
-        destination.Fill(0xFF);
+        destination.Clear();
         var gapEnd = checked(_fileOffset + _length);
         for (var i = 0; i < destination.Length; i++)
         {

--- a/backend/Streams/ContainerAwareFillStream.cs
+++ b/backend/Streams/ContainerAwareFillStream.cs
@@ -1,0 +1,215 @@
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Emits format-native discard markers for a permanently unavailable segment.
+/// The markers are intentionally dense so a demuxer that recovers partway through
+/// the gap can find another valid boundary. Unsupported formats retain zero-fill.
+/// </summary>
+internal sealed class ContainerAwareFillStream : Stream
+{
+    private enum FillFormat
+    {
+        Matroska,
+        TransportStream188,
+        TransportStream192,
+    }
+
+    private readonly long _length;
+    private readonly long _fileOffset;
+    private readonly FillFormat _format;
+    private long _position;
+    private bool _disposed;
+
+    private ContainerAwareFillStream(long length, long fileOffset, FillFormat format)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        ArgumentOutOfRangeException.ThrowIfNegative(fileOffset);
+        _length = length;
+        _fileOffset = fileOffset;
+        _format = format;
+    }
+
+    public static Stream Create(string? fileName, long length, long? fileOffset)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        var extension = Path.GetExtension(fileName)?.ToLowerInvariant() ?? string.Empty;
+        return extension switch
+        {
+            ".mkv" or ".mk3d" or ".webm" when length >= 2 =>
+                new ContainerAwareFillStream(length, fileOffset ?? 0, FillFormat.Matroska),
+            ".ts" when fileOffset is >= 0 =>
+                new ContainerAwareFillStream(length, fileOffset.Value, FillFormat.TransportStream188),
+            ".m2ts" or ".mts" when fileOffset is >= 0 =>
+                new ContainerAwareFillStream(length, fileOffset.Value, FillFormat.TransportStream192),
+            _ => new ZeroStream(length),
+        };
+    }
+
+    public override bool CanRead => !_disposed;
+    public override bool CanSeek => !_disposed;
+    public override bool CanWrite => false;
+
+    public override long Length
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _length;
+        }
+    }
+
+    public override long Position
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _position;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _position = value;
+        }
+    }
+
+    public override void Flush() => ThrowIfDisposed();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ValidateBufferArguments(buffer, offset, count);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        ThrowIfDisposed();
+        var remaining = _length - _position;
+        if (remaining <= 0 || buffer.IsEmpty) return 0;
+
+        var toRead = (int)Math.Min(buffer.Length, remaining);
+        var destination = buffer[..toRead];
+        switch (_format)
+        {
+            case FillFormat.Matroska:
+                FillMatroska(destination);
+                break;
+            case FillFormat.TransportStream188:
+                FillTransportStream(destination, packetSize: 188, transportHeaderOffset: 0);
+                break;
+            case FillFormat.TransportStream192:
+                FillTransportStream(destination, packetSize: 192, transportHeaderOffset: 4);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        _position += toRead;
+        return toRead;
+    }
+
+    public override Task<int> ReadAsync(
+        byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Read(buffer, offset, count));
+    }
+
+    public override ValueTask<int> ReadAsync(
+        Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<int>(Read(buffer.Span));
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        ThrowIfDisposed();
+        var next = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+        if (next < 0)
+            throw new IOException("An attempt was made to move the position before the beginning of the stream.");
+
+        _position = next;
+        return _position;
+    }
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    private void FillMatroska(Span<byte> destination)
+    {
+        // Tile the gap with valid global Void elements rather than one large Void.
+        // A gap usually begins inside a Block, so dense element boundaries give an
+        // EBML parser another resync target after it abandons the damaged Block.
+        var oddLength = (_length & 1) != 0;
+        for (var i = 0; i < destination.Length; i++)
+        {
+            var position = _position + i;
+            if (oddLength && position < 3)
+            {
+                destination[i] = position switch
+                {
+                    0 => 0xEC, // Void element ID
+                    1 => 0x81, // one-byte payload
+                    _ => 0x00,
+                };
+                continue;
+            }
+
+            var pairPosition = oddLength ? position - 3 : position;
+            destination[i] = (pairPosition & 1) == 0 ? (byte)0xEC : (byte)0x80;
+        }
+    }
+
+    private void FillTransportStream(
+        Span<byte> destination,
+        int packetSize,
+        int transportHeaderOffset)
+    {
+        destination.Fill(0xFF);
+        var gapEnd = checked(_fileOffset + _length);
+        for (var i = 0; i < destination.Length; i++)
+        {
+            var absolutePosition = _fileOffset + _position + i;
+            var packetStart = absolutePosition - absolutePosition % packetSize;
+
+            // Never mark a partial packet as null: doing so could make the demuxer
+            // discard valid bytes that resume after the gap.
+            if (packetStart < _fileOffset || packetStart + packetSize > gapEnd)
+                continue;
+
+            var packetPosition = (int)(absolutePosition - packetStart);
+            if (transportHeaderOffset == 4 && packetPosition < transportHeaderOffset)
+            {
+                destination[i] = 0x00; // M2TS arrival timestamp prefix
+                continue;
+            }
+
+            var transportPosition = packetPosition - transportHeaderOffset;
+            destination[i] = transportPosition switch
+            {
+                0 => 0x47,
+                1 => 0x1F,
+                2 => 0xFF,
+                3 => 0x10,
+                _ => 0xFF,
+            };
+        }
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+}

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -541,8 +541,24 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             // dropped socket takes out unrelated segments with it. Re-request this
             // segment on its own first, which is what gives provider failover and the
             // streaming-timeout retries a chance before any data is degraded.
-            var rescued = await TryRescueSegmentAsync(segmentId, segmentIndex, e, cancellationToken)
-                .ConfigureAwait(false);
+            Stream? rescued;
+            try
+            {
+                rescued = await TryRescueSegmentAsync(segmentId, segmentIndex, e, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (UsenetArticleNotFoundException notFound)
+            {
+                // Rescue confirmed the article is genuinely missing — gap-fill
+                // instead of treating it as a transient transport failure.
+                if (_failFastOnFirstSegment && isFirstSegment) throw;
+                return ZeroFillSegment(
+                    "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
+                    notFound.SegmentId,
+                    segmentIndex,
+                    notFound);
+            }
+
             if (rescued is not null)
                 return SegmentDownloadResult.Success(rescued, estimate);
 
@@ -557,8 +573,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
     /// <summary>
     /// Re-requests a segment individually after its pipelined response failed. Returns
-    /// null once the retries are spent, or as soon as the article is known to be missing
-    /// rather than unreachable.
+    /// null once the retries are spent. Throws <see cref="UsenetArticleNotFoundException"/>
+    /// if rescue confirms the article is genuinely missing, so the caller can gap-fill
+    /// rather than treating it as a transient transport failure.
     /// </summary>
     private async Task<Stream?> TryRescueSegmentAsync(
         string segmentId,
@@ -587,7 +604,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch (UsenetArticleNotFoundException)
             {
-                return null;
+                throw;
             }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested)
             {
@@ -786,14 +803,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             : new RetryableDownloadException(message, failure);
     }
 
-    private RetryableDownloadException CreateTransientSegmentFailure(
+    private TransientSegmentExhaustionException CreateTransientSegmentFailure(
         string segmentId, int segmentIndex, Exception failure)
     {
         var message =
             $"Segment {segmentIndex + 1} of {_segmentIds.Length} ({segmentId}) could not be downloaded " +
             $"while reading \"{_fileName}\" after all retry attempts were exhausted. " +
             "The client should retry this range request.";
-        return new RetryableDownloadException(message, failure);
+        return new TransientSegmentExhaustionException(message, failure);
     }
 
     private async Task<Stream> DrainSegmentAsync(

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -26,6 +26,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly long _estimatedSegmentSize;
     private readonly SegmentSizes _segmentSizes;
     private readonly bool _failFastOnFirstSegment;
+    private readonly bool _useContainerAwareFill;
+    private readonly long? _firstSegmentFileOffset;
     private readonly string _fileName;
     private readonly Channel<Task<SegmentDownloadResult>> _streamTasks;
     private readonly int _bodyPipelineBatchSize;
@@ -64,7 +66,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         string? fileName = null,
         long? readBudget = null,
         string[][]? segmentFallbacks = null,
-        InFlightArticleBudget? inFlightArticleBudget = null)
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false,
+        long? firstSegmentFileOffset = null)
     {
         return Create(
             segmentIds,
@@ -77,7 +81,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             fileName,
             readBudget,
             segmentFallbacks,
-            inFlightArticleBudget: inFlightArticleBudget);
+            inFlightArticleBudget: inFlightArticleBudget,
+            useContainerAwareFill: useContainerAwareFill,
+            firstSegmentFileOffset: firstSegmentFileOffset);
     }
 
     /// <param name="estimatedSegmentSize">
@@ -88,7 +94,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     /// <param name="exactSegmentSizes">
     /// Exact decoded size of each segment in <paramref name="segmentIds"/>, in the same
     /// order. Supplied when the import recorded per-segment byte ranges, and required
-    /// before a failed segment may be replaced with zeros.
+    /// before a failed segment may be replaced with same-length gap bytes.
     /// </param>
     public static Stream Create
     (
@@ -103,13 +109,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         long? readBudget = null,
         string[][]? segmentFallbacks = null,
         ReadOnlyMemory<long> exactSegmentSizes = default,
-        InFlightArticleBudget? inFlightArticleBudget = null
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false,
+        long? firstSegmentFileOffset = null
     )
     {
         return articleBufferSize == 0
             ? new UnbufferedMultiSegmentStream(
                 segmentIds, usenetClient, estimatedSegmentSize, fileName, segmentFallbacks,
-                exactSegmentSizes)
+                exactSegmentSizes, useContainerAwareFill, firstSegmentFileOffset)
             : new MultiSegmentStream(
                 segmentIds,
                 usenetClient,
@@ -122,7 +130,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 readBudget,
                 segmentFallbacks,
                 exactSegmentSizes,
-                inFlightArticleBudget);
+                inFlightArticleBudget,
+                useContainerAwareFill,
+                firstSegmentFileOffset);
     }
 
     private MultiSegmentStream
@@ -138,7 +148,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         long? readBudget,
         string[][]? segmentFallbacks,
         ReadOnlyMemory<long> exactSegmentSizes,
-        InFlightArticleBudget? inFlightArticleBudget
+        InFlightArticleBudget? inFlightArticleBudget,
+        bool useContainerAwareFill,
+        long? firstSegmentFileOffset
     )
     {
         _segmentIds = segmentIds;
@@ -147,6 +159,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _estimatedSegmentSize = estimatedSegmentSize;
         _segmentSizes = new SegmentSizes(exactSegmentSizes, segmentIds.Length);
         _failFastOnFirstSegment = failFastOnFirstSegment;
+        _useContainerAwareFill = useContainerAwareFill;
+        _firstSegmentFileOffset = firstSegmentFileOffset;
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _readBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         _budget = inFlightArticleBudget ?? InFlightArticleBudget.Current;
@@ -386,7 +400,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 }
 
                 return ZeroFillSegment(
-                    "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                    "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
                     e.SegmentId,
                     segmentIndex,
                     e);
@@ -412,7 +426,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     }
 
                     return ZeroFillSegment(
-                        "Article {SegmentId} persistently corrupt while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                        "Article {SegmentId} persistently corrupt while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
                         segmentId,
                         segmentIndex,
                         e);
@@ -492,7 +506,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             if (_failFastOnFirstSegment && isFirstSegment) throw;
             return ZeroFillSegment(
-                "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
                 e.SegmentId,
                 segmentIndex,
                 e);
@@ -512,7 +526,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 if (_failFastOnFirstSegment && isFirstSegment) throw;
                 return ZeroFillSegment(
-                    "Article {SegmentId} persistently corrupt while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                    "Article {SegmentId} persistently corrupt while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
                     segmentId,
                     segmentIndex,
                     persistent);
@@ -701,10 +715,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     }
 
     /// <summary>
-    /// Substitutes zeros for a segment that could not be downloaded, but only for its
-    /// exact length. Every byte after this segment is positioned by how many bytes it
-    /// contributes, so a wrong length corrupts the rest of the file instead of just the
-    /// part that failed — better to fail the read and let the player retry or report it.
+    /// Substitutes a bounded gap for a segment that could not be downloaded, but only for
+    /// a known fill length. Every byte after this segment is positioned by how many bytes
+    /// it contributes, so a wrong length corrupts the rest of the file instead of just
+    /// the part that failed — better to fail the read and let the player retry or report it.
     /// </summary>
     private SegmentDownloadResult ZeroFillSegment(
         string messageTemplate,
@@ -723,12 +737,42 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return SegmentDownloadResult.ZeroFill(
-            new ZeroStream(fill),
+            CreateGapFillStream(fill, segmentIndex),
             messageTemplate,
             segmentId,
             fill,
             exception,
             GetPlannedSegmentBytes(segmentIndex));
+    }
+
+    private Stream CreateGapFillStream(long fill, int segmentIndex)
+    {
+        if (!_useContainerAwareFill)
+            return new ZeroStream(fill);
+
+        long? fileOffset = _firstSegmentFileOffset;
+        if (fileOffset is not null)
+        {
+            try
+            {
+                for (var i = 0; i < segmentIndex; i++)
+                {
+                    if (!_segmentSizes.TryGetExactSize(i, out var size))
+                    {
+                        fileOffset = null;
+                        break;
+                    }
+
+                    fileOffset = checked(fileOffset.Value + size);
+                }
+            }
+            catch (OverflowException)
+            {
+                fileOffset = null;
+            }
+        }
+
+        return ContainerAwareFillStream.Create(_fileName, fill, fileOffset);
     }
 
     private Exception CreateUnknownLengthFailure(string segmentId, int segmentIndex, Exception failure)
@@ -1020,7 +1064,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         result.Stream.Dispose();
         _cts.Cancel();
         ExceptionDispatchInfo.Capture(result.Failure!).Throw();
-        throw new InvalidOperationException("Unreachable after rethrowing a zero-fill failure.");
+        throw new InvalidOperationException("Unreachable after rethrowing a gap-fill failure.");
     }
 
     private void ThrowIfDisposed()

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -451,9 +451,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     throw;
                 }
 
-                return ZeroFillSegment(
-                    "Segment {SegmentId} unavailable after retries while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
-                    segmentId, segmentIndex, e);
+                throw CreateTransientSegmentFailure(segmentId, segmentIndex, e);
             }
             finally
             {
@@ -535,9 +533,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 return SegmentDownloadResult.Success(rescued, estimate);
 
             if (_failFastOnFirstSegment && isFirstSegment) throw;
-            return ZeroFillSegment(
-                "Segment {SegmentId} unavailable after retries while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
-                segmentId, segmentIndex, e);
+            throw CreateTransientSegmentFailure(segmentId, segmentIndex, e);
         }
         finally
         {
@@ -744,6 +740,16 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return failure.IsNonRetryableDownloadException()
             ? new NonRetryableDownloadException(message, failure)
             : new RetryableDownloadException(message, failure);
+    }
+
+    private RetryableDownloadException CreateTransientSegmentFailure(
+        string segmentId, int segmentIndex, Exception failure)
+    {
+        var message =
+            $"Segment {segmentIndex + 1} of {_segmentIds.Length} ({segmentId}) could not be downloaded " +
+            $"while reading \"{_fileName}\" after all retry attempts were exhausted. " +
+            "The client should retry this range request.";
+        return new RetryableDownloadException(message, failure);
     }
 
     private async Task<Stream> DrainSegmentAsync(

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -20,7 +20,8 @@ public class NzbFileStream(
     bool usePipelinedBodyRequests = true,
     string? fileName = null,
     string[][]? segmentFallbacks = null,
-    InFlightArticleBudget? inFlightArticleBudget = null
+    InFlightArticleBudget? inFlightArticleBudget = null,
+    bool useContainerAwareFill = false
 ) : FastReadOnlyStream
 {
     private const long MaximumForwardDrainBytes = 1024 * 1024;
@@ -172,7 +173,7 @@ public class NzbFileStream(
                     // The probe segment itself is missing — fall back to a
                     // synthetic uniform-size range so interpolation can still
                     // converge. The actual body read of this segment (if it
-                    // turns out to be the seek target) gets zero-filled by
+                    // turns out to be the seek target) gets a same-length gap from
                     // MultiSegmentStream.
                     Log.Warning(
                         "Seek probe hit missing article {SegmentId} (segment index {Index}) while reading {FileName}. Using estimated range.",
@@ -240,7 +241,7 @@ public class NzbFileStream(
         {
             // The segment that should contain this offset delivered fewer bytes than the
             // index says it holds. Returning the exhausted stream would answer the range
-            // request with zeros or nothing at all, so report the seek as impossible.
+                // request with placeholder bytes or nothing at all, so report the seek as impossible.
             await stream.DisposeAsync().ConfigureAwait(false);
             throw new SeekPositionNotFoundException(
                 $"Byte position {rangeStart} of \"{fileName ?? "unknown"}\" is past the data " +
@@ -330,8 +331,8 @@ public class NzbFileStream(
                 {
                     // The guess was right (headers matched) but the body read failed,
                     // e.g. a mid-stream NNTP read timeout. Fall back to the slow seek
-                    // path, whose MultiSegmentStream retries and zero-fills instead of
-                    // surfacing a hard error to the WebDAV client.
+                    // path, whose MultiSegmentStream applies the normal retry and
+                    // failure policy for the segment.
                     var displayName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
                     if (e.TryGetKnownErrorMessage(out var reason))
                     {
@@ -397,6 +398,7 @@ public class NzbFileStream(
         var exactSizes = ExactSegmentSizes is { } sizes
             ? sizes.AsMemory(firstSegmentIndex)
             : default;
+        var firstSegmentFileOffset = _segmentByteRanges?[firstSegmentIndex].StartInclusive;
 
         return MultiSegmentStream.Create(
             segmentIds,
@@ -409,7 +411,9 @@ public class NzbFileStream(
             fileName,
             segmentFallbacks: fallbacks,
             exactSegmentSizes: exactSizes,
-            inFlightArticleBudget: inFlightArticleBudget);
+            inFlightArticleBudget: inFlightArticleBudget,
+            useContainerAwareFill: useContainerAwareFill,
+            firstSegmentFileOffset: firstSegmentFileOffset);
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -241,7 +241,7 @@ public class NzbFileStream(
         {
             // The segment that should contain this offset delivered fewer bytes than the
             // index says it holds. Returning the exhausted stream would answer the range
-                // request with placeholder bytes or nothing at all, so report the seek as impossible.
+            // request with placeholder bytes or nothing at all, so report the seek as impossible.
             await stream.DisposeAsync().ConfigureAwait(false);
             throw new SeekPositionNotFoundException(
                 $"Byte position {rangeStart} of \"{fileName ?? "unknown"}\" is past the data " +

--- a/backend/Streams/SegmentSizes.cs
+++ b/backend/Streams/SegmentSizes.cs
@@ -2,7 +2,7 @@ namespace NzbWebDAV.Streams;
 
 /// <summary>
 /// Tracks how many bytes each segment of a file must contribute to the reconstructed
-/// stream. A segment that fails may only be replaced with zeros when its length is
+/// stream. A segment that fails may only be replaced with gap bytes when its length is
 /// known precisely: any other length shifts every following byte in the file, which
 /// corrupts playback far beyond the segment that actually failed.
 /// </summary>

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -16,6 +16,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly INntpClient _usenetClient;
     private readonly SegmentSizes _segmentSizes;
     private readonly string _fileName;
+    private readonly bool _useContainerAwareFill;
+    private readonly long? _firstSegmentFileOffset;
     private Stream? _stream;
     private int _currentIndex;
     private int _openSegmentIndex = -1;
@@ -31,13 +33,17 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         long estimatedSegmentSize,
         string? fileName = null,
         string[][]? segmentFallbacks = null,
-        ReadOnlyMemory<long> exactSegmentSizes = default)
+        ReadOnlyMemory<long> exactSegmentSizes = default,
+        bool useContainerAwareFill = false,
+        long? firstSegmentFileOffset = null)
     {
         _segmentIds = segmentIds;
         _segmentFallbacks = segmentFallbacks;
         _usenetClient = usenetClient;
         _segmentSizes = new SegmentSizes(exactSegmentSizes, segmentIds.Length);
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
+        _useContainerAwareFill = useContainerAwareFill;
+        _firstSegmentFileOffset = firstSegmentFileOffset;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -96,7 +102,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 
                         _consecutiveZeroFills++;
                         ZeroFillLogLimiter.Write(
-                            "Article {SegmentId} missing on all providers while reading {FileName}. Zero-filling {Bytes} bytes to keep playback alive.",
+                            "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
                             e.SegmentId,
                             _fileName,
                             fill,
@@ -106,7 +112,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                         if (_consecutiveZeroFills >= MaxConsecutiveZeroFills)
                             throw;
 
-                        _stream = new ZeroStream(fill);
+                        _stream = CreateGapFillStream(fill, segmentIndex);
                     }
                 }
             }
@@ -148,6 +154,36 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 
             await FinishOpenSegmentAsync().ConfigureAwait(false);
         }
+    }
+
+    private Stream CreateGapFillStream(long fill, int segmentIndex)
+    {
+        if (!_useContainerAwareFill)
+            return new ZeroStream(fill);
+
+        long? fileOffset = _firstSegmentFileOffset;
+        if (fileOffset is not null)
+        {
+            try
+            {
+                for (var i = 0; i < segmentIndex; i++)
+                {
+                    if (!_segmentSizes.TryGetExactSize(i, out var size))
+                    {
+                        fileOffset = null;
+                        break;
+                    }
+
+                    fileOffset = checked(fileOffset.Value + size);
+                }
+            }
+            catch (OverflowException)
+            {
+                fileOffset = null;
+            }
+        }
+
+        return ContainerAwareFillStream.Create(_fileName, fill, fileOffset);
     }
 
     private bool TryGetRemainingExactBytes(out long remaining)

--- a/backend/Streams/ZeroFillLogLimiter.cs
+++ b/backend/Streams/ZeroFillLogLimiter.cs
@@ -5,7 +5,7 @@ using Serilog;
 namespace NzbWebDAV.Streams;
 
 /// <summary>
-/// Coalesces zero-fill warnings by file so a release with many unavailable
+/// Coalesces gap-fill warnings by file so a release with many unavailable
 /// articles cannot flood the application log.
 /// </summary>
 internal static class ZeroFillLogLimiter
@@ -53,7 +53,7 @@ internal static class ZeroFillLogLimiter
             if (suppressed > 0)
             {
                 Log.Warning(
-                    "Suppressed {SuppressedCount} additional zero-fill warnings for {FileName} in the previous 60 seconds.",
+                    "Suppressed {SuppressedCount} additional gap-fill warnings for {FileName} in the previous 60 seconds.",
                     suppressed,
                     fileName);
             }

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -45,7 +45,8 @@ public class DatabaseStoreNzbFile(
             configManager.IsPipelinedBodyRequestsEnabled(),
             davNzbFile.Path,
             nzbFile.SegmentFallbackIds,
-            inFlightArticleBudget
+            inFlightArticleBudget,
+            useContainerAwareFill: configManager.IsContainerAwareFillEnabled()
         );
     }
 }

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -66,3 +66,26 @@ re-probing the same provider for the same article until the TTL expires. Transie
 | Miss-cache max entries | `usenet.article-miss-cache-max-entries` | `10000` | Cap before oldest entries are evicted (clamped 100–1000000) |
 
 The cache clears automatically when Usenet providers are reconfigured.
+
+## Experimental container-aware gap fill [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+When a confirmed-missing or persistently corrupt article cannot be recovered from any
+provider or fallback Message-ID, NzbDAV normally emits the same number of zero bytes to
+keep every later file offset correct. Enable **Container-aware gap fill** to emit
+format-native discard markers instead for supported direct files:
+
+- Matroska (`.mkv`, `.mk3d`, `.webm`): dense EBML Void elements.
+- MPEG-TS (`.ts`, `.m2ts`, `.mts`): packet-aligned null packets when exact segment
+  offsets are available.
+
+This may help compatible players resynchronize sooner, but it cannot restore the missing
+audio or video data. MP4/MOV and archive-backed files retain zero-fill because inserting
+container boxes into media or compressed payload would not be valid.
+
+The setting is experimental and defaults to off. It does not affect transient transport
+failures: after their retries are exhausted, the current HTTP response fails so the player
+can request the range again.
+
+| Control | Config key | Default |
+|---------|------------|---------|
+| Container-aware gap fill | `usenet.container-aware-fill` | off |

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -74,13 +74,12 @@ provider or fallback Message-ID, NzbDAV normally emits the same number of zero b
 keep every later file offset correct. Enable **Container-aware gap fill** to emit
 format-native discard markers instead for supported direct files:
 
-- Matroska (`.mkv`, `.mk3d`, `.webm`): dense EBML Void elements.
 - MPEG-TS (`.ts`, `.m2ts`, `.mts`): packet-aligned null packets when exact segment
   offsets are available.
 
 This may help compatible players resynchronize sooner, but it cannot restore the missing
-audio or video data. MP4/MOV and archive-backed files retain zero-fill because inserting
-container boxes into media or compressed payload would not be valid.
+audio or video data. Matroska, MP4/MOV, and archive-backed files retain zero-fill because
+arbitrary article boundaries do not provide safe container-element boundaries.
 
 The setting is experimental and defaults to off. It does not affect transient transport
 failures: after their retries are exhausted, the current HTTP response fails so the player

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -71,6 +71,7 @@ const defaultConfig = {
     "usenet.cascade.retry-primary-on-miss": "true",
     "usenet.article-miss-cache-ttl-seconds": "300",
     "usenet.article-miss-cache-max-entries": "10000",
+    "usenet.container-aware-fill": "false",
     "webdav.user": "admin",
     "webdav.pass": "",
     "webdav.show-hidden-files": "false",

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -847,6 +847,36 @@ export function UsenetSettings({ config, setNewConfig, persistConfigPatch }: Use
             </section>
             </ManagedSetting>
 
+            <ManagedSetting configKey="usenet.container-aware-fill">
+                <section className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <h2 className="text-sm font-semibold text-base-content">Container-aware gap fill</h2>
+                                <Badge className="badge-warning badge-outline badge-xs">Experimental</Badge>
+                            </div>
+                            <p className="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/60">
+                                For permanently missing data in direct MKV/WebM and MPEG-TS files, emit native discard
+                                markers instead of raw zeros so compatible players can resynchronize sooner. Archive-backed
+                                files and unsupported containers keep the existing zero-fill behavior.
+                            </p>
+                        </div>
+                        <Tooltip content="Experimental. Applies only after all missing/corrupt article fallbacks are exhausted; transient transport failures still abort so the player can retry the range.">
+                            <Toggle
+                                id="container-aware-fill"
+                                className="shrink-0 cursor-pointer gap-2 p-0"
+                                checked={config["usenet.container-aware-fill"] === "true"}
+                                onChange={(e) => setNewConfig({
+                                    ...config,
+                                    "usenet.container-aware-fill": e.target.checked ? "true" : "false",
+                                })}
+                                label={<span className="text-sm text-base-content">Enable</span>}
+                            />
+                        </Tooltip>
+                    </div>
+                </section>
+            </ManagedSetting>
+
             <ManagedSetting configKey="usenet.providers">
             <section className="space-y-3">
                 <div className="flex items-end justify-between gap-4">
@@ -2248,6 +2278,7 @@ export function isUsenetSettingsUpdated(config: Record<string, string>, newConfi
         || config["usenet.cascade.retry-primary-on-miss"] !== newConfig["usenet.cascade.retry-primary-on-miss"]
         || config["usenet.article-miss-cache-ttl-seconds"] !== newConfig["usenet.article-miss-cache-ttl-seconds"]
         || config["usenet.article-miss-cache-max-entries"] !== newConfig["usenet.article-miss-cache-max-entries"]
+        || config["usenet.container-aware-fill"] !== newConfig["usenet.container-aware-fill"]
 }
 
 export function isPositiveInteger(value: string) {

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -856,9 +856,9 @@ export function UsenetSettings({ config, setNewConfig, persistConfigPatch }: Use
                                 <Badge className="badge-warning badge-outline badge-xs">Experimental</Badge>
                             </div>
                             <p className="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/60">
-                                For permanently missing data in direct MKV/WebM and MPEG-TS files, emit native discard
-                                markers instead of raw zeros so compatible players can resynchronize sooner. Archive-backed
-                                files and unsupported containers keep the existing zero-fill behavior.
+                                For permanently missing data in direct MPEG-TS files, emit packet-aligned null packets
+                                instead of raw zeros so compatible players can resynchronize sooner. Archive-backed files
+                                and unsupported containers keep the existing zero-fill behavior.
                             </p>
                         </div>
                         <Tooltip content="Experimental. Applies only after all missing/corrupt article fallbacks are exhausted; transient transport failures still abort so the player can retry the range.">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4327,9 +4327,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/tests/NzbWebDAV.Tests/Config/ContainerAwareFillConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ContainerAwareFillConfigTests.cs
@@ -1,0 +1,45 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class ContainerAwareFillConfigTests
+{
+    [Fact]
+    public void UnsetValue_DefaultsToDisabled()
+    {
+        var config = new ConfigManager();
+
+        Assert.False(config.IsContainerAwareFillEnabled());
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void ConfiguredValue_IsValidatedAndResolved(string configured, bool expected)
+    {
+        var item = new ConfigItem
+        {
+            ConfigName = ConfigKeys.UsenetContainerAwareFill,
+            ConfigValue = configured,
+        };
+        ConfigManager.ValidateConfigItems([item]);
+        var config = new ConfigManager();
+        config.UpdateValues([item]);
+
+        Assert.Equal(expected, config.IsContainerAwareFillEnabled());
+    }
+
+    [Fact]
+    public void InvalidValue_IsRejected()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetContainerAwareFill,
+                ConfigValue = "sometimes",
+            },
+        ]));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/ContainerAwareFillStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/ContainerAwareFillStreamTests.cs
@@ -1,0 +1,79 @@
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public sealed class ContainerAwareFillStreamTests
+{
+    [Theory]
+    [InlineData(6, new byte[] { 0xEC, 0x80, 0xEC, 0x80, 0xEC, 0x80 })]
+    [InlineData(7, new byte[] { 0xEC, 0x81, 0x00, 0xEC, 0x80, 0xEC, 0x80 })]
+    public async Task MatroskaFill_TilesExactLengthWithVoidElements(long length, byte[] expected)
+    {
+        await using var stream = ContainerAwareFillStream.Create("movie.mkv", length, fileOffset: null);
+
+        var output = await ReadWithSmallBufferAsync(stream);
+
+        Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task TransportStreamFill_EmitsOnlyCompleteAlignedNullPackets()
+    {
+        await using var stream = ContainerAwareFillStream.Create("video.ts", 400, fileOffset: 10);
+
+        var output = await ReadWithSmallBufferAsync(stream);
+
+        Assert.All(output[..178], value => Assert.Equal(0xFF, value));
+        Assert.Equal(new byte[] { 0x47, 0x1F, 0xFF, 0x10 }, output[178..182]);
+        Assert.All(output[182..366], value => Assert.Equal(0xFF, value));
+        Assert.All(output[366..], value => Assert.Equal(0xFF, value));
+    }
+
+    [Fact]
+    public async Task M2tsFill_PreservesArrivalPrefixBeforeNullPacket()
+    {
+        await using var stream = ContainerAwareFillStream.Create("video.m2ts", 384, fileOffset: 0);
+
+        var output = await ReadWithSmallBufferAsync(stream);
+
+        Assert.Equal(new byte[4], output[..4]);
+        Assert.Equal(new byte[] { 0x47, 0x1F, 0xFF, 0x10 }, output[4..8]);
+        Assert.Equal(new byte[4], output[192..196]);
+        Assert.Equal(new byte[] { 0x47, 0x1F, 0xFF, 0x10 }, output[196..200]);
+    }
+
+    [Theory]
+    [InlineData("movie.mp4", 16)]
+    [InlineData("movie.avi", 16)]
+    [InlineData("movie.mkv", 1)]
+    public async Task UnsupportedOrTinyFill_RetainsZeroFill(string fileName, long length)
+    {
+        await using var stream = ContainerAwareFillStream.Create(fileName, length, fileOffset: 0);
+
+        var output = await ReadWithSmallBufferAsync(stream);
+
+        Assert.Equal(new byte[(int)length], output);
+    }
+
+    [Fact]
+    public async Task TransportStreamWithoutExactOffset_RetainsZeroFill()
+    {
+        await using var stream = ContainerAwareFillStream.Create("video.ts", 188, fileOffset: null);
+
+        var output = await ReadWithSmallBufferAsync(stream);
+
+        Assert.Equal(new byte[188], output);
+    }
+
+    private static async Task<byte[]> ReadWithSmallBufferAsync(Stream stream)
+    {
+        using var output = new MemoryStream();
+        var buffer = new byte[3];
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer);
+            if (read == 0) return output.ToArray();
+            await output.WriteAsync(buffer.AsMemory(0, read));
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/ContainerAwareFillStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/ContainerAwareFillStreamTests.cs
@@ -11,10 +11,10 @@ public sealed class ContainerAwareFillStreamTests
 
         var output = await ReadWithSmallBufferAsync(stream);
 
-        Assert.All(output[..178], value => Assert.Equal(0xFF, value));
+        Assert.All(output[..178], value => Assert.Equal(0x00, value));
         Assert.Equal(new byte[] { 0x47, 0x1F, 0xFF, 0x10 }, output[178..182]);
         Assert.All(output[182..366], value => Assert.Equal(0xFF, value));
-        Assert.All(output[366..], value => Assert.Equal(0xFF, value));
+        Assert.All(output[366..], value => Assert.Equal(0x00, value));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/ContainerAwareFillStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/ContainerAwareFillStreamTests.cs
@@ -4,18 +4,6 @@ namespace NzbWebDAV.Tests.Streams;
 
 public sealed class ContainerAwareFillStreamTests
 {
-    [Theory]
-    [InlineData(6, new byte[] { 0xEC, 0x80, 0xEC, 0x80, 0xEC, 0x80 })]
-    [InlineData(7, new byte[] { 0xEC, 0x81, 0x00, 0xEC, 0x80, 0xEC, 0x80 })]
-    public async Task MatroskaFill_TilesExactLengthWithVoidElements(long length, byte[] expected)
-    {
-        await using var stream = ContainerAwareFillStream.Create("movie.mkv", length, fileOffset: null);
-
-        var output = await ReadWithSmallBufferAsync(stream);
-
-        Assert.Equal(expected, output);
-    }
-
     [Fact]
     public async Task TransportStreamFill_EmitsOnlyCompleteAlignedNullPackets()
     {
@@ -45,8 +33,8 @@ public sealed class ContainerAwareFillStreamTests
     [Theory]
     [InlineData("movie.mp4", 16)]
     [InlineData("movie.avi", 16)]
-    [InlineData("movie.mkv", 1)]
-    public async Task UnsupportedOrTinyFill_RetainsZeroFill(string fileName, long length)
+    [InlineData("movie.mkv", 16)]
+    public async Task UnsupportedFill_RetainsZeroFill(string fileName, long length)
     {
         await using var stream = ContainerAwareFillStream.Create(fileName, length, fileOffset: 0);
 

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -169,7 +169,7 @@ public class NzbFileStreamTests
                 e.Level == LogEventLevel.Warning &&
                 e.RenderMessage().Contains(fileName, StringComparison.Ordinal) &&
                 e.RenderMessage().Contains(segmentId, StringComparison.Ordinal) &&
-                e.RenderMessage().Contains("Zero-filling", StringComparison.Ordinal));
+                e.RenderMessage().Contains("Filling the 5-byte gap", StringComparison.Ordinal));
         }
         finally
         {
@@ -210,11 +210,11 @@ public class NzbFileStreamTests
             Assert.Equal(5, await stream.ReadAsync(buffer));
             Assert.Equal(5, await stream.ReadAsync(buffer));
 
-            var zeroFillWarnings = sink.Events.Count(e =>
+            var gapFillWarnings = sink.Events.Count(e =>
                 e.Level == LogEventLevel.Warning &&
                 e.RenderMessage().Contains(fileName, StringComparison.Ordinal) &&
-                e.RenderMessage().Contains("Zero-filling", StringComparison.Ordinal));
-            Assert.Equal(1, zeroFillWarnings);
+                e.RenderMessage().Contains("Filling the 5-byte gap", StringComparison.Ordinal));
+            Assert.Equal(1, gapFillWarnings);
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -102,6 +102,53 @@ public class NzbFileStreamTests
         Assert.Equal(offset + read, stream.Position);
     }
 
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(4, true)]
+    public async Task SeekToMissingTsSegment_UsesFileAlignedNullPacket(
+        int articleBufferSize,
+        bool usePipelinedBodyRequests)
+    {
+        string[] segmentIds = ["one", "two", "three"];
+        var firstPacket = Enumerable.Repeat((byte)'a', 188).ToArray();
+        var thirdPacket = Enumerable.Repeat((byte)'c', 188).ToArray();
+        var segmentRanges = new[]
+        {
+            new LongRange(0, 188),
+            new LongRange(188, 376),
+            new LongRange(376, 564),
+        };
+        var rangesById = segmentIds
+            .Zip(segmentRanges)
+            .ToDictionary(pair => pair.First, pair => pair.Second);
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["one"] = firstPacket,
+                ["three"] = thirdPacket,
+            },
+            useCachedYencStreams: true,
+            segmentRanges: rangesById);
+        await using var stream = new NzbFileStream(
+            segmentIds,
+            564,
+            client,
+            articleBufferSize,
+            segmentRanges,
+            usePipelinedBodyRequests,
+            fileName: "movie.ts",
+            useContainerAwareFill: true);
+        stream.Seek(188, SeekOrigin.Begin);
+        var buffer = new byte[188];
+
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true);
+
+        Assert.Equal(188, read);
+        Assert.Equal(new byte[] { 0x47, 0x1F, 0xFF, 0x10 }, buffer[..4]);
+        Assert.All(buffer[4..], value => Assert.Equal(0xFF, value));
+        Assert.Equal(376, stream.Position);
+    }
+
     [Fact]
     public void Seek_RejectsPositionsOutsideFile()
     {

--- a/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
@@ -109,33 +109,36 @@ public class SegmentAlignmentTests
     }
 
     [Fact]
-    public async Task ContainerAwareFill_UsesMatroskaVoidWithoutChangingFollowingOffsets()
+    public async Task ContainerAwareFill_UsesAlignedTsNullPacketWithoutChangingFollowingOffsets()
     {
+        var firstPacket = Enumerable.Repeat((byte)'a', 188).ToArray();
+        var thirdPacket = Enumerable.Repeat((byte)'c', 188).ToArray();
         var client = CreateClient(new Dictionary<string, byte[]>
         {
-            ["one"] = First,
-            ["three"] = Third,
+            ["one"] = firstPacket,
+            ["three"] = thirdPacket,
         });
 
         await using var stream = MultiSegmentStream.Create(
             new[] { "one", "two", "three" }.AsMemory(),
             client,
             articleBufferSize: 4,
-            estimatedSegmentSize: 6,
+            estimatedSegmentSize: 188,
             failFastOnFirstSegment: false,
             usePipelinedBodyRequests: true,
             cancellationToken: CancellationToken.None,
-            fileName: "movie.mkv",
-            exactSegmentSizes: new long[] { 5, 7, 5 },
+            fileName: "movie.ts",
+            exactSegmentSizes: new long[] { 188, 188, 188 },
             useContainerAwareFill: true,
             firstSegmentFileOffset: 0);
 
         var output = await ReadAllAsync(stream);
 
-        Assert.Equal(17, output.Length);
-        Assert.Equal("aaaaa", Encoding.ASCII.GetString(output, 0, 5));
-        Assert.Equal(new byte[] { 0xEC, 0x81, 0x00, 0xEC, 0x80, 0xEC, 0x80 }, output[5..12]);
-        Assert.Equal("ccccc", Encoding.ASCII.GetString(output, 12, 5));
+        Assert.Equal(564, output.Length);
+        Assert.Equal(firstPacket, output[..188]);
+        Assert.Equal(new byte[] { 0x47, 0x1F, 0xFF, 0x10 }, output[188..192]);
+        Assert.All(output[192..376], value => Assert.Equal(0xFF, value));
+        Assert.Equal(thirdPacket, output[376..]);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
@@ -46,7 +46,7 @@ public class SegmentAlignmentTests
         await using var stream = CreateStream(client, exactSizes: [5, 7, 5],
             usePipelinedBodyRequests: usePipelinedBodyRequests);
 
-        var failure = await Assert.ThrowsAsync<RetryableDownloadException>(
+        var failure = await Assert.ThrowsAsync<TransientSegmentExhaustionException>(
             () => ReadAllAsync(stream));
 
         Assert.Contains("two", failure.Message, StringComparison.Ordinal);
@@ -106,6 +106,35 @@ public class SegmentAlignmentTests
         Assert.Equal(15, output.Length);
         Assert.Equal(new byte[5], output[5..10]);
         Assert.Equal("ccccc", Encoding.ASCII.GetString(output, 10, 5));
+    }
+
+    [Fact]
+    public async Task BatchFailure_RescueConfirmsMissing_GapFillsInsteadOfThrowing()
+    {
+        var client = CreateClient(new Dictionary<string, byte[]>
+        {
+            ["one"] = First,
+            ["three"] = Third,
+        });
+        client.BatchFailures["two"] = 1;
+
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "one", "two", "three" }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: 6,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: true,
+            cancellationToken: CancellationToken.None,
+            fileName: "alignment.bin",
+            exactSegmentSizes: new long[] { 5, 7, 5 });
+
+        var output = await ReadAllAsync(stream);
+
+        Assert.Equal(17, output.Length);
+        Assert.Equal("aaaaa", Encoding.ASCII.GetString(output, 0, 5));
+        Assert.Equal(new byte[7], output[5..12]);
+        Assert.Equal("ccccc", Encoding.ASCII.GetString(output, 12, 5));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
@@ -34,21 +34,23 @@ public class SegmentAlignmentTests
         Assert.Contains("two", client.IndividualRequests);
     }
 
-    [Fact]
-    public async Task ExhaustedRetries_ZeroFillExactlyOneSegment_KeepingFollowingOffsets()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ExhaustedRetries_ThrowsRetryableDownloadException(bool usePipelinedBodyRequests)
     {
         var client = CreateClient();
         client.BatchFailures["two"] = int.MaxValue;
         client.IndividualFailures["two"] = int.MaxValue;
 
-        await using var stream = CreateStream(client, exactSizes: [5, 7, 5]);
-        var output = await ReadAllAsync(stream);
+        await using var stream = CreateStream(client, exactSizes: [5, 7, 5],
+            usePipelinedBodyRequests: usePipelinedBodyRequests);
 
-        // The middle segment is 7 bytes, not the 5.66-byte average of this file.
-        Assert.Equal(17, output.Length);
-        Assert.Equal("aaaaa", Encoding.ASCII.GetString(output, 0, 5));
-        Assert.Equal(new byte[7], output[5..12]);
-        Assert.Equal("ccccc", Encoding.ASCII.GetString(output, 12, 5));
+        var failure = await Assert.ThrowsAsync<RetryableDownloadException>(
+            () => ReadAllAsync(stream));
+
+        Assert.Contains("two", failure.Message, StringComparison.Ordinal);
+        Assert.IsType<TimeoutException>(failure.InnerException);
     }
 
     [Fact]
@@ -271,14 +273,15 @@ public class SegmentAlignmentTests
         Assert.Equal(readBudget, total);
     }
 
-    private static Stream CreateStream(ScriptedNntpClient client, long[] exactSizes) =>
+    private static Stream CreateStream(
+        ScriptedNntpClient client, long[] exactSizes, bool usePipelinedBodyRequests = true) =>
         MultiSegmentStream.Create(
             new[] { "one", "two", "three" }.AsMemory(),
             client,
             articleBufferSize: 4,
             estimatedSegmentSize: 6,
             failFastOnFirstSegment: false,
-            usePipelinedBodyRequests: true,
+            usePipelinedBodyRequests: usePipelinedBodyRequests,
             cancellationToken: CancellationToken.None,
             fileName: "alignment.bin",
             exactSegmentSizes: exactSizes);

--- a/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
@@ -109,6 +109,36 @@ public class SegmentAlignmentTests
     }
 
     [Fact]
+    public async Task ContainerAwareFill_UsesMatroskaVoidWithoutChangingFollowingOffsets()
+    {
+        var client = CreateClient(new Dictionary<string, byte[]>
+        {
+            ["one"] = First,
+            ["three"] = Third,
+        });
+
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "one", "two", "three" }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: 6,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: true,
+            cancellationToken: CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { 5, 7, 5 },
+            useContainerAwareFill: true,
+            firstSegmentFileOffset: 0);
+
+        var output = await ReadAllAsync(stream);
+
+        Assert.Equal(17, output.Length);
+        Assert.Equal("aaaaa", Encoding.ASCII.GetString(output, 0, 5));
+        Assert.Equal(new byte[] { 0xEC, 0x81, 0x00, 0xEC, 0x80, 0xEC, 0x80 }, output[5..12]);
+        Assert.Equal("ccccc", Encoding.ASCII.GetString(output, 12, 5));
+    }
+
+    [Fact]
     public async Task ResponseForAnotherSegment_IsRejectedAndRefetched()
     {
         var client = CreateClient();


### PR DESCRIPTION
## Summary

- Abort the active response with `RetryableDownloadException` when transient segment retries are exhausted, allowing the player to request the range again instead of receiving silent zero-byte corruption.
- Keep same-length gap filling for permanently missing or corrupt articles, with a new default-off **Experimental** setting that emits aligned null packets for direct MPEG-TS files with exact segment offsets.
- Preserve raw zero-fill for unsupported formats, partial TS packet boundaries, files without exact TS offsets, and archive-backed media where inserting container markers before extraction/decryption would be invalid.
- Expose `usenet.container-aware-fill` in the Usenet settings UI and environment configuration, with user documentation and validation.

## Test plan

- [x] Backend tests: 1,581 passed, 3 platform-specific skipped
- [x] Frontend typecheck
- [x] Frontend production build
- [x] Frontend tests: 356 passed
- [x] Strict documentation build
- [x] Focused coverage for buffered/non-pipelined transient failures, TS/M2TS packet alignment, nonzero range seeks, offset preservation, fallback-to-zero behavior, and config validation
- [ ] Manual: induce a transient provider timeout and confirm the player retries without A/V drift
- [ ] Manual: compare supported players with experimental gap fill off/on against a permanently missing TS segment