### PR TITLE
fix(support): support pack fields now use consistent camelCase names

### DIFF
--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -36,10 +36,15 @@ public sealed class SupportPackService(
     private const long HourMs = 60 * MinuteMs;
     private const long DayMs = 24 * HourMs;
     private static readonly TimeSpan MinimumMeaningfulUptime = TimeSpan.FromMinutes(2);
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
     private static readonly JsonSerializerOptions CompactJsonOptions = new()
     {
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
     /// <summary>
@@ -825,7 +830,7 @@ public sealed class SupportPackService(
         var (mainMigration, metricsMigration) = await ReadMigrationsAsync(cancellationToken).ConfigureAwait(false);
         return new
         {
-            schemaVersion = 3,
+            schemaVersion = 4,
             generatedAtUtc = generatedAt,
             appVersion = ConfigManager.AppVersion,
             commit = Environment.GetEnvironmentVariable("NZBDAV_COMMIT_SHA"),

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -461,27 +461,43 @@ public sealed class SupportPackContentsTests : IDisposable
         buffer.Segment(session, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
         buffer.RangeEnd(session, range, ReadSession.EndReasonCode.Completed, 100);
 
-        var entries = await ReadPackEntriesAsync(
-            new LogBufferSink(10),
-            new WarningLogBuffer(new LogBufferSink(50)),
-            buffer);
-
-        var offenders = new List<string>();
-        foreach (var (name, content) in entries)
+        // Migrate the metrics database so metrics/recent.json is produced and the
+        // recursive walk covers the metrics section too (providerHours/connections
+        // stay empty without seeded providers, but metricsHealth and the other
+        // subsections are populated and get checked).
+        MetricsDbContext.ResetOptionsForTests();
+        List<string> offenders;
+        try
         {
-            if (name.EndsWith(".json", StringComparison.Ordinal))
+            await using (var metricsDb = new MetricsDbContext())
+                await metricsDb.Database.MigrateAsync();
+
+            var entries = await ReadPackEntriesAsync(
+                new LogBufferSink(10),
+                new WarningLogBuffer(new LogBufferSink(50)),
+                buffer);
+
+            offenders = new List<string>();
+            foreach (var (name, content) in entries)
             {
-                using var doc = JsonDocument.Parse(content);
-                CollectNonCamelCaseNames(doc.RootElement, name, offenders);
-            }
-            else if (name.EndsWith(".jsonl", StringComparison.Ordinal))
-            {
-                foreach (var line in content.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                if (name.EndsWith(".json", StringComparison.Ordinal))
                 {
-                    using var doc = JsonDocument.Parse(line);
+                    using var doc = JsonDocument.Parse(content);
                     CollectNonCamelCaseNames(doc.RootElement, name, offenders);
                 }
+                else if (name.EndsWith(".jsonl", StringComparison.Ordinal))
+                {
+                    foreach (var line in content.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        using var doc = JsonDocument.Parse(line);
+                        CollectNonCamelCaseNames(doc.RootElement, name, offenders);
+                    }
+                }
             }
+        }
+        finally
+        {
+            MetricsDbContext.ResetOptionsForTests();
         }
 
         Assert.Empty(offenders);
@@ -506,7 +522,6 @@ public sealed class SupportPackContentsTests : IDisposable
             using var manifest = JsonDocument.Parse(entries["manifest.json"]);
             var logs = manifest.RootElement.GetProperty("logs");
             Assert.True(logs.TryGetProperty("oldestSequence", out _));
-            Assert.True(logs.TryGetProperty("newestSequence", out _));
             Assert.False(logs.TryGetProperty("OldestSequence", out _));
             var warnings = manifest.RootElement.GetProperty("warnings");
             Assert.True(warnings.TryGetProperty("oldestSequence", out _));
@@ -516,8 +531,8 @@ public sealed class SupportPackContentsTests : IDisposable
             using var metrics = JsonDocument.Parse(entries["metrics/recent.json"]);
             var metricsHealth = metrics.RootElement.GetProperty("metricsHealth");
             Assert.True(metricsHealth.TryGetProperty("lastSuccessfulFlushAtMs", out _));
-            Assert.True(metricsHealth.TryGetProperty("lastFlushError", out _));
             Assert.False(metricsHealth.TryGetProperty("LastSuccessfulFlushAtMs", out _));
+            Assert.True(metricsHealth.TryGetProperty("lastFlushError", out _));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -2,8 +2,10 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Services;
@@ -278,7 +280,7 @@ public sealed class SupportPackContentsTests : IDisposable
             buffer);
 
         using var enabledManifest = JsonDocument.Parse(enabled["manifest.json"]);
-        Assert.Equal(3, enabledManifest.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(4, enabledManifest.RootElement.GetProperty("schemaVersion").GetInt32());
         Assert.Equal(
             "included",
             enabledManifest.RootElement.GetProperty("sections").GetProperty("streamTraces").GetString());
@@ -317,7 +319,7 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.Contains("INCOMPLETE", pack["stream-traces/OVERFLOW.txt"]);
 
         using var manifest = JsonDocument.Parse(pack["manifest.json"]);
-        Assert.Equal(3, manifest.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(4, manifest.RootElement.GetProperty("schemaVersion").GetInt32());
         Assert.Equal(
             "included-truncated",
             manifest.RootElement.GetProperty("sections").GetProperty("streamTraces").GetString());
@@ -448,6 +450,110 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.DoesNotContain(packQuality, w => w!.Contains("No stream traces"));
         Assert.DoesNotContain(packQuality, w => w!.Contains("sampler window"));
     }
+
+    [Fact]
+    public async Task Pack_UsesCamelCaseFieldNamesThroughout()
+    {
+        var buffer = new StreamTraceBuffer(100, enabled: false);
+        buffer.EnableFor(TimeSpan.FromMinutes(15), 100, StreamTraceBuffer.SourceUi);
+        var session = Guid.NewGuid();
+        var range = buffer.RangeOpen(session, "/view/movie.mkv", "GET", 0, 99, 1000, "ua", null);
+        buffer.Segment(session, "provider-a", SegmentFetch.FetchStatus.Ok, 12, 0, "msgid@a");
+        buffer.RangeEnd(session, range, ReadSession.EndReasonCode.Completed, 100);
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            buffer);
+
+        var offenders = new List<string>();
+        foreach (var (name, content) in entries)
+        {
+            if (name.EndsWith(".json", StringComparison.Ordinal))
+            {
+                using var doc = JsonDocument.Parse(content);
+                CollectNonCamelCaseNames(doc.RootElement, name, offenders);
+            }
+            else if (name.EndsWith(".jsonl", StringComparison.Ordinal))
+            {
+                foreach (var line in content.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    using var doc = JsonDocument.Parse(line);
+                    CollectNonCamelCaseNames(doc.RootElement, name, offenders);
+                }
+            }
+        }
+
+        Assert.Empty(offenders);
+    }
+
+    [Fact]
+    public async Task Pack_RenamesPreviouslyMixedSectionsToCamelCase()
+    {
+        // metricsHealth lives in metrics/recent.json, which is only written once the
+        // metrics database has its tables; migrate so the section is produced here.
+        MetricsDbContext.ResetOptionsForTests();
+        try
+        {
+            await using (var metricsDb = new MetricsDbContext())
+                await metricsDb.Database.MigrateAsync();
+
+            var entries = await ReadPackEntriesAsync(
+                new LogBufferSink(10),
+                new WarningLogBuffer(new LogBufferSink(50)));
+
+            // manifest ring-buffer stats were PascalCase shorthand (OldestSequence/NewestSequence).
+            using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+            var logs = manifest.RootElement.GetProperty("logs");
+            Assert.True(logs.TryGetProperty("oldestSequence", out _));
+            Assert.True(logs.TryGetProperty("newestSequence", out _));
+            Assert.False(logs.TryGetProperty("OldestSequence", out _));
+            var warnings = manifest.RootElement.GetProperty("warnings");
+            Assert.True(warnings.TryGetProperty("oldestSequence", out _));
+            Assert.True(warnings.TryGetProperty("newestSequence", out _));
+
+            // metricsHealth mixed queued/dropped with LastSuccessfulFlushAtMs/LastFlushError.
+            using var metrics = JsonDocument.Parse(entries["metrics/recent.json"]);
+            var metricsHealth = metrics.RootElement.GetProperty("metricsHealth");
+            Assert.True(metricsHealth.TryGetProperty("lastSuccessfulFlushAtMs", out _));
+            Assert.True(metricsHealth.TryGetProperty("lastFlushError", out _));
+            Assert.False(metricsHealth.TryGetProperty("LastSuccessfulFlushAtMs", out _));
+        }
+        finally
+        {
+            MetricsDbContext.ResetOptionsForTests();
+        }
+    }
+
+    private static void CollectNonCamelCaseNames(JsonElement element, string path, List<string> offenders)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    // The environment map is keyed by environment-variable NAMES (LOG_LEVEL,
+                    // TZ, …) — opaque data keys the serializer intentionally leaves as-is
+                    // (no DictionaryKeyPolicy), not field names subject to the casing policy.
+                    var isOpaqueDataKey = path.Equals("environment.json/environment", StringComparison.Ordinal);
+                    if (!isOpaqueDataKey && !IsCamelCase(property.Name))
+                        offenders.Add($"{path}: {property.Name}");
+                    CollectNonCamelCaseNames(property.Value, $"{path}/{property.Name}", offenders);
+                }
+
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                    CollectNonCamelCaseNames(item, path, offenders);
+
+                break;
+        }
+    }
+
+    private static bool IsCamelCase(string name) =>
+        name.Length > 0
+        && char.IsLower(name[0])
+        && name.All(char.IsLetterOrDigit);
 
     private static Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,


### PR DESCRIPTION
## Summary
- Fixes infinidysk/infinidysk#781. Support pack JSON mixed camelCase and PascalCase field names across (and within) sections, which made pack-parsing tooling read empty values and misdiagnose retention as stale during triage.
- Applies a single `PropertyNamingPolicy = CamelCase` to the shared support-pack serializers so every section (`manifest`, `environment`, `metrics/recent.json`, `configuration`, `stream-traces/sessions.json`) uses one convention. Member-shorthand PascalCase (e.g. `providerHours.Articles`, `connections[].LiveConnections`, `metricsHealth.LastSuccessfulFlushAtMs`, manifest `OldestSequence`) now serializes camelCase.
- Bumps the pack `schemaVersion` **3 -> 4** so tooling can detect the change. Dictionary keys (environment-variable names in the `environment` map) are intentionally left untouched -- no `DictionaryKeyPolicy`.

**Note for anyone with pack-parsing tooling:** field names that were PascalCase in schema <= 3 are camelCase in schema 4. (The `diagnosing-nzbdav-support-dumps` analysis skill's `analyze_dump.py` is updated separately, outside this repo, to read both casings via its existing `get()` helper.)

## Test plan
- [x] `SupportPackContentsTests`: updated the two `schemaVersion` assertions to 4
- [x] New `Pack_UsesCamelCaseFieldNamesThroughout`: migrates the metrics DB so `metrics/recent.json` is produced, then recursively walks every `.json` entry and each `events.jsonl` line asserting camelCase field names (env-var map keys exempted)
- [x] New `Pack_RenamesPreviouslyMixedSectionsToCamelCase`: asserts `manifest` ring-buffer stats and `metricsHealth` use camelCase and that the old PascalCase names are gone
- [x] Focused SupportPack suite: 28/28 pass
- [x] Full backend suite: 2384 passed, 0 failed
- [x] `analyze_dump.py` verified against synthetic schema-3 (PascalCase) and schema-4 (camelCase) packs -- identical correct output (skill updated out-of-repo)
- [ ] Manual: generate a real support pack (Settings -> Support) with providers configured and spot-check `providerHours` / `connections` casing