### PR TITLE
fix(streaming): Article RAM no longer stays pinned at the cap after scrubbing

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -63,6 +63,7 @@ public static class ConfigKeys
     public const string UsenetStreamingSegmentTimeoutSeconds = "usenet.streaming-segment-timeout-seconds";
     public const string UsenetStreamingSegmentRetries = "usenet.streaming-segment-retries";
     public const string UsenetStreamingReadTimeoutSeconds = "usenet.streaming-read-timeout-seconds";
+    public const string UsenetStreamingWriteTimeoutSeconds = "usenet.streaming-write-timeout-seconds";
 
     // webdav
     public const string WebdavEnforceReadonly = "webdav.enforce-readonly";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -293,6 +293,7 @@ public class ConfigManager
                 case ConfigKeys.UsenetStreamingSegmentTimeoutSeconds:
                 case ConfigKeys.UsenetStreamingSegmentRetries:
                 case ConfigKeys.UsenetStreamingReadTimeoutSeconds:
+                case ConfigKeys.UsenetStreamingWriteTimeoutSeconds:
                 case ConfigKeys.WardenQuorum:
                 case ConfigKeys.WardenMaxSourceEntries:
                 case ConfigKeys.PlayTotalBudgetSeconds:
@@ -923,6 +924,19 @@ public class ConfigManager
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingReadTimeoutSeconds));
         var seconds = int.TryParse(v, out var n) ? Math.Clamp(n, 5, 120) : 30;
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    /// <summary>
+    /// Per-write deadline for streaming response bytes to the client. A write that has not
+    /// completed within this window means the client stopped reading but kept the connection
+    /// open (HTTP/2 flow control, tunnel, or proxy), so the handler is cancelled to release
+    /// its in-flight article budget instead of wedging until restart. 0 disables the watchdog.
+    /// </summary>
+    public TimeSpan GetStreamingWriteTimeout()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetStreamingWriteTimeoutSeconds));
+        var seconds = int.TryParse(v, out var n) ? Math.Clamp(n, 0, 600) : 60;
         return TimeSpan.FromSeconds(seconds);
     }
 

--- a/backend/Exceptions/StreamingWriteTimeoutException.cs
+++ b/backend/Exceptions/StreamingWriteTimeoutException.cs
@@ -1,0 +1,13 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Thrown when a WebDAV/`/view` GET or range read stalls writing to the client for longer
+/// than the configured streaming-write-timeout — the client stopped reading but kept the
+/// connection open (HTTP/2 flow control, tunnel, or proxy). Treated as a client-initiated
+/// abort (the response is a clean close, not a 500), and cancelling the linked read token
+/// releases the stream's in-flight article budget so the host does not wedge until restart.
+/// </summary>
+public class StreamingWriteTimeoutException(string message, Exception? innerException = null)
+    : OperationCanceledException(message, innerException)
+{
+}

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -21,6 +21,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentSeekErrors = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentReadErrors = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentStreamingReadTimeouts = new();
+    private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentStreamingWriteTimeouts = new();
     private static readonly ConcurrentDictionary<Guid, DateTime> RecentRepairTriggers = new();
     private static readonly TimeSpan DedupeWindow = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan RepairDedupeWindow = TimeSpan.FromMinutes(5);
@@ -42,6 +43,35 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                 context.Response.StatusCode = 499; // Non-standard status code for client closed request
                 await context.Response.WriteAsync("Client closed request.").ConfigureAwait(false);
             }
