### PR TITLE
chore(agents): document playback issue meta-label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,7 +353,7 @@ Assign closed issues to a version milestone (`0.7`, `0.8`, `0.9`, …) for the r
 
 ### Labels
 
-Do **not** recreate `priority:*` or `effort:*` labels. Meta labels are fine: `performance`, `cataloged`, `more-info-required`, `next-major`, `library`, and source tags (`upstream-audit`, `elfhosted`, etc.).
+Do **not** recreate `priority:*` or `effort:*` labels. Meta labels are fine: `performance`, `playback`, `cataloged`, `more-info-required`, `next-major`, `library`, and source tags (`upstream-audit`, `elfhosted`, etc.).
 
 Bug and feature issue templates set Issue Type only (no kind labels, no title prefix).
 


### PR DESCRIPTION
## Summary
- Documents the new GitHub meta-label `playback` in AGENTS.md (alongside `performance`, `library`, etc.).
- Label meaning: directly affects WebDAV media streaming/playback (GET/Range, seek, buffer, mid-stream continuity).
- Label already created on the repo and applied to open issues #317, #375, #510, #511, #512, #782, #783, #848, #863, #864.

## Test plan
- [ ] Confirm AGENTS.md Labels section lists `playback`
- [ ] Confirm https://github.com/infinidysk/infinidysk/labels/playback exists with the expected description