### PR TITLE
feat(usenet): enable Container-aware gap fill by default

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -860,7 +860,7 @@ public class ConfigManager
     {
         var configValue = StringUtil.EmptyToNull(
             GetConfigValue(ConfigKeys.UsenetContainerAwareFill));
-        return configValue != null && bool.Parse(configValue);
+        return configValue == null || bool.Parse(configValue);
     }
 
     public bool IsSegmentCacheEnabled()

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -43,7 +43,7 @@ is saturated.
 | In-flight article budget (MiB) [since 0.8.2](https://github.com/nzbdav/nzbdav/releases/tag/v0.8.2){ .nzbdav-since } | `usenet.in-flight-article-budget-mb` | auto | Host-wide decoded-byte cap, 64–8192 MiB |
 | Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | Close unused connections after 15–300 seconds |
 | Pipelined article downloads | `usenet.pipelined-body-requests` | on | Fetch WebDAV BODY requests in small batches |
-| Container-aware gap fill [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | off | Experimental MPEG-TS null-packet fill for confirmed gaps |
+| Container-aware gap fill [since 0.10.0](https://github.com/nzbdav/nzbdav/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | on | Experimental MPEG-TS null-packet fill for confirmed gaps |
 
 ## Article buffer and adaptive prefetch
 

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -73,7 +73,7 @@ const defaultConfig = {
     "usenet.cascade.retry-primary-on-miss": "true",
     "usenet.article-miss-cache-ttl-seconds": "300",
     "usenet.article-miss-cache-max-entries": "10000",
-    "usenet.container-aware-fill": "false",
+    "usenet.container-aware-fill": "true",
     "webdav.user": "admin",
     "webdav.pass": "",
     "webdav.show-hidden-files": "false",

--- a/frontend/app/routes/settings/streaming/streaming.test.ts
+++ b/frontend/app/routes/settings/streaming/streaming.test.ts
@@ -22,7 +22,7 @@ const validConfig = {
     "usenet.in-flight-article-budget-mb": "",
     "usenet.idle-connection-timeout-seconds": "60",
     "usenet.pipelined-body-requests": "true",
-    "usenet.container-aware-fill": "false",
+    "usenet.container-aware-fill": "true",
     "usenet.segment-cache.enabled": "false",
     "usenet.segment-cache.path": "/config/segment-cache",
     "usenet.segment-cache.max-gb": "10",
@@ -114,7 +114,7 @@ describe("Streaming settings", () => {
             name: /Container-aware gap fill/,
         });
         await user.click(gapFill);
-        expect(gapFill.checked).toBe(true);
+        expect(gapFill.checked).toBe(false);
     });
 
     it("detects changes to every owned setting", () => {

--- a/tests/NzbWebDAV.Tests/Config/ContainerAwareFillConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ContainerAwareFillConfigTests.cs
@@ -6,11 +6,11 @@ namespace NzbWebDAV.Tests.Config;
 public sealed class ContainerAwareFillConfigTests
 {
     [Fact]
-    public void UnsetValue_DefaultsToDisabled()
+    public void UnsetValue_DefaultsToEnabled()
     {
         var config = new ConfigManager();
 
-        Assert.False(config.IsContainerAwareFillEnabled());
+        Assert.True(config.IsContainerAwareFillEnabled());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- enable Container-aware gap fill for new and unset configurations
- preserve explicit opt-outs and align the settings UI and documentation
- update backend and frontend coverage for the default-on behavior

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~ContainerAwareFillConfigTests\"`
- [x] `npm test -- app/routes/settings/streaming/streaming.test.ts`
- [x] `npm run typecheck`