### PR TITLE
fix: resolve code-quality findings — resource leaks, null safety, and cancellation handling

### DIFF
--- a/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
+++ b/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
@@ -46,7 +46,7 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
                 if (file.Length > MaxRestoreBytes)
                     throw PayloadTooLarge("SQL dump exceeds the restore size limit.");
 
-                var target = Path.Combine(stagingPath, DatabaseBackupStore.DbSqlName);
+                var target = Path.Join(stagingPath, DatabaseBackupStore.DbSqlName);
                 await using var stream = file.OpenReadStream();
                 await using var output = System.IO.File.Create(target);
                 await CopyWithLimitAsync(stream, output, MaxRestoreBytes, HttpContext.RequestAborted).ConfigureAwait(false);
@@ -111,7 +111,7 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
             if (entry.CompressedLength > 0 && entry.Length / entry.CompressedLength > MaxCompressionRatio)
                 throw PayloadTooLarge("Zip entry compression ratio exceeds the restore safety limit.");
 
-            var dest = Path.Combine(stagingPath, fileName);
+            var dest = Path.Join(stagingPath, fileName);
             await using var entryStream = entry.Open();
             await using var output = System.IO.File.Create(dest);
             extractedBytes += await CopyWithLimitAsync(
@@ -151,7 +151,7 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
         var found = false;
         foreach (var name in sqlFiles)
         {
-            var path = Path.Combine(stagingPath, name);
+            var path = Path.Join(stagingPath, name);
             if (!System.IO.File.Exists(path))
                 continue;
             found = true;

--- a/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
+++ b/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
@@ -161,11 +161,10 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
             var sample = new string(sampleBuffer, 0, sampleLength);
             if (!sample.Contains("PRAGMA foreign_keys", StringComparison.OrdinalIgnoreCase)
                 && !sample.Contains("BEGIN", StringComparison.OrdinalIgnoreCase)
-                && !sample.Contains("CREATE", StringComparison.OrdinalIgnoreCase))
+                && !sample.Contains("CREATE", StringComparison.OrdinalIgnoreCase)
+                && !sample.Contains("CREATE TABLE", StringComparison.OrdinalIgnoreCase))
             {
-                if (!sample.Contains("CREATE TABLE", StringComparison.OrdinalIgnoreCase)
-                    && !sample.Contains("BEGIN", StringComparison.OrdinalIgnoreCase))
-                    throw new BadHttpRequestException($"{name} does not look like a SQLite SQL dump.");
+                throw new BadHttpRequestException($"{name} does not look like a SQLite SQL dump.");
             }
         }
 

--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -48,9 +48,8 @@ public class DeleteWebdavItemController(DavDatabaseClient dbClient, ConfigManage
         if (byPath is not null) return byPath;
 
         var current = DavItem.Root;
-        foreach (var raw in parts)
+        foreach (var name in parts.Select(Uri.UnescapeDataString))
         {
-            var name = Uri.UnescapeDataString(raw);
             var child = await dbClient.GetDirectoryChildAsync(current.Id, name, ct).ConfigureAwait(false);
             if (child is null) return null;
             current = child;

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -877,9 +877,8 @@ public class GetOverviewStatsController(
 
     private void ApplyLiveSpeedFallback(IEnumerable<GetOverviewStatsResponse.ProviderRow> providers)
     {
-        foreach (var provider in providers)
+        foreach (var provider in providers.Where(provider => provider.SpeedMbPerSec is null))
         {
-            if (provider.SpeedMbPerSec is not null) continue;
             var bytesPerMs = providerBytesTracker.GetRecentBytesPerMs(provider.Provider, LiveSpeedMaxAge);
             if (bytesPerMs > 0)
                 provider.SpeedMbPerSec = bytesPerMs * 1000 / 1_000_000;

--- a/backend/Api/Controllers/Profiles/Adapters/FailoverOrderController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/FailoverOrderController.cs
@@ -45,9 +45,8 @@ public class FailoverOrderController(
         var groups = new Dictionary<(string Type, string Id), List<string>>();
         var seen = new Dictionary<(string Type, string Id), HashSet<string>>();
         var matched = 0;
-        foreach (var id in ids)
+        foreach (var entry in ids.Select(cache.Get))
         {
-            var entry = cache.Get(id);
             if (entry is null || !entry.ProfileToken.FixedTimeEquals(token))
                 continue;
 

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -62,7 +62,7 @@ public class ProfilePlayController(
         {
             return await HandleAsync(token, nzbToken).ConfigureAwait(false);
         }
-        catch (Exception e)
+        catch (Exception e) when (!e.IsCancellationException(HttpContext.RequestAborted))
         {
             Log.Error(e, "Play handler crashed for token {Token} / nzbToken {NzbToken}", token, nzbToken);
             if (HttpContext.Response.HasStarted) return new EmptyResult();
@@ -810,7 +810,7 @@ public class ProfilePlayController(
             var nzb = await NzbDocument.LoadAsync(stream).ConfigureAwait(false);
             return nzb.Files.Any(f => SubtitlePreference.IsSubtitleFile(f.GetSubjectFileName()));
         }
-        catch
+        catch (Exception e) when (!e.IsCancellationException())
         {
             return false; // malformed NZB → no subtitle signal; never fail playback over this
         }

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -296,7 +296,8 @@ public class ProfilePlayController(
                 case BatchOutcome.Winner:
                 case BatchOutcome.Cancelled:
                     resolvedNzoId.Value = batch.WinnerNzoId;
-                    return batch.Action!;
+                    return batch.Action
+                           ?? throw new InvalidOperationException("Winner/Cancelled batch without an action result.");
                 case BatchOutcome.BudgetTimeout:
                     return await ResolveExistingOrErrorAsync(entry, 503,
                         "Still processing. Retry the link in a few seconds.", 5,

--- a/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
+++ b/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Indexers;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 
@@ -71,7 +72,7 @@ public class SearchIndexersController(
                     ElapsedMs = sw.ElapsedMilliseconds,
                 }, Results: mapped);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCancellationException(ct))
             {
                 return (Status: new SearchIndexersResponse.IndexerStatus
                 {

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -209,7 +209,10 @@ public sealed class UsenetMigrationController(
             query = query.Where(r => r.Verdict == verdict &&
                                      !r.VerdictReasons.Contains(VerdictReason.AlreadyMigrated));
         if (included is not null)
-            query = query.Where(r => r.Included == included.Value);
+        {
+            var includedFilter = included.Value;
+            query = query.Where(r => r.Included == includedFilter);
+        }
         if (!string.IsNullOrEmpty(targetCategory))
             query = query.Where(r => r.TargetCategory == targetCategory);
         if (!string.IsNullOrWhiteSpace(q))

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -980,7 +980,7 @@ public sealed class UsenetMigrationController(
         try
         {
             Directory.CreateDirectory(path);
-            var probe = Path.Combine(path, $".nzbdav-probe-{Guid.NewGuid():N}");
+            var probe = Path.Join(path, $".nzbdav-probe-{Guid.NewGuid():N}");
             System.IO.File.WriteAllText(probe, "ok");
             System.IO.File.Delete(probe);
         }

--- a/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
+++ b/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
@@ -107,6 +107,7 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
             }
             catch (JsonException)
             {
+                // Not a JSON bundle; fall through to line-based parsing.
             }
         }
 

--- a/backend/Api/Controllers/Watchtower/GetWatchtowerController.cs
+++ b/backend/Api/Controllers/Watchtower/GetWatchtowerController.cs
@@ -182,9 +182,9 @@ public class GetWatchtowerController(DavDatabaseClient dbClient, ConfigManager c
 
         var showAll = !hasState && !hasQ;
         var result = new List<GetWatchtowerResponse.ItemDto>();
-        foreach (var ex in expanders.OrderBy(e => e.Title, StringComparer.OrdinalIgnoreCase))
+        foreach (var ex in expanders.OrderBy(e => e.Title, StringComparer.OrdinalIgnoreCase)
+                     .Where(ex => showAll || relevant.Contains(ex.Key)))
         {
-            if (!showAll && !relevant.Contains(ex.Key)) continue;
             tally.TryGetValue(ex.Key, out var n);
             n ??= new int[3];
             result.Add(new GetWatchtowerResponse.ItemDto

--- a/backend/Api/Controllers/Watchtower/WatchtowerMutateController.cs
+++ b/backend/Api/Controllers/Watchtower/WatchtowerMutateController.cs
@@ -158,9 +158,8 @@ public class WatchtowerMutateController(DavDatabaseClient dbClient) : BaseApiCon
         var claimed = await dbClient.Ctx.WantedItems
             .Where(w => w.Provenance.Contains(srcId))
             .ToListAsync(ct).ConfigureAwait(false);
-        foreach (var item in claimed)
+        foreach (var item in claimed.Where(item => dbClient.Ctx.Entry(item).State != EntityState.Deleted))
         {
-            if (dbClient.Ctx.Entry(item).State == EntityState.Deleted) continue;
             var prov = WtJson.ReadStrings(item.Provenance);
             prov.Remove(srcId);
             if (prov.Count == 0)
@@ -282,9 +281,8 @@ public class WatchtowerMutateController(DavDatabaseClient dbClient) : BaseApiCon
             var items = await dbClient.Ctx.WantedItems
                 .Where(w => chunk.Contains(w.Key))
                 .ToListAsync(ct).ConfigureAwait(false);
-            foreach (var item in items)
+            foreach (var item in items.Where(item => dbClient.Ctx.Entry(item).State != EntityState.Deleted))
             {
-                if (dbClient.Ctx.Entry(item).State == EntityState.Deleted) continue;
                 await WtReconcile.RemoveWithChildrenAsync(dbClient.Ctx, item, now, ct).ConfigureAwait(false);
             }
         }
@@ -319,9 +317,8 @@ public class WatchtowerMutateController(DavDatabaseClient dbClient) : BaseApiCon
             var items = await dbClient.Ctx.WantedItems
                 .Where(w => chunk.Contains(w.Key))
                 .ToListAsync(ct).ConfigureAwait(false);
-            foreach (var item in items)
+            foreach (var item in items.Where(item => dbClient.Ctx.Entry(item).State != EntityState.Deleted))
             {
-                if (dbClient.Ctx.Entry(item).State == EntityState.Deleted) continue;
                 await WtReconcile.RemoveWithChildrenAsync(dbClient.Ctx, item, now, ct).ConfigureAwait(false);
             }
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -335,7 +335,7 @@ public class AddFileController(
             await using var dst = System.IO.File.Create(destPath);
             await src!.CopyToAsync(dst);
         }
-        catch (Exception e)
+        catch (Exception e) when (!e.IsCancellationException())
         {
             throw new Exception($"Could not save nzb to `{backupLocation}`", e);
         }

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -308,7 +308,7 @@ public class AddFileController(
             if (!Directory.Exists(backupRoot))
                 Directory.CreateDirectory(backupRoot);
 
-            var destDir = Path.GetFullPath(Path.Combine(backupRootPrefix, category));
+            var destDir = Path.GetFullPath(Path.Join(backupRootPrefix, category));
             if (!destDir.StartsWith(backupRootPrefix, StringComparison.Ordinal))
                 throw new ArgumentException("The NZB backup category must stay within the configured directory.");
             if (!Directory.Exists(destDir))
@@ -318,14 +318,14 @@ public class AddFileController(
                 ? destDir
                 : destDir + Path.DirectorySeparatorChar;
             var safeFileName = GetSafeBackupFileName(id, fileName);
-            var destPath = Path.GetFullPath(Path.Combine(destDirPrefix, safeFileName));
+            var destPath = Path.GetFullPath(Path.Join(destDirPrefix, safeFileName));
             if (!destPath.StartsWith(destDirPrefix, StringComparison.Ordinal))
                 throw new ArgumentException("The NZB backup file must stay within its category directory.");
             var counter = 2;
             while (System.IO.File.Exists(destPath))
             {
                 var safeBaseName = Path.GetFileNameWithoutExtension(safeFileName);
-                destPath = Path.GetFullPath(Path.Combine(destDirPrefix, $"{safeBaseName} ({counter}).nzb"));
+                destPath = Path.GetFullPath(Path.Join(destDirPrefix, $"{safeBaseName} ({counter}).nzb"));
                 if (!destPath.StartsWith(destDirPrefix, StringComparison.Ordinal))
                     throw new ArgumentException("The NZB backup file must stay within its category directory.");
                 counter++;

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -262,16 +262,9 @@ public class AddUrlRequest() : AddFileRequest
                 .ConfigureAwait(false);
         }
 
-        IPAddress[] addresses;
-
-        if (IPAddress.TryParse(host, out var literalAddress))
-        {
-            addresses = [literalAddress];
-        }
-        else
-        {
-            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
-        }
+        IPAddress[] addresses = IPAddress.TryParse(host, out var literalAddress)
+            ? [literalAddress]
+            : await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
 
         if (addresses.Length == 0)
             throw new HttpRequestException($"The host `{host}` did not resolve to an IP address.");
@@ -288,16 +281,9 @@ public class AddUrlRequest() : AddFileRequest
         int port,
         CancellationToken cancellationToken)
     {
-        IPAddress[] addresses;
-
-        if (IPAddress.TryParse(host, out var literalAddress))
-        {
-            addresses = [literalAddress];
-        }
-        else
-        {
-            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
-        }
+        IPAddress[] addresses = IPAddress.TryParse(host, out var literalAddress)
+            ? [literalAddress]
+            : await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
 
         if (addresses.Length == 0)
             throw new HttpRequestException($"The host `{host}` did not resolve to an IP address.");

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -456,7 +456,7 @@ public class AddUrlRequest() : AddFileRequest
             filename = AddNzbExtension(filename);
             return filename;
         }
-        catch
+        catch (Exception e) when (!e.IsCancellationException())
         {
             return null;
         }

--- a/backend/Clients/Indexers/NewznabClient.cs
+++ b/backend/Clients/Indexers/NewznabClient.cs
@@ -75,6 +75,7 @@ public class NewznabClient(
             catch (Exception e) when (attempt == 0 && !ct.IsCancellationRequested
                                       && e is HttpRequestException or IOException)
             {
+                // Transient network failure on the first attempt; loop retries once.
             }
         }
     }

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -77,7 +77,7 @@ public class ArrClient(string host, string apiKey)
 
     protected async Task<T> GetRoot<T>(string rootPath, CancellationToken ct = default)
     {
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
         using var response = await SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(ct);
@@ -86,7 +86,7 @@ public class ArrClient(string host, string apiKey)
 
     private async Task<T?> GetRootOrNull<T>(string rootPath, CancellationToken ct) where T : class
     {
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
         using var response = await SendAsync(request, ct);
         if (response.StatusCode == HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
@@ -96,7 +96,7 @@ public class ArrClient(string host, string apiKey)
 
     protected async Task<T> Post<T>(string path, object body, CancellationToken ct = default)
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestUri(path));
+        using var request = new HttpRequestMessage(HttpMethod.Post, GetRequestUri(path));
         var jsonBody = JsonSerializer.Serialize(body);
         request.Content = new StringContent(jsonBody, new MediaTypeHeaderValue("application/json"));
         using var response = await SendAsync(request, ct);
@@ -107,7 +107,7 @@ public class ArrClient(string host, string apiKey)
 
     protected async Task<HttpStatusCode> Delete(string path, Dictionary<string, string>? queryParams = null, CancellationToken ct = default)
     {
-        var request = new HttpRequestMessage(HttpMethod.Delete, GetRequestUri(path, queryParams));
+        using var request = new HttpRequestMessage(HttpMethod.Delete, GetRequestUri(path, queryParams));
         using var response = await SendAsync(request, ct);
         return response.StatusCode;
     }

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrField.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrField.cs
@@ -14,10 +14,14 @@ public class ArrField
     [JsonPropertyName("value")]
     public JsonElement? ValueJson { get; set; }
 
-    public object? Value => ValueJson?.ValueKind == JsonValueKind.Null ? null
-        : ValueJson?.ValueKind == JsonValueKind.String ? ValueJson?.ToString()
-        : ValueJson?.ValueKind == JsonValueKind.Number ? ValueJson?.GetInt64()
-        : ValueJson?.ValueKind == JsonValueKind.True ? true
-        : ValueJson?.ValueKind == JsonValueKind.False ? false
-        : ValueJson?.GetRawText();
+    public object? Value => ValueJson?.ValueKind switch
+    {
+        null => null,
+        JsonValueKind.Null => null,
+        JsonValueKind.String => ValueJson?.ToString(),
+        JsonValueKind.Number => ValueJson?.GetInt64(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        _ => ValueJson?.GetRawText(),
+    };
 }

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrField.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrField.cs
@@ -14,14 +14,20 @@ public class ArrField
     [JsonPropertyName("value")]
     public JsonElement? ValueJson { get; set; }
 
-    public object? Value => ValueJson?.ValueKind switch
+    public object? Value
     {
-        null => null,
-        JsonValueKind.Null => null,
-        JsonValueKind.String => ValueJson?.ToString(),
-        JsonValueKind.Number => ValueJson?.GetInt64(),
-        JsonValueKind.True => true,
-        JsonValueKind.False => false,
-        _ => ValueJson?.GetRawText(),
-    };
+        get
+        {
+            if (ValueJson is not { } json) return null;
+            return json.ValueKind switch
+            {
+                JsonValueKind.Null => null,
+                JsonValueKind.String => json.ToString(),
+                JsonValueKind.Number => json.GetInt64(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                _ => json.GetRawText(),
+            };
+        }
+    }
 }

--- a/backend/Clients/RadarrSonarr/BaseModels/DeleteQueueRecordRequest.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/DeleteQueueRecordRequest.cs
@@ -14,7 +14,7 @@ public class DeleteQueueRecordRequest
     {
         RemoveFromClient = queueAction >= ArrConfig.QueueAction.Remove;
         Blocklist = queueAction >= ArrConfig.QueueAction.RemoveAndBlocklist;
-        SkipRedownload = !(queueAction >= ArrConfig.QueueAction.RemoveAndBlocklistAndSearch);
+        SkipRedownload = queueAction < ArrConfig.QueueAction.RemoveAndBlocklistAndSearch;
     }
 
     public Dictionary<string, string> GetQueryParams()

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -53,7 +53,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         {
             var movie = await GetMovieOrNullAsync(movieId, ct).ConfigureAwait(false);
             var movieFile = movie?.MovieFile;
-            if (movieFile?.Path == symlinkOrStrmPath)
+            if (movieFile is not null && movieFile.Path == symlinkOrStrmPath)
                 return movieFile.Id;
             SymlinkOrStrmToMovieIdCache.TryRemove(cacheKey, out _);
         }
@@ -67,7 +67,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             var movieFile = movie.MovieFile;
             if (movieFile?.Path != null)
                 SymlinkOrStrmToMovieIdCache[(Host, movieFile.Path)] = movie.Id;
-            if (movieFile?.Path == symlinkOrStrmPath)
+            if (movieFile is not null && movieFile.Path == symlinkOrStrmPath)
                 result = movieFile.Id;
         }
 

--- a/backend/Clients/RadarrSonarr/RadarrModels/RadarrQueue.cs
+++ b/backend/Clients/RadarrSonarr/RadarrModels/RadarrQueue.cs
@@ -11,7 +11,7 @@ public class RadarrQueue : ArrQueue<RadarrQueueRecord>
             Page = Page,
             PageSize = PageSize,
             TotalRecords = TotalRecords,
-            Records = Records.Select(ArrQueueRecord (x) => x).ToList()
+            Records = Records.Select(x => (ArrQueueRecord)x).ToList()
         };
     }
 }

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -162,7 +162,7 @@ public class RcloneClient
     ) where T : RcloneResponse, new()
     {
         var url = $"{host}/{endpoint}";
-        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
 
         if (body != null)
         {

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -369,6 +369,7 @@ public class ArticleCachingNntpClient(
         }
         catch
         {
+            // Previous response failures surface on their own task; only ordering matters here.
         }
 
         return await response.ConfigureAwait(false);
@@ -405,6 +406,7 @@ public class ArticleCachingNntpClient(
         }
         catch
         {
+            // Callback exceptions must not fault transport tasks (streaming lifecycle invariant).
         }
     }
 

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -503,7 +503,7 @@ public class ArticleCachingNntpClient(
         // Use SHA256 hash of segment ID to create a valid filename
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(segmentId));
         var filename = Convert.ToHexString(hash);
-        return Path.Combine(_cacheDir, filename);
+        return Path.Join(_cacheDir, filename);
     }
 
     public override void Dispose()

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -266,8 +266,8 @@ public class ProviderCircuitBreaker
             Interlocked.Increment(ref _failureCount);
 
             var failures = 0;
-            foreach (var entry in _window)
-                if (entry.Failed) failures++;
+            foreach (var entry in _window.Where(entry => entry.Failed))
+                failures++;
 
             if (failures >= MinFailuresToTrip
                 && failures / (double)_window.Count >= TripFailureRate)

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -490,6 +490,14 @@ public class MultiConnectionNntpClient(
                 throw;
             }
 
+            // AcquireConnectionLockAsync either throws or returns a lock; this guard
+            // only documents that invariant for null-state analysis.
+            if (connectionLock is null)
+            {
+                LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
+                throw new InvalidOperationException("Connection acquisition returned no lock.");
+            }
+
             T? result;
             var deferredCallback = new DeferredArticleBodyCallback();
             CancellationTokenSource? attemptCts = null;

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -647,7 +647,7 @@ public class MultiConnectionNntpClient(
             }
 
             // body and article
-            else if ((result?.Success ?? false) == false)
+            else if (!(result?.Success ?? false))
             {
                 circuitBreaker.RecordArticleNotFound();
                 deferredCallback.Discard();

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1087,10 +1087,8 @@ public class MultiProviderNntpClient(
     {
         if (priorMisses is not { Count: > 0 }) return null;
         List<(string Host, SegmentFetch.FetchStatus Reason)>? cross = null;
-        foreach (var miss in priorMisses)
+        foreach (var miss in priorMisses.Where(miss => !string.Equals(miss.Host, rescuer, StringComparison.OrdinalIgnoreCase)))
         {
-            if (string.Equals(miss.Host, rescuer, StringComparison.OrdinalIgnoreCase))
-                continue;
             (cross ??= []).Add(miss);
         }
         return cross;

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -477,13 +477,10 @@ public class MultiProviderNntpClient(
             else
             {
                 retryProviders = [primaryProvider, .. fallbackProviders];
-                if (response == null || !definitiveMiss)
+                if ((response == null || !definitiveMiss) && response != null)
                 {
-                    if (response != null)
-                    {
-                        lastException = ExceptionDispatchInfo.Capture(
-                            new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage));
-                    }
+                    lastException = ExceptionDispatchInfo.Capture(
+                        new UsenetUnexpectedResponseException(segmentId, response.ResponseMessage));
                 }
             }
 

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -496,10 +496,9 @@ public abstract class NntpClient : INntpClient
         if (value.Length is < 3 or > 248) return false;
         if (value[0] == '@' || value[^1] == '@' || !value.Contains('@')) return false;
         if (value.Contains('<') || value.Contains('>')) return false;
-        foreach (var character in value)
+        foreach (var character in value.Where(character => char.IsWhiteSpace(character) || char.IsControl(character)))
         {
-            if (char.IsWhiteSpace(character) || char.IsControl(character))
-                return false;
+            return false;
         }
 
         return true;

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -278,7 +278,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         }
     }
 
-    private string BlobPath(string hash) => Path.Combine(_dir, hash[..2], hash);
+    private string BlobPath(string hash) => Path.Join(_dir, hash[..2], hash);
 
     private static string Hash(string id)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(id)));

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1240,19 +1240,19 @@ public class ConfigManager
     public bool IsWatchtowerEnabled()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerEnabled));
-        return v != null ? bool.Parse(v) : false;
+        return v != null && bool.Parse(v);
     }
 
     public bool IsWatchtowerAutoThroughput()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerAutoThroughput));
-        return v != null ? bool.Parse(v) : false;
+        return v != null && bool.Parse(v);
     }
 
     public bool IsWatchtowerVerboseLoggingEnabled()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerVerboseLogging));
-        return v != null ? bool.Parse(v) : false;
+        return v != null && bool.Parse(v);
     }
 
     public string GetWatchtowerProfileToken()
@@ -1406,13 +1406,13 @@ public class ConfigManager
     public bool IsWatchtowerSeasonBundlesEnabled()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundles));
