### PR TITLE
feat(ui): native URL_BASE support for sub-path hosting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,24 @@ jobs:
         working-directory: frontend
         run: npm run build && npm run build:server
 
+      # Sub-path build: the only automated coverage NZBDAV_URL_BASE can get.
+      # Asserts the baked bundle carries the prefix in its asset URLs and that
+      # the root build above was produced without one.
+      - name: Build with NZBDAV_URL_BASE
+        working-directory: frontend
+        env:
+          NZBDAV_URL_BASE: /nzbdav
+        run: |
+          mv build build-root
+          npm run build
+          if ! grep -rq '/nzbdav/assets/' build/server; then
+            echo "sub-path build did not bake /nzbdav into the bundle"; exit 1
+          fi
+          if grep -rq '/nzbdav/assets/' build-root/server; then
+            echo "root build unexpectedly contains the /nzbdav prefix"; exit 1
+          fi
+          rm -rf build && mv build-root build
+
       # Node ESM requires explicit .js extensions in emitted dist-node imports.
       # Import every helper under dist-node/server/ (not server.js, which listens).
       - name: Smoke-import dist-node server modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ FROM --platform=$BUILDPLATFORM node:24-alpine AS frontend-build
 
 WORKDIR /frontend
 
+# URL_BASE bakes the reverse-proxy sub-path (e.g. "/nzbdav") into the React
+# Router basename, Vite asset paths, and the client bundle. Leave unset for
+# root hosting (default, identical output to before this arg existed). Must
+# match the URL_BASE env var at container runtime — see docs/configuration/url-base.md.
+ARG URL_BASE=""
+ENV URL_BASE=${URL_BASE}
+
 COPY ./frontend/package.json ./frontend/package-lock.json ./
 RUN npm ci
 COPY ./frontend ./
@@ -86,5 +93,10 @@ ARG NZBDAV_COMMIT_SHA
 ENV NZBDAV_COMMIT_SHA=${NZBDAV_COMMIT_SHA}
 ENV NODE_ENV=production
 ENV LOG_LEVEL=warning
+# Default the runtime half of URL_BASE to the baked build-time value so a
+# `--build-arg URL_BASE=/x` image works without repeating the env var at run
+# time. Can still be overridden (must then match the build value).
+ARG URL_BASE=""
+ENV URL_BASE=${URL_BASE}
 
 CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ FROM --platform=$BUILDPLATFORM node:24-alpine AS frontend-build
 
 WORKDIR /frontend
 
-# URL_BASE bakes the reverse-proxy sub-path (e.g. "/nzbdav") into the React
-# Router basename, Vite asset paths, and the client bundle. Leave unset for
-# root hosting (default, identical output to before this arg existed). Must
-# match the URL_BASE env var at container runtime — see docs/configuration/url-base.md.
-ARG URL_BASE=""
-ENV URL_BASE=${URL_BASE}
+# NZBDAV_URL_BASE bakes the reverse-proxy sub-path (e.g. "/nzbdav") into the
+# React Router basename, Vite asset paths, and the client bundle. Leave unset
+# for root hosting (default, identical output to before this arg existed).
+# Namespaced to avoid picking up a stray URL_BASE from shared build
+# environments; the un-prefixed name is still honored as a fallback by the
+# build config. See docs/configuration/url-base.md.
+ARG NZBDAV_URL_BASE=""
+ENV NZBDAV_URL_BASE=${NZBDAV_URL_BASE}
 
 COPY ./frontend/package.json ./frontend/package-lock.json ./
 RUN npm ci
@@ -93,10 +95,10 @@ ARG NZBDAV_COMMIT_SHA
 ENV NZBDAV_COMMIT_SHA=${NZBDAV_COMMIT_SHA}
 ENV NODE_ENV=production
 ENV LOG_LEVEL=warning
-# Default the runtime half of URL_BASE to the baked build-time value so a
-# `--build-arg URL_BASE=/x` image works without repeating the env var at run
-# time. Can still be overridden (must then match the build value).
-ARG URL_BASE=""
-ENV URL_BASE=${URL_BASE}
+# Default the runtime half of NZBDAV_URL_BASE to the baked build-time value so
+# a `--build-arg NZBDAV_URL_BASE=/x` image works without repeating the env var
+# at run time. Overriding it with a different value fails fast at startup.
+ARG NZBDAV_URL_BASE=""
+ENV NZBDAV_URL_BASE=${NZBDAV_URL_BASE}
 
 CMD ["/entrypoint.sh"]

--- a/docs/configuration/url-base.md
+++ b/docs/configuration/url-base.md
@@ -1,44 +1,62 @@
-# URL base (sub-path hosting)
+# URL base (sub-path hosting) [since 0.11.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.11.0){ .nzbdav-since }
 
 Host the app under a reverse-proxy sub-path — e.g. `https://example.com/nzbdav/` —
 without any `sub_filter` response rewriting in the proxy.
 
-The setting is the `URL_BASE` value and it has **two halves that must match**:
+The setting is the `NZBDAV_URL_BASE` value (bare `URL_BASE` is accepted as a
+fallback) and it has **two halves that must match**:
 
 | Half | When | What it controls |
 | --- | --- | --- |
-| `--build-arg URL_BASE=/nzbdav` | Docker image build | React Router basename, Vite asset paths, and the `__URL_BASE__` constant baked into the client bundle |
-| `-e URL_BASE=/nzbdav` | Container runtime | The Express mount prefix, WebSocket endpoint path, and login-redirect Locations |
+| `--build-arg NZBDAV_URL_BASE=/nzbdav` | Docker image build | React Router basename, Vite asset paths, and the `__URL_BASE__` constant baked into the client bundle |
+| `NZBDAV_URL_BASE=/nzbdav` env var | Container runtime | The Express mount prefix, WebSocket endpoint path, and login-redirect Locations |
 
 React Router's `basename` is build-time only — the framework exposes no runtime
 override — so the sub-path cannot be changed without rebuilding the frontend.
-Images built with a `URL_BASE` build-arg default the runtime env var to the same
-value, so setting it once at build time is enough.
+Images built with the build-arg default the runtime env var to the same value,
+so setting it once at build time is enough. **The server refuses to start if
+the runtime value differs from the value the bundle was built with**, with an
+error naming both values — a root-built image cannot be switched to sub-path
+hosting by env var alone.
 
 Unset (or `/`) means root hosting and produces output identical to an image
 built without the arg. The official published images are built for root hosting;
 sub-path deployments build their own image:
 
 ```bash
-docker build -t nzbdav:subpath --build-arg URL_BASE=/nzbdav .
+docker build -t nzbdav:subpath --build-arg NZBDAV_URL_BASE=/nzbdav .
 docker run -d -p 3000:3000 -v ./config:/config nzbdav:subpath
 ```
 
 Accepted forms are normalized: `nzbdav`, `/nzbdav`, and `/nzbdav/` all mean
-`/nzbdav`. Multi-segment prefixes (`/tools/nzbdav`) work.
+`/nzbdav`. Multi-segment prefixes (`/tools/nzbdav`) work. Values are restricted
+to letters, digits, `.`, `_`, `~`, `-`, and `/` — anything else (spaces, `:`,
+`*`, parentheses) is rejected at startup, since Express would otherwise
+misparse the mount prefix as a route pattern.
 
 ## What moves, what stays
 
-- The web UI, `/api`, `/webdav` proxy paths, WebSocket (`<URL_BASE>/ws`), and
+- The web UI, `/api`, WebDAV proxy paths, WebSocket (`<URL_BASE>/ws`), and
   login all move under the prefix.
 - `GET /healthz` stays at the bare root **and** is served under the prefix, so
-  container healthchecks keep a stable URL regardless of `URL_BASE`.
-- A request to the bare root `/` redirects to `<URL_BASE>/`.
-- Direct backend consumers (rclone pointed at the backend port, `NZBDAV_CONFIG__…`
-  env config) are unaffected — the backend itself stays prefix-unaware.
+  container healthchecks keep a stable URL regardless of the setting.
+- A `GET` to the bare root `/` redirects to `<URL_BASE>/`. Other methods do
+  **not** redirect: WebDAV clients pointed at the **frontend** port must
+  include the prefix in their remote URL (e.g.
+  `http://host:3000/nzbdav/`), or point at the backend port directly.
+- Direct backend consumers (rclone pointed at the backend port,
+  `NZBDAV_CONFIG__…` env config) are unaffected — the backend itself stays
+  prefix-unaware.
 - When using OIDC behind a sub-path, register the callback as
   `<public origin><URL_BASE>/auth/oidc/callback` (derived automatically from
   `general.base-url` when set).
+
+!!! warning "Managed environments"
+
+    Environments that manage the deployment for you and assume root hosting —
+    DUMB's embedded-UI proxying, for example — should leave this setting unset.
+    Enabling it changes every frontend URL, including the ones such
+    integrations construct for you.
 
 ## Minimal nginx example
 

--- a/docs/configuration/url-base.md
+++ b/docs/configuration/url-base.md
@@ -1,4 +1,4 @@
-# URL base (sub-path hosting) [since 0.11.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.11.0){ .nzbdav-since }
+# URL base (sub-path hosting) [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since }
 
 Host the app under a reverse-proxy sub-path — e.g. `https://example.com/nzbdav/` —
 without any `sub_filter` response rewriting in the proxy.

