### PR TITLE
chore(docs): move documentation to www.infinidysk.com

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,5 +481,5 @@ Use the first stable release that shipped the capability (not every patch). Styl
 - [README.md](README.md) — product overview
 - [CONTRIBUTING.md](CONTRIBUTING.md) — dev environment setup
 - [docs/](docs/) — Zensical documentation sources (`pip install -r docs-requirements.txt && zensical serve`)
-- [https://nzbdav.com/](https://nzbdav.com/) — published documentation
+- [https://www.infinidysk.com/](https://www.infinidysk.com/) — published documentation
 - [CHANGELOG.md](CHANGELOG.md) — what shipped in each version

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 > [!NOTE]
-> **NzbDAV is becoming InfiniDysk.** The new identity is here first; the repository and Docker image will move later. No deployment change is needed yet. Read the [rename FAQ](https://nzbdav.com/community/renaming-to-infinidysk/).
+> **NzbDAV is becoming InfiniDysk.** The documentation has moved to the new domain; the repository and Docker image will move later. No deployment change is needed yet. Read the [rename FAQ](https://www.infinidysk.com/community/renaming-to-infinidysk/).
 
 <img width="1024" height="601" alt="InfiniDysk overview dashboard" src="docs/assets/overview.png" />
 
@@ -42,7 +42,7 @@ Please add feature requests and issues over on our [Issue Tracker](https://githu
 
 This project is a maintained fork of [nzbdav-dev/nzbdav](https://github.com/nzbdav-dev/nzbdav). We took ownership of the full Usenet streaming stack — nzbdav, UsenetSharp, RapidYencSharp, rapidyenc, and SharpCompress — so playback, connection, and decoding fixes could land in the right layer instead of waiting on a single upstream dependency chain.
 
-Read the full story in the [about page](https://nzbdav.com/community/about/).
+Read the full story in the [about page](https://www.infinidysk.com/community/about/).
 
 ## Special thanks
 
@@ -176,22 +176,22 @@ You'll also want to set a username and password for the WebDAV server itself.
 
 ## Documentation
 
-Full documentation is published at [nzbdav.com](https://nzbdav.com/).
+Full documentation is published at [www.infinidysk.com](https://www.infinidysk.com/).
 
-The [about page](https://nzbdav.com/community/about/) covers project heritage and the managed library ecosystem (UsenetSharp, RapidYencSharp, rapidyenc, SharpCompress).
+The [about page](https://www.infinidysk.com/community/about/) covers project heritage and the managed library ecosystem (UsenetSharp, RapidYencSharp, rapidyenc, SharpCompress).
 
-Start with the [getting started guide](https://nzbdav.com/getting-started/) for a full production deployment:
+Start with the [getting started guide](https://www.infinidysk.com/getting-started/) for a full production deployment:
 
 * **Docker Compose** — persistent deployment, container health checks, and updates
-* **Migration** — [official path from nzbdav-dev v0.6.4](https://nzbdav.com/getting-started/migration/) and community forks (Pukabyte, NzbDavEx)
+* **Migration** — [official path from nzbdav-dev v0.6.4](https://www.infinidysk.com/getting-started/migration/) and community forks (Pukabyte, NzbDavEx)
 * **Import strategies** — Rclone symlinks for Plex or STRM files for Emby/Jellyfin
 * **Performance tuning** — benchmarking WebDAV connection limits
 * **Integrations** — automating Radarr/Sonarr queue management and repairs
 * **Stremio** — streaming Usenet on demand via AIOStreams
 * **Search profiles** — token-scoped Newznab, Addon, and JSON adapter setup
-* **Watchtower** — proactive wanted-list resolution in the [Watchtower guide](https://nzbdav.com/features/watchtower/)
-* **Configuration** — [Settings walkthrough](https://nzbdav.com/configuration/) and [environment variables](https://nzbdav.com/configuration/environment-variables/)
-* **Compare** — [InfiniDysk vs AltMount vs classic download clients](https://nzbdav.com/guides/compare/)
+* **Watchtower** — proactive wanted-list resolution in the [Watchtower guide](https://www.infinidysk.com/features/watchtower/)
+* **Configuration** — [Settings walkthrough](https://www.infinidysk.com/configuration/) and [environment variables](https://www.infinidysk.com/configuration/environment-variables/)
+* **Compare** — [InfiniDysk vs AltMount vs classic download clients](https://www.infinidysk.com/guides/compare/)
 
 ## Development
 

--- a/docs/community/renaming-to-infinidysk.md
+++ b/docs/community/renaming-to-infinidysk.md
@@ -20,10 +20,12 @@ an infinite virtual disk, streamed on demand.
 
 - The app, documentation, and community branding now use **InfiniDysk**.
 - A new logo and favicon identify the project.
-- The current repository, documentation domain, and Docker image path remain
-  unchanged during this announcement stage.
+- Documentation is now published at
+  [www.infinidysk.com](https://www.infinidysk.com/).
+- The current repository and Docker image path remain unchanged during this
+  transition stage.
 
-There is no configuration or deployment change to make yet.
+There is no application configuration or deployment change to make yet.
 
 ## What will change later?
 
@@ -31,7 +33,6 @@ The project will move to:
 
 - GitHub: `github.com/infinidysk/infinidysk`
 - Container image: `ghcr.io/infinidysk/infinidysk`
-- Documentation: `infinidysk.com`
 
 Do not switch the image reference until the new package is published and the
 migration announcement says it is ready.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,8 @@ Mount NZBs as a virtual filesystem and stream directly from Usenet — without d
 
 !!! info "NzbDAV is becoming InfiniDysk"
 
-    The new name and look are here first. The repository, documentation domain,
-    and Docker image will move later; no deployment change is needed yet.
+    The documentation now lives at **www.infinidysk.com**. The repository and
+    Docker image will move later; no deployment change is needed yet.
     [Read the rename FAQ](community/renaming-to-infinidysk.md).
 
 InfiniDysk is a **WebDAV server** that mounts NZB documents as a browsable virtual filesystem. Content streams on demand from your Usenet provider. A **SABnzbd-compatible API** lets Sonarr, Radarr, and similar tools use it as a drop-in download client — so you can build an effectively infinite media library without storing full files on disk.

--- a/frontend/app/components/rename-announcement-banner.test.tsx
+++ b/frontend/app/components/rename-announcement-banner.test.tsx
@@ -17,7 +17,7 @@ describe("RenameAnnouncementBanner", () => {
 
     expect(await screen.findByText("NzbDAV is becoming InfiniDysk")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Read the rename FAQ" }).getAttribute("href"))
-      .toBe("https://nzbdav.com/community/renaming-to-infinidysk/");
+      .toBe("https://www.infinidysk.com/community/renaming-to-infinidysk/");
 
     await user.click(screen.getByRole("button", { name: "Dismiss rename announcement" }));
 

--- a/frontend/app/components/rename-announcement-banner.tsx
+++ b/frontend/app/components/rename-announcement-banner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Alert, Icon } from "~/components/ui";
 
 const DISMISSED_KEY = "infinidysk-rename-announcement-v1";
-const RENAME_FAQ_URL = "https://nzbdav.com/community/renaming-to-infinidysk/";
+const RENAME_FAQ_URL = "https://www.infinidysk.com/community/renaming-to-infinidysk/";
 
 export function RenameAnnouncementBanner() {
   const [isVisible, setIsVisible] = useState(false);

--- a/frontend/app/routes/_index/components/page-layout/page-layout.tsx
+++ b/frontend/app/routes/_index/components/page-layout/page-layout.tsx
@@ -59,7 +59,7 @@ export function PageLayout(props: PageLayoutProps) {
                                         <p>
                                             This installation of{" "}
                                             <a
-                                                href="https://nzbdav.com"
+                                                href="https://www.infinidysk.com"
                                                 target="_blank"
                                                 rel="noreferrer"
                                                 className="link link-hover font-semibold"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "InfiniDysk"
 site_description = "The NzbDAV SuperFork — stream media directly from Usenet"
-site_url = "https://nzbdav.com/"
+site_url = "https://www.infinidysk.com/"
 docs_dir = "docs"
 site_dir = "site"
 repo_url = "https://github.com/nzbdav/nzbdav"


### PR DESCRIPTION
## Summary
- set the Zensical canonical URL to `https://www.infinidysk.com/`
- update active documentation links in the README and app UI
- revise rename messaging to reflect the documentation-domain cutover

## Test plan
- [x] `cd frontend && npm test -- app/components/rename-announcement-banner.test.tsx`
- [x] `cd frontend && npm run typecheck`
- [x] `zensical build --clean --strict`

## Cutover note
Before changing DNS, update the repository's GitHub Pages custom domain from `www.nzbdav.com` to `www.infinidysk.com`. This Actions-based Pages deployment does not require a `CNAME` file.