-        return v != null ? bool.Parse(v) : true;
+        return v == null || bool.Parse(v);
     }
 
     public bool IsWatchtowerSeasonBundleFallbackEnabled()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSeasonBundleFallback));
-        return v != null ? bool.Parse(v) : false;
+        return v != null && bool.Parse(v);
     }
 
     public string GetWatchtowerSeasonBundleFallbackScope()

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -75,9 +75,8 @@ public static class UsenetProviderIdentity
             .ToHashSet();
 
         var assigned = false;
-        foreach (var provider in config.Providers)
+        foreach (var provider in config.Providers.Where(provider => provider.ProviderId == Guid.Empty))
         {
-            if (provider.ProviderId != Guid.Empty) continue;
             provider.ProviderId = AssignProviderId(provider, taken);
             assigned = true;
         }
@@ -154,10 +153,8 @@ public static class UsenetProviderIdentity
             .Concat(unusedExisting.Select(p => p.ProviderId))
             .ToHashSet();
 
-        foreach (var provider in incoming.Providers)
+        foreach (var provider in incoming.Providers.Where(provider => provider.ProviderId == Guid.Empty))
         {
-            if (provider.ProviderId != Guid.Empty) continue;
-
             var matchIndex = unusedExisting.FindIndex(p =>
                 string.Equals(p.Host, provider.Host, StringComparison.OrdinalIgnoreCase)
                 && p.Port == provider.Port

--- a/backend/Database/Backup/SqliteDumper.cs
+++ b/backend/Database/Backup/SqliteDumper.cs
@@ -185,10 +185,11 @@ public static class SqliteDumper
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
 
         var valueBuffer = new object[columns.Count];
+        var sb = new StringBuilder();
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             reader.GetValues(valueBuffer);
-            var sb = new StringBuilder();
+            sb.Clear();
             sb.Append("INSERT INTO ").Append(quotedTable)
                 .Append(" (").Append(quotedColumns).Append(") VALUES (");
 

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -24,7 +24,7 @@ public class BlobStore
         var nextTwo = guidStr.Substring(2, 2);
         var fileName = id.ToString(); // With hyphens for readability
 
-        return Path.Combine(ConfigPath, "blobs", firstTwo, nextTwo, fileName);
+        return Path.Join(ConfigPath, "blobs", firstTwo, nextTwo, fileName);
     }
 
     private static FileStream OpenBlobWrite(Guid id)

--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Par2Recovery.Packets;
 using Serilog;
 
@@ -34,7 +35,7 @@ namespace NzbWebDAV.Par2Recovery
                 {
                     packet = await ReadPacketAsync(stream).ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch (Exception e) when (!e.IsCancellationException(ct))
                 {
                     Log.Warning(e, "Failed to read PAR2 packet");
                     break;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -448,7 +448,7 @@ public partial class Program
         var hasPendingRestore = pendingRestore is not null
             && pendingRestore.StagedFiles.Count > 0
             && pendingRestore.StagedFiles.All(name =>
-                File.Exists(Path.Combine(backupStore.RestoreStagingRoot, name)));
+                File.Exists(Path.Join(backupStore.RestoreStagingRoot, name)));
         if (pendingRestore is not null && !hasPendingRestore)
         {
             Log.Warning(

--- a/backend/Queue/FileProcessors/RarProcessor.cs
+++ b/backend/Queue/FileProcessors/RarProcessor.cs
@@ -83,12 +83,12 @@ public class RarProcessor(
     private static int? GetPartNumberFromHeaders(List<IRarHeader> headers)
     {
         var archiveHeader = headers.OfType<IRarArchiveHeader>().FirstOrDefault();
-        if (archiveHeader?.VolumeNumber != null) return archiveHeader.VolumeNumber.Value;
+        if (archiveHeader?.VolumeNumber is { } archiveVolume) return archiveVolume;
 
         var endHeader = headers.OfType<IRarEndArchiveHeader>().FirstOrDefault();
-        if (endHeader?.VolumeNumber != null) return endHeader.VolumeNumber.Value;
+        if (endHeader?.VolumeNumber is { } endVolume) return endVolume;
 
-        if (archiveHeader?.IsFirstVolume == true) return -1;
+        if (archiveHeader is not null && archiveHeader.IsFirstVolume) return -1;
         return null;
     }
 

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -288,12 +288,12 @@ public static class NestedRarExpansionStep
     private static int? GetPartNumberFromHeaders(List<IRarHeader> headers)
     {
         var archiveHeader = headers.OfType<IRarArchiveHeader>().FirstOrDefault();
-        if (archiveHeader?.VolumeNumber != null) return archiveHeader.VolumeNumber.Value;
+        if (archiveHeader?.VolumeNumber is { } archiveVolume) return archiveVolume;
 
         var endHeader = headers.OfType<IRarEndArchiveHeader>().FirstOrDefault();
-        if (endHeader?.VolumeNumber != null) return endHeader.VolumeNumber.Value;
+        if (endHeader?.VolumeNumber is { } endVolume) return endVolume;
 
-        if (archiveHeader?.IsFirstVolume == true) return -1;
+        if (archiveHeader is not null && archiveHeader.IsFirstVolume) return -1;
         return null;
     }
 

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -715,8 +715,8 @@ public class QueueManager : IDisposable
             .Select(p => p.Host)
             .Where(h => !string.IsNullOrEmpty(h))
             .Distinct();
-        foreach (var host in configured)
-            if (!merged.ContainsKey(host)) merged[host] = 0;
+        foreach (var host in configured.Where(host => !merged.ContainsKey(host)))
+            merged[host] = 0;
         var payload = string.Join(",", merged.Select(kv => $"{kv.Key}={kv.Value}"));
         return $"{queueItemId}|{payload}";
     }

--- a/backend/Services/AnimeListMappingResolver.cs
+++ b/backend/Services/AnimeListMappingResolver.cs
@@ -39,7 +39,10 @@ public class AnimeListMappingResolver
                 // cold start: wait briefly for the first load, then let it finish in the background
                 var load = LoadIfDueAsync(CancellationToken.None);
                 try { await load.WaitAsync(FirstLoadWait, ct).ConfigureAwait(false); }
-                catch (TimeoutException) { }
+                catch (TimeoutException)
+                {
+                    // First load exceeded the wait window; serve empty and keep loading in the background.
+                }
                 index = _index;
             }
         }

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -75,7 +75,10 @@ public class ArrMonitoringService : BackgroundService
                 resolutions.Add((record.Title, action.Value));
             }
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Monitoring pass aborted on shutdown.
+        }
         catch (Exception e) when (e is HttpRequestException { InnerException: System.Net.Sockets.SocketException })
         {
             Log.Debug(e, "Could not reach Arr instance {Host} for queue monitoring", client.Host);

--- a/backend/Services/Benchmark/BenchmarkConnectionLadder.cs
+++ b/backend/Services/Benchmark/BenchmarkConnectionLadder.cs
@@ -1,6 +1,7 @@
 using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
 using Serilog;
 
 namespace NzbWebDAV.Services.Benchmark;
@@ -36,7 +37,7 @@ internal sealed class BenchmarkConnectionLadder(UsenetProviderConfig.ConnectionD
                 {
                     throw;
                 }
-                catch (Exception e)
+                catch (Exception e) when (!e.IsCancellationException(ct))
                 {
                     failure = e;
                     // Give the provider a beat to free a lingering slot before retrying.

--- a/backend/Services/Benchmark/BenchmarkConnectionLadder.cs
+++ b/backend/Services/Benchmark/BenchmarkConnectionLadder.cs
@@ -101,6 +101,7 @@ internal sealed class BenchmarkConnectionLadder(UsenetProviderConfig.ConnectionD
         }
         catch (OperationCanceledException)
         {
+            // Cancellation ends the delay early; callers re-check the token.
         }
     }
 }

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -599,7 +599,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         else
         {
             // Assume at least ~2 MB/s per connection until we have a real sample.
-            var bootstrap = (long)(Math.Max(1, connections) * 2_000_000 * 2.0 * seconds);
+            var bootstrap = (long)(Math.Max(1, connections) * 2_000_000.0 * 2.0 * seconds);
             est = Math.Max(profile.PerLevelBytes, bootstrap);
         }
 

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -662,11 +662,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         var confirmTight = result.ConfirmDeltaPct is <= 5;
         var confirmLoose = result.ConfirmDeltaPct is > 20;
 
-        string confidence;
-        if ((!confirmTight && result.WrappedPool) || maxCv > 0.15)
-            confidence = "medium";
-        else
-            confidence = "high";
+        var confidence = (!confirmTight && result.WrappedPool) || maxCv > 0.15
+            ? "medium"
+            : "high";
 
         // Budget ran out after a found plateau: downgrade high → medium at most.
         if (result.BudgetLimited && confidence == "high")

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -465,6 +465,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         }
         catch (OperationCanceledException)
         {
+            // Workers stop via cancellation during soft-stop.
         }
 
         ladder.Prune(dead.ToArray());
@@ -773,6 +774,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         }
         catch (OperationCanceledException)
         {
+            // Cancellation ends the delay early; callers re-check the token.
         }
     }
 

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -40,6 +40,9 @@ public class DatabaseBackupSchedulerService : BackgroundService
 
             var old = Interlocked.Exchange(ref _rescheduleCts, new CancellationTokenSource());
             old.Cancel();
+            // Not disposed: ExecuteAsync may access .Token on this source after the swap, which
+            // throws ObjectDisposedException once disposed. Cancelling wakes the loop; the old
+            // source is then unreferenced and GC'd.
         };
     }
 

--- a/backend/Services/DatabaseBackupStore.cs
+++ b/backend/Services/DatabaseBackupStore.cs
@@ -22,10 +22,10 @@ public sealed class DatabaseBackupStore
 
     private readonly object _gate = new();
 
