### PR TITLE
chore(ci): mirror InfiniDysk images to Docker Hub

### DIFF
--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -56,10 +56,14 @@ jobs:
       tags: |
         ghcr.io/${{ github.repository }}:${{ needs.resolve.outputs.tag }}
         ghcr.io/${{ github.repository }}:rc
+        docker.io/infinidysk/infinidysk:${{ needs.resolve.outputs.tag }}
+        docker.io/infinidysk/infinidysk:rc
       nzbdav_version: ${{ needs.resolve.outputs.version }}-rc.${{ needs.resolve.outputs.rc }}
       checkout_ref: ${{ needs.resolve.outputs.sha }}
+      dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   publish-release:
     needs: [resolve, build]

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,9 +16,16 @@ on:
         required: false
         type: string
         default: ""
+      dockerhub_username:
+        description: Docker Hub username (login skipped when empty)
+        required: false
+        type: string
+        default: ""
     secrets:
       registry_token:
         required: true
+      dockerhub_token:
+        required: false
 
 jobs:
   build-and-push:
@@ -45,6 +52,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.registry_token }}
+
+      - name: Log in to Docker Hub
+        if: inputs.dockerhub_username != ''
+        uses: docker/login-action@v4.5.2
+        with:
+          username: ${{ inputs.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
 
       - name: Build and push Docker image (amd64 + arm64)
         uses: docker/build-push-action@v7

--- a/.github/workflows/promote-lts.yml
+++ b/.github/workflows/promote-lts.yml
@@ -66,6 +66,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.5.2
+        with:
+          username: infinidysk
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -75,6 +81,10 @@ jobs:
         run: |
           set -euo pipefail
           SOURCE="ghcr.io/${{ github.repository }}:v${VERSION}"
-          TARGET="ghcr.io/${{ github.repository }}:lts"
-          docker buildx imagetools create --tag "$TARGET" "$SOURCE"
-          echo "Retagged ${SOURCE} -> ${TARGET}"
+          GHCR_TARGET="ghcr.io/${{ github.repository }}:lts"
+          DOCKERHUB_TARGET="docker.io/infinidysk/infinidysk:lts"
+          docker buildx imagetools create \
+            --tag "$GHCR_TARGET" \
+            --tag "$DOCKERHUB_TARGET" \
+            "$SOURCE"
+          echo "Retagged ${SOURCE} -> ${GHCR_TARGET}, ${DOCKERHUB_TARGET}"

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -23,10 +23,14 @@ jobs:
       contents: read
       packages: write
     with:
-      tags: "ghcr.io/${{ github.repository }}:dev"
+      tags: |
+        ghcr.io/${{ github.repository }}:dev
+        docker.io/infinidysk/infinidysk:dev
       nzbdav_version: dev-${{ needs.resolve.outputs.short_sha }}
+      dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   tag-dev:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,17 @@ jobs:
         ghcr.io/${{ github.repository }}:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
         ghcr.io/${{ github.repository }}:v${{ needs.release-please.outputs.major }}
         ghcr.io/${{ github.repository }}:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}
+        docker.io/infinidysk/infinidysk:latest
+        docker.io/infinidysk/infinidysk:dev
+        docker.io/infinidysk/infinidysk:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
+        docker.io/infinidysk/infinidysk:v${{ needs.release-please.outputs.major }}
+        docker.io/infinidysk/infinidysk:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}
       nzbdav_version: ${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
       checkout_ref: ${{ needs.release-please.outputs.sha }}
+      dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   deploy-manual:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
@@ -98,10 +105,17 @@ jobs:
         ghcr.io/${{ github.repository }}:${{ needs.resolve-version.outputs.ref }}
         ghcr.io/${{ github.repository }}:v${{ needs.resolve-version.outputs.major }}
         ghcr.io/${{ github.repository }}:v${{ needs.resolve-version.outputs.major }}.${{ needs.resolve-version.outputs.minor }}
+        docker.io/infinidysk/infinidysk:latest
+        docker.io/infinidysk/infinidysk:dev
+        docker.io/infinidysk/infinidysk:${{ needs.resolve-version.outputs.ref }}
+        docker.io/infinidysk/infinidysk:v${{ needs.resolve-version.outputs.major }}
+        docker.io/infinidysk/infinidysk:v${{ needs.resolve-version.outputs.major }}.${{ needs.resolve-version.outputs.minor }}
       nzbdav_version: ${{ needs.resolve-version.outputs.version }}
       checkout_ref: ${{ needs.resolve-version.outputs.ref }}
+      dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   tag-dev:
     if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
- authenticate the reusable image workflow with the reserved `infinidysk` Docker Hub account
- mirror stable, development, prerelease, and LTS tags to `docker.io/infinidysk/infinidysk`
- keep custom test images GHCR-only

## Test plan
- [x] Parse all modified workflow files as YAML
- [x] Run `git diff --check`
- [x] Confirm the `DOCKERHUB_TOKEN` repository secret exists
- [ ] Run **Refresh :dev** after merge and verify matching multi-arch manifests on GHCR and Docker Hub