### PR TITLE
fix(build): restore nzbdav-named release archives so DUMB installs and auto-updates work again

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -149,6 +149,13 @@ jobs:
           "./$archive_name/backend/NzbWebDAV" --yenc-self-test
           tar -czf "${archive_name}.tar.gz" "$archive_name"
 
+          # Legacy nzbdav-* named copy: DUMB's prebuilt installer matches asset
+          # names and archive roots as 'nzbdav-*-linux-<arch>'. Temporary compat
+          # until DUMB matches infinidysk-* names; remove both copies then.
+          compat_name="nzbdav-v${VERSION}-${RID}"
+          cp -a "$archive_name" "$compat_name"
+          tar -czf "${compat_name}.tar.gz" "$compat_name"
+
       - name: Attach archives to releases
         env:
           GH_TOKEN: ${{ github.token }}
@@ -159,10 +166,13 @@ jobs:
         run: |
           set -euo pipefail
           archive="infinidysk-v${VERSION}-${RID}.tar.gz"
-          gh release upload "$RELEASE_TAG" "$archive" --clobber
+          compat_archive="nzbdav-v${VERSION}-${RID}.tar.gz"
+          gh release upload "$RELEASE_TAG" "$archive" "$compat_archive" --clobber
 
           if [[ -n "$ROLLING_TAG" ]]; then
             rolling_archive="infinidysk-${ROLLING_TAG}-${RID}.tar.gz"
+            compat_rolling_archive="nzbdav-${ROLLING_TAG}-${RID}.tar.gz"
             cp "$archive" "$rolling_archive"
-            gh release upload "$ROLLING_TAG" "$rolling_archive" --clobber
+            cp "$compat_archive" "$compat_rolling_archive"
+            gh release upload "$ROLLING_TAG" "$rolling_archive" "$compat_rolling_archive" --clobber
           fi


### PR DESCRIPTION
## Summary
- Since the archive rename in #833, DUMB's verified-prebuilt installer (which only matches `nzbdav-*-linux-<arch>.tar.gz` asset names and archive roots) falls back to source builds for every release — the root cause of the wave of `Could not load file or assembly 'System.IO.Hashing'` reports from DUMB users on v1.0.0.
- `build-release-assets.yml` now additionally attaches a legacy-named `nzbdav-vX.Y.Z-linux-<arch>.tar.gz` copy (identical content, root folder renamed to match) to every release, plus `nzbdav-<rolling>-linux-<arch>.tar.gz` on rolling releases — so DUMB ≥2.15.0 installs get the complete, digest-verified prebuilt runtime again.
- Temporary compat shim, marked in the workflow comment; remove once DUMB's asset matcher handles `infinidysk-*` names (patch expected from DUMB upstream).

## Test plan
- [x] Manually verified the exact archive shape DUMB requires against DUMB master (`utils/setup.py::_validate_nzbdav_prebuilt_candidate`, `utils/download.py::_strict_relative_path`): asset name prefix/suffix, single match per arch, archive root folder pattern, critical-file manifest, ASP.NET Core 10 runtimeconfig, non-empty version.txt
- [x] Same repack already validated live: hand-built `nzbdav-v1.0.0-linux-{x64,arm64}.tar.gz` backfilled onto the v1.0.0 release with valid SHA-256 digests
- [ ] After merge: run **Release** workflow manually for `1.0.0` (or observe the next release/RC) and confirm both asset names attach correctly