+        }
+        catch (StreamingWriteTimeoutException e)
+        {
+            // Watchdog-fired write timeout: the client stopped reading but kept the connection
+            // open. This is an expected operational condition (a stalled/abandoned stream), so
+            // close cleanly and warn — not a 500 with a stack trace. The linked read token was
+            // already cancelled, releasing the stream's in-flight article budget.
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 499; // Client closed request (stalled read)
+            }
+
+            var filePath = GetRequestFilePath(context);
+            LogWithDedup(RecentStreamingWriteTimeouts, filePath, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "WebDAV write stalled; stream cancelled to release Article RAM. Path={Path} Reason: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        "streaming-write-timeout",
+                        suppressed);
+                else
+                    Log.Warning(
+                        "WebDAV write stalled; stream cancelled to release Article RAM. Path={Path} Reason: {Reason}",
+                        filePath,
+                        "streaming-write-timeout");
+            });
+            Log.Debug(e, "WebDAV streaming-write-timeout stack");
         }
         catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? notFound))
         {
@@ -465,6 +495,11 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         {
             if (kvp.Value.LastLogged < cutoff)
                 RecentStreamingReadTimeouts.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in RecentStreamingWriteTimeouts)
+        {
+            if (kvp.Value.LastLogged < cutoff)
+                RecentStreamingWriteTimeouts.TryRemove(kvp.Key, out _);
         }
         foreach (var kvp in RecentRepairTriggers)
         {

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -25,6 +25,10 @@ public class DavMultipartFileStream : FastReadOnlyStream
     private long _position;
     private CombinedStream? _innerStream;
     private bool _disposed;
+    // Teardown of the inner stream a Seek replaced is started non-blocking (Seek is
+    // synchronous); the next ReadAsync joins it before opening a new inner stream so
+    // rapid scrubbing cannot overlap generations and pin the article budget.
+    private Task? _pendingInnerDispose;
 
     public DavMultipartFileStream(
         DavMultipartFile mpf,
@@ -91,6 +95,12 @@ public class DavMultipartFileStream : FastReadOnlyStream
         Memory<byte> buffer,
         CancellationToken cancellationToken = default)
     {
+        if (_pendingInnerDispose is { } pendingDispose)
+        {
+            _pendingInnerDispose = null;
+            try { await pendingDispose.ConfigureAwait(false); }
+            catch { /* teardown-only */ }
+        }
         _innerStream ??= await GetFileStreamAsync(_position, cancellationToken).ConfigureAwait(false);
         var read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         _position += read;
@@ -120,8 +130,11 @@ public class DavMultipartFileStream : FastReadOnlyStream
 
         if (_position == absoluteOffset) return _position;
         _position = absoluteOffset;
-        _innerStream?.Dispose();
-        _innerStream = null;
+        if (_innerStream is { } replaced)
+        {
+            _pendingInnerDispose = replaced.DisposeAsync().AsTask();
+            _innerStream = null;
+        }
         return _position;
     }
 
@@ -311,15 +324,32 @@ public class DavMultipartFileStream : FastReadOnlyStream
     protected override void Dispose(bool disposing)
     {
         if (_disposed) return;
-        _innerStream?.Dispose();
+        if (disposing)
+        {
+            _innerStream?.Dispose();
+            var pending = _pendingInnerDispose;
+            if (pending is not null)
+            {
+                _pendingInnerDispose = null;
+                pending.ContinueWith(
+                    static t => { _ = t.Exception; },
+                    TaskContinuationOptions.OnlyOnFaulted);
+            }
+        }
         _disposed = true;
     }
 
     public override async ValueTask DisposeAsync()
     {
         if (_disposed) return;
-        if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         _disposed = true;
+        if (_pendingInnerDispose is { } pending)
+        {
+            _pendingInnerDispose = null;
+            try { await pending.ConfigureAwait(false); }
+            catch { /* teardown-only */ }
+        }
+        if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }
 }

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -99,7 +99,10 @@ public class DavMultipartFileStream : FastReadOnlyStream
         {
             _pendingInnerDispose = null;
             try { await pendingDispose.ConfigureAwait(false); }
-            catch { /* teardown-only */ }
+            catch (Exception)
+            {
+                // Teardown-only.
+            }
         }
         _innerStream ??= await GetFileStreamAsync(_position, cancellationToken).ConfigureAwait(false);
         var read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
@@ -347,7 +350,10 @@ public class DavMultipartFileStream : FastReadOnlyStream
         {
             _pendingInnerDispose = null;
             try { await pending.ConfigureAwait(false); }
-            catch { /* teardown-only */ }
+            catch (Exception)
+            {
+                // Teardown-only.
+            }
         }
         if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 using NzbWebDAV.Clients.Usenet;
@@ -46,6 +47,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly Task _downloadTask;
     private readonly object _disposeGate = new();
     private Task? _disposeTask;
+    // Segment tasks whose channel write was cancelled are disposed out-of-band by
+    // the producer; DisposeCoreAsync must join them so DisposeAsync does not return
+    // while their BudgetedStream leases are still held (#840 scrub wedge).
+    private readonly ConcurrentQueue<Task> _orphanedDisposals = new();
 
     /// <summary>
     /// Optional per-instance test hook invoked with the segment-boundary readiness sample,
@@ -284,7 +289,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 for (; responseIndex < streamTasks!.Length; responseIndex++)
                 {
-                    _ = DisposeStreamAsync(streamTasks[responseIndex]);
+                    _orphanedDisposals.Enqueue(DisposeStreamAsync(streamTasks[responseIndex]));
                 }
 
                 throw;
@@ -319,7 +324,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch
             {
-                _ = DisposeStreamAsync(streamTask);
+                _orphanedDisposals.Enqueue(DisposeStreamAsync(streamTask));
                 throw;
             }
         }
