### PR TITLE
fix(streaming): concurrent reads no longer wedge when Article RAM is full

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -210,7 +210,9 @@ public partial class Program
                     var cfg = sp.GetRequiredService<ConfigManager>();
                     var budgetMb = cfg.GetInFlightArticleBudgetMb();
                     MemoryBudget.LogInFlightBudget(budgetMb);
-                    var budget = new InFlightArticleBudget(cfg.GetInFlightArticleBudgetBytes());
+                    var budget = new InFlightArticleBudget(
+                        cfg.GetInFlightArticleBudgetBytes(),
+                        sp.GetRequiredService<ProviderLatencyTracker>());
                     InFlightArticleBudget.Current = budget;
                     cfg.OnConfigChanged += (_, args) =>
                     {

--- a/backend/Services/SupportPack/LatencySupportPackProjection.cs
+++ b/backend/Services/SupportPack/LatencySupportPackProjection.cs
@@ -180,6 +180,7 @@ internal static class LatencySupportPackProjection
                 response = "Successful NNTP response availability after a provider connection is acquired; excludes body drain.",
                 poolWait = "Wait to acquire a connection from the named provider pool.",
                 permitWait = "Top-level workload connection-budget wait; no provider is selected yet.",
+                localCapWait = "Wait to reserve process-wide decoded Article RAM; no provider or connection permit is held.",
             },
             providerSeries,
             admissionSeries,

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Services.Metrics;
 using Serilog;
 
 namespace NzbWebDAV.Streams;
@@ -13,6 +16,7 @@ public sealed class InFlightArticleBudget
     private long _capBytes;
     private long _throttleEvents;
     private long _lastWarningTicks;
+    private readonly ProviderLatencyTracker? _latencyTracker;
     private readonly object _gate = new();
     private readonly LinkedList<Waiter> _waiters = new();
 
@@ -22,8 +26,11 @@ public sealed class InFlightArticleBudget
     /// </summary>
     public static InFlightArticleBudget? Current { get; set; }
 
-    public InFlightArticleBudget(long capBytes) =>
+    public InFlightArticleBudget(long capBytes, ProviderLatencyTracker? latencyTracker = null)
+    {
         _capBytes = Math.Max(1, capBytes);
+        _latencyTracker = latencyTracker;
+    }
 
     public long LeasedBytes => Interlocked.Read(ref _leased);
     public long CapBytes => Interlocked.Read(ref _capBytes);
@@ -48,6 +55,7 @@ public sealed class InFlightArticleBudget
         if (bytes <= 0) return ArticleByteLease.Empty;
 
         Waiter? waiter = null;
