### PR TITLE
feat(docker): keep ghcr.io/nzbdav/nzbdav receiving releases during the rename transition

### DIFF
--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -79,12 +79,16 @@ jobs:
         ghcr.io/${{ github.repository }}:rc
         docker.io/infinidysk/infinidysk:${{ needs.resolve.outputs.tag }}
         docker.io/infinidysk/infinidysk:rc
+      legacy_tags: |
+        ghcr.io/nzbdav/nzbdav:${{ needs.resolve.outputs.tag }}
+        ghcr.io/nzbdav/nzbdav:rc
       nzbdav_version: ${{ needs.resolve.outputs.version }}-rc.${{ needs.resolve.outputs.rc }}
       checkout_ref: ${{ needs.resolve.outputs.sha }}
       dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      old_ghcr_token: ${{ secrets.OLD_GHCR_TOKEN }}
 
   publish-release:
     needs: [resolve, build]

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -21,10 +21,17 @@ on:
         required: false
         type: string
         default: ""
+      legacy_tags:
+        description: Legacy-namespace tags (newline-separated; skipped when empty)
+        required: false
+        type: string
+        default: ""
     secrets:
       registry_token:
         required: true
       dockerhub_token:
+        required: false
+      old_ghcr_token:
         required: false
 
 jobs:
@@ -61,6 +68,7 @@ jobs:
           password: ${{ secrets.dockerhub_token }}
 
       - name: Build and push Docker image (amd64 + arm64)
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -73,3 +81,35 @@ jobs:
             REPO_URL=https://github.com/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The legacy namespace lives in the old org, which this repo's
+      # GITHUB_TOKEN cannot write to; re-login with an old-org PAT. Docker
+      # keeps one credential per registry, so this replaces the GHCR login
+      # above — the new-namespace push has already completed by this point.
+      - name: Log in to GHCR (legacy namespace)
+        if: inputs.legacy_tags != ''
+        uses: docker/login-action@v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.old_ghcr_token }}
+
+      # One-layer derivative of the image just pushed: same content plus an
+      # env flag the frontend uses to show the deprecated-image-path banner.
+      - name: Build and push legacy-path derivative image
+        if: inputs.legacy_tags != ''
+        env:
+          BASE_IMAGE: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          LEGACY_TAGS: ${{ inputs.legacy_tags }}
+        run: |
+          set -euo pipefail
+          dir=$(mktemp -d)
+          printf 'FROM %s\nENV NZBDAV_LEGACY_IMAGE=true\nLABEL org.opencontainers.image.description="%s"\n' \
+            "$BASE_IMAGE" \
+            "Deprecated image path: NzbDAV is now InfiniDysk. Pull ghcr.io/infinidysk/infinidysk instead (same /config, no other changes). Details: https://www.infinidysk.com/community/renaming-to-infinidysk/" \
+            > "$dir/Dockerfile"
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && tag_args+=(--tag "$tag")
+          done <<< "$LEGACY_TAGS"
+          docker buildx build --platform linux/amd64,linux/arm64 --push "${tag_args[@]}" "$dir"

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -26,11 +26,14 @@ jobs:
       tags: |
         ghcr.io/${{ github.repository }}:dev
         docker.io/infinidysk/infinidysk:dev
+      legacy_tags: |
+        ghcr.io/nzbdav/nzbdav:dev
       nzbdav_version: dev-${{ needs.resolve.outputs.short_sha }}
       dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      old_ghcr_token: ${{ secrets.OLD_GHCR_TOKEN }}
 
   tag-dev:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,20 @@ jobs:
         docker.io/infinidysk/infinidysk:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
         docker.io/infinidysk/infinidysk:v${{ needs.release-please.outputs.major }}
         docker.io/infinidysk/infinidysk:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}
+      legacy_tags: |
+        ghcr.io/nzbdav/nzbdav:latest
+        ghcr.io/nzbdav/nzbdav:dev
+        ghcr.io/nzbdav/nzbdav:rc
+        ghcr.io/nzbdav/nzbdav:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
+        ghcr.io/nzbdav/nzbdav:v${{ needs.release-please.outputs.major }}
+        ghcr.io/nzbdav/nzbdav:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}
       nzbdav_version: ${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
       checkout_ref: ${{ needs.release-please.outputs.sha }}
       dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      old_ghcr_token: ${{ secrets.OLD_GHCR_TOKEN }}
 
   assets:
     if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'
@@ -125,12 +133,20 @@ jobs:
         docker.io/infinidysk/infinidysk:${{ needs.resolve-version.outputs.ref }}
         docker.io/infinidysk/infinidysk:v${{ needs.resolve-version.outputs.major }}
         docker.io/infinidysk/infinidysk:v${{ needs.resolve-version.outputs.major }}.${{ needs.resolve-version.outputs.minor }}
+      legacy_tags: |
+        ghcr.io/nzbdav/nzbdav:latest
+        ghcr.io/nzbdav/nzbdav:dev
+        ghcr.io/nzbdav/nzbdav:rc
+        ghcr.io/nzbdav/nzbdav:${{ needs.resolve-version.outputs.ref }}
+        ghcr.io/nzbdav/nzbdav:v${{ needs.resolve-version.outputs.major }}
+        ghcr.io/nzbdav/nzbdav:v${{ needs.resolve-version.outputs.major }}.${{ needs.resolve-version.outputs.minor }}
       nzbdav_version: ${{ needs.resolve-version.outputs.version }}
       checkout_ref: ${{ needs.resolve-version.outputs.ref }}
       dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      old_ghcr_token: ${{ secrets.OLD_GHCR_TOKEN }}
 
   assets-manual:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- Adds a `legacy_tags` input and optional `old_ghcr_token` secret to the shared `docker-build-push.yml` workflow. When set, after the main multi-arch push it re-logs into GHCR with the old-org PAT and pushes a one-layer derivative (`FROM` the just-pushed image by digest + `ENV NZBDAV_LEGACY_IMAGE=true` + a deprecation OCI description label) to the legacy namespace.
- Wires legacy tag lists into `release.yml` (both automatic and manual paths), `refresh-dev.yml`, and `cut-prerelease.yml`, mirroring the same tag names to `ghcr.io/nzbdav/nzbdav`.
- The `NZBDAV_LEGACY_IMAGE` env flag is the hook for the upcoming frontend deprecation banner (separate PR); it is inert until that ships.

Requires the `OLD_GHCR_TOKEN` repo secret (already configured).

## Test plan
- [ ] YAML validated locally
- [ ] Next `refresh-dev` dispatch publishes `ghcr.io/nzbdav/nzbdav:dev` successfully
- [ ] Verify the legacy image digest differs from the new-namespace image only by the derivative layer (`crane config` shows `NZBDAV_LEGACY_IMAGE=true`)