-    public string BackupsRoot => Path.Combine(DavDatabaseContext.ConfigPath, "backups");
-    public string RestoreStagingRoot => Path.Combine(DavDatabaseContext.ConfigPath, RestoreStagingFolderName);
-    public string PendingRestorePath => Path.Combine(DavDatabaseContext.ConfigPath, PendingRestoreFileName);
-    public string LastRestoreReportPath => Path.Combine(BackupsRoot, LastRestoreReportFileName);
+    public string BackupsRoot => Path.Join(DavDatabaseContext.ConfigPath, "backups");
+    public string RestoreStagingRoot => Path.Join(DavDatabaseContext.ConfigPath, RestoreStagingFolderName);
+    public string PendingRestorePath => Path.Join(DavDatabaseContext.ConfigPath, PendingRestoreFileName);
+    public string LastRestoreReportPath => Path.Join(BackupsRoot, LastRestoreReportFileName);
 
     public void EnsureInitialized()
     {
@@ -71,14 +71,14 @@ public sealed class DatabaseBackupStore
     public string GetBackupDirectory(string backupId)
     {
         ValidateBackupId(backupId);
-        return Path.Combine(BackupsRoot, backupId);
+        return Path.Join(BackupsRoot, backupId);
     }
 
     public string CreateStaging(string kind)
     {
         EnsureInitialized();
         var id = $"{DateTime.UtcNow:yyyyMMdd-HHmmssfff}-{SanitizeKind(kind)}-{Guid.NewGuid().ToString("N")[..6]}";
-        var stagingPath = Path.Combine(BackupsRoot, $".tmp-{id}");
+        var stagingPath = Path.Join(BackupsRoot, $".tmp-{id}");
         if (Directory.Exists(stagingPath))
             Directory.Delete(stagingPath, recursive: true);
         Directory.CreateDirectory(stagingPath);
@@ -105,7 +105,7 @@ public sealed class DatabaseBackupStore
         var files = new List<DatabaseBackupFileEntry>();
         foreach (var sqlName in new[] { DbSqlName, MetricsSqlName, WardenSqlName })
         {
-            var path = Path.Combine(stagingPath, sqlName);
+            var path = Path.Join(stagingPath, sqlName);
             if (!File.Exists(path))
                 continue;
             files.Add(new DatabaseBackupFileEntry
@@ -132,7 +132,7 @@ public sealed class DatabaseBackupStore
 
         WriteManifestAtomic(stagingPath, manifest);
 
-        var finalPath = Path.Combine(BackupsRoot, backupId);
+        var finalPath = Path.Join(BackupsRoot, backupId);
         if (Directory.Exists(finalPath))
             throw new InvalidOperationException($"Backup id already exists: {backupId}");
 
@@ -272,7 +272,7 @@ public sealed class DatabaseBackupStore
 
     private DatabaseBackupManifest? ReadManifest(string backupId)
     {
-        var path = Path.Combine(GetBackupDirectory(backupId), ManifestFileName);
+        var path = Path.Join(GetBackupDirectory(backupId), ManifestFileName);
         if (!File.Exists(path))
             return null;
         var json = File.ReadAllText(path);
@@ -282,7 +282,7 @@ public sealed class DatabaseBackupStore
     private void WriteManifestAtomic(string backupDirectory, DatabaseBackupManifest manifest)
     {
         Directory.CreateDirectory(backupDirectory);
-        var path = Path.Combine(backupDirectory, ManifestFileName);
+        var path = Path.Join(backupDirectory, ManifestFileName);
         var temp = path + ".tmp";
         var json = JsonSerializer.Serialize(manifest, DatabaseBackupJson.Options);
         lock (_gate)

--- a/backend/Services/DatabaseRestoreRunner.cs
+++ b/backend/Services/DatabaseRestoreRunner.cs
@@ -42,7 +42,7 @@ public static class DatabaseRestoreRunner
             return;
 
         if (intent.StagedFiles.Count == 0 ||
-            !intent.StagedFiles.All(name => File.Exists(Path.Combine(store.RestoreStagingRoot, name))))
+            !intent.StagedFiles.All(name => File.Exists(Path.Join(store.RestoreStagingRoot, name))))
         {
             Log.Warning(
                 "Pending restore intent {BackupId} is missing staged files; discarding and continuing startup",
@@ -56,7 +56,7 @@ public static class DatabaseRestoreRunner
         try
         {
             progress.BeginStep(RollbackStepId);
-            var rollbackDir = Path.Combine(
+            var rollbackDir = Path.Join(
                 store.GetBackupDirectory(intent.PreRestoreBackupId),
                 DatabaseBackupStore.RollbackFolderName);
             Directory.CreateDirectory(rollbackDir);
@@ -71,7 +71,7 @@ public static class DatabaseRestoreRunner
                 await CheckpointAndVacuumAsync(livePath, cancellationToken).ConfigureAwait(false);
                 SqliteConnection.ClearAllPools();
 
-                var rollbackPath = Path.Combine(rollbackDir, Path.GetFileName(livePath));
+                var rollbackPath = Path.Join(rollbackDir, Path.GetFileName(livePath));
                 MoveDatabaseFiles(livePath, rollbackPath);
                 movedAway.Add((livePath, rollbackPath));
             }
@@ -82,7 +82,7 @@ public static class DatabaseRestoreRunner
             foreach (var stagedName in intent.StagedFiles)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var stagedPath = Path.Combine(store.RestoreStagingRoot, stagedName);
+                var stagedPath = Path.Join(store.RestoreStagingRoot, stagedName);
                 var livePath = ResolveLivePath(stagedName);
                 Directory.CreateDirectory(Path.GetDirectoryName(livePath)!);
                 File.Move(stagedPath, livePath, overwrite: false);
@@ -102,7 +102,7 @@ public static class DatabaseRestoreRunner
                     {
                         pre.Files.Add(new DatabaseBackupFileEntry
                         {
-                            Name = Path.Combine(DatabaseBackupStore.RollbackFolderName, Path.GetFileName(file))
+                            Name = Path.Join(DatabaseBackupStore.RollbackFolderName, Path.GetFileName(file))
                                 .Replace('\\', '/'),
                             Bytes = new FileInfo(file).Length,
                         });
@@ -163,7 +163,7 @@ public static class DatabaseRestoreRunner
     {
         "db.sqlite" => DavDatabaseContext.DatabaseFilePath,
         "metrics.sqlite" => MetricsDbContext.DatabaseFilePath,
-        "warden.db" => Path.Combine(DavDatabaseContext.ConfigPath, "warden.db"),
+        "warden.db" => Path.Join(DavDatabaseContext.ConfigPath, "warden.db"),
         _ => throw new InvalidOperationException($"Unknown staged database file: {stagedFileName}"),
     };
 
@@ -303,6 +303,6 @@ public static class DatabaseRestoreRunner
         var firstTwo = guidStr[..2];
         var nextTwo = guidStr.Substring(2, 2);
         var fileName = id.ToString();
-        return Path.Combine(DavDatabaseContext.ConfigPath, "blobs", firstTwo, nextTwo, fileName);
+        return Path.Join(DavDatabaseContext.ConfigPath, "blobs", firstTwo, nextTwo, fileName);
     }
 }

--- a/backend/Services/ExternalIdResolver.cs
+++ b/backend/Services/ExternalIdResolver.cs
@@ -136,10 +136,11 @@ public class ExternalIdResolver(AnimeListMappingResolver animeList)
                     }
                     else if (int.TryParse(ext, out var id)) tvdbId ??= id;
                 }
-                else if (site.Equals("thetvdb/series", StringComparison.OrdinalIgnoreCase))
+                else if (site.Equals("thetvdb/series", StringComparison.OrdinalIgnoreCase)
+                    && int.TryParse(ext, out var id))
                 {
                     // fallback id source; never carries season
-                    if (int.TryParse(ext, out var id)) tvdbId ??= id;
+                    tvdbId ??= id;
                 }
                 // ignore "thetvdb/season" — its ext is the upstream row id, not a season number
             }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1200,9 +1200,8 @@ public class HealthCheckService : BackgroundService
     {
         lock (_missingSegmentIds)
         {
-            foreach (var segmentId in segmentIds)
-                if (_missingSegmentIds.Contains(segmentId))
-                    throw new UsenetArticleNotFoundException(segmentId);
+            foreach (var segmentId in segmentIds.Where(segmentId => _missingSegmentIds.Contains(segmentId)))
+                throw new UsenetArticleNotFoundException(segmentId);
         }
     }
 }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -249,7 +249,10 @@ public class HealthCheckService : BackgroundService
             progressHook.ProgressChanged += (_, progress) =>
             {
                 try { statCts?.CancelAfter(HealthCheckProgressTimeout); }
-                catch (ObjectDisposedException) { }
+                catch (ObjectDisposedException)
+                {
+                    // statCts may already be disposed when a progress event races teardown.
+                }
                 var message = $"{davItem.Id}|{progress}";
                 debounce(() => _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, message));
             };

--- a/backend/Services/IndexerResultFilter.cs
+++ b/backend/Services/IndexerResultFilter.cs
@@ -28,9 +28,8 @@ public static class IndexerResultFilter
             return items.ToList();
 
         var kept = new List<NewznabClient.NewznabItem>(items.Count);
-        foreach (var item in items)
+        foreach (var item in items.Where(item => !ShouldDrop(item, filter, now)))
         {
-            if (ShouldDrop(item, filter, now)) continue;
             kept.Add(item);
         }
 

--- a/backend/Services/IndexerResultFilter.cs
+++ b/backend/Services/IndexerResultFilter.cs
@@ -70,12 +70,9 @@ public static class IndexerResultFilter
         //    determine age, we apply the grace conservatively: skip the rule entirely.
         if (f.MinGrabs > 0 && item.Grabs is { } g && g < f.MinGrabs)
         {
-            if (f.GrabsGraceHours > 0)
-            {
-                // Bypass when within grace window. Unknown age = treat as within grace.
-                if (age is null || age.Value.TotalHours < f.GrabsGraceHours)
-                    return false;
-            }
+            // Bypass when within grace window. Unknown age = treat as within grace.
+            if (f.GrabsGraceHours > 0 && (age is null || age.Value.TotalHours < f.GrabsGraceHours))
+                return false;
             return true;
         }
 

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -336,6 +336,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         var size = MultipartFileSizeReconciler.TryGetPublishedSize(meta);
         if (size is null) return;
 
+        var publishedSize = size.Value;
         if (ReconcileFileSizeAsync is not null)
         {
             await ReconcileFileSizeAsync(fileBlobId, meta, ct).ConfigureAwait(false);
@@ -346,14 +347,14 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         {
             await using var ctx = new DavDatabaseContext();
             var updated = await ctx.Items
-                .Where(i => i.FileBlobId == fileBlobId && i.FileSize != size.Value)
-                .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, size.Value), ct)
+                .Where(i => i.FileBlobId == fileBlobId && i.FileSize != publishedSize)
+                .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, publishedSize), ct)
                 .ConfigureAwait(false);
             if (updated > 0)
             {
                 Log.Information(
                     "Reconciled DavItem FileSize for multipart blob {BlobId} to {Size}",
-                    fileBlobId, size.Value);
+                    fileBlobId, publishedSize);
             }
         }
         catch (Exception e)

--- a/backend/Services/Metrics/ProviderUsageHelper.cs
+++ b/backend/Services/Metrics/ProviderUsageHelper.cs
@@ -153,9 +153,8 @@ public static class ProviderUsageHelper
         try
         {
             await using var db = dbFactory();
-            foreach (var provider in config.Providers)
+            foreach (var provider in config.Providers.Where(provider => provider.ProviderId != Guid.Empty))
             {
-                if (provider.ProviderId == Guid.Empty) continue;
                 var key = UsenetProviderIdentity.MetricsKey(provider);
                 var bytes = await db.ProviderHourly
                     .Where(x => x.Provider == key && x.Hour >= provider.BytesUsedResetAt)

--- a/backend/Services/MultipartFileSizeRepairService.cs
+++ b/backend/Services/MultipartFileSizeRepairService.cs
@@ -100,9 +100,10 @@ public class MultipartFileSizeRepairService : BackgroundService
                 continue;
             }
 
+            var publishedSize = size.Value;
             var updated = await ctx.Items
                 .Where(i => i.Id == item.Id && i.FileSize == long.MaxValue)
-                .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, size.Value), ct)
+                .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, publishedSize), ct)
                 .ConfigureAwait(false);
             if (updated > 0)
                 repaired++;

--- a/backend/Services/MultipartFileSizeRepairService.cs
+++ b/backend/Services/MultipartFileSizeRepairService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using Serilog;
 
 namespace NzbWebDAV.Services;
@@ -64,7 +65,7 @@ public class MultipartFileSizeRepairService : BackgroundService
             {
                 multipart = await dbClient.GetDavMultipartFileAsync(item, ct).ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCancellationException(ct))
             {
                 missing++;
                 Log.Warning(

--- a/backend/Services/PlaybackFastVerifier.cs
+++ b/backend/Services/PlaybackFastVerifier.cs
@@ -174,7 +174,7 @@ public class PlaybackFastVerifier
         var indices = new SortedSet<int>();
         for (var i = 0; i < n; i++)
         {
-            var idx = (int)Math.Round(i * (segs.Count - 1) / (double)(n - 1));
+            var idx = (int)Math.Round(i * (segs.Count - 1.0) / (n - 1));
             indices.Add(idx);
         }
         return indices.Select(i => segs[i].MessageId).ToList();

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -192,8 +192,9 @@ public class PreflightOrchestrator(
                 .FirstOrDefaultAsync(ct).ConfigureAwait(false);
             if (historyId is null) return;
 
+            var completedHistoryId = historyId.Value;
             var davItem = await ctx.Items.AsNoTracking()
-                .Where(x => x.HistoryItemId == historyId.Value
+                .Where(x => x.HistoryItemId == completedHistoryId
                             && x.Type == DavItem.ItemType.UsenetFile
                             && x.SubType == DavItem.ItemSubType.MultipartFile)
                 .OrderByDescending(x => x.FileSize ?? 0)

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -43,7 +43,10 @@ public class PreflightOrchestrator(
             {
                 prepared = await PreflightAsync(mode, candidates, session.Token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException)
+            {
+                // Preflight cancelled: session ended or was superseded.
+            }
             catch (Exception e)
             {
                 Log.Debug(e, "Preflight failed for {Type}/{Id}", type, id);

--- a/backend/Services/PreflightSessionRegistry.cs
+++ b/backend/Services/PreflightSessionRegistry.cs
@@ -13,7 +13,11 @@ public class PreflightSessionRegistry
         var prior = _sessions.AddOrUpdate(key, _ => cts, (_, _) => cts);
         if (!ReferenceEquals(prior, cts))
         {
-            try { prior.Cancel(); } catch (ObjectDisposedException) { }
+            try { prior.Cancel(); }
+            catch (ObjectDisposedException)
+            {
+                // A completed session may race the swap and already be disposed.
+            }
             prior.Dispose();
         }
         return new Session(this, key, cts);
@@ -33,7 +37,11 @@ public class PreflightSessionRegistry
         var key = MakeKey(profileToken, type, id);
         if (_sessions.TryGetValue(key, out var cts))
         {
-            try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            try { cts.Cancel(); }
+            catch (ObjectDisposedException)
+            {
+                // Session completed and disposed between the lookup and Cancel.
+            }
         }
     }
 

--- a/backend/Services/SearchExcludeSyncService.cs
+++ b/backend/Services/SearchExcludeSyncService.cs
@@ -234,8 +234,8 @@ public sealed class SearchExcludeSyncService : BackgroundService
             && root.TryGetProperty("values", out var values)
             && values.ValueKind == JsonValueKind.Array)
         {
-            foreach (var el in values.EnumerateArray())
-                if (el.ValueKind == JsonValueKind.String) items.Add(el.GetString()!);
+            foreach (var el in values.EnumerateArray().Where(el => el.ValueKind == JsonValueKind.String))
+                items.Add(el.GetString()!);
             return items;
         }
 

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -857,10 +857,8 @@ public class SearchProfileService(
         void AddAll(string? raw)
         {
             if (string.IsNullOrWhiteSpace(raw)) return;
-            foreach (var part in raw.Split(','))
+            foreach (var v in raw.Split(',').Select(part => part.Trim()).Where(v => v.Length > 0))
             {
-                var v = part.Trim();
-                if (v.Length == 0) continue;
                 if (seen.Add(v)) result.Add(v);
             }
         }

--- a/backend/Services/UsenetFileToBlobstoreMigrationService.cs
+++ b/backend/Services/UsenetFileToBlobstoreMigrationService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Websocket;
 using Serilog;
 
@@ -111,7 +112,7 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
                     throw;
                 }
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCancellationException(ct))
             {
                 Log.Error(e, $"Error migrating usenet-file to blob-store: {e.Message}");
                 await Task.Delay(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -231,7 +231,10 @@ public partial class WardenBackupService : BackgroundService
                 return msg.Length > 120 ? msg[..120] : msg;
             }
         }
-        catch { }
+        catch
+        {
+            // Body isn't GitHub's JSON error shape; fall back to the reason phrase.
+        }
         return resp.ReasonPhrase ?? "request failed";
     }
 

--- a/backend/Services/WardenStore.cs
+++ b/backend/Services/WardenStore.cs
@@ -486,10 +486,11 @@ public partial class WardenStore
         {
             var providers = _configManager.GetUsenetProviderConfig().Providers;
             var set = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var p in providers)
+            foreach (var bk in providers
+                         .Select(p => WardenFingerprint.Backbone(p.Host))
+                         .Where(bk => bk != "unknown"))
             {
-                var bk = WardenFingerprint.Backbone(p.Host);
-                if (bk != "unknown") set.Add(bk);
+                set.Add(bk);
             }
             return set.Count == 0 ? new[] { "unknown" } : set.ToArray();
         }
@@ -621,9 +622,8 @@ public partial class WardenStore
                 cmd.Parameters.Add(pT);
                 cmd.Parameters.Add(pN);
                 cmd.Parameters.Add(pBk);
-                foreach (var r in model.Entries)
+                foreach (var r in model.Entries.Where(r => IsValidFp(r.Fp)))
                 {
-                    if (!IsValidFp(r.Fp)) continue;
                     pFp.Value = r.Fp;
                     pT.Value = r.DeadAt;
                     pN.Value = r.Count <= 0 ? 1 : r.Count;
@@ -645,8 +645,8 @@ public partial class WardenStore
     private static string MergeBackbones(string existingCsv, IEnumerable<string> add)
     {
         var set = new HashSet<string>(SplitBackbones(existingCsv), StringComparer.Ordinal);
-        foreach (var b in add)
-            if (!string.IsNullOrWhiteSpace(b)) set.Add(b);
+        foreach (var b in add.Where(b => !string.IsNullOrWhiteSpace(b)))
+            set.Add(b);
         return set.Count == 0 ? "unknown" : string.Join(",", set);
     }
 
@@ -666,10 +666,10 @@ public partial class WardenStore
     private static bool BackboneInScope(string entryCsv, HashSet<string> mine)
     {
         var known = false;
-        foreach (var b in SplitBackbones(entryCsv))
+        foreach (var rb in SplitBackbones(entryCsv)
+                     .Select(b => WardenFingerprint.RootDomain(b))
+                     .Where(rb => rb != "unknown"))
         {
-            var rb = WardenFingerprint.RootDomain(b);
-            if (rb == "unknown") continue;
             known = true;
             if (mine.Contains(rb)) return true;
         }

--- a/backend/Services/Watchtower/EpisodeEnumerator.cs
+++ b/backend/Services/Watchtower/EpisodeEnumerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.Json;
+using NzbWebDAV.Extensions;
 using Serilog;
 
 namespace NzbWebDAV.Services;
@@ -83,7 +84,7 @@ public class EpisodeEnumerator
             result.Sort(static (a, b) => a.Number.CompareTo(b.Number));
             return result;
         }
-        catch (Exception e)
+        catch (Exception e) when (!e.IsCancellationException(ct))
         {
             Log.Debug(e, "EpisodeEnumerator: Kitsu episode fetch failed for {Id}", kitsuId);
             return Array.Empty<Episode>();
@@ -123,7 +124,7 @@ public class EpisodeEnumerator
             result.Sort(static (a, b) => a.Season != b.Season ? a.Season.CompareTo(b.Season) : a.Number.CompareTo(b.Number));
             return result;
         }
-        catch (Exception e)
+        catch (Exception e) when (!e.IsCancellationException(ct))
         {
             Log.Debug(e, "EpisodeEnumerator: TVmaze episode fetch failed for {Imdb}", imdb);
             return Array.Empty<Episode>();

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -211,7 +212,7 @@ public class ListSourceEnumerator
     private static JsonDocument ParseOrThrow(string json)
     {
         try { return JsonDocument.Parse(json); }
-        catch (Exception e) { throw new InvalidOperationException("The addon response was not valid JSON.", e); }
+        catch (Exception e) when (!e.IsCancellationException()) { throw new InvalidOperationException("The addon response was not valid JSON.", e); }
     }
 
     public sealed class CatalogChoice
@@ -285,7 +286,7 @@ public class ListSourceEnumerator
                 }
             }
         }
-        catch
+        catch (Exception e) when (!e.IsCancellationException())
         {
             // Malformed list payload; yield whatever refs parsed before the failure.
         }

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -287,6 +287,7 @@ public class ListSourceEnumerator
         }
         catch
         {
+            // Malformed list payload; yield whatever refs parsed before the failure.
         }
         return refs;
     }

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -245,10 +245,10 @@ public class ListSourceEnumerator
         }
 
         var refs = new List<WtContentRef>();
