### PR TITLE
chore(ci): sync issue votes against the migrated InfiniDysk Ecosystem project

### DIFF
--- a/.github/workflows/sync-issue-votes.yml
+++ b/.github/workflows/sync-issue-votes.yml
@@ -1,5 +1,5 @@
 # Recounts thumbs-up (👍) reactions on issue bodies linked to the
-# NZBDav Ecosystem project and writes the count to the Votes number field.
+# InfiniDysk Ecosystem project and writes the count to the Votes number field.
 # Also appends an upvote footer to open Feature issues when missing.
 #
 # Requires repo secret PROJECT_VOTES_TOKEN: a fine-grained PAT (or GitHub App
@@ -24,7 +24,7 @@ jobs:
       - name: Sync thumbs-up counts to Votes
         env:
           GH_TOKEN: ${{ secrets.PROJECT_VOTES_TOKEN }}
-          PROJECT_OWNER: nzbdav
+          PROJECT_OWNER: infinidysk
           PROJECT_NUMBER: "1"
           FIELD_NAME: Votes
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,7 @@ Use **GitHub Issue Types** for kind — not kind labels:
 - Do **not** use (or recreate) `bug` / `enhancement` labels — they were removed; Issue Type is the source of truth.
 - Do **not** put `[Bug]:` / `[Feature]:` in issue titles; the type field already conveys that.
 
-Triage and release metadata live on the **[NZBDav Ecosystem](https://github.com/orgs/nzbdav/projects/1)** project and on GitHub **milestones**. Prefer those over org Issue Fields, labels, or duplicate project columns.
+Triage and release metadata live on the **[InfiniDysk Ecosystem](https://github.com/orgs/infinidysk/projects/1)** project and on GitHub **milestones**. Prefer those over org Issue Fields, labels, or duplicate project columns.
 
 ### Priority and Effort (project fields)
 


### PR DESCRIPTION
## Summary
- Points the votes sync workflow at the new org project (`PROJECT_OWNER: infinidysk`; project number is unchanged at 1)
- Updates the AGENTS.md triage link to [InfiniDysk Ecosystem](https://github.com/orgs/infinidysk/projects/1)

The project board itself was migrated via GraphQL: all 311 items were copied to the new org project with Status/Priority/Effort field values intact (Votes intentionally skipped — this cron repopulates it).

## Test plan
- [ ] After reissuing `PROJECT_VOTES_TOKEN` for the new org, run the Sync issue votes workflow manually and confirm it updates Votes on the new board