### PR TITLE
feat(webdav): downloads and streams from .ids links use the real filename instead of an id

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -74,17 +74,17 @@ public class GetWebdavItemController(
         if (idFile?.HistoryItemId is { } hid)
             HttpContext.Items["historyItemId"] = hid;
 
-        // Now that the real filename + size are known, update the active-read
-        // entry so the UI shows the human-readable name instead of the .ids GUID.
+        // .ids items expose the GUID as Name so symlink targets stay stable.
+        // Use the human-readable name for response headers and active reads.
+        var fileName = idFile?.FriendlyName ?? item.Name;
+
         if (HttpContext.Items["readSessionId"] is Guid sid)
-        {
-            var displayName = idFile?.FriendlyName ?? item.Name;
-            activeReadRegistry.UpdateInfo(sid, displayName, fileSize);
-        }
+            activeReadRegistry.UpdateInfo(sid, fileName, fileSize);
 
         // set the content-type and content-disposition headers
-        Response.Headers["Content-Type"] = GetContentType(item.Name);
-        Response.Headers["Content-Disposition"] = GetContentDisposition(item.Name, request.ShouldDownload);
+        Response.Headers["Content-Type"] = ContentHeaderUtil.GetContentType(fileName);
+        Response.Headers["Content-Disposition"] =
+            ContentHeaderUtil.GetContentDisposition(fileName, request.ShouldDownload);
 
         // disable compression to keep Content-Length intact for clients that need seeking
         Response.Headers["Content-Encoding"] = "identity";
@@ -358,36 +358,6 @@ public class GetWebdavItemController(
     /// </summary>
     internal static long ResolveRangeEnd(long? rangeEnd, long fileSize) =>
         Math.Min(rangeEnd ?? (fileSize - 1), fileSize - 1);
-
-    private static string GetContentType(string item)
-    {
-        if (item == "README") return "text/plain";
-        var extension = Path.GetExtension(item).ToLower();
-        // .mkv falls through to ContentTypeUtil → "video/x-matroska". The old
-        // override returned "video/webm", but WebM only permits VP8/VP9 + Vorbis/Opus.
-        // Releases using H.264/H.265 + AC3/DTS made strict players reject the
-        // video stream while still decoding audio.
-        return extension == ".rclonelink" ? "text/plain"
-            : extension == ".nfo" ? "text/plain"
-            : ContentTypeUtil.GetContentType(Path.GetFileName(item));
-    }
-
-    private static string GetContentDisposition(string filename, bool shouldDownload)
-    {
-        // Remove control characters (header safety)
-        filename = new string(filename.Where(c => !char.IsControl(c)).ToArray());
-
-        // ASCII fallback for legacy clients
-        var chars = filename.Select(c => (c >= 32 && c <= 126 && c != '"' && c != '\\' && c != ';') ? c : '_');
-        var ascii = new string(chars.ToArray());
-
-        // RFC 5987 UTF-8 filename
-        var utf8 = Uri.EscapeDataString(filename);
-
-        // return
-        var type = shouldDownload ? "attachment" : "inline";
-        return $"{type}; filename=\"{ascii}\"; filename*=UTF-8''{utf8}";
-    }
 
     private async Task<Stream> GetPar2PreviewStream(IStoreItem item, CancellationToken ct)
     {

--- a/backend/Utils/ContentHeaderUtil.cs
+++ b/backend/Utils/ContentHeaderUtil.cs
@@ -1,0 +1,30 @@
+namespace NzbWebDAV.Utils;
+
+public static class ContentHeaderUtil
+{
+    public static string GetContentType(string fileName)
+    {
+        if (fileName == "README") return "text/plain";
+        var extension = Path.GetExtension(fileName).ToLower();
+        // .mkv falls through to ContentTypeUtil → "video/x-matroska". WebM only
+        // permits VP8/VP9 + Vorbis/Opus, while MKV releases commonly use other codecs.
+        return extension == ".rclonelink" ? "text/plain"
+            : extension == ".nfo" ? "text/plain"
+            : ContentTypeUtil.GetContentType(Path.GetFileName(fileName));
+    }
+
+    public static string GetContentDisposition(string fileName, bool shouldDownload)
+    {
+        fileName = new string(fileName.Where(c => !char.IsControl(c)).ToArray());
+
+        var chars = fileName.Select(
+            c => c is >= (char)32 and <= (char)126 && c is not '"' and not '\\' and not ';'
+                ? c
+                : '_');
+        var ascii = new string(chars.ToArray());
+        var utf8 = Uri.EscapeDataString(fileName);
+        var type = shouldDownload ? "attachment" : "inline";
+
+        return $"{type}; filename=\"{ascii}\"; filename*=UTF-8''{utf8}";
+    }
+}

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -14,6 +14,7 @@ using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav.Requests;
 
 namespace NzbWebDAV.WebDav.Base;
@@ -170,6 +171,13 @@ public class GetAndHeadHandlerPatch : IRequestHandler
             var contentLanguage = (string?)await propertyManager.GetPropertyAsync(entry, DavGetContentLanguage<IStoreItem>.PropertyName, true, ct).ConfigureAwait(false);
             if (contentLanguage != null)
                 response.Headers.ContentLanguage = contentLanguage;
+        }
+
+        if (entry is DatabaseStoreIdFile friendlyIdFile)
+        {
+            response.ContentType = ContentHeaderUtil.GetContentType(friendlyIdFile.FriendlyName);
+            response.Headers.ContentDisposition =
+                ContentHeaderUtil.GetContentDisposition(friendlyIdFile.FriendlyName, shouldDownload: false);
         }
 
         // Stream the actual entry

--- a/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
@@ -62,6 +62,15 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
         await context.SaveChangesAsync();
     }
 
+    public async Task AddDavNzbFileAsync(DavItem item, DavNzbFile file)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DavDatabaseContext>();
+        context.Items.Add(item);
+        context.NzbFiles.Add(file);
+        await context.SaveChangesAsync();
+    }
+
     protected override void Dispose(bool disposing)
     {
         try

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Xml.Linq;
+using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.WebDav;
 
 namespace NzbWebDAV.Tests.WebDav;
 
@@ -86,6 +88,67 @@ public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactor
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.True(response.Content.Headers.ContentLength > 0);
         Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public async Task HeadViewIdsFile_UsesFriendlyNameForContentHeaders()
+    {
+        var item = await AddIdsFileAsync("My.Movie.2024.mkv");
+        var itemPath = DatabaseStoreSymlinkFile.GetTargetPath(item.Id, '/');
+        var downloadKey = GetWebdavItemRequest.GenerateDownloadKey(
+            NzbDavWebApplicationFactory.ApiKey,
+            itemPath);
+
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(
+            HttpMethod.Head,
+            $"/view/{itemPath}?downloadKey={downloadKey}");
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("video/x-matroska", response.Content.Headers.ContentType?.MediaType);
+        Assert.Contains(
+            "My.Movie.2024.mkv",
+            response.Content.Headers.ContentDisposition?.ToString());
+    }
+
+    [Fact]
+    public async Task HeadWebDavIdsFile_UsesFriendlyNameForContentHeaders()
+    {
+        var item = await AddIdsFileAsync("Another.Movie.2025.mkv");
+        var itemPath = DatabaseStoreSymlinkFile.GetTargetPath(item.Id, '/');
+
+        using var client = factory.CreateClient();
+        using var request = factory.CreateWebDavRequest(HttpMethod.Head, $"/{itemPath}");
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("video/x-matroska", response.Content.Headers.ContentType?.MediaType);
+        Assert.Contains(
+            "Another.Movie.2025.mkv",
+            response.Content.Headers.ContentDisposition?.ToString());
+    }
+
+    private async Task<DavItem> AddIdsFileAsync(string name)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            name,
+            1024,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            null);
+        var file = new DavNzbFile
+        {
+            Id = item.Id,
+            SegmentIds = []
+        };
+        await factory.AddDavNzbFileAsync(item, file);
+        return item;
     }
 
     private static async Task<string[]> ReadHrefsAsync(HttpResponseMessage response)


### PR DESCRIPTION
## Summary
- use stored filenames for `Content-Disposition` and `Content-Type` on `/view/.ids` streams
- mirror the same friendly response headers on native WebDAV `.ids` GET/HEAD requests
- preserve GUID-backed URLs and symlink targets unchanged

Fixes #807

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] focused integration coverage for `/view/.ids` and WebDAV `/.ids` HEAD responses