### PR TITLE
fix(nntp): providers recover from intermittent authentication failures automatically

### DIFF
--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -190,10 +190,25 @@ public class MultiConnectionNntpClient(
         return RunWithConnection(
             "DATE",
             SemaphorePriority.Low,
-            (connection, _, commandCt) => connection.DateAsync(commandCt),
+            RequireSuccessfulDateAsync,
             onConnectionReadyAgain: null,
             ct
         );
+    }
+
+    private static async Task<UsenetDateResponse> RequireSuccessfulDateAsync(
+        INntpClient connection,
+        Action<ArticleBodyResult> _,
+        CancellationToken ct)
+    {
+        var response = await connection.DateAsync(ct).ConfigureAwait(false);
+        if (response.ResponseType != UsenetResponseType.DateAndTime)
+        {
+            throw new RetryableDownloadException(
+                $"Unexpected NNTP response to DATE: {response.ResponseMessage}");
+        }
+
+        return response;
     }
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Database.Models.Metrics;
@@ -33,6 +34,8 @@ public class MultiProviderNntpClient(
     ConcurrentReadTracker? concurrentReadTracker = null
 ) : NntpClient, INntpConnectionStats
 {
+    private static readonly TimeSpan RecoveryProbeTimeout = TimeSpan.FromSeconds(15);
+
     /// <summary>
     /// Max concurrent batch-failover BODY starts. Admission stays strictly ordered;
     /// this only bounds how many fallback walks may be in flight at once so sequential
@@ -78,6 +81,52 @@ public class MultiProviderNntpClient(
                 p.GetConnectionChurn()))
             .ToList();
     }
+
+    public async Task ProbeLatchedProvidersAsync(CancellationToken cancellationToken)
+    {
+        foreach (var provider in providers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (provider.ProviderType == ProviderType.Disabled ||
+                provider.GetCircuitBreakerSnapshot().State != ProviderCircuitState.HalfOpen)
+            {
+                continue;
+            }
+
+            Log.Information(
+                "Probing provider {Provider} after circuit-breaker cooldown.",
+                provider.Host);
+
+            using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var timeoutContext = CancellationTokenContext.SetContext(
+                probeCts.Token,
+                new StreamingTimeoutContext
+                {
+                    PerSegmentTimeout = RecoveryProbeTimeout,
+                    MaxRetries = 0,
+                });
+
+            try
+            {
+                await provider.DateAsync(probeCts.Token).ConfigureAwait(false);
+            }
+            catch (NntpClientRetiredException e)
+            {
+                Log.Debug(
+                    e,
+                    "Stopped provider recovery probes because the NNTP client generation was retired.");
+                return;
+            }
+            catch (Exception e) when (!e.IsCancellationException(cancellationToken))
+            {
+                Log.Debug(
+                    e,
+                    "Provider {Provider} recovery probe did not succeed.",
+                    provider.Host);
+            }
+        }
+    }
+
     private readonly ProviderUsageTracker _usageTracker = usageTracker ?? new ProviderUsageTracker();
     private static readonly AsyncLocal<Guid?> ReadSessionScope = new();
     internal static Guid? CurrentReadSessionId => ReadSessionScope.Value;

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -136,6 +136,13 @@ public class UsenetStreamingClient : WrappingNntpClient
             : Array.Empty<ProviderConnectionSnapshot>();
     }
 
