### PR TITLE
fix(nntp): slow providers stay sidelined for their full cooldown

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -109,6 +109,12 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
+            // Commands that started before a trip can still complete while the
+            // provider is cooling down. They are not half-open probes and must
+            // not return the provider to normal rotation early.
+            if (_trippedUntilMs > Environment.TickCount64)
+                return;
+
             // Only a circuit that opened can recover. Failures that cleared without tripping
             // are routine, and announcing a recovery for them implies an outage that never
             // happened. Matches the transition notification below.

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConcurrencyTests.cs
@@ -19,6 +19,7 @@ public class ConcurrencyTests
         breaker.RecordFailure();
         Assert.True(breaker.IsTripped);
 
+        breaker.ExpireCooldownForTests();
         breaker.RecordSuccess();
         Assert.False(breaker.IsTripped);
         Assert.Equal(0, breaker.TrippedUntilMs);
@@ -37,6 +38,7 @@ public class ConcurrencyTests
         breaker.RecordFailure();
         breaker.RecordFailure();
         Assert.Single(transitions);
+        breaker.ExpireCooldownForTests();
         breaker.RecordSuccess();
         breaker.RecordSuccess();
 
@@ -126,6 +128,7 @@ public class ConcurrencyTests
         breaker.RecordFailure();
         Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
 
+        breaker.ExpireCooldownForTests();
         breaker.RecordSuccess();
         Assert.Equal(TimeSpan.FromSeconds(60), breaker.CurrentCooldown);
 
@@ -193,6 +196,27 @@ public class ConcurrencyTests
         // Further callers are fully open again (not stuck behind a half-open slot).
         Assert.False(breaker.IsTripped);
         Assert.False(breaker.IsTripped);
+    }
+
+    [Fact]
+    public void ProviderCircuitBreaker_SuccessDuringOpenCooldown_DoesNotCloseOrResetLadder()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("cooldown-success", transitions.Add);
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+
+        var trippedUntil = breaker.TrippedUntilMs;
+        var cooldown = breaker.CurrentCooldown;
+
+        breaker.RecordSuccess();
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(trippedUntil, breaker.TrippedUntilMs);
+        Assert.Equal(cooldown, breaker.CurrentCooldown);
+        Assert.DoesNotContain(transitions, transition =>
+            transition.State == ProviderCircuitTransitionState.Closed);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
@@ -236,6 +236,7 @@ public class ProviderCircuitBreakerConnectionFailureTests
         var transitions = new List<ProviderCircuitTransition>();
         var breaker = new ProviderCircuitBreaker("recovered", transitions.Add);
         breaker.RecordConnectionFailure();
+        breaker.ExpireCooldownForTests();
         breaker.RecordSuccess();
 
         breaker.RecordConnectionFailure();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerLoggingTests.cs
@@ -35,10 +35,26 @@ public class ProviderCircuitBreakerLoggingTests
             breaker.RecordFailure();
             Assert.True(breaker.IsTripped);
 
+            breaker.ExpireCooldownForTests();
             breaker.RecordSuccess();
         });
 
         Assert.Contains(events, RecoveryWasAnnounced);
+    }
+
+    [Fact]
+    public void RecordSuccess_DuringOpenCooldown_DoesNotAnnounceRecovery()
+    {
+        var events = CaptureLogs(breaker =>
+        {
+            breaker.RecordFailure();
+            breaker.RecordFailure();
+            breaker.RecordFailure();
+
+            breaker.RecordSuccess();
+        });
+
+        Assert.DoesNotContain(events, RecoveryWasAnnounced);
     }
 
     private static bool RecoveryWasAnnounced(LogEvent logEvent) =>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -367,7 +367,7 @@ public class StreamingTimeoutTests
     }
 
     [Fact]
-    public async Task RunWithConnection_StatSuccess_ClosesLatchedBreaker()
+    public async Task RunWithConnection_StatSuccess_ClosesBreakerOnlyAfterCooldown()
     {
         var breaker = new ProviderCircuitBreaker("stat-success-latched");
         using var pool = new ConnectionPool<INntpClient>(
@@ -383,6 +383,12 @@ public class StreamingTimeoutTests
         breaker.RecordFailure();
         Assert.True(breaker.IsLatched);
 
+        await client.StatAsync("seg", CancellationToken.None);
+
+        Assert.True(breaker.IsLatched);
+        Assert.True(breaker.TrippedUntilMs > Environment.TickCount64);
+
+        breaker.ExpireCooldownForTests();
         await client.StatAsync("seg", CancellationToken.None);
 
         Assert.False(breaker.IsLatched);


### PR DESCRIPTION
## Summary
- prevent in-flight command successes from closing an open provider circuit early
- preserve normal half-open recovery once the configured cooldown has elapsed
- cover cooldown behavior for direct and STAT command successes

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ConcurrencyTests|FullyQualifiedName~StreamingTimeoutTests|FullyQualifiedName~ProviderCircuitBreakerHalfOpenTests"`