### PR TITLE
chore(docs): point docs site at the new repo home and allow manual Pages deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,13 +35,13 @@ jobs:
         run: zensical build --clean --strict
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/zensical.toml
+++ b/zensical.toml
@@ -4,8 +4,8 @@ site_description = "The NzbDAV SuperFork — stream media directly from Usenet"
 site_url = "https://www.infinidysk.com/"
 docs_dir = "docs"
 site_dir = "site"
-repo_url = "https://github.com/nzbdav/nzbdav"
-repo_name = "nzbdav/nzbdav"
+repo_url = "https://github.com/infinidysk/infinidysk"
+repo_name = "infinidysk/infinidysk"
 edit_uri = "edit/main/docs/"
 copyright = "InfiniDysk is released under the MIT License"
 extra_css = ["stylesheets/extra.css"]
@@ -140,7 +140,7 @@ generator = false
 
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
-link = "https://github.com/nzbdav/nzbdav"
+link = "https://github.com/infinidysk/infinidysk"
 name = "GitHub"
 
 [[project.extra.social]]
@@ -155,12 +155,12 @@ name = "GHCR"
 
 [[project.extra.social]]
 icon = "material/tag"
-link = "https://github.com/nzbdav/nzbdav/releases"
+link = "https://github.com/infinidysk/infinidysk/releases"
 name = "Releases"
 
 [[project.extra.social]]
 icon = "material/bug"
-link = "https://github.com/nzbdav/nzbdav/issues"
+link = "https://github.com/infinidysk/infinidysk/issues"
 name = "Issues"
 
 [project.markdown_extensions.admonition]


### PR DESCRIPTION
## Summary
- Update `zensical.toml` `repo_url`/`repo_name` and the GitHub, Releases, and Issues social links to `infinidysk/infinidysk` after the repo transfer. The GHCR social link intentionally stays on the old package until `ghcr.io/infinidysk/infinidysk` exists.
- Allow `workflow_dispatch` runs of the Documentation workflow on `main` to upload and deploy the Pages artifact, so the docs site can be redeployed without a push (needed right after re-enabling Pages on the transferred repo).

## Test plan
- [ ] Docs build passes in CI (`zensical build --clean --strict`)
- [ ] After merge: manually dispatch the Documentation workflow and confirm it deploys to Pages