### PR TITLE
chore(ui): move container-aware gap fill to the WebDAV settings page

### DIFF
--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -66,25 +66,3 @@ re-probing the same provider for the same article until the TTL expires. Transie
 | Miss-cache max entries | `usenet.article-miss-cache-max-entries` | `10000` | Cap before oldest entries are evicted (clamped 100–1000000) |
 
 The cache clears automatically when Usenet providers are reconfigured.
-
-## Experimental container-aware gap fill [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
-
-When a confirmed-missing or persistently corrupt article cannot be recovered from any
-provider or fallback Message-ID, NzbDAV normally emits the same number of zero bytes to
-keep every later file offset correct. Enable **Container-aware gap fill** to emit
-format-native discard markers instead for supported direct files:
-
-- MPEG-TS (`.ts`, `.m2ts`, `.mts`): packet-aligned null packets when exact segment
-  offsets are available.
-
-This may help compatible players resynchronize sooner, but it cannot restore the missing
-audio or video data. Matroska, MP4/MOV, and archive-backed files retain zero-fill because
-arbitrary article boundaries do not provide safe container-element boundaries.
-
-The setting is experimental and defaults to off. It does not affect transient transport
-failures: after their retries are exhausted, the current HTTP response fails so the player
-can request the range again.
-
-| Control | Config key | Default |
-|---------|------------|---------|
-| Container-aware gap fill | `usenet.container-aware-fill` | off |

--- a/docs/configuration/webdav.md
+++ b/docs/configuration/webdav.md
@@ -29,6 +29,7 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 | In-flight article budget (MiB) [since 0.8.2](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.2){ .nzbdav-since } | `usenet.in-flight-article-budget-mb` | auto (≈25% of container memory, max 512) | Host-wide cap on decoded article bytes in RAM (64–8192); empty = derived; distinct from per-stream article buffer count |
 | Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | 15–300; pool rebuild/restart |
 | Pipelined article downloads | `usenet.pipelined-body-requests` | on | WebDAV BODY batches |
