### PR TITLE
fix(api): allow testing existing indexer connections

### DIFF
--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
@@ -9,7 +9,7 @@ public class TestIndexerConnectionController(NzbWebDAV.Config.ConfigManager conf
 {
     protected override async Task<IActionResult> HandleRequest()
     {
-        var request = new TestIndexerConnectionRequest(HttpContext);
+        var request = new TestIndexerConnectionRequest(HttpContext, configManager);
         try
         {
             var indexerConfig = configManager.GetIndexerConfig();

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestIndexerConnection;
 
@@ -11,13 +12,14 @@ public class TestIndexerConnectionRequest
     public int? TimeoutSeconds { get; init; }
     public bool SkipTlsVerification { get; init; }
 
-    public TestIndexerConnectionRequest(HttpContext context)
+    public TestIndexerConnectionRequest(HttpContext context, ConfigManager configManager)
     {
         Url = context.Request.Form["url"].FirstOrDefault()
               ?? throw new BadHttpRequestException("Indexer url is required");
 
-        ApiKey = context.Request.Form["apiKey"].FirstOrDefault()
-                 ?? throw new BadHttpRequestException("Indexer apiKey is required");
+        var submittedApiKey = context.Request.Form["apiKey"].FirstOrDefault()
+                              ?? throw new BadHttpRequestException("Indexer apiKey is required");
+        ApiKey = IndexerApiKeyResolver.Resolve(submittedApiKey, configManager);
 
         UserAgent = context.Request.Form["userAgent"].FirstOrDefault();
         ProxyUrl = context.Request.Form["proxyUrl"].FirstOrDefault();

--- a/backend/Config/IndexerApiKeyResolver.cs
+++ b/backend/Config/IndexerApiKeyResolver.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Resolves an indexer API key that may be a UI mask token back to the
+/// stored plaintext, so test-connection can auth without forcing re-entry.
+/// </summary>
+public static class IndexerApiKeyResolver
+{
+    public const string InstancesConfigName = ConfigKeys.IndexersInstances;
+
+    public static string Resolve(string submittedApiKey, ConfigManager configManager)
+    {
+        if (!ConfigSecretMasker.IsMaskToken(submittedApiKey))
+            return submittedApiKey;
+
+        var masker = new ConfigSecretMasker(
+            EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
+        var existingJson = JsonSerializer.Serialize(configManager.GetIndexerConfig());
+        return masker.ResolveMaskedJsonSecret(InstancesConfigName, submittedApiKey, existingJson);
+    }
+}

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -19,7 +19,6 @@ import {
     Tooltip,
     useIsAnyManaged,
 } from "~/components/ui";
-import { isMaskedSecret } from "~/utils/config-mask";
 
 type IndexersSettingsProps = {
     config: Record<string, string>
@@ -894,7 +893,6 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     }, []);
 
     const [testState, setTestState] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
-    const apiKeyIsMasked = isMaskedSecret(apiKey);
 
     useEffect(() => {
         if (show) {
@@ -939,7 +937,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     useEffect(() => { setTestState('idle'); }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
 
     const handleTest = useCallback(async () => {
-        if (!url.trim() || !apiKey.trim() || apiKeyIsMasked) return;
+        if (!url.trim() || !apiKey.trim()) return;
         setTestState('testing');
         try {
             const fd = new FormData();
@@ -955,7 +953,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
         } catch {
             setTestState('error');
         }
-    }, [url, apiKey, apiKeyIsMasked, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
+    }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
 
     const handleSave = useCallback(() => {
         const rpm = parseInt(maxRpm || "0", 10);
@@ -1056,8 +1054,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                     <Button
                         variant={testState === 'success' ? 'success' : testState === 'error' ? 'danger' : 'secondary'}
                         onClick={handleTest}
-                        disabled={!isUrlValid || !apiKey.trim() || apiKeyIsMasked || testState === 'testing'}
-                        title={apiKeyIsMasked ? "Enter a new API key to test this connection" : undefined}
+                        disabled={!isUrlValid || !apiKey.trim() || testState === 'testing'}
                     >
                         {testState === 'testing'
                             ? <Spinner size="sm" />

--- a/tests/NzbWebDAV.Tests/Config/IndexerApiKeyResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/IndexerApiKeyResolverTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+[Collection(nameof(SecretResolverCollection))]
+public class IndexerApiKeyResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsPlaintextUnchanged()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+
+        var resolved = IndexerApiKeyResolver.Resolve("typed-api-key", configManager);
+
+        Assert.Equal("typed-api-key", resolved);
+    }
+
+    [Fact]
+    public void Resolve_UnmasksStoredIndexerApiKey()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var stored = JsonSerializer.Serialize(new IndexerConfig
+        {
+            Indexers =
+            [
+                new IndexerConfig.ConnectionDetails
+                {
+                    Name = "Example",
+                    Url = "https://indexer.example",
+                    ApiKey = "stored-indexer-key",
+                }
+            ],
+        });
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = stored }
+        ]);
+
+        var masker = new ConfigSecretMasker("test-signing-key");
+        var masked = masker.MaskForResponse(ConfigKeys.IndexersInstances, stored);
+        using var document = JsonDocument.Parse(masked);
+        var token = document.RootElement
+            .GetProperty("Indexers")[0]
+            .GetProperty("ApiKey")
+            .GetString()!;
+
+        var resolved = IndexerApiKeyResolver.Resolve(token, configManager);
+
+        Assert.Equal("stored-indexer-key", resolved);
+    }
+
+    [Fact]
+    public void Resolve_ThrowsForUnknownMaskToken()
+    {
+        using var _ = TempEnv("FRONTEND_BACKEND_API_KEY", "test-signing-key");
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.IndexersInstances,
+                ConfigValue = JsonSerializer.Serialize(new IndexerConfig
+                {
+                    Indexers =
+                    [
+                        new IndexerConfig.ConnectionDetails
+                        {
+                            Name = "Example",
+                            Url = "https://indexer.example",
+                            ApiKey = "stored-secret",
+                        }
+                    ],
+                })
+            }
+        ]);
+
+        var forged = $"{ConfigSecretMasker.MaskPrefix}AAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Assert.Throws<BadHttpRequestException>(() =>
+            IndexerApiKeyResolver.Resolve(forged, configManager));
+    }
+
+    private static IDisposable TempEnv(string name, string value)
+    {
+        var previous = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+        return new RestoreEnv(name, previous);
+    }
+
+    private sealed class RestoreEnv(string name, string? previous) : IDisposable
+    {
+        public void Dispose() => Environment.SetEnvironmentVariable(name, previous);
+    }
+}


### PR DESCRIPTION
## Summary
- resolve masked saved indexer API keys when testing connections
- keep Test Connection enabled while editing an existing indexer
- reject forged or unknown secret-mask tokens with focused resolver coverage

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~IndexerApiKeyResolverTests\"`
- [x] `cd frontend && npm run typecheck`
- [x] IDE lint diagnostics