### PR TITLE
fix(usenet): fetch errors now show their real cause instead of "Other (unclassified)"

### DIFF
--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1171,6 +1171,12 @@ public class MultiProviderNntpClient(
     /// </summary>
     internal static SegmentFetch.FetchStatus ClassifyException(Exception ex)
     {
+        // Singular BODY/HEAD and streaming paths surface a definitive 430/451 as a thrown
+        // UsenetArticleNotFoundException; STAT/batch paths return it as a response that is
+        // already recorded Missing. Classify both the same.
+        if (ex.TryGetCausingException<UsenetArticleNotFoundException>(out _))
+            return SegmentFetch.FetchStatus.Missing;
+
         if (ex.TryGetCausingException<TimeoutException>(out _))
             return SegmentFetch.FetchStatus.Timeout;
 

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -15,6 +15,7 @@ using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
 using Serilog;
 using Serilog.Context;
+using UsenetSharp.Exceptions;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -1063,10 +1064,16 @@ public class MultiProviderNntpClient(
         RecordFetch(metricsKey, status, durationMs, retries, traceRange);
         if (status == SegmentFetch.FetchStatus.Other)
         {
-            Log.Debug(
-                exception,
+            // Keyed by exception type so a storm of the same novel failure logs once per
+            // minute and still names the type in support packs; the stack stays at Debug.
+            ThrottledSegmentWarning.Write(
+                exception.GetType().FullName ?? "unknown",
                 "Unclassified Usenet segment fetch failure. Host={Host} ExceptionType={ExceptionType}",
                 metricsKey, exception.GetType().FullName);
+            Log.Debug(
+                exception,
+                "Unclassified Usenet segment fetch failure stack. Host={Host}",
+                metricsKey);
         }
         return status;
     }
@@ -1180,7 +1187,10 @@ public class MultiProviderNntpClient(
         if (ex.TryGetCausingException<TimeoutException>(out _))
             return SegmentFetch.FetchStatus.Timeout;
 
-        if (ex.TryGetCausingException<UsenetCorruptArticleException>(out _))
+        // yEnc decode failures escape as InvalidDataException, which derives from
+        // IOException — it must be checked before the IOException -> Network case.
+        if (ex.TryGetCausingException<UsenetCorruptArticleException>(out _) ||
+            ex.TryGetCausingException<System.IO.InvalidDataException>(out _))
             return SegmentFetch.FetchStatus.Corrupt;
 
         if (ex.TryGetCausingException<CouldNotLoginToUsenetException>(out _) ||
@@ -1188,11 +1198,14 @@ public class MultiProviderNntpClient(
             return SegmentFetch.FetchStatus.Auth;
 
         if (ex.TryGetCausingException<CouldNotConnectToUsenetException>(out _) ||
+            ex.TryGetCausingException<UsenetNotConnectedException>(out _) ||
+            ex.TryGetCausingException<UsenetException>(out _) ||
             ex.TryGetCausingException<System.Net.Sockets.SocketException>(out _) ||
             ex.TryGetCausingException<System.IO.IOException>(out _))
             return SegmentFetch.FetchStatus.Network;
 
-        if (ex.TryGetCausingException<UsenetUnexpectedResponseException>(out _))
+        if (ex.TryGetCausingException<UsenetUnexpectedResponseException>(out _) ||
+            ex.TryGetCausingException<UsenetProtocolException>(out _))
             return SegmentFetch.FetchStatus.Protocol;
 
         return SegmentFetch.FetchStatus.Other;

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -1749,6 +1749,25 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public void ClassifyException_ArticleNotFound_ReturnsMissing()
+    {
+        // Singular BODY/HEAD and streaming paths throw on a definitive 430/451 instead of
+        // returning a response; it must classify the same as a response-path miss.
+        var exception = new UsenetArticleNotFoundException("<seg@example>", "430 No Such Article");
+        var status = MultiProviderNntpClient.ClassifyException(exception);
+        Assert.Equal(SegmentFetch.FetchStatus.Missing, status);
+    }
+
+    [Fact]
+    public void ClassifyException_ArticleNotFoundWrapped_StillReturnsMissing()
+    {
+        var inner = new UsenetArticleNotFoundException("<seg@example>", "430 No Such Article");
+        var wrapped = new InvalidOperationException("stream read failed", inner);
+        var status = MultiProviderNntpClient.ClassifyException(wrapped);
+        Assert.Equal(SegmentFetch.FetchStatus.Missing, status);
+    }
+
+    [Fact]
     public void ClassifyException_Timeout_ReturnsTimeout()
     {
         var status = MultiProviderNntpClient.ClassifyException(new TimeoutException());

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -9,6 +9,7 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
+using UsenetSharp.Exceptions;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -1783,6 +1784,24 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public void ClassifyException_InvalidData_ReturnsCorrupt()
+    {
+        // UsenetSharp yEnc header/decode failures escape as InvalidDataException.
+        var status = MultiProviderNntpClient.ClassifyException(new InvalidDataException("CRC mismatch"));
+        Assert.Equal(SegmentFetch.FetchStatus.Corrupt, status);
+    }
+
+    [Fact]
+    public void ClassifyException_InvalidDataWrapped_StillReturnsCorruptNotNetwork()
+    {
+        // InvalidDataException derives from IOException; the Corrupt case must win
+        // over the IOException -> Network case regardless of wrapping.
+        var wrapped = new InvalidOperationException("stream read failed", new InvalidDataException("bad yenc"));
+        var status = MultiProviderNntpClient.ClassifyException(wrapped);
+        Assert.Equal(SegmentFetch.FetchStatus.Corrupt, status);
+    }
+
+    [Fact]
     public void ClassifyException_CouldNotLogin_ReturnsAuth()
     {
         var exception = new CouldNotLoginToUsenetException("bad credentials");
@@ -1821,6 +1840,22 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public void ClassifyException_UsenetNotConnected_ReturnsNetwork()
+    {
+        var exception = new UsenetNotConnectedException("The NNTP connection closed before the article body was read.");
+        var status = MultiProviderNntpClient.ClassifyException(exception);
+        Assert.Equal(SegmentFetch.FetchStatus.Network, status);
+    }
+
+    [Fact]
+    public void ClassifyException_UsenetConnection_ReturnsNetwork()
+    {
+        var exception = new UsenetConnectionException("Server responded: 502") { ResponseCode = 502 };
+        var status = MultiProviderNntpClient.ClassifyException(exception);
+        Assert.Equal(SegmentFetch.FetchStatus.Network, status);
+    }
+
+    [Fact]
     public void ClassifyException_UnknownException_ReturnsOther()
     {
         var status = MultiProviderNntpClient.ClassifyException(new Exception("boom"));
@@ -1841,6 +1876,14 @@ public class MultiProviderNntpClientTests
         var inner = new UsenetUnexpectedResponseException("<seg@example>", "400 idle timeout");
         var wrapped = new InvalidOperationException("stream read failed", inner);
         var status = MultiProviderNntpClient.ClassifyException(wrapped);
+        Assert.Equal(SegmentFetch.FetchStatus.Protocol, status);
+    }
+
+    [Fact]
+    public void ClassifyException_UsenetProtocol_ReturnsProtocol()
+    {
+        var exception = new UsenetProtocolException("Invalid NNTP response: missing article headers.");
+        var status = MultiProviderNntpClient.ClassifyException(exception);
         Assert.Equal(SegmentFetch.FetchStatus.Protocol, status);
     }
 


### PR DESCRIPTION
## Summary

- Fixes the misclassification behind 509 "Other (unclassified)" errors in a real support dump: singular BODY/HEAD and streaming fetch paths throw `UsenetArticleNotFoundException` on a definitive 430/451, while STAT and pipelined batch paths return it as a response already recorded as **Missing**. The exception path fell through `ClassifyException` into **Other**. Both now classify as Missing.
- Audited every exception that can reach the classifier and mapped the remaining gaps: UsenetSharp protocol violations → **Protocol**, `UsenetNotConnectedException`/`UsenetException` (connection-level) → **Network**, and yEnc `InvalidDataException` → **Corrupt** (checked before its `IOException` base hits Network).
- The residual **Other** bucket stays as an honest safety net, but its per-failure log is now a throttled Warning keyed by exception type (60s window) instead of a Debug line — the dump proved Debug gets evicted by log spam, so future unclassified failures now name themselves in support packs.

No enum changes, no DB migration, no frontend changes: all 8 `FetchStatus` values already render with colors/labels in the error breakdown and backup-rescues cards. Existing `Other` rows in metrics DBs simply stop growing.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter ClassifyException` — 21 passed (7 new facts: article-not-found direct + wrapped, invalid-data direct + wrapped, usenet-protocol, not-connected, connection)
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2358 passed, 0 failed
- [x] `cd frontend && npm run typecheck` — clean
- [ ] CI