-        foreach (var raw in body.Split('\n'))
+        foreach (var line in body.Split('\n')
+                     .Select(raw => raw.Trim())
+                     .Where(line => line.Length > 0 && !line.StartsWith("#")))
         {
-            var line = raw.Trim();
-            if (line.Length == 0 || line.StartsWith("#")) continue;
             var (type, id) = SplitTypeId(line);
             if (id.Length == 0) continue;
             refs.Add(new WtContentRef { Type = type, ContentId = id });

--- a/backend/Services/Watchtower/WatchtowerModels.cs
+++ b/backend/Services/Watchtower/WatchtowerModels.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Services;
 
@@ -33,7 +34,7 @@ public static class WtJson
     {
         if (string.IsNullOrWhiteSpace(json)) return new List<WtPointer>();
         try { return JsonSerializer.Deserialize<List<WtPointer>>(json, Opts) ?? new List<WtPointer>(); }
-        catch { return new List<WtPointer>(); }
+        catch (Exception e) when (!e.IsCancellationException()) { return new List<WtPointer>(); }
     }
 
     public static string WritePointers(IEnumerable<WtPointer> pointers)
@@ -43,7 +44,7 @@ public static class WtJson
     {
         if (string.IsNullOrWhiteSpace(json)) return new List<string>();
         try { return JsonSerializer.Deserialize<List<string>>(json, Opts) ?? new List<string>(); }
-        catch { return new List<string>(); }
+        catch (Exception e) when (!e.IsCancellationException()) { return new List<string>(); }
     }
 
     public static string WriteStrings(IEnumerable<string> values)

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -232,9 +232,8 @@ public class WatchtowerService(
         var srcId = source.Id.ToString();
 
         var yielded = new Dictionary<string, WtContentRef>();
-        foreach (var r in refs)
+        foreach (var r in refs.Where(r => !string.IsNullOrWhiteSpace(r.Type) && !string.IsNullOrWhiteSpace(r.ContentId)))
         {
-            if (string.IsNullOrWhiteSpace(r.Type) || string.IsNullOrWhiteSpace(r.ContentId)) continue;
             yielded[$"{r.Type}:{r.ContentId}"] = r;
         }
 
@@ -304,9 +303,9 @@ public class WatchtowerService(
         }
 
         var staleIds = new List<Guid>();
-        foreach (var c in cascaded ? await LoadClaimedAsync().ConfigureAwait(false) : claimed)
+        foreach (var c in (cascaded ? await LoadClaimedAsync().ConfigureAwait(false) : claimed)
+                     .Where(c => !yielded.ContainsKey(c.Key)))
         {
-            if (yielded.ContainsKey(c.Key)) continue;
             var prov = WtJson.ReadStrings(c.Provenance);
             prov.Remove(srcId);
             if (prov.Count == 0)
@@ -582,9 +581,8 @@ public class WatchtowerService(
             .ToListAsync(ct).ConfigureAwait(false);
 
         var seasons = new HashSet<int>();
-        foreach (var id in ids)
+        foreach (var parts in ids.Select(id => id.Split(':')))
         {
-            var parts = id.Split(':');
             if (parts.Length >= 2 && int.TryParse(parts[^1], out var s)) seasons.Add(s);
         }
         return seasons;
@@ -1001,9 +999,8 @@ public class WatchtowerService(
             .ToListAsync(ct).ConfigureAwait(false);
 
         var maxSeason = season;
-        foreach (var id in ids)
+        foreach (var parts in ids.Select(id => id.Split(':')))
         {
-            var parts = id.Split(':');
             if (parts.Length >= 2 && int.TryParse(parts[^1], out var s) && s > maxSeason) maxSeason = s;
         }
 

--- a/backend/Streams/AesDecoderStream.cs
+++ b/backend/Streams/AesDecoderStream.cs
@@ -8,7 +8,7 @@ namespace NzbWebDAV.Streams
     internal sealed class AesDecoderStream : FastReadOnlyStream
     {
         private readonly Stream _mStream;
-        private Aes _aes; // keep Aes alive for transform lifetime
+        private readonly Aes _aes; // keep Aes alive for transform lifetime
         private ICryptoTransform _mDecoder;
         private readonly byte[] _plainBuffer; // decrypted bytes cache
         private int _plainStart;

--- a/backend/Tasks/DatabaseBackupTask.cs
+++ b/backend/Tasks/DatabaseBackupTask.cs
@@ -44,18 +44,18 @@ public class DatabaseBackupTask(
 
             await DumpIfExistsAsync(
                 DavDatabaseContext.DatabaseFilePath,
-                Path.Combine(stagingPath, DatabaseBackupStore.DbSqlName),
+                Path.Join(stagingPath, DatabaseBackupStore.DbSqlName),
                 "main database").ConfigureAwait(false);
 
             await DumpIfExistsAsync(
                 MetricsDbContext.DatabaseFilePath,
-                Path.Combine(stagingPath, DatabaseBackupStore.MetricsSqlName),
+                Path.Join(stagingPath, DatabaseBackupStore.MetricsSqlName),
                 "metrics database").ConfigureAwait(false);
 
-            var wardenPath = Path.Combine(DavDatabaseContext.ConfigPath, "warden.db");
+            var wardenPath = Path.Join(DavDatabaseContext.ConfigPath, "warden.db");
             await DumpIfExistsAsync(
                 wardenPath,
-                Path.Combine(stagingPath, DatabaseBackupStore.WardenSqlName),
+                Path.Join(stagingPath, DatabaseBackupStore.WardenSqlName),
                 "warden database").ConfigureAwait(false);
 
             var lastMigration = await ReadLastMainMigrationAsync().ConfigureAwait(false);

--- a/backend/Tasks/DatabaseRestoreStageTask.cs
+++ b/backend/Tasks/DatabaseRestoreStageTask.cs
@@ -35,7 +35,7 @@ public class DatabaseRestoreStageTask(
             var manifest = store.Get(backupId)
                 ?? throw new FileNotFoundException($"Backup not found: {backupId}");
             var backupDir = store.GetBackupDirectory(backupId);
-            var dbSql = Path.Combine(backupDir, DatabaseBackupStore.DbSqlName);
+            var dbSql = Path.Join(backupDir, DatabaseBackupStore.DbSqlName);
             if (!File.Exists(dbSql))
                 throw new InvalidOperationException("Backup is missing db.sql and cannot be restored.");
 
@@ -56,22 +56,22 @@ public class DatabaseRestoreStageTask(
             var stagedFiles = new List<string>();
 
             await ImportOptionalAsync(
-                Path.Combine(backupDir, DatabaseBackupStore.DbSqlName),
-                Path.Combine(store.RestoreStagingRoot, "db.sqlite"),
+                Path.Join(backupDir, DatabaseBackupStore.DbSqlName),
+                Path.Join(store.RestoreStagingRoot, "db.sqlite"),
                 requireMigrationsHistory: true,
                 "main database",
                 stagedFiles).ConfigureAwait(false);
 
             await ImportOptionalAsync(
-                Path.Combine(backupDir, DatabaseBackupStore.MetricsSqlName),
-                Path.Combine(store.RestoreStagingRoot, "metrics.sqlite"),
+                Path.Join(backupDir, DatabaseBackupStore.MetricsSqlName),
+                Path.Join(store.RestoreStagingRoot, "metrics.sqlite"),
                 requireMigrationsHistory: false,
                 "metrics database",
                 stagedFiles).ConfigureAwait(false);
 
             await ImportOptionalAsync(
-                Path.Combine(backupDir, DatabaseBackupStore.WardenSqlName),
-                Path.Combine(store.RestoreStagingRoot, "warden.db"),
+                Path.Join(backupDir, DatabaseBackupStore.WardenSqlName),
+                Path.Join(store.RestoreStagingRoot, "warden.db"),
                 requireMigrationsHistory: false,
                 "warden database",
                 stagedFiles).ConfigureAwait(false);

--- a/backend/UsenetMigration/Nzb/GoXmlEscaper.cs
+++ b/backend/UsenetMigration/Nzb/GoXmlEscaper.cs
@@ -43,7 +43,7 @@ public static class GoXmlEscaper
                     break;
                 default:
                     if (IsInCharacterRange(rune.Value))
-                        sb.Append(rune.ToString());
+                        sb.Append(rune);
                     else
                         sb.Append('�');
                     break;

--- a/backend/UsenetMigration/Runner/AltmountScanRunner.cs
+++ b/backend/UsenetMigration/Runner/AltmountScanRunner.cs
@@ -433,9 +433,8 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
         foreach (var (storeRef, list) in findings)
         {
             if (!byStoreRef.TryGetValue(storeRef, out var p)) continue;
-            foreach (var f in list)
-                if (!p.BaseReasons.Contains(f.Reason))
-                    p.BaseReasons.Add(f.Reason);
+            foreach (var f in list.Where(f => !p.BaseReasons.Contains(f.Reason)))
+                p.BaseReasons.Add(f.Reason);
         }
     }
 
@@ -619,17 +618,15 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
 
     private static DateTime? DeriveReleaseDate(IReadOnlyList<AltmountFileMetadata> metas)
     {
-        foreach (var m in metas)
-            if (m.ReleaseDate > 0)
-                return DateTimeOffset.FromUnixTimeSeconds(m.ReleaseDate).UtcDateTime;
+        foreach (var m in metas.Where(m => m.ReleaseDate > 0))
+            return DateTimeOffset.FromUnixTimeSeconds(m.ReleaseDate).UtcDateTime;
         return null;
     }
 
     private static string? DeriveEncryption(IReadOnlyList<AltmountFileMetadata> metas)
     {
-        foreach (var m in metas)
-            if (m.Encryption != AltmountEncryption.None)
-                return EncryptionHeadInjector.EncryptionToString(m.Encryption);
+        foreach (var m in metas.Where(m => m.Encryption != AltmountEncryption.None))
+            return EncryptionHeadInjector.EncryptionToString(m.Encryption);
         return null;
     }
 

--- a/backend/UsenetMigration/Runner/CollisionRecomputer.cs
+++ b/backend/UsenetMigration/Runner/CollisionRecomputer.cs
@@ -68,9 +68,8 @@ public sealed class CollisionRecomputer(UsenetMigrationStore store)
             foreach (var (storeRef, list) in findings)
             {
                 if (!merged.TryGetValue(storeRef, out var reasons)) continue;
-                foreach (var f in list)
-                    if (!reasons.Contains(f.Reason))
-                        reasons.Add(f.Reason);
+                foreach (var f in list.Where(f => !reasons.Contains(f.Reason)))
+                    reasons.Add(f.Reason);
             }
         }
 

--- a/backend/UsenetMigration/Runner/StoreLocator.cs
+++ b/backend/UsenetMigration/Runner/StoreLocator.cs
@@ -60,7 +60,7 @@ public static class StoreLocator
             return null;
 
         var suffix = normalised[(idx + 1)..].Replace('/', Path.DirectorySeparatorChar);
-        var candidate = Path.Combine(storeRoot, suffix);
+        var candidate = Path.Join(storeRoot, suffix);
         return File.Exists(candidate) ? candidate : null;
     }
 

--- a/backend/UsenetMigration/Source/AltmountPathDetector.cs
+++ b/backend/UsenetMigration/Source/AltmountPathDetector.cs
@@ -52,8 +52,8 @@ public static class AltmountPathDetector
             throw new ArgumentException("root cannot be the filesystem root.", nameof(root));
         }
 
-        var metadataRoot = Path.Combine(storeRoot, "metadata");
-        var configPath = Path.Combine(storeRoot, "config.yaml");
+        var metadataRoot = Path.Join(storeRoot, "metadata");
+        var configPath = Path.Join(storeRoot, "config.yaml");
 
         // This detector is reached through the API-key-guarded migration controller. A fixed
         // prefix would break supported custom bind mounts, and Advanced Connect already accepts

--- a/backend/UsenetMigration/Source/CategorySanitizer.cs
+++ b/backend/UsenetMigration/Source/CategorySanitizer.cs
@@ -17,10 +17,9 @@ public static class CategorySanitizer
         if (string.IsNullOrEmpty(category)) return "";
 
         var s = category.Replace('\\', '/').Trim('/');
-        foreach (var part in s.Split('/'))
+        foreach (var part in s.Split('/').Where(part => part is ".." or "."))
         {
-            if (part is ".." or ".")
-                return "";
+            return "";
         }
 
         return s;

--- a/backend/UsenetMigration/Source/MetadataTreeWalker.cs
+++ b/backend/UsenetMigration/Source/MetadataTreeWalker.cs
@@ -44,12 +44,10 @@ public static class MetadataTreeWalker
             }
 
             Array.Sort(subdirs, StringComparer.Ordinal);
-            foreach (var sub in subdirs)
+            // Do not recurse into directory symlinks (cycle / escape risk).
+            foreach (var sub in subdirs.Where(sub =>
+                         !IsExcludedDir(sub) && Directory.ResolveLinkTarget(sub, returnFinalTarget: false) is null))
             {
-                if (IsExcludedDir(sub)) continue;
-                // Do not recurse into directory symlinks (cycle / escape risk).
-                if (Directory.ResolveLinkTarget(sub, returnFinalTarget: false) is not null)
-                    continue;
                 stack.Push(sub);
             }
 
@@ -65,11 +63,9 @@ public static class MetadataTreeWalker
             }
 
             Array.Sort(files, StringComparer.Ordinal);
-            foreach (var file in files)
+            // Skip .meta entries that are themselves symlinks (e.g. .ids shards).
+            foreach (var file in files.Where(file => File.ResolveLinkTarget(file, returnFinalTarget: false) is null))
             {
-                // Skip .meta entries that are themselves symlinks (e.g. .ids shards).
-                if (File.ResolveLinkTarget(file, returnFinalTarget: false) is not null)
-                    continue;
                 yield return file;
             }
         }

--- a/backend/UsenetMigration/Source/StorePathParser.cs
+++ b/backend/UsenetMigration/Source/StorePathParser.cs
@@ -111,10 +111,9 @@ public static class StorePathParser
         if (dash <= 0) return (null, storeBasename);
 
         var left = storeBasename[..dash];
-        foreach (var c in left)
+        foreach (var c in left.Where(c => c is < '0' or > '9'))
         {
-            if (c is < '0' or > '9')
-                return (null, storeBasename);
+            return (null, storeBasename);
         }
 
         if (!long.TryParse(left, out var queueId))

--- a/backend/UsenetMigration/Symlinks/SymlinkOps.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkOps.cs
@@ -254,7 +254,7 @@ internal static class SymlinkPathGuard
                          [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
                          StringSplitOptions.RemoveEmptyEntries))
             {
-                current = Path.Combine(current, segment);
+                current = Path.Join(current, segment);
                 EnsureRealDirectory(current, "Symlink parent directory");
             }
         }

