### PR TITLE
fix(usenet): providers stop flapping at 60-second cooldowns when health checks run

### DIFF
--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -257,7 +257,7 @@ internal sealed class BenchmarkNntpClient(
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -275,7 +275,7 @@ internal sealed class BenchmarkNntpClient(
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         var responses = segmentIds
@@ -312,7 +312,7 @@ internal sealed class BenchmarkNntpClient(
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>
         throw new NotSupportedException();
 

--- a/backend/Api/Controllers/DownloadSupportPack/DownloadSupportPackController.cs
+++ b/backend/Api/Controllers/DownloadSupportPack/DownloadSupportPackController.cs
@@ -17,13 +17,15 @@ public sealed class DownloadSupportPackController(SupportPackService supportPack
 
         // Quality warnings must precede the streaming body so the Support UI can show
         // them after download. They are cheap point-in-time reads, not pack content.
+        // Compute once and thread through to the manifest so the header and the
+        // archive cannot disagree if state changes mid-generation.
         var packQuality = supportPack.GetPackQualityWarnings();
         if (packQuality.Count > 0)
             Response.Headers["X-Support-Pack-Quality"] = JsonSerializer.Serialize(packQuality);
 
         // ZipArchive performs synchronous finalization writes. BodyWriter's stream
         // supports those writes whereas Kestrel's Response.Body does not.
-        await supportPack.WriteAsync(Response.BodyWriter.AsStream(), HttpContext.RequestAborted)
+        await supportPack.WriteAsync(Response.BodyWriter.AsStream(), packQuality, HttpContext.RequestAborted)
             .ConfigureAwait(false);
         return new EmptyResult();
     }

--- a/backend/Api/Controllers/DownloadSupportPack/DownloadSupportPackController.cs
+++ b/backend/Api/Controllers/DownloadSupportPack/DownloadSupportPackController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Services.SupportPack;
 
@@ -13,6 +14,12 @@ public sealed class DownloadSupportPackController(SupportPackService supportPack
         Response.ContentType = "application/zip";
         Response.Headers.ContentDisposition = $"attachment; filename=\"infinidysk-support-{timestamp}.zip\"";
         Response.Headers.CacheControl = "no-store";
+
+        // Quality warnings must precede the streaming body so the Support UI can show
+        // them after download. They are cheap point-in-time reads, not pack content.
+        var packQuality = supportPack.GetPackQualityWarnings();
+        if (packQuality.Count > 0)
+            Response.Headers["X-Support-Pack-Quality"] = JsonSerializer.Serialize(packQuality);
 
         // ZipArchive performs synchronous finalization writes. BodyWriter's stream
         // supports those writes whereas Kestrel's Response.Body does not.

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -64,7 +64,7 @@ public class ArticleCachingNntpClient(
     }
 
     public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken)
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = _pendingRequests.GetOrAdd(segmentId, _ => new SemaphoreSlim(1, 1));
 
@@ -117,7 +117,7 @@ public class ArticleCachingNntpClient(
 
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         var partition = PartitionBatch(segmentIds);
@@ -137,7 +137,7 @@ public class ArticleCachingNntpClient(
     }
 
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken)
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = _pendingRequests.GetOrAdd(segmentId, _ => new SemaphoreSlim(1, 1));
 
@@ -395,12 +395,13 @@ public class ArticleCachingNntpClient(
     }
 
     private static void InvokeCompletionCallback(
-        Action<ArticleBodyResult>? callback,
-        ArticleBodyResult result)
+        ArticleBodyCompletionHandler? callback,
+        ArticleBodyResult result,
+        string? failureReason = null)
     {
         try
         {
-            callback?.Invoke(result);
+            callback?.Invoke(result, failureReason);
         }
         catch
         {

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -184,7 +184,7 @@ public class BaseNntpClient : NntpClient
     public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -207,7 +207,7 @@ public class BaseNntpClient : NntpClient
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync
     (
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -227,7 +227,7 @@ public class BaseNntpClient : NntpClient
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {

--- a/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
+++ b/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
@@ -1,0 +1,84 @@
+using NzbWebDAV.Clients.Usenet.Models;
+using Serilog;
+
+namespace NzbWebDAV.Clients.Usenet.Connections;
+
+/// <summary>
+/// Correlates circuit-breaker Open transitions across providers. When every enabled
+/// provider trips within a short window of each other, the likely cause is local
+/// (network, DNS, TLS interception, ISP routing) rather than simultaneous independent
+/// provider outages — a shape per-provider breakers cannot see. Emits one throttled
+/// warning so operators get a single actionable event instead of N isolated trips.
+/// </summary>
+public sealed class CorrelatedTripDetector
+{
+    private static readonly TimeSpan DefaultWindow = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan DefaultThrottle = TimeSpan.FromMinutes(5);
+
+    private readonly object _lock = new();
+    private readonly Dictionary<string, string> _providers = new(StringComparer.Ordinal); // key -> host
+    private readonly Dictionary<string, long> _openSinceMs = new(StringComparer.Ordinal);
+    private readonly TimeSpan _window;
+    private readonly TimeSpan _throttle;
+    private long? _lastWarningAtMs;
+
+    public CorrelatedTripDetector(TimeSpan? window = null, TimeSpan? throttle = null)
+    {
+        _window = window ?? DefaultWindow;
+        _throttle = throttle ?? DefaultThrottle;
+    }
+
+    /// <summary>Wall clock, injectable for tests.</summary>
+    internal Func<long> Clock { get; set; } =
+        () => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    /// <summary>
+    /// Tracks a provider that can carry traffic. Disabled providers never trip, so
+    /// registering them would wedge the "all providers tripped" condition forever.
+    /// </summary>
+    public void Register(string providerKey, string host)
+    {
+        lock (_lock)
+            _providers[providerKey] = host;
+    }
+
+    public void Unregister(string providerKey)
+    {
+        lock (_lock)
+        {
+            _providers.Remove(providerKey);
+            _openSinceMs.Remove(providerKey);
+        }
+    }
+
+    public void OnTransition(string providerKey, ProviderCircuitTransition transition)
+    {
+        lock (_lock)
+        {
+            if (transition.State == ProviderCircuitTransitionState.Open)
+                _openSinceMs[providerKey] = transition.AtUnixMilliseconds;
+            else
+                _openSinceMs.Remove(providerKey);
+
+            if (transition.State != ProviderCircuitTransitionState.Open) return;
+            if (_providers.Count < 2) return;
+            if (!_providers.Keys.All(_openSinceMs.ContainsKey)) return;
+
+            // All providers are open; only correlated if the trips cluster in time.
+            var opens = _providers.Keys.Select(p => _openSinceMs[p]).ToList();
+            if (opens.Max() - opens.Min() > (long)_window.TotalMilliseconds) return;
+
+            var now = Clock();
+            if (_lastWarningAtMs is { } lastWarning
+                && now - lastWarning < (long)_throttle.TotalMilliseconds) return;
+            _lastWarningAtMs = now;
+
+            Log.Warning(
+                "All {Count} NNTP providers tripped their circuit breakers within {WindowSeconds}s of each other ({Providers}). " +
+                "Simultaneous independent provider outages are unlikely — check local network, DNS, or TLS interception.",
+                _providers.Count,
+                _window.TotalSeconds,
+                string.Join(", ", _providers.Values));
+        }
+    }
+}

--- a/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
+++ b/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
@@ -9,6 +9,13 @@ namespace NzbWebDAV.Clients.Usenet.Connections;
 /// (network, DNS, TLS interception, ISP routing) rather than simultaneous independent
 /// provider outages — a shape per-provider breakers cannot see. Emits one throttled
 /// warning so operators get a single actionable event instead of N isolated trips.
+/// <para>
+/// Lifetime: one instance per <c>MultiProviderNntpClient</c> generation. A config-change
+/// rebuild creates a new detector for the new provider set; any in-flight trip state from
+/// the old generation is intentionally lost. This means a trip on provider A under the old
+/// client followed by a trip on provider B under the new client will not correlate — an
+/// acceptable gap since config changes are rare and the correlation window is short (10s).
+/// </para>
 /// </summary>
 public sealed class CorrelatedTripDetector
 {

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -105,7 +105,18 @@ public class ProviderCircuitBreaker
         }
     }
 
-    public void RecordSuccess()
+    /// <summary>
+    /// Records a successful command.
+    /// </summary>
+    /// <param name="resetsCooldownLadder">
+    /// True when the success proves the download path works (a BODY/ARTICLE fetch),
+    /// fully resetting the escalation ladder. False for reachability-only successes
+    /// (STAT/HEAD/DATE): the trip is cleared so the provider rejoins rotation, but the
+    /// current cooldown is preserved for the next trip. Health-check STAT traffic would
+    /// otherwise close every latched breaker seconds after cooldown expiry and pin a
+    /// provider with a persistently broken BODY path at the minimum cooldown forever.
+    /// </param>
+    public void RecordSuccess(bool resetsCooldownLadder = true)
     {
         lock (_lock)
         {
@@ -124,7 +135,8 @@ public class ProviderCircuitBreaker
 
             _window.Clear();
             _trippedUntilMs = 0;
-            _currentCooldown = InitialCooldown;
+            if (resetsCooldownLadder)
+                _currentCooldown = InitialCooldown;
             _lastFailureReason = null;
             Volatile.Write(ref _halfOpenProbeInFlight, 0);
             Volatile.Write(ref _probeStartedMs, 0);

--- a/backend/Clients/Usenet/DeferredArticleBodyCallback.cs
+++ b/backend/Clients/Usenet/DeferredArticleBodyCallback.cs
@@ -5,14 +5,14 @@ namespace NzbWebDAV.Clients.Usenet;
 internal sealed class DeferredArticleBodyCallback
 {
     private readonly object _lock = new();
-    private Action<ArticleBodyResult>? _target;
-    private ArticleBodyResult? _deferredResult;
+    private ArticleBodyCompletionHandler? _target;
+    private (ArticleBodyResult Result, string? FailureReason)? _deferred;
     private bool _invoked;
     private bool _discarded;
 
-    public void Invoke(ArticleBodyResult result)
+    public void Invoke(ArticleBodyResult result, string? failureReason = null)
     {
-        Action<ArticleBodyResult>? target;
+        ArticleBodyCompletionHandler? target;
         lock (_lock)
         {
             if (_discarded || _invoked) return;
@@ -20,28 +20,28 @@ internal sealed class DeferredArticleBodyCallback
             target = _target;
             if (target == null)
             {
-                _deferredResult ??= result;
+                _deferred ??= (result, failureReason);
                 return;
             }
         }
 
-        InvokeSafely(target, result);
+        InvokeSafely(target, result, failureReason);
     }
 
-    public void Activate(Action<ArticleBodyResult> target)
+    public void Activate(ArticleBodyCompletionHandler target)
     {
-        ArticleBodyResult? deferredResult;
+        (ArticleBodyResult Result, string? FailureReason)? deferred;
         lock (_lock)
         {
             if (_discarded) return;
             _target = target;
-            deferredResult = _deferredResult;
-            _deferredResult = null;
+            deferred = _deferred;
+            _deferred = null;
         }
 
-        if (deferredResult.HasValue)
+        if (deferred.HasValue)
         {
-            InvokeSafely(target, deferredResult.Value);
+            InvokeSafely(target, deferred.Value.Result, deferred.Value.FailureReason);
         }
     }
 
@@ -51,15 +51,18 @@ internal sealed class DeferredArticleBodyCallback
         {
             _discarded = true;
             _target = null;
-            _deferredResult = null;
+            _deferred = null;
         }
     }
 
-    private static void InvokeSafely(Action<ArticleBodyResult> target, ArticleBodyResult result)
+    private static void InvokeSafely(
+        ArticleBodyCompletionHandler target,
+        ArticleBodyResult result,
+        string? failureReason)
     {
         try
         {
-            target(result);
+            target(result, failureReason);
         }
         catch
         {

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -100,49 +100,49 @@ public class DownloadingNntpClient : WrappingNntpClient
     }
 
     public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken)
+        ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
         return await base.DecodedBodyAsync(segmentId, OnConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
 
-        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult)
+        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult, string? failureReason)
         {
             semaphore.Release();
-            onConnectionReadyAgain?.Invoke(articleBodyResult);
+            onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason);
         }
     }
 
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
         return await base.DecodedBodiesAsync(
             segmentIds, OnConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
 
-        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult)
+        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult, string? failureReason)
         {
             semaphore.Release();
-            onConnectionReadyAgain?.Invoke(articleBodyResult);
+            onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason);
         }
     }
 
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync(SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken)
+        ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
         return await base.DecodedArticleAsync(segmentId, OnConnectionReadyAgain, cancellationToken)
             .ConfigureAwait(false);
 
-        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult)
+        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult, string? failureReason)
         {
             semaphore.Release();
-            onConnectionReadyAgain?.Invoke(articleBodyResult);
+            onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason);
         }
     }
 
