### PR TITLE
fix(ui): restore Data Used after cascade provider reorder fix

### DIFF
--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageResponse.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageResponse.cs
@@ -12,8 +12,9 @@ public class GetProviderUsageResponse : BaseApiResponse
         public string Host { get; set; } = string.Empty;
         public string? Nickname { get; set; }
         /// <summary>
-        /// Stable metrics key (<c>ProviderId</c> in "N" format). Null when the
-        /// provider has not yet been assigned an id.
+        /// Stable metrics key (<c>ProviderId</c> in Guid "N" format — no dashes).
+        /// Callers must normalize dashed config UUIDs the same way before joining.
+        /// Null when the provider has not yet been assigned an id.
         /// </summary>
         public string? ProviderId { get; set; }
         public long BytesUsed { get; set; }

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -377,12 +377,18 @@ function providerKey(p: ConnectionDetails): string {
     return `${p.Host}::${p.Port}::${p.User}`;
 }
 
+// Match UsenetProviderIdentity.MetricsKey (Guid "N"): strip dashes, lowercase.
+// Demo ids like "demo-primary" are unchanged aside from case.
+function normalizeProviderId(id: string): string {
+    return id.replace(/-/g, "").toLowerCase();
+}
+
 function providerIdentity(p: ConnectionDetails): string {
-    return p.ProviderId || providerKey(p);
+    return p.ProviderId ? normalizeProviderId(p.ProviderId) : providerKey(p);
 }
 
 function usagePollIdentityKey(item: ProviderUsage, providers: ConnectionDetails[]): string {
-    if (item.providerId) return item.providerId;
+    if (item.providerId) return normalizeProviderId(item.providerId);
     const nickname = item.nickname?.trim() ?? "";
     const match = providers.find(
         p => p.Host === item.host && (p.Nickname?.trim() ?? "") === nickname,


### PR DESCRIPTION
## Summary

- Fixes #870: Data Used showed **0** for every provider after #869 because the usage poll keys on MetricsKey (`Guid` `"N"`, no dashes) while cards looked up dashed config UUIDs.
- Normalize both sides with the same strip-dashes / lowercase helper so usage joins again; cascade reorder still follows identity.
- Clarifies the API response comment that callers must treat `providerId` as MetricsKey `"N"`.

Related: #868, #869. Reported by Discord `Jackster` on 1.0.

## Test plan

- [x] `cd frontend && npm run typecheck`
- [ ] Open Usenet settings — Data Used is non-zero again for providers that have usage
- [ ] Confirm values still update on the ~10s poll while downloading
- [ ] Enable cascade, drag-reorder two providers with different usage — stats stay on the correct cards before Save