--- a/backend/UsenetMigration/Symlinks/SymlinkOrphanRemover.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkOrphanRemover.cs
@@ -163,9 +163,9 @@ public sealed class SymlinkOrphanRemover(UsenetMigrationStore store)
     private static string BuildBackupPath(string backupDir, DateTime createdAt, string archivePrefix)
     {
         var stem = $"{archivePrefix}{createdAt:yyyyMMdd-HHmmss}";
-        var path = Path.Combine(backupDir, $"{stem}.tar.gz");
+        var path = Path.Join(backupDir, $"{stem}.tar.gz");
         for (var suffix = 2; File.Exists(path); suffix++)
-            path = Path.Combine(backupDir, $"{stem}-{suffix}.tar.gz");
+            path = Path.Join(backupDir, $"{stem}-{suffix}.tar.gz");
         return path;
     }
 

--- a/backend/UsenetMigration/Symlinks/SymlinkPlanner.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkPlanner.cs
@@ -348,9 +348,9 @@ public sealed class SymlinkPlanner(UsenetMigrationStore store, ConfigManager con
                 }
             }
 
-            foreach (var unmatched in matches.Where(m => m.DavItemId == null))
+            foreach (var rf in matches.Where(m => m.DavItemId == null)
+                         .Select(unmatched => releaseFiles.First(f => f.Id == unmatched.ReleaseFileId)))
             {
-                var rf = releaseFiles.First(f => f.Id == unmatched.ReleaseFileId);
                 Log.Warning(
                     "Unable to match Altmount file {VirtualPath} using normalized name {NormalizedName} " +
                     "and size {FileSize}. Available leaves: {Leaves}",

--- a/backend/UsenetMigration/Symlinks/SymlinkRestoreService.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkRestoreService.cs
@@ -288,7 +288,7 @@ public sealed class SymlinkRestoreService(UsenetMigrationStore store)
             throw new InvalidDataException("The selected symlink restore archive name is invalid.");
 
         var root = Path.GetFullPath(backupDir);
-        var path = Path.GetFullPath(Path.Combine(root, fileName));
+        var path = Path.GetFullPath(Path.Join(root, fileName));
         if (!IsWithinRoot(root, path))
             throw new InvalidDataException("The selected symlink restore archive is outside the configured backup directory.");
         return path;

--- a/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
@@ -242,9 +242,9 @@ public sealed class SymlinkRewriter(UsenetMigrationStore store, ConfigManager co
     private static string BuildBackupPath(string backupDir, DateTime createdAt, string archivePrefix)
     {
         var stem = $"{archivePrefix}{createdAt:yyyyMMdd-HHmmss}";
-        var path = Path.Combine(backupDir, $"{stem}.tar.gz");
+        var path = Path.Join(backupDir, $"{stem}.tar.gz");
         for (var suffix = 2; File.Exists(path); suffix++)
-            path = Path.Combine(backupDir, $"{stem}-{suffix}.tar.gz");
+            path = Path.Join(backupDir, $"{stem}-{suffix}.tar.gz");
         return path;
     }
 

--- a/backend/UsenetMigration/Triage/CollisionDetector.cs
+++ b/backend/UsenetMigration/Triage/CollisionDetector.cs
@@ -67,9 +67,8 @@ public static class CollisionDetector
         var groups = candidates
             .GroupBy(c => (c.TargetCategory, c.JobName));
 
-        foreach (var group in groups)
+        foreach (var members in groups.Select(group => group.ToList()))
         {
-            var members = group.ToList();
             var redStoreRefs = new HashSet<string>(StringComparer.Ordinal);
 
             // Pass 1 (Red): a QueueFileName shared by ≥2 stores evicts silently.
@@ -98,9 +97,8 @@ public static class CollisionDetector
             // Pass 2 (Amber): multiple distinct QueueFileNames sharing one JobName.
             if (distinctQueueKeys > 1)
             {
-                foreach (var member in members)
+                foreach (var member in members.Where(member => !redStoreRefs.Contains(member.StoreRef)))
                 {
-                    if (redStoreRefs.Contains(member.StoreRef)) continue;
                     FindingsFor(member.StoreRef).Add(new CollisionFinding
                     {
                         Reason = VerdictReason.MountFolderCollision,

--- a/backend/UsenetMigration/Triage/Verdict.cs
+++ b/backend/UsenetMigration/Triage/Verdict.cs
@@ -132,9 +132,8 @@ public static class VerdictReason
     public static Verdict VerdictFor(IEnumerable<string> reasons)
     {
         var worst = Verdict.Green;
-        foreach (var r in reasons)
+        foreach (var s in reasons.Select(SeverityOf))
         {
-            var s = SeverityOf(r);
             if (s > worst) worst = s;
         }
 

--- a/backend/Utils/FilenameMatcher.cs
+++ b/backend/Utils/FilenameMatcher.cs
@@ -32,10 +32,8 @@ public static class FilenameMatcher
     {
         var decomposed = s.ToLowerInvariant().Normalize(NormalizationForm.FormD);
         var sb = new StringBuilder(decomposed.Length);
-        foreach (var c in decomposed)
+        foreach (var c in decomposed.Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark))
         {
-            if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
-                continue;
             if (LatinFolding.TryGetValue(c, out var rep))
                 sb.Append(rep);
             else

--- a/backend/Utils/ProxyHttpClientPool.cs
+++ b/backend/Utils/ProxyHttpClientPool.cs
@@ -117,12 +117,13 @@ public static class ProxyHttpClientPool
 
     private static void TrySetKeepAliveTuning(Socket socket)
     {
+        // Keep-alive tuning is best-effort; platforms missing an option simply skip it.
         try { socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 30); }
-        catch { }
+        catch { /* unsupported on this platform */ }
         try { socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 5); }
-        catch { }
+        catch { /* unsupported on this platform */ }
         try { socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 3); }
-        catch { }
+        catch { /* unsupported on this platform */ }
     }
 
     private static string? Normalize(string? raw)

--- a/backend/Utils/SubtitlePreference.cs
+++ b/backend/Utils/SubtitlePreference.cs
@@ -116,10 +116,10 @@ public static class SubtitlePreference
         var result = new HashSet<string>(StringComparer.Ordinal);
         if (string.IsNullOrWhiteSpace(value)) return result;
 
-        foreach (var raw in value.Split(Separators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        foreach (var token in value.Split(Separators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                     .Select(Fold)
+                     .Where(token => token.Length > 0))
         {
-            var token = Fold(raw);
-            if (token.Length == 0) continue;
             result.Add(LanguageAliases.TryGetValue(token, out var canonical) ? canonical : token);
         }
         return result;
@@ -153,10 +153,10 @@ public static class SubtitlePreference
     {
         var decomposed = s.ToLowerInvariant().Normalize(NormalizationForm.FormD);
         var sb = new StringBuilder(decomposed.Length);
-        foreach (var c in decomposed)
+        foreach (var c in decomposed.Where(c =>
+                     CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark && char.IsLetterOrDigit(c)))
         {
-            if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark) continue;
-            if (char.IsLetterOrDigit(c)) sb.Append(c);
+            sb.Append(c);
         }
         return sb.ToString();
     }

--- a/backend/Utils/TrustedHostsMatcher.cs
+++ b/backend/Utils/TrustedHostsMatcher.cs
@@ -108,10 +108,9 @@ public sealed class TrustedHostsMatcher
         if (_addresses.Contains(address))
             return true;
 
-        foreach (var network in _networks)
+        foreach (var network in _networks.Where(network => network.Contains(address)))
         {
-            if (network.Contains(address))
-                return true;
+            return true;
         }
 
         return false;

--- a/backend/WebDav/Base/BaseStoreCollection.cs
+++ b/backend/WebDav/Base/BaseStoreCollection.cs
@@ -93,16 +93,14 @@ public abstract class BaseStoreCollection : IStoreCollection
         // 1. CreateItemAsync is first called with an empty input stream to create an empty file.
         // 2. CreateItemAsync is then called again with actual input stream and overwrite set to true.
         // 3. If step #2 fails above, DeleteItemAsync is then called to remove the empty file created in step #1.
-        if (existingItem is null)
+        // This handles step #1 in the note above.
+        if (existingItem is null &&
+            SupportsEmptyFileStaging &&
+            await probingStream.IsEmptyAsync().ConfigureAwait(false))
         {
-            // This handles step #1 in the note above.
-            if (SupportsEmptyFileStaging &&
-                await probingStream.IsEmptyAsync().ConfigureAwait(false))
-            {
-                var emptyFile = new BaseStoreEmptyFile(name);
-                EmptyFileManager.Add(emptyFile);
-                return new StoreItemResult(DavStatusCode.Created, emptyFile);
-            }
+            var emptyFile = new BaseStoreEmptyFile(name);
+            EmptyFileManager.Add(emptyFile);
+            return new StoreItemResult(DavStatusCode.Created, emptyFile);
         }
 
         // this handles step #2 in the note above.

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -87,10 +87,9 @@ public class DatabaseStoreCollection(
         // include any missing category folders
         if (isContentFolder)
         {
-            foreach (var category in configManager.GetApiCategories())
+            foreach (var category in configManager.GetApiCategories().Where(category => !childNames!.Contains(category)))
             {
-                if (!childNames!.Contains(category))
-                    yield return new BaseStoreEmptyCollection(category);
+                yield return new BaseStoreEmptyCollection(category);
             }
         }
     }

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -148,19 +148,20 @@ public class DatabaseStoreCollection(
     private async Task PruneEmptyHistoryAsync(Guid? historyItemId, CancellationToken ct)
     {
         if (historyItemId is null) return;
+        var historyId = historyItemId.Value;
         var stillReferenced = await dbClient.Ctx.Items
             .AsNoTracking()
-            .AnyAsync(x => x.HistoryItemId == historyItemId.Value, ct)
+            .AnyAsync(x => x.HistoryItemId == historyId, ct)
             .ConfigureAwait(false);
         if (stillReferenced) return;
 
         var history = await dbClient.Ctx.HistoryItems
-            .FirstOrDefaultAsync(h => h.Id == historyItemId.Value, ct)
+            .FirstOrDefaultAsync(h => h.Id == historyId, ct)
             .ConfigureAwait(false);
         if (history is null) return;
 
         dbClient.Ctx.HistoryItems.Remove(history);
         await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, historyItemId.Value.ToString());
+        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, historyId.ToString());
     }
 }

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -80,11 +80,8 @@ public class DatabaseStoreSymlinkCollection(
 
         if (isSymlinkFolder)
         {
-            foreach (var category in configManager.GetApiCategories())
+            foreach (var category in configManager.GetApiCategories().Where(category => !childNames!.Contains(category)))
             {
-                if (childNames!.Contains(category))
-                    continue;
-
                 var item = new BaseStoreEmptyCollection(category);
                 if (!DeletedFiles.IsDeleted(item.Name))
                     yield return item;

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -208,9 +208,8 @@ public class WebsocketManager
 
             if (root.TryGetProperty("sub", out var subArray) && subArray.ValueKind == JsonValueKind.Array)
             {
-                foreach (var element in subArray.EnumerateArray())
+                foreach (var name in subArray.EnumerateArray().Select(element => element.GetString()))
                 {
-                    var name = element.GetString();
                     if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null
                         && session.AddSubscription(topic))
                     {
@@ -222,9 +221,8 @@ public class WebsocketManager
 
             if (root.TryGetProperty("unsub", out var unsubArray) && unsubArray.ValueKind == JsonValueKind.Array)
             {
-                foreach (var element in unsubArray.EnumerateArray())
+                foreach (var name in unsubArray.EnumerateArray().Select(element => element.GetString()))
                 {
-                    var name = element.GetString();
                     if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null
                         && session.RemoveSubscription(topic))
                     {

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -211,13 +211,11 @@ public class WebsocketManager
                 foreach (var element in subArray.EnumerateArray())
                 {
                     var name = element.GetString();
-                    if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null)
+                    if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null
+                        && session.AddSubscription(topic))
                     {
-                        if (session.AddSubscription(topic))
-                        {
-                            _subscriberCounts.AddOrUpdate(topic, 1, (_, c) => c + 1);
-                            ReplayStateForNewSubscription(session, topic);
-                        }
+                        _subscriberCounts.AddOrUpdate(topic, 1, (_, c) => c + 1);
+                        ReplayStateForNewSubscription(session, topic);
                     }
                 }
             }
@@ -227,10 +225,10 @@ public class WebsocketManager
                 foreach (var element in unsubArray.EnumerateArray())
                 {
                     var name = element.GetString();
-                    if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null)
+                    if (name is not null && WebsocketTopic.TryGetByName(name, out var topic) && topic is not null
+                        && session.RemoveSubscription(topic))
                     {
-                        if (session.RemoveSubscription(topic))
-                            _subscriberCounts.AddOrUpdate(topic, 0, (_, c) => Math.Max(0, c - 1));
+                        _subscriberCounts.AddOrUpdate(topic, 0, (_, c) => Math.Max(0, c - 1));
                     }
                 }
             }

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -61,7 +61,7 @@ export default function Health({ loaderData }: Route.ComponentProps) {
             }
         };
         refetchData();
-    }, [queueItems, setQueueState])
+    }, [queueItems, setQueueState]);
 
     // events
     const onHealthItemStatus = useCallback(async (message: string) => {

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -246,7 +246,7 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                 onConfirm={onConfirmRemoval}
                 onCancel={onCancelRemoval} />
         </>
-    )
+    );
 }
 
 export function Actions({

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -57,7 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         historyPage: historyPage,
         queuePageSize,
         historyPageSize,
-    }
+    };
 }
 
 export default function Queue(props: Route.ComponentProps) {

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -190,7 +190,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
             ...arrConfig,
             QueueRules: newQueueRules
         })
-    }, [arrConfig, updateConfig])
+    }, [arrConfig, updateConfig]);
 
 
     return (

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -9,7 +9,6 @@ import {
     Label,
     ManagedSetting,
     Modal,
-    Select,
     SettingsCard,
     SettingsIntro,
     SettingsPage,

--- a/frontend/app/utils/file-size.ts
+++ b/frontend/app/utils/file-size.ts
@@ -1,6 +1,6 @@
 export function formatFileSize(bytes: number | null | undefined) {
     let suffix = "B";
-    if (bytes === null || bytes === undefined) return "unknown size"
+    if (bytes === null || bytes === undefined) return "unknown size";
     if (bytes >= 1024) { bytes /= 1024; suffix = "KB"; }
     if (bytes >= 1024) { bytes /= 1024; suffix = "MB"; }
     if (bytes >= 1024) { bytes /= 1024; suffix = "GB"; }

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -119,12 +119,12 @@ const setWebsocketServer = (websocketServer: WebSocketServer) => {
   if (_websocketServer != null) return;
   if (_serverModule != null) _serverModule.initializeWebsocketServer(websocketServer);
   _websocketServer = websocketServer;
-}
+};
 const setServerModule = (serverModule: any) => {
   if (_serverModule != null) return;
   if (_websocketServer != null) serverModule.initializeWebsocketServer(_websocketServer);
   _serverModule = serverModule;
-}
+};
 
 // Handle development vs production
 if (DEVELOPMENT) {

--- a/tests/NzbWebDAV.Tests/Api/MoveInQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/MoveInQueueRequestTests.cs
@@ -33,8 +33,9 @@ public class MoveInQueueRequestTests
         var third = Guid.NewGuid();
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString($"?value={first},{second}&value2=0");
-        context.Request.Body = new MemoryStream(
+        using var bodyStream = new MemoryStream(
             System.Text.Encoding.UTF8.GetBytes($$"""{"nzo_ids":["{{third}}"]}"""));
+        context.Request.Body = bodyStream;
         context.Request.ContentType = "application/json";
 
         var request = await MoveInQueueRequest.New(context);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BaseNntpClientStatTests.cs
@@ -119,6 +119,7 @@ public class BaseNntpClientStatTests
             await foreach (var _ in client.StatsPipelinedAsync(
                                ["seg@example"], 8, CancellationToken.None))
             {
+                // Drain the pipeline; the 480 response surfaces as an exception mid-enumeration.
             }
         });
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -131,8 +131,8 @@ public class DownloadingNntpClientStatGateTests
     [Fact]
     public async Task StatAsync_PrimaryQueueContext_AdmittedBeforeSecondaryWaiters()
     {
-        var holdSecondary = new ManualResetEventSlim(false);
-        var holdPrimary = new ManualResetEventSlim(false);
+        using var holdSecondary = new ManualResetEventSlim(false);
+        using var holdPrimary = new ManualResetEventSlim(false);
         var entered = new ConcurrentQueue<string>();
         var fake = new SelectiveBlockingStatNntpClient(
             segmentId =>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -185,7 +185,7 @@ public class NntpClientCheckAllSegmentsTests
             result = item;
 
         Assert.NotNull(result);
-        Assert.False(result.Found);
+        Assert.False(result!.Found);
         Assert.Null(result.Stream);
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -118,7 +118,7 @@ public class NntpClientPipelinedMappingTests
             result = item;
 
         Assert.NotNull(result);
-        Assert.False(result.Found);
+        Assert.False(result!.Found);
         Assert.Null(result.Stream);
         Assert.Equal("expected@example.com", result.SegmentId);
     }
@@ -137,7 +137,7 @@ public class NntpClientPipelinedMappingTests
             result = item;
 
         Assert.NotNull(result);
-        Assert.True(result.Found);
+        Assert.True(result!.Found);
         Assert.NotNull(result.Stream);
         await result.Stream!.DisposeAsync();
     }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
@@ -126,6 +126,7 @@ public class ProviderCircuitBreakerConnectionFailureTests
             await foreach (var _ in client.DecodedBodiesPipelinedAsync(
                                ["segment"], depth: 1, CancellationToken.None))
             {
+                // Drain the pipeline; the unreachable provider surfaces an IOException.
             }
         });
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/StreamingTimeoutTests.cs
@@ -186,6 +186,7 @@ public class StreamingTimeoutTests
             await foreach (var _ in client.DecodedBodiesPipelinedAsync(
                                ["seg"], depth: 1, CancellationToken.None))
             {
+                // Drain the pipeline; touching the retired pool throws mid-enumeration.
             }
         }
 

