### PR TITLE
feat(queue): process up to 10 NZBs at once

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -685,7 +685,7 @@ public class ConfigManager
 
     /// <summary>
     /// How many NZB queue items may process concurrently. Default 1 preserves
-    /// historical single-item behavior. Clamped to 1–4 while the feature is new.
+    /// historical single-item behavior. Clamped to 1–10.
     /// Workers share <see cref="GetMaxQueueConnections"/>.
     /// </summary>
     public int GetQueueWorkerCount()
@@ -693,7 +693,7 @@ public class ConfigManager
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.QueueWorkerCount));
         if (configured is null || !int.TryParse(configured, out var value))
             return 1;
-        return Math.Clamp(value, 1, 4);
+        return Math.Clamp(value, 1, 10);
     }
 
     public int GetQueueMaxItems()

--- a/docs/configuration/queue.md
+++ b/docs/configuration/queue.md
@@ -13,7 +13,7 @@ provider connections available to active imports.
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
-| Concurrent Queue Downloads [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Process 1–4 NZBs concurrently; the oldest active item is preferred |
+| Concurrent Queue Downloads [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `queue.worker-count` | `1` | Process 1–10 NZBs concurrently; the oldest active item is preferred |
 | Queue Download Connections | `usenet.max-queue-connections` | blank = all | Provider connections shared by queue workers and background health checks |
 
 Adding workers does not add provider capacity. Additional workers use spare

--- a/frontend/app/routes/settings/queue/queue.test.ts
+++ b/frontend/app/routes/settings/queue/queue.test.ts
@@ -67,7 +67,7 @@ describe("Queue settings", () => {
         expect(isQueueSettingsValid(validConfig)).toBe(true);
         expect(isQueueSettingsValid({
             ...validConfig,
-            "queue.worker-count": "4",
+            "queue.worker-count": "10",
             "usenet.max-queue-connections": "20",
             "queue.max-items": "50",
             "queue.resume-threshold": "25",
@@ -77,7 +77,7 @@ describe("Queue settings", () => {
     it("rejects out-of-range workers and invalid admission thresholds", () => {
         expect(isQueueSettingsValid({
             ...validConfig,
-            "queue.worker-count": "5",
+            "queue.worker-count": "11",
         })).toBe(false);
         expect(isQueueSettingsValid({
             ...validConfig,

--- a/frontend/app/routes/settings/queue/queue.tsx
+++ b/frontend/app/routes/settings/queue/queue.tsx
@@ -48,6 +48,12 @@ export function QueueSettings({ config, setNewConfig }: QueueSettingsProps) {
                                 <option value="2">2</option>
                                 <option value="3">3</option>
                                 <option value="4">4</option>
+                                <option value="5">5</option>
+                                <option value="6">6</option>
+                                <option value="7">7</option>
+                                <option value="8">8</option>
+                                <option value="9">9</option>
+                                <option value="10">10</option>
                             </Select>
                             <p className="text-[11px] leading-relaxed text-base-content/45" id="queue-worker-count-help">
                                 How many NZB queue items may process at once. The oldest active item gets
@@ -160,7 +166,7 @@ export function isQueueSettingsValid(config: Record<string, string>): boolean {
 function isValidQueueWorkerCount(value: string | undefined): boolean {
     if (value == null || value.trim() === "") return true;
     const number = Number(value);
-    return Number.isInteger(number) && number >= 1 && number <= 4;
+    return Number.isInteger(number) && number >= 1 && number <= 10;
 }
 
 function isValidMaxQueueConnections(value: string | undefined): boolean {

--- a/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
@@ -149,11 +149,12 @@ public class QueueWorkerCountConfigTests
     [InlineData("", 1)]
     [InlineData("1", 1)]
     [InlineData("4", 4)]
-    [InlineData("8", 4)]
+    [InlineData("8", 8)]
+    [InlineData("10", 10)]
     [InlineData("0", 1)]
-    [InlineData("99", 4)]
+    [InlineData("99", 10)]
     [InlineData("abc", 1)]
-    public void GetQueueWorkerCount_ClampsToOneThroughFour(string? configured, int expected)
+    public void GetQueueWorkerCount_ClampsToOneThroughTen(string? configured, int expected)
     {
         var config = new ConfigManager();
         if (configured is not null)


### PR DESCRIPTION
## Summary
- Raises the **Concurrent Queue Downloads** setting (`queue.worker-count`) from 1–4 to 1–10, so the queue can process up to 10 NZBs concurrently.
- Updates the settings dropdown, frontend validation, backend clamp, and queue configuration docs to match.

Workers still share the same Queue Download Connections budget — raising concurrency does not add provider capacity.

## Test plan
- [x] `cd frontend && npm run typecheck` — clean
- [x] `npx vitest run app/routes/settings/queue/queue.test.ts` — 4/4 passed
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "QueueWorkerCountConfigTests|ConcurrentQueueManagerTests"` — 13/13 passed
- [ ] Manual: Settings → Queue shows options 1–10; saving 10 persists and queue fans out to 10 items