### PR TITLE
fix(ui): stop false update notices for current :dev images

### DIFF
--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -140,8 +140,8 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
                 >
                   <Icon name="arrow_circle_up" className="!text-[18px]" />
                   {updateAvailable.commitsBehind === 1
-                    ? "1 new commit on main"
-                    : `${updateAvailable.commitsBehind} new commits on main`}
+                    ? `1 new commit on ${updateAvailable.trackRef}`
+                    : `${updateAvailable.commitsBehind} new commits on ${updateAvailable.trackRef}`}
                 </a>
               </li>
             )}

--- a/frontend/app/utils/update-check.server.test.ts
+++ b/frontend/app/utils/update-check.server.test.ts
@@ -227,6 +227,7 @@ describe("checkForUpdate", () => {
       kind: "dev",
       commitsBehind: 2,
       compareUrl: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+      trackRef: "main",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -285,6 +286,7 @@ describe("checkForUpdate", () => {
       kind: "dev",
       commitsBehind: 2,
       compareUrl: "https://github.com/nzbdav/nzbdav/compare/e0eef520...main",
+      trackRef: "main",
     });
     expect(getBuildCommitMock).toHaveBeenCalledWith({ version: "main-e0eef520" });
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/compare/e0eef520...main");
@@ -297,27 +299,43 @@ describe("checkForUpdate (dev builds)", () => {
   beforeEach(() => {
     getBuildCommitMock.mockResolvedValue({
       sha: buildSha,
-      branch: "main",
+      branch: "dev",
       source: "env",
     });
   });
 
-  it("returns commits behind for dev builds when main is ahead", async () => {
+  it("returns commits behind for :dev images when the dev tag is ahead", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         status: "ahead",
         ahead_by: 3,
-        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
       }),
     );
 
     await expect(checkForUpdate("dev-e0eef52")).resolves.toEqual({
       kind: "dev",
       commitsBehind: 3,
-      compareUrl: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+      compareUrl: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
+      trackRef: "dev",
     });
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
-      `/compare/${encodeURIComponent(buildSha)}...main`,
+      `/compare/${encodeURIComponent(buildSha)}...dev`,
+    );
+  });
+
+  it("returns null when the running :dev image matches the dev tag tip", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: "identical",
+        ahead_by: 0,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
+      }),
+    );
+
+    await expect(checkForUpdate("dev-e0eef52")).resolves.toBeNull();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      `/compare/${encodeURIComponent(buildSha)}...dev`,
     );
   });
 
@@ -326,7 +344,7 @@ describe("checkForUpdate (dev builds)", () => {
       jsonResponse({
         status: "identical",
         ahead_by: 0,
-        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
       }),
     );
 
@@ -339,7 +357,7 @@ describe("checkForUpdate (dev builds)", () => {
         status: "behind",
         ahead_by: 0,
         behind_by: 2,
-        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
       }),
     );
 
@@ -352,7 +370,7 @@ describe("checkForUpdate (dev builds)", () => {
         status: "diverged",
         ahead_by: 1,
         behind_by: 1,
-        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
       }),
     );
 