--- a/tests/NzbWebDAV.Tests/Extensions/WithConcurrencyAsyncCancellationTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/WithConcurrencyAsyncCancellationTests.cs
@@ -16,6 +16,7 @@ public class WithConcurrencyAsyncCancellationTests
         {
             await foreach (var _ in tasks.WithConcurrencyAsync(2, cts.Token).ConfigureAwait(false))
             {
+                // Drain; the pre-cancelled token aborts enumeration before any item arrives.
             }
         });
     }

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -211,7 +211,8 @@ public class ExceptionMiddlewareTests
     {
         var lifetimeFeature = new TestHttpRequestLifetimeFeature();
         var context = CreateContext(hasStarted: false, lifetimeFeature);
-        context.Response.Body = new MemoryStream();
+        using var responseBody = new MemoryStream();
+        context.Response.Body = responseBody;
         var middleware = CreateMiddleware(
             _ => throw new StreamingReadTimeoutException(
                 "WebDAV read exceeded the 5s streaming-read-timeout while waiting for the Usenet backend."));

--- a/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
@@ -114,7 +114,7 @@ public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
     [Fact]
     public async Task ProcessQueueAsync_WithWorkerCountTwo_RunsTwoItemsConcurrently()
     {
-        var gate = new ManualResetEventSlim(false);
+        using var gate = new ManualResetEventSlim(false);
         var item1 = CreateQueueItem("a.nzb", "movies", "JobA");
         var item2 = CreateQueueItem("b.nzb", "movies", "JobB");
 
@@ -173,7 +173,7 @@ public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
     [Fact]
     public async Task ProcessQueueAsync_SkipsSameMountKeyWhileSiblingIsActive()
     {
-        var gate = new ManualResetEventSlim(false);
+        using var gate = new ManualResetEventSlim(false);
         var first = CreateQueueItem("dup1.nzb", "tv", "SameJob");
         var sibling = CreateQueueItem("dup2.nzb", "tv", "SameJob");
         var other = CreateQueueItem("other.nzb", "tv", "OtherJob");
@@ -231,7 +231,7 @@ public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
     [Fact]
     public async Task ProcessQueueAsync_DoesNotSpinAfterAwakenWhileWorkerRuns()
     {
-        var gate = new ManualResetEventSlim(false);
+        using var gate = new ManualResetEventSlim(false);
         var item = CreateQueueItem("spin.nzb", "movies", "SpinJob");
 
         await using (var ctx = new DavDatabaseContext(_options))

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -96,7 +96,7 @@ public class LazyRarProcessorTests
             .ProcessAsync() as LazyRarProcessor.Result;
 
         Assert.NotNull(result);
-        Assert.Equal("movie.mkv", result.PathInArchive);
+        Assert.Equal("movie.mkv", result!.PathInArchive);
         Assert.Equal(uncompressed, result.TotalFileSize);
         Assert.Single(result.PendingParts);
     }
@@ -124,7 +124,7 @@ public class LazyRarProcessorTests
             .ProcessAsync() as LazyRarProcessor.Result;
 
         Assert.NotNull(result);
-        Assert.True(result.FirstPart.SegmentIdByteRange.Contains(result.FirstPart.FilePartByteRange));
+        Assert.True(result!.FirstPart.SegmentIdByteRange.Contains(result.FirstPart.FilePartByteRange));
         Assert.Equal(result.FirstPart.FilePartByteRange.EndExclusive, result.FirstPart.SegmentIdByteRange.Count);
         Assert.True(result.FirstPart.SegmentIdByteRange.Count > underestimatedSize);
     }

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -97,8 +97,8 @@ public class LazyRarProcessorTests
 
         Assert.NotNull(result);
         Assert.Equal("movie.mkv", result!.PathInArchive);
-        Assert.Equal(uncompressed, result.TotalFileSize);
-        Assert.Single(result.PendingParts);
+        Assert.Equal(uncompressed, result!.TotalFileSize);
+        Assert.Single(result!.PendingParts);
     }
 
     [Fact]
@@ -124,9 +124,9 @@ public class LazyRarProcessorTests
             .ProcessAsync() as LazyRarProcessor.Result;
 
         Assert.NotNull(result);
-        Assert.True(result!.FirstPart.SegmentIdByteRange.Contains(result.FirstPart.FilePartByteRange));
-        Assert.Equal(result.FirstPart.FilePartByteRange.EndExclusive, result.FirstPart.SegmentIdByteRange.Count);
-        Assert.True(result.FirstPart.SegmentIdByteRange.Count > underestimatedSize);
+        Assert.True(result!.FirstPart.SegmentIdByteRange.Contains(result!.FirstPart.FilePartByteRange));
+        Assert.Equal(result!.FirstPart.FilePartByteRange.EndExclusive, result!.FirstPart.SegmentIdByteRange.Count);
+        Assert.True(result!.FirstPart.SegmentIdByteRange.Count > underestimatedSize);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Diagnostics/RuntimeUsageTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Diagnostics/RuntimeUsageTrackerTests.cs
@@ -81,7 +81,7 @@ public class RuntimeUsageTrackerTests
 
         Record(tracker, cpuMs: 20000, wallMs: 5000, at: busyAt); // every core pegged
         for (var i = 1; i <= RuntimeUsageTracker.WindowSampleCount; i++)
-            Record(tracker, cpuMs: 0, wallMs: 5000, at: Origin.AddSeconds(5 * i));
+            Record(tracker, cpuMs: 0, wallMs: 5000, at: Origin.AddSeconds(5.0 * i));
 
         var snapshot = tracker.Snapshot();
 

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -160,8 +160,8 @@ public class StreamTraceBufferTests
         var opens = events.Where(e => e.Kind == StreamTraceKind.RangeOpen.ToString()).ToList();
         var ends = events.Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString()).ToList();
 
-        Assert.Equal(first.Value.Generation, opens[0].RangeGeneration);
-        Assert.Equal(second.Value.Generation, opens[1].RangeGeneration);
+        Assert.Equal(first!.Value.Generation, opens[0].RangeGeneration);
+        Assert.Equal(second!.Value.Generation, opens[1].RangeGeneration);
         Assert.Equal(second.Value.Generation, ends[0].RangeGeneration);
         Assert.Equal(90, ends[0].ProviderWaitMs);
         Assert.Equal(first.Value.Generation, ends[1].RangeGeneration);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -434,7 +434,7 @@ public sealed class SupportPackContentsTests : IDisposable
                 TimeSpan.FromMilliseconds(10),
                 TimeSpan.FromSeconds(5),
                 activeReads: 1,
-                at.AddSeconds(5 * i));
+                at.AddSeconds(5.0 * i));
         }
 
         var entries = await ReadPackEntriesAsync(

--- a/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
@@ -76,7 +76,11 @@ public class BasicStreamTests
             EncryptedPartContext() with { IsEncrypted = false });
 
         var failure = await Assert.ThrowsAsync<IncompleteMultipartPartException>(
-            () => stream.CopyToAsync(new MemoryStream()));
+            () =>
+            {
+                using var destination = new MemoryStream();
+                return stream.CopyToAsync(destination);
+            });
 
         Assert.Contains("ended 3 bytes early", failure.Message, StringComparison.Ordinal);
         Assert.Contains("delivered 2 of 5 expected bytes", failure.Message, StringComparison.Ordinal);
@@ -93,7 +97,11 @@ public class BasicStreamTests
             EncryptedPartContext());
 
         var failure = await Assert.ThrowsAsync<IncompleteMultipartPartException>(
-            () => stream.CopyToAsync(new MemoryStream()));
+            () =>
+            {
+                using var destination = new MemoryStream();
+                return stream.CopyToAsync(destination);
+            });
 
         Assert.Contains("ended 1022 bytes early", failure.Message, StringComparison.Ordinal);
         Assert.Contains("encrypted: True", failure.Message, StringComparison.Ordinal);
@@ -106,7 +114,11 @@ public class BasicStreamTests
             new MemoryStream(Encoding.ASCII.GetBytes("ab")), 5, "part-1", "test.bin");
 
         await Assert.ThrowsAsync<IncompleteMultipartPartException>(
-            () => stream.CopyToAsync(new MemoryStream()));
+            () =>
+            {
+                using var destination = new MemoryStream();
+                return stream.CopyToAsync(destination);
+            });
     }
 
     private static MultipartPartContext EncryptedPartContext() => new()

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
@@ -52,6 +52,7 @@ public class MultiSegmentStreamAdaptiveWidthTests
         await foreach (var _ in ConsumeWithStarvationLockstepAsync(
             stream, client, buffer, segmentCount, readinessSamples, widthSamples))
         {
+            // Drain to completion; readiness/width samples are collected by the consumer.
         }
 
         // Production reported starvation at every boundary: the consumer always arrived
@@ -164,6 +165,7 @@ public class MultiSegmentStreamAdaptiveWidthTests
         var buffer = new byte[segmentSize];
         while (await stream.ReadAsync(buffer) > 0)
         {
+            // Discard bytes; draining completes lease/batch accounting for the asserts.
         }
 
         Assert.True(budget.LeasedBytes <= budget.CapBytes);

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
@@ -183,7 +183,7 @@ public class MultiSegmentStreamAdaptiveWidthTests
             client, segmentCount, articleBufferSize, segmentSize);
 
         var buffer = new byte[segmentSize];
-        var actual = new MemoryStream();
+        using var actual = new MemoryStream();
 
         // Starve to force 4→2→1, then release ahead to recover toward 4.
         await foreach (var n in ConsumeWithStarvationLockstepAsync(stream, client, buffer, 40))

--- a/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
@@ -97,7 +97,11 @@ public class SegmentFallbackTests
             exactSegmentSizes: Enumerable.Repeat(5L, segmentIds.Length).ToArray());
 
         await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
-            async () => await stream.CopyToAsync(new MemoryStream()));
+            () =>
+            {
+                using var destination = new MemoryStream();
+                return stream.CopyToAsync(destination);
+            });
         await Task.Delay(50);
 
         Assert.True(

--- a/tests/NzbWebDAV.Tests/Utils/ExcludePatternParserTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ExcludePatternParserTests.cs
@@ -11,7 +11,7 @@ public class ExcludePatternParserTests
         var parsed = ExcludePatternParser.Parse(@"\.iso$");
         Assert.NotNull(parsed);
         Assert.Matches(parsed!.Value.Regex, "FILE.ISO");
-        Assert.DoesNotMatch(parsed.Value.Regex, "FILE.mkv");
+        Assert.DoesNotMatch(parsed!.Value.Regex, "FILE.mkv");
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class ExcludePatternParserTests
         Assert.NotNull(bare);
         Assert.NotNull(wrapped);
         Assert.Equal(bare!.Value.Key, wrapped!.Value.Key);
-        Assert.Matches(wrapped.Value.Regex, "Movie.ISO");
+        Assert.Matches(wrapped!.Value.Regex, "Movie.ISO");
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class ExcludePatternParserTests
         Assert.NotNull(ms);
         Assert.NotNull(sm);
         Assert.Equal(ms!.Value.Key, sm!.Value.Key);
-        Assert.True((ms.Value.Regex.Options & RegexOptions.Multiline) != 0);
+        Assert.True((ms!.Value.Regex.Options & RegexOptions.Multiline) != 0);
         Assert.True((ms.Value.Regex.Options & RegexOptions.Singleline) != 0);
     }
 
@@ -54,6 +54,6 @@ public class ExcludePatternParserTests
         var parsed = ExcludePatternParser.Parse("/foo/gu");
         Assert.NotNull(parsed);
         Assert.Equal("foo ", parsed!.Value.Key);
-        Assert.Matches(parsed.Value.Regex, "FOO");
+        Assert.Matches(parsed!.Value.Regex, "FOO");
     }
 }

--- a/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
@@ -31,7 +31,7 @@ public class OrganizedLinksUtilTests
         var link = OrganizedLinksUtil.GetDavItemLink(symlink, "/mnt/nzbdav");
 
         Assert.NotNull(link);
-        Assert.Equal(id, link.Value.DavItemId);
+        Assert.Equal(id, link!.Value.DavItemId);
         Assert.Equal("/library/movie.mkv", link.Value.LinkPath);
     }
 
@@ -76,7 +76,7 @@ public class OrganizedLinksUtilTests
         var link = OrganizedLinksUtil.GetDavItemLink(strm);
 
         Assert.NotNull(link);
-        Assert.Equal(id, link.Value.DavItemId);
+        Assert.Equal(id, link!.Value.DavItemId);
         Assert.Equal("/library/movie.strm", link.Value.LinkPath);
     }
 }

--- a/tests/SharpCompress.Tests/ArchiveTests.cs
+++ b/tests/SharpCompress.Tests/ArchiveTests.cs
@@ -342,7 +342,7 @@ public class ArchiveTests : ReaderTests
         {
             if (!entry.IsDirectory)
             {
-                var memory = new MemoryStream();
+                using var memory = new MemoryStream();
                 entry.WriteTo(memory);
 
                 memory.Position = 0;
@@ -484,7 +484,8 @@ public class ArchiveTests : ReaderTests
         {
             foreach (var kvp in files)
             {
-                writer.Write(kvp.Key, new MemoryStream(kvp.Value));
+                using var entryStream = new MemoryStream(kvp.Value);
+                writer.Write(kvp.Key, entryStream);
             }
         }
         return zipStream;

--- a/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
+++ b/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
@@ -329,7 +329,8 @@ public class AsyncParityAndCancellationTests : TestBase
             )
         )
         {
-            writer.Write("large.bin", new MemoryStream(new byte[64 * 1024]));
+            using var entryStream = new MemoryStream(new byte[64 * 1024]);
+            writer.Write("large.bin", entryStream);
         }
         return stream.ToArray();
     }

--- a/tests/SharpCompress.Tests/BZip2/BZip2ReaderTests.cs
+++ b/tests/SharpCompress.Tests/BZip2/BZip2ReaderTests.cs
@@ -13,7 +13,7 @@ public class BZip2ReaderTests : ReaderTests
     [Fact]
     public void BZip2_Reader_Factory()
     {
-        Stream stream = new MemoryStream(
+        using Stream stream = new MemoryStream(
             new byte[] { 0x42, 0x5a, 0x68, 0x34, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59, 0x35 }
         );
         Assert.Throws<ArchiveOperationException>(() => ReaderFactory.OpenReader(stream));

--- a/tests/SharpCompress.Tests/CompressionProviderTests.cs
+++ b/tests/SharpCompress.Tests/CompressionProviderTests.cs
@@ -648,7 +648,8 @@ public class CompressionProviderTests
         )
         {
             var data = Encoding.UTF8.GetBytes("zip async provider usage");
-            writer.Write("test.txt", new MemoryStream(data));
+            using var writeStream = new MemoryStream(data);
+            writer.Write("test.txt", writeStream);
         }
 
         var trackingProvider = new TrackingCompressionProvider(new DeflateCompressionProvider());
@@ -701,7 +702,8 @@ public class CompressionProviderTests
         )
         {
             var data = Encoding.UTF8.GetBytes("hook provider");
-            writer.Write("test.txt", new MemoryStream(data));
+            using var entryStream = new MemoryStream(data);
+            writer.Write("test.txt", entryStream);
         }
 
         trackingProvider.PreCalls.Should().BeGreaterThan(0);

--- a/tests/SharpCompress.Tests/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipArchiveAsyncTests.cs
@@ -98,31 +98,33 @@ public class GZipArchiveAsyncTests : ArchiveTests
         );
         var archiveEntry = await archive.EntriesAsync.FirstAsync();
 
-        MemoryStream tarStream;
+        long size;
         await using (var entryStream = await archiveEntry.OpenEntryStreamAsync())
         {
-            tarStream = new MemoryStream();
+            using var tarStream = new MemoryStream();
             await entryStream.CopyToAsync(tarStream);
+            size = tarStream.Length;
         }
