### PR TITLE
chore(docs): clarify where to configure repair integrations

### DIFF
--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -7,7 +7,7 @@ Background health monitoring and replacement of unhealthy library items.
     Map config keys below to `NZBDAV_CONFIG__...` with the
     [naming algorithm](headless.md#naming-algorithm)
     (`repair.enable` → `NZBDAV_CONFIG__REPAIR__ENABLE`). Enabling repairs via ENV
-    also needs `media.library-dir` and *Arr instances.
+    also needs `media.library-dir` and configured [*Arr instances](arrs.md).
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -7,7 +7,7 @@
 Requires:
 
 - **Library Directory** visible inside the container
-- At least one configured Radarr/Sonarr instance
+- At least one configured [Radarr/Sonarr instance](../configuration/arrs.md)
 - **Enable Background Repairs**
 
 Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since }, and streaming-failure thresholds — [Repairs settings](../configuration/repairs.md).


### PR DESCRIPTION
## Summary
- link repair prerequisites directly to the Arr Apps configuration guide
- make the required Sonarr/Radarr setup easier to find from both repair docs

## Test plan
- [x] `python3 -m zensical build --clean --strict`