### PR TITLE
fix(build)!: prebuilt Linux archives are named infinidysk instead of nzbdav

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -138,7 +138,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          archive_name="nzbdav-v${VERSION}-${RID}"
+          archive_name="infinidysk-v${VERSION}-${RID}"
           mkdir -p "$archive_name/backend" "$archive_name/frontend"
           cp -a backend-publish/. "$archive_name/backend/"
           tar -xzf release-frontend/frontend-package.tar.gz -C "$archive_name/frontend"
@@ -158,11 +158,11 @@ jobs:
           ROLLING_TAG: ${{ inputs.rolling_tag }}
         run: |
           set -euo pipefail
-          archive="nzbdav-v${VERSION}-${RID}.tar.gz"
+          archive="infinidysk-v${VERSION}-${RID}.tar.gz"
           gh release upload "$RELEASE_TAG" "$archive" --clobber
 
           if [[ -n "$ROLLING_TAG" ]]; then
-            rolling_archive="nzbdav-${ROLLING_TAG}-${RID}.tar.gz"
+            rolling_archive="infinidysk-${ROLLING_TAG}-${RID}.tar.gz"
             cp "$archive" "$rolling_archive"
             gh release upload "$ROLLING_TAG" "$rolling_archive" --clobber
           fi

--- a/docs/getting-started/prebuilt-archives.md
+++ b/docs/getting-started/prebuilt-archives.md
@@ -18,14 +18,14 @@ The .NET SDK, CMake, Ninja, npm install, and Git submodules are not required.
 Download the archive for your system from the
 [latest GitHub release](https://github.com/infinidysk/infinidysk/releases/latest):
 
-- `nzbdav-v<version>-linux-x64.tar.gz`
-- `nzbdav-v<version>-linux-arm64.tar.gz`
+- `infinidysk-v<version>-linux-x64.tar.gz`
+- `infinidysk-v<version>-linux-arm64.tar.gz`
 
 Extract it and start the launcher:
 
 ```bash
-tar -xzf nzbdav-v<version>-linux-<architecture>.tar.gz
-cd nzbdav-v<version>-linux-<architecture>
+tar -xzf infinidysk-v<version>-linux-<architecture>.tar.gz
+cd infinidysk-v<version>-linux-<architecture>
 ./run.sh
 ```
 
@@ -46,12 +46,12 @@ Other container environment variables are supported, including `PORT`,
 ## Pre-release testing
 
 Each release candidate has a permanent GitHub Pre-release and versioned
-archives such as `nzbdav-v0.10.0-rc.1-linux-x64.tar.gz`.
+archives such as `infinidysk-v0.10.0-rc.1-linux-x64.tar.gz`.
 
 For automation, the rolling `rc` pre-release always exposes stable asset URLs:
 
-- [linux-x64](https://github.com/infinidysk/infinidysk/releases/download/rc/nzbdav-rc-linux-x64.tar.gz)
-- [linux-arm64](https://github.com/infinidysk/infinidysk/releases/download/rc/nzbdav-rc-linux-arm64.tar.gz)
+- [linux-x64](https://github.com/infinidysk/infinidysk/releases/download/rc/infinidysk-rc-linux-x64.tar.gz)
+- [linux-arm64](https://github.com/infinidysk/infinidysk/releases/download/rc/infinidysk-rc-linux-arm64.tar.gz)
 
 The archive's `version.txt` identifies the exact release candidate. The rolling
 `rc` release remains on the last candidate after a stable release ships, so


### PR DESCRIPTION
## Summary
- rename versioned Linux release archives and their extracted directories from `nzbdav-` to `infinidysk-`
- rename stable rolling `rc` assets to the `infinidysk-` prefix
- update prebuilt archive documentation and download links for the new filenames

## Test plan
- [x] Run `zensical build --clean --strict`
- [x] Run `git diff --check`
- [x] Confirm no legacy release archive names remain in the workflow or prebuilt archive guide

## Breaking change
Scripts using the rolling `nzbdav-rc-linux-*.tar.gz` URLs must switch to `infinidysk-rc-linux-*.tar.gz`.