### PR TITLE
fix(ui): prevent stale Explore links showing proxy error pages

### DIFF
--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -109,6 +109,22 @@ function Body(props: ExplorePageData) {
         lastClickedRef.current = null;
     }, [location.pathname]);
 
+    // Keep long-lived directory views in sync with queue and *Arr removals.
+    useEffect(() => {
+        const revalidateWhenVisible = () => {
+            if (document.visibilityState === "visible" && revalidator.state === "idle") {
+                revalidator.revalidate();
+            }
+        };
+
+        const interval = window.setInterval(revalidateWhenVisible, 60_000);
+        document.addEventListener("visibilitychange", revalidateWhenVisible);
+        return () => {
+            window.clearInterval(interval);
+            document.removeEventListener("visibilitychange", revalidateWhenVisible);
+        };
+    }, [revalidator]);
+
     const visibleItems = useMemo(() => {
         const q = query.trim().toLowerCase();
         const filtered = q

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -65,6 +65,7 @@ function logProxyFailure(message: string, error: unknown) {
 const forwardToBackend = createProxyMiddleware({
   target: process.env.BACKEND_URL,
   changeOrigin: true,
+  selfHandleResponse: true,
   ...backendProxyTimeoutOptions,
   on: {
     proxyReq: (proxyReq, req) => {

--- a/frontend/server/backend-proxy-response.test.ts
+++ b/frontend/server/backend-proxy-response.test.ts
@@ -11,6 +11,7 @@ vi.mock("./logger", () => ({
 type TransferResult = {
   status: number;
   bytes: number;
+  body: string;
   endedCleanly: boolean;
 };
 
@@ -41,25 +42,46 @@ function close(server: http.Server): Promise<void> {
  * Settles on a clean end, an aborted response, or a request error, so a request
  * that hangs instead fails the test by timing out.
  */
-function fetchThroughProxy(port: number, path: string): Promise<TransferResult> {
+function fetchThroughProxy(
+  port: number,
+  path: string,
+  headers?: http.OutgoingHttpHeaders,
+): Promise<TransferResult> {
   return new Promise((resolve, reject) => {
     const req = http.request(
-      { hostname: "127.0.0.1", port, path, method: "GET" },
+      { hostname: "127.0.0.1", port, path, method: "GET", headers },
       (res) => {
         let bytes = 0;
+        const chunks: Buffer[] = [];
         const status = res.statusCode ?? 0;
         res.on("data", (chunk: Buffer) => {
           bytes += chunk.length;
+          chunks.push(chunk);
         });
-        res.on("end", () => resolve({ status, bytes, endedCleanly: true }));
-        res.on("aborted", () => resolve({ status, bytes, endedCleanly: false }));
-        res.on("error", () => resolve({ status, bytes, endedCleanly: false }));
+        res.on("end", () => resolve({
+          status,
+          bytes,
+          body: Buffer.concat(chunks).toString("utf8"),
+          endedCleanly: true,
+        }));
+        res.on("aborted", () => resolve({
+          status,
+          bytes,
+          body: Buffer.concat(chunks).toString("utf8"),
+          endedCleanly: false,
+        }));
+        res.on("error", () => resolve({
+          status,
+          bytes,
+          body: Buffer.concat(chunks).toString("utf8"),
+          endedCleanly: false,
+        }));
       },
     );
     req.on("error", (error) => {
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ECONNRESET" || error.message === "socket hang up") {
-        resolve({ status: 0, bytes: 0, endedCleanly: false });
+        resolve({ status: 0, bytes: 0, body: "", endedCleanly: false });
         return;
       }
       reject(error);
@@ -98,6 +120,7 @@ describe("handleBackendProxyResponse", () => {
     const proxy = createProxyMiddleware({
       target: `http://127.0.0.1:${backendPort}`,
       changeOrigin: true,
+      selfHandleResponse: true,
       on: { proxyRes: handleBackendProxyResponse },
     });
 
@@ -162,6 +185,41 @@ describe("handleBackendProxyResponse", () => {
 
     expect(result.status).toBe(404);
     expect(result.endedCleanly).toBe(true);
+  });
+
+  it("renders a friendly page for browser requests to unavailable view files", async () => {
+    const frontendPort = await startProxy((_req, res) => {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("The file does not exist.");
+    });
+
+    const result = await fetchThroughProxy(
+      frontendPort,
+      "/view/content/tv/example-show/example.mkv?downloadKey=abc",
+      { Accept: "text/html,application/xhtml+xml" },
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.endedCleanly).toBe(true);
+    expect(result.body).toContain("File unavailable");
+    expect(result.body).toContain('href="/explore/content/tv/example-show"');
+  });
+
+  it("passes unavailable view files through unchanged for non-browser clients", async () => {
+    const frontendPort = await startProxy((_req, res) => {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("The file does not exist.");
+    });
+
+    const result = await fetchThroughProxy(
+      frontendPort,
+      "/view/content/tv/example-show/example.mkv?downloadKey=abc",
+      { Accept: "application/octet-stream" },
+    );
+
+    expect(result.status).toBe(404);
+    expect(result.endedCleanly).toBe(true);
+    expect(result.body).toBe("The file does not exist.");
   });
 
   it("ends a chunked backend response that finishes normally", async () => {

--- a/frontend/server/backend-proxy-response.ts
+++ b/frontend/server/backend-proxy-response.ts
@@ -16,6 +16,20 @@ export function handleBackendProxyResponse(
   req: IncomingMessage,
   res: ServerResponse,
 ): void {
+  if (shouldRenderFileUnavailablePage(proxyRes, req)) {
+    proxyRes.resume();
+    const explorePaths = getExplorePaths(req);
+    res.writeHead(200, {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+    res.end(renderFileUnavailablePage(explorePaths));
+    return;
+  }
+
+  res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+  proxyRes.pipe(res);
+
   proxyRes.on("close", () => {
     if (res.writableEnded) return;
 
@@ -33,4 +47,74 @@ export function handleBackendProxyResponse(
     );
     res.destroy();
   });
+}
+
+function shouldRenderFileUnavailablePage(proxyRes: IncomingMessage, req: IncomingMessage): boolean {
+  const statusCode = proxyRes.statusCode;
+  if (statusCode !== 400 && statusCode !== 404) return false;
+
+  const accept = req.headers.accept?.toLowerCase() ?? "";
+  if (!accept.includes("text/html")) return false;
+
+  return getRequestPath(req).pathname.startsWith("/view/");
+}
+
+function getExplorePaths(req: IncomingMessage): { directory: string; root: string } {
+  const { pathname, viewIndex } = getRequestPath(req);
+  const basePath = viewIndex > 0 ? pathname.slice(0, viewIndex) : "";
+  const itemPath = pathname.slice(viewIndex + "/view/".length);
+  const parentPath = itemPath.slice(0, itemPath.lastIndexOf("/"));
+  const root = `${basePath}/explore`;
+  return { directory: `${root}${parentPath ? `/${parentPath}` : ""}`, root };
+}
+
+function getRequestPath(req: IncomingMessage): { pathname: string; viewIndex: number } {
+  const originalUrl = (req as IncomingMessage & { originalUrl?: string }).originalUrl;
+  const pathname = new URL(originalUrl ?? req.url ?? "/", "http://localhost").pathname;
+  return { pathname, viewIndex: pathname.indexOf("/view/") };
+}
+
+function renderFileUnavailablePage(explorePaths: { directory: string; root: string }): string {
+  const escapedDirectoryPath = escapeHtml(explorePaths.directory);
+  const escapedRootPath = escapeHtml(explorePaths.root);
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>File unavailable · InfiniDysk</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { align-items: center; background: #111827; color: #f9fafb; display: flex; font-family: ui-sans-serif, system-ui, sans-serif; justify-content: center; margin: 0; min-height: 100vh; padding: 1.5rem; }
+    main { background: #1f2937; border: 1px solid #374151; border-radius: 1rem; box-shadow: 0 20px 25px rgb(0 0 0 / 0.25); max-width: 34rem; padding: 2rem; text-align: center; }
+    h1 { font-size: 1.5rem; margin: 0 0 0.75rem; }
+    p { color: #d1d5db; line-height: 1.5; margin: 0 0 1.5rem; }
+    .actions { display: flex; flex-wrap: wrap; gap: 0.75rem; justify-content: center; }
+    a { background: #6366f1; border-radius: 0.5rem; color: white; display: inline-block; font-weight: 600; padding: 0.65rem 1rem; text-decoration: none; }
+    a:hover { background: #4f46e5; }
+    .secondary { background: #374151; }
+    .secondary:hover { background: #4b5563; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>File unavailable</h1>
+    <p>This file may have been removed or is no longer available. Refresh the directory to see its current contents.</p>
+    <div class="actions">
+      <a href="${escapedDirectoryPath}">Back to directory</a>
+      <a class="secondary" href="${escapedRootPath}">Explore root</a>
+    </div>
+  </main>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[character]!);
 }


### PR DESCRIPTION
## Summary
- refresh visible Explore directory listings every minute and when returning to the tab
- replace browser-facing missing-file proxy responses with an InfiniDysk page that links back to the directory or Explore root
- preserve raw missing-file responses for rclone and other non-browser clients

## Test plan
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`