-    private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(Action<ArticleBodyResult>? onConnectionReadyAgain,
+    private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         try
@@ -217,7 +217,7 @@ public class DownloadingNntpClient : WrappingNntpClient
     )
     {
         var semaphore = await AcquireExclusiveConnectionAsync(cancellationToken).ConfigureAwait(false);
-        return new UsenetExclusiveConnection(_ => semaphore.Release());
+        return new UsenetExclusiveConnection((_, _) => semaphore.Release());
     }
 
     public override async Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync
@@ -233,7 +233,7 @@ public class DownloadingNntpClient : WrappingNntpClient
         }
 
         var semaphore = await AcquireExclusiveConnectionAsync(cancellationToken).ConfigureAwait(false);
-        return new UsenetExclusiveConnection(_ => semaphore.Release());
+        return new UsenetExclusiveConnection((_, _) => semaphore.Release());
     }
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId,

--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -25,17 +25,17 @@ public interface INntpClient : IDisposable
         SegmentId segmentId, CancellationToken cancellationToken);
 
     Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken);
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
     Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-        IReadOnlyList<SegmentId> segmentIds, Action<ArticleBodyResult>? onConnectionReadyAgain,
+        IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken);
 
     Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 
     Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken);
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
     Task<UsenetDateResponse> DateAsync(
         CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/Models/UsenetExclusiveConnection.cs
+++ b/backend/Clients/Usenet/Models/UsenetExclusiveConnection.cs
@@ -2,7 +2,7 @@
 
 namespace NzbWebDAV.Clients.Usenet.Models;
 
-public readonly struct UsenetExclusiveConnection(Action<ArticleBodyResult>? onConnectionReadyAgain)
+public readonly struct UsenetExclusiveConnection(ArticleBodyCompletionHandler? onConnectionReadyAgain)
 {
-    public Action<ArticleBodyResult>? OnConnectionReadyAgain => onConnectionReadyAgain;
+    public ArticleBodyCompletionHandler? OnConnectionReadyAgain => onConnectionReadyAgain;
 }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -625,8 +625,11 @@ public class MultiConnectionNntpClient(
                 // Once latched the breaker is no longer tracking a streak, it is waiting
                 // for proof the provider answers at all. A provider that sees little body
                 // traffic would otherwise stay latched with nothing able to close it.
+                // Reachability is not proof the download path works, so the cooldown
+                // ladder survives the close; only a BODY success resets it. Constant
+                // health-check STATs must not pin a BODY-broken provider at 60s forever.
                 if (circuitBreaker.IsLatched)
-                    circuitBreaker.RecordSuccess();
+                    circuitBreaker.RecordSuccess(resetsCooldownLadder: false);
                 deferredCallback.Discard();
                 LogException(() => connectionLock?.Dispose());
             }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -198,7 +198,7 @@ public class MultiConnectionNntpClient(
 
     private static async Task<UsenetDateResponse> RequireSuccessfulDateAsync(
         INntpClient connection,
-        Action<ArticleBodyResult> _,
+        ArticleBodyCompletionHandler _,
         CancellationToken ct)
     {
         var response = await connection.DateAsync(ct).ConfigureAwait(false);
@@ -214,7 +214,7 @@ public class MultiConnectionNntpClient(
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken ct
     )
     {
@@ -230,7 +230,7 @@ public class MultiConnectionNntpClient(
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync
     (
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken ct
     )
     {
@@ -273,7 +273,7 @@ public class MultiConnectionNntpClient(
                 deferredCallback.Activate(OnConnectionReadyAgain);
                 return new UsenetDecodedBodyBatch { Responses = wrapped };
 
-                void OnConnectionReadyAgain(ArticleBodyResult result)
+                void OnConnectionReadyAgain(ArticleBodyResult result, string? failureReason)
                 {
                     if (Interlocked.Exchange(ref callbackInvoked, 1) != 0) return;
                     switch (result)
@@ -292,16 +292,20 @@ public class MultiConnectionNntpClient(
                             // client cancellation as provider health failure.
                             LogException(connectionLock.Replace);
                             if (!ct.IsCancellationRequested)
-                                circuitBreaker.RecordFailure($"pipeline-callback-{result}");
+                                circuitBreaker.RecordFailure(failureReason is null
+                                    ? $"pipeline-callback-{result}"
+                                    : $"pipeline-callback-{result} ({failureReason})");
                             break;
                         default:
-                            circuitBreaker.RecordFailure($"pipeline-callback-{result}");
+                            circuitBreaker.RecordFailure(failureReason is null
+                                ? $"pipeline-callback-{result}"
+                                : $"pipeline-callback-{result} ({failureReason})");
                             LogException(connectionLock.Replace);
                             break;
                     }
 
                     LogException(connectionLock.Dispose);
-                    LogException(() => onConnectionReadyAgain?.Invoke(result));
+                    LogException(() => onConnectionReadyAgain?.Invoke(result, failureReason));
                 }
             }
             catch (Exception e) when (
@@ -417,7 +421,7 @@ public class MultiConnectionNntpClient(
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken ct
     )
     {
@@ -434,8 +438,8 @@ public class MultiConnectionNntpClient(
     (
         string name,
         SemaphorePriority priority,
-        Func<INntpClient, Action<ArticleBodyResult>, CancellationToken, Task<T>> command,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        Func<INntpClient, ArticleBodyCompletionHandler, CancellationToken, Task<T>> command,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken ct,
         int retryCount = 1
     ) where T : UsenetResponse
@@ -645,7 +649,7 @@ public class MultiConnectionNntpClient(
             else
             {
                 var callbackInvoked = 0;
-                deferredCallback.Activate(articleBodyResult =>
+                deferredCallback.Activate((articleBodyResult, failureReason) =>
                 {
                     if (Interlocked.Exchange(ref callbackInvoked, 1) != 0) return;
 
@@ -654,7 +658,9 @@ public class MultiConnectionNntpClient(
                         LogException(() => connectionLock?.Replace());
                         // Client abort (seek) must not trip the provider circuit breaker.
                         if (!ct.IsCancellationRequested)
-                            circuitBreaker.RecordFailure($"body-callback-{name}-NotRetrieved");
+                            circuitBreaker.RecordFailure(failureReason is null
+                                ? $"body-callback-{name}-NotRetrieved"
+                                : $"body-callback-{name}-NotRetrieved ({failureReason})");
                     }
                     else if (articleBodyResult == ArticleBodyResult.Retrieved)
                     {
@@ -666,7 +672,7 @@ public class MultiConnectionNntpClient(
                     }
 
                     LogException(() => connectionLock?.Dispose());
-                    LogException(() => onConnectionReadyAgain?.Invoke(articleBodyResult));
+                    LogException(() => onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason));
                 });
             }
 

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -230,7 +230,7 @@ public class MultiProviderNntpClient(
     public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -242,11 +242,11 @@ public class MultiProviderNntpClient(
                     provider.DecodedBodyAsync(segmentId, callback, cancellationToken),
                 UsenetResponseType.ArticleRetrievedBodyFollows,
                 segmentId,
-                result =>
+                (result, failureReason) =>
                 {
                     try
                     {
-                        InvokeCompletionCallback(onConnectionReadyAgain, result);
+                        InvokeCompletionCallback(onConnectionReadyAgain, result, failureReason);
                     }
                     finally
                     {
@@ -265,7 +265,7 @@ public class MultiProviderNntpClient(
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync
     (
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -273,11 +273,11 @@ public class MultiProviderNntpClient(
             ? []
             : segmentIds.Select(x => concurrentReadTracker.BeginSegmentFetch(x)).ToArray();
 
-        void CompleteBatchFetches(ArticleBodyResult result)
+        void CompleteBatchFetches(ArticleBodyResult result, string? failureReason)
         {
             try
             {
-                InvokeCompletionCallback(onConnectionReadyAgain, result);
+                InvokeCompletionCallback(onConnectionReadyAgain, result, failureReason);
             }
             finally
             {
@@ -538,11 +538,11 @@ public class MultiProviderNntpClient(
                                 traceRange, priorMisses);
                             response = WrapProviderResponse(response, provider.MetricsKey);
                             gateOwnedByTransfer = true;
-                            deferredCallback.Activate(result =>
+                            deferredCallback.Activate((result, failureReason) =>
                             {
                                 try
                                 {
-                                    coordinator.CompleteTransfer(result);
+                                    coordinator.CompleteTransfer(result, failureReason);
                                 }
                                 finally
                                 {
@@ -621,23 +621,25 @@ public class MultiProviderNntpClient(
 
     private sealed class BatchCallbackCoordinator(
         int responseCount,
-        Action<ArticleBodyResult>? callback)
+        ArticleBodyCompletionHandler? callback)
     {
         private int _remaining = responseCount + 1;
         private int _transportFailed;
         private int _resolutionFailed;
         private int _callbackInvoked;
+        private string? _firstFailureReason;
 
         public void AddTransfer()
         {
             Interlocked.Increment(ref _remaining);
         }
 
-        public void CompleteTransfer(ArticleBodyResult result)
+        public void CompleteTransfer(ArticleBodyResult result, string? failureReason = null)
         {
             if (result == ArticleBodyResult.NotRetrieved)
             {
                 Volatile.Write(ref _transportFailed, 1);
+                Interlocked.CompareExchange(ref _firstFailureReason, failureReason, null);
             }
             else if (result == ArticleBodyResult.Cancelled)
             {
@@ -670,19 +672,19 @@ public class MultiProviderNntpClient(
                 return;
             }
 
+            var failed = Volatile.Read(ref _transportFailed) != 0 ||
+                         Volatile.Read(ref _resolutionFailed) != 0;
             InvokeCompletionCallback(
                 callback,
-                Volatile.Read(ref _transportFailed) == 0 &&
-                Volatile.Read(ref _resolutionFailed) == 0
-                    ? ArticleBodyResult.Retrieved
-                    : ArticleBodyResult.NotRetrieved);
+                failed ? ArticleBodyResult.NotRetrieved : ArticleBodyResult.Retrieved,
+                failed ? _firstFailureReason : null);
         }
     }
 
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -696,10 +698,10 @@ public class MultiProviderNntpClient(
     }
 
     private async Task<T> RunStreamingFromPoolWithBackup<T>(
-        Func<INntpClient, Action<ArticleBodyResult>, Task<T>> task,
+        Func<INntpClient, ArticleBodyCompletionHandler, Task<T>> task,
         UsenetResponseType successResponseType,
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
         where T : UsenetResponse
     {
@@ -751,7 +753,7 @@ public class MultiProviderNntpClient(
                         provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
                         stopwatch.ElapsedMilliseconds, attemptIndex, traceRange, priorMisses);
                     result = WrapProviderResponse(result, provider.MetricsKey);
-                    deferredCallback.Activate(onConnectionReadyAgain ?? (_ => { }));
+                    deferredCallback.Activate(onConnectionReadyAgain ?? ((_, _) => { }));
                     return result;
                 }
 
@@ -1361,12 +1363,13 @@ public class MultiProviderNntpClient(
     }
 
     private static void InvokeCompletionCallback(
-        Action<ArticleBodyResult>? callback,
-        ArticleBodyResult result)
+        ArticleBodyCompletionHandler? callback,
+        ArticleBodyResult result,
+        string? failureReason = null)
     {
         try
         {
-            callback?.Invoke(result);
+            callback?.Invoke(result, failureReason);
         }
         catch (Exception e)
         {

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -677,7 +677,7 @@ public class MultiProviderNntpClient(
             InvokeCompletionCallback(
                 callback,
                 failed ? ArticleBodyResult.NotRetrieved : ArticleBodyResult.Retrieved,
-                failed ? _firstFailureReason : null);
+                failed ? Volatile.Read(ref _firstFailureReason) : null);
         }
     }
 

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -42,17 +42,17 @@ public abstract class NntpClient : INntpClient
         SegmentId segmentId, CancellationToken cancellationToken);
 
     public abstract Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken);
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
     public abstract Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-        IReadOnlyList<SegmentId> segmentIds, Action<ArticleBodyResult>? onConnectionReadyAgain,
+        IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken);
 
     public abstract Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 
     public abstract Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken);
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
     public abstract Task<UsenetDateResponse> DateAsync(
         CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -68,7 +68,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     }
 
     public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken ct)
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken ct)
     {
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
@@ -168,6 +169,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         var connectionPoolStats = new ConnectionPoolStats(providerConfig, websocketManager);
         var idleTimeoutSeconds = configManager.GetIdleConnectionTimeoutSeconds();
         var streamingPriority = configManager.GetStreamingPriority();
+        var tripDetector = new CorrelatedTripDetector();
         var providerClients = providerConfig.Providers
             .Select((provider, index) => CreateProviderClient(
                 provider,
@@ -175,7 +177,8 @@ public class UsenetStreamingClient : WrappingNntpClient
                 idleTimeoutSeconds,
                 metricsWriter,
                 streamingPriority,
-                latencyTracker
+                latencyTracker,
+                tripDetector
             ))
             .ToList();
         return new MultiProviderNntpClient(
@@ -196,7 +199,8 @@ public class UsenetStreamingClient : WrappingNntpClient
         int idleTimeoutSeconds,
         MetricsWriter metricsWriter,
         SemaphorePriorityOdds? streamingPriority = null,
-        ProviderLatencyTracker? latencyTracker = null
+        ProviderLatencyTracker? latencyTracker = null,
+        CorrelatedTripDetector? tripDetector = null
     )
     {
         var maxConnections = connectionDetails.MaxConnections;
@@ -242,20 +246,28 @@ public class UsenetStreamingClient : WrappingNntpClient
         if (connectionDetails.ProviderId == Guid.Empty)
             connectionDetails.ProviderId = Guid.NewGuid();
         var metricsKey = UsenetProviderIdentity.MetricsKey(connectionDetails);
+        // Only providers that can carry traffic participate in correlation; a Disabled
+        // provider never trips and would wedge the "all tripped" condition forever.
+        if (connectionDetails.Type != ProviderType.Disabled)
+            tripDetector?.Register(metricsKey, connectionDetails.Host);
         var circuitBreaker = new ProviderCircuitBreaker(
             connectionDetails.Host,
-            transition => metricsWriter.RecordEvent(new MetricEvent
+            transition =>
             {
-                At = transition.AtUnixMilliseconds,
-                Kind = "circuit",
-                Tag1 = metricsKey,
-                Tag2 = transition.State == ProviderCircuitTransitionState.Open
-                    ? "open"
-                    : "closed",
-                Num = transition.Cooldown is { } cooldown
-                    ? (long)cooldown.TotalMilliseconds
-                    : null,
-            }));
+                metricsWriter.RecordEvent(new MetricEvent
+                {
+                    At = transition.AtUnixMilliseconds,
+                    Kind = "circuit",
+                    Tag1 = metricsKey,
+                    Tag2 = transition.State == ProviderCircuitTransitionState.Open
+                        ? "open"
+                        : "closed",
+                    Num = transition.Cooldown is { } cooldown
+                        ? (long)cooldown.TotalMilliseconds
+                        : null,
+                });
+                tripDetector?.OnTransition(metricsKey, transition);
+            });
         return new MultiConnectionNntpClient(
             connectionPool,
             connectionDetails.Type,

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -58,16 +58,16 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
         _usenetClient.DateAsync(cancellationToken);
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken) =>
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken) =>
         _usenetClient.DecodedBodyAsync(segmentId, onConnectionReadyAgain, cancellationToken);
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-        IReadOnlyList<SegmentId> segmentIds, Action<ArticleBodyResult>? onConnectionReadyAgain,
+        IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>
         _usenetClient.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken);
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken) =>
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken) =>
         _usenetClient.DecodedArticleAsync(segmentId, onConnectionReadyAgain, cancellationToken);
 
     public override int PipeliningDepth => _usenetClient.PipeliningDepth;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -46,7 +46,11 @@ public class HealthCheckService : BackgroundService
     /// One-time boot delay before the first background sweep. Queue resume, first streams,
     /// and pool warm-up hit cold connection pools simultaneously at startup; giving them a
     /// short grace window keeps health-check STATs out of the connection storm (#881).
-    /// Settable for tests so coverage does not wait on the real delay.
+    /// <para>
+    /// Settable for tests so coverage does not wait on the real delay. Tests that override
+    /// it must restore the original value in a finally block; otherwise later tests in the
+    /// same process silently skip the grace.
+    /// </para>
     /// </summary>
     internal static TimeSpan StartupGracePeriod { get; set; } = TimeSpan.FromSeconds(20);
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -42,6 +42,14 @@ public class HealthCheckService : BackgroundService
     // Files at or below this many segments are checked in full, before any aging taper.
     public const int SampleFloor = 8000;
 
+    /// <summary>
+    /// One-time boot delay before the first background sweep. Queue resume, first streams,
+    /// and pool warm-up hit cold connection pools simultaneously at startup; giving them a
+    /// short grace window keeps health-check STATs out of the connection storm (#881).
+    /// Settable for tests so coverage does not wait on the real delay.
+    /// </summary>
+    internal static TimeSpan StartupGracePeriod { get; set; } = TimeSpan.FromSeconds(20);
+
     // A release keeps full depth for its first year, then tapers until it stops aging at ten.
     private const double FullDepthDays = 365;
     private const double MinDepthDays = 3650;
@@ -89,6 +97,15 @@ public class HealthCheckService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        try
+        {
+            await Task.Delay(StartupGracePeriod, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -87,7 +87,13 @@ public sealed class SupportPackService(
         return warnings;
     }
 
-    internal async Task WriteAsync(Stream output, CancellationToken cancellationToken)
+    internal async Task WriteAsync(Stream output, CancellationToken cancellationToken) =>
+        await WriteAsync(output, GetPackQualityWarnings(), cancellationToken).ConfigureAwait(false);
+
+    internal async Task WriteAsync(
+        Stream output,
+        IReadOnlyList<string> packQuality,
+        CancellationToken cancellationToken)
     {
         var generatedAt = DateTimeOffset.UtcNow;
         var config = configManager.GetDiagnosticSnapshot();
@@ -195,6 +201,7 @@ public sealed class SupportPackService(
                     sectionStatus,
                     redactor,
                     traceSnapshot,
+                    packQuality,
                     cancellationToken)
                 .ConfigureAwait(false),
             redactor,
@@ -812,6 +819,7 @@ public sealed class SupportPackService(
         IReadOnlyDictionary<string, string> sectionStatus,
         SupportPackRedactor redactor,
         StreamTraceSnapshot traceSnapshot,
+        IReadOnlyList<string> packQuality,
         CancellationToken cancellationToken)
     {
         var (mainMigration, metricsMigration) = await ReadMigrationsAsync(cancellationToken).ConfigureAwait(false);
@@ -845,7 +853,7 @@ public sealed class SupportPackService(
                 retainedSessionCount = traceSnapshot.RetainedSessionCount,
             },
             sections = sectionStatus,
-            packQuality = GetPackQualityWarnings(),
+            packQuality,
             redaction = new { secrets = redactor.SecretsRedacted, ipAddresses = redactor.AddressesPseudonymized },
         };
     }

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -35,11 +35,57 @@ public sealed class SupportPackService(
     private const long MinuteMs = 60_000;
     private const long HourMs = 60 * MinuteMs;
     private const long DayMs = 24 * HourMs;
+    private static readonly TimeSpan MinimumMeaningfulUptime = TimeSpan.FromMinutes(2);
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
     private static readonly JsonSerializerOptions CompactJsonOptions = new()
     {
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
     };
+
+    /// <summary>
+    /// Cheap up-front quality flags for the pack that is about to be generated. Surfaced
+    /// in manifest.json and as a response header so the Support UI can tell the operator
+    /// when a capture cannot answer playback questions and should be re-collected.
+    /// </summary>
+    public IReadOnlyList<string> GetPackQualityWarnings()
+    {
+        var warnings = new List<string>();
+
+        var uptime = ProcessUptime();
+        if (uptime < MinimumMeaningfulUptime)
+        {
+            warnings.Add(
+                $"Captured {(int)uptime.TotalSeconds}s after process start — CPU, GC, and " +
+                "connection-pool gauges reflect startup, not sustained load.");
+        }
+
+        var tracing = streamTraceBuffer.GetStatus();
+        if (tracing.EventCount == 0)
+        {
+            warnings.Add(
+                "No stream traces were captured — stall attribution for playback problems is " +
+                "impossible. Enable stream tracing, reproduce the issue, then re-collect.");
+        }
+
+        var sampler = runtimeUsage.Snapshot();
+        if (sampler.WindowSpanMs < MinuteMs)
+        {
+            warnings.Add(
+                "The runtime sampler window is under a minute — rolling CPU/GC averages " +
+                "cover a partial window.");
+        }
+
+        var logs = logBuffer.Snapshot(1, null, null, null, null);
+        if (logs.OldestSequence > 1)
+        {
+            warnings.Add(
+                "The log ring buffer has wrapped since startup — earlier context was evicted. " +
+                "If the symptom began before the oldest retained entry, re-collect with a " +
+                "larger LOG_BUFFER_SIZE.");
+        }
+
+        return warnings;
+    }
 
     internal async Task WriteAsync(Stream output, CancellationToken cancellationToken)
     {
@@ -799,6 +845,7 @@ public sealed class SupportPackService(
                 retainedSessionCount = traceSnapshot.RetainedSessionCount,
             },
             sections = sectionStatus,
+            packQuality = GetPackQualityWarnings(),
             redaction = new { secrets = redactor.SecretsRedacted, ipAddresses = redactor.AddressesPseudonymized },
         };
     }

--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -47,6 +47,7 @@ function formatUtcWindow(unixMs: number): string | null {
 export function SupportSettings() {
     const [busy, setBusy] = useState(false);
     const [message, setMessage] = useState<Message>(null);
+    const [packQuality, setPackQuality] = useState<string[]>([]);
     const [tracingBusy, setTracingBusy] = useState(false);
     const [tracingMessage, setTracingMessage] = useState<Message>(null);
     const [minutes, setMinutes] = useState<number>(30);
@@ -90,11 +91,24 @@ export function SupportSettings() {
     const download = useCallback(async () => {
         setBusy(true);
         setMessage(null);
+        setPackQuality([]);
         try {
             const response = await fetch(withUrlBase("/api/download-support-pack"), { cache: "no-store" });
             if (!response.ok) {
                 const body = await response.json().catch(() => null);
                 throw new Error(body?.error || `Support pack failed (${response.status})`);
+            }
+
+            const qualityHeader = response.headers.get("x-support-pack-quality");
+            if (qualityHeader) {
+                try {
+                    const parsed = JSON.parse(qualityHeader) as unknown;
+                    if (Array.isArray(parsed)) {
+                        setPackQuality(parsed.filter((item): item is string => typeof item === "string"));
+                    }
+                } catch {
+                    // a malformed quality header must not break a successful download
+                }
             }
 
             const blob = await response.blob();
@@ -239,6 +253,21 @@ export function SupportSettings() {
                     </span>
                 </div>
                 {message && <Alert variant={message.variant}>{message.text}</Alert>}
+                {packQuality.length > 0 && (
+                    <Alert variant="warning" className="items-start text-sm">
+                        <Icon name="warning" className="mt-0.5 !text-[20px]" />
+                        <span>
+                            <span className="mb-1 block font-semibold">
+                                This pack may not answer playback questions — consider re-collecting:
+                            </span>
+                            <ul className="list-inside list-disc space-y-1">
+                                {packQuality.map((warning) => (
+                                    <li key={warning}>{warning}</li>
+                                ))}
+                            </ul>
+                        </span>
+                    </Alert>
+                )}
             </SettingsCard>
 
             <SettingsCard

--- a/libs/UsenetSharp/Clients/IUsenetClient.cs
+++ b/libs/UsenetSharp/Clients/IUsenetClient.cs
@@ -46,13 +46,13 @@ public interface IUsenetClient
         SegmentId segmentId, CancellationToken cancellationToken);
 
     Task<UsenetBodyResponse> BodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken);
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
     Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 
     Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain,
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -80,7 +80,7 @@ public interface IUsenetClient
     /// connection unsafe to reuse.
     /// </remarks>
     Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-        IReadOnlyList<SegmentId> segmentIds, Action<ArticleBodyResult>? onConnectionReadyAgain,
+        IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         throw new NotSupportedException(
@@ -112,7 +112,7 @@ public interface IUsenetClient
     /// </remarks>
     IAsyncEnumerable<UsenetDecodedBodyResponse> EnumerateDecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         throw new NotSupportedException(
@@ -123,7 +123,7 @@ public interface IUsenetClient
         SegmentId segmentId, CancellationToken cancellationToken);
 
     Task<UsenetArticleResponse> ArticleAsync
-        (SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain, CancellationToken cancellationToken);
+        (SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
     Task<UsenetDateResponse> DateAsync(
         CancellationToken cancellationToken);

--- a/libs/UsenetSharp/Clients/UsenetClient.ArticleAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.ArticleAsync.cs
@@ -15,7 +15,7 @@ public partial class UsenetClient
     public async Task<UsenetArticleResponse> ArticleAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -23,7 +23,7 @@ public partial class UsenetClient
     public async Task<UsenetBodyResponse> BodyAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -111,7 +111,7 @@ public partial class UsenetClient
     public async Task<UsenetDecodedBodyResponse> DecodedBodyAsync
     (
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken
     )
     {
@@ -200,7 +200,7 @@ public partial class UsenetClient
         TaskCompletionSource<UsenetYencHeader?> headersCompletion,
         CancellationTokenSource operationCts,
         CancellationToken callerCancellationToken,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         DecodedBodyReadStream decodedStream,
         bool releaseCommandLock = true,
         CoalescedReadTimeout? sharedReadTimeout = null,
@@ -512,7 +512,9 @@ public partial class UsenetClient
                         ArticleBodyResult.Cancelled,
                     _ => ArticleBodyResult.NotRetrieved
                 };
-                onConnectionReadyAgain?.Invoke(result);
+                onConnectionReadyAgain?.Invoke(
+                    result,
+                    result == ArticleBodyResult.NotRetrieved ? DescribeFailure(failure) : null);
             }
             catch
             {
@@ -663,7 +665,7 @@ public partial class UsenetClient
         PipeWriter writer,
         CancellationTokenSource operationCts,
         CancellationToken callerCancellationToken,
-        Action<ArticleBodyResult>? onConnectionReadyAgain)
+        ArticleBodyCompletionHandler? onConnectionReadyAgain)
     {
         Exception? failure = null;
         try
@@ -785,7 +787,8 @@ public partial class UsenetClient
             try
             {
                 onConnectionReadyAgain?.Invoke(
-                    failure == null ? ArticleBodyResult.Retrieved : ArticleBodyResult.NotRetrieved);
+                    failure == null ? ArticleBodyResult.Retrieved : ArticleBodyResult.NotRetrieved,
+                    failure == null ? null : DescribeFailure(failure));
             }
             catch
             {

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -37,7 +37,7 @@ public partial class UsenetClient
     /// </remarks>
     public async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
@@ -147,7 +147,7 @@ public partial class UsenetClient
     /// </summary>
     public async IAsyncEnumerable<UsenetDecodedBodyResponse> EnumerateDecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         using var enumerationCts =
@@ -259,10 +259,11 @@ public partial class UsenetClient
         IReadOnlyList<SegmentId> segmentIds,
         IReadOnlyList<TaskCompletionSource<UsenetDecodedBodyResponse>> completions,
         CancellationToken callerCancellationToken,
-        Action<ArticleBodyResult>? onConnectionReadyAgain)
+        ArticleBodyCompletionHandler? onConnectionReadyAgain)
     {
         Exception? failure = null;
         var completionResult = ArticleBodyResult.Retrieved;
+        string? completionReason = null;
         var nextResponseIndex = 0;
         using var operationCts = CreateOperationTokenSource(callerCancellationToken);
         using var sharedReadTimeout = new CoalescedReadTimeout(
@@ -284,11 +285,16 @@ public partial class UsenetClient
                 {
                     await DrainUnexpectedMultiLineAsync(responseCode, operationCts.Token)
                         .ConfigureAwait(false);
-                    completionResult =
-                        responseCode == (int)UsenetResponseType.NoArticleWithThatMessageId &&
-                        completionResult != ArticleBodyResult.NotRetrieved
-                            ? ArticleBodyResult.NotFound
-                            : ArticleBodyResult.NotRetrieved;
+                    if (responseCode == (int)UsenetResponseType.NoArticleWithThatMessageId &&
+                        completionResult != ArticleBodyResult.NotRetrieved)
+                    {
+                        completionResult = ArticleBodyResult.NotFound;
+                    }
+                    else if (responseCode != (int)UsenetResponseType.NoArticleWithThatMessageId)
+                    {
+                        completionResult = ArticleBodyResult.NotRetrieved;
+                        completionReason ??= $"unexpected-response-{responseCode}";
+                    }
                     completions[nextResponseIndex].TrySetResult(new UsenetDecodedBodyResponse
                     {
                         SegmentId = segmentId,
@@ -343,6 +349,7 @@ public partial class UsenetClient
                 {
                     RecordConnectionFailure(bodyReadResult.Failure);
                     completionResult = ArticleBodyResult.NotRetrieved;
+                    completionReason = DescribeFailure(bodyReadResult.Failure);
                     break;
                 }
 
@@ -360,6 +367,12 @@ public partial class UsenetClient
                     drainFailure == null
                         ? ArticleBodyResult.Cancelled
                         : ArticleBodyResult.NotRetrieved;
+                if (completionResult == ArticleBodyResult.NotRetrieved)
+                {
+                    completionReason = drainFailure != null
+                        ? DescribeFailure(drainFailure)
+                        : DescribeFailure(bodyReadResult.Failure);
+                }
                 break;
             }
         }
@@ -370,6 +383,7 @@ public partial class UsenetClient
             {
                 RecordConnectionFailure(exception);
                 completionResult = ArticleBodyResult.NotRetrieved;
+                completionReason = DescribeFailure(exception);
             }
             else
             {
@@ -384,12 +398,17 @@ public partial class UsenetClient
                 completionResult = drainFailure == null
                     ? ArticleBodyResult.Cancelled
                     : ArticleBodyResult.NotRetrieved;
+                if (drainFailure != null)
+                {
+                    completionReason = DescribeFailure(drainFailure);
+                }
             }
         }
         catch (Exception exception)
         {
             failure = exception;
             completionResult = ArticleBodyResult.NotRetrieved;
+            completionReason = DescribeFailure(exception);
             RecordConnectionFailure(exception);
         }
         finally
@@ -406,7 +425,8 @@ public partial class UsenetClient
             _commandLock.Release();
             InvokeBatchCallback(
                 onConnectionReadyAgain,
-                completionResult);
+                completionResult,
+                completionReason);
         }
     }
 
@@ -449,16 +469,37 @@ public partial class UsenetClient
     }
 
     private static void InvokeBatchCallback(
-        Action<ArticleBodyResult>? callback,
-        ArticleBodyResult result)
+        ArticleBodyCompletionHandler? callback,
+        ArticleBodyResult result,
+        string? failureReason = null)
     {
         try
         {
-            callback?.Invoke(result);
+            callback?.Invoke(result, failureReason);
         }
         catch
         {
             // User callbacks must not fault command setup or the background pump.
         }
+    }
+
+    /// <summary>
+    /// Short, log-friendly failure classification: the outermost exception type, plus the
+    /// socket error when one is wrapped — e.g. "IOException (SocketException: ConnectionReset)".
+    /// Lets circuit-breaker and metrics reasons name the root cause instead of "NotRetrieved".
+    /// </summary>
+    internal static string? DescribeFailure(Exception? failure)
+    {
+        if (failure == null) return null;
+        var description = failure.GetType().Name;
+        for (var inner = failure.InnerException; inner != null; inner = inner.InnerException)
+        {
+            if (inner is System.Net.Sockets.SocketException socketException)
+                return $"{description} (SocketException: {socketException.SocketErrorCode})";
+        }
+
+        return failure.InnerException is { } direct
+            ? $"{description} ({direct.GetType().Name})"
+            : description;
     }
 }

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -494,8 +494,9 @@ public partial class UsenetClient
         var description = failure.GetType().Name;
 
         // A direct SocketException (no wrapper) carries the socket error code on itself.
+        // Format matches the wrapped case so "SocketException:" filters work uniformly.
         if (failure is System.Net.Sockets.SocketException directSocket)
-            return $"{description} ({directSocket.SocketErrorCode})";
+            return $"SocketException: {directSocket.SocketErrorCode}";
 
         // Otherwise look for a SocketException wrapped by an outer transport exception.
         for (var inner = failure.InnerException; inner != null; inner = inner.InnerException)

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -492,6 +492,12 @@ public partial class UsenetClient
     {
         if (failure == null) return null;
         var description = failure.GetType().Name;
+
+        // A direct SocketException (no wrapper) carries the socket error code on itself.
+        if (failure is System.Net.Sockets.SocketException directSocket)
+            return $"{description} ({directSocket.SocketErrorCode})";
+
+        // Otherwise look for a SocketException wrapped by an outer transport exception.
         for (var inner = failure.InnerException; inner != null; inner = inner.InnerException)
         {
             if (inner is System.Net.Sockets.SocketException socketException)

--- a/libs/UsenetSharp/Models/ArticleBodyResult.cs
+++ b/libs/UsenetSharp/Models/ArticleBodyResult.cs
@@ -17,3 +17,14 @@ public enum ArticleBodyResult
     /// <summary>The caller cancelled the operation and the connection was successfully drained.</summary>
     Cancelled,
 }
+
+/// <summary>
+/// Completion callback for body operations. <paramref name="failureReason"/> carries a
+/// short classification of the transport failure (exception type, socket error) when
+/// <paramref name="result"/> is <see cref="ArticleBodyResult.NotRetrieved"/>, so callers
+/// recording circuit-breaker or metrics reasons can name the root cause. It is null for
+/// clean outcomes and for cancellations.
+/// </summary>
+public delegate void ArticleBodyCompletionHandler(
+    ArticleBodyResult result,
+    string? failureReason = null);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
@@ -213,7 +213,7 @@ public class BaseNntpClientStatTests
 
         public Task<UsenetBodyResponse> BodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -223,7 +223,7 @@ public class BaseNntpClientStatTests
 
         public Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -233,7 +233,7 @@ public class BaseNntpClientStatTests
 
         public Task<UsenetArticleResponse> ArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
@@ -1,0 +1,182 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public class CorrelatedTripDetectorTests
+{
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan Throttle = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public void SingleProvider_NeverWarns()
+    {
+        var events = Capture((d, _) =>
+        {
+            d.Unregister("b");
+            d.OnTransition("a", Open(atMs: 1_000));
+        });
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void AllProvidersTrippingWithinTheWindow_WarnsOnce()
+    {
+        var events = Capture((d, _) =>
+        {
+            d.OnTransition("a", Open(atMs: 1_000));
+            d.OnTransition("b", Open(atMs: 2_000));
+        });
+
+        Assert.Single(events, IsCorrelationWarning);
+    }
+
+    [Fact]
+    public void TripsOutsideTheWindow_DoNotWarn()
+    {
+        var events = Capture((d, _) =>
+        {
+            d.OnTransition("a", Open(atMs: 1_000));
+            d.OnTransition("b", Open(atMs: 1_000 + (long)Window.TotalMilliseconds + 1));
+        });
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ClosedBetweenOpens_ResetsTheCorrelation()
+    {
+        var events = Capture((d, _) =>
+        {
+            d.OnTransition("a", Open(atMs: 1_000));
+            d.OnTransition("a", Closed(atMs: 2_000));
+            d.OnTransition("b", Open(atMs: 3_000));
+        });
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void OnlySomeProvidersTripped_DoesNotWarn()
+    {
+        var events = Capture((d, _) =>
+        {
+            d.Register("c", "c.example.com");
+            d.OnTransition("a", Open(atMs: 1_000));
+            d.OnTransition("b", Open(atMs: 2_000));
+        });
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void SecondCorrelation_WithinThrottle_DoesNotWarnAgain()
+    {
+        var events = Capture((d, clock) =>
+        {
+            d.OnTransition("a", Open(atMs: 1_000));
+            clock.Now = 2_000;
+            d.OnTransition("b", Open(atMs: 2_000));
+
+            // Recover, then both trip again one minute later — still throttled.
+            var t1 = 61_000L;
+            clock.Now = t1;
+            d.OnTransition("a", Closed(atMs: t1));
+            d.OnTransition("b", Closed(atMs: t1));
+            d.OnTransition("a", Open(atMs: t1 + 100));
+            clock.Now = t1 + 200;
+            d.OnTransition("b", Open(atMs: t1 + 200));
+        });
+
+        Assert.Single(events, IsCorrelationWarning);
+    }
+
+    [Fact]
+    public void SecondCorrelation_AfterThrottle_WarnsAgain()
+    {
+        var events = Capture((d, clock) =>
+        {
+            d.OnTransition("a", Open(atMs: 1_000));
+            clock.Now = 2_000;
+            d.OnTransition("b", Open(atMs: 2_000));
+
+            var t1 = 1_000 + (long)Throttle.TotalMilliseconds + 1_000;
+            clock.Now = t1;
+            d.OnTransition("a", Closed(atMs: t1));
+            d.OnTransition("b", Closed(atMs: t1));
+            d.OnTransition("a", Open(atMs: t1 + 100));
+            clock.Now = t1 + 200;
+            d.OnTransition("b", Open(atMs: t1 + 200));
+        });
+
+        Assert.Equal(2, events.Count(IsCorrelationWarning));
+    }
+
+    private static bool IsCorrelationWarning(LogEvent logEvent) =>
+        logEvent.Level == LogEventLevel.Warning
+        && logEvent.MessageTemplate.Text.Contains("circuit breakers", StringComparison.Ordinal);
+
+    private static ProviderCircuitTransition Open(long atMs) =>
+        new(ProviderCircuitTransitionState.Open, atMs, TimeSpan.FromSeconds(60));
+
+    private static ProviderCircuitTransition Closed(long atMs) =>
+        new(ProviderCircuitTransitionState.Closed, atMs, null);
+
+    private static IReadOnlyList<LogEvent> Capture(Action<CorrelatedTripDetector, TestClock> act)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        var clock = new TestClock();
+        var detector = new CorrelatedTripDetector(window: Window, throttle: Throttle)
+        {
+            Clock = () => clock.Now,
+        };
+        detector.Register("a", "a.example.com");
+        detector.Register("b", "b.example.com");
+
+        try
+        {
+            act(detector, clock);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class TestClock
+    {
+        public long Now;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CreateNewConnectionTests.cs
@@ -265,13 +265,13 @@ public class CreateNewConnectionTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -281,7 +281,7 @@ public class CreateNewConnectionTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DeferredArticleBodyCallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DeferredArticleBodyCallbackTests.cs
@@ -13,7 +13,7 @@ public class DeferredArticleBodyCallbackTests
 
         callback.Invoke(ArticleBodyResult.Retrieved);
         Assert.Empty(results);
-        callback.Activate(results.Add);
+        callback.Activate((result, _) => results.Add(result));
 
         Assert.Equal([ArticleBodyResult.Retrieved], results);
     }
@@ -23,7 +23,7 @@ public class DeferredArticleBodyCallbackTests
     {
         var callback = new DeferredArticleBodyCallback();
         var results = new List<ArticleBodyResult>();
-        callback.Activate(results.Add);
+        callback.Activate((result, _) => results.Add(result));
 
         callback.Invoke(ArticleBodyResult.NotFound);
 
@@ -35,7 +35,7 @@ public class DeferredArticleBodyCallbackTests
     {
         var callback = new DeferredArticleBodyCallback();
         var results = new List<ArticleBodyResult>();
-        callback.Activate(results.Add);
+        callback.Activate((result, _) => results.Add(result));
 
         callback.Invoke(ArticleBodyResult.Cancelled);
         callback.Invoke(ArticleBodyResult.Retrieved);
@@ -54,7 +54,7 @@ public class DeferredArticleBodyCallbackTests
             callback.Invoke(ArticleBodyResult.NotRetrieved);
 
         callback.Discard();
-        callback.Activate(results.Add);
+        callback.Activate((result, _) => results.Add(result));
         callback.Invoke(ArticleBodyResult.Retrieved);
 
         Assert.Empty(results);
@@ -64,7 +64,7 @@ public class DeferredArticleBodyCallbackTests
     public void ThrowingTarget_IsContained()
     {
         var callback = new DeferredArticleBodyCallback();
-        callback.Activate(_ => throw new InvalidOperationException("callback failure"));
+        callback.Activate((_, _) => throw new InvalidOperationException("callback failure"));
 
         var exception = Record.Exception(() => callback.Invoke(ArticleBodyResult.Retrieved));
 
@@ -87,7 +87,7 @@ public class DeferredArticleBodyCallbackTests
             var activate = Task.Run(async () =>
             {
                 await ready.Task;
-                callback.Activate(_ => Interlocked.Increment(ref delivered));
+                callback.Activate((_, _) => Interlocked.Increment(ref delivered));
             });
 
             ready.SetResult();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -345,13 +345,13 @@ public class DownloadingNntpClientStatGateTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -361,7 +361,7 @@ public class DownloadingNntpClientStatGateTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/HeaderCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/HeaderCachingNntpClientTests.cs
@@ -48,13 +48,13 @@ public class HeaderCachingNntpClientTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -64,7 +64,7 @@ public class HeaderCachingNntpClientTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionStatsPipelinedTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionStatsPipelinedTests.cs
@@ -85,13 +85,13 @@ public class MultiConnectionStatsPipelinedTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -101,7 +101,7 @@ public class MultiConnectionStatsPipelinedTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -615,7 +615,7 @@ public class MultiProviderNntpClientTests
         ]);
 
         var response = await client.DecodedBodyAsync(
-            "segment", callbacks.Add, CancellationToken.None);
+            "segment", (result, _) => callbacks.Add(result), CancellationToken.None);
 
         Assert.Equal(UsenetResponseType.NoArticleWithThatMessageId, response.ResponseType);
         Assert.Equal(1, first.SingularRequests);
@@ -1009,13 +1009,13 @@ public class MultiProviderNntpClientTests
 
         Assert.Equal(
             UsenetResponseType.ArticleRetrievedBodyFollows,
-            (await client.DecodedBodyAsync("segment", _ => { }, CancellationToken.None)).ResponseType);
+            (await client.DecodedBodyAsync("segment", (_, _) => { }, CancellationToken.None)).ResponseType);
         Assert.Equal(1, missing.SingularRequests);
         Assert.Equal(1, backup.SingularRequests);
 
         Assert.Equal(
             UsenetResponseType.ArticleRetrievedBodyFollows,
-            (await client.DecodedBodyAsync("segment", _ => { }, CancellationToken.None)).ResponseType);
+            (await client.DecodedBodyAsync("segment", (_, _) => { }, CancellationToken.None)).ResponseType);
         Assert.Equal(1, missing.SingularRequests);
         Assert.Equal(2, backup.SingularRequests);
     }
@@ -1116,7 +1116,7 @@ public class MultiProviderNntpClientTests
         Assert.Equal(0, backup.SingularRequests);
 
         await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
-            client.DecodedBodyAsync("segment", _ => { }, CancellationToken.None));
+            client.DecodedBodyAsync("segment", (_, _) => { }, CancellationToken.None));
         Assert.Equal(0, primary.SingularRequests);
         Assert.Equal(0, backup.SingularRequests);
 
@@ -1978,11 +1978,11 @@ public class MultiProviderNntpClientTests
         public bool DeferSingularCompletion { get; init; }
         public int BatchRequests { get; private set; }
         public int SingularRequests { get; private set; }
-        private readonly Queue<Action<ArticleBodyResult>> _pendingSingularCallbacks = new();
+        private readonly Queue<ArticleBodyCompletionHandler> _pendingSingularCallbacks = new();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             BatchRequests++;
@@ -2009,7 +2009,7 @@ public class MultiProviderNntpClientTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             SingularRequests++;
@@ -2087,7 +2087,7 @@ public class MultiProviderNntpClientTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -272,13 +272,13 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -288,7 +288,7 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -329,13 +329,13 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -345,7 +345,7 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -381,7 +381,7 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var success = responseCode == (int)UsenetResponseType.ArticleRetrievedBodyFollows;
@@ -396,7 +396,7 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var responses = segmentIds
@@ -411,7 +411,7 @@ public class NntpClientCheckAllSegmentsTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientNonYencHeadersTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientNonYencHeadersTests.cs
@@ -62,7 +62,7 @@ public class NntpClientNonYencHeadersTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var bytes = Encoding.ASCII.GetBytes("this is not a yEnc article\r\n.\r\n");
@@ -77,7 +77,7 @@ public class NntpClientNonYencHeadersTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -87,7 +87,7 @@ public class NntpClientNonYencHeadersTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -169,7 +169,7 @@ public class NntpClientPipelinedMappingTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             Assert.Equal(requestedId, segmentId.ToString());
@@ -179,7 +179,7 @@ public class NntpClientPipelinedMappingTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             Assert.Single(segmentIds);
@@ -197,7 +197,7 @@ public class NntpClientPipelinedMappingTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
@@ -202,7 +202,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             _batchToken = cancellationToken;
@@ -253,7 +253,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -263,7 +263,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -283,7 +283,7 @@ public class NntpClientPipelinedTeardownTests
     {
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var gates = new List<TaskCompletionSource>();
@@ -334,7 +334,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -344,7 +344,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -374,7 +374,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             BatchPriority = cancellationToken.GetContext<DownloadPriorityContext>()?.Priority;
@@ -417,7 +417,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -427,7 +427,7 @@ public class NntpClientPipelinedTeardownTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
@@ -276,6 +276,132 @@ public class ProviderCircuitBreakerConnectionFailureTests
         Assert.False(breaker.IsTripped);
     }
 
+    [Fact]
+    public async Task DecodedBodiesAsync_BodyCallbackFailure_TripReasonCarriesTransportDetail()
+    {
+        var breaker = new ProviderCircuitBreaker("reason-batch");
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ => ValueTask.FromResult<INntpClient>(new ReasonReportingBodyClient()));
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "reason-batch");
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            await client.DecodedBodiesAsync(
+                new List<SegmentId> { "segment" },
+                onConnectionReadyAgain: null,
+                CancellationToken.None);
+        }
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.Contains("NotRetrieved", snapshot.LastFailureReason);
+        Assert.Contains("SocketException", snapshot.LastFailureReason);
+        Assert.Contains("ConnectionReset", snapshot.LastFailureReason);
+    }
+
+    [Fact]
+    public async Task DecodedBodyAsync_BodyCallbackFailure_TripReasonCarriesTransportDetail()
+    {
+        var breaker = new ProviderCircuitBreaker("reason-single");
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1,
+            _ => ValueTask.FromResult<INntpClient>(new ReasonReportingBodyClient()));
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "reason-single");
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            await client.DecodedBodyAsync(
+                "segment", onConnectionReadyAgain: null, CancellationToken.None);
+        }
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.Contains("NotRetrieved", snapshot.LastFailureReason);
+        Assert.Contains("SocketException", snapshot.LastFailureReason);
+        Assert.Contains("ConnectionReset", snapshot.LastFailureReason);
+    }
+
+    private sealed class ReasonReportingBodyClient : NntpClient
+    {
+        public const string Reason = "IOException (SocketException: ConnectionReset)";
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            // A body that dies mid-drain: the response headers succeeded, but the
+            // completion callback reports the transport failure with its reason.
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved, Reason);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body follows",
+                Stream = null,
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds.Select(id =>
+            {
+                var completion = new TaskCompletionSource<UsenetDecodedBodyResponse>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                completion.SetException(new IOException("Connection reset by peer."));
+                return completion.Task;
+            }).ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved, Reason);
+            return Task.FromResult(new UsenetDecodedBodyBatch
+            {
+                Responses = responses,
+            });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
     private sealed class FailingStatClient : NntpClient
     {
         public override Task ConnectAsync(
@@ -300,13 +426,13 @@ public class ProviderCircuitBreakerConnectionFailureTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -316,7 +442,7 @@ public class ProviderCircuitBreakerConnectionFailureTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -357,13 +483,13 @@ public class ProviderCircuitBreakerConnectionFailureTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -373,7 +499,7 @@ public class ProviderCircuitBreakerConnectionFailureTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerHalfOpenTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerHalfOpenTests.cs
@@ -51,6 +51,78 @@ public class ProviderCircuitBreakerHalfOpenTests
     }
 
     [Fact]
+    public void RecordSuccess_WhileHalfOpen_ResetsTheCooldownLadder()
+    {
+        var breaker = HalfOpen();
+
+        breaker.RecordSuccess();
+
+        Assert.Equal(TimeSpan.FromSeconds(60), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void StatOnlyRecovery_ClosesButPreservesTheCooldownLadder()
+    {
+        var breaker = HalfOpen();
+
+        breaker.RecordSuccess(resetsCooldownLadder: false);
+
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void StatOnlyRecovery_StillEmitsTheClosedTransition()
+    {
+        var transitions = new List<ProviderCircuitTransition>();
+        var breaker = new ProviderCircuitBreaker("stat-transition", transitions.Add);
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.ExpireCooldownForTests();
+
+        breaker.RecordSuccess(resetsCooldownLadder: false);
+
+        Assert.Contains(transitions, t => t.State == ProviderCircuitTransitionState.Closed);
+    }
+
+    [Fact]
+    public void StatOnlyRecovery_ReTripsAtTheEscalatedCooldown()
+    {
+        var breaker = new ProviderCircuitBreaker("stat-ladder");
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        breaker.ExpireCooldownForTests();
+        breaker.RecordSuccess(resetsCooldownLadder: false);
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+
+        // A fresh failure burst re-trips at the preserved 120s cooldown, then doubles past it.
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+        breaker.RecordFailure();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.InRange(snapshot.CooldownRemainingSeconds ?? 0, 61, 120);
+        Assert.Equal(TimeSpan.FromSeconds(240), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void BodySuccess_AfterStatOnlyRecovery_ResetsTheCooldownLadder()
+    {
+        var breaker = HalfOpen();
+        breaker.RecordSuccess(resetsCooldownLadder: false);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        breaker.RecordSuccess();
+
+        Assert.Equal(TimeSpan.FromSeconds(60), breaker.CurrentCooldown);
+    }
+
+    [Fact]
     public void ArticleNotFound_DoesNotCloseAnOpenCircuit()
     {
         var transitions = new List<ProviderCircuitTransition>();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderRecoveryProbeTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderRecoveryProbeTests.cs
@@ -152,13 +152,13 @@ public class ProviderRecoveryProbeTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -168,7 +168,7 @@ public class ProviderRecoveryProbeTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -42,7 +42,7 @@ public class StreamingTimeoutTests
         ArticleBodyResult? callbackResult = null;
         var request = client.DecodedBodyAsync(
             "seg",
-            result =>
+            (result, _) =>
             {
                 callbackResult = result;
                 Interlocked.Increment(ref callbacks);
@@ -80,7 +80,7 @@ public class StreamingTimeoutTests
         ArticleBodyResult? callbackResult = null;
         var request = client.DecodedBodiesAsync(
             ["seg-a", "seg-b"],
-            result =>
+            (result, _) =>
             {
                 callbackResult = result;
                 Interlocked.Increment(ref callbacks);
@@ -113,7 +113,7 @@ public class StreamingTimeoutTests
         var exception = await Assert.ThrowsAsync<NntpClientRetiredException>(() =>
             client.DecodedBodyAsync(
                 "seg",
-                result => callbackResult = result,
+                (result, _) => callbackResult = result,
                 CancellationToken.None));
 
         Assert.IsAssignableFrom<ObjectDisposedException>(exception.InnerException);
@@ -157,7 +157,7 @@ public class StreamingTimeoutTests
         await Assert.ThrowsAsync<NntpClientRetiredException>(() =>
             client.DecodedBodyAsync(
                 "seg",
-                result =>
+                (result, _) =>
                 {
                     callbackResult = result;
                     Interlocked.Increment(ref callbacks);
@@ -232,7 +232,7 @@ public class StreamingTimeoutTests
         var sw = Stopwatch.StartNew();
         var response = await client.DecodedBodyAsync(
             "seg",
-            _ => Interlocked.Increment(ref outerCallbacks),
+            (_, _) => Interlocked.Increment(ref outerCallbacks),
             cts.Token);
         sw.Stop();
 
@@ -304,7 +304,7 @@ public class StreamingTimeoutTests
         var outerCallbacks = 0;
         var sw = Stopwatch.StartNew();
         var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
-            client.DecodedBodyAsync("seg", _ => Interlocked.Increment(ref outerCallbacks), cts.Token));
+            client.DecodedBodyAsync("seg", (_, _) => Interlocked.Increment(ref outerCallbacks), cts.Token));
         sw.Stop();
 
         Assert.Contains("2 attempts", ex.Message);
@@ -479,7 +479,7 @@ public class StreamingTimeoutTests
 
         var batch = await client.DecodedBodiesAsync(
             [new SegmentId("one"), new SegmentId("two")],
-            result => callbacks.Add(result),
+            (result, _) => callbacks.Add(result),
             cts.Token);
 
         Assert.Equal(2, batch.Responses.Count);
@@ -515,7 +515,7 @@ public class StreamingTimeoutTests
         var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
             client.DecodedBodiesAsync(
                 [new SegmentId("one"), new SegmentId("two")],
-                result => callbacks.Add(result),
+                (result, _) => callbacks.Add(result),
                 cts.Token));
 
         Assert.Contains("2 attempts", exception.Message, StringComparison.Ordinal);
@@ -551,7 +551,7 @@ public class StreamingTimeoutTests
         var callbacks = new List<ArticleBodyResult>();
         var batchTask = client.DecodedBodiesAsync(
             [new SegmentId("one")],
-            result => callbacks.Add(result),
+            (result, _) => callbacks.Add(result),
             cts.Token);
 
         await hanging.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -803,7 +803,7 @@ public class StreamingTimeoutTests
 
         public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             BodyRequestCount++;
@@ -824,7 +824,7 @@ public class StreamingTimeoutTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -850,7 +850,7 @@ public class StreamingTimeoutTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -913,7 +913,7 @@ public class StreamingTimeoutTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -933,7 +933,7 @@ public class StreamingTimeoutTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -943,7 +943,7 @@ public class StreamingTimeoutTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -1021,7 +1021,7 @@ public class StreamingTimeoutTests
 
         public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             Started.TrySetResult();
@@ -1046,7 +1046,7 @@ public class StreamingTimeoutTests
     {
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
@@ -153,12 +153,12 @@ public class WrappingNntpClientRetirementTests
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-            SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain,
+            SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-            IReadOnlyList<SegmentId> segmentIds, Action<ArticleBodyResult>? onConnectionReadyAgain,
+            IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -167,7 +167,7 @@ public class WrappingNntpClientRetirementTests
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-            SegmentId segmentId, Action<ArticleBodyResult>? onConnectionReadyAgain,
+            SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -55,7 +55,7 @@ internal sealed class FakeNntpClient(
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -77,7 +77,7 @@ internal sealed class FakeNntpClient(
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         BatchRequestCount++;
@@ -94,7 +94,7 @@ internal sealed class FakeNntpClient(
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>
         throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FetchFirstSegmentsStepTests.cs
@@ -291,7 +291,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -322,13 +322,13 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -352,7 +352,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -405,13 +405,13 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -431,7 +431,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
@@ -466,13 +466,13 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -516,7 +516,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             ArticleFetches++;
@@ -546,13 +546,13 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -594,7 +594,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             ArticleFetches++;
@@ -637,13 +637,13 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -661,7 +661,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var responses = segmentIds.Select(id =>
@@ -689,7 +689,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             DecodedArticleAsync(segmentId, cancellationToken);
 
@@ -715,7 +715,7 @@ public class FetchFirstSegmentsStepTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -267,7 +267,7 @@ public class LazyRarProcessorTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -297,7 +297,7 @@ public class LazyRarProcessorTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var responses = segmentIds
@@ -313,7 +313,7 @@ public class LazyRarProcessorTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -267,13 +267,13 @@ public class LazyRarResolverTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId id,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -283,7 +283,7 @@ public class LazyRarResolverTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId id,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -380,6 +380,75 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.False(discarded.ContainsKey("stream-traces/events.jsonl"));
     }
 
+    [Fact]
+    public async Task Pack_FlagsAnUntracedFreshCaptureAsLowQuality()
+    {
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+        var packQuality = manifest.RootElement.GetProperty("packQuality")
+            .EnumerateArray().Select(x => x.GetString()).ToList();
+
+        Assert.Contains(packQuality, w => w!.Contains("No stream traces"));
+        Assert.Contains(packQuality, w => w!.Contains("sampler window"));
+    }
+
+    [Fact]
+    public async Task Pack_FlagsAWrappedLogBuffer()
+    {
+        var logBuffer = new LogBufferSink(2);
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(logBuffer)
+            .CreateLogger();
+        for (var i = 0; i < 5; i++) logger.Information("entry {Index}", i);
+
+        var entries = await ReadPackEntriesAsync(
+            logBuffer,
+            new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+        var packQuality = manifest.RootElement.GetProperty("packQuality")
+            .EnumerateArray().Select(x => x.GetString()).ToList();
+
+        Assert.Contains(packQuality, w => w!.Contains("ring buffer has wrapped"));
+    }
+
+    [Fact]
+    public async Task Pack_OmitsTracingAndSamplerWarningsForAHealthyCapture()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        buffer.EnableFor(TimeSpan.FromMinutes(15), 100, StreamTraceBuffer.SourceUi);
+        buffer.RangeOpen(Guid.NewGuid(), "/view/movie.mkv", "GET", 0, 99, 1000, "ua", null);
+
+        var runtimeUsage = new RuntimeUsageTracker(processorCount: 4);
+        var at = new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero);
+        for (var i = 0; i < 13; i++)
+        {
+            runtimeUsage.Record(
+                TimeSpan.FromMilliseconds(1000),
+                TimeSpan.FromMilliseconds(10),
+                TimeSpan.FromSeconds(5),
+                activeReads: 1,
+                at.AddSeconds(5 * i));
+        }
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            buffer,
+            runtimeUsage);
+
+        using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+        var packQuality = manifest.RootElement.GetProperty("packQuality")
+            .EnumerateArray().Select(x => x.GetString()).ToList();
+
+        Assert.DoesNotContain(packQuality, w => w!.Contains("No stream traces"));
+        Assert.DoesNotContain(packQuality, w => w!.Contains("sampler window"));
+    }
+
     private static Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,
         WarningLogBuffer warningBuffer,

--- a/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
@@ -85,7 +85,7 @@ public class CorruptionDetectionTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             CreateResponse(segmentId);
 
@@ -140,7 +140,7 @@ public class CorruptionDetectionTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
@@ -150,7 +150,7 @@ public class CorruptionDetectionTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
@@ -478,7 +478,7 @@ internal sealed class ControlledBatchNntpClient : NntpClient
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -492,7 +492,7 @@ internal sealed class ControlledBatchNntpClient : NntpClient
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -543,7 +543,7 @@ internal sealed class ControlledBatchNntpClient : NntpClient
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>
         throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamCapacityHintTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamCapacityHintTests.cs
@@ -204,7 +204,7 @@ file sealed class HeaderThrowingBodyClient(byte[] payload, Exception headerExcep
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -220,7 +220,7 @@ file sealed class HeaderThrowingBodyClient(byte[] payload, Exception headerExcep
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>
         throw new NotSupportedException();
 
@@ -230,7 +230,7 @@ file sealed class HeaderThrowingBodyClient(byte[] payload, Exception headerExcep
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
         SegmentId segmentId,
-        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>
         throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -696,7 +696,7 @@ public class NzbFileStreamTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var response = DecodedBodyAsync(segmentId, cancellationToken);
@@ -706,7 +706,7 @@ public class NzbFileStreamTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var responses = segmentIds
@@ -722,7 +722,7 @@ public class NzbFileStreamTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentAlignmentTests.cs
@@ -384,7 +384,7 @@ public class SegmentAlignmentTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -403,7 +403,7 @@ public class SegmentAlignmentTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var responses = segmentIds.Select(CreateBatchResponse).ToArray();
@@ -502,7 +502,7 @@ public class SegmentAlignmentTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
@@ -216,7 +216,7 @@ public class SegmentFallbackTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -242,7 +242,7 @@ public class SegmentFallbackTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
             var responses = segmentIds
@@ -258,7 +258,7 @@ public class SegmentFallbackTests
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId,
-            Action<ArticleBodyResult>? onConnectionReadyAgain,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/tests/UsenetSharp.Tests/Clients/UsenetClient.ArticleAsyncTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClient.ArticleAsyncTests.cs
@@ -310,7 +310,7 @@ public class UsenetClientArticleAsyncTests
         await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
 
         var callbackInvoked = false;
-        Action<ArticleBodyResult> onConnectionReadyAgain = _ => { callbackInvoked = true; };
+        ArticleBodyCompletionHandler onConnectionReadyAgain = (_, _) => { callbackInvoked = true; };
 
         // Act
         var segmentId = "8mthBMhpfyOJFM7OPe2RsZhm@CAtZlPkA1OiI.WLo";
@@ -342,7 +342,7 @@ public class UsenetClientArticleAsyncTests
         await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
 
         var callbackInvoked = false;
-        Action<ArticleBodyResult> onConnectionReadyAgain = _ => { callbackInvoked = true; };
+        ArticleBodyCompletionHandler onConnectionReadyAgain = (_, _) => { callbackInvoked = true; };
 
         // Act - Try to get an invalid segment
         var invalidSegmentId = "invalid-segment-id-does-not-exist@test.com";

--- a/tests/UsenetSharp.Tests/Clients/UsenetClient.BodyAsyncTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClient.BodyAsyncTests.cs
@@ -198,7 +198,7 @@ public class UsenetClientBodyAsyncTests
         await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
 
         var callbackInvoked = false;
-        Action<ArticleBodyResult> onConnectionReadyAgain = _ => { callbackInvoked = true; };
+        ArticleBodyCompletionHandler onConnectionReadyAgain = (_, _) => { callbackInvoked = true; };
 
         // Act
         var segmentId = "8mthBMhpfyOJFM7OPe2RsZhm@CAtZlPkA1OiI.WLo";
@@ -230,7 +230,7 @@ public class UsenetClientBodyAsyncTests
         await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
 
         var callbackInvoked = false;
-        Action<ArticleBodyResult> onConnectionReadyAgain = _ => { callbackInvoked = true; };
+        ArticleBodyCompletionHandler onConnectionReadyAgain = (_, _) => { callbackInvoked = true; };
 
         // Act - Try to get an invalid segment
         var invalidSegmentId = "invalid-segment-id-does-not-exist@test.com";

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -197,7 +197,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.BodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
         using var reader = new StreamReader(response.Stream!, Encoding.Latin1);
         var content = await reader.ReadToEndAsync();
 
@@ -344,7 +344,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.DecodedBodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
         var headers = await response.Stream!.GetYencHeadersAsync();
         using var decoded = new MemoryStream();
         await response.Stream.CopyToAsync(decoded);
@@ -432,7 +432,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.DecodedBodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
 
         var exception = Assert.ThrowsAsync<InvalidDataException>(async () =>
             await response.Stream!.CopyToAsync(Stream.Null));
@@ -496,7 +496,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.DecodedBodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
 
         Assert.ThrowsAsync<UsenetProtocolException>(async () =>
             await response.Stream!.CopyToAsync(Stream.Null));
@@ -527,7 +527,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.DecodedBodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
         _ = await response.Stream!.GetYencHeadersAsync();
         var copyTask = response.Stream.CopyToAsync(Stream.Null);
         timeProvider.Advance(readTimeout);
@@ -571,7 +571,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.DecodedBodyAsync(
-            "article@example.com", completion.SetResult, cts.Token);
+            "article@example.com", (result, _) => completion.SetResult(result), cts.Token);
         var copyTask = response.Stream!.CopyToAsync(Stream.Null);
         await firstLineSent.Task.WaitAsync(TimeSpan.FromSeconds(2));
         cts.Cancel();
@@ -606,7 +606,7 @@ public class UsenetClientDeterministicTests
         var completion = new TaskCompletionSource<ArticleBodyResult>(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var response = await client.BodyAsync("article@example.com", completion.SetResult, cts.Token);
+        var response = await client.BodyAsync("article@example.com", (result, _) => completion.SetResult(result), cts.Token);
         var copyTask = response.Stream!.CopyToAsync(Stream.Null);
         await firstLineSent.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await Task.Delay(50);
@@ -646,7 +646,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.DecodedBodyAsync(
-            "article@example.com", completion.SetResult, cts.Token);
+            "article@example.com", (result, _) => completion.SetResult(result), cts.Token);
         var copyTask = response.Stream!.CopyToAsync(Stream.Null);
         await firstLineSent.Task.WaitAsync(TimeSpan.FromSeconds(2));
         var cancelledAt = Environment.TickCount64;
@@ -688,7 +688,7 @@ public class UsenetClientDeterministicTests
 
         var batch = await client.DecodedBodiesAsync(
             new SegmentId[] { "first@example.com", "second@example.com" },
-            result => completion.TrySetResult(result),
+            (result, _) => completion.TrySetResult(result),
             cts.Token);
         var first = await batch.Responses[0];
         var copyTask = first.Stream!.CopyToAsync(Stream.Null);
@@ -743,7 +743,7 @@ public class UsenetClientDeterministicTests
 
         var batch = await client.DecodedBodiesAsync(
             new SegmentId[] { "first@example.com", "second@example.com" },
-            result =>
+            (result, _) =>
             {
                 Interlocked.Increment(ref callbackCount);
                 completion.TrySetResult(result);
@@ -888,7 +888,7 @@ public class UsenetClientDeterministicTests
 
         await foreach (var response in client.EnumerateDecodedBodiesAsync(
                            new SegmentId[] { "first@example.com", "second@example.com" },
-                           completion.SetResult,
+                           (result, _) => completion.SetResult(result),
                            CancellationToken.None))
         {
             using var decoded = new MemoryStream();
@@ -942,7 +942,7 @@ public class UsenetClientDeterministicTests
                                "second@example.com",
                                "third@example.com"
                            },
-                           completion.SetResult,
+                           (result, _) => completion.SetResult(result),
                            CancellationToken.None))
         {
             await response.Stream!.CopyToAsync(Stream.Null);
@@ -985,7 +985,7 @@ public class UsenetClientDeterministicTests
 
         await foreach (var _ in client.EnumerateDecodedBodiesAsync(
                            new SegmentId[] { "first@example.com", "second@example.com" },
-                           completion.SetResult,
+                           (result, _) => completion.SetResult(result),
                            CancellationToken.None))
         {
             await WaitForConditionAsync(
@@ -1024,7 +1024,7 @@ public class UsenetClientDeterministicTests
 
         var batch = await client.DecodedBodiesAsync(
             new SegmentId[] { "missing@example.com", "available@example.com" },
-            completion.SetResult,
+            (result, _) => completion.SetResult(result),
             CancellationToken.None);
         var missing = await batch.Responses[0];
         var available = await batch.Responses[1];
@@ -1064,7 +1064,7 @@ public class UsenetClientDeterministicTests
 
         var batch = await client.DecodedBodiesAsync(
             new SegmentId[] { "truncated@example.com", "pending@example.com" },
-            completion.SetResult,
+            (result, _) => completion.SetResult(result),
             CancellationToken.None);
         var truncated = await batch.Responses[0];
 
@@ -1125,7 +1125,7 @@ public class UsenetClientDeterministicTests
 
         var batch = await client.DecodedBodiesAsync(
             new SegmentId[] { "first@example.com", "second@example.com" },
-            result =>
+            (result, _) =>
             {
                 Interlocked.Increment(ref callbackCount);
                 completion.TrySetResult(result);
@@ -1197,7 +1197,7 @@ public class UsenetClientDeterministicTests
 
         var batch = await client.DecodedBodiesAsync(
             new SegmentId[] { "first@example.com" },
-            completion.SetResult,
+            (result, _) => completion.SetResult(result),
             cts.Token);
         var response = await batch.Responses[0];
         var copyTask = response.Stream!.CopyToAsync(Stream.Null);
@@ -1225,7 +1225,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.BodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
 
         Assert.ThrowsAsync<UsenetProtocolException>(async () =>
             await response.Stream!.CopyToAsync(Stream.Null));
@@ -1236,6 +1236,50 @@ public class UsenetClientDeterministicTests
             Assert.That(client.IsConnected, Is.True);
             Assert.That(client.IsHealthy, Is.False);
         });
+    }
+
+    [Test]
+    public async Task BodyAsync_TruncatedTransfer_ReportsTheFailureReason()
+    {
+        await using var server = new ScriptedNntpServer(async (_, writer, _) =>
+        {
+            await writer.WriteAsync("222 body follows\r\npartial\r\n");
+            throw new IOException("Close scripted connection.");
+        });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        var completion = new TaskCompletionSource<string?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var response = await client.BodyAsync(
+            "article@example.com", (_, reason) => completion.SetResult(reason), CancellationToken.None);
+
+        Assert.ThrowsAsync<UsenetProtocolException>(async () =>
+            await response.Stream!.CopyToAsync(Stream.Null));
+        Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
+            Does.Contain(nameof(UsenetProtocolException)));
+    }
+
+    [Test]
+    public async Task BodyAsync_Success_ReportsNullFailureReason()
+    {
+        await using var server = new ScriptedNntpServer(async (_, writer, _) =>
+        {
+            await writer.WriteAsync("222 body follows\r\nhello\r\n.\r\n");
+        });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        var completion = new TaskCompletionSource<(ArticleBodyResult, string?)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var response = await client.BodyAsync(
+            "article@example.com", (result, reason) => completion.SetResult((result, reason)),
+            CancellationToken.None);
+        await response.Stream!.CopyToAsync(Stream.Null);
+
+        var (result, reason) = await completion.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(result, Is.EqualTo(ArticleBodyResult.Retrieved));
+        Assert.That(reason, Is.Null);
     }
 
     [Test]
@@ -2142,7 +2186,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.BodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
         using var reader = new StreamReader(response.Stream!, Encoding.Latin1);
         Assert.ThrowsAsync<UsenetProtocolException>(async () => await reader.ReadToEndAsync());
         Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
@@ -2184,7 +2228,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.BodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
         var copyTask = response.Stream!.CopyToAsync(Stream.Null);
         timeProvider.Advance(readTimeout);
 
@@ -2403,7 +2447,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.BodyAsync(
-            "article@example.com", completion.SetResult, CancellationToken.None);
+            "article@example.com", (result, _) => completion.SetResult(result), CancellationToken.None);
         await response.Stream!.DisposeAsync();
         continueBody.SetResult();
 
@@ -2442,7 +2486,7 @@ public class UsenetClientDeterministicTests
         var completion = new TaskCompletionSource<ArticleBodyResult>(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var response = await client.BodyAsync("article@example.com", completion.SetResult, cts.Token);
+        var response = await client.BodyAsync("article@example.com", (result, _) => completion.SetResult(result), cts.Token);
         var copyTask = response.Stream!.CopyToAsync(Stream.Null);
         await firstLineSent.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await Task.Delay(50);
@@ -2482,7 +2526,7 @@ public class UsenetClientDeterministicTests
             TaskCreationOptions.RunContinuationsAsynchronously);
 
         var response = await client.BodyAsync(
-            "article@example.com", completion.SetResult, callerCts.Token);
+            "article@example.com", (result, _) => completion.SetResult(result), callerCts.Token);
         var buffer = new byte[4096];
         Assert.That(
             await response.Stream!.ReadAsync(buffer.AsMemory()).AsTask().WaitAsync(TimeSpan.FromSeconds(2)),
@@ -2763,9 +2807,9 @@ public class UsenetClientDeterministicTests
 
         // First body holds the command lock; the second command queues behind it.
         _ = await client.BodyAsync(
-            "active@example.com", activeCompletion.SetResult, CancellationToken.None);
+            "active@example.com", (result, _) => activeCompletion.SetResult(result), CancellationToken.None);
         var queuedBody = client.BodyAsync(
-            "queued@example.com", queuedCompletion.SetResult, CancellationToken.None);
+            "queued@example.com", (result, _) => queuedCompletion.SetResult(result), CancellationToken.None);
         await Task.Delay(100);
 
         await client.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -1280,6 +1281,24 @@ public class UsenetClientDeterministicTests
         var (result, reason) = await completion.Task.WaitAsync(TimeSpan.FromSeconds(2));
         Assert.That(result, Is.EqualTo(ArticleBodyResult.Retrieved));
         Assert.That(reason, Is.Null);
+    }
+
+    [Test]
+    public void DescribeFailure_DirectSocketException_ReportsTheSocketErrorCode()
+    {
+        var reason = UsenetClient.DescribeFailure(
+            new SocketException((int)SocketError.ConnectionReset));
+
+        Assert.That(reason, Does.Contain(nameof(SocketError.ConnectionReset)));
+    }
+
+    [Test]
+    public void DescribeFailure_WrappedSocketException_ReportsTheSocketErrorCode()
+    {
+        var reason = UsenetClient.DescribeFailure(
+            new IOException("transport failure", new SocketException((int)SocketError.ConnectionReset)));
+
+        Assert.That(reason, Does.Contain(nameof(SocketError.ConnectionReset)));
     }
 
     [Test]

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -1289,7 +1289,7 @@ public class UsenetClientDeterministicTests
         var reason = UsenetClient.DescribeFailure(
             new SocketException((int)SocketError.ConnectionReset));
 
-        Assert.That(reason, Does.Contain(nameof(SocketError.ConnectionReset)));
+        Assert.That(reason, Is.EqualTo("SocketException: ConnectionReset"));
     }
 
     [Test]


### PR DESCRIPTION
Closes #881

## Summary

Found from a support pack on my own install: **46 circuit-breaker transitions in one hour, every one at a 60s cooldown** — the escalation ladder never engaged, and both providers tripped simultaneously 20s before capture while a live stream's prefetch was squeezed.

- **Cooldown ladder preserved on stat-only recovery** — health-check STAT traffic (~100k/hour with repairs enabled) was closing every tripped breaker seconds after cooldown expiry and resetting the ladder, so a provider with a broken download path flapped at 60s forever. Only a successful download (BODY) now resets the ladder; a STAT close still unlatches the breaker so low-traffic providers can't get stuck.
- **Trip reasons name the root cause** — `body-callback-BODY-NotRetrieved` becomes e.g. `body-callback-BODY-NotRetrieved (IOException (SocketException: ConnectionReset))`. The completion callback (`ArticleBodyCompletionHandler`) carries an optional failure reason classified in UsenetSharp, threaded through the deferred-callback and batch-coordinator plumbing.
- **All-providers-tripped warning** — when every enabled provider trips within a 10s window, one throttled warning tells the operator to check local network/DNS/TLS rather than chase two "independent" provider outages.
- **Health checks stagger at boot** — a 20s one-time grace period keeps the health-sweep backlog out of the cold-pool connection storm (queue resume + first streams establish pools first).
- **Support packs flag low-value captures** — `manifest.json` gains a `packQuality` array (fresh restart, no stream traces, partial sampler window, wrapped log ring), repeated in an `X-Support-Pack-Quality` header and shown on the Support page after generation so operators know to re-collect.

Verified none of these were fixed in 1.0.1: the only plan-relevant file that changed in the 1.0.0→1.0.1 delta was `MultiProviderNntpClient.cs` (#878, metrics classification — which this extends to breaker reasons).

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2382 passed, 0 failed
- [x] `dotnet test tests/UsenetSharp.Tests/UsenetSharp.Tests.csproj -c Release` — 229 passed, 0 failed
- [x] Frontend `npm run typecheck`, `npm run build`, `npm test` — 519 passed
- [x] New coverage: ladder preserved on STAT-close / reset on BODY success / re-trip at escalated cooldown; correlated-trip detector (window, closed-in-between, throttle); trip-reason detail end-to-end for singular + batch paths; UsenetSharp reason plumbing (truncated body, success); pack-quality warnings (untraced capture, wrapped log, healthy capture)
- [ ] Manual: watch a provider with a broken BODY path escalate 60s → 120s → 240s → 300s instead of flapping at 60s