-        var size = tarStream.Length;
+        long secondSize;
         await using (var entryStream = await archiveEntry.OpenEntryStreamAsync())
         {
-            tarStream = new MemoryStream();
+            using var tarStream = new MemoryStream();
             await entryStream.CopyToAsync(tarStream);
+            secondSize = tarStream.Length;
         }
-        Assert.Equal(size, tarStream.Length);
+        Assert.Equal(size, secondSize);
         await using (var entryStream = await archiveEntry.OpenEntryStreamAsync())
         {
             var result = await TarArchive.IsTarFileAsync(entryStream);
             Assert.True(result);
         }
-        Assert.Equal(size, tarStream.Length);
+        Assert.Equal(size, secondSize);
         await using (var entryStream = await archiveEntry.OpenEntryStreamAsync())
         {
-            tarStream = new MemoryStream();
+            using var tarStream = new MemoryStream();
             await entryStream.CopyToAsync(tarStream);
+            Assert.Equal(size, tarStream.Length);
         }
-        Assert.Equal(size, tarStream.Length);
     }
 
     [Fact]
@@ -191,7 +193,8 @@ public class GZipArchiveAsyncTests : ArchiveTests
                 closeStream: true,
                 size: entryStream.Length
             );
-            await archive.SaveToAsync(new MemoryStream(), new GZipWriterOptions());
+            using var outputStream = new MemoryStream();
+            await archive.SaveToAsync(outputStream, new GZipWriterOptions());
         }
 
         Assert.True(entryStream.IsDisposed);

--- a/tests/SharpCompress.Tests/GZip/GZipArchiveTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipArchiveTests.cs
@@ -81,31 +81,33 @@ public class GZipArchiveTests : ArchiveTests
         using var archive = GZipArchive.OpenArchive(inputStream);
         var archiveEntry = archive.Entries.First();
 
-        MemoryStream tarStream;
+        long size;
         using (var entryStream = archiveEntry.OpenEntryStream())
         {
-            tarStream = new MemoryStream();
+            using var tarStream = new MemoryStream();
             entryStream.CopyTo(tarStream);
+            size = tarStream.Length;
         }
-        var size = tarStream.Length;
+        long secondSize;
         using (var entryStream = archiveEntry.OpenEntryStream())
         {
-            tarStream = new MemoryStream();
+            using var tarStream = new MemoryStream();
             entryStream.CopyTo(tarStream);
+            secondSize = tarStream.Length;
         }
-        Assert.Equal(size, tarStream.Length);
+        Assert.Equal(size, secondSize);
         using (var entryStream = archiveEntry.OpenEntryStream())
         {
             var result = TarArchive.IsTarFile(entryStream);
             Assert.True(result);
         }
-        Assert.Equal(size, tarStream.Length);
+        Assert.Equal(size, secondSize);
         using (var entryStream = archiveEntry.OpenEntryStream())
         {
-            tarStream = new MemoryStream();
+            using var tarStream = new MemoryStream();
             entryStream.CopyTo(tarStream);
+            Assert.Equal(size, tarStream.Length);
         }
-        Assert.Equal(size, tarStream.Length);
     }
 
     [Fact]

--- a/tests/SharpCompress.Tests/LazyAsyncReadOnlyCollectionTests.cs
+++ b/tests/SharpCompress.Tests/LazyAsyncReadOnlyCollectionTests.cs
@@ -165,7 +165,7 @@ public class LazyAsyncReadOnlyCollectionTests
     public async Task CancellationToken_PassedToGetAsyncEnumerator_HonorsToken()
     {
         // Arrange
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         var source = new TrackingAsyncEnumerable<int>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         var collection = new LazyAsyncReadOnlyCollection<int>(source);
 
@@ -191,7 +191,7 @@ public class LazyAsyncReadOnlyCollectionTests
     public async Task CancellationDuringMoveNextAsync_ThrowsOperationCanceledException()
     {
         // Arrange
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         var source = CreateDelayedAsyncEnumerable(
             new[] { 1, 2, 3, 4, 5 },
             TimeSpan.FromMilliseconds(50)

--- a/tests/SharpCompress.Tests/Rar/RarHeaderFactoryDeferredSkipTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarHeaderFactoryDeferredSkipTests.cs
@@ -51,7 +51,7 @@ public class RarHeaderFactoryDeferredSkipTests : TestBase
 
         Assert.NotNull(first);
         // The stream must still sit at the start of the packed data — no seek past it.
-        Assert.Equal(first.DataStartPosition, stream.Position);
+        Assert.Equal(first!.DataStartPosition, stream.Position);
     }
 
     [Theory]

--- a/tests/SharpCompress.Tests/Rar/RarStoredEntryStreamTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarStoredEntryStreamTests.cs
@@ -236,7 +236,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
         Assert.NotNull(entry);
         var full = await ReadFullyAsync(entry);
 
-        await using var stream = await entry.OpenEntryStreamAsync();
+        await using var stream = await entry!.OpenEntryStreamAsync();
         Assert.IsType<StoredRarEntryStream>(stream);
         Assert.True(stream.CanSeek);
 
@@ -269,7 +269,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
             }
 
             Assert.NotNull(entry);
-            await using var stream = await entry.OpenEntryStreamAsync();
+            await using var stream = await entry!.OpenEntryStreamAsync();
             Assert.IsType<StoredRarEntryStream>(stream);
             using var ms = new MemoryStream();
             await stream.CopyToAsync(ms);

--- a/tests/SharpCompress.Tests/Rar/RarUncompressedSizeUnknownTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarUncompressedSizeUnknownTests.cs
@@ -82,7 +82,7 @@ public class RarUncompressedSizeUnknownTests
         }
 
         Assert.NotNull(first);
-        Assert.False(first.IsUncompressedSizeUnknown);
+        Assert.False(first!.IsUncompressedSizeUnknown);
         Assert.NotEqual(long.MaxValue, first.UncompressedSize);
     }
 

--- a/tests/SharpCompress.Tests/Streams/LzmaStreamAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Streams/LzmaStreamAsyncTests.cs
@@ -567,7 +567,7 @@ public class LzmaStreamAsyncTests : TestBase
     [Fact]
     public async ValueTask TestLzmaEncodingAccuracyAsync()
     {
-        var input = new MemoryStream(LzmaResultData);
+        using var input = new MemoryStream(LzmaResultData);
         var compressed = new MemoryStream();
         var lzmaEncodingStream = LzmaStream.Create(
             LzmaEncoderProperties.Default,
@@ -578,7 +578,7 @@ public class LzmaStreamAsyncTests : TestBase
         await lzmaEncodingStream.DisposeAsync().ConfigureAwait(false);
         compressed.Position = 0;
 
-        var output = new MemoryStream();
+        using var output = new MemoryStream();
         await DecompressLzmaStreamAsync(
                 lzmaEncodingStream.Properties,
                 compressed,

--- a/tests/SharpCompress.Tests/Streams/LzmaStreamTests.cs
+++ b/tests/SharpCompress.Tests/Streams/LzmaStreamTests.cs
@@ -596,7 +596,7 @@ public class LzmaStreamTests
     [Fact]
     public void TestLzmaEncodingAccuracy()
     {
-        var input = new MemoryStream(LzmaResultData);
+        using var input = new MemoryStream(LzmaResultData);
         var compressed = new MemoryStream();
         var lzmaEncodingStream = LzmaStream.Create(
             LzmaEncoderProperties.Default,
@@ -607,7 +607,7 @@ public class LzmaStreamTests
         lzmaEncodingStream.Close();
         compressed.Position = 0;
 
-        var output = new MemoryStream();
+        using var output = new MemoryStream();
         DecompressLzmaStream(
             lzmaEncodingStream.Properties,
             compressed,

--- a/tests/SharpCompress.Tests/Streams/LzwStreamAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Streams/LzwStreamAsyncTests.cs
@@ -91,7 +91,7 @@ public class LzwStreamAsyncTests : TestBase
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         var buffer = new byte[4096];
 
         cts.Cancel();

--- a/tests/SharpCompress.Tests/Streams/SeekableSharpCompressStreamAsyncTest.cs
+++ b/tests/SharpCompress.Tests/Streams/SeekableSharpCompressStreamAsyncTest.cs
@@ -27,7 +27,7 @@ public class SeekableSharpCompressStreamAsyncTest
         var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = new SeekableSharpCompressStream(ms);
         var buffer = new byte[5];
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         int bytesRead = await stream
             .ReadAsync(buffer, 0, buffer.Length, cts.Token)
             .ConfigureAwait(false);
@@ -62,7 +62,7 @@ public class SeekableSharpCompressStreamAsyncTest
         var ms = new MemoryStream();
         var stream = new SeekableSharpCompressStream(ms);
         var data = new byte[] { 1, 2, 3, 4, 5 };
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         await stream.WriteAsync(data, 0, data.Length, cts.Token).ConfigureAwait(false);
         Assert.Equal(data, ms.ToArray());
     }
@@ -83,7 +83,7 @@ public class SeekableSharpCompressStreamAsyncTest
     {
         var sourceMs = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = new SeekableSharpCompressStream(sourceMs);
-        var destinationMs = new MemoryStream();
+        using var destinationMs = new MemoryStream();
         await stream.CopyToAsync(destinationMs, 4096).ConfigureAwait(false);
         Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, destinationMs.ToArray());
     }
@@ -143,7 +143,7 @@ public partial class SeekableSharpCompressStreamMemoryAsyncTest
         var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = new SeekableSharpCompressStream(ms);
         var buffer = new byte[5];
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         int bytesRead = await stream.ReadAsync(buffer, cts.Token).ConfigureAwait(false);
         Assert.Equal(5, bytesRead);
         Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, buffer);
@@ -165,7 +165,7 @@ public partial class SeekableSharpCompressStreamMemoryAsyncTest
         var ms = new MemoryStream();
         var stream = new SeekableSharpCompressStream(ms);
         var data = new byte[] { 1, 2, 3, 4, 5 };
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         await stream.WriteAsync(data, cts.Token).ConfigureAwait(false);
         Assert.Equal(data, ms.ToArray());
     }

--- a/tests/SharpCompress.Tests/Streams/SharpCompressStreamEdgeAsyncTest.cs
+++ b/tests/SharpCompress.Tests/Streams/SharpCompressStreamEdgeAsyncTest.cs
@@ -76,7 +76,7 @@ public class SharpCompressStreamEdgeAsyncTest
     {
         var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = SharpCompressStream.CreateNonDisposing(ms);
-        var destination = new MemoryStream();
+        using var destination = new MemoryStream();
         await stream.CopyToAsync(destination).ConfigureAwait(false);
         Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, destination.ToArray());
     }
@@ -86,7 +86,7 @@ public class SharpCompressStreamEdgeAsyncTest
     {
         var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = SharpCompressStream.CreateNonDisposing(ms);
-        var destination = new MemoryStream();
+        using var destination = new MemoryStream();
         await stream.CopyToAsync(destination, 2).ConfigureAwait(false);
         Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, destination.ToArray());
     }

--- a/tests/SharpCompress.Tests/Streams/SharpCompressStreamErrorAsyncTest.cs
+++ b/tests/SharpCompress.Tests/Streams/SharpCompressStreamErrorAsyncTest.cs
@@ -144,7 +144,7 @@ public class SharpCompressStreamErrorAsyncTest
     {
         var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = SharpCompressStream.CreateNonDisposing(ms);
-        var destination = new MemoryStream();
+        using var destination = new MemoryStream();
         await stream.CopyToAsync(destination).ConfigureAwait(false);
         Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, destination.ToArray());
     }

--- a/tests/SharpCompress.Tests/Streams/SharpCompressStreamPassthroughAsyncTest.cs
+++ b/tests/SharpCompress.Tests/Streams/SharpCompressStreamPassthroughAsyncTest.cs
@@ -54,7 +54,7 @@ public class SharpCompressStreamPassthroughAsyncTest
         var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
         var stream = SharpCompressStream.CreateNonDisposing(ms);
         var buffer = new byte[5];
-        var cts = new System.Threading.CancellationTokenSource();
+        using var cts = new System.Threading.CancellationTokenSource();
         int bytesRead = await stream
             .ReadAsync(buffer, 0, buffer.Length, cts.Token)
             .ConfigureAwait(false);
@@ -67,7 +67,7 @@ public class SharpCompressStreamPassthroughAsyncTest
         var ms = new MemoryStream();
         var stream = SharpCompressStream.CreateNonDisposing(ms);
         var data = new byte[] { 1, 2, 3, 4, 5 };
-        var cts = new System.Threading.CancellationTokenSource();
+        using var cts = new System.Threading.CancellationTokenSource();
         await stream.WriteAsync(data, 0, data.Length, cts.Token).ConfigureAwait(false);
         Assert.Equal(data, ms.ToArray());
     }
@@ -78,7 +78,7 @@ public class SharpCompressStreamPassthroughAsyncTest
         var ms = new MemoryStream();
         var stream = SharpCompressStream.CreateNonDisposing(ms);
         await stream.WriteAsync(new byte[] { 1, 2, 3 }, 0, 3).ConfigureAwait(false);
-        var cts = new System.Threading.CancellationTokenSource();
+        using var cts = new System.Threading.CancellationTokenSource();
         await stream.FlushAsync(cts.Token).ConfigureAwait(false);
         Assert.Equal(3, ms.Length);
     }

--- a/tests/SharpCompress.Tests/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarArchiveAsyncTests.cs
@@ -97,7 +97,7 @@ public class TarArchiveAsyncTests : ArchiveTests
             )
             using (Stream inputStream = new MemoryStream())
             {
-                var sw = new StreamWriter(inputStream);
+                await using var sw = new StreamWriter(inputStream);
                 await sw.WriteAsync("dummy filecontent");
                 await sw.FlushAsync();
 
@@ -156,7 +156,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         )
         using (Stream inputStream = new MemoryStream())
         {
-            var sw = new StreamWriter(inputStream);
+            await using var sw = new StreamWriter(inputStream);
             await sw.WriteAsync("dummy filecontent");
             await sw.FlushAsync();
 
@@ -220,8 +220,9 @@ public class TarArchiveAsyncTests : ArchiveTests
                 closeStream: true,
                 size: entryStream.Length
             );
+            using var outputStream = new MemoryStream();
             await archive.SaveToAsync(
-                new MemoryStream(),
+                outputStream,
                 new TarWriterOptions(CompressionType.None, true)
             );
         }

--- a/tests/SharpCompress.Tests/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarArchiveTests.cs
@@ -77,7 +77,7 @@ public class TarArchiveTests : ArchiveTests
         )
         using (Stream inputStream = new MemoryStream())
         {
-            var sw = new StreamWriter(inputStream);
+            using var sw = new StreamWriter(inputStream);
             sw.Write("dummy filecontent");
             sw.Flush();
 
@@ -143,7 +143,7 @@ public class TarArchiveTests : ArchiveTests
         )
         using (Stream inputStream = new MemoryStream())
         {
-            var sw = new StreamWriter(inputStream);
+            using var sw = new StreamWriter(inputStream);
             sw.Write("dummy filecontent");
             sw.Flush();
 

--- a/tests/SharpCompress.Tests/Tar/TarReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarReaderAsyncTests.cs
@@ -352,7 +352,7 @@ public class TarReaderAsyncTests : ReaderTests
         var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
-        var memoryStream = new MemoryStream();
+        using var memoryStream = new MemoryStream();
 
         Assert.True(await reader.MoveToNextEntryAsync());
         Assert.True(await reader.MoveToNextEntryAsync());
@@ -428,7 +428,7 @@ public class TarReaderAsyncTests : ReaderTests
         var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "TarCorrupted.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
-        var memoryStream = new MemoryStream();
+        using var memoryStream = new MemoryStream();
 
         Assert.True(await reader.MoveToNextEntryAsync());
         Assert.True(await reader.MoveToNextEntryAsync());

--- a/tests/SharpCompress.Tests/Tar/TarReaderTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarReaderTests.cs
@@ -372,7 +372,7 @@ public class TarReaderTests : ReaderTests
         var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
-        var memoryStream = new MemoryStream();
+        using var memoryStream = new MemoryStream();
 
         Assert.True(reader.MoveToNextEntry());
         Assert.True(reader.MoveToNextEntry());
@@ -444,7 +444,7 @@ public class TarReaderTests : ReaderTests
         var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "TarCorrupted.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
-        var memoryStream = new MemoryStream();
+        using var memoryStream = new MemoryStream();
 
         Assert.True(reader.MoveToNextEntry());
         Assert.True(reader.MoveToNextEntry());

--- a/tests/SharpCompress.Tests/Zip/Zip64VersionConsistencyTests.cs
+++ b/tests/SharpCompress.Tests/Zip/Zip64VersionConsistencyTests.cs
@@ -39,7 +39,8 @@ public class Zip64VersionConsistencyTests : WriterTests
         };
 
         var zipArchive = ZipArchive.CreateArchive();
-        zipArchive.AddEntry("empty", new MemoryStream());
+        using var entryStream = new MemoryStream();
+        zipArchive.AddEntry("empty", entryStream);
         zipArchive.SaveTo(filename, writerOptions);
 
         // Now read the raw bytes to verify version consistency
@@ -143,7 +144,8 @@ public class Zip64VersionConsistencyTests : WriterTests
         };
 
         var zipArchive = ZipArchive.CreateArchive();
-        zipArchive.AddEntry("empty", new MemoryStream());
+        using var entryStream = new MemoryStream();
+        zipArchive.AddEntry("empty", entryStream);
         zipArchive.SaveTo(filename, writerOptions);
 
         // Read the raw bytes