+    public Task ProbeLatchedProvidersAsync(CancellationToken cancellationToken)
+    {
+        return WrappingNntpClient.Unwrap(InnerClient) is MultiProviderNntpClient multi
+            ? multi.ProbeLatchedProvidersAsync(cancellationToken)
+            : Task.CompletedTask;
+    }
+
     private static MultiProviderNntpClient CreateMultiProviderClient
     (
         ConfigManager configManager,

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -233,6 +233,7 @@ public partial class Program
                 .AddSingleton<QueueItemSourceTracker>()
                 .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<UsenetStreamingClient>()
+                .AddHostedService<ProviderRecoveryProbeService>()
                 // LazyRarResolver takes INntpClient (for testability) but must
                 // use the shared streaming client; wire it explicitly instead
                 // of registering a container-wide INntpClient binding.

--- a/backend/Services/ProviderRecoveryProbeService.cs
+++ b/backend/Services/ProviderRecoveryProbeService.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Clients.Usenet;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+public sealed class ProviderRecoveryProbeService(
+    UsenetStreamingClient usenetClient) : BackgroundService
+{
+    private static readonly TimeSpan ScanInterval = TimeSpan.FromSeconds(30);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(ScanInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    await usenetClient.ProbeLatchedProvidersAsync(stoppingToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e) when (!stoppingToken.IsCancellationRequested)
+                {
+                    Log.Debug(e, "Provider recovery probe round failed.");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal application shutdown.
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderRecoveryProbeTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderRecoveryProbeTests.cs
@@ -1,0 +1,195 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ProviderRecoveryProbeTests
+{
+    [Fact]
+    public async Task HalfOpenProvider_SuccessfulProbe_ClosesCircuit()
+    {
+        var breaker = HalfOpenBreaker();
+        var dateClient = new DateProbeClient(UsenetResponseType.DateAndTime);
+        using var client = CreateClient(
+            breaker,
+            _ => ValueTask.FromResult<INntpClient>(dateClient));
+
+        await client.ProbeLatchedProvidersAsync(CancellationToken.None);
+
+        Assert.Equal(1, dateClient.DateRequests);
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+    }
+
+    [Fact]
+    public async Task HalfOpenProvider_AuthenticationFailure_ReopensCircuitWithBackoff()
+    {
+        var breaker = HalfOpenBreaker();
+        var cooldownBeforeProbe = breaker.CurrentCooldown;
+        var attempts = 0;
+        using var client = CreateClient(
+            breaker,
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                return ValueTask.FromException<INntpClient>(
+                    new CouldNotLoginToUsenetException("481 Access Denied"));
+            });
+
+        await client.ProbeLatchedProvidersAsync(CancellationToken.None);
+
+        Assert.Equal(1, attempts);
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.True(breaker.CurrentCooldown > cooldownBeforeProbe);
+    }
+
+    [Fact]
+    public async Task OpenProvider_IsNotProbedBeforeCooldownExpires()
+    {
+        var breaker = new ProviderCircuitBreaker("open");
+        breaker.RecordConnectionFailure("auth");
+        var attempts = 0;
+        using var client = CreateClient(
+            breaker,
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                return ValueTask.FromResult<INntpClient>(
+                    new DateProbeClient(UsenetResponseType.DateAndTime));
+            });
+
+        await client.ProbeLatchedProvidersAsync(CancellationToken.None);
+
+        Assert.Equal(0, attempts);
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+    }
+
+    [Fact]
+    public async Task ClosedProvider_IsNotProbed()
+    {
+        var breaker = new ProviderCircuitBreaker("closed");
+        var attempts = 0;
+        using var client = CreateClient(
+            breaker,
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                return ValueTask.FromResult<INntpClient>(
+                    new DateProbeClient(UsenetResponseType.DateAndTime));
+            });
+
+        await client.ProbeLatchedProvidersAsync(CancellationToken.None);
+
+        Assert.Equal(0, attempts);
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+    }
+
+    [Fact]
+    public async Task HalfOpenProvider_RejectedDateResponse_DoesNotCloseCircuit()
+    {
+        var breaker = HalfOpenBreaker();
+        var dateClient = new DateProbeClient(UsenetResponseType.AuthenticationRejected);
+        using var client = CreateClient(
+            breaker,
+            _ => ValueTask.FromResult<INntpClient>(dateClient));
+
+        await client.ProbeLatchedProvidersAsync(CancellationToken.None);
+
+        Assert.Equal(1, dateClient.DateRequests);
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+    }
+
+    private static ProviderCircuitBreaker HalfOpenBreaker()
+    {
+        var breaker = new ProviderCircuitBreaker("recovering");
+        breaker.RecordConnectionFailure("auth");
+        breaker.ExpireCooldownForTests();
+        Assert.Equal(ProviderCircuitState.HalfOpen, breaker.GetSnapshot().State);
+        return breaker;
+    }
+
+    private static MultiProviderNntpClient CreateClient(
+        ProviderCircuitBreaker breaker,
+        Func<CancellationToken, ValueTask<INntpClient>> connectionFactory)
+    {
+        var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            connectionFactory);
+        var provider = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            breaker,
+            "recovering");
+        return new MultiProviderNntpClient([provider]);
+    }
+
+    private sealed class DateProbeClient(UsenetResponseType responseType) : NntpClient
+    {
+        public int DateRequests { get; private set; }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DateRequests++;
+            return Task.FromResult(new UsenetDateResponse
+            {
+                ResponseCode = (int)responseType,
+                ResponseMessage = responseType == UsenetResponseType.DateAndTime
+                    ? "111 20260804120000"
+                    : "481 Access Denied",
+                DateTime = responseType == UsenetResponseType.DateAndTime
+                    ? DateTimeOffset.Parse("2026-08-04T12:00:00Z")
+                    : null,
+            });
+        }
+
+        public override void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- actively probe half-open Usenet providers after their circuit-breaker cooldown
- restore recovered providers to rotation without a settings save or restart
- retain exponential backoff for providers that continue failing authentication

Fixes #809

## Test plan
- [x] Cover successful recovery probes and rejected authentication responses
- [x] Cover open and closed providers being skipped
- [x] Run `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (2,337 passed; 9 platform-specific skips)