--- a/docs/configuration/url-base.md
+++ b/docs/configuration/url-base.md
@@ -1,0 +1,65 @@
+# URL base (sub-path hosting)
+
+Host the app under a reverse-proxy sub-path — e.g. `https://example.com/nzbdav/` —
+without any `sub_filter` response rewriting in the proxy.
+
+The setting is the `URL_BASE` value and it has **two halves that must match**:
+
+| Half | When | What it controls |
+| --- | --- | --- |
+| `--build-arg URL_BASE=/nzbdav` | Docker image build | React Router basename, Vite asset paths, and the `__URL_BASE__` constant baked into the client bundle |
+| `-e URL_BASE=/nzbdav` | Container runtime | The Express mount prefix, WebSocket endpoint path, and login-redirect Locations |
+
+React Router's `basename` is build-time only — the framework exposes no runtime
+override — so the sub-path cannot be changed without rebuilding the frontend.
+Images built with a `URL_BASE` build-arg default the runtime env var to the same
+value, so setting it once at build time is enough.
+
+Unset (or `/`) means root hosting and produces output identical to an image
+built without the arg. The official published images are built for root hosting;
+sub-path deployments build their own image:
+
+```bash
+docker build -t nzbdav:subpath --build-arg URL_BASE=/nzbdav .
+docker run -d -p 3000:3000 -v ./config:/config nzbdav:subpath
+```
+
+Accepted forms are normalized: `nzbdav`, `/nzbdav`, and `/nzbdav/` all mean
+`/nzbdav`. Multi-segment prefixes (`/tools/nzbdav`) work.
+
+## What moves, what stays
+
+- The web UI, `/api`, `/webdav` proxy paths, WebSocket (`<URL_BASE>/ws`), and
+  login all move under the prefix.
+- `GET /healthz` stays at the bare root **and** is served under the prefix, so
+  container healthchecks keep a stable URL regardless of `URL_BASE`.
+- A request to the bare root `/` redirects to `<URL_BASE>/`.
+- Direct backend consumers (rclone pointed at the backend port, `NZBDAV_CONFIG__…`
+  env config) are unaffected — the backend itself stays prefix-unaware.
+- When using OIDC behind a sub-path, register the callback as
+  `<public origin><URL_BASE>/auth/oidc/callback` (derived automatically from
+  `general.base-url` when set).
+
+## Minimal nginx example
+
+```nginx
+location ^~ /nzbdav/ {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # WebSocket upgrade — the live queue/health panels need this.
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        $http_connection;
+
+    # Long-running streams (WebDAV reads of large files).
+    proxy_buffering    off;
+    proxy_read_timeout 1h;
+    proxy_send_timeout 1h;
+}
+```
+
+No `sub_filter`, no `proxy_redirect`, no manifest rewriting: the app emits
+correctly-prefixed URLs itself.

--- a/frontend/app/auth/auth-middleware.server.ts
+++ b/frontend/app/auth/auth-middleware.server.ts
@@ -1,6 +1,14 @@
 import type express from "express";
 import { isAuthenticated } from "~/auth/authentication.server";
+import { normalizeUrlBase } from "~/utils/url-base";
 import { safeDecodePath } from "../../server/proxy-path";
