### PR TITLE
fix(sab): prevent unsafe backup paths and play redirects

### DIFF
--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       short_sha: ${{ steps.sha.outputs.short_sha }}
     steps:

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -1246,10 +1246,17 @@ public class ProfilePlayController(
 
     private async Task<IActionResult> BuildRedirectAsync(Guid davItemId, string extension, CancellationToken ct)
     {
-        var baseUrl = HttpContext.GetPublicBaseUrl(configManager.GetBaseUrl());
         var path = DatabaseStoreSymlinkFile.GetTargetPath(davItemId, "", '/').TrimStart('/');
         var dlKey = GetWebdavItemRequest.GenerateDownloadKey(configManager.GetStrmKey(), path);
-        return Redirect($"{baseUrl}/view/{path}?downloadKey={dlKey}&extension={extension}");
+        var relativeUrl = $"/view/{path}?downloadKey={dlKey}&extension={extension}";
+        var configuredBaseUrl = configManager.GetBaseUrl().TrimEnd('/');
+        if (!string.IsNullOrWhiteSpace(configuredBaseUrl) &&
+            configuredBaseUrl != "http://localhost:3000")
+        {
+            return Redirect($"{configuredBaseUrl}{relativeUrl}");
+        }
+
+        return LocalRedirect(relativeUrl);
     }
 
     private readonly record struct PreVerifyResult(

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -317,19 +317,15 @@ public class AddFileController(
             var destDirPrefix = Path.EndsInDirectorySeparator(destDir)
                 ? destDir
                 : destDir + Path.DirectorySeparatorChar;
-            var leafName = Path.GetFileName(fileName);
-            var baseName = Path.GetFileNameWithoutExtension(leafName);
-            if (string.IsNullOrWhiteSpace(baseName)) baseName = id.ToString();
-            var ext = Path.GetExtension(leafName);
-            if (string.IsNullOrEmpty(ext)) ext = ".nzb";
-
-            var destPath = Path.GetFullPath(Path.Combine(destDirPrefix, $"{baseName}{ext}"));
+            var safeFileName = GetSafeBackupFileName(id, fileName);
+            var destPath = Path.GetFullPath(Path.Combine(destDirPrefix, safeFileName));
             if (!destPath.StartsWith(destDirPrefix, StringComparison.Ordinal))
                 throw new ArgumentException("The NZB backup file must stay within its category directory.");
             var counter = 2;
             while (System.IO.File.Exists(destPath))
             {
-                destPath = Path.GetFullPath(Path.Combine(destDirPrefix, $"{baseName} ({counter}){ext}"));
+                var safeBaseName = Path.GetFileNameWithoutExtension(safeFileName);
+                destPath = Path.GetFullPath(Path.Combine(destDirPrefix, $"{safeBaseName} ({counter}).nzb"));
                 if (!destPath.StartsWith(destDirPrefix, StringComparison.Ordinal))
                     throw new ArgumentException("The NZB backup file must stay within its category directory.");
                 counter++;
@@ -342,6 +338,28 @@ public class AddFileController(
         catch (Exception e)
         {
             throw new Exception($"Could not save nzb to `{backupLocation}`", e);
+        }
+    }
+
+    internal static string GetSafeBackupFileName(Guid id, string fileName)
+    {
+        ValidateBackupLeafName(fileName);
+        var leafName = Path.GetFileName(fileName);
+        var baseName = Path.GetFileNameWithoutExtension(leafName);
+        if (string.IsNullOrWhiteSpace(baseName)) baseName = id.ToString();
+        return $"{baseName}.nzb";
+    }
+
+    private static void ValidateBackupLeafName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) ||
+            Path.IsPathRooted(fileName) ||
+            fileName is "." or ".." ||
+            fileName.Contains('/') ||
+            fileName.Contains('\\') ||
+            fileName.Contains('\0'))
+        {
+            throw new ArgumentException("The NZB backup file name must be a single file name.", nameof(fileName));
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
@@ -42,4 +42,26 @@ public class AddFileRequestTests
         ex = Assert.Throws<BadHttpRequestException>(() => AddFileRequest.ResolveFileName("  ", ""));
         Assert.Contains("filename", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Theory]
+    [InlineData("release.nzb", "release.nzb")]
+    [InlineData("release", "release.nzb")]
+    public void GetSafeBackupFileName_UsesSingleNzbFileName(string input, string expected)
+    {
+        Assert.Equal(
+            expected,
+            AddFileController.GetSafeBackupFileName(Guid.NewGuid(), input));
+    }
+
+    [Theory]
+    [InlineData("../outside.nzb")]
+    [InlineData("..\\outside.nzb")]
+    [InlineData("/tmp/outside.nzb")]
+    [InlineData("nested/outside.nzb")]
+    [InlineData("nested\\outside.nzb")]
+    public void GetSafeBackupFileName_RejectsPathComponents(string input)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            AddFileController.GetSafeBackupFileName(Guid.NewGuid(), input));
+    }
 }


### PR DESCRIPTION
## Summary
- Reject path components in SAB NZB backup filenames and always write `.nzb` backups beneath the configured directory.
- Use local redirects when no configured public base URL exists, avoiding Host-header open redirects while preserving configured absolute URLs.
- Restrict the refresh-dev resolve job token permissions.
- Dismiss CodeQL alert #19 as a false positive because TLS selection is intentional for authenticated admin-configured NNTP connections.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `git diff --check`
- [x] CodeQL alert #19 dismissed as `false positive`