@@ -369,7 +387,7 @@ describe("checkForUpdate (dev builds)", () => {
       jsonResponse({
         status: "identical",
         ahead_by: 0,
-        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
       }),
     );
 
@@ -395,13 +413,14 @@ describe("checkForUpdate (dev builds)", () => {
         jsonResponse({
           status: "ahead",
           ahead_by: 2,
-          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
         }),
       );
 
     await expect(checkForUpdate("pre-42")).resolves.toBeNull();
     await expect(checkForUpdate("pre-42")).resolves.toMatchObject({
       commitsBehind: 2,
+      trackRef: "dev",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -414,13 +433,14 @@ describe("checkForUpdate (dev builds)", () => {
         jsonResponse({
           status: "ahead",
           ahead_by: 1,
-          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
         }),
       );
 
     await expect(checkForUpdate("pre-42")).resolves.toBeNull();
     await expect(checkForUpdate("pre-42")).resolves.toMatchObject({
       commitsBehind: 1,
+      trackRef: "dev",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -432,14 +452,14 @@ describe("checkForUpdate (dev builds)", () => {
         jsonResponse({
           status: "identical",
           ahead_by: 0,
-          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
         }),
       )
       .mockResolvedValueOnce(
         jsonResponse({
           status: "ahead",
           ahead_by: 4,
-          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
         }),
       );
 
@@ -449,6 +469,7 @@ describe("checkForUpdate (dev builds)", () => {
 
     await expect(checkForUpdate("pre-42")).resolves.toMatchObject({
       commitsBehind: 4,
+      trackRef: "dev",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -464,7 +485,8 @@ describe("checkForUpdate (dev builds)", () => {
     await expect(checkForUpdate("pre-42")).resolves.toEqual({
       kind: "dev",
       commitsBehind: 1,
-      compareUrl: "https://github.com/nzbdav/nzbdav/commits/main",
+      compareUrl: "https://github.com/nzbdav/nzbdav/commits/dev",
+      trackRef: "dev",
     });
   });
 
@@ -473,7 +495,7 @@ describe("checkForUpdate (dev builds)", () => {
       jsonResponse({
         status: "ahead",
         ahead_by: 2,
-        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+        html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
       }),
     );
 
@@ -489,25 +511,27 @@ describe("checkForUpdate (dev builds)", () => {
         jsonResponse({
           status: "ahead",
           ahead_by: 2,
-          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
         }),
       )
       .mockResolvedValueOnce(
         jsonResponse({
           status: "ahead",
           ahead_by: 5,
-          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...main`,
+          html_url: `https://github.com/nzbdav/nzbdav/compare/${buildSha}...dev`,
         }),
       );
 
     await expect(checkForUpdate("pre-42")).resolves.toMatchObject({
       commitsBehind: 2,
+      trackRef: "dev",
     });
 
     vi.advanceTimersByTime(60 * 60 * 1000);
 
     await expect(checkForUpdate("pre-42")).resolves.toMatchObject({
       commitsBehind: 5,
+      trackRef: "dev",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/frontend/app/utils/update-check.server.ts
+++ b/frontend/app/utils/update-check.server.ts
@@ -23,7 +23,7 @@ const GITHUB_COMPARE_URL_PREFIX =
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const FETCH_TIMEOUT_MS = 5_000;
 const RELEASES_FALLBACK_URL = "https://github.com/nzbdav/nzbdav/releases";
-const COMPARE_FALLBACK_URL = "https://github.com/nzbdav/nzbdav/commits/main";
+const COMMITS_URL_PREFIX = "https://github.com/nzbdav/nzbdav/commits/";
 
 type CachedRelease = {
   latestVersion: string;
@@ -34,8 +34,13 @@ type CachedRelease = {
 type CachedCompare = {
   commitsBehind: number;
   compareUrl: string;
+  trackRef: string;
   checkedAt: number;
 };
+
+function compareFallbackUrl(trackRef: string): string {
+  return `${COMMITS_URL_PREFIX}${encodeURIComponent(trackRef)}`;
+}
 
 let releaseCache: CachedRelease | null = null;
 let releaseInFlight: Promise<CachedRelease | null> | null = null;
@@ -124,19 +129,21 @@ async function getCachedLatestRelease(): Promise<CachedRelease | null> {
  */
 async function fetchCompare(
   sha: string,
-  branch: string,
+  trackRef: string,
 ): Promise<CachedCompare | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const fallbackUrl = compareFallbackUrl(trackRef);
 
   const noUpdate: CachedCompare = {
     commitsBehind: 0,
-    compareUrl: COMPARE_FALLBACK_URL,
+    compareUrl: fallbackUrl,
+    trackRef,
     checkedAt: Date.now(),
   };
 
   try {
-    const url = `${GITHUB_COMPARE_URL_PREFIX}${encodeURIComponent(sha)}...${encodeURIComponent(branch)}`;
+    const url = `${GITHUB_COMPARE_URL_PREFIX}${encodeURIComponent(sha)}...${encodeURIComponent(trackRef)}`;
     const response = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -156,7 +163,7 @@ async function fetchCompare(
       html_url?: string;
     };
 
-    // We only notify when main is ahead of the running commit.
+    // We only notify when the track ref is ahead of the running commit.
     if (data.status !== "ahead") return noUpdate;
 
     const aheadBy = data.ahead_by ?? 0;
@@ -164,7 +171,8 @@ async function fetchCompare(
 
     return {
       commitsBehind: aheadBy,
-      compareUrl: data.html_url?.trim() || COMPARE_FALLBACK_URL,
+      compareUrl: data.html_url?.trim() || fallbackUrl,
+      trackRef,
       checkedAt: Date.now(),
     };
   } catch {
@@ -232,12 +240,14 @@ async function checkForDevUpdate(
     kind: "dev",
     commitsBehind: compare.commitsBehind,
     compareUrl: compare.compareUrl,
+    trackRef: build.branch,
   };
 }
 
 /**
  * Returns update metadata when a newer stable GitHub release exists than
- * `currentVersion`, or when a non-release build is behind commits on `main`.
+ * `currentVersion`, or when a non-release build is behind commits on its
+ * track ref (`main` for source/`main-<sha>` builds, `dev` for `:dev` images).
  * Failures yield null.
  */
 export async function checkForUpdate(

--- a/frontend/app/utils/update-check.ts
+++ b/frontend/app/utils/update-check.ts
@@ -8,6 +8,8 @@ export type DevUpdateAvailable = {
   kind: "dev";
   commitsBehind: number;
   compareUrl: string;
+  /** GitHub ref compared against (e.g. `main` or `dev`). */
+  trackRef: string;
 };
 
 export type UpdateAvailable = ReleaseUpdateAvailable | DevUpdateAvailable;

--- a/frontend/app/utils/version.server.test.ts
+++ b/frontend/app/utils/version.server.test.ts
@@ -2,14 +2,16 @@ import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getBuildCommit, parseBuildCommitFromVersion } from "./version.server";
+import { getBuildCommit, parseBuildCommitFromVersion, resolveTrackRef } from "./version.server";
 
 describe("getBuildCommit", () => {
   const originalEnv = process.env.NZBDAV_COMMIT_SHA;
+  const originalVersion = process.env.NZBDAV_VERSION;
   let tempGitDir: string;
 
   beforeEach(async () => {
     delete process.env.NZBDAV_COMMIT_SHA;
+    delete process.env.NZBDAV_VERSION;
     tempGitDir = await mkdtemp(join(tmpdir(), "nzbdav-git-"));
   });
 
@@ -18,6 +20,11 @@ describe("getBuildCommit", () => {
       delete process.env.NZBDAV_COMMIT_SHA;
     } else {
       process.env.NZBDAV_COMMIT_SHA = originalEnv;
+    }
+    if (originalVersion === undefined) {
+      delete process.env.NZBDAV_VERSION;
+    } else {
+      process.env.NZBDAV_VERSION = originalVersion;
     }
     await rm(tempGitDir, { recursive: true, force: true });
     vi.restoreAllMocks();
@@ -35,6 +42,34 @@ describe("getBuildCommit", () => {
     await expect(getBuildCommit({ gitDir: tempGitDir })).resolves.toEqual({
       sha: "abcdef0123456789abcdef0123456789abcdef01",
       branch: "main",
+      source: "env",
+    });
+  });
+
+  it("uses the dev track for NZBDAV_COMMIT_SHA when version is dev-*", async () => {
+    process.env.NZBDAV_COMMIT_SHA = "ABCDEF0123456789abcdef0123456789abcdef01";
+
+    await expect(
+      getBuildCommit({
+        gitDir: join(tempGitDir, "missing"),
+        version: "dev-abcdef0",
+      }),
+    ).resolves.toEqual({
+      sha: "abcdef0123456789abcdef0123456789abcdef01",
+      branch: "dev",
+      source: "env",
+    });
+  });
+
+  it("falls back to NZBDAV_VERSION for the env track ref", async () => {
+    process.env.NZBDAV_COMMIT_SHA = "ABCDEF0123456789abcdef0123456789abcdef01";
+    process.env.NZBDAV_VERSION = "dev-abcdef0";
+
+    await expect(
+      getBuildCommit({ gitDir: join(tempGitDir, "missing") }),
+    ).resolves.toEqual({
+      sha: "abcdef0123456789abcdef0123456789abcdef01",
+      branch: "dev",
       source: "env",
     });
   });
@@ -177,5 +212,35 @@ describe("parseBuildCommitFromVersion", () => {
     ["feature-e0eef520"],
   ])("returns undefined for %s", (version) => {
     expect(parseBuildCommitFromVersion(version)).toBeUndefined();
+  });
+});
+
+describe("resolveTrackRef", () => {
+  const originalVersion = process.env.NZBDAV_VERSION;
+
+  afterEach(() => {
+    if (originalVersion === undefined) {
+      delete process.env.NZBDAV_VERSION;
+    } else {
+      process.env.NZBDAV_VERSION = originalVersion;
+    }
+  });
+
+  it.each([
+    ["dev-e0eef52", "dev"],
+    ["DEV-abcdef0", "dev"],
+    ["main-e0eef520", "main"],
+    ["0.8.0", "main"],
+    ["pre-42", "main"],
+    [undefined, "main"],
+    [null, "main"],
+  ])("maps version %s to track %s", (version, expected) => {
+    delete process.env.NZBDAV_VERSION;
+    expect(resolveTrackRef(version)).toBe(expected);
+  });
+
+  it("falls back to NZBDAV_VERSION when no version argument is passed", () => {
+    process.env.NZBDAV_VERSION = "dev-abcdef0";
+    expect(resolveTrackRef()).toBe("dev");
   });
 });

--- a/frontend/app/utils/version.server.ts
+++ b/frontend/app/utils/version.server.ts
@@ -38,6 +38,9 @@ export async function getAppVersion(): Promise<string | undefined> {
  *
  * Non-main branches and detached HEAD return undefined so feature-branch /
  * fork checkouts do not produce false update notifications.
+ *
+ * Env builds use a track ref derived from the version label: `dev-*` images
+ * compare against the movable `dev` tag (which tracks `:dev`), not `main`.
  */
 export async function getBuildCommit(
   options: BuildCommitOptions = {},
@@ -46,13 +49,27 @@ export async function getBuildCommit(
 
   const envSha = process.env.NZBDAV_COMMIT_SHA?.trim();
   if (envSha && isValidSha(envSha)) {
-    return { sha: envSha.toLowerCase(), branch: "main", source: "env" };
+    return {
+      sha: envSha.toLowerCase(),
+      branch: resolveTrackRef(version),
+      source: "env",
+    };
   }
 
   const local = await readLocalMainCommit(gitDir);
   if (local) return local;
 
   return parseBuildCommitFromVersion(version);
+}
+
+/**
+ * GitHub compare target for a build. Docker `:dev` images (`dev-<sha>`) track
+ * the movable `dev` tag; everything else compares against `main`.
+ */
+export function resolveTrackRef(version?: string | null): string {
+  const label = (version ?? process.env.NZBDAV_VERSION)?.trim() ?? "";
+  if (/^dev-/i.test(label)) return "dev";
+  return "main";
 }
 
 /** Parse a commit SHA embedded in a `main-<sha>` version label. */


### PR DESCRIPTION
## Summary
- `:dev` Docker images now compare the running commit against the movable git `dev` tag (which tracks `:dev`), not against `main`
- Stops false "Update available" badges when users are already on the latest `:dev` image but `main` has unpublished commits
- Update badge copy is track-aware (`on dev` / `on main`)

## Test plan
- [x] `cd frontend && npm test -- update-check.server.test.ts version.server.test.ts`
- [ ] After merge and next `:dev` refresh: pull latest `:dev`, confirm no update badge when on tip of `dev` tag while `main` is ahead
- [ ] Confirm badge appears after a newer `:dev` image is published and an older container is still running