### PR TITLE
fix(health): stalled library checks release provider resources

### DIFF
--- a/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
+++ b/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
@@ -9,6 +9,7 @@ public class ContextualCancellationTokenSource : IDisposable
     private bool _disposed;
 
     public CancellationToken Token => _cts.Token;
+    public bool IsCancellationRequested => _cts.IsCancellationRequested;
 
     private ContextualCancellationTokenSource(CancellationTokenSource cts)
     {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -227,7 +227,8 @@ public class HealthCheckService : BackgroundService
             var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
             progressHook.ProgressChanged += (_, progress) =>
             {
-                statCts?.CancelAfter(HealthCheckProgressTimeout);
+                try { statCts?.CancelAfter(HealthCheckProgressTimeout); }
+                catch (ObjectDisposedException) { }
                 var message = $"{davItem.Id}|{progress}";
                 debounce(() => _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, message));
             };

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -243,8 +243,7 @@ public class HealthCheckService : BackgroundService
                 await ArticleExistenceChecker.CheckAsync(
                     _usenetClient, sampled, concurrency, progress, statCts.Token).ConfigureAwait(false);
             }
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            CompleteHealthProgress(davItem.Id);
 
             // update the database.
             // the next check is scheduled so the interval doubles with the item's age since release.
@@ -267,8 +266,7 @@ public class HealthCheckService : BackgroundService
         catch (OperationCanceledException) when (
             !ct.IsCancellationRequested && statCts?.IsCancellationRequested == true)
         {
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            CompleteHealthProgress(davItem.Id);
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
@@ -284,8 +282,7 @@ public class HealthCheckService : BackgroundService
         }
         catch (UsenetArticleNotFoundException e)
         {
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            CompleteHealthProgress(davItem.Id);
             if (FilenameUtil.IsImportantFileType(davItem.Name))
             {
                 lock (_missingSegmentIds)
@@ -304,8 +301,7 @@ public class HealthCheckService : BackgroundService
         {
             // Connection-level STAT failures (e.g. buffered 400 goodbye) must not trigger
             // repair or leave NextHealthCheck unset — defer and surface ActionNeeded.
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            CompleteHealthProgress(davItem.Id);
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
@@ -319,8 +315,7 @@ public class HealthCheckService : BackgroundService
         {
             // STAT/read timeouts and socket/IO failures must not dump stacks or trigger Arr repair —
             // defer and surface ActionNeeded with a single human-readable Warning.
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
-            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            CompleteHealthProgress(davItem.Id);
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
@@ -341,6 +336,12 @@ public class HealthCheckService : BackgroundService
         }
     }
 
+    private void CompleteHealthProgress(Guid davItemId)
+    {
+        _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItemId}|100");
+        _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItemId}|done");
+    }
+
     private async Task DeferHealthCheck(
         DavItem davItem,
         DavDatabaseClient dbClient,
@@ -352,8 +353,7 @@ public class HealthCheckService : BackgroundService
         davItem.LastHealthCheck = utcNow;
         davItem.NextHealthCheck = ComputeFailureNextHealthCheck(utcNow, isKnownFailure);
 
-        _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
-        _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+        CompleteHealthProgress(davItem.Id);
 
         if (isKnownFailure)
         {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -201,7 +201,7 @@ public class HealthCheckService : BackgroundService
         // Attribution for latency histograms — does not change pool admission priority.
         using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
 
-        CancellationTokenSource? statCts = null;
+        ContextualCancellationTokenSource? statCts = null;
         try
         {
             if (isUrgentRepair)
@@ -235,7 +235,7 @@ public class HealthCheckService : BackgroundService
             // Only cancel a STAT sweep after it has made no progress for a sustained
             // period. A complete/deep scan can otherwise run as long as it continues
             // advancing; cancellation reaches and drains every in-flight STAT request.
-            using (statCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
+            using (statCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(ct))
             {
                 statCts.CancelAfter(HealthCheckProgressTimeout);
                 var progress = progressHook.ToPercentage(sampled.Count);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -25,6 +25,7 @@ public class HealthCheckService : BackgroundService
 {
     private const int MaximumMissingSegmentIds = 100_000;
     private const int NoMatchConfirmationsRequired = 2;
+    private static readonly TimeSpan HealthCheckProgressTimeout = TimeSpan.FromMinutes(5);
 
     // Repeated remove-and-blocklist repairs for the same library path in a short window indicate
     // a replacement loop (Arr keeps re-grabbing a release repair keeps rejecting, issue #732).
@@ -200,6 +201,7 @@ public class HealthCheckService : BackgroundService
         // Attribution for latency histograms — does not change pool admission priority.
         using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
 
+        CancellationTokenSource? statCts = null;
         try
         {
             if (isUrgentRepair)
@@ -225,14 +227,21 @@ public class HealthCheckService : BackgroundService
             var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
             progressHook.ProgressChanged += (_, progress) =>
             {
+                statCts?.CancelAfter(HealthCheckProgressTimeout);
                 var message = $"{davItem.Id}|{progress}";
                 debounce(() => _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, message));
             };
 
-            // perform health check
-            var progress = progressHook.ToPercentage(sampled.Count);
-            await ArticleExistenceChecker.CheckAsync(_usenetClient, sampled, concurrency, progress, ct)
-                .ConfigureAwait(false);
+            // Only cancel a STAT sweep after it has made no progress for a sustained
+            // period. A complete/deep scan can otherwise run as long as it continues
+            // advancing; cancellation reaches and drains every in-flight STAT request.
+            using (statCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
+            {
+                statCts.CancelAfter(HealthCheckProgressTimeout);
+                var progress = progressHook.ToPercentage(sampled.Count);
+                await ArticleExistenceChecker.CheckAsync(
+                    _usenetClient, sampled, concurrency, progress, statCts.Token).ConfigureAwait(false);
+            }
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
 
@@ -253,6 +262,24 @@ public class HealthCheckService : BackgroundService
                 HealthCheckResult.HealthResult.Healthy,
                 HealthCheckResult.RepairAction.None,
                 healthyMessage, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (
+            !ct.IsCancellationRequested && statCts?.IsCancellationRequested == true)
+        {
+            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|100");
+            _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
+            var utcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+            Log.Warning(
+                "Health check for {Path} made no STAT progress for {Timeout}. Deferred next check.",
+                davItem.Path, HealthCheckProgressTimeout);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                $"Health check deferred: no STAT progress for {HealthCheckProgressTimeout.TotalMinutes:0} minutes.",
+                ct).ConfigureAwait(false);
         }
         catch (UsenetArticleNotFoundException e)
         {


### PR DESCRIPTION
## Summary
- cancel library STAT sweeps only after five minutes without progress
- defer timed-out checks for one day as Action Needed without triggering repair
- clear live health progress and log a human-readable timeout warning

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~HealthCheck"`