+        Stopwatch? waitTimer = null;
         try
         {
             while (true)
@@ -55,10 +63,22 @@ public sealed class InFlightArticleBudget
                 ct.ThrowIfCancellationRequested();
 
                 if (TryLease(bytes))
+                {
+                    if (waitTimer is not null)
+                    {
+                        _latencyTracker?.Record(
+                            providerKey: null,
+                            LatencyPhase.LocalCapWait,
+                            DownloadWorkloadClassifier.Classify(ct),
+                            NntpOperation.Admission,
+                            waitTimer.Elapsed);
+                    }
                     return new ArticleByteLease(this, bytes);
+                }
 
                 Interlocked.Increment(ref _throttleEvents);
                 MaybeWarn(bytes);
+                waitTimer ??= Stopwatch.StartNew();
 
                 waiter ??= new Waiter(bytes);
                 lock (_gate)

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -225,23 +225,52 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
 
             await _streamTasks.Writer.WaitToWriteAsync(cancellationToken);
-            var connection = await _usenetClient.AcquireExclusiveConnectionAsync(
-                segmentIds, cancellationToken);
-            var batch = await _usenetClient.DecodedBodiesAsync(
-                segmentIds, connection, cancellationToken).ConfigureAwait(false);
-            var streamTasks = batch.Responses
-                .Select((response, index) => DownloadBatchSegment(
-                    response,
-                    segmentIds[index],
-                    segmentIndex: batchStart + index,
-                    isFirstSegment: batchStart + index == 0,
-                    cancellationToken))
-                .ToArray();
+            var leases = new ArticleByteLease?[batchCount];
+            Task<SegmentDownloadResult>[]? streamTasks = null;
+            try
+            {
+                // Reserve decoded-memory capacity before the request takes a streaming
+                // permit. A saturated budget must never occupy all download slots with
+                // requests that cannot yet be drained.
+                for (var index = 0; index < leases.Length; index++)
+                {
+                    leases[index] = await LeaseSegmentBytesAsync(
+                        GetPlannedSegmentBytes(batchStart + index), cancellationToken).ConfigureAwait(false);
+                }
+
+                // Use the normal client path so cache hits still bypass admission.
+                var batch = await _usenetClient.DecodedBodiesAsync(
+                    segmentIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
+                if (batch.Responses.Count != batchCount)
+                    throw new InvalidOperationException(
+                        $"Pipelined BODY returned {batch.Responses.Count} responses for {batchCount} requests.");
+
+                streamTasks = batch.Responses
+                    .Select((response, index) =>
+                    {
+                        var lease = leases[index]!;
+                        leases[index] = null;
+                        return DownloadBatchSegment(
+                            response,
+                            segmentIds[index],
+                            segmentIndex: batchStart + index,
+                            isFirstSegment: batchStart + index == 0,
+                            lease,
+                            cancellationToken);
+                    })
+                    .ToArray();
+            }
+            catch
+            {
+                foreach (var lease in leases)
+                    lease?.Dispose();
+                throw;
+            }
 
             var responseIndex = 0;
             try
             {
-                for (; responseIndex < streamTasks.Length; responseIndex++)
+                for (; responseIndex < streamTasks!.Length; responseIndex++)
                 {
                     var planned = GetPlannedSegmentBytes(batchStart + responseIndex);
                     await _streamTasks.Writer.WriteAsync(
@@ -253,7 +282,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch
             {
-                for (; responseIndex < streamTasks.Length; responseIndex++)
+                for (; responseIndex < streamTasks!.Length; responseIndex++)
                 {
                     _ = DisposeStreamAsync(streamTasks[responseIndex]);
                 }
@@ -277,10 +306,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             var segmentId = _segmentIds.Span[index];
             await _streamTasks.Writer.WaitToWriteAsync(cancellationToken);
-            var connection = await _usenetClient.AcquireExclusiveConnectionAsync(
-                segmentId, cancellationToken);
+            var lease = await LeaseSegmentBytesAsync(
+                GetPlannedSegmentBytes(index), cancellationToken).ConfigureAwait(false);
             var streamTask = DownloadSegment(
-                segmentId, index, connection, isFirstSegment: index == 0, cancellationToken);
+                segmentId, index, lease, isFirstSegment: index == 0, cancellationToken);
             var planned = GetPlannedSegmentBytes(index);
             try
             {
@@ -355,7 +384,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private async Task<SegmentDownloadResult> DownloadSegment(
         string segmentId,
         int segmentIndex,
-        UsenetExclusiveConnection exclusiveConnection,
+        ArticleByteLease initialLease,
         bool isFirstSegment,
         CancellationToken cancellationToken
     )
@@ -363,16 +392,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var estimate = GetPlannedSegmentBytes(segmentIndex);
         for (var attempt = 0; ; attempt++)
         {
-            var lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
+            var lease = attempt == 0
+                ? initialLease
+                : await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
             try
             {
-                var bodyResponse = attempt == 0
-                    ? await _usenetClient
-                        .DecodedBodyAsync(segmentId, exclusiveConnection, cancellationToken)
-                        .ConfigureAwait(false)
-                    : await _usenetClient
-                        .DecodedBodyAsync(segmentId, cancellationToken)
-                        .ConfigureAwait(false);
+                var bodyResponse = await _usenetClient
+                    .DecodedBodyAsync(segmentId, cancellationToken)
+                    .ConfigureAwait(false);
 
                 await ThrowOnSegmentIdMismatchAsync(segmentId, bodyResponse).ConfigureAwait(false);
                 var stream = await DrainSegmentAsync(
@@ -479,12 +506,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         string segmentId,
         int segmentIndex,
         bool isFirstSegment,
+        ArticleByteLease initialLease,
         CancellationToken cancellationToken)
     {
-        // Lease before awaiting the pipelined response so a burst of batch tasks
-        // cannot materialize beyond the host-wide byte budget.
         var estimate = GetPlannedSegmentBytes(segmentIndex);
-        var lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
+        var lease = initialLease;
         try
         {
             var response = await responseTask.ConfigureAwait(false);
@@ -596,11 +622,22 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(250 * attempt), cancellationToken)
                     .ConfigureAwait(false);
-                var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
-                    .ConfigureAwait(false);
-                await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
-                return await DrainSegmentAsync(response.Stream!, segmentIndex, cancellationToken)
-                    .ConfigureAwait(false);
+                ArticleByteLease? lease = await LeaseSegmentBytesAsync(
+                    GetPlannedSegmentBytes(segmentIndex), cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                        .ConfigureAwait(false);
+                    await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
+                    var stream = await DrainSegmentAsync(
+                        response.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
+                    lease = null;
+                    return stream;
+                }
+                finally
+                {
+                    lease?.Dispose();
+                }
             }
             catch (UsenetArticleNotFoundException)
             {
@@ -641,11 +678,22 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             try
             {
-                var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
-                    .ConfigureAwait(false);
-                await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
-                return await DrainSegmentAsync(response.Stream!, segmentIndex, cancellationToken)
-                    .ConfigureAwait(false);
+                ArticleByteLease? lease = await LeaseSegmentBytesAsync(
+                    GetPlannedSegmentBytes(segmentIndex), cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                        .ConfigureAwait(false);
+                    await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
+                    var stream = await DrainSegmentAsync(
+                        response.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
+                    lease = null;
+                    return stream;
+                }
+                finally
+                {
+                    lease?.Dispose();
+                }
             }
             catch (UsenetCorruptArticleException exception)
             {
@@ -677,15 +725,26 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             try
             {
-                var bodyResponse = await _usenetClient
-                    .DecodedBodyAsync(fallbackId, cancellationToken)
-                    .ConfigureAwait(false);
-                await ThrowOnSegmentIdMismatchAsync(fallbackId, bodyResponse).ConfigureAwait(false);
-                Log.Debug(
-                    "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
-                    segmentIndex, fallbackId, _fileName);
-                return await DrainSegmentAsync(bodyResponse.Stream!, segmentIndex, cancellationToken)
-                    .ConfigureAwait(false);
+                ArticleByteLease? lease = await LeaseSegmentBytesAsync(
+                    GetPlannedSegmentBytes(segmentIndex), cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var bodyResponse = await _usenetClient
+                        .DecodedBodyAsync(fallbackId, cancellationToken)
+                        .ConfigureAwait(false);
+                    await ThrowOnSegmentIdMismatchAsync(fallbackId, bodyResponse).ConfigureAwait(false);
+                    Log.Debug(
+                        "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
+                        segmentIndex, fallbackId, _fileName);
+                    var stream = await DrainSegmentAsync(
+                        bodyResponse.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
+                    lease = null;
+                    return stream;
+                }
+                finally
+                {
+                    lease?.Dispose();
+                }
             }
             catch (UsenetArticleNotFoundException)
             {


### PR DESCRIPTION
## Summary
- reserve decoded Article RAM before a streaming BODY request takes download admission
- retain cache-hit admission bypasses and release reserved bytes on setup, retry, fallback, and cancellation paths
- expose Article RAM backpressure as `local-cap-wait` support-pack latency

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~MultiSegmentStream|FullyQualifiedName~SegmentFallback|FullyQualifiedName~CorruptionDetection|FullyQualifiedName~Latency"`