@@ -196,7 +198,8 @@ public class Zip64VersionConsistencyTests : WriterTests
         var zipArchive = ZipArchive.CreateArchive();
         var data = new byte[100];
         new Random(42).NextBytes(data);
-        zipArchive.AddEntry("test.bin", new MemoryStream(data));
+        using var entryStream = new MemoryStream(data);
+        zipArchive.AddEntry("test.bin", entryStream);
         zipArchive.SaveTo(filename, writerOptions);
 
         // Read the raw bytes
@@ -249,7 +252,8 @@ public class Zip64VersionConsistencyTests : WriterTests
         var zipArchive = ZipArchive.CreateArchive();
         var data = new byte[100];
         new Random(42).NextBytes(data);
-        zipArchive.AddEntry("test.bin", new MemoryStream(data));
+        using var entryStream = new MemoryStream(data);
+        zipArchive.AddEntry("test.bin", entryStream);
         zipArchive.SaveTo(filename, writerOptions);
 
         // Read the raw bytes

--- a/tests/SharpCompress.Tests/Zip/ZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipArchiveAsyncTests.cs
@@ -199,8 +199,9 @@ public class ZipArchiveAsyncTests : ArchiveTests
                 closeStream: true,
                 size: entryStream.Length
             );
+            using var outputStream = new MemoryStream();
             await archive.SaveToAsync(
-                new MemoryStream(),
+                outputStream,
                 new ZipWriterOptions(CompressionType.Deflate)
             );
         }

--- a/tests/SharpCompress.Tests/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipArchiveTests.cs
@@ -351,8 +351,10 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Create_NoDups()
     {
         using var arc = ZipArchive.CreateArchive();
-        arc.AddEntry("1.txt", new MemoryStream());
-        Assert.Throws<ArchiveException>(() => arc.AddEntry("\\1.txt", new MemoryStream()));
+        using var entryStream = new MemoryStream();
+        arc.AddEntry("1.txt", entryStream);
+        using var duplicateStream = new MemoryStream();
+        Assert.Throws<ArchiveException>(() => arc.AddEntry("\\1.txt", duplicateStream));
     }
 
     [Fact]
@@ -789,8 +791,10 @@ public class ZipArchiveTests : ArchiveTests
             )
         )
         {
-            zipWriter.Write("foo.txt", new MemoryStream(Array.Empty<byte>()));
-            zipWriter.Write("foo2.txt", new MemoryStream(new byte[10]));
+            using var fooStream = new MemoryStream(Array.Empty<byte>());
+            zipWriter.Write("foo.txt", fooStream);
+            using var foo2Stream = new MemoryStream(new byte[10]);
+            zipWriter.Write("foo2.txt", foo2Stream);
         }
 
         stream = new MemoryStream(stream.ToArray());
@@ -801,7 +805,7 @@ public class ZipArchiveTests : ArchiveTests
             foreach (var entry in zipArchive.Entries)
             {
                 using var entryStream = entry.OpenEntryStream();
-                var tempStream = new MemoryStream();
+                using var tempStream = new MemoryStream();
                 const int bufSize = 0x1000;
                 var buf = new byte[bufSize];
                 var bytesRead = 0;
@@ -1020,7 +1024,7 @@ public class ZipArchiveTests : ArchiveTests
         var entries = archive.Entries.Where(x => !x.IsDirectory).ToList();
         Assert.Single(entries);
         Assert.Equal(0, entries[0].Size);
-        var outStream = new MemoryStream();
+        using var outStream = new MemoryStream();
         entries[0].WriteTo(outStream);
         Assert.Equal(0, outStream.Length);
     }

--- a/tests/SharpCompress.Tests/Zip/ZipCrcExtractionTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipCrcExtractionTests.cs
@@ -184,7 +184,8 @@ public class ZipCrcExtractionTests : ArchiveTests
             )
         )
         {
-            writer.Write(EntryName, new MemoryStream(EntryData));
+            using var entryStream = new MemoryStream(EntryData);
+            writer.Write(EntryName, entryStream);
         }
 
         var bytes = zipStream.ToArray();

--- a/tests/SharpCompress.Tests/Zip/ZipMemoryArchiveWithCrcAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipMemoryArchiveWithCrcAsyncTests.cs
@@ -68,11 +68,14 @@ public class ZipTypesLevelsWithCrcRatioAsyncTests : ArchiveTests
             )
         )
         {
-            await writer.WriteAsync($"file1_{sizeMb}MiB.txt", new MemoryStream(file1Data));
-            await writer.WriteAsync($"data/file2_{sizeMb * 2}MiB.txt", new MemoryStream(file2Data));
+            using var file1Stream = new MemoryStream(file1Data);
+            await writer.WriteAsync($"file1_{sizeMb}MiB.txt", file1Stream);
+            using var file2Stream = new MemoryStream(file2Data);
+            await writer.WriteAsync($"data/file2_{sizeMb * 2}MiB.txt", file2Stream);
+            using var file3Stream = new MemoryStream(file3Data);
             await writer.WriteAsync(
                 $"deep/nested/file3_{sizeMb * 3}MiB.txt",
-                new MemoryStream(file3Data)
+                file3Stream
             );
         }
 
@@ -142,9 +145,10 @@ public class ZipTypesLevelsWithCrcRatioAsyncTests : ArchiveTests
             )
         )
         {
+            using var testDataStream = new MemoryStream(testData);
             await writer.WriteAsync(
                 $"{compressionType}_level_{compressionLevel}_{sizeMb}MiB.txt",
-                new MemoryStream(testData)
+                testDataStream
             );
         }
 
@@ -209,9 +213,10 @@ public class ZipTypesLevelsWithCrcRatioAsyncTests : ArchiveTests
             )
         )
         {
+            using var testDataStream = new MemoryStream(testData);
             await writer.WriteAsync(
                 $"{compressionType}_{compressionLevel}_{sizeMb}MiB.txt",
-                new MemoryStream(testData)
+                testDataStream
             );
         }
 

--- a/tests/SharpCompress.Tests/Zip/ZipMemoryArchiveWithCrcTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipMemoryArchiveWithCrcTests.cs
@@ -60,9 +60,12 @@ public class ZipTypesLevelsWithCrcRatioTests : ArchiveTests
         using var zipStream = new MemoryStream();
         using (var writer = CreateWriterWithLevel(zipStream, compressionType, compressionLevel))
         {
-            writer.Write($"file1_{sizeMb}MiB.txt", new MemoryStream(file1Data));
-            writer.Write($"data/file2_{sizeMb * 2}MiB.txt", new MemoryStream(file2Data));
-            writer.Write($"deep/nested/file3_{sizeMb * 3}MiB.txt", new MemoryStream(file3Data));
+            using var file1Stream = new MemoryStream(file1Data);
+            writer.Write($"file1_{sizeMb}MiB.txt", file1Stream);
+            using var file2Stream = new MemoryStream(file2Data);
+            writer.Write($"data/file2_{sizeMb * 2}MiB.txt", file2Stream);
+            using var file3Stream = new MemoryStream(file3Data);
+            writer.Write($"deep/nested/file3_{sizeMb * 3}MiB.txt", file3Stream);
         }
 
         // Calculate and output actual compression ratio
@@ -125,9 +128,10 @@ public class ZipTypesLevelsWithCrcRatioTests : ArchiveTests
 
         using (var writer = WriterFactory.OpenWriter(zipStream, ArchiveType.Zip, writerOptions))
         {
+            using var testDataStream = new MemoryStream(testData);
             writer.Write(
                 $"{compressionType}_level_{compressionLevel}_{sizeMb}MiB.txt",
-                new MemoryStream(testData)
+                testDataStream
             );
         }
 
@@ -186,9 +190,10 @@ public class ZipTypesLevelsWithCrcRatioTests : ArchiveTests
         using var zipStream = new MemoryStream();
         using (var writer = CreateWriterWithLevel(zipStream, compressionType, compressionLevel))
         {
+            using var testDataStream = new MemoryStream(testData);
             writer.Write(
                 $"{compressionType}_{compressionLevel}_{sizeMb}MiB.txt",
-                new MemoryStream(testData)
+                testDataStream
             );
         }
 

--- a/tests/SharpCompress.Tests/Zip/ZipReaderTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipReaderTests.cs
@@ -320,8 +320,10 @@ public class ZipReaderTests : ReaderTests
             )
         )
         {
-            zipWriter.Write(expected[0].Item1, new MemoryStream(expected[0].Item2));
-            zipWriter.Write(expected[1].Item1, new MemoryStream(expected[1].Item2));
+            using var expected0Stream = new MemoryStream(expected[0].Item2);
+            zipWriter.Write(expected[0].Item1, expected0Stream);
+            using var expected1Stream = new MemoryStream(expected[1].Item2);
+            zipWriter.Write(expected[1].Item1, expected1Stream);
         }
 
         stream = new MemoryStream(memory.ToArray());
@@ -335,7 +337,7 @@ public class ZipReaderTests : ReaderTests
         {
             using (var entry = zipReader.OpenEntryStream())
             {
-                var tempStream = new MemoryStream();
+                using var tempStream = new MemoryStream();
                 const int bufSize = 0x1000;
                 var buf = new byte[bufSize];
                 var bytesRead = 0;
@@ -464,7 +466,7 @@ public class ZipReaderTests : ReaderTests
         using var reader = ReaderFactory.OpenReader(stream);
         while (reader.MoveToNextEntry())
         {
-            var target = new MemoryStream();
+            using var target = new MemoryStream();
             reader.OpenEntryStream().CopyTo(target);
         }
     }
@@ -663,7 +665,7 @@ public class ZipReaderTests : ReaderTests
             {
                 count++;
                 Assert.Equal(0, reader.Entry.Size);
-                var outStream = new MemoryStream();
+                using var outStream = new MemoryStream();
                 reader.WriteEntryTo(outStream);
                 Assert.Equal(0, outStream.Length);
             }

--- a/tests/UsenetSharp.Tests/Clients/UsenetClient.DateAsyncTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClient.DateAsyncTests.cs
@@ -43,7 +43,7 @@ public class DateAsyncTests
         // Assert
         Assert.That(dateResult.ResponseCode, Is.EqualTo(111), "Response code should be 111");
         Assert.That(dateResult.DateTime, Is.Not.Null, "DateTime should be populated");
-        Assert.That(dateResult.DateTime.Value.Offset, Is.EqualTo(TimeSpan.Zero), "DateTime should be UTC");
+        Assert.That(dateResult.DateTime!.Value.Offset, Is.EqualTo(TimeSpan.Zero), "DateTime should be UTC");
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class DateAsyncTests
         Assert.That(dateResult.DateTime, Is.Not.Null, "DateTime should be populated");
 
         var now = DateTimeOffset.UtcNow;
-        var timeDifference = (now - dateResult.DateTime.Value).Duration();
+        var timeDifference = (now - dateResult.DateTime!.Value).Duration();
 
         // Server time should be within 5 minutes of current time
         Assert.That(timeDifference, Is.LessThan(TimeSpan.FromMinutes(5)),
@@ -152,7 +152,7 @@ public class DateAsyncTests
         Assert.That(dateResult2.DateTime, Is.Not.Null, "Second DateTime should be populated");
 
         // Second time should be equal to or greater than the first
-        Assert.That(dateResult2.DateTime.Value, Is.GreaterThanOrEqualTo(dateResult1.DateTime.Value),
+        Assert.That(dateResult2.DateTime!.Value, Is.GreaterThanOrEqualTo(dateResult1.DateTime!.Value),
             "Second DATE should be later than or equal to the first");
     }
 

--- a/tests/UsenetSharp.Tests/Integration/YencStreamIntegrationTests.cs
+++ b/tests/UsenetSharp.Tests/Integration/YencStreamIntegrationTests.cs
@@ -14,7 +14,8 @@ public class YencStreamIntegrationTests
         var segmentId = "8mthBMhpfyOJFM7OPe2RsZhm@CAtZlPkA1OiI.WLo";
 
         using var client = new UsenetClient();
-        var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = timeoutSource.Token;
 
         // Connect to server
         await client.ConnectAsync(Credentials.Host, 563, true, cancellationToken);
@@ -69,7 +70,8 @@ public class YencStreamIntegrationTests
         };
 
         using var client = new UsenetClient();
-        var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var cancellationToken = timeoutSource.Token;
 
         // Connect and authenticate
         await client.ConnectAsync(Credentials.Host, 563, true, cancellationToken);
@@ -104,7 +106,8 @@ public class YencStreamIntegrationTests
         var segmentId = "8mthBMhpfyOJFM7OPe2RsZhm@CAtZlPkA1OiI.WLo";
 
         using var client = new UsenetClient();
-        var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = timeoutSource.Token;
 
         await client.ConnectAsync(Credentials.Host, 563, true, cancellationToken);
 

--- a/tests/UsenetSharp.Tests/Integration/YencStreamValidationTests.cs
+++ b/tests/UsenetSharp.Tests/Integration/YencStreamValidationTests.cs
@@ -27,7 +27,8 @@ public class YencStreamValidationTests
             "vAOEczfxpsXMjg0bUPUGO7Bb@KDqE994Bw3O0.BG5",
         };
 
-        var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(120)).Token;
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        var cancellationToken = timeoutSource.Token;
 
         // Connect both clients once
         var usenetClient = new NntpClient(new NntpConnection());
@@ -115,7 +116,8 @@ public class YencStreamValidationTests
     {
         // Arrange - Most thorough test: compare every single byte
         var segmentId = "439e9msqibLI2Ckyt7z6EMUY@iLqyzimBg7ac.t2n";
-        var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var cancellationToken = timeoutSource.Token;
 
         // Decode with Usenet package
         byte[] usenetPackageDecoded;


### PR DESCRIPTION
## Summary

Resolves the GitHub Code Quality findings ([/security/quality](https://github.com/infinidysk/infinidysk/security/quality)) across backend, frontend, and tests — 2,230 open findings at scan time. This PR fixes **285** in code; the remaining **1,945** are deliberately unchanged and are listed for dismissal below with reasons (vendored libraries, test-code style notes, and intentional containment patterns per our streaming lifecycle invariants).

User-visible improvements among the fixes:
- **Resource leaks**: undisposed `HttpRequestMessage`s in the Arr and Rclone clients.
- **Null-safety**: 11 possible null dereferences in backend paths (WebDAV deletes, preflight, profile play, Radarr client) now guarded explicitly.
- **Cancellation correctness**: 15 generic catch clauses now let genuine caller/shutdown cancellation propagate instead of logging spurious crash stacks or caching bogus empty results (Watchtower episode enumeration, profile play aborts, PAR2 parsing, per-item service loops). Previously an aborted play request logged `Error + stack`; it now produces a clean 499.
- **Path handling**: 48 `Path.Combine` calls converted to `Path.Join` so a rooted later argument can never silently drop the base directory (hardens the NZB backup containment guard).
- **Precision**: integer-overflow-before-double-conversion fixes in benchmark/playback sampling math.
- Tests: disposal, null-guard, and drain-loop hygiene across 56 test files; frontend ASI/unused-import cleanups.

## Dismissal plan (post-merge maintainer action)

The findings API is read-only, so these need one bulk-dismiss pass in [/security/quality](https://github.com/infinidysk/infinidysk/security/quality) after merge (filter by path/rule):

- **`libs/` (577)** — vendored SharpCompress/UsenetSharp forks track upstream; fixing style findings there creates permanent merge friction. Reason: vendored upstream.
- **Test style notes (1,022)** — incl. 900 `cs/path-combine` in tests where later arguments are literal constants (false positives). Reason: used in tests.
- **Intentional backend containment (307)** — documented per site:
  - 208 `cs/catch-of-all-exceptions`: deliberate containment per streaming lifecycle invariants (callback containment, connection/permit settling, queue awaken-signal, background-service outer catches, last-resort API boundaries).
  - 14 `cs/missed-using-statement`: manual `finally` disposal is load-bearing (conditional Replace vs Dispose, or deferred to stream-completion callbacks).
  - 6 `cs/local-not-disposed`: ownership transfers to callers/NWebDav, or lifetime-bound by design (DebounceUtil timer, scheduler CTS — documented in code comments).
  - 71 LINQ skips: side-effecting guards, dictionary mutation during enumeration, out-var/is-pattern scoping, nullable-flow limits.
  - 5 `class-name-matches-base-class` + 3 `static-field-written-by-instance`: deliberate processor-Result shadowing and shared single-flight task slot.
- **Test false positives (39)** — mock `HttpResponseMessage`s disposed by the SUT's own `using`; streams handed to `CombinedStream`/archive writers with `closeStream: true`; 2 `GC.Collect` calls that are the point of the pool-rooting test; 2 third-party `NntpConnection`s (not disposable) in manual live-Usenet integration tests.

## Test plan

- [x] `dotnet build backend -c Release` — 0 errors
- [x] `dotnet test tests/NzbWebDAV.Tests -c Release` — 2,384 passed, 0 failed
- [x] `dotnet test tests/SharpCompress.Tests -c Release --filter "format!=stress"` — 2,124 passed, 0 failed
- [x] Frontend `npm run typecheck`, `npm test` (519 passed), `npm run build` — green
- [x] Full-branch regression review by an independent model (GLM): all 20 commits verified behavior-preserving; verdict **SHIP** (two non-blocking test-only nits)
- [ ] After merge: bulk-dismiss the findings listed above, then verify the next Code Quality scan reports ~0 open findings