+
+// The Express server mounts middleware under URL_BASE, so `req.path` here is
+// already stripped of the prefix and PUBLIC_PATHS work unchanged. But
+// `res.redirect("/login")` emits an absolute path the browser resolves against
+// the origin, not the mount point — outgoing Location values need the prefix
+// put back on. Read at runtime, same as the mount in server.ts.
+const URL_BASE = normalizeUrlBase(process.env.URL_BASE);
 
 // Paths that do not require authentication. Every other path is protected.
 const PUBLIC_PATHS = [
@@ -26,5 +34,5 @@ export async function authMiddleware(
   if (await isAuthenticated(req)) return next();
 
   // Redirect everything else to the login page
-  res.redirect(302, "/login");
+  res.redirect(302, `${URL_BASE}/login`);
 }

--- a/frontend/app/auth/auth-middleware.server.ts
+++ b/frontend/app/auth/auth-middleware.server.ts
@@ -1,14 +1,14 @@
 import type express from "express";
 import { isAuthenticated } from "~/auth/authentication.server";
-import { normalizeUrlBase } from "~/utils/url-base";
+import { URL_BASE } from "~/utils/url-base";
 import { safeDecodePath } from "../../server/proxy-path";
 
 // The Express server mounts middleware under URL_BASE, so `req.path` here is
 // already stripped of the prefix and PUBLIC_PATHS work unchanged. But
 // `res.redirect("/login")` emits an absolute path the browser resolves against
 // the origin, not the mount point — outgoing Location values need the prefix
-// put back on. Read at runtime, same as the mount in server.ts.
-const URL_BASE = normalizeUrlBase(process.env.URL_BASE);
+// put back on. This module is part of the Vite SSR bundle, so the baked
+// URL_BASE constant applies (server.ts guarantees it matches the runtime env).
 
 // Paths that do not require authentication. Every other path is protected.
 const PUBLIC_PATHS = [

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { withUrlBase } from "~/utils/url-base";
 
 export type MigrationStepStatus = "pending" | "running" | "completed" | "failed";
 
@@ -113,7 +114,7 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
 
     const poll = async () => {
       try {
-        const res = await fetch("/api/migration-status", {
+        const res = await fetch(withUrlBase("/api/migration-status"), {
           headers: { accept: "application/json" },
           cache: "no-store",
         });
@@ -316,7 +317,7 @@ export function MigrationShell({
             <div className="flex items-center gap-3">
               <img
                 className="h-12 w-12 rounded-2xl bg-gradient-to-br from-primary via-info to-success p-0.5 shadow-md shadow-primary/20"
-                src="/logo.png"
+                src={withUrlBase("/logo.png")}
                 alt="InfiniDysk"
               />
               <div className="space-y-1">

--- a/frontend/app/components/stream-tracing-banner.tsx
+++ b/frontend/app/components/stream-tracing-banner.tsx
@@ -1,3 +1,4 @@
+import { withUrlBase } from "~/utils/url-base";
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Icon } from "~/components/ui";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
@@ -46,7 +47,7 @@ export function StreamTracingBanner({ isReadOnly = false }: { isReadOnly?: boole
         try {
             const form = new FormData();
             form.append("enabled", "false");
-            const response = await fetch("/settings/stream-tracing", { method: "POST", body: form });
+            const response = await fetch(withUrlBase("/settings/stream-tracing"), { method: "POST", body: form });
             if (response.ok) {
                 const next = await response.json() as Record<string, unknown>;
                 setStatus(toStreamTracingStatus(next));

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -27,6 +27,7 @@ import { StreamTracingBanner } from "./components/stream-tracing-banner";
 import { RenameAnnouncementBanner } from "./components/rename-announcement-banner";
 import { isOidcEnabled } from "../server/oidc.server";
 import { getServiceProvider } from "./utils/service-provider.server";
+import { withUrlBase } from "~/utils/url-base";
 
 export async function loader({ request }: Route.LoaderArgs) {
   // Single-fetch navigation/revalidation uses internal `.data` URLs
@@ -118,11 +119,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="description"
           content="The NzbDAV SuperFork — stream media directly from Usenet."
         />
-        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-        <link rel="icon" href="/favicon.ico" />
-        <link rel="manifest" href="/site.webmanifest" />
+        <link rel="apple-touch-icon" sizes="180x180" href={withUrlBase("/apple-touch-icon.png")} />
+        <link rel="icon" type="image/png" sizes="32x32" href={withUrlBase("/favicon-32x32.png")} />
+        <link rel="icon" type="image/png" sizes="16x16" href={withUrlBase("/favicon-16x16.png")} />
+        <link rel="icon" href={withUrlBase("/favicon.ico")} />
+        <link rel="manifest" href={withUrlBase("/site.webmanifest")} />
         <Meta />
         <Links />
       </head>

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -4,6 +4,7 @@ import type { RequiredTopNavProps } from "../page-layout/page-layout";
 import { LiveUsenetConnections } from "../live-usenet-connections/live-usenet-connections";
 import { Icon } from "~/components/ui";
 import { isComparableVersion, type UpdateAvailable } from "~/utils/update-check";
+import { withUrlBase } from "~/utils/url-base";
 
 export type TopNavigationProps = RequiredTopNavProps & {
   version?: string,
@@ -69,7 +70,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
         >
           <img
             className="h-10 w-10 rounded-xl bg-gradient-to-br from-primary via-info to-success p-0.5 shadow-md shadow-primary/20"
-            src="/logo.png"
+            src={withUrlBase("/logo.png")}
             alt=""
           />
           <span className="flex flex-col items-start leading-none">

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -17,6 +17,7 @@ import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { classNames } from "~/utils/styling";
 import { Icon, Checkbox, Button } from "~/components/ui";
 import { useIsReadOnly } from "~/auth/authorization";
+import { withUrlBase } from "~/utils/url-base";
 
 const ITEM_MENU_CLASS =
     "flex select-none items-center self-stretch rounded-r-lg px-5 py-[15px]";
@@ -173,7 +174,7 @@ function Body(props: ExplorePageData) {
             const fd = new FormData();
             fd.append('path', fullPath);
             try {
-                const resp = await fetch('/api/delete-webdav-item', { method: 'POST', body: fd });
+                const resp = await fetch(withUrlBase('/api/delete-webdav-item'), { method: 'POST', body: fd });
                 if (!resp.ok) {
                     const data = await resp.json().catch(() => ({} as any));
                     failures.push(`${name}: ${data.error || resp.statusText}`);

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -7,6 +7,7 @@ import { useWebsocketTopics } from "~/utils/shared-websocket";
 import { Alert, Icon } from "~/components/ui";
 import type { HealthCheckQueueResponse } from "~/clients/backend-client.server";
 import { completeHealthCheck, type HealthQueueState } from "./health-queue-state";
+import { withUrlBase } from "~/utils/url-base";
 
 const topicNames = {
     healthItemStatus: 'hs',
@@ -50,7 +51,7 @@ export default function Health({ loaderData }: Route.ComponentProps) {
     useEffect(() => {
         if (queueItems.length >= 15) return;
         const refetchData = async () => {
-            const response = await fetch('/api/get-health-check-queue?pageSize=30');
+            const response = await fetch(withUrlBase('/api/get-health-check-queue?pageSize=30'));
             if (response.ok) {
                 const healthCheckQueue: HealthCheckQueueResponse = await response.json();
                 setQueueState({

--- a/frontend/app/routes/login/route.tsx
+++ b/frontend/app/routes/login/route.tsx
@@ -5,6 +5,7 @@ import { backendClient } from "~/clients/backend-client.server";
 import { Alert, Button, Icon, Input, Spinner } from "~/components/ui";
 import { RenameAnnouncementBanner } from "~/components/rename-announcement-banner";
 import { isOidcEnabled } from "../../../server/oidc.server";
+import { withUrlBase } from "~/utils/url-base";
 
 type LoginPageData = {
     loginError: string | null;
@@ -50,7 +51,7 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                         <div className="flex flex-col items-center gap-3 text-center">
                             <img
                                 className="h-16 w-16 rounded-2xl bg-gradient-to-br from-primary via-info to-success p-0.5 shadow-lg shadow-primary/20"
-                                src="/logo.png"
+                                src={withUrlBase("/logo.png")}
                                 alt="InfiniDysk"
                             />
                             <div>
@@ -108,7 +109,7 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                                 </div>
                                 <a
                                     className="btn btn-outline w-full gap-2"
-                                    href="/auth/oidc/login"
+                                    href={withUrlBase("/auth/oidc/login")}
                                 >
                                     <Icon name="login" className="!text-[18px]" />
                                     Sign in with SSO

--- a/frontend/app/routes/logs/route.tsx
+++ b/frontend/app/routes/logs/route.tsx
@@ -12,6 +12,7 @@ import { backendClient, type LogEntry, type LogLevel } from "~/clients/backend-c
 import { useLogsWebsocket, type ConnectionStatus } from "./controllers/websocket-controller";
 import { Alert, Badge, Icon } from "~/components/ui";
 import { Input } from "~/components/ui/form";
+import { withUrlBase } from "~/utils/url-base";
 
 const ALL_LEVELS: LogLevel[] = ["Verbose", "Debug", "Information", "Warning", "Error", "Fatal"];
 const DEFAULT_LEVELS: LogLevel[] = ["Information", "Warning", "Error", "Fatal"];
@@ -109,7 +110,7 @@ export default function Logs({ loaderData }: Route.ComponentProps) {
         }
         if (search) params.set("search", search);
         if (source) params.set("source", source);
-        fetch(`/api/get-logs?${params.toString()}`)
+        fetch(withUrlBase(`/api/get-logs?${params.toString()}`))
             .then(async r => {
                 if (!r.ok) throw new Error(`HTTP ${r.status}`);
                 return r.json();

--- a/frontend/app/routes/onboarding/route.tsx
+++ b/frontend/app/routes/onboarding/route.tsx
@@ -5,6 +5,7 @@ import { Form, redirect, useNavigation } from "react-router";
 import { isAuthenticated, setSessionUser } from "~/auth/authentication.server";
 import { Alert, Button, Input, Spinner } from "~/components/ui";
 import { RenameAnnouncementBanner } from "~/components/rename-announcement-banner";
+import { withUrlBase } from "~/utils/url-base";
 
 type OnboardingPageData = {
     error: string
@@ -59,7 +60,7 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
                         <div className="flex flex-col items-center gap-3 text-center">
                             <img
                                 className="h-16 w-16 rounded-2xl bg-gradient-to-br from-primary via-info to-success p-0.5 shadow-lg shadow-primary/20"
-                                src="/logo.png"
+                                src={withUrlBase("/logo.png")}
                                 alt="InfiniDysk"
                             />
                             <div>

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -1,3 +1,4 @@
+import { withUrlBase } from "~/utils/url-base";
 import type { Route } from "./+types/route";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
@@ -112,7 +113,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         const fetchWindow = async () => {
             if (typeof document !== "undefined" && document.hidden) return;
             try {
-                const res = await fetch(`/api/get-overview-stats?window=${window}&sections=window`);
+                const res = await fetch(withUrlBase(`/api/get-overview-stats?window=${window}&sections=window`));
                 if (!res.ok || cancelled) return;
                 const data: OverviewStatsResponse = await res.json();
                 if (cancelled) return;
@@ -144,7 +145,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         let cancelled = false;
         (async () => {
             try {
-                const res = await fetch(`/api/get-overview-stats?window=${window}&sections=detail`);
+                const res = await fetch(withUrlBase(`/api/get-overview-stats?window=${window}&sections=detail`));
                 if (!res.ok || cancelled) return;
                 const data: OverviewStatsResponse = await res.json();
                 if (cancelled) return;
@@ -160,7 +161,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         let cancelled = false;
         (async () => {
             try {
-                const res = await fetch(`/api/get-overview-stats?window=${window}&sections=static`);
+                const res = await fetch(withUrlBase(`/api/get-overview-stats?window=${window}&sections=static`));
                 if (!res.ok || cancelled) return;
                 const data: OverviewStatsResponse = await res.json();
                 if (cancelled) return;

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -4,6 +4,7 @@ import { SettingsCard, SettingsIntro, SettingsPage, ManagedSetting } from "~/com
 import { Input, Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
+import { withUrlBase } from "~/utils/url-base";
 
 type ArrsSettingsProps = {
     config: Record<string, string>
@@ -331,7 +332,7 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
             formData.append('host', host);
             formData.append('apiKey', apiKey);
 
-            const response = await fetch('/api/test-arr-connection', {
+            const response = await fetch(withUrlBase('/api/test-arr-connection'), {
                 method: 'POST',
                 body: formData
             });

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -12,6 +12,7 @@ import { Checkbox, Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { ManagedSetting, SettingsIntro, SettingsPage } from "~/components/ui";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
 
 type BackupSettingsProps = {
     config: Record<string, string>;
@@ -69,7 +70,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
 
     const refreshList = useCallback(async () => {
         try {
-            const res = await fetch("/api/db-backup-list", { cache: "no-store" });
+            const res = await fetch(withUrlBase("/api/db-backup-list"), { cache: "no-store" });
             const data = (await res.json().catch(() => null)) as BackupListResponse | null;
             if (!res.ok) {
                 setListError(data?.error || `Failed to load backups (${res.status})`);
@@ -118,7 +119,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         let cancelled = false;
         const poll = async () => {
             try {
-                const res = await fetch("/api/migration-status", {
+                const res = await fetch(withUrlBase("/api/migration-status"), {
                     headers: { accept: "application/json" },
                     cache: "no-store",
                 });
@@ -157,7 +158,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         try {
             const form = new FormData();
             if (notes.trim()) form.append("notes", notes.trim());
-            const res = await fetch("/api/db-backup-create", { method: "POST", body: form });
+            const res = await fetch(withUrlBase("/api/db-backup-create"), { method: "POST", body: form });
             if (res.status === 409) {
                 setMessage({ text: "A backup or restore task is already running.", variant: "warning" });
                 return;
@@ -182,7 +183,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         form.append("id", id);
         if (patch.preserved !== undefined) form.append("preserved", String(patch.preserved));
         if (patch.notes !== undefined) form.append("notes", patch.notes);
-        const res = await fetch("/api/db-backup-update", { method: "POST", body: form });
+        const res = await fetch(withUrlBase("/api/db-backup-update"), { method: "POST", body: form });
         if (!res.ok) {
             const data = await res.json().catch(() => null);
             setMessage({ text: data?.error || `Update failed (${res.status})`, variant: "danger" });
@@ -197,7 +198,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         try {
             const form = new FormData();
             form.append("id", id);
-            const res = await fetch("/api/db-backup-delete", { method: "POST", body: form });
+            const res = await fetch(withUrlBase("/api/db-backup-delete"), { method: "POST", body: form });
             if (!res.ok) {
                 const data = await res.json().catch(() => null);
                 setMessage({ text: data?.error || `Delete failed (${res.status})`, variant: "danger" });
@@ -216,7 +217,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         setBusy(`download-${id}`);
         setMessage(null);
         try {
-            const res = await fetch(`/api/db-backup-download?id=${encodeURIComponent(id)}`);
+            const res = await fetch(withUrlBase(`/api/db-backup-download?id=${encodeURIComponent(id)}`));
             if (!res.ok) {
                 const data = await res.json().catch(() => null);
                 setMessage({ text: data?.error || `Download failed (${res.status})`, variant: "danger" });
@@ -244,7 +245,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         try {
             const form = new FormData();
             form.append("file", file);
-            const res = await fetch("/api/db-backup-upload", { method: "POST", body: form });
+            const res = await fetch(withUrlBase("/api/db-backup-upload"), { method: "POST", body: form });
             const data = await res.json().catch(() => null);
             if (!res.ok) {
                 setMessage({ text: data?.error || `Upload failed (${res.status})`, variant: "danger" });
@@ -274,7 +275,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         try {
             const form = new FormData();
             form.append("id", id);
-            const res = await fetch("/api/db-restore", { method: "POST", body: form });
+            const res = await fetch(withUrlBase("/api/db-restore"), { method: "POST", body: form });
             const data = await res.json().catch(() => null);
             if (res.status === 409) {
                 setMessage({ text: "A backup or restore task is already running.", variant: "warning" });

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -20,6 +20,7 @@ import {
     useIsAnyManaged,
 } from "~/components/ui";
 import { isMaskedSecret } from "~/utils/config-mask";
+import { withUrlBase } from "~/utils/url-base";
 
 type IndexersSettingsProps = {
     config: Record<string, string>
@@ -288,7 +289,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
     const [isSyncing, setIsSyncing] = useState(false);
     const loadSyncStatus = useCallback(async () => {
         try {
-            const res = await fetch("/settings/exclude-sync");
+            const res = await fetch(withUrlBase("/settings/exclude-sync"));
             if (res.ok) setSyncStatus((await res.json()).urls ?? []);
         } catch {
             // status is best-effort; ignore transient failures
@@ -310,7 +311,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         if (excludeSyncManaged) return;
         setIsSyncing(true);
         try {
-            const res = await fetch("/settings/exclude-sync", { method: "POST" });
+            const res = await fetch(withUrlBase("/settings/exclude-sync"), { method: "POST" });
             if (res.ok) setSyncStatus((await res.json()).urls ?? []);
         } catch {
             // ignore; the row shows the backend-reported error on the next status load
@@ -949,7 +950,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             if (proxyUrl.trim()) fd.append('proxyUrl', proxyUrl);
             if (timeoutSeconds.trim()) fd.append('timeoutSeconds', timeoutSeconds);
             fd.append('skipTlsVerification', skipTlsVerification.toString());
-            const r = await fetch('/api/test-indexer-connection', { method: 'POST', body: fd });
+            const r = await fetch(withUrlBase('/api/test-indexer-connection'), { method: 'POST', body: fd });
             const data = await r.json();
             setTestState(data.status && data.connected ? 'success' : 'error');
         } catch {

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -4,6 +4,7 @@ import { Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
 
 type RecreateStrmFilesProps = {
     savedConfig: Record<string, string>
@@ -48,7 +49,7 @@ export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
         setProgress(null);
         try {
             const qs = rewriteAll ? "?rewriteAll=true" : "";
-            const response = await fetch(`/api/recreate-strm-files${qs}`);
+            const response = await fetch(withUrlBase(`/api/recreate-strm-files${qs}`));
             if (response.status === 409) {
                 setError("Another maintenance task is already running.");
                 setRunStarted(false);

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -3,6 +3,7 @@ import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useEffect, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
 
 type RemoveUnlinkedFilesProps = {
     savedConfig: Record<string, string>
@@ -131,7 +132,7 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
                         >
                             {statusError ?? progress ?? "Ready to scan."}
                             {isDone && <>
-                                {" "}<a className="link link-primary" href="/api/remove-unlinked-files/audit">View audit</a>
+                                {" "}<a className="link link-primary" href={withUrlBase("/api/remove-unlinked-files/audit")}>View audit</a>
                             </>}
                         </div>
                     </div>

--- a/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
+++ b/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
@@ -3,6 +3,7 @@ import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useEffect, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
 
 type RenameWindowsInvalidDavPathsProps = {
     savedConfig: Record<string, string>
@@ -127,7 +128,7 @@ export function RenameWindowsInvalidDavPaths({ savedConfig }: RenameWindowsInval
                         >
                             {statusError ?? progress ?? "Ready to scan."}
                             {isDone && <>
-                                {" "}<a className="link link-primary" href="/api/rename-windows-invalid-dav-paths/audit">View report</a>
+                                {" "}<a className="link link-primary" href={withUrlBase("/api/rename-windows-invalid-dav-paths/audit")}>View report</a>
                             </>}
                         </div>
                     </div>

--- a/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
+import { withUrlBase } from "~/utils/url-base";
 
 export function ResetHealthCheckStats() {
     const [isRunning, setIsRunning] = useState(false);
@@ -19,7 +20,7 @@ export function ResetHealthCheckStats() {
         setMessage(null);
         setError(null);
         try {
-            const response = await fetch("/api/clear-health-check-history", { method: "POST" });
+            const response = await fetch(withUrlBase("/api/clear-health-check-history"), { method: "POST" });
             if (!response.ok) {
                 const body = await response.json().catch(() => ({}));
                 throw new Error(body.error || `Request failed (${response.status})`);

--- a/frontend/app/routes/settings/maintenance/reset-overview-stats/reset-overview-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-overview-stats/reset-overview-stats.tsx
@@ -3,6 +3,7 @@ import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
 import { Select } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
+import { withUrlBase } from "~/utils/url-base";
 
 type ProviderOption = { providerId: string; label: string };
 
@@ -15,7 +16,7 @@ export function ResetOverviewStats() {
 
     useEffect(() => {
         let cancelled = false;
-        fetch("/api/get-provider-usage")
+        fetch(withUrlBase("/api/get-provider-usage"))
             .then(r => (r.ok ? r.json() : Promise.reject()))
             .then(data => {
                 if (cancelled) return;

--- a/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
+++ b/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
@@ -3,6 +3,7 @@ import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
 import { useCallback, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
 
 type ConvertStrmToSymlinksProps = {
     savedConfig: Record<string, string>
@@ -30,7 +31,7 @@ export function ConvertStrmToSymlinks({ savedConfig }: ConvertStrmToSymlinksProp
     // events
     const onRun = useCallback(async () => {
         setIsFetching(true);
-        await fetch("/api/convert-strm-to-symlinks");
+        await fetch(withUrlBase("/api/convert-strm-to-symlinks"));
         setIsFetching(false);
     }, [setIsFetching]);
 

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -4,6 +4,7 @@ import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/com
 import { Input, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
+import { withUrlBase } from "~/utils/url-base";
 
 type RcloneSettingsProps = {
     config: Record<string, string>
@@ -34,7 +35,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
             formData.append('user', config["rclone.user"] ?? '');
             formData.append('pass', config["rclone.pass"] ?? '');
 
-            const response = await fetch('/api/test-rclone-connection', {
+            const response = await fetch(withUrlBase('/api/test-rclone-connection'), {
                 method: 'POST',
                 body: formData
             });

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -29,6 +29,7 @@ import { parseSettingsTab, getSettingsTabItem, type SettingsTab } from "./settin
 import { Icon } from "~/components/ui";
 import type { AppOutletContext } from "~/auth/authorization";
 import { isSettingsTabDisabled } from "~/utils/service-provider";
+import { withUrlBase } from "~/utils/url-base";
 
 const defaultConfig = {
     "general.base-url": "",
@@ -289,7 +290,7 @@ function Body(props: BodyProps) {
     }, [config]);
 
     const postConfigUpdate = useCallback(async (changedConfig: Record<string, string>) => {
-        const response = await fetch("/settings/update", {
+        const response = await fetch(withUrlBase("/settings/update"), {
             method: "POST",
             body: (() => {
                 const form = new FormData();

--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -1,3 +1,4 @@
+import { withUrlBase } from "~/utils/url-base";
 import { useCallback, useEffect, useState } from "react";
 import {
     Alert,
@@ -56,7 +57,7 @@ export function SupportSettings() {
 
     useEffect(() => {
         let cancelled = false;
-        void fetch("/settings/stream-tracing")
+        void fetch(withUrlBase("/settings/stream-tracing"))
             .then(async (response) => {
                 if (!response.ok) return;
                 const next = await response.json() as Record<string, unknown>;
@@ -90,7 +91,7 @@ export function SupportSettings() {
         setBusy(true);
         setMessage(null);
         try {
-            const response = await fetch("/api/download-support-pack", { cache: "no-store" });
+            const response = await fetch(withUrlBase("/api/download-support-pack"), { cache: "no-store" });
             if (!response.ok) {
                 const body = await response.json().catch(() => null);
                 throw new Error(body?.error || `Support pack failed (${response.status})`);
@@ -125,7 +126,7 @@ export function SupportSettings() {
             form.append("enabled", enabled ? "true" : "false");
             form.append("minutes", String(durationMinutes));
             form.append("capacity", String(capacity));
-            const response = await fetch("/settings/stream-tracing", { method: "POST", body: form });
+            const response = await fetch(withUrlBase("/settings/stream-tracing"), { method: "POST", body: form });
             if (!response.ok) {
                 const body = await response.json().catch(() => null);
                 throw new Error(body?.error || `Could not update stream tracing (${response.status})`);
@@ -159,7 +160,7 @@ export function SupportSettings() {
         try {
             const form = new FormData();
             form.append("intent", "discard");
-            const response = await fetch("/settings/stream-tracing", { method: "POST", body: form });
+            const response = await fetch(withUrlBase("/settings/stream-tracing"), { method: "POST", body: form });
             if (!response.ok) {
                 const body = await response.json().catch(() => null);
                 throw new Error(body?.error || `Could not discard stream traces (${response.status})`);

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -22,6 +22,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { useSearchParams } from "react-router";
 import { isPositiveInteger } from "../validation";
+import { withUrlBase } from "~/utils/url-base";
 
 const USAGE_POLL_INTERVAL_MS = 10_000;
 
@@ -582,7 +583,7 @@ export function UsenetSettings({ config, setNewConfig, persistConfigPatch }: Use
         let disposed = false;
         async function fetchUsage() {
             try {
-                const response = await fetch('/api/get-provider-usage');
+                const response = await fetch(withUrlBase('/api/get-provider-usage'));
                 if (!response.ok || disposed) return;
                 const data: { providers?: ProviderUsage[] } = await response.json();
                 if (disposed || !data.providers) return;
@@ -1153,7 +1154,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
     useEffect(() => {
         if (!show) {
             benchmarkAbortRef.current?.abort();
-            void fetch('/api/benchmark-usenet-connection', {
+            void fetch(withUrlBase('/api/benchmark-usenet-connection'), {
                 method: 'POST',
                 body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
             }).catch(() => { /* best-effort cancel */ });
@@ -1161,7 +1162,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
     }, [show]);
     useEffect(() => () => {
         benchmarkAbortRef.current?.abort();
-        void fetch('/api/benchmark-usenet-connection', {
+        void fetch(withUrlBase('/api/benchmark-usenet-connection'), {
             method: 'POST',
             body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
         }).catch(() => { /* best-effort cancel */ });
@@ -1181,7 +1182,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
             formData.append('user', user);
             formData.append('pass', pass);
 
-            const response = await fetch('/api/test-usenet-connection', {
+            const response = await fetch(withUrlBase('/api/test-usenet-connection'), {
                 method: 'POST',
                 body: formData,
             });
@@ -1208,7 +1209,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
     const handleAutoTune = useCallback(async (verifyConnections?: number) => {
         // Abort any previous run still in flight before starting a new one.
         benchmarkAbortRef.current?.abort();
-        await fetch('/api/benchmark-usenet-connection', {
+        await fetch(withUrlBase('/api/benchmark-usenet-connection'), {
             method: 'POST',
             body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
         }).catch(() => { /* best-effort */ });
@@ -1274,7 +1275,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
             if (dataBudget) formData.append('data-budget-mb', dataBudget);
             if (verifyConnections) formData.append('verify-connections', String(verifyConnections));
 
-            const response = await fetch('/api/benchmark-usenet-connection', {
+            const response = await fetch(withUrlBase('/api/benchmark-usenet-connection'), {
                 method: 'POST', body: formData, signal: controller.signal,
             });
             const data = await response.json().catch(() => null);
@@ -1321,7 +1322,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
 
     const handleCancelBenchmark = useCallback(() => {
         benchmarkAbortRef.current?.abort();
-        void fetch('/api/benchmark-usenet-connection', {
+        void fetch(withUrlBase('/api/benchmark-usenet-connection'), {
             method: 'POST',
             body: (() => { const f = new FormData(); f.append('cancel', 'true'); return f; })(),
         }).catch(() => { /* best-effort cancel */ });

--- a/frontend/app/routes/settings/warden/warden.tsx
+++ b/frontend/app/routes/settings/warden/warden.tsx
@@ -1,6 +1,7 @@
 import { type ChangeEvent, type DragEvent, type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { Alert, Button, Icon, ManagedSetting, Modal, NativeForm as Form, SettingsIntro, SettingsPage, Spinner, Textarea, Tooltip } from "~/components/ui";
+import { withUrlBase } from "~/utils/url-base";
 
 type WardenSettingsProps = {
     config: Record<string, string>;
@@ -118,14 +119,14 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
 
     const refresh = async () => {
         try {
-            const res = await fetch("/api/warden-sources");
+            const res = await fetch(withUrlBase("/api/warden-sources"));
             if (res.ok) setSnap(await res.json());
         } catch { /* ignore */ }
     };
 
     const loadBackup = async () => {
         try {
-            const res = await fetch("/api/warden-backup");
+            const res = await fetch(withUrlBase("/api/warden-backup"));
             if (res.ok) setBackup(await res.json());
         } catch { }
     };

--- a/frontend/app/routes/watchdog/route.tsx
+++ b/frontend/app/routes/watchdog/route.tsx
@@ -5,6 +5,7 @@ import { backendClient, type WatchdogEntry, type WatchdogOutcome } from "~/clien
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { Alert, Badge, Icon } from "~/components/ui";
 import { useIsReadOnly } from "~/auth/authorization";
+import { withUrlBase } from "~/utils/url-base";
 
 const POLL_INTERVAL_MS = 3000;
 
@@ -44,7 +45,7 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
     const refresh = useCallback(async (silent: boolean = false) => {
         if (!silent) setRefreshing(true);
         try {
-            const r = await fetch("/settings/watchdog-attempts?limit=200");
+            const r = await fetch(withUrlBase("/settings/watchdog-attempts?limit=200"));
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             const data = await r.json();
             const next: WatchdogEntry[] = data.entries ?? [];
@@ -61,7 +62,7 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
         setShowClearConfirm(false);
         setClearing(true);
         try {
-            const r = await fetch("/settings/watchdog-attempts", { method: "POST" });
+            const r = await fetch(withUrlBase("/settings/watchdog-attempts"), { method: "POST" });
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             setAttempts([]);
             setError(null);

--- a/frontend/app/utils/shared-websocket.ts
+++ b/frontend/app/utils/shared-websocket.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { URL_BASE } from "./url-base";
 import { receiveMessage } from "~/utils/websocket-util";
 
 export type TopicKind = "state" | "stream" | "event";
@@ -15,7 +16,7 @@ type Subscriber = {
 const RECONNECT_MS = 1000;
 
 function websocketUrl(): string {
-    return `${globalThis.location.origin.replace(/^http/, "ws")}/ws`;
+    return `${globalThis.location.origin.replace(/^http/, "ws")}${URL_BASE}/ws`;
 }
 
 /**

--- a/frontend/app/utils/url-base.test.ts
+++ b/frontend/app/utils/url-base.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeUrlBase, withUrlBase } from "./url-base";
+
+describe("normalizeUrlBase", () => {
+  it("treats unset, empty, and bare-slash values as root", () => {
+    expect(normalizeUrlBase(undefined)).toBe("");
+    expect(normalizeUrlBase("")).toBe("");
+    expect(normalizeUrlBase("/")).toBe("");
+    expect(normalizeUrlBase("  ")).toBe("");
+  });
+
+  it("forces a single leading slash and strips trailing slashes", () => {
+    expect(normalizeUrlBase("nzbdav")).toBe("/nzbdav");
+    expect(normalizeUrlBase("/nzbdav")).toBe("/nzbdav");
+    expect(normalizeUrlBase("/nzbdav/")).toBe("/nzbdav");
+    expect(normalizeUrlBase("/nzbdav///")).toBe("/nzbdav");
+    expect(normalizeUrlBase(" /nzbdav ")).toBe("/nzbdav");
+  });
+
+  it("preserves multi-segment prefixes", () => {
+    expect(normalizeUrlBase("/tools/nzbdav/")).toBe("/tools/nzbdav");
+  });
+});
+
+describe("withUrlBase", () => {
+  // __URL_BASE__ is not defined under vitest, so URL_BASE resolves to "" here;
+  // these assert the path-joining contract rather than a specific prefix.
+  it("always emits a leading slash", () => {
+    expect(withUrlBase("/api/foo")).toBe("/api/foo");
+    expect(withUrlBase("api/foo")).toBe("/api/foo");
+  });
+
+  it("leaves query strings intact", () => {
+    expect(withUrlBase("/api?mode=queue")).toBe("/api?mode=queue");
+  });
+});

--- a/frontend/app/utils/url-base.test.ts
+++ b/frontend/app/utils/url-base.test.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { normalizeUrlBase, withUrlBase } from "./url-base";
+import { normalizeUrlBase, urlBaseFromEnv, withUrlBase } from "./url-base";
 
 describe("normalizeUrlBase", () => {
   it("treats unset, empty, and bare-slash values as root", () => {
@@ -20,11 +21,37 @@ describe("normalizeUrlBase", () => {
   it("preserves multi-segment prefixes", () => {
     expect(normalizeUrlBase("/tools/nzbdav/")).toBe("/tools/nzbdav");
   });
+
+  it("rejects characters Express 5 would misparse as route patterns", () => {
+    // ":" and "*" mount successfully in path-to-regexp v8 but silently turn
+    // the prefix into a pattern; "(" and "{" crash at boot with a raw stack.
+    for (const bad of ["/nzb:dav", "/nzb*dav", "/nzb(dav", "/nzb{dav", "/nzb dav", "/nzb%64av", "/nzb?x=1"]) {
+      expect(() => normalizeUrlBase(bad), bad).toThrow(/Invalid URL base/);
+    }
+  });
+
+  it("allows the full unreserved path charset", () => {
+    expect(normalizeUrlBase("/My.App_v2~x-1")).toBe("/My.App_v2~x-1");
+  });
+});
+
+describe("urlBaseFromEnv", () => {
+  it("prefers NZBDAV_URL_BASE over bare URL_BASE", () => {
+    expect(urlBaseFromEnv({ NZBDAV_URL_BASE: "/a", URL_BASE: "/b" })).toBe("/a");
+  });
+
+  it("falls back to bare URL_BASE", () => {
+    expect(urlBaseFromEnv({ URL_BASE: "/b" })).toBe("/b");
+  });
+
+  it("returns root when neither is set", () => {
+    expect(urlBaseFromEnv({})).toBe("");
+  });
 });
 
 describe("withUrlBase", () => {
-  // __URL_BASE__ is not defined under vitest, so URL_BASE resolves to "" here;
-  // these assert the path-joining contract rather than a specific prefix.
+  // __URL_BASE__ is not defined under vitest, so URL_BASE resolves from the
+  // (unset) test environment; these assert the path-joining contract.
   it("always emits a leading slash", () => {
     expect(withUrlBase("/api/foo")).toBe("/api/foo");
     expect(withUrlBase("api/foo")).toBe("/api/foo");
@@ -32,5 +59,28 @@ describe("withUrlBase", () => {
 
   it("leaves query strings intact", () => {
     expect(withUrlBase("/api?mode=queue")).toBe("/api?mode=queue");
+  });
+});
+
+describe("server.ts mirror parity", () => {
+  // server.ts is compiled by tsc into dist-node without the app graph, so it
+  // carries a hand-synced copy of the normalizer. Assert the copies cannot
+  // drift: the same charset guard and the same normalization steps must appear
+  // verbatim in both files.
+  const here = readFileSync(new URL("./url-base.ts", import.meta.url), "utf8");
+  const server = readFileSync(new URL("../../server.ts", import.meta.url), "utf8");
+
+  it.each([
+    ['const SAFE_URL_BASE = /^[A-Za-z0-9._~\\-/]+$/;'],
+    ['if (trimmed === "" || trimmed === "/") return "";'],
+    ['const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;'],
+    ['return withLeading.replace(/\\/+$/, "");'],
+  ])("both copies contain %s", (line) => {
+    expect(here).toContain(line);
+    expect(server).toContain(line);
+  });
+
+  it("server.ts reads NZBDAV_URL_BASE with URL_BASE fallback", () => {
+    expect(server).toContain("process.env.NZBDAV_URL_BASE ?? process.env.URL_BASE");
   });
 });

--- a/frontend/app/utils/url-base.ts
+++ b/frontend/app/utils/url-base.ts
@@ -1,9 +1,10 @@
-// URL_BASE controls the sub-path the app is hosted under, e.g. "/nzbdav".
+// NZBDAV_URL_BASE controls the sub-path the app is hosted under, e.g. "/nzbdav".
 //
-// - Configured via the `URL_BASE` env var. Set as a Docker build arg so it gets baked
-//   into the React Router basename, Vite asset paths, and the `__URL_BASE__` global below.
-//   Also read at runtime by the Express server so it mounts middleware under the same
-//   prefix. Both ends must agree — the build arg and the runtime env var.
+// - Configured via the `NZBDAV_URL_BASE` env var (bare `URL_BASE` is accepted as
+//   a fallback). Set as a Docker build arg so it gets baked into the React Router
+//   basename, Vite asset paths, and the `__URL_BASE__` global below. Also read at
+//   runtime by the Express server so it mounts middleware under the same prefix.
+//   Both ends must agree — server.ts refuses to start on a mismatch.
 // - Empty string ("") and "/" both mean "app is at the root".
 // - The Vite `define` in vite.config.ts replaces `__URL_BASE__` with the normalized
 //   value (e.g. `"/nzbdav"` or `""`) at compile time.
@@ -12,24 +13,41 @@
 
 declare const __URL_BASE__: string;
 
+// Path segments only: unreserved URL characters plus "/". Anything else is
+// rejected — Express 5 hands the mount prefix to path-to-regexp v8, where "("
+// or "{" crash at boot with a raw stack and ":" or "*" silently turn the
+// prefix into a route pattern (e.g. "/nzb:dav" would serve under "/nzbanything").
+const SAFE_URL_BASE = /^[A-Za-z0-9._~\-/]+$/;
+
 /**
  * Normalize a raw URL_BASE value into "" (root) or "/path" form — single leading
- * slash, no trailing slash. Mirrored (not imported) in react-router.config.ts,
- * vite.config.ts, and server.ts because those run outside the Vite app graph —
- * keep them in sync.
+ * slash, no trailing slash. Throws on characters that Express would misparse as
+ * a route pattern. Mirrored (not imported) in server.ts, which is compiled by
+ * tsc into dist-node without the app graph — keep them in sync (url-base.test.ts
+ * asserts parity).
  */
 export function normalizeUrlBase(raw: string | undefined): string {
   if (!raw) return "";
   const trimmed = raw.trim();
   if (trimmed === "" || trimmed === "/") return "";
+  if (!SAFE_URL_BASE.test(trimmed)) {
+    throw new Error(
+      `Invalid URL base ${JSON.stringify(raw)}: only letters, digits, ".", "_", "~", "-", and "/" are allowed`,
+    );
+  }
   const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
   return withLeading.replace(/\/+$/, "");
+}
+
+/** Read the URL base from the environment: NZBDAV_URL_BASE, then bare URL_BASE. */
+export function urlBaseFromEnv(env: Record<string, string | undefined>): string {
+  return normalizeUrlBase(env.NZBDAV_URL_BASE ?? env.URL_BASE);
 }
 
 export const URL_BASE: string =
   typeof __URL_BASE__ !== "undefined"
     ? __URL_BASE__
-    : normalizeUrlBase(typeof process !== "undefined" ? process.env?.URL_BASE : "");
+    : urlBaseFromEnv(typeof process !== "undefined" ? process.env ?? {} : {});
 
 /**
  * Prefix a server-relative path with URL_BASE. Always returns a leading slash.

--- a/frontend/app/utils/url-base.ts
+++ b/frontend/app/utils/url-base.ts
@@ -1,0 +1,43 @@
+// URL_BASE controls the sub-path the app is hosted under, e.g. "/nzbdav".
+//
+// - Configured via the `URL_BASE` env var. Set as a Docker build arg so it gets baked
+//   into the React Router basename, Vite asset paths, and the `__URL_BASE__` global below.
+//   Also read at runtime by the Express server so it mounts middleware under the same
+//   prefix. Both ends must agree — the build arg and the runtime env var.
+// - Empty string ("") and "/" both mean "app is at the root".
+// - The Vite `define` in vite.config.ts replaces `__URL_BASE__` with the normalized
+//   value (e.g. `"/nzbdav"` or `""`) at compile time.
+// - The normalized form never has a trailing slash, so `URL_BASE + "/api"` is always
+//   well-formed.
+
+declare const __URL_BASE__: string;
+
+/**
+ * Normalize a raw URL_BASE value into "" (root) or "/path" form — single leading
+ * slash, no trailing slash. Mirrored (not imported) in react-router.config.ts,
+ * vite.config.ts, and server.ts because those run outside the Vite app graph —
+ * keep them in sync.
+ */
+export function normalizeUrlBase(raw: string | undefined): string {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "/") return "";
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeading.replace(/\/+$/, "");
+}
+
+export const URL_BASE: string =
+  typeof __URL_BASE__ !== "undefined"
+    ? __URL_BASE__
+    : normalizeUrlBase(typeof process !== "undefined" ? process.env?.URL_BASE : "");
+
+/**
+ * Prefix a server-relative path with URL_BASE. Always returns a leading slash.
+ *   withUrlBase("/api/foo")      // "/nzbdav/api/foo" or "/api/foo"
+ *   withUrlBase("api/foo")       // "/nzbdav/api/foo" or "/api/foo"
+ *   withUrlBase("/api?mode=x")   // "/nzbdav/api?mode=x" or "/api?mode=x"
+ */
+export function withUrlBase(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${URL_BASE}${normalizedPath}`;
+}

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,14 +1,16 @@
 {
   "name": "InfiniDysk",
   "short_name": "InfiniDysk",
+  "start_url": "./",
+  "scope": "./",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -1,25 +1,12 @@
 import type { Config } from "@react-router/dev/config";
-
-/**
- * Normalizes URL_BASE for use as a React Router basename: anything truthy and not "/"
- * is forced into "/path" form (single leading slash, no trailing slash). Empty or "/"
- * yields "/" which is React Router's default. Mirror of normalizeUrlBase in
- * `app/utils/url-base.ts` (this file runs outside the Vite app graph) — keep in sync.
- */
-function normalizeBasename(raw: string | undefined): string {
-  if (!raw) return "/";
-  const trimmed = raw.trim();
-  if (trimmed === "" || trimmed === "/") return "/";
-  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  const withoutTrailing = withLeading.replace(/\/+$/, "");
-  return withoutTrailing || "/";
-}
+import { urlBaseFromEnv } from "./app/utils/url-base";
 
 export default {
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
-  // URL_BASE env var, read at build time, controls the React Router basename so
-  // <Link> and useFetcher generate the correct paths when the app is hosted under
-  // a sub-path. Must match the URL_BASE env var at runtime (see server.ts).
-  basename: normalizeBasename(process.env.URL_BASE),
+  // NZBDAV_URL_BASE (or bare URL_BASE), read at build time, controls the React
+  // Router basename so <Link> and useFetcher generate the correct paths when
+  // the app is hosted under a sub-path. Must match the runtime env var — see
+  // server.ts, which enforces the pairing.
+  basename: urlBaseFromEnv(process.env) || "/",
 } satisfies Config;

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -1,7 +1,25 @@
 import type { Config } from "@react-router/dev/config";
 
+/**
+ * Normalizes URL_BASE for use as a React Router basename: anything truthy and not "/"
+ * is forced into "/path" form (single leading slash, no trailing slash). Empty or "/"
+ * yields "/" which is React Router's default. Mirror of normalizeUrlBase in
+ * `app/utils/url-base.ts` (this file runs outside the Vite app graph) — keep in sync.
+ */
+function normalizeBasename(raw: string | undefined): string {
+  if (!raw) return "/";
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "/") return "/";
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutTrailing = withLeading.replace(/\/+$/, "");
+  return withoutTrailing || "/";
+}
+
 export default {
-  // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
+  // URL_BASE env var, read at build time, controls the React Router basename so
+  // <Link> and useFetcher generate the correct paths when the app is hosted under
+  // a sub-path. Must match the URL_BASE env var at runtime (see server.ts).
+  basename: normalizeBasename(process.env.URL_BASE),
 } satisfies Config;

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -17,6 +17,20 @@ const BUILD_PATH = "../build/server/index.js";
 const DEVELOPMENT = process.env.NODE_ENV === "development";
 const PORT = Number.parseInt(process.env.PORT || "3000");
 
+// URL_BASE controls the sub-path the app is mounted under (e.g. "/nzbdav").
+// Mirror of normalizeUrlBase in app/utils/url-base.ts (this file is compiled by
+// tsc outside the Vite app graph) — keep them in sync. The Vite build bakes the
+// same value into the client bundle at build time; the runtime env var here
+// mounts middleware at the matching prefix so both ends agree.
+function normalizeUrlBase(raw: string | undefined): string {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "/") return "";
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeading.replace(/\/+$/, "");
+}
+const URL_BASE = normalizeUrlBase(process.env.URL_BASE);
+
 // Keep the frontend alive when the backend is slow. SSR loaders fetch the
 // backend; when those fetches reject and a loader doesn't catch them, the
 // rejection can become an unhandledRejection that Node terminates on by
@@ -53,11 +67,26 @@ app.use(securityHeadersMiddleware);
 // Frontend-local healthcheck. Registered BEFORE request logging and the React
 // Router catch-all so probes bypass SSR and stay quiet in access logs.
 // Adopted from elfhosted/rebased-v3.
+// Served at the bare root regardless of URL_BASE so container healthchecks
+// have a stable URL, and additionally under URL_BASE for reverse-proxy probes.
 app.get("/healthz", (_req, res) => {
   res.status(200).type("text/plain").send("ok");
 });
+if (URL_BASE) {
+  app.get(`${URL_BASE}/healthz`, (_req, res) => {
+    res.status(200).type("text/plain").send("ok");
+  });
+}
 
 app.use(requestLogger);
+
+// Path-sensitive middleware (static assets and the app module) goes on a
+// sub-router mounted under URL_BASE, so it inherits the prefix without
+// per-middleware path arithmetic. Inside the router `req.path` is stripped of
+// URL_BASE — existing path-prefix checks (`/api`, `/nzbs`, …) work unchanged —
+// while the React Router request handler reads `req.originalUrl` and therefore
+// still sees the full, basename-prefixed path.
+const router = express.Router();
 
 // Initialize the websocket server as soon as both it and the server-module are ready
 let _serverModule: any = null;
@@ -81,8 +110,10 @@ if (DEVELOPMENT) {
       server: { middlewareMode: true },
     }),
   );
+  // Vite's dev middlewares handle their own `base` prefix, so they stay on the
+  // root app; only the SSR module goes on the URL_BASE-mounted router.
   app.use(viteDevServer.middlewares);
-  app.use(async (req, res, next) => {
+  router.use(async (req, res, next) => {
     try {
       const serverModule = await viteDevServer.ssrLoadModule("./server/app.ts");
       setServerModule(serverModule);
@@ -96,14 +127,24 @@ if (DEVELOPMENT) {
   });
 } else {
   logger.info("Starting frontend production server");
-  app.use(
+  router.use(
     "/assets",
     express.static("build/client/assets", { immutable: true, maxAge: "1y" }),
   );
-  app.use(express.static("build/client", { maxAge: "1h" }));
+  router.use(express.static("build/client", { maxAge: "1h" }));
   const serverModule = await import(BUILD_PATH);
-  app.use(serverModule.app);
+  router.use(serverModule.app);
   setServerModule(serverModule);
+}
+
+// Mount the router. When URL_BASE is empty we mount at root (no prefix).
+// Otherwise we mount under URL_BASE and redirect the bare host root so users
+// hitting `/` land in the right place.
+if (URL_BASE) {
+  app.get("/", (_req, res) => res.redirect(`${URL_BASE}/`));
+  app.use(URL_BASE, router);
+} else {
+  app.use(router);
 }
 
 // Create both the http and websocket servers
@@ -113,9 +154,9 @@ const server = http.createServer(app);
 const LONG_RUNNING_REQUEST_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
 server.requestTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS;
 server.headersTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS + 1000;
-setWebsocketServer(new WebSocketServer({ server, path: "/ws", maxPayload: 64 * 1024 }));
+setWebsocketServer(new WebSocketServer({ server, path: `${URL_BASE}/ws`, maxPayload: 64 * 1024 }));
 
 // Begin listening for connections
 server.listen(PORT, () => {
-  logger.info(`Frontend server listening on http://localhost:${PORT}`);
+  logger.info(`Frontend server listening on http://localhost:${PORT}${URL_BASE}`);
 });

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -17,19 +17,42 @@ const BUILD_PATH = "../build/server/index.js";
 const DEVELOPMENT = process.env.NODE_ENV === "development";
 const PORT = Number.parseInt(process.env.PORT || "3000");
 
-// URL_BASE controls the sub-path the app is mounted under (e.g. "/nzbdav").
-// Mirror of normalizeUrlBase in app/utils/url-base.ts (this file is compiled by
-// tsc outside the Vite app graph) — keep them in sync. The Vite build bakes the
-// same value into the client bundle at build time; the runtime env var here
-// mounts middleware at the matching prefix so both ends agree.
+// NZBDAV_URL_BASE (or bare URL_BASE as a fallback) controls the sub-path the
+// app is mounted under (e.g. "/nzbdav"). Mirror of normalizeUrlBase in
+// app/utils/url-base.ts (this file is compiled by tsc into dist-node without
+// the app graph) — keep them in sync; url-base.test.ts asserts parity. The
+// Vite build bakes the same value into the client bundle at build time; the
+// runtime env var here mounts middleware at the matching prefix, and the
+// baked-vs-runtime guard below refuses to start when the two halves disagree.
+const SAFE_URL_BASE = /^[A-Za-z0-9._~\-/]+$/;
 function normalizeUrlBase(raw: string | undefined): string {
   if (!raw) return "";
   const trimmed = raw.trim();
   if (trimmed === "" || trimmed === "/") return "";
+  if (!SAFE_URL_BASE.test(trimmed)) {
+    throw new Error(
+      `Invalid URL base ${JSON.stringify(raw)}: only letters, digits, ".", "_", "~", "-", and "/" are allowed`,
+    );
+  }
   const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
   return withLeading.replace(/\/+$/, "");
 }
-const URL_BASE = normalizeUrlBase(process.env.URL_BASE);
+const URL_BASE = normalizeUrlBase(process.env.NZBDAV_URL_BASE ?? process.env.URL_BASE);
+
+// The server build exports the value baked into the bundle at build time.
+// Mounting under a different prefix than the bundle was built for produces a
+// fully broken app (assets and basename at one prefix, routes at another), so
+// fail fast with an actionable message instead.
+function assertUrlBaseMatchesBuild(bakedUrlBase: unknown): void {
+  if (typeof bakedUrlBase !== "string" || bakedUrlBase === URL_BASE) return;
+  logger.error(
+    `NZBDAV_URL_BASE mismatch: this build was compiled with ${JSON.stringify(bakedUrlBase)} `
+    + `but the runtime environment says ${JSON.stringify(URL_BASE)}. The two halves of the `
+    + `setting must match — rebuild with --build-arg NZBDAV_URL_BASE=${URL_BASE || '""'} or `
+    + `set NZBDAV_URL_BASE=${bakedUrlBase || '""'} at runtime. See docs/configuration/url-base.md.`,
+  );
+  process.exit(1);
+}
 
 // Keep the frontend alive when the backend is slow. SSR loaders fetch the
 // backend; when those fetches reject and a loader doesn't catch them, the
@@ -62,7 +85,6 @@ app.use(
   }),
 );
 app.disable("x-powered-by");
-app.use(securityHeadersMiddleware);
 
 // Frontend-local healthcheck. Registered BEFORE request logging and the React
 // Router catch-all so probes bypass SSR and stay quiet in access logs.
@@ -80,13 +102,15 @@ if (URL_BASE) {
 
 app.use(requestLogger);
 
-// Path-sensitive middleware (static assets and the app module) goes on a
-// sub-router mounted under URL_BASE, so it inherits the prefix without
-// per-middleware path arithmetic. Inside the router `req.path` is stripped of
-// URL_BASE — existing path-prefix checks (`/api`, `/nzbs`, …) work unchanged —
-// while the React Router request handler reads `req.originalUrl` and therefore
-// still sees the full, basename-prefixed path.
+// Path-sensitive middleware (security headers, static assets, and the app
+// module) goes on a sub-router mounted under URL_BASE, so it inherits the
+// prefix without per-middleware path arithmetic. Inside the router `req.path`
+// is stripped of URL_BASE — existing path-prefix checks (`/api`, `/nzbs`, …,
+// including securityHeadersMiddleware's proxied-path exemption) work
+// unchanged — while the React Router request handler reads `req.originalUrl`
+// and therefore still sees the full, basename-prefixed path.
 const router = express.Router();
+router.use(securityHeadersMiddleware);
 
 // Initialize the websocket server as soon as both it and the server-module are ready
 let _serverModule: any = null;
@@ -116,6 +140,7 @@ if (DEVELOPMENT) {
   router.use(async (req, res, next) => {
     try {
       const serverModule = await viteDevServer.ssrLoadModule("./server/app.ts");
+      assertUrlBaseMatchesBuild(serverModule.bakedUrlBase);
       setServerModule(serverModule);
       return await serverModule.app(req, res, next);
     } catch (error) {
@@ -133,6 +158,7 @@ if (DEVELOPMENT) {
   );
   router.use(express.static("build/client", { maxAge: "1h" }));
   const serverModule = await import(BUILD_PATH);
+  assertUrlBaseMatchesBuild(serverModule.bakedUrlBase);
   router.use(serverModule.app);
   setServerModule(serverModule);
 }

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -17,8 +17,14 @@ import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
 import { backendProxyTimeoutOptions } from "./backend-proxy-options";
 import { handleBackendProxyResponse } from "./backend-proxy-response";
 import { oidcRouter } from "./oidc-routes";
+import { URL_BASE } from "~/utils/url-base";
 
 export const app = express();
+
+// The URL base this bundle was compiled with (Vite bakes it via __URL_BASE__).
+// server.ts compares this against the runtime env var and refuses to start on
+// a mismatch — the two halves of the setting cannot work independently.
+export const bakedUrlBase = URL_BASE;
 app.disable("x-powered-by");
 export const initializeWebsocketServer = websocketServer.initialize;
 

--- a/frontend/server/oidc-routes.ts
+++ b/frontend/server/oidc-routes.ts
@@ -15,6 +15,18 @@ import {
   resolveOidcUsername,
 } from "./oidc.server";
 import { logger } from "./logger";
+
+// Mounted under URL_BASE by server.ts, so incoming req.path values are already
+// stripped — but outgoing redirect Locations are browser-absolute and need the
+// prefix restored. Mirror of normalizeUrlBase in app/utils/url-base.ts.
+function normalizeUrlBase(raw: string | undefined): string {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "/") return "";
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeading.replace(/\/+$/, "");
+}
+const URL_BASE = normalizeUrlBase(process.env.URL_BASE);
 import { backendClient } from "~/clients/backend-client.server";
 
 export const oidcRouter = Router();
@@ -24,7 +36,7 @@ oidcRouter.get("/auth/oidc/callback", oidcCallbackHandler);
 
 export async function oidcLoginHandler(req: Request, res: Response): Promise<void> {
   if (!isOidcEnabled()) {
-    res.redirect(302, "/login?error=oidc_not_configured");
+    res.redirect(302, `${URL_BASE}/login?error=oidc_not_configured`);
     return;
   }
 
@@ -55,13 +67,13 @@ export async function oidcLoginHandler(req: Request, res: Response): Promise<voi
     res.redirect(302, authorizationUrl.href);
   } catch (error) {
     logOidcFailure("Could not start OIDC sign-in", error);
-    res.redirect(302, "/login?error=oidc_failed");
+    res.redirect(302, `${URL_BASE}/login?error=oidc_failed`);
   }
 }
 
 export async function oidcCallbackHandler(req: Request, res: Response): Promise<void> {
   if (!isOidcEnabled()) {
-    res.redirect(302, "/login?error=oidc_not_configured");
+    res.redirect(302, `${URL_BASE}/login?error=oidc_not_configured`);
     return;
   }
 
@@ -92,12 +104,12 @@ export async function oidcCallbackHandler(req: Request, res: Response): Promise<
 
     applySetCookie(res, session);
     logger.info(`OIDC sign-in succeeded for ${username} with ${role} role`);
-    res.redirect(302, "/");
+    res.redirect(302, `${URL_BASE}/`);
   } catch (error) {
     logOidcFailure("OIDC sign-in failed", error);
     const session = await clearOidcFlowState(req);
     applySetCookie(res, session);
-    res.redirect(302, "/login?error=oidc_failed");
+    res.redirect(302, `${URL_BASE}/login?error=oidc_failed`);
   }
 }
 
@@ -122,7 +134,7 @@ async function resolveRedirectUri(req: Request): Promise<string> {
 
   const host = req.get("host");
   if (!host) throw new Error("Unable to determine OIDC callback host");
-  return new URL("/auth/oidc/callback", `${req.protocol}://${host}`).href;
+  return new URL(`${URL_BASE}/auth/oidc/callback`, `${req.protocol}://${host}`).href;
 }
 
 function buildCallbackUrl(req: Request, redirectUri: string): URL {

--- a/frontend/server/oidc-routes.ts
+++ b/frontend/server/oidc-routes.ts
@@ -15,18 +15,11 @@ import {
   resolveOidcUsername,
 } from "./oidc.server";
 import { logger } from "./logger";
-
 // Mounted under URL_BASE by server.ts, so incoming req.path values are already
 // stripped — but outgoing redirect Locations are browser-absolute and need the
-// prefix restored. Mirror of normalizeUrlBase in app/utils/url-base.ts.
-function normalizeUrlBase(raw: string | undefined): string {
-  if (!raw) return "";
-  const trimmed = raw.trim();
-  if (trimmed === "" || trimmed === "/") return "";
-  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return withLeading.replace(/\/+$/, "");
-}
-const URL_BASE = normalizeUrlBase(process.env.URL_BASE);
+// prefix restored. Part of the Vite SSR bundle, so the baked constant applies.
+import { URL_BASE } from "~/utils/url-base";
+
 import { backendClient } from "~/clients/backend-client.server";
 
 export const oidcRouter = Router();

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/compression-filter.ts", "server/request-log-throttle.ts", "server/startup-grace.ts", "server/security-headers.ts", "vite.config.ts", "vitest.config.ts"],
+  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/compression-filter.ts", "server/request-log-throttle.ts", "server/startup-grace.ts", "server/security-headers.ts", "app/utils/url-base.ts", "vite.config.ts", "vitest.config.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,24 +8,44 @@ function resolveAllowedHosts(): string[] {
   return raw.split(",").map((host) => host.trim()).filter(Boolean);
 }
 
-export default defineConfig({
-  server: {
-    allowedHosts: resolveAllowedHosts(),
-  },
-  resolve: {
-    tsconfigPaths: true,
-  },
-  environments: {
-    ssr: {
-      build: {
-        rollupOptions: {
-          input: "./server/app.ts",
+// Mirror of normalizeUrlBase in app/utils/url-base.ts (this file runs outside the
+// Vite app graph, so the helper cannot be imported). Produces:
+//   - `viteBase`: Vite's `base` option form, "/" or "/path/" (trailing slash required).
+//   - `token`: value baked into `__URL_BASE__` for browser code, "" or "/path" (no slash).
+function normalizeUrlBase(raw: string | undefined): { viteBase: string; token: string } {
+  if (!raw) return { viteBase: "/", token: "" };
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "/") return { viteBase: "/", token: "" };
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutTrailing = withLeading.replace(/\/+$/, "");
+  return { viteBase: `${withoutTrailing}/`, token: withoutTrailing };
+}
+
+export default defineConfig(() => {
+  const { viteBase, token } = normalizeUrlBase(process.env.URL_BASE);
+  return {
+    base: viteBase,
+    server: {
+      allowedHosts: resolveAllowedHosts(),
+    },
+    resolve: {
+      tsconfigPaths: true,
+    },
+    environments: {
+      ssr: {
+        build: {
+          rollupOptions: {
+            input: "./server/app.ts",
+          },
         },
       },
     },
-  },
-  plugins: [
-    tailwindcss(),
-    reactRouter(),
-  ],
+    define: {
+      __URL_BASE__: JSON.stringify(token),
+    },
+    plugins: [
+      tailwindcss(),
+      reactRouter(),
+    ],
+  };
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
+import { urlBaseFromEnv } from "./app/utils/url-base";
 
 function resolveAllowedHosts(): string[] {
   const raw = process.env.VITE_ALLOWED_HOSTS?.trim();
@@ -8,23 +9,13 @@ function resolveAllowedHosts(): string[] {
   return raw.split(",").map((host) => host.trim()).filter(Boolean);
 }
 
-// Mirror of normalizeUrlBase in app/utils/url-base.ts (this file runs outside the
-// Vite app graph, so the helper cannot be imported). Produces:
-//   - `viteBase`: Vite's `base` option form, "/" or "/path/" (trailing slash required).
-//   - `token`: value baked into `__URL_BASE__` for browser code, "" or "/path" (no slash).
-function normalizeUrlBase(raw: string | undefined): { viteBase: string; token: string } {
-  if (!raw) return { viteBase: "/", token: "" };
-  const trimmed = raw.trim();
-  if (trimmed === "" || trimmed === "/") return { viteBase: "/", token: "" };
-  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  const withoutTrailing = withLeading.replace(/\/+$/, "");
-  return { viteBase: `${withoutTrailing}/`, token: withoutTrailing };
-}
-
 export default defineConfig(() => {
-  const { viteBase, token } = normalizeUrlBase(process.env.URL_BASE);
+  // NZBDAV_URL_BASE (or bare URL_BASE), read at build time. `token` is the
+  // "" / "/path" form baked into __URL_BASE__; Vite's `base` needs the
+  // trailing-slash variant.
+  const token = urlBaseFromEnv(process.env);
   return {
-    base: viteBase,
+    base: token === "" ? "/" : `${token}/`,
     server: {
       allowedHosts: resolveAllowedHosts(),
     },

--- a/zensical.toml
+++ b/zensical.toml
@@ -53,6 +53,7 @@ nav = [
     { "SABnzbd" = "configuration/sabnzbd.md" },
     { "Streaming" = "configuration/streaming.md" },
     { "WebDAV" = "configuration/webdav.md" },
+    { "URL base (sub-path hosting)" = "configuration/url-base.md" },
     { "Watchdog" = "configuration/watchdog.md" },
     { "Preflight" = "configuration/preflight.md" },
     { "Watchtower" = "configuration/watchtower.md" },


### PR DESCRIPTION
## What

Adds first-class support for hosting the app under a reverse-proxy sub-path — e.g. `https://example.com/nzbdav/` — without any `sub_filter` response rewriting in the proxy. Deployments that share one domain across many services (Swizzin/organizr-style setups, corporate proxies) currently need ~15 fragile nginx rewrite rules to keep the SSR app, SAB API, WebSocket, and hashed asset paths internally consistent; this replaces all of that with a single `URL_BASE` value.

## Design

`URL_BASE` has two halves that must match (documented in `docs/configuration/url-base.md`):

- **Build time** (`--build-arg URL_BASE=/nzbdav`): React Router basename, Vite `base`, and a `__URL_BASE__` constant baked into the client bundle. React Router's basename is build-time only — the framework exposes no runtime override — so this half cannot be avoided. The Dockerfile defaults the runtime env var to the baked value, so build-arg-only is enough.
- **Runtime** (`URL_BASE` env): `server.ts` mounts static assets and the app module on a sub-router under the prefix, the WebSocket endpoint moves to `<URL_BASE>/ws`, and login redirect Locations get the prefix restored.

Key property: inside the mounted router `req.path` is stripped of the prefix, so the existing backend-proxy path checks, credential rate-limiter paths, and auth public paths all work **unchanged** — while the React Router request handler reads `req.originalUrl` and still sees the full basename-prefixed path. The backend stays completely prefix-unaware (rclone and `NZBDAV_CONFIG__…` consumers are unaffected).

- `GET /healthz` stays at the bare root (stable container healthchecks) and is additionally served under the prefix.
- Bare `/` redirects to `<URL_BASE>/`.
- Client code uses a new `~/utils/url-base` helper (`withUrlBase`) instead of hand-rolled prefix arithmetic; `<Link>`/`navigate()` need no changes since the basename covers them.
- **Unset `URL_BASE` produces output identical to before this change** — the published root-hosted images are unaffected.

## Testing

- New unit tests for the normalizer/joiner (`url-base.test.ts`); full suite passes (507 tests), `typecheck` and `lint` clean.
- Built with `--build-arg URL_BASE=/nzbdav` and functionally verified end-to-end on a migrated production-scale database: bare-root redirect, unauthenticated redirect to `<URL_BASE>/login`, login POST → 302 `<URL_BASE>/`, authenticated SSR pages with all asset/manifest URLs prefixed, SAB API under `<URL_BASE>/api`, WebSocket 101 on `<URL_BASE>/ws`, WebDAV PROPFIND under the prefix, and root+prefixed `/healthz`.
- Also verified a default build (no `URL_BASE`) behaves identically to current `main`.

This mirrors a patch we've run in production since May on the nzbdav-dev lineage (STiXzoOR/nzbdav) and have now ported/re-validated on current `main`. Happy to adjust naming (`URL_BASE` vs `general.base-url` interplay), split commits, or add CI matrix coverage for a sub-path build if you'd take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)