+| Container-aware gap fill [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | off | Experimental; MPEG-TS null packets instead of zeros for confirmed missing articles |
 | Enforce Read-Only | `webdav.enforce-readonly` | on | `/content` readonly |
 | Show hidden files | `webdav.show-hidden-files` | off | Dot-prefixed names in Explore |
 | Preview par2 files | `webdav.preview-par2-files` | off | Render as text |
@@ -43,6 +44,24 @@ WebDAV authentication and streaming/connection behavior for playback mounts.
 `usenet.article-buffer-size` bounds how many decoded articles a stream may keep ahead of the consumer — and therefore per-stream memory — not how many provider connections playback may use.
 
 When **Pipelined article downloads** is on, WebDAV BODY requests start in batches of up to four articles on one connection. If playback starves waiting for the next segment, NzbDAV automatically narrows that batch width (`4 → 2 → 1`) so more connections can work in parallel at the same buffer depth. When the consumer stays ahead, batch width recovers gradually. Connection and host-wide byte budgets still apply.
+
+## Experimental container-aware gap fill [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
+
+When a confirmed-missing or persistently corrupt article cannot be recovered from any
+provider or fallback Message-ID, NzbDAV normally emits the same number of zero bytes to
+keep every later file offset correct. Enable **Container-aware gap fill** to emit
+format-native discard markers instead for supported direct files:
+
+- MPEG-TS (`.ts`, `.m2ts`, `.mts`): packet-aligned null packets when exact segment
+  offsets are available.
+
+This may help compatible players resynchronize sooner, but it cannot restore the missing
+audio or video data. Matroska, MP4/MOV, and archive-backed files retain zero-fill because
+arbitrary article boundaries do not provide safe container-element boundaries.
+
+The setting is experimental and defaults to off. It does not affect transient transport
+failures: after their retries are exhausted, the current HTTP response fails so the player
+can request the range again.
 
 ## Capturing a buffering support pack
 

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -847,36 +847,6 @@ export function UsenetSettings({ config, setNewConfig, persistConfigPatch }: Use
             </section>
             </ManagedSetting>
 
-            <ManagedSetting configKey="usenet.container-aware-fill">
-                <section className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="min-w-0">
-                            <div className="flex flex-wrap items-center gap-2">
-                                <h2 className="text-sm font-semibold text-base-content">Container-aware gap fill</h2>
-                                <Badge className="badge-warning badge-outline badge-xs">Experimental</Badge>
-                            </div>
-                            <p className="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/60">
-                                For permanently missing data in direct MPEG-TS files, emit packet-aligned null packets
-                                instead of raw zeros so compatible players can resynchronize sooner. Archive-backed files
-                                and unsupported containers keep the existing zero-fill behavior.
-                            </p>
-                        </div>
-                        <Tooltip content="Experimental. Applies only after all missing/corrupt article fallbacks are exhausted; transient transport failures still abort so the player can retry the range.">
-                            <Toggle
-                                id="container-aware-fill"
-                                className="shrink-0 cursor-pointer gap-2 p-0"
-                                checked={config["usenet.container-aware-fill"] === "true"}
-                                onChange={(e) => setNewConfig({
-                                    ...config,
-                                    "usenet.container-aware-fill": e.target.checked ? "true" : "false",
-                                })}
-                                label={<span className="text-sm text-base-content">Enable</span>}
-                            />
-                        </Tooltip>
-                    </div>
-                </section>
-            </ManagedSetting>
-
             <ManagedSetting configKey="usenet.providers">
             <section className="space-y-3">
                 <div className="flex items-end justify-between gap-4">
@@ -2278,7 +2248,6 @@ export function isUsenetSettingsUpdated(config: Record<string, string>, newConfi
         || config["usenet.cascade.retry-primary-on-miss"] !== newConfig["usenet.cascade.retry-primary-on-miss"]
         || config["usenet.article-miss-cache-ttl-seconds"] !== newConfig["usenet.article-miss-cache-ttl-seconds"]
         || config["usenet.article-miss-cache-max-entries"] !== newConfig["usenet.article-miss-cache-max-entries"]
-        || config["usenet.container-aware-fill"] !== newConfig["usenet.container-aware-fill"]
 }
 
 export function isPositiveInteger(value: string) {

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -1,4 +1,4 @@
-import { ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
+import { Badge, ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/components/ui";
 import { Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type ReactNode, type SetStateAction } from "react";
@@ -432,6 +432,33 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                         />
                     </Tooltip>
                 </ManagedSetting>
+
+                <ManagedSetting configKey="usenet.container-aware-fill">
+                    <div className="space-y-2">
+                        <Tooltip content="Experimental. Applies only after all missing/corrupt article fallbacks are exhausted; transient transport failures still abort so the player can retry the range.">
+                            <Toggle
+                                id="container-aware-fill"
+                                className="cursor-pointer gap-2 p-0"
+                                checked={config["usenet.container-aware-fill"] === "true"}
+                                onChange={e => setNewConfig({
+                                    ...config,
+                                    "usenet.container-aware-fill": e.target.checked ? "true" : "false",
+                                })}
+                                label={
+                                    <span className="inline-flex items-center gap-2 text-sm text-base-content">
+                                        Container-aware gap fill
+                                        <Badge className="badge-warning badge-outline badge-xs">Experimental</Badge>
+                                    </span>
+                                }
+                            />
+                        </Tooltip>
+                        <p className="text-[11px] leading-relaxed text-base-content/45">
+                            For permanently missing data in direct MPEG-TS files, emit packet-aligned null packets
+                            instead of raw zeros so compatible players can resynchronize sooner. Archive-backed files
+                            and unsupported containers keep the existing zero-fill behavior.
+                        </p>
+                    </div>
+                </ManagedSetting>
             </SettingsCard>
         </SettingsPage>
     );
@@ -453,6 +480,7 @@ export function isWebdavSettingsUpdated(config: Record<string, string>, newConfi
         || config["usenet.in-flight-article-budget-mb"] !== newConfig["usenet.in-flight-article-budget-mb"]
         || config["usenet.idle-connection-timeout-seconds"] !== newConfig["usenet.idle-connection-timeout-seconds"]
         || config["usenet.pipelined-body-requests"] !== newConfig["usenet.pipelined-body-requests"]
+        || config["usenet.container-aware-fill"] !== newConfig["usenet.container-aware-fill"]
         || config["webdav.show-hidden-files"] !== newConfig["webdav.show-hidden-files"]
         || config["webdav.enforce-readonly"] !== newConfig["webdav.enforce-readonly"]
         || config["webdav.preview-par2-files"] !== newConfig["webdav.preview-par2-files"]


### PR DESCRIPTION
## Summary
- Moves the experimental **Container-aware gap fill** toggle from Settings → Usenet to Settings → WebDAV (Streaming performance).
- Relocates the matching docs section from `docs/configuration/usenet.md` to `docs/configuration/webdav.md`.
- Keeps config key `usenet.container-aware-fill` (same pattern as other streaming settings already on WebDAV).

## Test plan
- [ ] Open Settings → WebDAV and confirm the toggle appears under Streaming performance with Experimental badge
- [ ] Confirm Settings → Usenet no longer shows the control
- [ ] Toggle on/off, save, reload — value persists
- [ ] Confirm dirty-state Save enables when only this toggle changes