@@ -1213,6 +1218,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
         while (_streamTasks.Reader.TryRead(out var streamTask))
             pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
+
+        // Join the producer's out-of-band disposals so leases they hold are released
+        // before DisposeAsync completes. The producer has exited by now (awaited above),
+        // so no new orphans can be enqueued; drain is safe without a lock.
+        while (_orphanedDisposals.TryDequeue(out var orphaned))
+            pending.Add(orphaned);
 
         if (pending.Count > 0)
             await Task.WhenAll(pending).ConfigureAwait(false);

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -29,6 +29,11 @@ public class NzbFileStream(
     private long _pendingForwardDrain;
     private bool _disposed;
     private Stream? _innerStream;
+    // Teardown of the inner stream a Seek replaced is started non-blocking (Seek is
+    // synchronous), but the next ReadAsync must await it before opening a new inner
+    // stream — otherwise rapid scrubbing overlaps generations and pins the article
+    // budget (#840 scrub wedge).
+    private Task? _pendingInnerDispose;
     private readonly LongRange[]? _segmentByteRanges =
         AreSegmentByteRangesValid(segmentByteRanges, fileSegmentIds.Length, fileSize)
             ? segmentByteRanges
@@ -77,6 +82,14 @@ public class NzbFileStream(
     {
         if (buffer.IsEmpty) return 0;
         if (_position >= fileSize) return 0;
+        // A prior Seek started the old inner stream's teardown non-blocking; join it
+        // here so its article-budget leases release before a new stream leases again.
+        if (_pendingInnerDispose is { } pendingDispose)
+        {
+            _pendingInnerDispose = null;
+            try { await pendingDispose.ConfigureAwait(false); }
+            catch { /* teardown-only; producer failures surface on ReadAsync */ }
+        }
         _innerStream ??= await GetFileStream(_position, cancellationToken).ConfigureAwait(false);
         if (_pendingForwardDrain > 0)
         {
@@ -136,8 +149,13 @@ public class NzbFileStream(
         }
 
         _position = absoluteOffset;
-        _innerStream?.Dispose();
-        _innerStream = null;
+        if (_innerStream is { } replaced)
+        {
+            // Start the inner stream's async teardown without blocking (Seek is sync),
+            // but retain the task so the next ReadAsync can join it before leasing again.
+            _pendingInnerDispose = replaced.DisposeAsync().AsTask();
+            _innerStream = null;
+        }
         _pendingForwardDrain = 0;
         if (MultiProviderNntpClient.CurrentReadSessionId is { } seekSession)
             StreamTrace.TrySeek(seekSession, _position);
@@ -420,7 +438,21 @@ public class NzbFileStream(
     {
         if (!_disposed)
         {
-            if (disposing) _innerStream?.Dispose();
+            if (disposing)
+            {
+                _innerStream?.Dispose();
+                // The prior Seek's teardown is async and cannot be awaited here; observe
+                // any fault so it is not left unobserved, matching the fire-and-forget
+                // dispose it replaced.
+                var pending = _pendingInnerDispose;
+                if (pending is not null)
+                {
+                    _pendingInnerDispose = null;
+                    pending.ContinueWith(
+                        static t => { _ = t.Exception; },
+                        TaskContinuationOptions.OnlyOnFaulted);
+                }
+            }
             _disposed = true;
         }
 
@@ -430,8 +462,14 @@ public class NzbFileStream(
     public override async ValueTask DisposeAsync()
     {
         if (_disposed) return;
-        if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         _disposed = true;
+        if (_pendingInnerDispose is { } pending)
+        {
+            _pendingInnerDispose = null;
+            try { await pending.ConfigureAwait(false); }
+            catch { /* teardown-only */ }
+        }
+        if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }
 }

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -88,7 +88,10 @@ public class NzbFileStream(
         {
             _pendingInnerDispose = null;
             try { await pendingDispose.ConfigureAwait(false); }
-            catch { /* teardown-only; producer failures surface on ReadAsync */ }
+            catch (Exception)
+            {
+                // Teardown-only; producer failures surface on ReadAsync.
+            }
         }
         _innerStream ??= await GetFileStream(_position, cancellationToken).ConfigureAwait(false);
         if (_pendingForwardDrain > 0)
@@ -467,7 +470,10 @@ public class NzbFileStream(
         {
             _pendingInnerDispose = null;
             try { await pending.ConfigureAwait(false); }
-            catch { /* teardown-only */ }
+            catch (Exception)
+            {
+                // Teardown-only.
+            }
         }
         if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -306,6 +306,14 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Aborted);
                         throw;
                     }
+                    catch (StreamingWriteTimeoutException)
+                    {
+                        // Watchdog-fired write timeout: the client stopped reading but kept the
+                        // connection open. Treat as a client abort so the response is a clean
+                        // close, not a 500 with a stack trace.
+                        FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Aborted);
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Error, ex.Message);
@@ -489,10 +497,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         catch (TimeoutException)
         {
             // Cancel the linked token so the producer stops prefetching and the stream is
-            // disposed, releasing its in-flight article budget. The OperationCanceledException
-            // surfaces as a client-abort on the next read/write.
+            // disposed, releasing its in-flight article budget. Surface as a
+            // StreamingWriteTimeoutException (an OperationCanceledException) so the request
+            // unwinds through the client-abort path rather than a 500 with a stack trace.
             await readCts.CancelAsync().ConfigureAwait(false);
-            throw;
+            throw new StreamingWriteTimeoutException(
+                "Client stopped reading; streaming write timed out.");
         }
     }
 }

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -290,7 +290,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                            traceRange, ct).ConfigureAwait(false);
+                            traceRange, readCts, ct).ConfigureAwait(false);
                         FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Completed);
                         ClearStreamingFailureAfterCompletedRead(
                             _failureTracker,
@@ -394,6 +394,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         long? end,
         Action<long, long>? onBytesServed,
         StreamTraceRangeContext? traceRange,
+        CancellationTokenSource readCts,
         CancellationToken cancellationToken)
     {
         // Skip to the first offset
@@ -426,10 +427,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                 if (bytesRead == 0)
                     return;
 
-                // Write the data to the destination stream
+                // Write the data to the destination stream. Bound the write so a client
+                // that stopped reading but kept the connection open (HTTP/2 flow control,
+                // tunnel, or proxy) cannot hold its in-flight article budget until restart.
                 var writeStarted = Stopwatch.GetTimestamp();
-                await dest.WriteAsync(
-                    buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+                await WriteWithProgressTimeoutAsync(
+                    dest, buffer.AsMemory(0, bytesRead), readCts, cancellationToken).ConfigureAwait(false);
                 _streamTrace.AddStall(
                     traceRange, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
 
@@ -445,6 +448,51 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private ValueTask WriteWithProgressTimeoutAsync(
+        Stream dest,
+        Memory<byte> chunk,
+        CancellationTokenSource readCts,
+        CancellationToken cancellationToken) =>
+        WriteWithProgressTimeoutAsync(
+            dest, chunk, _configManager.GetStreamingWriteTimeout(), readCts, cancellationToken);
+
+    /// <summary>
+    /// Writes one chunk to the client, enforcing a per-write progress deadline. A healthy
+    /// client completes a 64 KB write in milliseconds; a write that has not completed within
+    /// the configured window means the client stopped reading but kept the connection open,
+    /// which would otherwise pin the in-flight article budget until the container restarts.
+    /// On timeout the linked read token is cancelled so the whole pipeline unwinds and the
+    /// stream's leases are released.
+    /// </summary>
+    internal static async ValueTask WriteWithProgressTimeoutAsync(
+        Stream dest,
+        Memory<byte> chunk,
+        TimeSpan timeout,
+        CancellationTokenSource readCts,
+        CancellationToken cancellationToken)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            await dest.WriteAsync(chunk, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            await dest.WriteAsync(chunk, cancellationToken).AsTask()
+                .WaitAsync(timeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // Cancel the linked token so the producer stops prefetching and the stream is
+            // disposed, releasing its in-flight article budget. The OperationCanceledException
+            // surfaces as a client-abort on the next read/write.
+            await readCts.CancelAsync().ConfigureAwait(false);
+            throw;
         }
     }
 }

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -38,6 +38,7 @@ is saturated.
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | Segment-cache size limit |
 | Streaming Segment Timeout | `usenet.streaming-segment-timeout-seconds` | `8` | Per-segment deadline, 2–40 seconds |
 | Streaming Read Timeout [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.streaming-read-timeout-seconds` | `30` | Initial 5–120 second wait to open a GET/range |
+| Streaming Write Timeout | `usenet.streaming-write-timeout-seconds` | `60` | Per-write deadline, 0–600 seconds (0 disables); cancels a stream whose client stopped reading but kept the connection open, releasing its Article RAM |
 | Streaming Segment Retries | `usenet.streaming-segment-retries` | `3` | Fresh-connection retries after timeout, 0–5 |
 | Article Buffer Size | `usenet.article-buffer-size` | `40` | Articles buffered ahead per stream |
 | In-flight article budget (MiB) [since 0.8.2](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.2){ .nzbdav-since } | `usenet.in-flight-article-budget-mb` | auto | Host-wide decoded-byte cap, 64–8192 MiB |

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -60,6 +60,7 @@ const defaultConfig = {
     "usenet.streaming-priority": "80",
     "usenet.streaming-segment-timeout-seconds": "8",
     "usenet.streaming-read-timeout-seconds": "30",
+    "usenet.streaming-write-timeout-seconds": "60",
     "usenet.streaming-segment-retries": "3",
     "usenet.article-buffer-size": "40",
     "usenet.in-flight-article-budget-mb": "",

--- a/frontend/app/routes/settings/streaming/streaming.test.ts
+++ b/frontend/app/routes/settings/streaming/streaming.test.ts
@@ -17,6 +17,7 @@ const validConfig = {
     "usenet.streaming-priority": "80",
     "usenet.streaming-segment-timeout-seconds": "8",
     "usenet.streaming-read-timeout-seconds": "30",
+    "usenet.streaming-write-timeout-seconds": "60",
     "usenet.streaming-segment-retries": "3",
     "usenet.article-buffer-size": "40",
     "usenet.in-flight-article-budget-mb": "",

--- a/frontend/app/routes/settings/streaming/streaming.tsx
+++ b/frontend/app/routes/settings/streaming/streaming.tsx
@@ -237,6 +237,36 @@ export function StreamingSettings({ config, setNewConfig }: StreamingSettingsPro
                     </div>
                 </ManagedSetting>
 
+                <ManagedSetting configKey="usenet.streaming-write-timeout-seconds">
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-base-content" htmlFor="streaming-write-timeout-input">
+                            Streaming Write Timeout
+                        </label>
+                        <div className="flex w-full">
+                            <Input
+                                className={!isValidStreamingWriteTimeout(config["usenet.streaming-write-timeout-seconds"]) ? "input-error" : undefined}
+                                type="text"
+                                inputMode="numeric"
+                                id="streaming-write-timeout-input"
+                                aria-describedby="streaming-write-timeout-help"
+                                placeholder="60"
+                                value={config["usenet.streaming-write-timeout-seconds"]}
+                                onChange={e => setNewConfig({
+                                    ...config,
+                                    "usenet.streaming-write-timeout-seconds": e.target.value,
+                                })} />
+                            <span className="flex items-center rounded-r border border-l-0 border-base-content/20 bg-base-200 px-2 text-sm text-base-content/80">
+                                sec
+                            </span>
+                        </div>
+                        <p className="text-[11px] leading-relaxed text-base-content/45" id="streaming-write-timeout-help">
+                            Per-write deadline for streaming bytes to the client (0–600s, default 60; 0 disables).
+                            Cancels a stream whose client stopped reading but kept the connection open, releasing
+                            its Article RAM instead of wedging until restart.
+                        </p>
+                    </div>
+                </ManagedSetting>
+
                 <ManagedSetting configKey="usenet.streaming-segment-retries">
                     <div className="space-y-2">
                         <label className="block text-sm font-medium text-base-content" htmlFor="streaming-segment-retries-input">
@@ -385,6 +415,7 @@ export function isStreamingSettingsUpdated(
         || config["usenet.streaming-priority"] !== newConfig["usenet.streaming-priority"]
         || config["usenet.streaming-segment-timeout-seconds"] !== newConfig["usenet.streaming-segment-timeout-seconds"]
         || config["usenet.streaming-read-timeout-seconds"] !== newConfig["usenet.streaming-read-timeout-seconds"]
+        || config["usenet.streaming-write-timeout-seconds"] !== newConfig["usenet.streaming-write-timeout-seconds"]
         || config["usenet.streaming-segment-retries"] !== newConfig["usenet.streaming-segment-retries"]
         || config["usenet.article-buffer-size"] !== newConfig["usenet.article-buffer-size"]
         || config["usenet.in-flight-article-budget-mb"] !== newConfig["usenet.in-flight-article-budget-mb"]
@@ -404,6 +435,7 @@ export function isStreamingSettingsValid(config: Record<string, string>): boolea
         && isValidStreamingPriority(config["usenet.streaming-priority"])
         && isValidStreamingSegmentTimeout(config["usenet.streaming-segment-timeout-seconds"])
         && isValidStreamingReadTimeout(config["usenet.streaming-read-timeout-seconds"])
+        && isValidStreamingWriteTimeout(config["usenet.streaming-write-timeout-seconds"])
         && isValidStreamingSegmentRetries(config["usenet.streaming-segment-retries"])
         && isValidArticleBufferSize(config["usenet.article-buffer-size"])
         && isValidInFlightArticleBudget(config["usenet.in-flight-article-budget-mb"])
@@ -435,6 +467,12 @@ function isValidStreamingReadTimeout(value: string): boolean {
     if (value.trim() === "") return false;
     const number = Number(value);
     return Number.isInteger(number) && number >= 5 && number <= 120;
+}
+
+function isValidStreamingWriteTimeout(value: string): boolean {
+    if (value.trim() === "") return false;
+    const number = Number(value);
+    return Number.isInteger(number) && number >= 0 && number <= 600;
 }
 
 function isValidStreamingSegmentRetries(value: string): boolean {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4992,9 +4992,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -430,6 +430,47 @@ public class MultiSegmentStreamPrefetchBudgetTests
         }
     }
 
+    [Fact]
+    public async Task DisposeAsync_JoinsPipelinedBatchOrphanedDisposals()
+    {
+        // Pipelined prefetch takes a lease per batch segment before writing each to the
+        // channel. When the channel writer is completed during teardown, the producer's
+        // WriteAsync throws and it disposes the unwritten segment tasks out-of-band.
+        // DisposeAsync must join those disposals so their leases release before it returns
+        // (the #840 scrub wedge: leases held after NNTP goes idle).
+        const int segmentSize = 20_000;
+        var budget = new InFlightArticleBudget(segmentSize * 16);
+        var segments = Enumerable.Range(0, 20)
+            .ToDictionary(
+                i => $"seg-{i}",
+                _ => Enumerable.Repeat((byte)9, segmentSize).ToArray());
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true);
+
+        using var cts = new CancellationTokenSource();
+        var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            client,
+            articleBufferSize: 8,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: true,
+            cts.Token,
+            fileName: "orphan-pipelined.bin",
+            readBudget: null,
+            inFlightArticleBudget: budget);
+
+        // Start prefetch, then cancel while batches are in flight so the producer hits
+        // the orphan-dispose path for unwritten segment tasks.
+        var buffer = new byte[1024];
+        _ = await stream.ReadAsync(buffer, CancellationToken.None);
+        Assert.True(budget.LeasedBytes > 0);
+
+        cts.Cancel();
+        await stream.DisposeAsync();
+
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
     private sealed class ThrowingCorruptStream(string segmentId) : Stream
     {
         public override bool CanRead => true;

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -498,6 +498,90 @@ public class NzbFileStreamTests
         }
     }
 
+    [Fact]
+    public async Task RapidScrubbing_ReleasesArticleBudgetAcrossGenerations()
+    {
+        // Models the pringles dump: many overlapping offset reads on one file pin the
+        // global article budget after NNTP goes idle. Each Seek replaces the inner
+        // stream; the next ReadAsync must join the prior teardown before leasing again
+        // so generations do not overlap, and DisposeAsync must drain everything.
+        const int segmentSize = 1000;
+        const int segmentCount = 12;
+        var budget = new InFlightArticleBudget(segmentSize * 40);
+        var segmentIds = Enumerable.Range(0, segmentCount).Select(i => $"seg-{i}").ToArray();
+        var segments = segmentIds.ToDictionary(id => id, _ => Enumerable.Repeat((byte)1, segmentSize).ToArray());
+        var rangesById = segmentIds
+            .Zip(Enumerable.Range(0, segmentCount).Select(i => new LongRange(i * segmentSize, (i + 1) * segmentSize)))
+            .ToDictionary(pair => pair.First, pair => pair.Second);
+        var ranges = Enumerable.Range(0, segmentCount)
+            .Select(i => new LongRange(i * segmentSize, (i + 1) * segmentSize))
+            .ToArray();
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true, segmentRanges: rangesById);
+
+        await using var stream = new NzbFileStream(
+            segmentIds,
+            fileSize: segmentSize * segmentCount,
+            client,
+            articleBufferSize: 4,
+            segmentByteRanges: ranges,
+            usePipelinedBodyRequests: false,
+            fileName: "scrub.bin",
+            inFlightArticleBudget: budget);
+
+        var buffer = new byte[segmentSize / 4];
+        for (var scrub = 0; scrub < 16; scrub++)
+        {
+            // Jump to a different segment each iteration, simulating scroll back/forward.
+            var pos = ((scrub * 5 + 1) * segmentSize) % (segmentSize * segmentCount);
+            stream.Seek(pos, SeekOrigin.Begin);
+            _ = await stream.ReadAsync(buffer);
+            Assert.True(budget.LeasedBytes <= budget.CapBytes,
+                $"Leased {budget.LeasedBytes} exceeded cap {budget.CapBytes} during scrub {scrub}");
+        }
+
+        await stream.DisposeAsync();
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task SeekThenDisposeAsync_AwaitsPriorTeardownBeforeReleasingBudget()
+    {
+        // A Seek with no following Read still starts the old inner stream's teardown;
+        // DisposeAsync must join it so leases are released before it returns.
+        const int segmentSize = 1000;
+        const int segmentCount = 6;
+        var budget = new InFlightArticleBudget(segmentSize * 40);
+        var segmentIds = Enumerable.Range(0, segmentCount).Select(i => $"seg-{i}").ToArray();
+        var segments = segmentIds.ToDictionary(id => id, _ => Enumerable.Repeat((byte)1, segmentSize).ToArray());
+        var rangesById = segmentIds
+            .Zip(Enumerable.Range(0, segmentCount).Select(i => new LongRange(i * segmentSize, (i + 1) * segmentSize)))
+            .ToDictionary(pair => pair.First, pair => pair.Second);
+        var ranges = Enumerable.Range(0, segmentCount)
+            .Select(i => new LongRange(i * segmentSize, (i + 1) * segmentSize))
+            .ToArray();
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true, segmentRanges: rangesById);
+
+        var stream = new NzbFileStream(
+            segmentIds,
+            fileSize: segmentSize * segmentCount,
+            client,
+            articleBufferSize: 4,
+            segmentByteRanges: ranges,
+            usePipelinedBodyRequests: false,
+            fileName: "seek-dispose.bin",
+            inFlightArticleBudget: budget);
+
+        var buffer = new byte[segmentSize / 2];
+        _ = await stream.ReadAsync(buffer);
+        Assert.True(budget.LeasedBytes > 0);
+
+        // Seek away from the data we just read; this starts the old stream's teardown.
+        stream.Seek(segmentSize * 4, SeekOrigin.Begin);
+
+        await stream.DisposeAsync();
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
     private static FakeNntpClient CreateClient()
     {
         return new FakeNntpClient(

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -120,11 +120,12 @@ public class GetAndHeadHandlerRangeTests
         using var readCts = new CancellationTokenSource();
         using var dest = new NeverCompletingWriteStream();
 
-        await Assert.ThrowsAsync<TimeoutException>(async () =>
+        var ex = await Assert.ThrowsAsync<NzbWebDAV.Exceptions.StreamingWriteTimeoutException>(async () =>
             await GetAndHeadHandlerPatch.WriteWithProgressTimeoutAsync(
                 dest, new byte[1024], TimeSpan.FromMilliseconds(50), readCts, CancellationToken.None));
 
         Assert.True(readCts.IsCancellationRequested);
+        Assert.IsAssignableFrom<OperationCanceledException>(ex);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -100,4 +100,65 @@ public class GetAndHeadHandlerRangeTests
     {
         return new DavItem { Id = Guid.NewGuid() };
     }
+
+    [Fact]
+    public async Task WriteWithProgressTimeout_CompletesWhenClientReads()
+    {
+        using var readCts = new CancellationTokenSource();
+        using var dest = new MemoryStream();
+
+        await GetAndHeadHandlerPatch.WriteWithProgressTimeoutAsync(
+            dest, new byte[1024], TimeSpan.FromSeconds(5), readCts, CancellationToken.None);
+
+        Assert.Equal(1024, dest.Length);
+        Assert.False(readCts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task WriteWithProgressTimeout_CancelsReadTokenWhenClientStalls()
+    {
+        using var readCts = new CancellationTokenSource();
+        using var dest = new NeverCompletingWriteStream();
+
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
+            await GetAndHeadHandlerPatch.WriteWithProgressTimeoutAsync(
+                dest, new byte[1024], TimeSpan.FromMilliseconds(50), readCts, CancellationToken.None));
+
+        Assert.True(readCts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task WriteWithProgressTimeout_ZeroTimeoutDisablesWatchdog()
+    {
+        using var readCts = new CancellationTokenSource();
+        using var dest = new MemoryStream();
+
+        await GetAndHeadHandlerPatch.WriteWithProgressTimeoutAsync(
+            dest, new byte[512], TimeSpan.Zero, readCts, CancellationToken.None);
+
+        Assert.Equal(512, dest.Length);
+        Assert.False(readCts.IsCancellationRequested);
+    }
+
+    private sealed class NeverCompletingWriteStream : Stream
+    {
+        public override bool CanWrite => true;
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override long Length => 0;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => 0;
+        public override long Seek(long offset, SeekOrigin origin) => 0;
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            // Never complete: simulates a client that stopped reading but kept the
+            // connection open. Honors cancellation so the test does not hang.
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Scrubbing (seeking back and forth during a stream) can leave the in-flight **Article RAM** budget pinned at the 512 MiB cap with **zero active NNTP connections**, so new streams stall on `LeaseAsync` until the container is restarted. Two support packs (`pringles`, `pringles2`) confirm the mechanism; this PR fixes it.

**Root cause (confirmed by pringles2 stream traces):** an Android player (ExoPlayer/Media3, `Dalvik`/`stagefright` user-agents) scrubbing a 28.6 GB file opened many overlapping range GETs. Each abandoned GET's handler stayed alive holding a full prefetch buffer of article-budget leases because the client stopped reading but kept the connection open (HTTP/2 flow control / tunnel / proxy — Kestrel's HTTP/1.x min-response-rate abort never fired). 26 such stuck handlers × ~29 segments ≈ the 748 leases frozen at the cap for 3.5 hours. Prefetch (18 MB/s) outpaced consumption (8.6 MB/s) ~2:1.

## What this PR does

1. **Write-progress watchdog (the wedge fix)** — `GetAndHeadHandlerPatch.CopyToAsync` now bounds each client write with a per-write deadline (`usenet.streaming-write-timeout-seconds`, default 60, 0 disables). A 64 KB write that hasn't completed in the window means the client isn't reading; the linked read token is cancelled so the pipeline unwinds and the budget is released. Converts "restart required" into "self-heals in ≤60s."
2. **Join orphaned producer disposals** — `MultiSegmentStream.DisposeCoreAsync` now awaits the producer's out-of-band `DisposeStreamAsync` tasks (hit when a channel write is cancelled mid-batch), so `DisposeAsync` no longer returns while `BudgetedStream` leases are still held.
3. **Serialize seek teardown** — `NzbFileStream` / `DavMultipartFileStream` `Seek` starts the old inner stream's teardown non-blocking but the next `ReadAsync` awaits it before leasing again, so rapid scrubbing can't overlap generations.

Items 2–3 are hygiene that close real races but do **not** clear the wedge on their own (they only run once teardown starts; the wedge is that teardown never starts). Item 1 is the actual self-heal.

## Evidence

- **pringles:** Article RAM frozen at `536,166,400 / 536,870,912` (~99.9%), 211 throttle events, 0 active NNTP connections, segment-buffer rents 2389 vs returns 1645 (~780 MB checked out), 21 read starts / 1 completed / peak 18 readers on one path.
- **pringles2 (traces on):** same frozen figure held 3.5 hours; 4 sessions on one file, 32 range generations, heavy scrubbing; 26 handlers still open at capture holding ~29 segments each; 9 new range requests blocked at `LeaseAsync` (zero-segment generations); 420 duplicate in-flight segment fetches from overlapping readers.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2354 passed, 9 skipped (platform), 0 failed
- [x] `cd frontend && npm run typecheck && npm run build && npm test` — 519 passed
- [x] New backend: `WriteWithProgressTimeout_CompletesWhenClientReads`, `..._CancelsReadTokenWhenClientStalls`, `..._ZeroTimeoutDisablesWatchdog`
- [x] New backend (hygiene): `RapidScrubbing_ReleasesArticleBudgetAcrossGenerations`, `SeekThenDisposeAsync_AwaitsPriorTeardownBeforeReleasingBudget`, `DisposeAsync_JoinsPipelinedBatchOrphanedDisposals`
- [ ] Manual: scrub a large file over HTTP/2 or a tunnel and confirm Article RAM recovers within the write timeout instead of wedging

Draft until validated against the reporter's setup.