### PR TITLE
chore(analyzers): enable latest-All .NET analyzers with triaged rule policy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -118,6 +118,14 @@ dotnet_diagnostic.CA1515.severity = none
 # Justification: repeated false positives under nullable flow analysis in
 # streaming/decoder state machines.
 dotnet_diagnostic.CA1508.severity = none
+# Justification: DI-injected services deliberately expose instance methods for
+# substitutability (fakes/mocks in tests) even when they touch no instance
+# state today; forcing them static is a design constraint for micro-perf.
+dotnet_diagnostic.CA1822.severity = none
+# Justification: existing case-normalization sites pair ToUpperInvariant with
+# upper-case protocol constants consistently; mass-converting to
+# ToLowerInvariant risks breaking those pairings for no runtime benefit.
+dotnet_diagnostic.CA1308.severity = none
 # Justification: sealing every internal class churns the codebase and breaks
 # test doubles for a micro-optimization the hot paths already get via CA1859.
 dotnet_diagnostic.CA1852.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,104 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# ==========================================================================
+# Analyzer policy (see CONTRIBUTING.md "Static analysis policy")
+#
+# latest-All enables every CA rule as a warning. Rules listed here as `none`
+# are disabled project-wide with a recorded justification; everything else
+# stays enabled and must be fixed, not suppressed. Security rules (CA53xx)
+# are never disabled here — rare intentional violations get a targeted
+# GlobalSuppressions.cs entry with justification.
+#
+# NOTE: libs/* and the rapidyenc submodule ship their own root .editorconfig
+# files (root = true) and do not inherit this section. Keep the mirrored
+# policy blocks in libs/UsenetSharp/.editorconfig and
+# libs/RapidYencSharp/.editorconfig in sync with this list.
+# ==========================================================================
+[*.cs]
+
+# --- Application-design rules: target reusable libraries, not an app -------
+
+# Justification: app-internal DTOs/services are not a public library surface;
+# List<T>/array/writable-collection members are fine on internal models.
+dotnet_diagnostic.CA1002.severity = none
+dotnet_diagnostic.CA1819.severity = none
+dotnet_diagnostic.CA2227.severity = none
+# Justification: public fields are deliberate on plain data structs/DTOs.
+dotnet_diagnostic.CA1051.severity = none
+# Justification: nested types are used intentionally for scoping helpers.
+dotnet_diagnostic.CA1034.severity = none
+# Justification: nullable reference types already guard the app boundary;
+# per-parameter null re-validation of every visible method is library noise.
+dotnet_diagnostic.CA1062.severity = none
+# Justification: enum values are defined by wire/storage formats (e.g.
+# AccountType); a mandatory zero/'None' member does not fit every enum.
+dotnet_diagnostic.CA1008.severity = none
+# Justification: Get*/method-vs-property naming is chosen for clarity, not
+# by mechanical rule.
+dotnet_diagnostic.CA1024.severity = none
+# Justification: empty marker interfaces are used deliberately.
+dotnet_diagnostic.CA1040.severity = none
+# Justification: internal URI/config values are stored and passed as strings
+# by design (settings persistence, NNTP/HTTP endpoint configuration).
+dotnet_diagnostic.CA1054.severity = none
+dotnet_diagnostic.CA1055.severity = none
+dotnet_diagnostic.CA1056.severity = none
+dotnet_diagnostic.CA2234.severity = none
+# Justification: operator-overload alternate-method naming does not apply to
+# the few protocol value types that define operators.
+dotnet_diagnostic.CA2225.severity = none
+
+# --- Error handling ---------------------------------------------------------
+
+# Justification: background hosted services intentionally catch broadly to
+# stay alive; the AGENTS.md exception-logging policy (known failure -> warning,
+# unexpected -> error + stack) governs this, not per-site analyzer noise.
+dotnet_diagnostic.CA1031.severity = none
+# Justification: domain exceptions define the constructors they actually use;
+# the full standard-exception constructor set is library boilerplate (YAGNI).
+dotnet_diagnostic.CA1032.severity = none
+# Justification: reserved exception types are fixed (CA2201 stays on);
+# CA2208's param-name plumbing is covered by throw helpers and tests.
+# (CA2208 itself stays enabled; nothing to disable here.)
+
+# --- Globalization ----------------------------------------------------------
+
+# Justification: the server is not localized; protocol parsing targets
+# invariant/ASCII Usenet data. StringComparison rules that affect semantics
+# (CA1307-CA1311) stay enabled and are fixed; culture-provision rules do not
+# apply to an English-only admin UI + protocol daemon.
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
+
+# --- Naming -----------------------------------------------------------------
+
+# Justification: identifiers follow protocol/field names (NNTP, yEnc, RAR)
+# and test conventions; mechanical naming rules are not enforced.
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1711.severity = none
+dotnet_diagnostic.CA1716.severity = none
+dotnet_diagnostic.CA1720.severity = none
+dotnet_diagnostic.CA1724.severity = none
+dotnet_diagnostic.CA1725.severity = none
+
+# --- Misc noise -------------------------------------------------------------
+
+# Justification: ASP.NET Core apps gain nothing from making every public type
+# internal (controllers, DI registrations, EF models are public by convention).
+dotnet_diagnostic.CA1515.severity = none
+# Justification: repeated false positives under nullable flow analysis in
+# streaming/decoder state machines.
+dotnet_diagnostic.CA1508.severity = none
+# Justification: sealing every internal class churns the codebase and breaks
+# test doubles for a micro-optimization the hot paths already get via CA1859.
+dotnet_diagnostic.CA1852.severity = none
+# Justification: data access is EF Core parameterized queries; the few raw
+# SQL statements are fixed literal strings in maintenance/migration helpers.
+dotnet_diagnostic.CA2100.severity = none
+# Justification: WebDAV "paths" are virtual store keys sanitized by the
+# DatabaseStore layer, not raw filesystem paths; per-site taint review of a
+# path-centric server is not actionable.
+dotnet_diagnostic.CA3003.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -98,6 +98,18 @@ dotnet_diagnostic.CA1720.severity = none
 dotnet_diagnostic.CA1724.severity = none
 dotnet_diagnostic.CA1725.severity = none
 
+# --- Async ------------------------------------------------------------------
+
+# Justification: ASP.NET Core has no SynchronizationContext, so plain awaits
+# do not capture anything worth configuring; the AGENTS.md ConfigureAwait
+# guidance is scoped to library-style code (libs/ keep CA2007 enabled). The
+# rule's code fix also cannot correctly handle `await using` locals — it
+# retypes the variable to ConfiguredAsyncDisposable (roslyn-analyzers #7087),
+# which breaks member access, so the remaining ~540 await-using sites cannot
+# be mechanically fixed. Plain awaits that were configured before this policy
+# was introduced keep their ConfigureAwait(false) for consistency.
+dotnet_diagnostic.CA2007.severity = none
+
 # --- Misc noise -------------------------------------------------------------
 
 # Justification: ASP.NET Core apps gain nothing from making every public type

--- a/.editorconfig
+++ b/.editorconfig
@@ -126,6 +126,10 @@ dotnet_diagnostic.CA1822.severity = none
 # upper-case protocol constants consistently; mass-converting to
 # ToLowerInvariant risks breaking those pairings for no runtime benefit.
 dotnet_diagnostic.CA1308.severity = none
+# Justification: fires overwhelmingly on cold paths (startup EF migrations,
+# config maps) where one constant-array allocation is immaterial; streaming
+# hot paths already use pooled buffers.
+dotnet_diagnostic.CA1861.severity = none
 # Justification: sealing every internal class churns the codebase and breaks
 # test doubles for a micro-optimization the hot paths already get via CA1859.
 dotnet_diagnostic.CA1852.severity = none

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,47 @@ Build and run container:
 docker compose up
 ```
 
+## Static analysis policy
+
+All first-party C# projects build with the full .NET analyzer set
+(`AnalysisLevel=latest-All` via the pinned `Microsoft.CodeAnalysis.NetAnalyzers`
+package in the root `Directory.Build.props`). New code must not introduce
+analyzer or compiler warnings.
+
+When a rule fires, resolve it in this order:
+
+1. **Fix it.** Most rules catch real issues (disposal, async, culture) or have
+   a mechanical code fix.
+2. **Per-site suppression** — `#pragma warning disable` (or a targeted
+   `GlobalSuppressions.cs` entry) with a justification comment — when the rule
+   misfires on intent at a specific place. Typical legit cases: ownership
+   transfers the analyzer cannot see (e.g. CA2000/CA2025 around background
+   tasks or response-lifetime disposal via `Response.OnCompleted`),
+   format-mandated weak hashes (CA5351), user-facing opt-outs
+   (CA5359/CA5398), and classification sites that must not bind the ambient
+   cancellation token (CA2016).
+3. **Rule-level policy** in the root `.editorconfig` (`tests/.editorconfig`
+   for test-only noise) with a written justification — only for rules that are
+   structural for this codebase (e.g. CA1515 "make types internal" in an
+   ASP.NET app, xUnit naming conventions in tests).
+
+Rules that must **never** be disabled rule-wide: the security rules (CA53xx) —
+use per-site justification suppressions so each instance stays auditable.
+
+Notes:
+
+- `libs/UsenetSharp` and `libs/RapidYencSharp` have their own `root = true`
+  `.editorconfig` files with a mirrored policy block — keep them in sync with
+  the root policy.
+- `libs/SharpCompress` and `tests/SharpCompress.Tests` are vendored upstream
+  code and exempt via per-project `<NoWarn>` (justification in the csproj).
+  Do not fix analyzer warnings in them; keep ports clean instead.
+- Bulk `dotnet format analyzers` runs: temporarily remove the analyzer package
+  from `Directory.Build.props` first — with the package referenced, the format
+  workspace loads both the SDK and packaged analyzer copies and applies every
+  code fix twice. Restore the package afterwards (builds are unaffected either
+  way; only the format tool is).
+
 ## Contributing
 
 Before creating a PR:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,5 +25,11 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,17 +10,20 @@
 
     The NetAnalyzers package is pinned (instead of relying on the SDK-bundled
     analyzers) so the rule set only changes on a deliberate dependency bump.
+
+    NOTE: while the package is referenced, `dotnet format analyzers` applies
+    every code fix twice (its workspace loads both the SDK-bundled and the
+    packaged analyzer copies), producing broken output such as
+    `.ConfigureAwait(false).ConfigureAwait(false)` and
+    `expr.ConfigureAwait(false)` on `await using` declarations. Run bulk
+    `dotnet format analyzers` fixes with the package temporarily removed from
+    this file (SDK-bundled analyzers apply the same fixes correctly), then
+    restore it. Builds and CI are unaffected — only the format tool.
   -->
   <PropertyGroup>
     <AnalysisLevel>latest-All</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,26 @@
+<Project>
+
+  <!--
+    Shared static-analysis configuration for all first-party projects
+    (backend, tests, libs/UsenetSharp, libs/RapidYencSharp, backend.Benchmarks).
+
+    Vendored upstream code (libs/SharpCompress and its ported test suite
+    tests/SharpCompress.Tests) opts out per project via <NoWarn>; see the
+    respective csproj files and CONTRIBUTING.md for the suppression policy.
+
+    The NetAnalyzers package is pinned (instead of relying on the SDK-bundled
+    analyzers) so the rule set only changes on a deliberate dependency bump.
+  -->
+  <PropertyGroup>
+    <AnalysisLevel>latest-All</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/backend.Benchmarks/GlobalSuppressions.cs
+++ b/backend.Benchmarks/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+
+// Benchmark data generation (segment corpora, shuffles) is not
+// security-sensitive; Random is intentional for reproducible cheap fixtures.
+[assembly: SuppressMessage(
+    "Security",
+    "CA5394:Do not use insecure randomness",
+    Justification = "Benchmark data generation only; no security decision depends on this randomness.")]

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -11,195 +11,183 @@ using UsenetSharp.Streams;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
-[MemoryDiagnoser]
-public class SegmentBufferPoolBenchmarks
+
+namespace NzbWebDAV.Benchmarks
 {
-    private const int SegmentsPerStream = 20;
-    private byte[] _payload = null!;
-    private SegmentBufferPool _segmentPool = null!;
-    private BufferPoolDiagnostics _sharedDiagnostics = null!;
-    private BufferPoolDiagnostics _segmentDiagnostics = null!;
-
-    [Params(700_000, 750_000, 800_000)]
-    public int SegmentSize { get; set; }
-
-    [Params(1, 8)]
-    public int ConcurrentStreams { get; set; }
-
-    [GlobalSetup]
-    public void Setup()
+    [MemoryDiagnoser]
+    public class SegmentBufferPoolBenchmarks
     {
-        _payload = new byte[SegmentSize];
-        new Random(42).NextBytes(_payload);
-        _segmentPool = new SegmentBufferPool(128 * 1024 * 1024);
-        _sharedDiagnostics = new BufferPoolDiagnostics();
-        _segmentDiagnostics = new BufferPoolDiagnostics();
-    }
+        private const int SegmentsPerStream = 20;
+        private byte[] _payload = null!;
+        private SegmentBufferPool _segmentPool = null!;
+        private BufferPoolDiagnostics _sharedDiagnostics = null!;
+        private BufferPoolDiagnostics _segmentDiagnostics = null!;
 
-    [Benchmark(Baseline = true)]
-    public long ArrayPoolShared() =>
-        DrainSegments(SharedArrayPoolAdapter.Instance, _sharedDiagnostics);
+        [Params(700_000, 750_000, 800_000)]
+        public int SegmentSize { get; set; }
 
-    [Benchmark]
-    public long SegmentBufferPool_128MB() =>
-        DrainSegments(_segmentPool, _segmentDiagnostics);
+        [Params(1, 8)]
+        public int ConcurrentStreams { get; set; }
 
-    private long DrainSegments(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
-    {
-        if (ConcurrentStreams == 1)
-            return DrainStream(pool, diagnostics);
-
-        long totalBytesRead = 0;
-        Parallel.For(0, ConcurrentStreams, _ =>
+        [GlobalSetup]
+        public void Setup()
         {
-            var bytesRead = DrainStream(pool, diagnostics);
-            Interlocked.Add(ref totalBytesRead, bytesRead);
-        });
-        return totalBytesRead;
-    }
-
-    private long DrainStream(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
-    {
-        long bytesRead = 0;
-        for (var segment = 0; segment < SegmentsPerStream; segment++)
-        {
-            using var buffer = new PooledBufferStream(SegmentSize, pool, diagnostics);
-            buffer.Write(_payload);
-            buffer.Position = 0;
-            buffer.CopyTo(Stream.Null);
-            bytesRead += buffer.Length;
-        }
-        return bytesRead;
-    }
-}
-
-[MemoryDiagnoser]
-public class YencDecodeBenchmarks
-{
-    private byte[] _decoded = null!;
-    private byte[] _encoded = null!;
-
-    [Params(256 * 1024, 1024 * 1024)]
-    public int SegmentSize { get; set; }
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        _decoded = new byte[SegmentSize];
-        new Random(42).NextBytes(_decoded);
-        _encoded = EncodeYenc(_decoded);
-    }
-
-    [Benchmark(Baseline = true)]
-    public async Task DecodeYencSegment()
-    {
-        await using var source = new MemoryStream(_encoded, writable: false);
-        await using var stream = new YencStream(source);
-        await stream.CopyToAsync(Stream.Null);
-    }
-
-    [Benchmark]
-    public async Task CopyDecodedSegment()
-    {
-        await using var stream = new MemoryStream(_decoded, writable: false);
-        await stream.CopyToAsync(Stream.Null);
-    }
-
-    internal static byte[] EncodeYenc(ReadOnlySpan<byte> source)
-    {
-        using var output = new MemoryStream(source.Length + source.Length / 100);
-        WriteAscii(output, $"=ybegin line=128 size={source.Length} name=benchmark.bin\r\n");
-
-        var lineLength = 0;
-        foreach (var value in source)
-        {
-            var encoded = unchecked((byte)(value + 42));
-            if (encoded is 0 or (byte)'\n' or (byte)'\r' or (byte)'=')
-            {
-                output.WriteByte((byte)'=');
-                output.WriteByte(unchecked((byte)(encoded + 64)));
-                lineLength += 2;
-            }
-            else
-            {
-                output.WriteByte(encoded);
-                lineLength++;
-            }
-
-            if (lineLength < 128) continue;
-            WriteAscii(output, "\r\n");
-            lineLength = 0;
+            _payload = new byte[SegmentSize];
+            new Random(42).NextBytes(_payload);
+            _segmentPool = new SegmentBufferPool(128 * 1024 * 1024);
+            _sharedDiagnostics = new BufferPoolDiagnostics();
+            _segmentDiagnostics = new BufferPoolDiagnostics();
         }
 
-        if (lineLength > 0) WriteAscii(output, "\r\n");
-        WriteAscii(output, $"=yend size={source.Length}\r\n");
-        return output.ToArray();
-    }
+        [Benchmark(Baseline = true)]
+        public long ArrayPoolShared() =>
+            DrainSegments(SharedArrayPoolAdapter.Instance, _sharedDiagnostics);
 
-    private static void WriteAscii(Stream output, string value)
-    {
-        output.Write(Encoding.ASCII.GetBytes(value));
-    }
-}
+        [Benchmark]
+        public long SegmentBufferPool_128MB() =>
+            DrainSegments(_segmentPool, _segmentDiagnostics);
 
-[MemoryDiagnoser]
-public class SegmentStreamBenchmarks
-{
-    private const int SegmentSize = 256 * 1024;
-    private BenchmarkNntpClient _client = null!;
-    private BenchmarkNntpClient _missingClient = null!;
-    private string[] _segmentIds = null!;
-    private LongRange[] _segmentRanges = null!;
-    private int[] _seekOffsets = null!;
+        private long DrainSegments(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
+        {
+            if (ConcurrentStreams == 1)
+                return DrainStream(pool, diagnostics);
 
-    [Params(0, 4)]
-    public int ArticleBufferSize { get; set; }
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        var segments = Enumerable.Range(0, 8).ToDictionary(
-            index => $"segment-{index}",
-            index =>
+            long totalBytesRead = 0;
+            Parallel.For(0, ConcurrentStreams, _ =>
             {
-                var bytes = new byte[SegmentSize];
-                new Random(index).NextBytes(bytes);
-                return bytes;
+                var bytesRead = DrainStream(pool, diagnostics);
+                Interlocked.Add(ref totalBytesRead, bytesRead);
             });
-        _segmentIds = segments.Keys.ToArray();
-        _segmentRanges = Enumerable.Range(0, segments.Count)
-            .Select(index => new LongRange(
-                index * SegmentSize, (index + 1L) * SegmentSize))
-            .ToArray();
-        _client = new BenchmarkNntpClient(segments);
-        _missingClient = new BenchmarkNntpClient(
-            segments
-                .Where(pair => pair.Key != "segment-3")
-                .ToDictionary(pair => pair.Key, pair => pair.Value));
-        var random = new Random(42);
-        var fileSize = segments.Count * SegmentSize;
-        _seekOffsets = Enumerable.Range(0, 16)
-            .Select(_ => random.Next(fileSize - 64 * 1024))
-            .ToArray();
+            return totalBytesRead;
+        }
+
+        private long DrainStream(ISegmentBufferPool pool, BufferPoolDiagnostics diagnostics)
+        {
+            long bytesRead = 0;
+            for (var segment = 0; segment < SegmentsPerStream; segment++)
+            {
+                using var buffer = new PooledBufferStream(SegmentSize, pool, diagnostics);
+                buffer.Write(_payload);
+                buffer.Position = 0;
+                buffer.CopyTo(Stream.Null);
+                bytesRead += buffer.Length;
+            }
+            return bytesRead;
+        }
     }
 
-    [Benchmark]
-    public async Task ReadSegmentStream()
+    [MemoryDiagnoser]
+    public class YencDecodeBenchmarks
     {
-        await using var stream = new NzbFileStream(
-            _segmentIds,
-            (long)_segmentIds.Length * SegmentSize,
-            _client,
-            ArticleBufferSize,
-            _segmentRanges);
-        await stream.CopyToAsync(Stream.Null);
+        private byte[] _decoded = null!;
+        private byte[] _encoded = null!;
+
+        [Params(256 * 1024, 1024 * 1024)]
+        public int SegmentSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _decoded = new byte[SegmentSize];
+            new Random(42).NextBytes(_decoded);
+            _encoded = EncodeYenc(_decoded);
+        }
+
+        [Benchmark(Baseline = true)]
+        public async Task DecodeYencSegment()
+        {
+            await using var source = new MemoryStream(_encoded, writable: false);
+            await using var stream = new YencStream(source);
+            await stream.CopyToAsync(Stream.Null);
+        }
+
+        [Benchmark]
+        public async Task CopyDecodedSegment()
+        {
+            await using var stream = new MemoryStream(_decoded, writable: false);
+            await stream.CopyToAsync(Stream.Null);
+        }
+
+        internal static byte[] EncodeYenc(ReadOnlySpan<byte> source)
+        {
+            using var output = new MemoryStream(source.Length + source.Length / 100);
+            WriteAscii(output, $"=ybegin line=128 size={source.Length} name=benchmark.bin\r\n");
+
+            var lineLength = 0;
+            foreach (var value in source)
+            {
+                var encoded = unchecked((byte)(value + 42));
+                if (encoded is 0 or (byte)'\n' or (byte)'\r' or (byte)'=')
+                {
+                    output.WriteByte((byte)'=');
+                    output.WriteByte(unchecked((byte)(encoded + 64)));
+                    lineLength += 2;
+                }
+                else
+                {
+                    output.WriteByte(encoded);
+                    lineLength++;
+                }
+
+                if (lineLength < 128) continue;
+                WriteAscii(output, "\r\n");
+                lineLength = 0;
+            }
+
+            if (lineLength > 0) WriteAscii(output, "\r\n");
+            WriteAscii(output, $"=yend size={source.Length}\r\n");
+            return output.ToArray();
+        }
+
+        private static void WriteAscii(Stream output, string value)
+        {
+            output.Write(Encoding.ASCII.GetBytes(value));
+        }
     }
 
-    [Benchmark]
-    public async Task<int> RandomSeekAndRead()
+    [MemoryDiagnoser]
+    public sealed class SegmentStreamBenchmarks : IDisposable
     {
-        var checksum = 0;
-        foreach (var offset in _seekOffsets)
+        private const int SegmentSize = 256 * 1024;
+        private BenchmarkNntpClient _client = null!;
+        private BenchmarkNntpClient _missingClient = null!;
+        private string[] _segmentIds = null!;
+        private LongRange[] _segmentRanges = null!;
+        private int[] _seekOffsets = null!;
+
+        [Params(0, 4)]
+        public int ArticleBufferSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var segments = Enumerable.Range(0, 8).ToDictionary(
+                index => $"segment-{index}",
+                index =>
+                {
+                    var bytes = new byte[SegmentSize];
+                    new Random(index).NextBytes(bytes);
+                    return bytes;
+                });
+            _segmentIds = segments.Keys.ToArray();
+            _segmentRanges = Enumerable.Range(0, segments.Count)
+                .Select(index => new LongRange(
+                    index * SegmentSize, (index + 1L) * SegmentSize))
+                .ToArray();
+            _client = new BenchmarkNntpClient(segments);
+            _missingClient = new BenchmarkNntpClient(
+                segments
+                    .Where(pair => pair.Key != "segment-3")
+                    .ToDictionary(pair => pair.Key, pair => pair.Value));
+            var random = new Random(42);
+            var fileSize = segments.Count * SegmentSize;
+            _seekOffsets = Enumerable.Range(0, 16)
+                .Select(_ => random.Next(fileSize - 64 * 1024))
+                .ToArray();
+        }
+
+        [Benchmark]
+        public async Task ReadSegmentStream()
         {
             await using var stream = new NzbFileStream(
                 _segmentIds,
@@ -207,141 +195,164 @@ public class SegmentStreamBenchmarks
                 _client,
                 ArticleBufferSize,
                 _segmentRanges);
-            stream.Seek(offset, SeekOrigin.Begin);
-            var buffer = new byte[64 * 1024];
-            var read = await stream.ReadAtLeastAsync(
-                buffer, buffer.Length, throwOnEndOfStream: false);
-            checksum = read == 0
-                ? HashCode.Combine(checksum, 0)
-                : HashCode.Combine(checksum, read, buffer[0], buffer[read - 1]);
+            await stream.CopyToAsync(Stream.Null);
         }
 
-        return checksum;
-    }
-
-    [Benchmark]
-    public async Task ReadSegmentStreamWithExactZeroFill()
-    {
-        await using var stream = new NzbFileStream(
-            _segmentIds,
-            (long)_segmentIds.Length * SegmentSize,
-            _missingClient,
-            ArticleBufferSize,
-            _segmentRanges);
-        await stream.CopyToAsync(Stream.Null);
-    }
-}
-
-internal sealed class BenchmarkNntpClient(
-    IReadOnlyDictionary<string, byte[]> segments) : NntpClient
-{
-    public override Task ConnectAsync(
-        string host, int port, bool useSsl, CancellationToken cancellationToken) =>
-        Task.CompletedTask;
-
-    public override Task<UsenetResponse> AuthenticateAsync(
-        string user, string pass, CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override Task<UsenetStatResponse> StatAsync(
-        SegmentId segmentId, CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override Task<UsenetHeadResponse> HeadAsync(
-        SegmentId segmentId, CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId, CancellationToken cancellationToken) =>
-        DecodedBodyAsync(segmentId, null, cancellationToken);
-
-    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId,
-        ArticleBodyCompletionHandler? onConnectionReadyAgain,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        try
+        [Benchmark]
+        public async Task<int> RandomSeekAndRead()
         {
-            var response = CreateResponse(segmentId);
+            var checksum = 0;
+            foreach (var offset in _seekOffsets)
+            {
+                await using var stream = new NzbFileStream(
+                    _segmentIds,
+                    (long)_segmentIds.Length * SegmentSize,
+                    _client,
+                    ArticleBufferSize,
+                    _segmentRanges);
+                stream.Seek(offset, SeekOrigin.Begin);
+                var buffer = new byte[64 * 1024];
+                var read = await stream.ReadAtLeastAsync(
+                    buffer, buffer.Length, throwOnEndOfStream: false);
+                checksum = read == 0
+                    ? HashCode.Combine(checksum, 0)
+                    : HashCode.Combine(checksum, read, buffer[0], buffer[read - 1]);
+            }
+
+            return checksum;
+        }
+
+        [Benchmark]
+        public async Task ReadSegmentStreamWithExactZeroFill()
+        {
+            await using var stream = new NzbFileStream(
+                _segmentIds,
+                (long)_segmentIds.Length * SegmentSize,
+                _missingClient,
+                ArticleBufferSize,
+                _segmentRanges);
+            await stream.CopyToAsync(Stream.Null);
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+            _missingClient.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    internal sealed class BenchmarkNntpClient(
+        IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var response = CreateResponse(segmentId);
+                onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+                return Task.FromResult(response);
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException<UsenetDecodedBodyResponse>(exception);
+            }
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(segmentId => DecodedBodyAsync(segmentId, cancellationToken))
+                .ToArray();
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
-            return Task.FromResult(response);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
         }
-        catch (Exception exception)
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodiesAsync(
+                segmentIds, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
         {
-            return Task.FromException<UsenetDecodedBodyResponse>(exception);
         }
-    }
 
-    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-        IReadOnlyList<SegmentId> segmentIds,
-        ArticleBodyCompletionHandler? onConnectionReadyAgain,
-        CancellationToken cancellationToken)
-    {
-        var responses = segmentIds
-            .Select(segmentId => DecodedBodyAsync(segmentId, cancellationToken))
-            .ToArray();
-        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
-        return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
-    }
-
-    public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
-        string segmentId, CancellationToken cancellationToken) =>
-        Task.FromResult(new UsenetExclusiveConnection(null));
-
-    public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
-        IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
-        Task.FromResult(new UsenetExclusiveConnection(null));
-
-    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-        SegmentId segmentId,
-        UsenetExclusiveConnection exclusiveConnection,
-        CancellationToken cancellationToken) =>
-        DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
-
-    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-        IReadOnlyList<SegmentId> segmentIds,
-        UsenetExclusiveConnection exclusiveConnection,
-        CancellationToken cancellationToken) =>
-        DecodedBodiesAsync(
-            segmentIds, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
-
-    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId, CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId,
-        ArticleBodyCompletionHandler? onConnectionReadyAgain,
-        CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-        SegmentId segmentId,
-        UsenetExclusiveConnection exclusiveConnection,
-        CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
-
-    public override void Dispose()
-    {
-    }
-
-    private UsenetDecodedBodyResponse CreateResponse(SegmentId segmentId)
-    {
-        var key = segmentId.ToString();
-        if (!segments.TryGetValue(key, out var bytes))
-            throw new UsenetArticleNotFoundException(key, "430 No such article");
-
-        return new UsenetDecodedBodyResponse
+        private UsenetDecodedBodyResponse CreateResponse(SegmentId segmentId)
         {
-            SegmentId = key,
-            ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
-            ResponseMessage = "222 benchmark body",
-            Stream = new YencStream(new MemoryStream(
-                YencDecodeBenchmarks.EncodeYenc(bytes), writable: false))
-        };
+            var key = segmentId.ToString();
+            if (!segments.TryGetValue(key, out var bytes))
+                throw new UsenetArticleNotFoundException(key, "430 No such article");
+
+            return new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 benchmark body",
+                Stream = new YencStream(new MemoryStream(
+                    YencDecodeBenchmarks.EncodeYenc(bytes), writable: false))
+            };
+        }
     }
 }

--- a/backend/Api/Controllers/Authenticate/AuthenticateRequest.cs
+++ b/backend/Api/Controllers/Authenticate/AuthenticateRequest.cs
@@ -11,7 +11,7 @@ public class AuthenticateRequest
 
     public AuthenticateRequest(HttpContext context)
     {
-        Username = context.Request.Form["username"].FirstOrDefault()?.ToLower() ??
+        Username = context.Request.Form["username"].FirstOrDefault()?.ToLowerInvariant() ??
             throw new BadHttpRequestException("Username is required");
 
         Password = context.Request.Form["password"].FirstOrDefault() ??

--- a/backend/Api/Controllers/CreateAccount/CreateAccountRequest.cs
+++ b/backend/Api/Controllers/CreateAccount/CreateAccountRequest.cs
@@ -11,7 +11,7 @@ public class CreateAccountRequest
 
     public CreateAccountRequest(HttpContext context)
     {
-        Username = context.Request.Form["username"].FirstOrDefault()?.ToLower() ??
+        Username = context.Request.Form["username"].FirstOrDefault()?.ToLowerInvariant() ??
             throw new BadHttpRequestException("Username is required");
 
         Password = context.Request.Form["password"].FirstOrDefault() ??

--- a/backend/Api/Controllers/DbBackupDownload/DbBackupDownloadController.cs
+++ b/backend/Api/Controllers/DbBackupDownload/DbBackupDownloadController.cs
@@ -46,7 +46,7 @@ public class DbBackupDownloadController(DatabaseBackupStore store) : BaseApiCont
                 continue;
 
             var entry = archive.CreateEntry(relative, CompressionLevel.Fastest);
-            await using var entryStream = entry.Open();
+            await using var entryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var fileStream = System.IO.File.OpenRead(file);
             await fileStream.CopyToAsync(entryStream, cancellationToken).ConfigureAwait(false);
         }

--- a/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
+++ b/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
@@ -28,7 +28,8 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
         if (!HttpContext.Request.HasFormContentType)
             throw new BadHttpRequestException("Expected multipart form body.");
 
-        var file = HttpContext.Request.Form.Files.FirstOrDefault();
+        var formFiles = HttpContext.Request.Form.Files;
+        var file = formFiles.Count > 0 ? formFiles[0] : null;
         if (file is null || file.Length == 0)
             throw new BadHttpRequestException("No backup file was uploaded.");
 

--- a/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
+++ b/backend/Api/Controllers/DbBackupUpload/DbBackupUploadController.cs
@@ -112,7 +112,7 @@ public class DbBackupUploadController(DatabaseBackupStore store) : BaseApiContro
                 throw PayloadTooLarge("Zip entry compression ratio exceeds the restore safety limit.");
 
             var dest = Path.Join(stagingPath, fileName);
-            await using var entryStream = entry.Open();
+            await using var entryStream = await entry.OpenAsync(ct).ConfigureAwait(false);
             await using var output = System.IO.File.Create(dest);
             extractedBytes += await CopyWithLimitAsync(
                 entryStream,

--- a/backend/Api/Controllers/DownloadNzb/DownloadNzbController.cs
+++ b/backend/Api/Controllers/DownloadNzb/DownloadNzbController.cs
@@ -24,7 +24,9 @@ public class DownloadNzbController(DavDatabaseContext dbContext) : BaseApiContro
             throw new BadHttpRequestException("NZB not found.");
 
         // Open the NZB blob from the blob store
+        #pragma warning disable CA2000 // the MVC File() result disposes the stream after the response is sent
         var stream = BlobStore.ReadBlob(nzbBlobId);
+        #pragma warning restore CA2000
         if (stream == null)
             throw new BadHttpRequestException("NZB file is no longer available.");
 

--- a/backend/Api/Controllers/DownloadNzb/DownloadNzbController.cs
+++ b/backend/Api/Controllers/DownloadNzb/DownloadNzbController.cs
@@ -24,9 +24,9 @@ public class DownloadNzbController(DavDatabaseContext dbContext) : BaseApiContro
             throw new BadHttpRequestException("NZB not found.");
 
         // Open the NZB blob from the blob store
-        #pragma warning disable CA2000 // the MVC File() result disposes the stream after the response is sent
+#pragma warning disable CA2000 // the MVC File() result disposes the stream after the response is sent
         var stream = BlobStore.ReadBlob(nzbBlobId);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         if (stream == null)
             throw new BadHttpRequestException("NZB file is no longer available.");
 

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -211,10 +211,14 @@ public class GetOverviewStatsController(
             .Select(x => new { x.StartedAt, x.EndedAt, x.DurationMs, x.BytesServed, x.FailoverSaves })
             .ToListAsync();
         #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var heatmapTask = BuildHeatmapAsync(metricsHeatmap, window, nowMs);
         #pragma warning restore CA2025
+        #pragma warning restore CA2025
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var previousSavesTask = LoadPreviousFailoverSavesAsync(metricsPrev, window, windowStart, windowMs);
+        #pragma warning restore CA2025
         #pragma warning restore CA2025
         var sinceMinute = nowMs - OneMinute;
         var liveCountsTask = metricsLive.SegmentFetches
@@ -478,15 +482,23 @@ public class GetOverviewStatsController(
         await using var davIndexers = new DavDatabaseContext();
 
         #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var catalogueTask = BuildCatalogueAsync(davDb.Ctx);
         #pragma warning restore CA2025
+        #pragma warning restore CA2025
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var indexersTask = BuildIndexersAsync(davIndexers);
+        #pragma warning restore CA2025
         var apiUsageTask = BuildIndexerApiUsageAsync();
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var lifetimeTask = BuildLifetimeAsync(metricsLifetime);
         #pragma warning restore CA2025
+        #pragma warning restore CA2025
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var recordsTask = BuildRecordsAsync(metricsRecords);
+        #pragma warning restore CA2025
         #pragma warning restore CA2025
 
         await Task.WhenAll(catalogueTask, indexersTask, apiUsageTask, lifetimeTask, recordsTask)

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -210,16 +210,16 @@ public class GetOverviewStatsController(
             .Where(x => x.EndedAt >= windowStart)
             .Select(x => new { x.StartedAt, x.EndedAt, x.DurationMs, x.BytesServed, x.FailoverSaves })
             .ToListAsync();
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var heatmapTask = BuildHeatmapAsync(metricsHeatmap, window, nowMs);
-        #pragma warning restore CA2025
-        #pragma warning restore CA2025
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning restore CA2025
+#pragma warning restore CA2025
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var previousSavesTask = LoadPreviousFailoverSavesAsync(metricsPrev, window, windowStart, windowMs);
-        #pragma warning restore CA2025
-        #pragma warning restore CA2025
+#pragma warning restore CA2025
+#pragma warning restore CA2025
         var sinceMinute = nowMs - OneMinute;
         var liveCountsTask = metricsLive.SegmentFetches
             .Where(x => x.At >= sinceMinute)
@@ -481,25 +481,25 @@ public class GetOverviewStatsController(
         await using var metricsRecords = new MetricsDbContext();
         await using var davIndexers = new DavDatabaseContext();
 
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var catalogueTask = BuildCatalogueAsync(davDb.Ctx);
-        #pragma warning restore CA2025
-        #pragma warning restore CA2025
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning restore CA2025
+#pragma warning restore CA2025
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var indexersTask = BuildIndexersAsync(davIndexers);
-        #pragma warning restore CA2025
+#pragma warning restore CA2025
         var apiUsageTask = BuildIndexerApiUsageAsync();
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var lifetimeTask = BuildLifetimeAsync(metricsLifetime);
-        #pragma warning restore CA2025
-        #pragma warning restore CA2025
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
-        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning restore CA2025
+#pragma warning restore CA2025
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
+#pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var recordsTask = BuildRecordsAsync(metricsRecords);
-        #pragma warning restore CA2025
-        #pragma warning restore CA2025
+#pragma warning restore CA2025
+#pragma warning restore CA2025
 
         await Task.WhenAll(catalogueTask, indexersTask, apiUsageTask, lifetimeTask, recordsTask)
             .ConfigureAwait(false);

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -892,7 +892,7 @@ public class GetOverviewStatsController(
 
     private static List<double> BuildSpeedSpark(
         IReadOnlyList<long> bytes,
-        IReadOnlyList<long> durations) =>
+        long[] durations) =>
         bytes.Select((value, index) =>
                 CalculateSpeedMbPerSec(value, durations[index]) ?? 0)
             .ToList();

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -210,8 +210,12 @@ public class GetOverviewStatsController(
             .Where(x => x.EndedAt >= windowStart)
             .Select(x => new { x.StartedAt, x.EndedAt, x.DurationMs, x.BytesServed, x.FailoverSaves })
             .ToListAsync();
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var heatmapTask = BuildHeatmapAsync(metricsHeatmap, window, nowMs);
+        #pragma warning restore CA2025
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var previousSavesTask = LoadPreviousFailoverSavesAsync(metricsPrev, window, windowStart, windowMs);
+        #pragma warning restore CA2025
         var sinceMinute = nowMs - OneMinute;
         var liveCountsTask = metricsLive.SegmentFetches
             .Where(x => x.At >= sinceMinute)
@@ -473,11 +477,17 @@ public class GetOverviewStatsController(
         await using var metricsRecords = new MetricsDbContext();
         await using var davIndexers = new DavDatabaseContext();
 
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var catalogueTask = BuildCatalogueAsync(davDb.Ctx);
+        #pragma warning restore CA2025
         var indexersTask = BuildIndexersAsync(davIndexers);
         var apiUsageTask = BuildIndexerApiUsageAsync();
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var lifetimeTask = BuildLifetimeAsync(metricsLifetime);
+        #pragma warning restore CA2025
+        #pragma warning disable CA2025 // all parallel query tasks are awaited via Task.WhenAll before the await using contexts dispose at method end
         var recordsTask = BuildRecordsAsync(metricsRecords);
+        #pragma warning restore CA2025
 
         await Task.WhenAll(catalogueTask, indexersTask, apiUsageTask, lifetimeTask, recordsTask)
             .ConfigureAwait(false);

--- a/backend/Api/Controllers/GetWatchdogEntries/GetWatchdogEntriesController.cs
+++ b/backend/Api/Controllers/GetWatchdogEntries/GetWatchdogEntriesController.cs
@@ -59,7 +59,7 @@ public partial class GetWatchdogEntriesController(
     // nickname (or kept as-is when no nickname is configured). Returns null
     // when no part has a nickname, so the frontend can fall back to its own
     // formatProviderShort for the host string.
-    private static string? ResolveNickname(string? providerHost, IReadOnlyDictionary<string, string?> nicknamesByHost)
+    private static string? ResolveNickname(string? providerHost, Dictionary<string, string?> nicknamesByHost)
     {
         if (string.IsNullOrWhiteSpace(providerHost) || nicknamesByHost.Count == 0) return null;
         var parts = providerHost.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -60,7 +60,7 @@ public class GetWebdavItemController(
         Response.Headers["Content-Encoding"] = "identity";
 
         // handle par2 preview
-        if (Path.GetExtension(item.Name).ToLowerInvariant() == ".par2" && configManager.IsPreviewPar2FilesEnabled())
+        if (string.Equals(Path.GetExtension(item.Name), ".par2", StringComparison.OrdinalIgnoreCase) && configManager.IsPreviewPar2FilesEnabled())
             return await GetPar2PreviewStream(item, ct).ConfigureAwait(false);
 
         // Provisional budget for fully-specified ranges before stream creation.
@@ -264,7 +264,7 @@ public class GetWebdavItemController(
             int read;
             try
             {
-                read = await src.ReadAsync(buffer, 0, buffer.Length, ct).ConfigureAwait(false);
+                read = await src.ReadAsync(buffer, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -284,7 +284,7 @@ public class GetWebdavItemController(
             }
             if (read <= 0) break;
             var writeStarted = Stopwatch.GetTimestamp();
-            await dest.WriteAsync(buffer, 0, read, ct).ConfigureAwait(false);
+            await dest.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
             streamTrace.AddStall(
                 traceRange, StreamStallKind.ClientWrite, Stopwatch.GetElapsedTime(writeStarted));
             position += read;
@@ -367,7 +367,7 @@ public class GetWebdavItemController(
     {
         Response.Headers.ContentType = "text/plain";
         await using var stream = await item.GetReadableStreamAsync(ct).ConfigureAwait(false);
-        var fileDescriptors = await Par2.ReadFileDescriptions(stream, ct).GetAllAsync()
+        var fileDescriptors = await Par2.ReadFileDescriptions(stream, ct).GetAllAsync(ct: ct)
             .ConfigureAwait(false);
         return new MemoryStream(Encoding.UTF8.GetBytes(fileDescriptors.ToIndentedJson()));
     }

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -43,7 +43,9 @@ public class GetWebdavItemController(
             PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
             MaxRetries = configManager.GetStreamingSegmentRetries(),
         };
+        #pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
         var scopedStreamingTimeoutContext = ct.SetContext(streamingTimeoutContext);
+        #pragma warning restore CA2000
         HttpContext.Response.OnCompleted(() =>
         {
             scopedStreamingTimeoutContext.Dispose();
@@ -127,7 +129,9 @@ public class GetWebdavItemController(
 
             // seek
             stream.Seek(rangeStart.Value, SeekOrigin.Begin);
+            #pragma warning disable CA2000 // the length-limited wrapper is returned as the response stream; the response pipeline disposes it (and the inner stream)
             if (rangeEnd is not null) stream = stream.LimitLength(chunkSize);
+            #pragma warning restore CA2000
 
             // set response headers
             Response.Headers["Content-Range"] = $"bytes {rangeStart}-{end}/{fileSize}";

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -58,7 +58,7 @@ public class GetWebdavItemController(
         Response.Headers["Content-Encoding"] = "identity";
 
         // handle par2 preview
-        if (Path.GetExtension(item.Name).ToLower() == ".par2" && configManager.IsPreviewPar2FilesEnabled())
+        if (Path.GetExtension(item.Name).ToLowerInvariant() == ".par2" && configManager.IsPreviewPar2FilesEnabled())
             return await GetPar2PreviewStream(item, ct).ConfigureAwait(false);
 
         // Provisional budget for fully-specified ranges before stream creation.

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -43,9 +43,9 @@ public class GetWebdavItemController(
             PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
             MaxRetries = configManager.GetStreamingSegmentRetries(),
         };
-        #pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
+#pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
         var scopedStreamingTimeoutContext = ct.SetContext(streamingTimeoutContext);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         HttpContext.Response.OnCompleted(() =>
         {
             scopedStreamingTimeoutContext.Dispose();
@@ -129,9 +129,9 @@ public class GetWebdavItemController(
 
             // seek
             stream.Seek(rangeStart.Value, SeekOrigin.Begin);
-            #pragma warning disable CA2000 // the length-limited wrapper is returned as the response stream; the response pipeline disposes it (and the inner stream)
+#pragma warning disable CA2000 // the length-limited wrapper is returned as the response stream; the response pipeline disposes it (and the inner stream)
             if (rangeEnd is not null) stream = stream.LimitLength(chunkSize);
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
 
             // set response headers
             Response.Headers["Content-Range"] = $"bytes {rangeStart}-{end}/{fileSize}";

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -171,7 +171,7 @@ public class GetWebdavItemController(
             StreamTraceRangeContext? traceRange = null;
             try
             {
-                await using var response = await GetWebdavItem(request, ct);
+                await using var response = await GetWebdavItem(request, ct).ConfigureAwait(false);
                 if (response == Stream.Null)
                     return;
                 var effectiveStart = (long)(HttpContext.Items["effectiveRangeStart"] ?? 0L);
@@ -192,7 +192,7 @@ public class GetWebdavItemController(
                     // Body transfer can run for minutes; drop the admission/open
                     // deadline and rely on per-segment mid-stream timeouts.
                     readCts.CancelAfter(Timeout.InfiniteTimeSpan);
-                    await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, traceRange, ct);
+                    await CopyAndReportAsync(response, Response.Body, sessionId, effectiveStart, traceRange, ct).ConfigureAwait(false);
                     FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Completed);
                 }
                 catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -27,7 +27,7 @@ public class GetWebdavItemRequest
         Item = path;
 
         // determine whether to download
-        ShouldDownload = context.GetQueryParam("download")?.ToLower() == "true";
+        ShouldDownload = context.GetQueryParam("download")?.ToLowerInvariant() == "true";
 
         // authenticate the downloadKey
         var downloadKey = context.Request.Query["downloadKey"];

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -21,9 +21,9 @@ public class GetWebdavItemRequest
     {
         // normalize path
         var path = context.Request.Path.Value ?? "";
-        if (path.StartsWith("/", StringComparison.Ordinal)) path = path[1..];
+        if (path.StartsWith('/')) path = path[1..];
         if (path.StartsWith("view", StringComparison.Ordinal)) path = path[4..];
-        if (path.StartsWith("/", StringComparison.Ordinal)) path = path[1..];
+        if (path.StartsWith('/')) path = path[1..];
         Item = path;
 
         // determine whether to download

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -21,9 +21,9 @@ public class GetWebdavItemRequest
     {
         // normalize path
         var path = context.Request.Path.Value ?? "";
-        if (path.StartsWith("/")) path = path[1..];
-        if (path.StartsWith("view")) path = path[4..];
-        if (path.StartsWith("/")) path = path[1..];
+        if (path.StartsWith("/", StringComparison.Ordinal)) path = path[1..];
+        if (path.StartsWith("view", StringComparison.Ordinal)) path = path[4..];
+        if (path.StartsWith("/", StringComparison.Ordinal)) path = path[1..];
         Item = path;
 
         // determine whether to download
@@ -65,7 +65,7 @@ public class GetWebdavItemRequest
 
         var spec = rangeHeader["bytes=".Length..];
         // Multi-range or garbage with commas is unparseable for our single-range path.
-        if (spec.Contains(','))
+        if (spec.Contains(',', StringComparison.Ordinal))
             return false;
 
         if (spec.StartsWith('-'))
@@ -76,7 +76,7 @@ public class GetWebdavItemRequest
             return true;
         }
 
-        var dash = spec.IndexOf('-');
+        var dash = spec.IndexOf('-', StringComparison.Ordinal);
         if (dash < 0)
             return false;
 
@@ -101,7 +101,7 @@ public class GetWebdavItemRequest
 
     private static bool VerifyDownloadKey(string? downloadKey, string path, ConfigManager configManager)
     {
-        if (path.StartsWith(".ids"))
+        if (path.StartsWith(".ids", StringComparison.Ordinal))
         {
             // strm streams link items by id and use a different download key
             var strmKey = configManager.GetStrmKey();

--- a/backend/Api/Controllers/ListWebdavDirectory/ListWebdavDirectoryController.cs
+++ b/backend/Api/Controllers/ListWebdavDirectory/ListWebdavDirectoryController.cs
@@ -18,7 +18,7 @@ public class ListWebdavDirectoryController(DatabaseStore store, ConfigManager co
         if (item is not IStoreCollection dir) throw new BadHttpRequestException("The directory does not exist.");
         var children = new List<ListWebdavDirectoryResponse.DirectoryItem>();
         var showHiddenWebdavFiles = configManager.ShowHiddenWebdavFiles();
-        await foreach (var child in dir.GetItemsAsync(HttpContext.RequestAborted))
+        await foreach (var child in dir.GetItemsAsync(HttpContext.RequestAborted).ConfigureAwait(false))
         {
             if (!showHiddenWebdavFiles && child.Name.StartsWith('.'))
                 continue;

--- a/backend/Api/Controllers/Profiles/Adapters/JsonSearchController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/JsonSearchController.cs
@@ -45,7 +45,7 @@ public class JsonSearchController(
 
         if (type.Equals("series", StringComparison.OrdinalIgnoreCase)
             && season.HasValue && episode.HasValue
-            && !id.Contains(':'))
+            && !id.Contains(':', StringComparison.Ordinal))
         {
             id = $"{id}:{season.Value}:{episode.Value}";
         }

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -792,7 +792,9 @@ public class ProfilePlayController(
         {
             return new PreVerifyResult(candidate, null, PlaybackFastVerifier.Verdict.Timeout, null, false);
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Debug(e, "Pre-verify failed for {Url}", candidate.NzbUrl);
             return new PreVerifyResult(candidate, null, PlaybackFastVerifier.Verdict.Dead, null, false);
@@ -870,7 +872,9 @@ public class ProfilePlayController(
                 _ = hitTracker.RecordAsync(c.IndexerName, IndexerApiHit.HitType.Download, CancellationToken.None);
                 return bytes;
             }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
+            #pragma warning restore CA2016
             {
                 Log.Debug("NZB fetch failed for {Url}: {Message}", c.NzbUrl, e.Message);
                 return null;
@@ -1007,7 +1011,7 @@ public class ProfilePlayController(
                         {
                             Log.Debug(e, "Variants: background cap enforcement failed for group {Group}", keyCopy);
                         }
-                    });
+                    }, CancellationToken.None);
                 }
 
                 Log.Debug("play-timing commit {Indexer} newEnqueue={NewEnqueue} waited={Waited}ms",

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -404,7 +404,7 @@ public class ProfilePlayController(
             var settled = await Task.WhenAny(preVerifies[0], hedgeTask).ConfigureAwait(false);
             var primaryReady = settled == preVerifies[0]
                                && preVerifies[0].IsCompletedSuccessfully
-                               && preVerifies[0].Result.Verdict == PlaybackFastVerifier.Verdict.Available;
+                               && (await preVerifies[0].ConfigureAwait(false)).Verdict == PlaybackFastVerifier.Verdict.Available;
 
             if (!primaryReady)
             {

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -792,9 +792,9 @@ public class ProfilePlayController(
         {
             return new PreVerifyResult(candidate, null, PlaybackFastVerifier.Verdict.Timeout, null, false);
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Debug(e, "Pre-verify failed for {Url}", candidate.NzbUrl);
             return new PreVerifyResult(candidate, null, PlaybackFastVerifier.Verdict.Dead, null, false);
@@ -872,9 +872,9 @@ public class ProfilePlayController(
                 _ = hitTracker.RecordAsync(c.IndexerName, IndexerApiHit.HitType.Download, CancellationToken.None);
                 return bytes;
             }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
             {
                 Log.Debug("NZB fetch failed for {Url}: {Message}", c.NzbUrl, e.Message);
                 return null;

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -218,7 +218,9 @@ public sealed class UsenetMigrationController(
         if (!string.IsNullOrWhiteSpace(q))
         {
             var normalizedSearch = q.Trim().ToLowerInvariant();
+            #pragma warning disable CA1862 // IQueryable: ToLowerInvariant().Contains() is translatable by EF Core; the StringComparison overload is not reliably translated to SQL
             query = query.Where(r => r.SubmitFileName.ToLowerInvariant().Contains(normalizedSearch));
+            #pragma warning restore CA1862
         }
 
         var total = await query.CountAsync(HttpContext.RequestAborted).ConfigureAwait(false);

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -218,9 +218,9 @@ public sealed class UsenetMigrationController(
         if (!string.IsNullOrWhiteSpace(q))
         {
             var normalizedSearch = q.Trim().ToLowerInvariant();
-            #pragma warning disable CA1862 // IQueryable: ToLowerInvariant().Contains() is translatable by EF Core; the StringComparison overload is not reliably translated to SQL
+#pragma warning disable CA1862 // IQueryable: ToLowerInvariant().Contains() is translatable by EF Core; the StringComparison overload is not reliably translated to SQL
             query = query.Where(r => r.SubmitFileName.ToLowerInvariant().Contains(normalizedSearch));
-            #pragma warning restore CA1862
+#pragma warning restore CA1862
         }
 
         var total = await query.CountAsync(HttpContext.RequestAborted).ConfigureAwait(false);

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -1042,7 +1042,7 @@ public sealed class UsenetMigrationController(
     /// <summary>Wrap in single quotes, escaping embedded quotes as <c>'\''</c>.</summary>
     internal static string ShQuote(string value)
     {
-        return "'" + value.Replace("'", "'\\''") + "'";
+        return "'" + value.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
     }
 
     /// <summary>
@@ -1055,7 +1055,7 @@ public sealed class UsenetMigrationController(
         var safe = value[0] is '=' or '+' or '-' or '@' ? "'" + value : value;
         // Quote when the field contains a delimiter, quote, or newline; double interior quotes.
         if (safe.IndexOfAny([',', '"', '\n', '\r']) < 0) return safe;
-        return "\"" + safe.Replace("\"", "\"\"") + "\"";
+        return "\"" + safe.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
     }
 
     private static string[] Reasons(string json)

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationController.cs
@@ -218,7 +218,7 @@ public sealed class UsenetMigrationController(
         if (!string.IsNullOrWhiteSpace(q))
         {
             var normalizedSearch = q.Trim().ToLowerInvariant();
-            query = query.Where(r => r.SubmitFileName.ToLower().Contains(normalizedSearch));
+            query = query.Where(r => r.SubmitFileName.ToLowerInvariant().Contains(normalizedSearch));
         }
 
         var total = await query.CountAsync(HttpContext.RequestAborted).ConfigureAwait(false);
@@ -944,7 +944,7 @@ public sealed class UsenetMigrationController(
         var relativeBa = Path.GetRelativePath(b, a);
         return IsWithinOrEqual(relativeAb) || IsWithinOrEqual(relativeBa);
 
-        static bool IsWithinOrEqual(string relative) =>
+        bool IsWithinOrEqual(string relative) =>
             relative == "."
             || (!Path.IsPathRooted(relative)
                 && relative != ".."

--- a/backend/Api/Controllers/Warden/WardenBackupController.cs
+++ b/backend/Api/Controllers/Warden/WardenBackupController.cs
@@ -70,7 +70,7 @@ public class WardenBackupNowController(WardenBackupService backup) : BaseApiCont
     protected override async Task<IActionResult> HandleRequest()
     {
         var msg = await backup.PushAsync(HttpContext.RequestAborted).ConfigureAwait(false);
-        return Ok(new WardenBackupMutateResponse { Status = !msg.StartsWith("error"), Message = msg });
+        return Ok(new WardenBackupMutateResponse { Status = !msg.StartsWith("error", StringComparison.Ordinal), Message = msg });
     }
 }
 

--- a/backend/Api/Controllers/Warden/WardenBackupController.cs
+++ b/backend/Api/Controllers/Warden/WardenBackupController.cs
@@ -14,16 +14,16 @@ public class WardenBackupController(WardenStore warden) : BaseApiController
 
     protected override Task<IActionResult> HandleRequest()
     {
-        return Task.FromResult(HttpContext.Request.Method == HttpMethods.Post ? Save() : Status());
+        return Task.FromResult<IActionResult>(HttpContext.Request.Method == HttpMethods.Post ? Save() : Status());
     }
 
-    private IActionResult Status()
+    private OkObjectResult Status()
     {
         var s = warden.GetBackupSettings();
         return Ok(ToResponse(s));
     }
 
-    private IActionResult Save()
+    private OkObjectResult Save()
     {
         var form = HttpContext.Request.Form;
         var repo = form["repo"].ToString().Trim();

--- a/backend/Api/Controllers/Warden/WardenExportController.cs
+++ b/backend/Api/Controllers/Warden/WardenExportController.cs
@@ -30,7 +30,7 @@ public class WardenExportController(WardenStore warden) : BaseApiController
         Response.ContentType = "application/gzip";
         Response.Headers["Content-Disposition"] = "attachment; filename=\"warden.ndjson.gz\"";
         await using var gz = new GZipStream(Response.Body, CompressionLevel.Optimal, leaveOpen: true);
-        await warden.ExportToAsync(gz, sourceIds, dedup, ct);
+        await warden.ExportToAsync(gz, sourceIds, dedup, ct).ConfigureAwait(false);
         return new EmptyResult();
     }
 }

--- a/backend/Api/Controllers/Warden/WardenImportController.cs
+++ b/backend/Api/Controllers/Warden/WardenImportController.cs
@@ -36,7 +36,7 @@ public class WardenImportController(WardenStore warden) : BaseApiController
         {
             var name = form["name"].ToString();
             if (string.IsNullOrWhiteSpace(name))
-                name = Path.GetFileNameWithoutExtension(file.FileName).Replace(".ndjson", "");
+                name = Path.GetFileNameWithoutExtension(file.FileName).Replace(".ndjson", "", StringComparison.Ordinal);
             if (string.IsNullOrWhiteSpace(name)) name = "Imported list";
             var trust = form["trust"].ToString();
             var (sourceId, count) = await warden.ImportAsNewSourceAsync(buffered, name, trust, ct).ConfigureAwait(false);

--- a/backend/Api/Controllers/Warden/WardenImportController.cs
+++ b/backend/Api/Controllers/Warden/WardenImportController.cs
@@ -30,7 +30,7 @@ public class WardenImportController(WardenStore warden) : BaseApiController
         if (file.Length > 256L * 1024 * 1024)
             throw new BadHttpRequestException("Warden upload exceeds the 256 MiB size limit.", StatusCodes.Status413PayloadTooLarge);
 
-        await using var buffered = await BufferAndDecompressAsync(file, ct);
+        await using var buffered = await BufferAndDecompressAsync(file, ct).ConfigureAwait(false);
 
         if (target == "separate")
         {
@@ -39,12 +39,12 @@ public class WardenImportController(WardenStore warden) : BaseApiController
                 name = Path.GetFileNameWithoutExtension(file.FileName).Replace(".ndjson", "");
             if (string.IsNullOrWhiteSpace(name)) name = "Imported list";
             var trust = form["trust"].ToString();
-            var (sourceId, count) = await warden.ImportAsNewSourceAsync(buffered, name, trust, ct);
+            var (sourceId, count) = await warden.ImportAsNewSourceAsync(buffered, name, trust, ct).ConfigureAwait(false);
             return Ok(new WardenImportResponse { Status = true, Added = count, Total = warden.Count, Cleared = 0, SourceId = sourceId });
         }
 
         var before = warden.LocalCount;
-        await warden.MergeIntoLocalAsync(buffered, ct);
+        await warden.MergeIntoLocalAsync(buffered, ct).ConfigureAwait(false);
         var after = warden.LocalCount;
         return Ok(new WardenImportResponse { Status = true, Added = Math.Max(0, after - before), Total = warden.Count, Cleared = 0 });
     }
@@ -53,7 +53,7 @@ public class WardenImportController(WardenStore warden) : BaseApiController
     {
         var ms = new MemoryStream();
         await using (var raw = file.OpenReadStream())
-            await raw.CopyToAsync(ms, ct);
+            await raw.CopyToAsync(ms, ct).ConfigureAwait(false);
         ms.Position = 0;
         if (ms.Length >= 2)
         {
@@ -62,7 +62,7 @@ public class WardenImportController(WardenStore warden) : BaseApiController
             {
                 var decompressed = new MemoryStream();
                 await using (var gz = new GZipStream(ms, CompressionMode.Decompress, leaveOpen: true))
-                    await CopyWithLimitAsync(gz, decompressed, WardenInputLimits.MaxDecompressedBytes, ct);
+                    await CopyWithLimitAsync(gz, decompressed, WardenInputLimits.MaxDecompressedBytes, ct).ConfigureAwait(false);
                 decompressed.Position = 0;
                 return decompressed;
             }

--- a/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
+++ b/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
@@ -139,6 +139,12 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
 [Route("api/warden-sources-export")]
 public class WardenSourcesExportController(WardenStore warden) : BaseApiController
 {
+    private static readonly JsonSerializerOptions BundleJsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
     protected override Task<IActionResult> HandleRequest()
     {
         var items = warden.GetSources()
@@ -153,11 +159,7 @@ public class WardenSourcesExportController(WardenStore warden) : BaseApiControll
             .ToList();
 
         var bundle = new Bundle { Version = 1, Items = items };
-        var json = JsonSerializer.Serialize(bundle, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        });
+        var json = JsonSerializer.Serialize(bundle, BundleJsonOptions);
 
         return Task.FromResult<IActionResult>(File(Encoding.UTF8.GetBytes(json), "application/json", "bundle.json"));
     }

--- a/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
+++ b/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
@@ -33,7 +33,7 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
             if (file.Length > MaxUploadBytes)
                 throw new BadHttpRequestException("File is too large.");
             using var reader = new StreamReader(file.OpenReadStream());
-            content = await reader.ReadToEndAsync(ct);
+            content = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
         }
         else
         {
@@ -54,7 +54,7 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
         if (added > 0)
             _ = Task.Run(async () =>
             {
-                try { await remote.RefreshDueAsync(CancellationToken.None); }
+                try { await remote.RefreshDueAsync(CancellationToken.None).ConfigureAwait(false); }
                 catch (Exception e) { Log.Debug(e, "Warden: post-import refresh failed"); }
             });
 

--- a/backend/Api/Controllers/Warden/WardenSourcesController.cs
+++ b/backend/Api/Controllers/Warden/WardenSourcesController.cs
@@ -47,7 +47,7 @@ public class WardenSourceAddController(WardenStore warden, WardenRemoteSourceSer
 
         var id = warden.AddSource("remote", name, url, trust, refreshHours);
         var source = warden.GetSources().FirstOrDefault(s => s.Id == id);
-        var status = source is null ? "error" : await remote.RefreshAsync(source, HttpContext.RequestAborted);
+        var status = source is null ? "error" : await remote.RefreshAsync(source, HttpContext.RequestAborted).ConfigureAwait(false);
 
         return Ok(new WardenSourceMutateResponse { Status = true, SourceId = id, Message = status });
     }
@@ -107,7 +107,7 @@ public class WardenSourceRefreshController(WardenStore warden, WardenRemoteSourc
         var source = warden.GetSources().FirstOrDefault(s => s.Id == id);
         if (source is null) throw new BadHttpRequestException("Unknown source.");
 
-        var status = await remote.RefreshAsync(source, HttpContext.RequestAborted);
+        var status = await remote.RefreshAsync(source, HttpContext.RequestAborted).ConfigureAwait(false);
         return Ok(new WardenSourceMutateResponse { Status = true, SourceId = id, Message = status });
     }
 }

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -355,9 +355,9 @@ public class AddFileController(
         if (string.IsNullOrWhiteSpace(fileName) ||
             Path.IsPathRooted(fileName) ||
             fileName is "." or ".." ||
-            fileName.Contains('/') ||
-            fileName.Contains('\\') ||
-            fileName.Contains('\0'))
+            fileName.Contains('/', StringComparison.Ordinal) ||
+            fileName.Contains('\\', StringComparison.Ordinal) ||
+            fileName.Contains('\0', StringComparison.Ordinal))
         {
             throw new ArgumentException("The NZB backup file name must be a single file name.", nameof(fileName));
         }
@@ -368,9 +368,9 @@ public class AddFileController(
         if (string.IsNullOrWhiteSpace(category) ||
             Path.IsPathRooted(category) ||
             category is "." or ".." ||
-            category.Contains('/') ||
-            category.Contains('\\') ||
-            category.Contains('\0'))
+            category.Contains('/', StringComparison.Ordinal) ||
+            category.Contains('\\', StringComparison.Ordinal) ||
+            category.Contains('\0', StringComparison.Ordinal))
         {
             throw new ArgumentException("The NZB backup category must be a single directory name.", nameof(category));
         }

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -47,7 +47,7 @@ public class AddFileController(
         await using var sourceStream = request.NzbFileStream;
         var id = request.NzoId ?? Guid.NewGuid();
         var category = StringUtil.EmptyToNull(request.Category)
-                       ?? configManager.GetManualUploadCategory();
+                       ?? Config.GetManualUploadCategory();
 
         var replacesExisting = await dbClient.Ctx.QueueItems
             .AnyAsync(
@@ -58,13 +58,13 @@ public class AddFileController(
         IDisposable? admissionReservation = null;
         if (!replacesExisting)
         {
-            var maxItems = configManager.GetQueueMaxItems();
+            var maxItems = Config.GetQueueMaxItems();
             if (maxItems > 0)
             {
                 var currentCount = await dbClient.Ctx.QueueItems
                     .CountAsync(request.CancellationToken)
                     .ConfigureAwait(false);
-                var resumeThreshold = configManager.GetQueueResumeThreshold();
+                var resumeThreshold = Config.GetQueueResumeThreshold();
                 admissionReservation = queueManager.TryReserveQueueSlot(
                     currentCount, maxItems, resumeThreshold);
                 if (admissionReservation is null)
@@ -113,9 +113,9 @@ public class AddFileController(
             }
 
             // backup the nzb file if enabled
-            if (configManager.IsNzbBackupEnabled())
+            if (Config.IsNzbBackupEnabled())
             {
-                var backupLocation = configManager.GetNzbBackupLocation();
+                var backupLocation = Config.GetNzbBackupLocation();
                 if (backupLocation != null)
                 {
                     await BackupNzbAsync(id, request.FileName, category, backupLocation).ConfigureAwait(false);
@@ -291,7 +291,7 @@ public class AddFileController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = await AddFileRequest.New(httpContext, configManager).ConfigureAwait(false);
+        var request = await AddFileRequest.New(Context, Config).ConfigureAwait(false);
         return Ok(await AddFileAsync(request).ConfigureAwait(false));
     }
 

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -65,8 +65,10 @@ public class AddFileController(
                     .CountAsync(request.CancellationToken)
                     .ConfigureAwait(false);
                 var resumeThreshold = Config.GetQueueResumeThreshold();
+#pragma warning disable CA2000 // reservation is assigned to the method-scoped using below; the only statements between creation and the using are a null check and logging
                 admissionReservation = queueManager.TryReserveQueueSlot(
                     currentCount, maxItems, resumeThreshold);
+#pragma warning restore CA2000
                 if (admissionReservation is null)
                 {
                     Log.Warning(

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -118,7 +118,7 @@ public class AddFileController(
                 var backupLocation = configManager.GetNzbBackupLocation();
                 if (backupLocation != null)
                 {
-                    await BackupNzbAsync(id, request.FileName, category, backupLocation);
+                    await BackupNzbAsync(id, request.FileName, category, backupLocation).ConfigureAwait(false);
                 }
             }
 
@@ -333,7 +333,7 @@ public class AddFileController(
 
             await using var src = BlobStore.ReadBlob(id);
             await using var dst = System.IO.File.Create(destPath);
-            await src!.CopyToAsync(dst);
+            await src!.CopyToAsync(dst).ConfigureAwait(false);
         }
         catch (Exception e) when (!e.IsCancellationException())
         {

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -337,7 +337,7 @@ public class AddFileController(
         }
         catch (Exception e) when (!e.IsCancellationException())
         {
-            throw new Exception($"Could not save nzb to `{backupLocation}`", e);
+            throw new InvalidOperationException($"Could not save nzb to `{backupLocation}`", e);
         }
     }
 

--- a/backend/Api/SabControllers/AddUrl/AddUrlController.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlController.cs
@@ -20,7 +20,7 @@ public class AddUrlController(
 {
     public async Task<AddUrlResponse> AddUrlAsync(AddUrlRequest request)
     {
-        var controller = new AddFileController(httpContext, dbClient, queueManager, configManager, websocketManager);
+        var controller = new AddFileController(Context, dbClient, queueManager, Config, websocketManager);
         var response = await controller.AddFileAsync(request).ConfigureAwait(false);
         return new AddUrlResponse()
         {
@@ -31,7 +31,7 @@ public class AddUrlController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = await AddUrlRequest.New(httpContext, configManager, hitTracker).ConfigureAwait(false);
+        var request = await AddUrlRequest.New(Context, Config, hitTracker).ConfigureAwait(false);
         return Ok(await AddUrlAsync(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -209,9 +209,9 @@ public class AddUrlRequest() : AddFileRequest
 
     private static HttpClient InitializeHttpClient(bool skipTlsVerification)
     {
-        #pragma warning disable CA2000 // handler is owned by the static HttpClient (process lifetime by design)
+#pragma warning disable CA2000 // handler is owned by the static HttpClient (process lifetime by design)
         var handler = new SocketsHttpHandler
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         {
             AllowAutoRedirect = false,
             UseProxy = false,
@@ -304,9 +304,9 @@ public class AddUrlRequest() : AddFileRequest
         Exception? lastException = null;
         foreach (var address in addresses.Distinct())
         {
-            #pragma warning disable CA2000 // socket is disposed on connect failure; on success the returned NetworkStream owns it (ownsSocket: true)
+#pragma warning disable CA2000 // socket is disposed on connect failure; on success the returned NetworkStream owns it (ownsSocket: true)
             var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
             {
                 NoDelay = true
             };

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -221,7 +221,9 @@ public class AddUrlRequest() : AddFileRequest
         {
             handler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
             {
+#pragma warning disable CA5359 // behind the explicit per-request/per-provider skip-TLS-verification setting for hosts with broken/self-signed certs
                 RemoteCertificateValidationCallback = static (_, _, _, _) => true,
+#pragma warning restore CA5359
             };
         }
         return new HttpClient(handler);

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -209,7 +209,9 @@ public class AddUrlRequest() : AddFileRequest
 
     private static HttpClient InitializeHttpClient(bool skipTlsVerification)
     {
+        #pragma warning disable CA2000 // handler is owned by the static HttpClient (process lifetime by design)
         var handler = new SocketsHttpHandler
+        #pragma warning restore CA2000
         {
             AllowAutoRedirect = false,
             UseProxy = false,
@@ -300,7 +302,9 @@ public class AddUrlRequest() : AddFileRequest
         Exception? lastException = null;
         foreach (var address in addresses.Distinct())
         {
+            #pragma warning disable CA2000 // socket is disposed on connect failure; on success the returned NetworkStream owns it (ownsSocket: true)
             var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            #pragma warning restore CA2000
             {
                 NoDelay = true
             };

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -96,14 +96,14 @@ public class AddUrlRequest() : AddFileRequest
         try
         {
             if (string.IsNullOrWhiteSpace(url))
-                throw new Exception($"The url is invalid.");
+                throw new InvalidOperationException($"The url is invalid.");
 
             var response = await GetAsync(
                 url, userAgent, proxyUrl, skipTlsVerification, trustedHosts, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 response.Dispose();
-                throw new Exception($"Received status code {response.StatusCode}.");
+                throw new InvalidOperationException($"Received status code {response.StatusCode}.");
             }
 
             var contentType = response.Content.Headers.ContentType?.MediaType;
@@ -111,7 +111,7 @@ public class AddUrlRequest() : AddFileRequest
             var resolvedFileName = nzbName
                                    ?? GetFilenameFromResponseHeader(response)
                                    ?? GetFilenameFromUrl(url)
-                                   ?? throw new Exception("Nzb filename could not be determined.");
+                                   ?? throw new InvalidOperationException("Nzb filename could not be determined.");
             var fileName = NzbStreamUtil.NormalizeFileName(resolvedFileName);
 
             var fileStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);

--- a/backend/Api/SabControllers/GetCategories/GetCategoriesController.cs
+++ b/backend/Api/SabControllers/GetCategories/GetCategoriesController.cs
@@ -11,14 +11,14 @@ public class GetCategoriesController(
 {
     protected override Task<IActionResult> Handle()
     {
-        var categories = BuildCategories(configManager);
+        var categories = BuildCategories(Config);
         var response = new { categories };
         return Task.FromResult<IActionResult>(Ok(response));
     }
 
-    internal static List<string> BuildCategories(ConfigManager configManager)
+    internal static List<string> BuildCategories(ConfigManager Config)
     {
-        return configManager.GetApiCategories()
+        return Config.GetApiCategories()
             .Where(category => category != "*")
             .Prepend("*")
             .ToList();

--- a/backend/Api/SabControllers/GetConfig/GetConfigController.cs
+++ b/backend/Api/SabControllers/GetConfig/GetConfigController.cs
@@ -23,11 +23,11 @@ public class GetConfigController(
         var root = JsonNode.Parse(config)!;
 
         // update the complete_dir
-        root["config"]!["misc"]!["complete_dir"] = SabPathResolver.GetCompletedDir(configManager);
+        root["config"]!["misc"]!["complete_dir"] = SabPathResolver.GetCompletedDir(Config);
 
         // update the categories
         var categoriesRoot = root["config"]?["categories"]?.AsArray()!;
-        var categories = configManager.GetApiCategories();
+        var categories = Config.GetApiCategories();
         foreach (var category in categories)
         {
             categoriesRoot.Add(new JsonObject

--- a/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
+++ b/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
@@ -16,7 +16,7 @@ public class GetFullStatusController(
         {
             Status = new SabStatusObject
             {
-                CompleteDir = SabPathResolver.GetCompletedDir(configManager),
+                CompleteDir = SabPathResolver.GetCompletedDir(Config),
             }
         };
 

--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -51,13 +51,13 @@ public class GetHistoryController(
         // get slots (in-memory provider counts only survive until app restart)
         var providerUsages = providerUsageTracker.SnapshotMany(historyItems.Select(x => x.Id));
         var displayByMetricsKey = ProviderUsageHelper
-            .BuildDisplayByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
+            .BuildDisplayByMetricsKey(Config.GetUsenetProviderConfig().Providers);
         var slots = historyItems
             .Select(x =>
                 GetHistoryResponse.HistorySlot.FromHistoryItem(
                     x,
                     x.DownloadDirId != null ? davItemsDict.GetValueOrDefault(x.DownloadDirId.Value) : null,
-                    configManager,
+                    Config,
                     providerUsages.GetValueOrDefault(x.Id),
                     displayByMetricsKey
                 )
@@ -77,7 +77,7 @@ public class GetHistoryController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = new GetHistoryRequest(httpContext, configManager);
+        var request = new GetHistoryRequest(Context, Config);
         return Ok(await GetHistoryAsync(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -6,7 +6,7 @@ namespace NzbWebDAV.Api.SabControllers.GetHistory;
 
 public class GetHistoryRequest
 {
-    public int Start { get; init; } = 0;
+    public int Start { get; init; }
     public int Limit { get; init; } = int.MaxValue;
     public string? Category { get; init; }
     public List<Guid> NzoIds { get; init; } = [];

--- a/backend/Api/SabControllers/GetHistory/GetHistoryResponse.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryResponse.cs
@@ -149,7 +149,7 @@ public class GetHistoryResponse : SabBaseResponse
                 });
             }
 
-            throw new Exception("Unknown import strategy");
+            throw new InvalidOperationException("Unknown import strategy");
         }
     }
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -50,7 +50,7 @@ public class GetQueueController(
 
         // Metrics keys of every configured Usenet provider — used to show idle providers
         // alongside active ones for in-progress downloads.
-        var configuredProviders = configManager.GetUsenetProviderConfig().Providers;
+        var configuredProviders = Config.GetUsenetProviderConfig().Providers;
         var configuredKeys = configuredProviders
             .Where(p => p.ProviderId != Guid.Empty)
             .Select(UsenetProviderIdentity.MetricsKey)
@@ -86,12 +86,12 @@ public class GetQueueController(
             .ToList();
 
         // return response
-        var speedLimitKbps = configManager.GetSabSpeedLimitKbps();
+        var speedLimitKbps = Config.GetSabSpeedLimitKbps();
         return new GetQueueResponse()
         {
             Queue = new GetQueueResponse.QueueObject()
             {
-                Paused = configManager.IsSabQueuePaused(),
+                Paused = Config.IsSabQueuePaused(),
                 Slots = slots,
                 TotalCount = totalCount,
                 SpeedLimit = speedLimitKbps.ToString(),
@@ -116,7 +116,7 @@ public class GetQueueController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = new GetQueueRequest(httpContext, configManager);
+        var request = new GetQueueRequest(Context, Config);
         return Ok(await GetQueueAsync(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -6,7 +6,7 @@ namespace NzbWebDAV.Api.SabControllers.GetQueue;
 
 public class GetQueueRequest
 {
-    public int Start { get; init; } = 0;
+    public int Start { get; init; }
     public int Limit { get; init; } = int.MaxValue;
     public string? Category { get; init; }
     public CancellationToken CancellationToken { get; init; }

--- a/backend/Api/SabControllers/GetStatus/GetStatusController.cs
+++ b/backend/Api/SabControllers/GetStatus/GetStatusController.cs
@@ -15,7 +15,7 @@ public class GetStatusController(
         {
             Status = new SabStatusObject
             {
-                CompleteDir = SabPathResolver.GetCompletedDir(configManager),
+                CompleteDir = SabPathResolver.GetCompletedDir(Config),
             },
         };
         return Task.FromResult<IActionResult>(Ok(response));

--- a/backend/Api/SabControllers/MoveInQueue/MoveInQueueController.cs
+++ b/backend/Api/SabControllers/MoveInQueue/MoveInQueueController.cs
@@ -33,7 +33,7 @@ public class MoveInQueueController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = await MoveInQueueRequest.New(httpContext).ConfigureAwait(false);
+        var request = await MoveInQueueRequest.New(Context).ConfigureAwait(false);
         return Ok(await MoveInQueue(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/Pause/PauseController.cs
+++ b/backend/Api/SabControllers/Pause/PauseController.cs
@@ -19,12 +19,12 @@ public class PauseController(
     public async Task<PauseResponse> Pause(CancellationToken ct)
     {
         await ConfigPersistenceUtil.SetValueAsync(
-            dbClient, configManager, ConfigKeys.QueuePaused, "true", ct).ConfigureAwait(false);
+            dbClient, Config, ConfigKeys.QueuePaused, "true", ct).ConfigureAwait(false);
         return new PauseResponse { Status = true };
     }
 
     protected override async Task<IActionResult> Handle()
     {
-        return Ok(await Pause(httpContext.RequestAborted).ConfigureAwait(false));
+        return Ok(await Pause(Context.RequestAborted).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -64,7 +64,7 @@ public class RemoveFromHistoryController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = await RemoveFromHistoryRequest.New(httpContext).ConfigureAwait(false);
+        var request = await RemoveFromHistoryRequest.New(Context).ConfigureAwait(false);
         return Ok(await RemoveFromHistory(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -36,7 +36,7 @@ public class RemoveFromQueueController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = await RemoveFromQueueRequest.New(httpContext).ConfigureAwait(false);
+        var request = await RemoveFromQueueRequest.New(Context).ConfigureAwait(false);
         return Ok(await RemoveFromQueue(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/Resume/ResumeController.cs
+++ b/backend/Api/SabControllers/Resume/ResumeController.cs
@@ -21,13 +21,13 @@ public class ResumeController(
     public async Task<ResumeResponse> Resume(CancellationToken ct)
     {
         await ConfigPersistenceUtil.SetValueAsync(
-            dbClient, configManager, ConfigKeys.QueuePaused, "false", ct).ConfigureAwait(false);
+            dbClient, Config, ConfigKeys.QueuePaused, "false", ct).ConfigureAwait(false);
         queueManager.AwakenQueue();
         return new ResumeResponse { Status = true };
     }
 
     protected override async Task<IActionResult> Handle()
     {
-        return Ok(await Resume(httpContext.RequestAborted).ConfigureAwait(false));
+        return Ok(await Resume(Context.RequestAborted).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
@@ -51,7 +51,7 @@ public class RetryHistoryController(
         };
 
         var addFileController = new AddFileController(
-            httpContext, dbClient, queueManager, configManager, websocketManager);
+            Context, dbClient, queueManager, Config, websocketManager);
         var addResponse = await addFileController.AddFileAsync(addFileRequest).ConfigureAwait(false);
         if (addResponse.NzoIds.Count == 0)
             throw new BadHttpRequestException("Failed to re-queue NZB.");
@@ -65,7 +65,7 @@ public class RetryHistoryController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = RetryHistoryRequest.New(httpContext);
+        var request = RetryHistoryRequest.New(Context);
         return Ok(await RetryHistoryAsync(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -138,6 +138,11 @@ public class SabApiController(
 
     public abstract class BaseController(HttpContext httpContext, ConfigManager configManager) : ControllerBase
     {
+        // Derived controllers must use these properties instead of capturing
+        // the primary-constructor parameters (CS9107 double-capture).
+        protected HttpContext Context => httpContext;
+        protected ConfigManager Config => configManager;
+
         public Task<IActionResult> HandleRequest()
         {
             if (RequiresAuthentication)

--- a/backend/Api/SabControllers/SpeedLimit/SpeedLimitController.cs
+++ b/backend/Api/SabControllers/SpeedLimit/SpeedLimitController.cs
@@ -19,14 +19,14 @@ public class SpeedLimitController(
     public async Task<SpeedLimitResponse> SetSpeedLimit(SpeedLimitRequest request, CancellationToken ct)
     {
         await ConfigPersistenceUtil.SetValueAsync(
-            dbClient, configManager, ConfigKeys.QueueSpeedLimitKbps,
+            dbClient, Config, ConfigKeys.QueueSpeedLimitKbps,
             request.LimitKbps.ToString(), ct).ConfigureAwait(false);
         return new SpeedLimitResponse { Status = true };
     }
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = SpeedLimitRequest.New(httpContext);
-        return Ok(await SetSpeedLimit(request, httpContext.RequestAborted).ConfigureAwait(false));
+        var request = SpeedLimitRequest.New(Context);
+        return Ok(await SetSpeedLimit(request, Context.RequestAborted).ConfigureAwait(false));
     }
 }

--- a/backend/Clients/Indexers/NewznabClient.cs
+++ b/backend/Clients/Indexers/NewznabClient.cs
@@ -126,7 +126,7 @@ public class NewznabClient(
             {
                 var code = doc.Root.Attribute("code")?.Value;
                 var desc = doc.Root.Attribute("description")?.Value ?? "Indexer returned an error.";
-                throw new Exception(code is null ? desc : $"[{code}] {desc}");
+                throw new InvalidOperationException(code is null ? desc : $"[{code}] {desc}");
             }
             var items = doc.Root?.Element("channel")?.Elements("item") ?? [];
             return items.Select(ParseItem).ToList();

--- a/backend/Clients/Indexers/NewznabClient.cs
+++ b/backend/Clients/Indexers/NewznabClient.cs
@@ -145,7 +145,7 @@ public class NewznabClient(
 
         var enclosure = item.Element("enclosure");
         var sizeStr = enclosure?.Attribute("length")?.Value ?? GetAttr(attrs, "size");
-        long.TryParse(sizeStr, out var size);
+        var size = long.TryParse(sizeStr, out var parsedSize) ? parsedSize : 0;
 
         var nzbUrl = enclosure?.Attribute("url")?.Value
                      ?? item.Element("link")?.Value

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -81,7 +81,7 @@ public class ArrClient(string host, string apiKey)
         using var response = await SendAsync(request, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new NullReferenceException();
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new InvalidDataException("The response deserialized to null.");
     }
 
     private async Task<T?> GetRootOrNull<T>(string rootPath, CancellationToken ct) where T : class
@@ -91,7 +91,7 @@ public class ArrClient(string host, string apiKey)
         if (response.StatusCode == HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new NullReferenceException();
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new InvalidDataException("The response deserialized to null.");
     }
 
     protected async Task<T> Post<T>(string path, object body, CancellationToken ct = default)
@@ -102,7 +102,7 @@ public class ArrClient(string host, string apiKey)
         using var response = await SendAsync(request, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new NullReferenceException();
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new InvalidDataException("The response deserialized to null.");
     }
 
     protected async Task<HttpStatusCode> Delete(string path, Dictionary<string, string>? queryParams = null, CancellationToken ct = default)

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -43,7 +43,7 @@ public class ArrClient(string host, string apiKey)
         Get<ArrQueue<ArrQueueRecord>>($"/queue?protocol=usenet&pageSize=5000", ct);
 
     public async Task<int> GetQueueCountAsync() =>
-        (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1")).TotalRecords;
+        (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1").ConfigureAwait(false)).TotalRecords;
 
     public Task<HttpStatusCode> DeleteQueueRecord(int id, DeleteQueueRecordRequest request) =>
         Delete($"/queue/{id}", request.GetQueryParams());
@@ -78,20 +78,20 @@ public class ArrClient(string host, string apiKey)
     protected async Task<T> GetRoot<T>(string rootPath, CancellationToken ct = default)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
-        using var response = await SendAsync(request, ct);
+        using var response = await SendAsync(request, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        await using var stream = await response.Content.ReadAsStreamAsync(ct);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new NullReferenceException();
     }
 
     private async Task<T?> GetRootOrNull<T>(string rootPath, CancellationToken ct) where T : class
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"{Host}{rootPath}");
-        using var response = await SendAsync(request, ct);
+        using var response = await SendAsync(request, ct).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
-        await using var stream = await response.Content.ReadAsStreamAsync(ct);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new NullReferenceException();
     }
 
     protected async Task<T> Post<T>(string path, object body, CancellationToken ct = default)
@@ -99,16 +99,16 @@ public class ArrClient(string host, string apiKey)
         using var request = new HttpRequestMessage(HttpMethod.Post, GetRequestUri(path));
         var jsonBody = JsonSerializer.Serialize(body);
         request.Content = new StringContent(jsonBody, new MediaTypeHeaderValue("application/json"));
-        using var response = await SendAsync(request, ct);
+        using var response = await SendAsync(request, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        await using var stream = await response.Content.ReadAsStreamAsync(ct);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct) ?? throw new NullReferenceException();
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: ct).ConfigureAwait(false) ?? throw new NullReferenceException();
     }
 
     protected async Task<HttpStatusCode> Delete(string path, Dictionary<string, string>? queryParams = null, CancellationToken ct = default)
     {
         using var request = new HttpRequestMessage(HttpMethod.Delete, GetRequestUri(path, queryParams));
-        using var response = await SendAsync(request, ct);
+        using var response = await SendAsync(request, ct).ConfigureAwait(false);
         return response.StatusCode;
     }
 

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrQueueRecord.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrQueueRecord.cs
@@ -35,6 +35,6 @@ public class ArrQueueRecord
     {
         return StatusMessages
             .SelectMany(x => x.Messages)
-            .Any(x => x.Contains(message));
+            .Any(x => x.Contains(message, StringComparison.Ordinal));
     }
 }

--- a/backend/Clients/RadarrSonarr/BaseModels/DeleteQueueRecordRequest.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/DeleteQueueRecordRequest.cs
@@ -21,9 +21,9 @@ public class DeleteQueueRecordRequest
     {
         return new Dictionary<string, string>()
         {
-            { "removeFromClient", RemoveFromClient.ToString().ToLower() },
-            { "blocklist", Blocklist.ToString().ToLower() },
-            { "skipRedownload", SkipRedownload.ToString().ToLower() },
+            { "removeFromClient", RemoveFromClient.ToString().ToLowerInvariant() },
+            { "blocklist", Blocklist.ToString().ToLowerInvariant() },
+            { "skipRedownload", SkipRedownload.ToString().ToLowerInvariant() },
         };
     }
 }

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -37,7 +37,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
         if (await DeleteMovieFile(movieFileId.Value, ct).ConfigureAwait(false) != HttpStatusCode.OK)
-            throw new Exception($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
+            throw new InvalidOperationException($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
         return ArrRepairOutcome.RemoveAndBlocklistSucceeded;

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -54,7 +54,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
         if (await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false) != HttpStatusCode.OK)
-            throw new Exception($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
+            throw new InvalidOperationException($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
         return ArrRepairOutcome.RemoveAndBlocklistSucceeded;

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -107,7 +107,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         if (cachedSeriesPath != null)
         {
             var series = await GetSeriesOrNull(cachedSeriesId, ct).ConfigureAwait(false);
-            if (series?.Path != null && symlinkOrStrmPath.StartsWith(series.Path))
+            if (series?.Path != null && symlinkOrStrmPath.StartsWith(series.Path, StringComparison.Ordinal))
                 return cachedSeriesId;
             SeriesPathToSeriesIdCache.TryRemove((Host, cachedSeriesPath), out _);
         }
@@ -117,7 +117,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         foreach (var series in await GetAllSeries(ct).ConfigureAwait(false))
         {
             SeriesPathToSeriesIdCache[(Host, series.Path!)] = series.Id;
-            if (symlinkOrStrmPath.StartsWith(series.Path!))
+            if (symlinkOrStrmPath.StartsWith(series.Path!, StringComparison.Ordinal))
                 result = series.Id;
         }
 

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -27,7 +27,7 @@ public static class RcloneClient
     public static string? Host { get; private set; }
     private static string? User { get; set; }
     private static string? Pass { get; set; }
-    public static bool IsRemoteControlEnabled { get; private set; } = false;
+    public static bool IsRemoteControlEnabled { get; private set; }
 
     public static void Initialize(ConfigManager configManager)
     {

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -72,7 +72,7 @@ public class RcloneClient
             request["recursive"] = true;
 
         Log.Debug("Rclone vfs/refresh: {0}", paths.ToIndentedJson());
-        return await Post<RcloneResponse>("vfs/refresh", request);
+        return await Post<RcloneResponse>("vfs/refresh", request).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public class RcloneClient
         }
 
         Log.Debug("Rclone vfs/forget: {0}", paths.ToIndentedJson());
-        return await Post<VfsForgetResponse>("vfs/forget", request);
+        return await Post<VfsForgetResponse>("vfs/forget", request).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -106,7 +106,7 @@ public class RcloneClient
     public static async Task<VfsStatsResponse> GetVfsStats(string? fs = null)
     {
         var request = fs != null ? new { fs } : null;
-        return await Post<VfsStatsResponse>("vfs/stats", request);
+        return await Post<VfsStatsResponse>("vfs/stats", request).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ public class RcloneClient
     /// </summary>
     public static async Task<CoreVersionResponse> GetVersion()
     {
-        return await Post<CoreVersionResponse>("core/version", null);
+        return await Post<CoreVersionResponse>("core/version", null).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public class RcloneClient
     /// </summary>
     public static async Task<RcloneResponse> NoOp()
     {
-        return await Post<RcloneResponse>("rc/noop", null);
+        return await Post<RcloneResponse>("rc/noop", null).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -132,7 +132,7 @@ public class RcloneClient
     {
         try
         {
-            await NoOp();
+            await NoOp().ConfigureAwait(false);
             return true;
         }
         catch
@@ -146,7 +146,7 @@ public class RcloneClient
     /// </summary>
     public static async Task<RcloneResponse> TestConnection(string host, string? user, string? pass)
     {
-        var result = await Post<CoreVersionResponse>(host, user, pass, "core/version", null);
+        var result = await Post<CoreVersionResponse>(host, user, pass, "core/version", null).ConfigureAwait(false);
         if (result.Success && string.IsNullOrEmpty(result.Version))
             return new RcloneResponse { Success = false, Error = "Connected but received empty version" };
         return result;
@@ -178,8 +178,8 @@ public class RcloneClient
 
         try
         {
-            using var response = await HttpClient.SendAsync(request);
-            var content = await response.Content.ReadAsStringAsync();
+            using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -14,7 +14,7 @@ namespace NzbWebDAV.Clients.Rclone;
 /// Client for interacting with rclone's remote control (RC) API.
 /// See https://rclone.org/rc/ for API documentation.
 /// </summary>
-public class RcloneClient
+public static class RcloneClient
 {
     private static readonly HttpClient HttpClient = new();
 

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -230,7 +230,7 @@ public class ArticleCachingNntpClient(
         {
             return _cachedSegments.ContainsKey(segmentId)
                 ? new UsenetExclusiveConnection(onConnectionReadyAgain: null)
-                : await base.AcquireExclusiveConnectionAsync(segmentId, cancellationToken);
+                : await base.AcquireExclusiveConnectionAsync(segmentId, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -521,7 +521,7 @@ public class ArticleCachingNntpClient(
         _cachedSegments.Clear();
         _trackedSegments.Clear();
 
-        Task.Run(async () => await DeleteCacheDir(_cacheDir));
+        Task.Run(async () => await DeleteCacheDir(_cacheDir).ConfigureAwait(false));
         GC.SuppressFinalize(this);
     }
 

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -51,7 +51,7 @@ public class BaseNntpClient : NntpClient
     {
         try
         {
-            await _client.ConnectAsync(host, port, useSsl, cancellationToken);
+            await _client.ConnectAsync(host, port, useSsl, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (!e.IsCancellationException())
         {
@@ -69,7 +69,7 @@ public class BaseNntpClient : NntpClient
     {
         try
         {
-            var response = await _client.AuthenticateAsync(user, pass, cancellationToken);
+            var response = await _client.AuthenticateAsync(user, pass, cancellationToken).ConfigureAwait(false);
             if (!response.Success)
             {
                 var message = $"Could not login to usenet host: {response.ResponseMessage}";
@@ -158,7 +158,7 @@ public class BaseNntpClient : NntpClient
     public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
         segmentId = PrepareSegmentId(segmentId);
-        var headResponse = await _client.HeadAsync(segmentId, cancellationToken);
+        var headResponse = await _client.HeadAsync(segmentId, cancellationToken).ConfigureAwait(false);
 
         if (headResponse.ResponseType != UsenetResponseType.ArticleRetrievedHeadFollows)
             throw CreateArticleFetchException(segmentId, headResponse);
@@ -190,7 +190,7 @@ public class BaseNntpClient : NntpClient
     {
         segmentId = PrepareSegmentId(segmentId);
         var bodyResponse = await _client.DecodedBodyAsync(
-            segmentId, onConnectionReadyAgain, cancellationToken);
+            segmentId, onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
 
         if (bodyResponse.ResponseType != UsenetResponseType.ArticleRetrievedBodyFollows)
             throw CreateArticleFetchException(segmentId, bodyResponse);

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -53,7 +53,9 @@ public class BaseNntpClient : NntpClient
         {
             await _client.ConnectAsync(host, port, useSsl, cancellationToken).ConfigureAwait(false);
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             const string message = "Could not connect to usenet host. Check connection settings.";
             throw new CouldNotConnectToUsenetException(message, e);
@@ -78,7 +80,9 @@ public class BaseNntpClient : NntpClient
 
             return response;
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             throw new CouldNotLoginToUsenetException("Could not login to usenet host.", e);
         }

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -31,9 +31,9 @@ public class BaseNntpClient : NntpClient
     {
     }
 
-    #pragma warning disable CA2000 // the client is stored in _client and disposed with this instance
+#pragma warning disable CA2000 // the client is stored in _client and disposed with this instance
     public BaseNntpClient(bool skipTlsVerification) : this(new UsenetClient(new UsenetClientOptions
-    #pragma warning restore CA2000
+#pragma warning restore CA2000
     {
         CrcValidation = EnvironmentUtil.GetEnvironmentVariable("USENET_DISABLE_CRC_VALIDATION") == "1"
             ? YencCrcValidationMode.Off
@@ -55,9 +55,9 @@ public class BaseNntpClient : NntpClient
         {
             await _client.ConnectAsync(host, port, useSsl, cancellationToken).ConfigureAwait(false);
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             const string message = "Could not connect to usenet host. Check connection settings.";
             throw new CouldNotConnectToUsenetException(message, e);
@@ -82,9 +82,9 @@ public class BaseNntpClient : NntpClient
 
             return response;
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             throw new CouldNotLoginToUsenetException("Could not login to usenet host.", e);
         }

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -31,7 +31,9 @@ public class BaseNntpClient : NntpClient
     {
     }
 
+    #pragma warning disable CA2000 // the client is stored in _client and disposed with this instance
     public BaseNntpClient(bool skipTlsVerification) : this(new UsenetClient(new UsenetClientOptions
+    #pragma warning restore CA2000
     {
         CrcValidation = EnvironmentUtil.GetEnvironmentVariable("USENET_DISABLE_CRC_VALIDATION") == "1"
             ? YencCrcValidationMode.Off

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -279,7 +279,7 @@ public class BaseNntpClient : NntpClient
             : CreateConnectionLevelException(segmentId, response);
     }
 
-    private static Exception CreateConnectionLevelException(SegmentId segmentId, UsenetResponse response)
+    private static UsenetUnexpectedResponseException CreateConnectionLevelException(SegmentId segmentId, UsenetResponse response)
     {
         if (response.ResponseCode == 480)
         {

--- a/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
+++ b/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
@@ -15,7 +15,7 @@ namespace NzbWebDAV.Clients.Usenet.Concurrency;
 /// These configurable odds prevent the high-priority queue from fully starving the
 /// low-priority queue.
 /// </summary>
-public class PrioritizedSemaphore : IDisposable
+public sealed class PrioritizedSemaphore : IDisposable
 {
     private readonly LinkedList<TaskCompletionSource<bool>> _highPriorityWaiters = [];
     private readonly LinkedList<TaskCompletionSource<bool>> _lowPriorityWaiters = [];

--- a/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
+++ b/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
@@ -40,8 +40,7 @@ public sealed class PrioritizedSemaphore : IDisposable
     {
         lock (_lock)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(AsyncSemaphore));
+            ObjectDisposedException.ThrowIf(_disposed, typeof(AsyncSemaphore));
 
             if (_enteredCount < _maxAllowed)
             {

--- a/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
+++ b/backend/Clients/Usenet/Concurrency/PrioritizedSemaphore.cs
@@ -22,7 +22,7 @@ public class PrioritizedSemaphore : IDisposable
     private SemaphorePriorityOdds _priorityOdds;
     private int _maxAllowed;
     private int _enteredCount;
-    private bool _disposed = false;
+    private bool _disposed;
     private readonly Lock _lock = new();
     private int _accumulatedOdds;
 

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -98,8 +98,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         TimeSpan? idleTimeout = null,
         SemaphorePriorityOdds? priorityOdds = null)
     {
-        if (maxConnections <= 0)
-            throw new ArgumentOutOfRangeException(nameof(maxConnections));
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConnections);
 
         _factory = connectionFactory
                    ?? throw new ArgumentNullException(nameof(connectionFactory));

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -410,7 +410,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             OnConnectionPoolChanged = null;
         }
 
-        await _sweepCts.CancelAsync();
+        await _sweepCts.CancelAsync().ConfigureAwait(false);
 
         try
         {

--- a/backend/Clients/Usenet/Contexts/CancellationTokenContext.cs
+++ b/backend/Clients/Usenet/Contexts/CancellationTokenContext.cs
@@ -13,12 +13,14 @@ public sealed class CancellationTokenContext : IDisposable
         _lookupKey = lookupKey;
     }
 
+    #pragma warning disable CA1068 // extension method on CancellationToken: the token must remain the this (first) parameter
     public static CancellationTokenContext SetContext<T>(CancellationToken ct, T? value)
     {
         var lookupKey = new LookupKey() { CancellationToken = ct, Type = typeof(T) };
         Context[lookupKey] = value;
         return new CancellationTokenContext(lookupKey);
     }
+    #pragma warning restore CA1068
 
     public static T? GetContext<T>(CancellationToken ct)
     {

--- a/backend/Clients/Usenet/Contexts/CancellationTokenContext.cs
+++ b/backend/Clients/Usenet/Contexts/CancellationTokenContext.cs
@@ -13,14 +13,14 @@ public sealed class CancellationTokenContext : IDisposable
         _lookupKey = lookupKey;
     }
 
-    #pragma warning disable CA1068 // extension method on CancellationToken: the token must remain the this (first) parameter
+#pragma warning disable CA1068 // extension method on CancellationToken: the token must remain the this (first) parameter
     public static CancellationTokenContext SetContext<T>(CancellationToken ct, T? value)
     {
         var lookupKey = new LookupKey() { CancellationToken = ct, Type = typeof(T) };
         Context[lookupKey] = value;
         return new CancellationTokenContext(lookupKey);
     }
-    #pragma warning restore CA1068
+#pragma warning restore CA1068
 
     public static T? GetContext<T>(CancellationToken ct)
     {

--- a/backend/Clients/Usenet/Contexts/CancellationTokenContext.cs
+++ b/backend/Clients/Usenet/Contexts/CancellationTokenContext.cs
@@ -2,7 +2,7 @@
 
 namespace NzbWebDAV.Clients.Usenet.Contexts;
 
-public class CancellationTokenContext : IDisposable
+public sealed class CancellationTokenContext : IDisposable
 {
     private static readonly ConcurrentDictionary<LookupKey, object?> Context = new();
 

--- a/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
+++ b/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
@@ -2,7 +2,7 @@
 
 namespace NzbWebDAV.Clients.Usenet.Contexts;
 
-public class ContextualCancellationTokenSource : IDisposable
+public sealed class ContextualCancellationTokenSource : IDisposable
 {
     private readonly CancellationTokenSource _cts;
     private readonly List<CancellationTokenContext> _contexts;

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -316,6 +316,10 @@ public class DownloadingNntpClient : WrappingNntpClient
     public override void Dispose()
     {
         _configManager.OnConfigChanged -= OnConfigChanged;
+        // Owned per generation: retired generations must release their
+        // semaphores once in-flight streams have drained (see Retire()).
+        _streamingSemaphore.Dispose();
+        _queueSemaphore.Dispose();
         base.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -310,7 +310,9 @@ public class MultiConnectionNntpClient(
             }
             catch (Exception e) when (
                 streamingTimeout != null
+                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 && e.IsCancellationException()
+                #pragma warning restore CA2016
                 && !ct.IsCancellationRequested)
             {
                 // Per-segment deadline fired while the caller is still reading. The
@@ -750,7 +752,9 @@ public class MultiConnectionNntpClient(
                         operation,
                         Stopwatch.GetElapsedTime(moveStarted));
                 }
+                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 catch (Exception e) when (!e.IsCancellationException())
+                #pragma warning restore CA2016
                 {
                     // Do not RecordFailure — STAT must not feed the breaker — but the
                     // connection is poisoned and must not return to the pool.
@@ -803,7 +807,9 @@ public class MultiConnectionNntpClient(
                         operation,
                         Stopwatch.GetElapsedTime(moveStarted));
                 }
+                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 catch (Exception e) when (!e.IsCancellationException())
+                #pragma warning restore CA2016
                 {
                     circuitBreaker.RecordFailure($"pipelined-enum-{e.GetType().Name}");
                     connectionLock.Replace();
@@ -877,7 +883,9 @@ public class MultiConnectionNntpClient(
         {
             throw;
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             // A client abort mid-connect can surface as an IOException rather than
             // a cancellation exception; it must not trip a healthy provider.

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -333,7 +333,7 @@ public class MultiConnectionNntpClient(
                 circuitBreaker.RecordFailure("streaming-timeout-pipelined-BODY");
                 Log.Warning(
                     "Streaming timeout executing pipelined nntp BODY commands for provider {Provider} after {Timeout}s. No retries left.",
-                    providerName, streamingTimeout.PerSegmentTimeout.TotalSeconds);
+                    Host, streamingTimeout.PerSegmentTimeout.TotalSeconds);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw new TimeoutException(
                     "Timeout executing pipelined nntp BODY commands after " +
@@ -394,7 +394,7 @@ public class MultiConnectionNntpClient(
                 {
                     Log.Debug(e,
                         "Pooled connection for provider {Provider} failed pipelined NNTP BODY commands. Retrying with another connection.",
-                        providerName);
+                        Host);
                     continue;
                 }
 
@@ -402,14 +402,14 @@ public class MultiConnectionNntpClient(
                 {
                     Log.Debug(e,
                         "Error executing pipelined NNTP BODY commands for provider {Provider}. Retrying with a new connection.",
-                        providerName);
+                        Host);
                     retryCount--;
                     continue;
                 }
 
                 e.LogWarningKnownOrStack(
                     "Error executing pipelined NNTP BODY commands for provider {Provider}.",
-                    providerName);
+                    Host);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
@@ -482,12 +482,12 @@ public class MultiConnectionNntpClient(
                 LogException(() => connectionLock?.Dispose());
                 if (retryCount > 0)
                 {
-                    Log.Debug(e, "Error getting connection-lock for provider {Provider}. Retrying with a new connection.", providerName);
+                    Log.Debug(e, "Error getting connection-lock for provider {Provider}. Retrying with a new connection.", Host);
                     retryCount--;
                     continue;
                 }
 
-                e.LogWarningKnownOrStack("Error getting connection-lock for provider {Provider}.", providerName);
+                e.LogWarningKnownOrStack("Error getting connection-lock for provider {Provider}.", Host);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
@@ -553,7 +553,7 @@ public class MultiConnectionNntpClient(
                 circuitBreaker.RecordFailure($"streaming-timeout-{name}");
                 Log.Warning(
                     "Streaming timeout executing nntp {Command} command for provider {Provider} after {Timeout}s. No retries left.",
-                    name, providerName, streamingTimeout.PerSegmentTimeout.TotalSeconds);
+                    name, Host, streamingTimeout.PerSegmentTimeout.TotalSeconds);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw new TimeoutException(
                     $"Timeout executing nntp {name} command after {streamingTimeout.MaxRetries + 1} attempts.");
@@ -581,7 +581,7 @@ public class MultiConnectionNntpClient(
                 // the wait before MultiProviderNntpClient can fall over to the next
                 // provider. Replace the socket (the read may have left partial bytes
                 // on the wire) and propagate so the outer provider loop moves on.
-                IncrementTimeoutCount(providerName);
+                IncrementTimeoutCount(Host);
                 deferredCallback.Discard();
                 circuitBreaker.RecordFailure($"read-timeout-{name}");
                 LogException(() => connectionLock?.Replace());
@@ -604,13 +604,13 @@ public class MultiConnectionNntpClient(
                 // its failure says nothing about provider health. Drain and retry.
                 if (wasReused)
                 {
-                    Log.Debug(e, "Pooled connection for provider {Provider} failed nntp {Command} command. Retrying with another connection.", providerName, name);
+                    Log.Debug(e, "Pooled connection for provider {Provider} failed nntp {Command} command. Retrying with another connection.", Host, name);
                     continue;
                 }
 
                 if (retryCount > 0)
                 {
-                    Log.Debug(e, "Error executing nntp {Command} command for provider {Provider}. Retrying with a new connection.", name, providerName);
+                    Log.Debug(e, "Error executing nntp {Command} command for provider {Provider}. Retrying with a new connection.", name, Host);
                     retryCount--;
                     continue;
                 }
@@ -622,7 +622,7 @@ public class MultiConnectionNntpClient(
                     circuitBreaker.RecordFailure($"cmd-{name}-{e.GetType().Name}");
 
                 e.LogWarningKnownOrStack(
-                    "Error executing nntp {Command} command for provider {Provider}.", name, providerName);
+                    "Error executing nntp {Command} command for provider {Provider}.", name, Host);
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
@@ -909,10 +909,10 @@ public class MultiConnectionNntpClient(
             Log.Warning(
                 "Connection pool for provider {Provider} retired while requests were waiting. " +
                 "Abandoning stale requests without retrying or penalizing provider health.",
-                providerName);
+                Host);
         }
         return new NntpClientRetiredException(
-            $"Connection pool for provider '{providerName}' retired while the request was waiting.",
+            $"Connection pool for provider '{Host}' retired while the request was waiting.",
             inner);
     }
 

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -310,9 +310,9 @@ public class MultiConnectionNntpClient(
             }
             catch (Exception e) when (
                 streamingTimeout != null
-                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 && e.IsCancellationException()
-                #pragma warning restore CA2016
+#pragma warning restore CA2016
                 && !ct.IsCancellationRequested)
             {
                 // Per-segment deadline fired while the caller is still reading. The
@@ -752,9 +752,9 @@ public class MultiConnectionNntpClient(
                         operation,
                         Stopwatch.GetElapsedTime(moveStarted));
                 }
-                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 catch (Exception e) when (!e.IsCancellationException())
-                #pragma warning restore CA2016
+#pragma warning restore CA2016
                 {
                     // Do not RecordFailure — STAT must not feed the breaker — but the
                     // connection is poisoned and must not return to the pool.
@@ -807,9 +807,9 @@ public class MultiConnectionNntpClient(
                         operation,
                         Stopwatch.GetElapsedTime(moveStarted));
                 }
-                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 catch (Exception e) when (!e.IsCancellationException())
-                #pragma warning restore CA2016
+#pragma warning restore CA2016
                 {
                     circuitBreaker.RecordFailure($"pipelined-enum-{e.GetType().Name}");
                     connectionLock.Replace();
@@ -883,9 +883,9 @@ public class MultiConnectionNntpClient(
         {
             throw;
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             // A client abort mid-connect can surface as an IOException rather than
             // a cancellation exception; it must not trip a healthy provider.

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -330,6 +330,7 @@ public class MultiProviderNntpClient(
                     {
                         var fallbackAdmission = new TaskCompletionSource(
                             TaskCreationOptions.RunContinuationsAsynchronously);
+#pragma warning disable CA2025 // batch response tasks intentionally outlive this scope: releasePending only returns the pending-admission reservation, while in-flight transfers hold (and release via completion callbacks) their own per-provider connection locks
                         responses[index] = ResolveBatchResponseAsync(
                             primaryBatch.Responses[index],
                             segmentIds[index],
@@ -339,6 +340,7 @@ public class MultiProviderNntpClient(
                             fallbackAdmission,
                             coordinator,
                             cancellationToken);
+#pragma warning restore CA2025
                         previousFallbackAdmission = fallbackAdmission.Task;
                     }
                     return new UsenetDecodedBodyBatch { Responses = responses };

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -234,7 +234,9 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken
     )
     {
+        #pragma warning disable CA2000 // fetch scope is disposed on both the success and failure paths below
         var fetchScope = concurrentReadTracker?.BeginSegmentFetch(segmentId);
+        #pragma warning restore CA2000
         try
         {
             return await RunStreamingFromPoolWithBackup(

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -374,7 +374,7 @@ public class MultiProviderNntpClient(
 
             InvokeCompletionCallback(CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
             lastException?.Throw();
-            throw new Exception("There are no usenet providers configured.");
+            throw new InvalidOperationException("There are no usenet providers configured.");
         }
     }
 
@@ -382,7 +382,7 @@ public class MultiProviderNntpClient(
         Task<UsenetDecodedBodyResponse> primaryResponse,
         SegmentId segmentId,
         MultiConnectionNntpClient primaryProvider,
-        IReadOnlyList<MultiConnectionNntpClient> fallbackProviders,
+        MultiConnectionNntpClient[] fallbackProviders,
         Task previousFallbackAdmission,
         TaskCompletionSource fallbackAdmission,
         BatchCallbackCoordinator coordinator,
@@ -467,7 +467,7 @@ public class MultiProviderNntpClient(
                 && lastException.SourceException.TryGetCausingException<TimeoutException>(out _);
             var reprobePrimary = !definitiveMiss
                 || (retryPrimaryOnMiss?.Invoke() != false && !primaryCachedMiss);
-            if ((exhaustedTimeout && fallbackProviders.Count > 0)
+            if ((exhaustedTimeout && fallbackProviders.Length > 0)
                 || (definitiveMiss && !reprobePrimary))
             {
                 var primaryGroup = NormalizeStorageGroup(primaryProvider.StorageGroup);
@@ -807,7 +807,7 @@ public class MultiProviderNntpClient(
         if (lastOutcomeWasException) lastException!.Throw();
         if (lastNoArticleResult is not null) return lastNoArticleResult;
         if (orderedProviders.Count == 0)
-            throw new Exception("There are no usenet providers configured.");
+            throw new InvalidOperationException("There are no usenet providers configured.");
         // All providers were skipped (negative cache / storage-group) without a probe.
         throw new UsenetArticleNotFoundException(segmentId.ToString()!);
     }
@@ -940,11 +940,11 @@ public class MultiProviderNntpClient(
         }
         if (lastNoArticleResult is not null) return lastNoArticleResult;
         if (orderedProviders.Count == 0)
-            throw new Exception("There are no usenet providers configured.");
+            throw new InvalidOperationException("There are no usenet providers configured.");
         // All providers were skipped (negative cache / storage-group) without a probe.
         if (articleId is { } exhaustedId)
             throw new UsenetArticleNotFoundException(exhaustedId.ToString()!);
-        throw new Exception("There are no usenet providers configured.");
+        throw new InvalidOperationException("There are no usenet providers configured.");
     }
 
     private bool IsCachedMissing(SegmentId segmentId, MultiConnectionNntpClient provider)

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -234,9 +234,9 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken
     )
     {
-        #pragma warning disable CA2000 // fetch scope is disposed on both the success and failure paths below
+#pragma warning disable CA2000 // fetch scope is disposed on both the success and failure paths below
         var fetchScope = concurrentReadTracker?.BeginSegmentFetch(segmentId);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         try
         {
             return await RunStreamingFromPoolWithBackup(

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -556,9 +556,9 @@ public abstract class NntpClient : INntpClient
                 missing.Add(result.SegmentId);
             }
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             // Session/protocol/transport failure during the primary-only sweep (e.g.
             // UsenetUnexpectedResponseException for a buffered 400 goodbye, or

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -494,8 +494,8 @@ public abstract class NntpClient : INntpClient
     {
         var value = NormalizeSegmentId(id);
         if (value.Length is < 3 or > 248) return false;
-        if (value[0] == '@' || value[^1] == '@' || !value.Contains('@')) return false;
-        if (value.Contains('<') || value.Contains('>')) return false;
+        if (value[0] == '@' || value[^1] == '@' || !value.Contains('@', StringComparison.Ordinal)) return false;
+        if (value.Contains('<', StringComparison.Ordinal) || value.Contains('>', StringComparison.Ordinal)) return false;
         foreach (var character in value.Where(character => char.IsWhiteSpace(character) || char.IsControl(character)))
         {
             return false;
@@ -521,7 +521,7 @@ public abstract class NntpClient : INntpClient
     {
         messageId = "";
         if (string.IsNullOrEmpty(message)) return false;
-        var start = message.IndexOf('<');
+        var start = message.IndexOf('<', StringComparison.Ordinal);
         if (start < 0) return false;
         var end = message.IndexOf('>', start + 1);
         if (end < 0) return false;

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -556,7 +556,9 @@ public abstract class NntpClient : INntpClient
                 missing.Add(result.SegmentId);
             }
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             // Session/protocol/transport failure during the primary-only sweep (e.g.
             // UsenetUnexpectedResponseException for a buffered 400 goodbye, or

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -29,7 +29,9 @@ public class UsenetStreamingClient : WrappingNntpClient
         ArticleMissNegativeCache? articleMissCache = null,
         ProviderLatencyTracker? latencyTracker = null,
         ConcurrentReadTracker? concurrentReadTracker = null)
+        #pragma warning disable CA2000 // the client chain transfers to the base class and is disposed with this instance
         : base(CreateDownloadingNntpClient(
+        #pragma warning restore CA2000
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
             streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker))
     {
@@ -88,16 +90,22 @@ public class UsenetStreamingClient : WrappingNntpClient
         ConcurrentReadTracker? concurrentReadTracker
     )
     {
+        #pragma warning disable CA2000 // wrapped by DownloadingNntpClient below; the returned client chain is disposed with this instance
         var multiProviderClient = CreateMultiProviderClient(
+        #pragma warning restore CA2000
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
             streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker);
+        #pragma warning disable CA2000 // ownership transfers to the wrapping/returned client chain, disposed with this instance
         var downloadingClient = new DownloadingNntpClient(multiProviderClient, configManager, latencyTracker);
+        #pragma warning restore CA2000
         INntpClient inner = downloadingClient;
         if (configManager.IsSegmentCacheEnabled())
         {
             try
             {
+                #pragma warning disable CA2000 // on construction failure the inner chain is returned unwrapped; the returned chain is disposed with this instance
                 inner = new SegmentCacheNntpClient(
+                #pragma warning restore CA2000
                     downloadingClient,
                     configManager.GetSegmentCachePath(),
                     configManager.GetSegmentCacheMaxBytes(),
@@ -235,7 +243,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                 label);
         }
 
+        #pragma warning disable CA2000 // the pool is owned by the provider's MultiConnectionNntpClient and disposed on provider config change
         var connectionPool = CreateNewConnectionPool(
+        #pragma warning restore CA2000
             maxConnections: maxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
             onConnectionPoolChanged,

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -74,7 +74,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         };
     }
 
-    private static INntpClient CreateDownloadingNntpClient
+    private static HeaderCachingNntpClient CreateDownloadingNntpClient
     (
         ConfigManager configManager,
         WebsocketManager websocketManager,

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -348,7 +348,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                     connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
                     timeoutCts.Token).ConfigureAwait(false);
             }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (e.IsCancellationException() &&
+            #pragma warning restore CA2016
                                       timeoutCts.IsCancellationRequested &&
                                       !ct.IsCancellationRequested)
             {
@@ -370,7 +372,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                         connectionDetails.User, connectionDetails.Pass,
                         timeoutCts.Token).ConfigureAwait(false);
                 }
+                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 catch (Exception e) when (e.IsCancellationException() &&
+                #pragma warning restore CA2016
                                           timeoutCts.IsCancellationRequested &&
                                           !ct.IsCancellationRequested)
                 {

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -331,7 +331,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         if (ContainsControlChars(connectionDetails.Host) ||
             ContainsControlChars(connectionDetails.User) ||
             ContainsControlChars(connectionDetails.Pass) ||
-            connectionDetails.Host.Contains(' '))
+            connectionDetails.Host.Contains(' ', StringComparison.Ordinal))
         {
             throw new ArgumentException(
                 "Provider host/username/password must not contain whitespace or control characters.");

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -341,6 +341,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         if (ContainsControlChars(connectionDetails.Host) ||
             ContainsControlChars(connectionDetails.User) ||
             ContainsControlChars(connectionDetails.Pass) ||
+            // codeql[cs/user-controlled-bypass] — false positive: the operator configures their own NNTP provider host; connecting to a user-specified host is the core feature of a Usenet streaming server (not a multi-tenant app). This ContainsControlChars check is a format guard (no control chars / whitespace in hostnames), not an authorization boundary.
             connectionDetails.Host.Contains(' ', StringComparison.Ordinal))
         {
             throw new ArgumentException(

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -29,9 +29,9 @@ public class UsenetStreamingClient : WrappingNntpClient
         ArticleMissNegativeCache? articleMissCache = null,
         ProviderLatencyTracker? latencyTracker = null,
         ConcurrentReadTracker? concurrentReadTracker = null)
-        #pragma warning disable CA2000 // the client chain transfers to the base class and is disposed with this instance
+#pragma warning disable CA2000 // the client chain transfers to the base class and is disposed with this instance
         : base(CreateDownloadingNntpClient(
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
             streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker))
     {
@@ -90,22 +90,22 @@ public class UsenetStreamingClient : WrappingNntpClient
         ConcurrentReadTracker? concurrentReadTracker
     )
     {
-        #pragma warning disable CA2000 // wrapped by DownloadingNntpClient below; the returned client chain is disposed with this instance
+#pragma warning disable CA2000 // wrapped by DownloadingNntpClient below; the returned client chain is disposed with this instance
         var multiProviderClient = CreateMultiProviderClient(
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
             streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker);
-        #pragma warning disable CA2000 // ownership transfers to the wrapping/returned client chain, disposed with this instance
+#pragma warning disable CA2000 // ownership transfers to the wrapping/returned client chain, disposed with this instance
         var downloadingClient = new DownloadingNntpClient(multiProviderClient, configManager, latencyTracker);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         INntpClient inner = downloadingClient;
         if (configManager.IsSegmentCacheEnabled())
         {
             try
             {
-                #pragma warning disable CA2000 // on construction failure the inner chain is returned unwrapped; the returned chain is disposed with this instance
+#pragma warning disable CA2000 // on construction failure the inner chain is returned unwrapped; the returned chain is disposed with this instance
                 inner = new SegmentCacheNntpClient(
-                #pragma warning restore CA2000
+#pragma warning restore CA2000
                     downloadingClient,
                     configManager.GetSegmentCachePath(),
                     configManager.GetSegmentCacheMaxBytes(),
@@ -243,9 +243,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                 label);
         }
 
-        #pragma warning disable CA2000 // the pool is owned by the provider's MultiConnectionNntpClient and disposed on provider config change
+#pragma warning disable CA2000 // the pool is owned by the provider's MultiConnectionNntpClient and disposed on provider config change
         var connectionPool = CreateNewConnectionPool(
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
             maxConnections: maxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
             onConnectionPoolChanged,
@@ -358,9 +358,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                     connectionDetails.Host, connectionDetails.Port, connectionDetails.UseSsl,
                     timeoutCts.Token).ConfigureAwait(false);
             }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (e.IsCancellationException() &&
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
                                       timeoutCts.IsCancellationRequested &&
                                       !ct.IsCancellationRequested)
             {
@@ -382,9 +382,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                         connectionDetails.User, connectionDetails.Pass,
                         timeoutCts.Token).ConfigureAwait(false);
                 }
-                #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
                 catch (Exception e) when (e.IsCancellationException() &&
-                #pragma warning restore CA2016
+#pragma warning restore CA2016
                                           timeoutCts.IsCancellationRequested &&
                                           !ct.IsCancellationRequested)
                 {

--- a/backend/Config/ConfigEnvMapping.cs
+++ b/backend/Config/ConfigEnvMapping.cs
@@ -63,7 +63,7 @@ public static class ConfigEnvMapping
         return EnvPrefix + body;
     }
 
-    private static IReadOnlyDictionary<string, string> BuildConfigKeyToEnvVarMap()
+    private static Dictionary<string, string> BuildConfigKeyToEnvVarMap()
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var field in typeof(ConfigKeys).GetFields(BindingFlags.Public | BindingFlags.Static))
@@ -77,7 +77,7 @@ public static class ConfigEnvMapping
         return map;
     }
 
-    private static IReadOnlyDictionary<string, string> BuildEnvVarToConfigKeyMap()
+    private static Dictionary<string, string> BuildEnvVarToConfigKeyMap()
     {
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (configKey, envVar) in ConfigKeyToEnvVar.Value)

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -413,33 +413,33 @@ public class ConfigManager
 
         return;
 
-        static void RequireLong(string key, string value)
+        void RequireLong(string key, string value)
         {
             if (!long.TryParse(value, out _))
                 throw new ArgumentException($"Config value for '{key}' must be a whole number, but was '{value}'.");
         }
 
-        static void RequireNonNegativeInt(string key, string value)
+        void RequireNonNegativeInt(string key, string value)
         {
             if (!int.TryParse(value, out var parsed) || parsed < 0)
                 throw new ArgumentException(
                     $"Config value for '{key}' must be a non-negative whole number, but was '{value}'.");
         }
 
-        static void RequireBool(string key, string value)
+        void RequireBool(string key, string value)
         {
             if (!bool.TryParse(value, out _))
                 throw new ArgumentException($"Config value for '{key}' must be 'true' or 'false', but was '{value}'.");
         }
 
-        static void RequireOneOf(string key, string value, params string[] allowed)
+        void RequireOneOf(string key, string value, params string[] allowed)
         {
             if (!allowed.Contains(value, StringComparer.OrdinalIgnoreCase))
                 throw new ArgumentException(
                     $"Config value for '{key}' must be one of '{string.Join("', '", allowed)}', but was '{value}'.");
         }
 
-        static void RequireJson<T>(string key, string value, JsonSerializerOptions? options)
+        void RequireJson<T>(string key, string value, JsonSerializerOptions? options)
         {
             try
             {
@@ -455,7 +455,7 @@ public class ConfigManager
         // the type, so a strict failure can only be property naming and the path is
         // safe to surface. One that fails both is malformed, and that message can
         // quote part of the value.
-        static ArgumentException DescribeJsonFailure<T>(
+        ArgumentException DescribeJsonFailure<T>(
             string key, string value, JsonSerializerOptions? options, JsonException e)
         {
             if (options is null || !ParsesIgnoringCase<T>(value))
@@ -464,7 +464,7 @@ public class ConfigManager
             return new ConfigUnmappedPropertyException(key, TruncatePath(e.Path));
         }
 
-        static bool ParsesIgnoringCase<T>(string value)
+        bool ParsesIgnoringCase<T>(string value)
         {
             try
             {
@@ -478,13 +478,13 @@ public class ConfigManager
         }
 
         // A property name is operator-supplied text, so bound what reaches the log.
-        static string TruncatePath(string? path)
+        string TruncatePath(string? path)
         {
             if (string.IsNullOrEmpty(path)) return "$";
             return path.Length <= 120 ? path : path[..120] + "...";
         }
 
-        static void RequireValidUsenetProviders(string key, string value, JsonSerializerOptions? options)
+        void RequireValidUsenetProviders(string key, string value, JsonSerializerOptions? options)
         {
             UsenetProviderConfig? config;
             try
@@ -519,7 +519,7 @@ public class ConfigManager
                     throw new ArgumentException($"Provider '{label}': byte limit must not be negative.");
             }
 
-            static bool ContainsControlChars(string? s) =>
+            bool ContainsControlChars(string? s) =>
                 !string.IsNullOrEmpty(s) && s.Any(c => c < 0x20 || c == 0x7F);
         }
     }
@@ -959,7 +959,7 @@ public class ConfigManager
         var configValue = GetConfigValue(ConfigKeys.ApiEnsureArticleExistenceCategories);
         return (configValue ?? "").Split(',')
             .Select(x => x.Trim())
-            .Select(x => x.ToLower())
+            .Select(x => x.ToLowerInvariant())
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .ToHashSet();
     }
@@ -1574,7 +1574,7 @@ public class ConfigManager
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())
             .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select(x => x.ToLower())
+            .Select(x => x.ToLowerInvariant())
             .ToHashSet();
     }
 

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -503,7 +503,7 @@ public class ConfigManager
                 var label = string.IsNullOrWhiteSpace(p.Nickname) ? p.Host : p.Nickname;
                 if (string.IsNullOrWhiteSpace(p.Host))
                     throw new ArgumentException($"Provider #{i + 1}: host must not be empty.");
-                if (ContainsControlChars(p.Host) || p.Host.Contains(' '))
+                if (ContainsControlChars(p.Host) || p.Host.Contains(' ', StringComparison.Ordinal))
                     throw new ArgumentException($"Provider '{label}': host contains whitespace or control characters.");
                 if (ContainsControlChars(p.User))
                     throw new ArgumentException($"Provider '{label}': username contains control characters.");

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1081,7 +1081,7 @@ public class ConfigManager
     // Synced patterns (last-good cache, in configured-URL order) take precedence and are
     // emitted first; the manual textarea is appended after, with exact duplicates dropped
     // so a pattern present in both sources is compiled and evaluated only once.
-    private IReadOnlyList<Regex> BuildExcludePatterns()
+    private List<Regex> BuildExcludePatterns()
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var compiled = new List<Regex>();

--- a/backend/Config/ConfigSecretMasker.cs
+++ b/backend/Config/ConfigSecretMasker.cs
@@ -225,7 +225,7 @@ public sealed class ConfigSecretMasker(string signingKey)
         }
     }
 
-    private static IReadOnlyCollection<string> GetExistingJsonSecrets(string? existingValue, string propertyName)
+    private static List<string> GetExistingJsonSecrets(string? existingValue, string propertyName)
     {
         if (existingValue == null)
             return [];

--- a/backend/Config/IndexerConfig.cs
+++ b/backend/Config/IndexerConfig.cs
@@ -62,9 +62,9 @@ public class IndexerConfig
         public string? UserAgent { get; set; }
         public string? SearchUserAgent { get; set; }
         public string? RetrieveUserAgent { get; set; }
-        public bool SkipTlsVerification { get; set; } = false;
-        public int MaxRequestsPerMinute { get; set; } = 0;
-        public bool EnableStrictMatching { get; set; } = false;
+        public bool SkipTlsVerification { get; set; }
+        public int MaxRequestsPerMinute { get; set; }
+        public bool EnableStrictMatching { get; set; }
         // Per-indexer HTTP(S) proxy URL. Overrides the global ProxyUrl. Empty/null = inherit global.
         public string? ProxyUrl { get; set; }
         // Per-indexer HTTP timeout (seconds). Overrides the global TimeoutSeconds.
@@ -82,21 +82,21 @@ public class IndexerConfig
         public int? HitLimitResetTime { get; set; }
         public string? ExtraMovieCategories { get; set; }
         public string? ExtraTvCategories { get; set; }
-        public bool IgnoreCategoryFilter { get; set; } = false;
+        public bool IgnoreCategoryFilter { get; set; }
         public ResultFilter? Filter { get; set; }
     }
 
     public class ResultFilter
     {
         // Master toggle. When false, all rules below are ignored regardless of value.
-        public bool Enabled { get; set; } = false;
+        public bool Enabled { get; set; }
 
         // Drop rules. Each defaults to "no effect".
         // Skip releases where password != 0 (RAR-passworded or contains inner archive).
-        public bool SkipPassworded { get; set; } = false;
+        public bool SkipPassworded { get; set; }
 
         // Minimum download count to keep a release. 0 = disabled (any count is fine).
-        public int MinGrabs { get; set; } = 0;
+        public int MinGrabs { get; set; }
 
         // Grace window for the MinGrabs rule. Releases newer than this many hours bypass
         // the MinGrabs check (so a fresh post isn't punished for having no grabs yet).
@@ -105,11 +105,11 @@ public class IndexerConfig
 
         // Drop releases older than N days that still have zero recorded grabs.
         // 0 = disabled.
-        public int MaxAgeDaysWithoutGrabs { get; set; } = 0;
+        public int MaxAgeDaysWithoutGrabs { get; set; }
 
         // Ranking. When true, this indexer's items will be sorted by grabs descending
         // before merging with other indexers' results. Items missing the grabs attribute
         // sort to the bottom of this indexer's slice (treated as unknown).
-        public bool PreferDownloaded { get; set; } = false;
+        public bool PreferDownloaded { get; set; }
     }
 }

--- a/backend/Config/UsenetProviderConfig.cs
+++ b/backend/Config/UsenetProviderConfig.cs
@@ -24,7 +24,7 @@ public class UsenetProviderConfig
         public required string Host { get; set; }
         public required int Port { get; set; }
         public required bool UseSsl { get; set; }
-        public bool SkipTlsVerification { get; set; } = false;
+        public bool SkipTlsVerification { get; set; }
         public required string User { get; set; }
         public required string Pass { get; set; }
         public required int MaxConnections { get; set; }

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -280,7 +280,7 @@ public static class UsenetProviderIdentity
     /// double-count rows when the remap is retried on the next startup.
     /// </summary>
     private static async Task ExecuteAtomicallyAsync(
-        MetricsDbContext db, CancellationToken ct, Func<Task> work)
+        MetricsDbContext db, Func<Task> work, CancellationToken ct)
     {
         await using var tx = await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
         await work().ConfigureAwait(false);
@@ -290,7 +290,7 @@ public static class UsenetProviderIdentity
     private static Task MergeProviderMinutesAsync(
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
-        return ExecuteAtomicallyAsync(db, ct, async () =>
+        return ExecuteAtomicallyAsync(db, async () =>
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
@@ -310,13 +310,13 @@ public static class UsenetProviderIdentity
             await db.Database.ExecuteSqlRawAsync(
                 "DELETE FROM ProviderMinutes WHERE Provider = {0}",
                 new object[] { host }, ct).ConfigureAwait(false);
-        });
+        }, ct);
     }
 
     private static Task MergeProviderHourlyAsync(
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
-        return ExecuteAtomicallyAsync(db, ct, async () =>
+        return ExecuteAtomicallyAsync(db, async () =>
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
@@ -336,7 +336,7 @@ public static class UsenetProviderIdentity
             await db.Database.ExecuteSqlRawAsync(
                 "DELETE FROM ProviderHourly WHERE Provider = {0}",
                 new object[] { host }, ct).ConfigureAwait(false);
-        });
+        }, ct);
     }
 
     private static async Task RemapFailoverMissesAsync(
@@ -356,7 +356,7 @@ public static class UsenetProviderIdentity
         MetricsDbContext db, string host, string metricsKey, CancellationToken ct)
     {
         // Remap FromProvider first, then ToProvider, merging on conflict.
-        await ExecuteAtomicallyAsync(db, ct, async () =>
+        await ExecuteAtomicallyAsync(db, async () =>
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
@@ -370,9 +370,9 @@ public static class UsenetProviderIdentity
             await db.Database.ExecuteSqlRawAsync(
                 "DELETE FROM FailoverHourly WHERE FromProvider = {0}",
                 new object[] { host }, ct).ConfigureAwait(false);
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
 
-        await ExecuteAtomicallyAsync(db, ct, async () =>
+        await ExecuteAtomicallyAsync(db, async () =>
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
@@ -386,6 +386,6 @@ public static class UsenetProviderIdentity
             await db.Database.ExecuteSqlRawAsync(
                 "DELETE FROM FailoverHourly WHERE ToProvider = {0}",
                 new object[] { host }, ct).ConfigureAwait(false);
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
     }
 }

--- a/backend/Database/Backup/SqliteDumper.cs
+++ b/backend/Database/Backup/SqliteDumper.cs
@@ -161,7 +161,7 @@ public static class SqliteDumper
         {
             results.Add(new MasterObject(
                 reader.GetString(0),
-                reader.IsDBNull(1) ? null : reader.GetString(1)));
+                await reader.IsDBNullAsync(1, cancellationToken).ConfigureAwait(false) ? null : reader.GetString(1)));
         }
 
         return results;

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -6,9 +6,9 @@ using ZstdSharp;
 
 namespace NzbWebDAV.Database;
 
-public class BlobStore
+public static class BlobStore
 {
-    private static readonly int CompressionLevel = 1;
+    private const int CompressionLevel = 1;
     private static string ConfigPath => DavDatabaseContext.ConfigPath;
     private static readonly Lock LockObj = new();
     private static readonly MemoryCache MetadataCache = new(new MemoryCacheOptions

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -61,7 +61,7 @@ public class BlobStore
     {
         await using var fileStream = OpenBlobWrite(id);
         await using var compressionStream = new CompressionStream(fileStream, CompressionLevel);
-        await MemoryPackSerializer.SerializeAsync(compressionStream, blob);
+        await MemoryPackSerializer.SerializeAsync(compressionStream, blob).ConfigureAwait(false);
         MetadataCache.Remove(id);
     }
 
@@ -79,7 +79,7 @@ public class BlobStore
         if (stream == null) return default;
         await using var fileStream = stream;
         await using var decompressionStream = new DecompressionStream(fileStream);
-        var blob = await MemoryPackSerializer.DeserializeAsync<T>(decompressionStream);
+        var blob = await MemoryPackSerializer.DeserializeAsync<T>(decompressionStream).ConfigureAwait(false);
         if (blob is not null)
         {
             MetadataCache.Set(id, blob, new MemoryCacheEntryOptions()

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -110,7 +110,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            var blob = await BlobStore.ReadBlob<DavNzbFile>(blobId.Value);
+            var blob = await BlobStore.ReadBlob<DavNzbFile>(blobId.Value).ConfigureAwait(false);
             if (blob is not null) return blob;
         }
 
@@ -127,7 +127,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            var blob = await BlobStore.ReadBlob<DavRarFile>(blobId.Value);
+            var blob = await BlobStore.ReadBlob<DavRarFile>(blobId.Value).ConfigureAwait(false);
             if (blob is not null) return blob;
         }
 
@@ -144,7 +144,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            var blob = await BlobStore.ReadBlob<DavMultipartFile>(blobId.Value);
+            var blob = await BlobStore.ReadBlob<DavMultipartFile>(blobId.Value).ConfigureAwait(false);
             if (blob is not null) return blob;
         }
 

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -792,7 +792,7 @@ public sealed class DavDatabaseContext : DbContext
             .ToList();
 
         var completedSymlinkDirs = contentDirs
-            .Where(x => x.StartsWith("/content"))
+            .Where(x => x.StartsWith("/content", StringComparison.Ordinal))
             .Select(x => $"/completed-symlinks{x["/content".Length..]}")
             .ToList();
 

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -738,15 +738,15 @@ public sealed class DavDatabaseContext : DbContext
         {
             // save blobs to blob-store
             foreach (var blobNzbFile in BlobNzbFiles)
-                await BlobStore.WriteBlob(blobNzbFile.Id, blobNzbFile);
+                await BlobStore.WriteBlob(blobNzbFile.Id, blobNzbFile).ConfigureAwait(false);
             foreach (var blobRarFile in BlobRarFiles)
-                await BlobStore.WriteBlob(blobRarFile.Id, blobRarFile);
+                await BlobStore.WriteBlob(blobRarFile.Id, blobRarFile).ConfigureAwait(false);
             foreach (var blobMultipartFile in BlobMultipartFiles)
-                await BlobStore.WriteBlob(blobMultipartFile.Id, blobMultipartFile);
+                await BlobStore.WriteBlob(blobMultipartFile.Id, blobMultipartFile).ConfigureAwait(false);
 
             // save db changes
             var addedOrRemovedDavItems = GetAddedOrRemovedDavItems();
-            var result = await base.SaveChangesAsync(cancellationToken);
+            var result = await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             _ = RcloneVfsForget(addedOrRemovedDavItems);
 
             // clear pending blob writes

--- a/backend/Database/DavDatabaseContexts.cs
+++ b/backend/Database/DavDatabaseContexts.cs
@@ -1,0 +1,19 @@
+namespace NzbWebDAV.Database;
+
+/// <summary>
+/// Creates <see cref="DavDatabaseContext"/> instances while honoring the
+/// optional injection overrides used by tests and migration runners.
+/// Centralized because CA2000 cannot follow the inline
+/// `factory?.Invoke() ?? new DavDatabaseContext()` coalescing pattern and
+/// false-flags every such site; the early returns here are clean ownership
+/// transfers.
+/// </summary>
+internal static class DavDatabaseContexts
+{
+    public static DavDatabaseContext Create(Func<DavDatabaseContext>? factoryOverride)
+    {
+        var overridden = factoryOverride?.Invoke();
+        if (overridden is not null) return overridden;
+        return new DavDatabaseContext();
+    }
+}

--- a/backend/Database/MigrationHelpers/Attributes/ExecuteAfterAttribute.cs
+++ b/backend/Database/MigrationHelpers/Attributes/ExecuteAfterAttribute.cs
@@ -1,6 +1,6 @@
 namespace NzbWebDAV.Database.MigrationHelpers.Attributes;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-public class ExecuteAfterAttribute : Attribute
+public sealed class ExecuteAfterAttribute : Attribute
 {
 }

--- a/backend/Database/MigrationHelpers/Attributes/ExecuteBeforeAttribute.cs
+++ b/backend/Database/MigrationHelpers/Attributes/ExecuteBeforeAttribute.cs
@@ -1,6 +1,6 @@
 namespace NzbWebDAV.Database.MigrationHelpers.Attributes;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-public class ExecuteBeforeAttribute : Attribute
+public sealed class ExecuteBeforeAttribute : Attribute
 {
 }

--- a/backend/Database/Migrations/20250529081501_InitializeDatabase.cs
+++ b/backend/Database/Migrations/20250529081501_InitializeDatabase.cs
@@ -164,7 +164,9 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "DavItems",
                 columns: new[] { "Id", "ParentId", "Name", "FileSize", "Type" },
+                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
+                #pragma warning restore CA1814
                 {
                     {
                         // Root

--- a/backend/Database/Migrations/20250529081501_InitializeDatabase.cs
+++ b/backend/Database/Migrations/20250529081501_InitializeDatabase.cs
@@ -164,7 +164,7 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "DavItems",
                 columns: new[] { "Id", "ParentId", "Name", "FileSize", "Type" },
-                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
+#pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
                 #pragma warning restore CA1814
                 {

--- a/backend/Database/Migrations/20250722004955_Ensure-Api-Key-Exists.cs
+++ b/backend/Database/Migrations/20250722004955_Ensure-Api-Key-Exists.cs
@@ -14,7 +14,7 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "ConfigItems",
                 columns: new[] { "ConfigName", "ConfigValue" },
-                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
+#pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
                 #pragma warning restore CA1814
                 {

--- a/backend/Database/Migrations/20250722004955_Ensure-Api-Key-Exists.cs
+++ b/backend/Database/Migrations/20250722004955_Ensure-Api-Key-Exists.cs
@@ -14,7 +14,9 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "ConfigItems",
                 columns: new[] { "ConfigName", "ConfigValue" },
+                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
+                #pragma warning restore CA1814
                 {
                     {
                         "api.key",

--- a/backend/Database/Migrations/20250819091746_Add-Ids-Root-Directory.cs
+++ b/backend/Database/Migrations/20250819091746_Add-Ids-Root-Directory.cs
@@ -13,7 +13,9 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "DavItems",
                 columns: new[] { "Id", "ParentId", "Name", "FileSize", "Type" },
+                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
+                #pragma warning restore CA1814
                 {
                     {
                         // Root

--- a/backend/Database/Migrations/20250819091746_Add-Ids-Root-Directory.cs
+++ b/backend/Database/Migrations/20250819091746_Add-Ids-Root-Directory.cs
@@ -13,7 +13,7 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "DavItems",
                 columns: new[] { "Id", "ParentId", "Name", "FileSize", "Type" },
-                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
+#pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
                 #pragma warning restore CA1814
                 {

--- a/backend/Database/Migrations/20251106165542_Ensure-Strm-Key-Exists.cs
+++ b/backend/Database/Migrations/20251106165542_Ensure-Strm-Key-Exists.cs
@@ -14,7 +14,7 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "ConfigItems",
                 columns: new[] { "ConfigName", "ConfigValue" },
-                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
+#pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
                 #pragma warning restore CA1814
                 {

--- a/backend/Database/Migrations/20251106165542_Ensure-Strm-Key-Exists.cs
+++ b/backend/Database/Migrations/20251106165542_Ensure-Strm-Key-Exists.cs
@@ -14,7 +14,9 @@ namespace NzbWebDAV.Database.Migrations
             migrationBuilder.InsertData(
                 table: "ConfigItems",
                 columns: new[] { "ConfigName", "ConfigValue" },
+                #pragma warning disable CA1814 // EF Core migrationBuilder.InsertData requires the object[,] values shape
                 values: new object[,]
+                #pragma warning restore CA1814
                 {
                     {
                         "api.strm-key",

--- a/backend/Extensions/IAsyncEnumerableTaskExtensions.cs
+++ b/backend/Extensions/IAsyncEnumerableTaskExtensions.cs
@@ -7,8 +7,8 @@ public static class IAsyncEnumerableTaskExtensions
     public static async Task<List<T>> GetAllAsync<T>
     (
         this IAsyncEnumerable<T> asyncEnumerable,
-        CancellationToken ct = default,
-        IProgress<int>? progress = null
+        IProgress<int>? progress = null,
+        CancellationToken ct = default
     )
     {
         var done = 0;

--- a/backend/Extensions/IEnumerableExtensions.cs
+++ b/backend/Extensions/IEnumerableExtensions.cs
@@ -6,8 +6,7 @@ public static class IEnumerableExtensions
 {
     public static IEnumerable<List<T>> ToBatches<T>(this IEnumerable<T> items, int batchSize)
     {
-        if (items == null)
-            throw new ArgumentNullException(nameof(items));
+        ArgumentNullException.ThrowIfNull(items);
         if (batchSize <= 0)
             throw new ArgumentOutOfRangeException(
                 nameof(batchSize),

--- a/backend/Extensions/IEnumerableTaskExtensions.cs
+++ b/backend/Extensions/IEnumerableTaskExtensions.cs
@@ -57,7 +57,7 @@ public static class IEnumerableTaskExtensions
                 {
                     if (x.Status == TaskStatus.RanToCompletion)
                         x.Result.Dispose();
-                });
+                }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
             }
         }
     }

--- a/backend/Extensions/NWebDavOptionsExtensions.cs
+++ b/backend/Extensions/NWebDavOptionsExtensions.cs
@@ -7,11 +7,11 @@ public static class NWebDavOptionsExtensions
 {
     public static Func<HttpContext, bool> GetFilter(this NWebDavOptions options)
     {
-        return context => !context.Request.Path.StartsWithSegments("/api") &&
-                          !context.Request.Path.StartsWithSegments("/view") &&
-                          !context.Request.Path.StartsWithSegments("/health") &&
-                          !context.Request.Path.StartsWithSegments("/ws") &&
-                          !context.Request.Path.StartsWithSegments("/p") &&
-                          !context.Request.Path.StartsWithSegments("/adapters");
+        return context => !context.Request.Path.StartsWithSegments("/api", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/view", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/health", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/ws", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/p", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/adapters", StringComparison.Ordinal);
     }
 }

--- a/backend/Extensions/StringExtensions.cs
+++ b/backend/Extensions/StringExtensions.cs
@@ -21,6 +21,6 @@ public static class StringExtensions
 
     public static string RemovePrefix(this string value, string prefix)
     {
-        return value.StartsWith(prefix) ? value[prefix.Length..] : value;
+        return value.StartsWith(prefix, StringComparison.Ordinal) ? value[prefix.Length..] : value;
     }
 }

--- a/backend/GlobalSuppressions.cs
+++ b/backend/GlobalSuppressions.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+// Targeted analyzer suppressions with justification, per the static-analysis
+// policy in CONTRIBUTING.md. Rule-level policy lives in the root .editorconfig;
+// this file is for specific APIs where the rule misfires on intent.
+
+// The abstract NntpClient hierarchy manages only managed resources and has no
+// finalizers anywhere in the hierarchy, so the full Dispose(bool) pattern
+// ceremony (a base Dispose() wrapper plus ~30 override conversions across
+// production clients and test doubles) buys nothing. The abstract
+// public-Dispose contract is the simpler correct pattern here.
+[assembly: SuppressMessage(
+    "Design",
+    "CA1063:Implement IDisposable Correctly",
+    Scope = "type",
+    Target = "~T:NzbWebDAV.Clients.Usenet.NntpClient",
+    Justification = "Abstract NNTP client hierarchy manages only managed resources; no finalizers exist. The abstract public Dispose contract is intentional.")]

--- a/backend/GlobalSuppressions.cs
+++ b/backend/GlobalSuppressions.cs
@@ -15,3 +15,38 @@ using System.Diagnostics.CodeAnalysis;
     Scope = "type",
     Target = "~T:NzbWebDAV.Clients.Usenet.NntpClient",
     Justification = "Abstract NNTP client hierarchy manages only managed resources; no finalizers exist. The abstract public Dispose contract is intentional.")]
+
+// These structs are transient data carriers that are never compared for
+// equality, used as collection keys, or stored in hashed containers, so the
+// default ValueType.Equals reflection path is never exercised. (Par2PacketHeader
+// is a P/Invoke-marshaled layout struct where member equality is meaningless.)
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1815:Override equals and operator equals on value types",
+    Scope = "type",
+    Target = "~T:NzbWebDAV.Utils.OrganizedLinksUtil.DavItemLink",
+    Justification = "Transient helper struct; never compared or used as a key.")]
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1815:Override equals and operator equals on value types",
+    Scope = "type",
+    Target = "~T:NzbWebDAV.Utils.SymlinkAndStrmUtil.StrmInfo",
+    Justification = "Transient helper struct; never compared or used as a key.")]
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1815:Override equals and operator equals on value types",
+    Scope = "type",
+    Target = "~T:NzbWebDAV.Utils.SymlinkAndStrmUtil.SymlinkInfo",
+    Justification = "Transient helper struct; never compared or used as a key.")]
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1815:Override equals and operator equals on value types",
+    Scope = "type",
+    Target = "~T:NzbWebDAV.Par2Recovery.Packets.Par2PacketHeader",
+    Justification = "P/Invoke-marshaled layout struct; member equality is meaningless for a packet read view.")]
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1815:Override equals and operator equals on value types",
+    Scope = "type",
+    Target = "~T:NzbWebDAV.Clients.Usenet.Models.UsenetExclusiveConnection",
+    Justification = "Single-field delegate wrapper; never compared or used as a key.")]

--- a/backend/Logging/LogBufferSink.cs
+++ b/backend/Logging/LogBufferSink.cs
@@ -101,9 +101,9 @@ public sealed class LogBufferSink : ILogEventSink
 
     private static bool MatchesSearch(LogEntry entry, string search)
     {
-        if (entry.Message.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0) return true;
-        if (entry.Exception is { } ex && ex.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0) return true;
-        if (entry.Source is { } src && src.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        if (entry.Message.Contains(search, StringComparison.OrdinalIgnoreCase)) return true;
+        if (entry.Exception is { } ex && ex.Contains(search, StringComparison.OrdinalIgnoreCase)) return true;
+        if (entry.Source is { } src && src.Contains(search, StringComparison.OrdinalIgnoreCase)) return true;
         return false;
     }
 

--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -40,7 +40,7 @@ public class NzbDocument
         }
         catch (XmlException e)
         {
-            throw new Exception("Could not parse the nzb document (malformed nzb)", e);
+            throw new InvalidOperationException("Could not parse the nzb document (malformed nzb)", e);
         }
     }
 

--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -40,7 +40,7 @@ public class NzbDocument
         }
         catch (XmlException e)
         {
-            throw new InvalidOperationException("Could not parse the nzb document (malformed nzb)", e);
+            throw new InvalidDataException("Could not parse the nzb document (malformed nzb)", e);
         }
     }
 

--- a/backend/Models/Nzb/NzbFile.cs
+++ b/backend/Models/Nzb/NzbFile.cs
@@ -267,6 +267,6 @@ public class NzbFile
         return funcs
             .Select(x => x.Invoke())
             .Where(x => x == Path.GetFileName(x))
-            .FirstOrDefault(x => x != "") ?? "";
+            .FirstOrDefault(x => !string.IsNullOrEmpty(x)) ?? "";
     }
 }

--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -8,7 +8,7 @@ using Serilog;
 
 namespace NzbWebDAV.Par2Recovery
 {
-    public class Par2
+    public static class Par2
     {
         internal static readonly Regex ParVolume = new(
             @"(.+)\.vol[0-9]{1,10}\+[0-9]{1,10}\.par2$",

--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -71,7 +71,7 @@ namespace NzbWebDAV.Par2Recovery
 
             // Test if the magic constant matches.
             var magic = Encoding.ASCII.GetString(header.Magic);
-            if (!Par2PacketHeaderMagic.Equals(magic))
+            if (!Par2PacketHeaderMagic.Equals(magic, StringComparison.Ordinal))
                 throw new ApplicationException("Invalid Magic Constant");
 
             // Determine which type of packet we have.
@@ -145,7 +145,7 @@ namespace NzbWebDAV.Par2Recovery
             {
                 var header = ReadStruct<Par2PacketHeader>(bytes);
                 var magic = Encoding.ASCII.GetString(header.Magic);
-                return Par2PacketHeaderMagic.Equals(magic);
+                return Par2PacketHeaderMagic.Equals(magic, StringComparison.Ordinal);
             }
             catch (Exception e)
             {

--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -72,7 +72,7 @@ namespace NzbWebDAV.Par2Recovery
             // Test if the magic constant matches.
             var magic = Encoding.ASCII.GetString(header.Magic);
             if (!Par2PacketHeaderMagic.Equals(magic, StringComparison.Ordinal))
-                throw new ApplicationException("Invalid Magic Constant");
+                throw new InvalidDataException("Invalid Magic Constant");
 
             // Determine which type of packet we have.
             var packetType = Encoding.ASCII.GetString(header.PacketType);
@@ -147,7 +147,7 @@ namespace NzbWebDAV.Par2Recovery
                 var magic = Encoding.ASCII.GetString(header.Magic);
                 return Par2PacketHeaderMagic.Equals(magic, StringComparison.Ordinal);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return false;
             }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -368,7 +368,7 @@ public partial class Program
         }
         finally
         {
-            Log.CloseAndFlush();
+            await Log.CloseAndFlushAsync().ConfigureAwait(false);
         }
     }
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -662,7 +662,7 @@ public partial class Program
         {
             Log.Information("Performing database vacuum");
             await using var databaseContext = new DavDatabaseContext();
-            await databaseContext.Database.ExecuteSqlRawAsync("VACUUM;");
+            await databaseContext.Database.ExecuteSqlRawAsync("VACUUM;").ConfigureAwait(false);
             Log.Information("Database vacuum completed");
         }
     }

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -211,7 +211,9 @@ public static class FetchFirstSegmentsStep
                 nzbFile.GetSubjectFileName());
             return (index, BuildMissingFirstSegment(nzbFile));
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             // Transient provider errors must not be treated as permanent missing segments
             // (otherwise fail-fast would mark good NZBs failed — see nzbdav-dev#245).
@@ -319,7 +321,9 @@ public static class FetchFirstSegmentsStep
             return BuildMissingFirstSegment(nzbFile);
         }
         catch (Exception e) when (
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             e.IsTransientTransportException() && !e.IsCancellationException())
+            #pragma warning restore CA2016
         {
             throw new RetryableDownloadException(
                 $"Transient provider error fetching first segment of " +

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -135,7 +135,7 @@ public static class FetchFirstSegmentsStep
                     if (DeadNzbFailFast.IsImportantNzbFile(files[i]))
                     {
                         abortFile = files[i];
-                        abortCts.Cancel();
+                        await abortCts.CancelAsync().ConfigureAwait(false);
                         break;
                     }
                 }

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -211,9 +211,9 @@ public static class FetchFirstSegmentsStep
                 nzbFile.GetSubjectFileName());
             return (index, BuildMissingFirstSegment(nzbFile));
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             // Transient provider errors must not be treated as permanent missing segments
             // (otherwise fail-fast would mark good NZBs failed — see nzbdav-dev#245).
@@ -321,9 +321,9 @@ public static class FetchFirstSegmentsStep
             return BuildMissingFirstSegment(nzbFile);
         }
         catch (Exception e) when (
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             e.IsTransientTransportException() && !e.IsCancellationException())
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             throw new RetryableDownloadException(
                 $"Transient provider error fetching first segment of " +

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -53,7 +53,7 @@ public static class FetchFirstSegmentsStep
         await foreach (var result in files
                            .Select(x => FetchFirstSegment(x, usenetClient, abortCts.Token))
                            .WithConcurrencyAsync(
-                               QueueFanOut.GetConcurrency(abortCts.Token, configManager),
+                               QueueFanOut.GetConcurrency(configManager, abortCts.Token),
                                abortCts.Token)
                            .WithCancellation(abortCts.Token)
                            .ConfigureAwait(false))
@@ -166,7 +166,7 @@ public static class FetchFirstSegmentsStep
             await foreach (var (i, result) in pending
                                .Select(i => RescueFirstSegment(i, files[i], usenetClient, rescueAbortCts.Token))
                                .WithConcurrencyAsync(
-                                   QueueFanOut.GetConcurrency(rescueAbortCts.Token, configManager),
+                                   QueueFanOut.GetConcurrency(configManager, rescueAbortCts.Token),
                                    rescueAbortCts.Token)
                                .WithCancellation(rescueAbortCts.Token)
                                .ConfigureAwait(false))

--- a/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
+++ b/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
@@ -17,7 +17,9 @@ public static class GetFileInfosStep
         List<FileDesc> par2FileDescriptors
     )
     {
+#pragma warning disable CA5351 // MD5 here is content hashing for the NZB/PAR2 ecosystem (dedup/integrity per format conventions), not security
         using var md5 = MD5.Create();
+#pragma warning restore CA5351
         var hashToFileDescMap = GetHashToFileDescMap(par2FileDescriptors);
         var picks = files.Select(x =>
         {

--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -15,7 +15,7 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
         foreach (var processorResult in processorResults)
         {
             if (processorResult is not FileProcessor.Result result) continue;
-            if (result.FileName == "") continue; // skip files whose name we can't determine
+            if (string.IsNullOrEmpty(result.FileName)) continue; // skip files whose name we can't determine
             var parentDirectory = EnsureParentDirectory(result.FileName);
             var name = SanitizeDavName(Path.GetFileName(result.FileName));
 

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -333,13 +333,14 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
         return (decoded, aesParams);
     }
 
-    [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
     private static void ValidatePartNumbers(IEnumerable<int> partNumbers)
     {
-        var count = partNumbers.Count();
-        var uniqueCount = partNumbers.Distinct().Count();
-        if (count != uniqueCount)
-            throw new InvalidDataException("Rar archive has duplicate volume numbers.");
+        var seen = new HashSet<int>();
+        foreach (var partNumber in partNumbers)
+        {
+            if (!seen.Add(partNumber))
+                throw new InvalidDataException("Rar archive has duplicate volume numbers.");
+        }
     }
 
     private static int GetNormalizedPartNumber(

--- a/backend/Queue/FileProcessors/BaseProcessor.cs
+++ b/backend/Queue/FileProcessors/BaseProcessor.cs
@@ -17,7 +17,7 @@ public abstract class BaseProcessor
     {
         try
         {
-            return await ProcessAsync();
+            return await ProcessAsync().ConfigureAwait(false);
         }
         finally
         {

--- a/backend/Queue/FileProcessors/RarProcessor.cs
+++ b/backend/Queue/FileProcessors/RarProcessor.cs
@@ -75,7 +75,7 @@ public class RarProcessor(
         };
 
         if (partNumber.PartNumberFromHeader == null && partNumber.PartNumberFromFilename == null)
-            throw new Exception("Could not determine part number for RAR file.");
+            throw new InvalidOperationException("Could not determine part number for RAR file.");
 
         return partNumber;
     }

--- a/backend/Queue/FileProcessors/SevenZipProcessor.cs
+++ b/backend/Queue/FileProcessors/SevenZipProcessor.cs
@@ -130,8 +130,8 @@ public class SevenZipProcessor : BaseProcessor
         var progressPercentage = progress.ToPercentage(missingFileSizes.Count);
         var populatedFileSizes = await missingFileSizes
             .Select(PopulateMissingFileSize)
-            .WithConcurrencyAsync(NzbWebDAV.Queue.QueueFanOut.GetExactQueueConcurrency(_ct, _configManager))
-            .GetAllAsync(_ct, progressPercentage)
+            .WithConcurrencyAsync(NzbWebDAV.Queue.QueueFanOut.GetExactQueueConcurrency(_configManager, _ct))
+            .GetAllAsync(progressPercentage, _ct)
             .ConfigureAwait(false);
         progress.Report(100);
         return withFileSizes.Concat(populatedFileSizes).ToList();

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -238,7 +238,9 @@ public static class NestedRarExpansionStep
                 path, expanded.Count);
             return expanded;
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Information(e,
                 "NestedRarExpansion: failed to expand {Path}; keeping opaque",

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -238,9 +238,9 @@ public static class NestedRarExpansionStep
                 path, expanded.Count);
             return expanded;
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Information(e,
                 "NestedRarExpansion: failed to expand {Path}; keeping opaque",

--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -110,7 +110,7 @@ public class CreateStrmFilesPostProcessor(
         if (pathUrl.StartsWith('/')) pathUrl = pathUrl.TrimStart('/');
         var strmKey = configManager.GetStrmKey();
         var downloadKey = GetWebdavItemRequest.GenerateDownloadKey(strmKey, pathUrl);
-        var extension = Path.GetExtension(davItem.Name).ToLower().TrimStart('.');
+        var extension = Path.GetExtension(davItem.Name).ToLowerInvariant().TrimStart('.');
         return $"{baseUrl}/view/{pathUrl}?downloadKey={downloadKey}&extension={extension}";
     }
 

--- a/backend/Queue/QueueFanOut.cs
+++ b/backend/Queue/QueueFanOut.cs
@@ -40,7 +40,7 @@ public static class QueueFanOut
     /// Reads <see cref="QueueDownloadContext"/> from <paramref name="ct"/> when present;
     /// otherwise falls back to primary fan-out (single-item / test paths).
     /// </summary>
-    public static int GetConcurrency(CancellationToken ct, ConfigManager configManager)
+    public static int GetConcurrency(ConfigManager configManager, CancellationToken ct)
     {
         var ctx = ct.GetContext<QueueDownloadContext>();
         if (ctx is not null)
@@ -51,7 +51,7 @@ public static class QueueFanOut
     /// <summary>
     /// Fan-out for SevenZip size population — never applies the primary +5 overshoot.
     /// </summary>
-    public static int GetExactQueueConcurrency(CancellationToken ct, ConfigManager configManager)
+    public static int GetExactQueueConcurrency(ConfigManager configManager, CancellationToken ct)
     {
         var maxQueue = Math.Max(1, configManager.GetMaxQueueConnections());
         var ctx = ct.GetContext<QueueDownloadContext>();

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -375,7 +375,7 @@ public class QueueItemProcessor(
         // step 3 -- Optionally check full article existence
         var checkedFullHealth = false;
         var healthCheckCategories = configManager.GetEnsureArticleExistenceCategories();
-        if (healthCheckCategories.Contains(queueItem.Category.ToLower()))
+        if (healthCheckCategories.Contains(queueItem.Category.ToLowerInvariant()))
         {
             var segmentsByFile = fileInfos
                 .Where(x => x.IsRar || FilenameUtil.IsImportantFileType(x.FileName))

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -243,7 +243,7 @@ public class QueueItemProcessor(
         // if the `/blobs` folder is tampered with outside the nzbdav process,
         // then it is possible that the nzb file goes missing.
         if (queueNzbStream is null)
-            throw new Exception($"The NZB file could not be found.");
+            throw new InvalidOperationException($"The NZB file could not be found.");
 
         // load config for handling duplicate nzbs
         var existingMountFolder = await GetMountFolder().ConfigureAwait(false);
@@ -569,7 +569,7 @@ public class QueueItemProcessor(
             return mountFolder;
         }
 
-        throw new Exception("Duplicate nzb with more than 100 existing copies.");
+        throw new InvalidOperationException("Duplicate nzb with more than 100 existing copies.");
     }
 
     private HistoryItem CreateHistoryItem(DavItem? mountFolder, DateTime jobStartTime, string? errorMessage = null)

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -359,8 +359,8 @@ public class QueueItemProcessor(
         {
             var fileProcessingResultsAll = await fileProcessors
                 .Select(x => x!.ProcessAsync(part2Progress.SubProgress))
-                .WithConcurrencyAsync(QueueFanOut.GetConcurrency(ct, configManager))
-                .GetAllAsync(ct).ConfigureAwait(false);
+                .WithConcurrencyAsync(QueueFanOut.GetConcurrency(configManager, ct))
+                .GetAllAsync(ct: ct).ConfigureAwait(false);
             var results = fileProcessingResultsAll
                 .Where(x => x is not null)
                 .Select(x => x!)
@@ -397,7 +397,7 @@ public class QueueItemProcessor(
                 .ToPercentage(articlesToCheck.Count);
             var healthCheckConcurrency = Math.Min(
                 configManager.GetHealthCheckConcurrency(),
-                QueueFanOut.GetConcurrency(ct, configManager));
+                QueueFanOut.GetConcurrency(configManager, ct));
             await RunStageAsync(
                     "health",
                     () => ArticleExistenceChecker

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -203,7 +203,9 @@ public class QueueItemProcessor(
         }
     }
 
+#pragma warning disable CA1859 // non-generic facade over RunStageAsync<T>; returning Task<object?> would leak the wrapper's shape for no benefit
     private Task RunStageAsync(string stage, Func<Task> action)
+#pragma warning restore CA1859
     {
         return RunStageAsync<object?>(stage, async () =>
         {

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -48,8 +48,7 @@ public class QueueManager : IDisposable
     internal Func<CancellationToken, Task<DateTime?>>? GetNextPauseUntilOverride { get; set; }
     internal Func<DavDatabaseContext>? CreateDbContextOverride { get; set; }
 
-    private DavDatabaseContext CreateDbContext() =>
-        CreateDbContextOverride?.Invoke() ?? new DavDatabaseContext();
+    private DavDatabaseContext CreateDbContext() => DavDatabaseContexts.Create(CreateDbContextOverride);
 
     public QueueManager(
         UsenetStreamingClient usenetClient,
@@ -406,8 +405,12 @@ public class QueueManager : IDisposable
                     GetFanOutConcurrency = () => ComputeFanOutConcurrency(queueItem.Id),
                 };
 
+                #pragma warning disable CA2000 // worker CTS ownership transfers to InProgressQueueItem and is disposed when the queue item completes; the not-transferred path disposes in finally
                 var workerCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                #pragma warning restore CA2000
+                #pragma warning disable CA2000 // registration ownership transfers to InProgressQueueItem (disposed on completion); otherwise disposed in finally
                 queueContextRegistration = workerCts.Token.SetContext(queueDownloadContext);
+                #pragma warning restore CA2000
 
                 inProgress = BeginProcessingQueueItem(
                     dbClient!,

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -223,9 +223,9 @@ public sealed class QueueManager : IDisposable
                 await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
                 await item.ProcessingTask.ConfigureAwait(false);
             }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
             {
                 Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
             }
@@ -303,9 +303,9 @@ public sealed class QueueManager : IDisposable
         if (remaining.Length > 0)
         {
             try { await Task.WhenAll(remaining).ConfigureAwait(false); }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
             {
                 Log.Debug(e, "Queue workers finished with errors during shutdown");
             }
@@ -405,12 +405,12 @@ public sealed class QueueManager : IDisposable
                     GetFanOutConcurrency = () => ComputeFanOutConcurrency(queueItem.Id),
                 };
 
-                #pragma warning disable CA2000 // worker CTS ownership transfers to InProgressQueueItem and is disposed when the queue item completes; the not-transferred path disposes in finally
+#pragma warning disable CA2000 // worker CTS ownership transfers to InProgressQueueItem and is disposed when the queue item completes; the not-transferred path disposes in finally
                 var workerCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                #pragma warning restore CA2000
-                #pragma warning disable CA2000 // registration ownership transfers to InProgressQueueItem (disposed on completion); otherwise disposed in finally
+#pragma warning restore CA2000
+#pragma warning disable CA2000 // registration ownership transfers to InProgressQueueItem (disposed on completion); otherwise disposed in finally
                 queueContextRegistration = workerCts.Token.SetContext(queueDownloadContext);
-                #pragma warning restore CA2000
+#pragma warning restore CA2000
 
                 inProgress = BeginProcessingQueueItem(
                     dbClient!,
@@ -531,9 +531,9 @@ public sealed class QueueManager : IDisposable
             {
                 await item.ProcessingTask.ConfigureAwait(false);
             }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
             {
                 Log.Error(e, "Queue worker for {QueueItemId} faulted", item.QueueItem.Id);
             }
@@ -777,9 +777,9 @@ public sealed class QueueManager : IDisposable
             if (untilNextPause <= TimeSpan.Zero) return TimeSpan.FromMilliseconds(250);
             return untilNextPause < IdleDelay ? untilNextPause : IdleDelay;
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Debug(e, "Failed to compute next queue pause; falling back to idle delay");
             return IdleDelay;

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -224,7 +224,9 @@ public class QueueManager : IDisposable
                 await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
                 await item.ProcessingTask.ConfigureAwait(false);
             }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
+            #pragma warning restore CA2016
             {
                 Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
             }
@@ -302,7 +304,9 @@ public class QueueManager : IDisposable
         if (remaining.Length > 0)
         {
             try { await Task.WhenAll(remaining).ConfigureAwait(false); }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
+            #pragma warning restore CA2016
             {
                 Log.Debug(e, "Queue workers finished with errors during shutdown");
             }
@@ -524,7 +528,9 @@ public class QueueManager : IDisposable
             {
                 await item.ProcessingTask.ConfigureAwait(false);
             }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
+            #pragma warning restore CA2016
             {
                 Log.Error(e, "Queue worker for {QueueItemId} faulted", item.QueueItem.Id);
             }
@@ -768,7 +774,9 @@ public class QueueManager : IDisposable
             if (untilNextPause <= TimeSpan.Zero) return TimeSpan.FromMilliseconds(250);
             return untilNextPause < IdleDelay ? untilNextPause : IdleDelay;
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Debug(e, "Failed to compute next queue pause; falling back to idle delay");
             return IdleDelay;

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -13,7 +13,7 @@ using Serilog;
 
 namespace NzbWebDAV.Queue;
 
-public class QueueManager : IDisposable
+public sealed class QueueManager : IDisposable
 {
     private readonly ConcurrentDictionary<Guid, InProgressQueueItem> _inProgress = new();
     private readonly ConcurrentDictionary<Guid, int> _retryAttempts = new();

--- a/backend/Services/AnimeListMappingResolver.cs
+++ b/backend/Services/AnimeListMappingResolver.cs
@@ -158,9 +158,9 @@ public sealed class AnimeListMappingResolver : IDisposable
 
     private static HttpClient CreateClient()
     {
-        #pragma warning disable CA2000 // handler is owned by the static HttpClient (process lifetime by design)
+#pragma warning disable CA2000 // handler is owned by the static HttpClient (process lifetime by design)
         var handler = new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.All };
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(60) };
         client.DefaultRequestHeaders.UserAgent.ParseAdd("InfiniDysk (https://github.com/infinidysk/infinidysk)");
         return client;

--- a/backend/Services/AnimeListMappingResolver.cs
+++ b/backend/Services/AnimeListMappingResolver.cs
@@ -158,7 +158,9 @@ public class AnimeListMappingResolver
 
     private static HttpClient CreateClient()
     {
+        #pragma warning disable CA2000 // handler is owned by the static HttpClient (process lifetime by design)
         var handler = new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.All };
+        #pragma warning restore CA2000
         var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(60) };
         client.DefaultRequestHeaders.UserAgent.ParseAdd("InfiniDysk (https://github.com/infinidysk/infinidysk)");
         return client;

--- a/backend/Services/AnimeListMappingResolver.cs
+++ b/backend/Services/AnimeListMappingResolver.cs
@@ -10,7 +10,7 @@ namespace NzbWebDAV.Services;
 /// Fribb/anime-lists dataset, which frequently carries the id Kitsu's API omits.
 /// The dataset is a single large json file; we download, index, and cache it in memory.
 /// </summary>
-public class AnimeListMappingResolver
+public sealed class AnimeListMappingResolver : IDisposable
 {
     private const string DatasetUrl =
         "https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-full.json";
@@ -195,6 +195,13 @@ public class AnimeListMappingResolver
             return dict is not null && dict.TryGetValue(id, out var m) ? m : null;
         }
     }
+
+    public void Dispose()
+    {
+        _loadGate.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
 }
 
 public sealed record AnimeMapping(int? TvdbId, string? ImdbId, bool IsMovie, int? TvdbSeason);

--- a/backend/Services/AnimeListMappingResolver.cs
+++ b/backend/Services/AnimeListMappingResolver.cs
@@ -32,7 +32,7 @@ public class AnimeListMappingResolver
             if (index.HasData)
             {
                 // serve the (stale) data we already have and refresh in the background
-                _ = Task.Run(() => LoadIfDueAsync(CancellationToken.None));
+                _ = Task.Run(() => LoadIfDueAsync(CancellationToken.None), CancellationToken.None);
             }
             else
             {

--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -127,7 +127,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
     {
         for (var i = list.Count - 1; i > 0; i--)
         {
-            #pragma warning disable CA5394 // benchmark corpus shuffling is not security-sensitive
+#pragma warning disable CA5394 // benchmark corpus shuffling is not security-sensitive
             var j = Random.Shared.Next(i + 1);
 #pragma warning restore CA5394
             (list[i], list[j]) = (list[j], list[i]);

--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -127,7 +127,9 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
     {
         for (var i = list.Count - 1; i > 0; i--)
         {
+            #pragma warning disable CA5394 // benchmark corpus shuffling is not security-sensitive
             var j = Random.Shared.Next(i + 1);
+#pragma warning restore CA5394
             (list[i], list[j]) = (list[j], list[i]);
         }
     }

--- a/backend/Services/Benchmark/BenchmarkRunControl.cs
+++ b/backend/Services/Benchmark/BenchmarkRunControl.cs
@@ -6,7 +6,7 @@ namespace NzbWebDAV.Services.Benchmark;
 /// still going; we must not treat that disconnect as user cancel. Explicit
 /// cancel (UI Cancel / modal close) calls <see cref="Cancel"/> instead.
 /// </summary>
-public sealed class BenchmarkRunControl
+public sealed class BenchmarkRunControl : IDisposable
 {
     private readonly object _lock = new();
     private CancellationTokenSource? _cts;
@@ -31,4 +31,15 @@ public sealed class BenchmarkRunControl
             _cts?.Cancel();
         }
     }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            _cts?.Dispose();
+            _cts = null;
+        }
+        GC.SuppressFinalize(this);
+    }
+
 }

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -545,7 +545,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         {
             return false;
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Debug(e, "Benchmark download worker stopped early.");
             return false;

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -545,9 +545,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         {
             return false;
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Debug(e, "Benchmark download worker stopped early.");
             return false;

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -18,6 +18,8 @@ public class DatabaseBackupSchedulerService : BackgroundService
     private readonly WebsocketManager _websocketManager;
     private readonly DatabaseBackupStore _store;
     private CancellationTokenSource _rescheduleCts = new();
+    // NOTE: swapped-out instances are intentionally not disposed (ExecuteAsync may
+    // still read .Token after the swap); the current instance is disposed in Dispose.
 
     private static readonly TimeSpan MaxSleepSlice = TimeSpan.FromMinutes(30);
     private DateTime? _lastLoggedNextRun;
@@ -123,4 +125,14 @@ public class DatabaseBackupSchedulerService : BackgroundService
             }
         }
     }
+
+    public override void Dispose()
+    {
+        // ExecuteAsync has stopped when the host disposes the service, so the
+        // current reschedule source is safe to dispose. Swapped-out instances
+        // are intentionally leaked (see the swap note in ExecuteAsync).
+        _rescheduleCts.Dispose();
+        base.Dispose();
+    }
+
 }

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -132,6 +132,7 @@ public class DatabaseBackupSchedulerService : BackgroundService
         // current reschedule source is safe to dispose. Swapped-out instances
         // are intentionally leaked (see the swap note in ExecuteAsync).
         _rescheduleCts.Dispose();
+        GC.SuppressFinalize(this);
         base.Dispose();
     }
 

--- a/backend/Services/DatabaseBackupStore.cs
+++ b/backend/Services/DatabaseBackupStore.cs
@@ -324,7 +324,7 @@ public sealed class DatabaseBackupStore
     {
         if (string.IsNullOrWhiteSpace(backupId))
             throw new ArgumentException("Backup id is required.", nameof(backupId));
-        if (backupId.Contains('/') || backupId.Contains('\\') || backupId.Contains("..", StringComparison.Ordinal))
+        if (backupId.Contains('/', StringComparison.Ordinal) || backupId.Contains('\\', StringComparison.Ordinal) || backupId.Contains("..", StringComparison.Ordinal))
             throw new ArgumentException("Invalid backup id.", nameof(backupId));
         if (backupId.StartsWith('.'))
             throw new ArgumentException("Invalid backup id.", nameof(backupId));

--- a/backend/Services/DatabaseBackupStore.cs
+++ b/backend/Services/DatabaseBackupStore.cs
@@ -187,8 +187,7 @@ public sealed class DatabaseBackupStore
 
     public int Prune(int retentionCount)
     {
-        if (retentionCount < 0)
-            throw new ArgumentOutOfRangeException(nameof(retentionCount));
+        ArgumentOutOfRangeException.ThrowIfNegative(retentionCount);
         if (retentionCount == 0)
             return 0;
 

--- a/backend/Services/DatabaseRestoreRunner.cs
+++ b/backend/Services/DatabaseRestoreRunner.cs
@@ -286,7 +286,7 @@ public static class DatabaseRestoreRunner
             await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (!reader.IsDBNull(0))
+                if (!await reader.IsDBNullAsync(0, cancellationToken).ConfigureAwait(false))
                     ids.Add(reader.GetString(0));
             }
         }

--- a/backend/Services/ExternalIdResolver.cs
+++ b/backend/Services/ExternalIdResolver.cs
@@ -128,7 +128,7 @@ public class ExternalIdResolver(AnimeListMappingResolver animeList)
                 else if (site.Equals("thetvdb", StringComparison.OrdinalIgnoreCase))
                 {
                     // ext is "<seriesId>" or "<seriesId>/<season>" — canonical season source
-                    var slashIdx = ext.IndexOf('/');
+                    var slashIdx = ext.IndexOf('/', StringComparison.Ordinal);
                     if (slashIdx > 0)
                     {
                         if (int.TryParse(ext[..slashIdx], out var id)) tvdbId ??= id;

--- a/backend/Services/HealthCheckRetentionService.cs
+++ b/backend/Services/HealthCheckRetentionService.cs
@@ -14,8 +14,6 @@ namespace NzbWebDAV.Services;
 /// </summary>
 public class HealthCheckRetentionService(ConfigManager configManager) : BackgroundService
 {
-    private static readonly TimeSpan DefaultInterval = TimeSpan.FromHours(6);
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await SafeSweepAsync(stoppingToken).ConfigureAwait(false);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -59,7 +59,7 @@ public class HealthCheckService : BackgroundService
     private const double MinDepthDays = 3650;
 
     private readonly ConfigManager _configManager;
-    private readonly INntpClient _usenetClient;
+    private readonly UsenetStreamingClient _usenetClient;
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
     private readonly StreamingFailureTracker _failureTracker;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -726,7 +726,7 @@ public class HealthCheckService : BackgroundService
             List<ArrRootFolder> rootFolders;
             try
             {
-                rootFolders = await arrClient.GetRootFolders().ConfigureAwait(false);
+                rootFolders = await arrClient.GetRootFolders(ct).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -900,7 +900,7 @@ public class HealthCheckService : BackgroundService
                 string deleteMessage;
                 if (symlinkOrStrmPath != null)
                 {
-                    var forceDeleteLinkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+                    var forceDeleteLinkType = symlinkOrStrmPath.ToLowerInvariant().EndsWith("strm") ? "strm-file" : "symlink";
                     deleteMessage = string.Join(" ", [
                         "File failed during streaming.",
                         $"Auto-removed after repeated streaming failures.{failureNote}",
@@ -943,7 +943,7 @@ public class HealthCheckService : BackgroundService
             }
 
             var linkedPath = symlinkOrStrmPath!;
-            var linkType = linkedPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+            var linkType = linkedPath.ToLowerInvariant().EndsWith("strm") ? "strm-file" : "symlink";
 
             // Rate-limit repairs per library file: when Arr keeps re-importing broken
             // replacements to the same location, deleting again only fuels the loop.
@@ -1054,7 +1054,7 @@ public class HealthCheckService : BackgroundService
             var noMatchConfirmations = _arrNoMatchConfirmations.AddOrUpdate(
                 davItem.Id,
                 1,
-                static (_, previous) => previous + 1);
+                (_, previous) => previous + 1);
             if (!ShouldDeleteAfterArrNoMatch(noMatchConfirmations))
             {
                 var noMatchUtcNow = DateTimeOffset.UtcNow;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -742,7 +742,7 @@ public class HealthCheckService : BackgroundService
             // A null/empty path is a malformed response we can't rule this instance in or out
             // with, so if nothing else matches, treat it like an unreachable instance rather
             // than falling through to a delete this instance may not have sanctioned.
-            if (!rootFolders.Any(x => !string.IsNullOrEmpty(x.Path) && symlinkOrStrmPath.StartsWith(x.Path)))
+            if (!rootFolders.Any(x => !string.IsNullOrEmpty(x.Path) && symlinkOrStrmPath.StartsWith(x.Path, StringComparison.Ordinal)))
             {
                 if (rootFolders.Any(x => string.IsNullOrEmpty(x.Path))) anInstanceFailed = true;
                 continue;
@@ -900,7 +900,7 @@ public class HealthCheckService : BackgroundService
                 string deleteMessage;
                 if (symlinkOrStrmPath != null)
                 {
-                    var forceDeleteLinkType = symlinkOrStrmPath.ToLowerInvariant().EndsWith("strm") ? "strm-file" : "symlink";
+                    var forceDeleteLinkType = symlinkOrStrmPath.ToLowerInvariant().EndsWith("strm", StringComparison.Ordinal) ? "strm-file" : "symlink";
                     deleteMessage = string.Join(" ", [
                         "File failed during streaming.",
                         $"Auto-removed after repeated streaming failures.{failureNote}",
@@ -943,7 +943,7 @@ public class HealthCheckService : BackgroundService
             }
 
             var linkedPath = symlinkOrStrmPath!;
-            var linkType = linkedPath.ToLowerInvariant().EndsWith("strm") ? "strm-file" : "symlink";
+            var linkType = linkedPath.ToLowerInvariant().EndsWith("strm", StringComparison.Ordinal) ? "strm-file" : "symlink";
 
             // Rate-limit repairs per library file: when Arr keeps re-importing broken
             // replacements to the same location, deleting again only fuels the loop.

--- a/backend/Services/HistoryCleanupService.cs
+++ b/backend/Services/HistoryCleanupService.cs
@@ -35,7 +35,7 @@ public class HistoryCleanupService : BackgroundService
                     var deletedItems = await dbContext.Items
                         .Where(x => x.HistoryItemId == cleanupItem.Id)
                         .Select(x => new DavItem { Id = x.Id, Type = x.Type, Path = x.Path })
-                        .ToListAsync(stoppingToken);
+                        .ToListAsync(stoppingToken).ConfigureAwait(false);
 
                     // Loud warning for large deletes; does not block (SAB semantics unchanged).
                     DeletionAuditLog.WarnBulkDelete(
@@ -54,7 +54,7 @@ public class HistoryCleanupService : BackgroundService
                     // Delete the corresponding dav-items
                     await dbContext.Items
                         .Where(x => x.HistoryItemId == cleanupItem.Id)
-                        .ExecuteDeleteAsync(stoppingToken);
+                        .ExecuteDeleteAsync(stoppingToken).ConfigureAwait(false);
 
                     // Trigger rclone vfs/forget for deleted items
                     _ = DavDatabaseContext.RcloneVfsForget(deletedItems);
@@ -67,7 +67,7 @@ public class HistoryCleanupService : BackgroundService
                         .ExecuteUpdateAsync(
                             x => x.SetProperty(p => p.HistoryItemId, (Guid?)null),
                             stoppingToken
-                        );
+                        ).ConfigureAwait(false);
                 }
 
                 // Remove the cleanup item from the database

--- a/backend/Services/IndexerHitTracker.cs
+++ b/backend/Services/IndexerHitTracker.cs
@@ -122,7 +122,9 @@ public class IndexerHitTracker
             });
             await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
 
+            #pragma warning disable CA5394 // probabilistic metric pruning is not security-sensitive
             if (Rng.NextDouble() < PruneProbability)
+#pragma warning restore CA5394
                 _ = Task.Run(() => PruneAsync(CancellationToken.None), CancellationToken.None);
         }
         catch (Exception e)

--- a/backend/Services/IndexerHitTracker.cs
+++ b/backend/Services/IndexerHitTracker.cs
@@ -122,7 +122,7 @@ public class IndexerHitTracker
             });
             await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
 
-            #pragma warning disable CA5394 // probabilistic metric pruning is not security-sensitive
+#pragma warning disable CA5394 // probabilistic metric pruning is not security-sensitive
             if (Rng.NextDouble() < PruneProbability)
 #pragma warning restore CA5394
                 _ = Task.Run(() => PruneAsync(CancellationToken.None), CancellationToken.None);

--- a/backend/Services/IndexerHitTracker.cs
+++ b/backend/Services/IndexerHitTracker.cs
@@ -92,7 +92,7 @@ public class IndexerHitTracker
         foreach (var i in indexers)
         {
             var (windowStart, nextResetAt) = ComputeWindow(now, i.ResetHourUtc);
-            var indexerHits = hits.Where(h => h.IndexerName == i.Name && h.AccessedAt >= windowStart);
+            var indexerHits = hits.Where(h => h.IndexerName == i.Name && h.AccessedAt >= windowStart).ToList();
             var apiCount = indexerHits.Count(h => h.Type == IndexerApiHit.HitType.Search);
             var downloadCount = indexerHits.Count(h => h.Type == IndexerApiHit.HitType.Download);
             result.Add(new UsageSnapshot(

--- a/backend/Services/IndexerHitTracker.cs
+++ b/backend/Services/IndexerHitTracker.cs
@@ -123,7 +123,7 @@ public class IndexerHitTracker
             await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
 
             if (Rng.NextDouble() < PruneProbability)
-                _ = Task.Run(() => PruneAsync(CancellationToken.None));
+                _ = Task.Run(() => PruneAsync(CancellationToken.None), CancellationToken.None);
         }
         catch (Exception e)
         {

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -38,11 +38,13 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         set;
     }
 
+#pragma warning disable CA1001 // Persistor entries live for the process lifetime in _persistors (never evicted); SemaphoreSlim holds no native resources unless WaitHandle is materialized, and only WaitAsync is used
     private sealed class Persistor
     {
         public readonly SemaphoreSlim Sem = new(1, 1);
         public long LatestStamp;
     }
+#pragma warning restore CA1001
 
     // Resolve enough trailing volumes to cover targetByteOffset and return
     // the updated Meta. All needed volumes run in parallel (capped by

--- a/backend/Services/Metrics/CircuitOutageSparkBuilder.cs
+++ b/backend/Services/Metrics/CircuitOutageSparkBuilder.cs
@@ -16,15 +16,14 @@ public static class CircuitOutageSparkBuilder
         int bucketCount,
         long nowMs)
     {
-        var result = providerKeys
-            .Distinct(StringComparer.Ordinal)
+        var distinctProviderKeys = providerKeys.Distinct(StringComparer.Ordinal).ToArray();
+        var result = distinctProviderKeys
             .ToDictionary(
                 key => key,
                 _ => new long[bucketCount],
                 StringComparer.Ordinal);
 
-        var tripBuckets = providerKeys
-            .Distinct(StringComparer.Ordinal)
+        var tripBuckets = distinctProviderKeys
             .ToDictionary(
                 key => key,
                 _ => new bool[bucketCount],

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -484,4 +484,11 @@ public class MetricsWriter : BackgroundService
         long LastSuccessfulFlushAtMs,
         string? LastFlushError
     );
+
+    public override void Dispose()
+    {
+        _flushGate.Dispose();
+        base.Dispose();
+    }
+
 }

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -488,6 +488,7 @@ public class MetricsWriter : BackgroundService
     public override void Dispose()
     {
         _flushGate.Dispose();
+        GC.SuppressFinalize(this);
         base.Dispose();
     }
 

--- a/backend/Services/NzbFetchCoalescer.cs
+++ b/backend/Services/NzbFetchCoalescer.cs
@@ -91,7 +91,7 @@ public class NzbFetchCoalescer
                 _currentBytes -= existing.Bytes.LongLength;
 
             while ((_cache.Count >= _maxCacheEntries || _currentBytes + bytes.LongLength > _maxCacheBytes)
-                   && _cache.Count > 0)
+                   && !_cache.IsEmpty)
             {
                 var oldest = default(KeyValuePair<FetchKey, Entry>);
                 var found = false;

--- a/backend/Services/NzbResolutionCacheRetentionService.cs
+++ b/backend/Services/NzbResolutionCacheRetentionService.cs
@@ -46,7 +46,9 @@ public class NzbResolutionCacheRetentionService(
                 await cache.PurgeExpiredAsync(configManager.GetPlayResolutionCacheTtl(), stoppingToken)
                     .ConfigureAwait(false);
             }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception ex) when (ex.IsCancellationException() &&
+            #pragma warning restore CA2016
                                       (stoppingToken.IsCancellationRequested ||
                                        SigtermUtil.IsSigtermTriggered()))
             {

--- a/backend/Services/NzbResolutionCacheRetentionService.cs
+++ b/backend/Services/NzbResolutionCacheRetentionService.cs
@@ -46,9 +46,9 @@ public class NzbResolutionCacheRetentionService(
                 await cache.PurgeExpiredAsync(configManager.GetPlayResolutionCacheTtl(), stoppingToken)
                     .ConfigureAwait(false);
             }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception ex) when (ex.IsCancellationException() &&
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
                                       (stoppingToken.IsCancellationRequested ||
                                        SigtermUtil.IsSigtermTriggered()))
             {

--- a/backend/Services/PlaybackFastVerifier.cs
+++ b/backend/Services/PlaybackFastVerifier.cs
@@ -100,7 +100,9 @@ public class PlaybackFastVerifier
             Log.Debug("Fast-verify timed out after {Timeout:n0}s on {Segment}", timeout.TotalSeconds, messageId);
             return Verdict.Timeout;
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Debug("Fast-verify errored on {Segment}: {Message}", messageId, e.Message);
             return Verdict.Timeout;

--- a/backend/Services/PlaybackFastVerifier.cs
+++ b/backend/Services/PlaybackFastVerifier.cs
@@ -73,12 +73,12 @@ public class PlaybackFastVerifier
         // The priority context lives on this candidate's own child token: registering it on
         // the parent token shared by concurrent candidates would let one candidate's disposal
         // strip priority from its siblings.
-        #pragma warning disable CA2000 // disposed by the work.ContinueWith continuation once the probe finishes (see the finally block below)
+#pragma warning disable CA2000 // disposed by the work.ContinueWith continuation once the probe finishes (see the finally block below)
         var timeoutCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(ct);
-        #pragma warning restore CA2000
-        #pragma warning disable CA2000 // disposed by the work.ContinueWith continuation once the probe finishes (see the finally block below)
+#pragma warning restore CA2000
+#pragma warning disable CA2000 // disposed by the work.ContinueWith continuation once the probe finishes (see the finally block below)
         var priorityScope = timeoutCts.Token.SetContext(new DownloadPriorityContext
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
         {
             Priority = priority,
         });
@@ -104,9 +104,9 @@ public class PlaybackFastVerifier
             Log.Debug("Fast-verify timed out after {Timeout:n0}s on {Segment}", timeout.TotalSeconds, messageId);
             return Verdict.Timeout;
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Debug("Fast-verify errored on {Segment}: {Message}", messageId, e.Message);
             return Verdict.Timeout;

--- a/backend/Services/PlaybackFastVerifier.cs
+++ b/backend/Services/PlaybackFastVerifier.cs
@@ -73,8 +73,12 @@ public class PlaybackFastVerifier
         // The priority context lives on this candidate's own child token: registering it on
         // the parent token shared by concurrent candidates would let one candidate's disposal
         // strip priority from its siblings.
+        #pragma warning disable CA2000 // disposed by the work.ContinueWith continuation once the probe finishes (see the finally block below)
         var timeoutCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(ct);
+        #pragma warning restore CA2000
+        #pragma warning disable CA2000 // disposed by the work.ContinueWith continuation once the probe finishes (see the finally block below)
         var priorityScope = timeoutCts.Token.SetContext(new DownloadPriorityContext
+        #pragma warning restore CA2000
         {
             Priority = priority,
         });

--- a/backend/Services/PreflightCache.cs
+++ b/backend/Services/PreflightCache.cs
@@ -72,7 +72,7 @@ public class PreflightCache
                 _currentBytes -= ByteLength(existing.NzbBytes);
 
             while ((_entries.Count >= _maxCacheEntries || _currentBytes + bytes > _maxCacheBytes)
-                   && _entries.Count > 0)
+                   && !_entries.IsEmpty)
             {
                 var oldest = default(KeyValuePair<string, Entry>);
                 var found = false;

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -33,9 +33,9 @@ public class PreflightOrchestrator(
         var mode = configManager.GetPreflightMode();
         if (mode == "off" || candidates.Count == 0) return;
 
-        #pragma warning disable CA2000 // session ownership transfers to the background task, which disposes it on completion
+#pragma warning disable CA2000 // session ownership transfers to the background task, which disposes it on completion
         var session = sessionRegistry.BeginSession(profileToken, type, id);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
 
         _ = Task.Run(async () =>
         {
@@ -174,9 +174,9 @@ public class PreflightOrchestrator(
                     return null;
                 }
             }
-            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
-            #pragma warning restore CA2016
+#pragma warning restore CA2016
             {
                 Log.Debug("Preflight NZB fetch failed for {Url}: {Message}", c.NzbUrl, e.Message);
                 return null;

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -172,7 +172,9 @@ public class PreflightOrchestrator(
                     return null;
                 }
             }
+            #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException())
+            #pragma warning restore CA2016
             {
                 Log.Debug("Preflight NZB fetch failed for {Url}: {Message}", c.NzbUrl, e.Message);
                 return null;

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -33,7 +33,9 @@ public class PreflightOrchestrator(
         var mode = configManager.GetPreflightMode();
         if (mode == "off" || candidates.Count == 0) return;
 
+        #pragma warning disable CA2000 // session ownership transfers to the background task, which disposes it on completion
         var session = sessionRegistry.BeginSession(profileToken, type, id);
+        #pragma warning restore CA2000
 
         _ = Task.Run(async () =>
         {

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -83,7 +83,7 @@ public class PreflightOrchestrator(
     private async Task<bool> PreflightCandidateAsync(
         string mode,
         NzbResolutionCache.Candidate candidate,
-        IReadOnlyDictionary<string, IndexerConfig.ConnectionDetails> indexers,
+        Dictionary<string, IndexerConfig.ConnectionDetails> indexers,
         TimeSpan maxWait,
         CancellationToken ct)
     {

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -129,6 +129,7 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
         // current reschedule source is safe to dispose. Swapped-out instances
         // are intentionally leaked (see the swap note in ExecuteAsync).
         _rescheduleCts.Dispose();
+        GC.SuppressFinalize(this);
         base.Dispose();
     }
 

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -122,4 +122,14 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
             }
         }
     }
+
+    public override void Dispose()
+    {
+        // ExecuteAsync has stopped when the host disposes the service, so the
+        // current reschedule source is safe to dispose. Swapped-out instances
+        // are intentionally leaked (see the swap note in ExecuteAsync).
+        _rescheduleCts.Dispose();
+        base.Dispose();
+    }
+
 }

--- a/backend/Services/SearchExcludeSyncService.cs
+++ b/backend/Services/SearchExcludeSyncService.cs
@@ -252,7 +252,7 @@ public sealed class SearchExcludeSyncService : BackgroundService
         {
             if (ms.Length + read > MaxDownloadBytes)
                 throw new InvalidOperationException("Synced list exceeds the size limit.");
-            ms.Write(buffer, 0, read);
+            await ms.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
         }
         return Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
     }

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -252,7 +252,7 @@ public class SearchProfileService(
         id.StartsWith("tmdb:", StringComparison.OrdinalIgnoreCase)
         || id.StartsWith("tmdb-", StringComparison.OrdinalIgnoreCase);
 
-    private static IReadOnlyDictionary<string, string>? BuildTvdbQuery(string type, string id)
+    private static Dictionary<string, string>? BuildTvdbQuery(string type, string id)
     {
         if (type != "series") return null;
 

--- a/backend/Services/SupportPack/LatencySupportPackProjection.cs
+++ b/backend/Services/SupportPack/LatencySupportPackProjection.cs
@@ -38,7 +38,7 @@ internal static class LatencySupportPackProjection
             return false;
         if (refId is null)
             return false;
-        var slash = refId.IndexOf('/');
+        var slash = refId.IndexOf('/', StringComparison.Ordinal);
         if (slash <= 0 || slash >= refId.Length - 1)
             return false;
         if (!LatencyNames.TryParseWorkload(refId[..slash], out var workload))

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -899,7 +899,7 @@ public sealed class SupportPackService(
         CancellationToken cancellationToken)
     {
         var entry = archive.CreateEntry(name, CompressionLevel.Fastest);
-        await using var stream = entry.Open();
+        await using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var writer = new StreamWriter(stream, Encoding.UTF8);
         foreach (var evt in events)
         {
@@ -1013,7 +1013,7 @@ public sealed class SupportPackService(
         CancellationToken cancellationToken)
     {
         var entry = archive.CreateEntry(name, CompressionLevel.Fastest);
-        await using var stream = entry.Open();
+        await using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         var bytes = Encoding.UTF8.GetBytes(content);
         await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
     }

--- a/backend/Services/UsenetFileToBlobstoreMigrationService.cs
+++ b/backend/Services/UsenetFileToBlobstoreMigrationService.cs
@@ -17,12 +17,12 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         Report("Determining number of files to migrate...");
-        var initialRemaining = await GetTotalCountLeft(stoppingToken);
+        var initialRemaining = await GetTotalCountLeft(stoppingToken).ConfigureAwait(false);
         var totalRemaining = initialRemaining;
         ReportProgress(totalRemaining, initialRemaining);
-        totalRemaining = await MigrateNzbFiles(totalRemaining, initialRemaining, stoppingToken);
-        totalRemaining = await MigrateRarFiles(totalRemaining, initialRemaining, stoppingToken);
-        totalRemaining = await MigrateMultipartFiles(totalRemaining, initialRemaining, stoppingToken);
+        totalRemaining = await MigrateNzbFiles(totalRemaining, initialRemaining, stoppingToken).ConfigureAwait(false);
+        totalRemaining = await MigrateRarFiles(totalRemaining, initialRemaining, stoppingToken).ConfigureAwait(false);
+        totalRemaining = await MigrateMultipartFiles(totalRemaining, initialRemaining, stoppingToken).ConfigureAwait(false);
         var complete = initialRemaining - totalRemaining;
         Report(complete == 0
             ? $"Done! Nothing to migrate."
@@ -32,9 +32,9 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
     private async Task<int> GetTotalCountLeft(CancellationToken ct)
     {
         await using var dbContext = new DavDatabaseContext();
-        return await dbContext.NzbFiles.CountAsync(ct) +
-               await dbContext.RarFiles.CountAsync(ct) +
-               await dbContext.MultipartFiles.CountAsync(ct);
+        return await dbContext.NzbFiles.CountAsync(ct).ConfigureAwait(false) +
+               await dbContext.RarFiles.CountAsync(ct).ConfigureAwait(false) +
+               await dbContext.MultipartFiles.CountAsync(ct).ConfigureAwait(false);
     }
 
     private Task<int> MigrateNzbFiles(int totalRemaining, int initialRemaining, CancellationToken ct)
@@ -91,18 +91,18 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
             try
             {
                 await using var dbContext = new DavDatabaseContext();
-                var fileToMigrate = await getFileToMigrate(dbContext);
+                var fileToMigrate = await getFileToMigrate(dbContext).ConfigureAwait(false);
                 if (fileToMigrate == null) return totalRemaining;
-                var davItem = await GetDavItem(getFileToMigrateId(fileToMigrate), dbContext, ct);
+                var davItem = await GetDavItem(getFileToMigrateId(fileToMigrate), dbContext, ct).ConfigureAwait(false);
                 dbContext.Entry(fileToMigrate).State = EntityState.Detached;
                 setFileToMigrateNewId(fileToMigrate);
-                await BlobStore.WriteBlob(getFileToMigrateId(fileToMigrate), fileToMigrate);
+                await BlobStore.WriteBlob(getFileToMigrateId(fileToMigrate), fileToMigrate).ConfigureAwait(false);
                 try
                 {
                     // database changes
                     davItem.FileBlobId = getFileToMigrateId(fileToMigrate);
                     removeFileToMigrateFromDb(dbContext, davItem.Id);
-                    await dbContext.SaveChangesAsync(ct);
+                    await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
                     totalRemaining--;
                     ReportProgress(totalRemaining, initialRemaining);
                 }
@@ -124,7 +124,7 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
 
     private static async Task<DavItem> GetDavItem(Guid id, DavDatabaseContext dbContext, CancellationToken ct)
     {
-        return (await dbContext.Items.Where(x => x.Id == id).FirstOrDefaultAsync(ct))
+        return (await dbContext.Items.Where(x => x.Id == id).FirstOrDefaultAsync(ct).ConfigureAwait(false))
                ?? throw new Exception($"DavItem with id `{id}` not found");
     }
 

--- a/backend/Services/UsenetFileToBlobstoreMigrationService.cs
+++ b/backend/Services/UsenetFileToBlobstoreMigrationService.cs
@@ -125,7 +125,7 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
     private static async Task<DavItem> GetDavItem(Guid id, DavDatabaseContext dbContext, CancellationToken ct)
     {
         return (await dbContext.Items.Where(x => x.Id == id).FirstOrDefaultAsync(ct).ConfigureAwait(false))
-               ?? throw new Exception($"DavItem with id `{id}` not found");
+               ?? throw new InvalidOperationException($"DavItem with id `{id}` not found");
     }
 
     private void Report(string message)

--- a/backend/Services/VariantResolver.cs
+++ b/backend/Services/VariantResolver.cs
@@ -122,9 +122,9 @@ public class VariantResolver(ConfigManager configManager)
                 _ = websocketManager.SendMessage(
                     WebsocketTopic.HistoryItemRemoved, string.Join(",", toRemove));
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Warning(e, "Variants: failed to evict surplus variants for group {Group}", contentGroupKey);
             return Array.Empty<Guid>();
@@ -145,9 +145,9 @@ public class VariantResolver(ConfigManager configManager)
             item.LastPlayedAt = now;
             await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
         }
-        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
-        #pragma warning restore CA2016
+#pragma warning restore CA2016
         {
             Log.Debug(e, "Variants: failed to update LastPlayedAt for {Id}", historyItemId);
         }

--- a/backend/Services/VariantResolver.cs
+++ b/backend/Services/VariantResolver.cs
@@ -122,7 +122,9 @@ public class VariantResolver(ConfigManager configManager)
                 _ = websocketManager.SendMessage(
                     WebsocketTopic.HistoryItemRemoved, string.Join(",", toRemove));
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Warning(e, "Variants: failed to evict surplus variants for group {Group}", contentGroupKey);
             return Array.Empty<Guid>();
@@ -143,7 +145,9 @@ public class VariantResolver(ConfigManager configManager)
             item.LastPlayedAt = now;
             await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
         }
+        #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
         catch (Exception e) when (!e.IsCancellationException())
+        #pragma warning restore CA2016
         {
             Log.Debug(e, "Variants: failed to update LastPlayedAt for {Id}", historyItemId);
         }

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -287,6 +287,7 @@ public partial class WardenBackupService : BackgroundService
     public override void Dispose()
     {
         _gate.Dispose();
+        GC.SuppressFinalize(this);
         base.Dispose();
     }
 

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -284,5 +284,11 @@ public partial class WardenBackupService : BackgroundService
         public bool StaleConflict { get; init; }
     }
 
+    public override void Dispose()
+    {
+        _gate.Dispose();
+        base.Dispose();
+    }
+
     private sealed class GithubException(string message) : Exception(message);
 }

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -259,7 +259,7 @@ public partial class WardenBackupService : BackgroundService
         {
             if (ms.Length + read > MaxRestoreBytes)
                 throw new InvalidOperationException("Backup file exceeds the size limit.");
-            ms.Write(buf, 0, read);
+            await ms.WriteAsync(buf.AsMemory(0, read), ct).ConfigureAwait(false);
         }
         ms.Position = 0;
         return ms;

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -154,7 +154,7 @@ public partial class WardenBackupService : BackgroundService
 
             await using var raw = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             using var buffer = await BufferAsync(raw, ct).ConfigureAwait(false);
-            Stream body = LooksGzip(buffer) ? new GZipStream(buffer, CompressionMode.Decompress) : buffer;
+            using Stream body = LooksGzip(buffer) ? new GZipStream(buffer, CompressionMode.Decompress) : buffer;
             using var limitedBody = new LimitedReadStream(body, WardenInputLimits.MaxDecompressedBytes);
             var count = await _store.ReplaceSourceAsync(WardenStore.LocalSourceId, limitedBody, ct).ConfigureAwait(false);
             Log.Information("Warden backup: restored {Count} fingerprints from {Repo}", count, s.Repo);

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -18,7 +18,7 @@ public partial class WardenBackupService : BackgroundService
     private const long MaxRestoreBytes = 256L * 1024 * 1024;
     private const long MaxPushBytes = 95L * 1024 * 1024;
 
-    private static readonly HttpClient Http = new(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None })
+    private static readonly HttpClient Http = new(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None, CheckCertificateRevocationList = true })
     {
         Timeout = TimeSpan.FromSeconds(100),
     };

--- a/backend/Services/WardenRemoteSourceService.cs
+++ b/backend/Services/WardenRemoteSourceService.cs
@@ -76,8 +76,7 @@ public class WardenRemoteSourceService : BackgroundService
             await using var raw = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             using var buffer = await BufferAsync(raw, ct).ConfigureAwait(false);
 
-            Stream body = buffer;
-            if (LooksGzip(buffer)) body = new GZipStream(buffer, CompressionMode.Decompress);
+            using Stream body = LooksGzip(buffer) ? new GZipStream(buffer, CompressionMode.Decompress) : buffer;
 
             using var limitedBody = new LimitedReadStream(body, WardenInputLimits.MaxDecompressedBytes);
             var count = await _store.ReplaceSourceAsync(source.Id, limitedBody, ct).ConfigureAwait(false);

--- a/backend/Services/WardenRemoteSourceService.cs
+++ b/backend/Services/WardenRemoteSourceService.cs
@@ -102,7 +102,7 @@ public class WardenRemoteSourceService : BackgroundService
         {
             if (ms.Length + read > MaxDownloadBytes)
                 throw new InvalidOperationException("Download exceeds the size limit.");
-            ms.Write(buf, 0, read);
+            await ms.WriteAsync(buf.AsMemory(0, read), ct).ConfigureAwait(false);
         }
         ms.Position = 0;
         return ms;

--- a/backend/Services/WardenRemoteSourceService.cs
+++ b/backend/Services/WardenRemoteSourceService.cs
@@ -9,7 +9,7 @@ public class WardenRemoteSourceService : BackgroundService
 {
     private const long MaxDownloadBytes = 256L * 1024 * 1024;
 
-    private static readonly HttpClient Http = new(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None })
+    private static readonly HttpClient Http = new(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None, CheckCertificateRevocationList = true })
     {
         Timeout = TimeSpan.FromSeconds(90),
     };

--- a/backend/Services/WardenStore.cs
+++ b/backend/Services/WardenStore.cs
@@ -351,7 +351,7 @@ public partial class WardenStore
         var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         using var reader = new StreamReader(input);
         using var conn = Open();
-        var tx = conn.BeginTransaction();
+        var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct).ConfigureAwait(false);
 
         if (replace)
         {
@@ -359,7 +359,7 @@ public partial class WardenStore
             del.Transaction = tx;
             del.CommandText = "DELETE FROM warden_entries WHERE source_id = $sid";
             del.Parameters.AddWithValue("$sid", sourceId);
-            del.ExecuteNonQuery();
+            await del.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
         using var sel = conn.CreateCommand();
@@ -413,13 +413,13 @@ public partial class WardenStore
             }
 
             pSfp.Value = rec.Fp;
-            var existing = sel.ExecuteScalar() is string s ? s : "";
+            var existing = await sel.ExecuteScalarAsync(ct).ConfigureAwait(false) is string s ? s : "";
 
             pFp.Value = rec.Fp;
             pT.Value = Math.Clamp(rec.DeadAt, 0, now + 86400);
             pN.Value = rec.Count <= 0 ? 1 : Math.Min(rec.Count, 1000000000);
             pBk.Value = MergeBackbones(existing, rec.Backbones ?? Array.Empty<string>());
-            cmd.ExecuteNonQuery();
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
             processed++;
 
             // Replacements must remain invisible until the complete source has
@@ -428,7 +428,7 @@ public partial class WardenStore
             {
                 await tx.CommitAsync(ct).ConfigureAwait(false);
                 await tx.DisposeAsync().ConfigureAwait(false);
-                tx = conn.BeginTransaction();
+                tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct).ConfigureAwait(false);
                 sel.Transaction = tx;
                 cmd.Transaction = tx;
                 inBatch = 0;
@@ -464,8 +464,8 @@ public partial class WardenStore
             : $"SELECT fp, dead_at, n, backbones FROM warden_entries WHERE source_id IN ({placeholders})";
         for (var i = 0; i < ids.Length; i++) cmd.Parameters.AddWithValue("$s" + i, ids[i]);
 
-        using var reader = cmd.ExecuteReader();
-        while (reader.Read())
+        using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
             ct.ThrowIfCancellationRequested();
             var rec = new WardenRecord

--- a/backend/Services/Watchtower/EpisodeEnumerator.cs
+++ b/backend/Services/Watchtower/EpisodeEnumerator.cs
@@ -159,7 +159,7 @@ public class EpisodeEnumerator
     {
         if (string.IsNullOrWhiteSpace(raw)) return null;
         var s = raw.Trim();
-        var colon = s.IndexOf(':');
+        var colon = s.IndexOf(':', StringComparison.Ordinal);
         if (colon > 0) s = s[..colon];
         if (s.StartsWith("tt", StringComparison.OrdinalIgnoreCase)) s = s[2..];
         return s.Length > 0 && s.All(char.IsDigit) ? "tt" + s : null;

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -238,7 +238,7 @@ public class ListSourceEnumerator
             throw new InvalidOperationException("List request failed or returned an empty response.");
 
         var trimmed = body.TrimStart();
-        if (trimmed.StartsWith("[", StringComparison.Ordinal) || trimmed.StartsWith("{", StringComparison.Ordinal))
+        if (trimmed.StartsWith('[') || trimmed.StartsWith('{'))
         {
             var fromJson = TryParseJsonList(trimmed);
             if (fromJson.Count > 0) return fromJson;
@@ -247,7 +247,7 @@ public class ListSourceEnumerator
         var refs = new List<WtContentRef>();
         foreach (var line in body.Split('\n')
                      .Select(raw => raw.Trim())
-                     .Where(line => line.Length > 0 && !line.StartsWith("#", StringComparison.Ordinal)))
+                     .Where(line => line.Length > 0 && !line.StartsWith('#')))
         {
             var (type, id) = SplitTypeId(line);
             if (id.Length == 0) continue;

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -160,7 +160,7 @@ public class ListSourceEnumerator
 
         const string ext = ".json";
         if (!url.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
-            return url.Contains('?') ? $"{url}&skip={skip}" : $"{url}?skip={skip}";
+            return url.Contains('?', StringComparison.Ordinal) ? $"{url}&skip={skip}" : $"{url}?skip={skip}";
 
         var stem = url[..^ext.Length];
         const string marker = "/catalog/";
@@ -170,7 +170,7 @@ public class ListSourceEnumerator
         var head = stem[..(markerIdx + marker.Length)];
         var segments = stem[(markerIdx + marker.Length)..].Split('/');
 
-        if (segments.Length >= 3 && segments[^1].Contains('='))
+        if (segments.Length >= 3 && segments[^1].Contains('=', StringComparison.Ordinal))
         {
             var merged = segments[^1].Split('&')
                 .Where(p => !p.StartsWith("skip=", StringComparison.OrdinalIgnoreCase))
@@ -238,7 +238,7 @@ public class ListSourceEnumerator
             throw new InvalidOperationException("List request failed or returned an empty response.");
 
         var trimmed = body.TrimStart();
-        if (trimmed.StartsWith("[") || trimmed.StartsWith("{"))
+        if (trimmed.StartsWith("[", StringComparison.Ordinal) || trimmed.StartsWith("{", StringComparison.Ordinal))
         {
             var fromJson = TryParseJsonList(trimmed);
             if (fromJson.Count > 0) return fromJson;
@@ -247,7 +247,7 @@ public class ListSourceEnumerator
         var refs = new List<WtContentRef>();
         foreach (var line in body.Split('\n')
                      .Select(raw => raw.Trim())
-                     .Where(line => line.Length > 0 && !line.StartsWith("#")))
+                     .Where(line => line.Length > 0 && !line.StartsWith("#", StringComparison.Ordinal)))
         {
             var (type, id) = SplitTypeId(line);
             if (id.Length == 0) continue;
@@ -295,10 +295,10 @@ public class ListSourceEnumerator
 
     private static (string Type, string Id) SplitTypeId(string line)
     {
-        if (line.StartsWith("tt", StringComparison.OrdinalIgnoreCase) && !line.Contains(':'))
+        if (line.StartsWith("tt", StringComparison.OrdinalIgnoreCase) && !line.Contains(':', StringComparison.Ordinal))
             return ("movie", line);
 
-        var firstColon = line.IndexOf(':');
+        var firstColon = line.IndexOf(':', StringComparison.Ordinal);
         if (firstColon > 0)
         {
             var maybeType = line[..firstColon].ToLowerInvariant();

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -95,7 +95,9 @@ public class WatchtowerService(
                         {
                             Log.Warning("Watchtower: cycle exceeded {Budget:n0}s watchdog; abandoning and restarting",
                                 CycleWatchdog.TotalSeconds);
-                            lock (_ctsLock) cycleCts.Cancel();
+                            #pragma warning disable CA1849 // synchronous Cancel is required here -- CancelAsync cannot be awaited while holding _ctsLock, and the cancel must be ordered before the abandoned-cycle continuation
+lock (_ctsLock) cycleCts.Cancel();
+#pragma warning restore CA1849
                             _ = cycle.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
                                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                                 TaskScheduler.Default);

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -703,7 +703,7 @@ public class WatchtowerService(
     private static bool IsImdbId(string contentId)
     {
         var s = contentId;
-        var colon = s.IndexOf(':');
+        var colon = s.IndexOf(':', StringComparison.Ordinal);
         if (colon > 0) s = s[..colon];
         if (s.StartsWith("tt", StringComparison.OrdinalIgnoreCase)) s = s[2..];
         return s.Length > 0 && s.All(char.IsDigit);
@@ -712,7 +712,7 @@ public class WatchtowerService(
     private static string CanonicalImdb(string contentId)
     {
         var s = contentId;
-        var colon = s.IndexOf(':');
+        var colon = s.IndexOf(':', StringComparison.Ordinal);
         if (colon > 0) s = s[..colon];
         return s.StartsWith("tt", StringComparison.OrdinalIgnoreCase) ? s : "tt" + s;
     }

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -1268,6 +1268,7 @@ lock (_ctsLock) cycleCts.Cancel();
             _disabledCts = null;
         }
         _indexerGate.Dispose();
+        GC.SuppressFinalize(this);
         base.Dispose();
     }
 

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -95,8 +95,8 @@ public class WatchtowerService(
                         {
                             Log.Warning("Watchtower: cycle exceeded {Budget:n0}s watchdog; abandoning and restarting",
                                 CycleWatchdog.TotalSeconds);
-                            #pragma warning disable CA1849 // synchronous Cancel is required here -- CancelAsync cannot be awaited while holding _ctsLock, and the cancel must be ordered before the abandoned-cycle continuation
-lock (_ctsLock) cycleCts.Cancel();
+#pragma warning disable CA1849 // synchronous Cancel is required here -- CancelAsync cannot be awaited while holding _ctsLock, and the cancel must be ordered before the abandoned-cycle continuation
+                            lock (_ctsLock) cycleCts.Cancel();
 #pragma warning restore CA1849
                             _ = cycle.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
                                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -420,7 +420,7 @@ public class WatchtowerService(
     }
 
     private static List<string> EffectiveScopes(
-        WantedItem expander, IReadOnlyDictionary<string, string> scopeBySource, string globalScope)
+        WantedItem expander, Dictionary<string, string> scopeBySource, string globalScope)
     {
         var scopes = new List<string>();
         foreach (var srcId in WtJson.ReadStrings(expander.Provenance))
@@ -590,7 +590,7 @@ public class WatchtowerService(
 
     private Dictionary<string, DesiredRow> BuildDesiredRows(
         IReadOnlyList<EpisodeEnumerator.Episode> episodes, string? seriesTitle, string imdb, string scope, long now,
-        IReadOnlySet<int> parkedFallbackSeasons)
+        HashSet<int> parkedFallbackSeasons)
     {
         var desired = new Dictionary<string, DesiredRow>();
         var aired = episodes.Where(e => e.AirDateUnix is null || e.AirDateUnix <= now).ToList();

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -1259,4 +1259,16 @@ lock (_ctsLock) cycleCts.Cancel();
         TimeSpan.FromSeconds(configManager.GetWatchtowerVerifyTimeoutSeconds());
 
     private static long Now() => DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+    public override void Dispose()
+    {
+        lock (_ctsLock)
+        {
+            _disabledCts?.Dispose();
+            _disabledCts = null;
+        }
+        _indexerGate.Dispose();
+        base.Dispose();
+    }
+
 }

--- a/backend/Streams/AesDecoderStream.cs
+++ b/backend/Streams/AesDecoderStream.cs
@@ -18,7 +18,7 @@ namespace NzbWebDAV.Streams
         private long _mWritten; // number of decoded bytes returned already
         private readonly long _mLimit;
         private bool _isDisposed;
-        private long? _pendingSeekPosition = null;
+        private long? _pendingSeekPosition;
 
         // store for reinitializing on Seek
         private readonly byte[] _mKey;

--- a/backend/Streams/AesDecoderStream.cs
+++ b/backend/Streams/AesDecoderStream.cs
@@ -33,8 +33,8 @@ namespace NzbWebDAV.Streams
         {
             _mStream = input ?? throw new ArgumentNullException(nameof(input));
             _mLimit = aesParams.DecodedSize;
-            _mKey = aesParams.Key ?? throw new ArgumentNullException(nameof(aesParams.Key));
-            _mBaseIv = aesParams.Iv ?? throw new ArgumentNullException(nameof(aesParams.Iv));
+            _mKey = aesParams.Key ?? throw new ArgumentNullException(nameof(aesParams), "Key is required.");
+            _mBaseIv = aesParams.Iv ?? throw new ArgumentNullException(nameof(aesParams), "Iv is required.");
 
             if (((uint)input.Length & (BlockSize - 1)) != 0)
             {
@@ -268,7 +268,7 @@ namespace NzbWebDAV.Streams
                 int read = 0;
                 while (read < BlockSize)
                 {
-                    int r = await _mStream.ReadAsync(iv, read, BlockSize - read, ct).ConfigureAwait(false);
+                    int r = await _mStream.ReadAsync(iv.AsMemory(read, BlockSize - read), ct).ConfigureAwait(false);
                     if (r == 0) throw new EndOfStreamException("Unable to read previous block for IV during seek.");
                     read += r;
                 }
@@ -297,7 +297,7 @@ namespace NzbWebDAV.Streams
                 int read = 0;
                 while (read < BlockSize)
                 {
-                    int r = await _mStream.ReadAsync(block, read, BlockSize - read, ct).ConfigureAwait(false);
+                    int r = await _mStream.ReadAsync(block.AsMemory(read, BlockSize - read), ct).ConfigureAwait(false);
                     if (r == 0) throw new EndOfStreamException("Unable to read target block during seek.");
                     read += r;
                 }

--- a/backend/Streams/BudgetedStream.cs
+++ b/backend/Streams/BudgetedStream.cs
@@ -64,6 +64,7 @@ public sealed class BudgetedStream : Stream
         await _inner.DisposeAsync().ConfigureAwait(false);
         ReleaseLease();
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     private void ReleaseLease()

--- a/backend/Streams/BudgetedStream.cs
+++ b/backend/Streams/BudgetedStream.cs
@@ -7,7 +7,9 @@ namespace NzbWebDAV.Streams;
 public sealed class BudgetedStream : Stream
 {
     private readonly Stream _inner;
+#pragma warning disable CA2213 // the lease is disposed race-safely via ReleaseLease()'s Interlocked.Exchange + Dispose; the analyzer cannot follow the exchange-and-dispose-local pattern
     private ArticleByteLease? _lease;
+#pragma warning restore CA2213
 
     public BudgetedStream(Stream inner, ArticleByteLease lease)
     {

--- a/backend/Streams/CancellableStream.cs
+++ b/backend/Streams/CancellableStream.cs
@@ -88,10 +88,7 @@ public class CancellableStream(Stream innerStream, CancellationToken token) : Fa
 
     private void CheckDisposed()
     {
-        if (_disposed)
-        {
-            throw new ObjectDisposedException(nameof(CancellableStream));
-        }
+        ObjectDisposedException.ThrowIf(_disposed, typeof(CancellableStream));
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/CombinedStream.cs
+++ b/backend/Streams/CombinedStream.cs
@@ -54,11 +54,13 @@ public class CombinedStream(IEnumerable<Task<Stream>> streams) : FastReadOnlyNon
 
     protected override void Dispose(bool disposing)
     {
-        if (_isDisposed) return;
-        if (!disposing) return;
-        _streams.Dispose();
-        _currentStream?.Dispose();
-        _isDisposed = true;
+        if (!_isDisposed && disposing)
+        {
+            _streams.Dispose();
+            _currentStream?.Dispose();
+            _isDisposed = true;
+        }
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -68,5 +70,6 @@ public class CombinedStream(IEnumerable<Task<Stream>> streams) : FastReadOnlyNon
         _streams.Dispose();
         _isDisposed = true;
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/ContainerAwareFillStream.cs
+++ b/backend/Streams/ContainerAwareFillStream.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 namespace NzbWebDAV.Streams;
 
 /// <summary>
@@ -95,7 +96,7 @@ internal sealed class ContainerAwareFillStream : Stream
                 FillTransportStream(destination, packetSize: 192, transportHeaderOffset: 4);
                 break;
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new UnreachableException($"Unsupported fill format: {_format}");
         }
 
         _position += toRead;

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -238,7 +238,7 @@ public class DavMultipartFileStream : FastReadOnlyStream
             {
                 var part = fileParts[i];
                 var extraOffset = (i == firstFilePartIndex) ? firstOffset : 0;
-                yield return Task.FromResult(OpenPart(part, extraOffset, i));
+                yield return Task.FromResult<System.IO.Stream>(OpenPart(part, extraOffset, i));
                 i++;
                 continue;
             }
@@ -254,7 +254,7 @@ public class DavMultipartFileStream : FastReadOnlyStream
         }
     }
 
-    private Stream OpenPart(DavMultipartFile.FilePart part, long extraOffset, int partIndex)
+    private PaddedLengthStream OpenPart(DavMultipartFile.FilePart part, long extraOffset, int partIndex)
     {
         if (part.SegmentIdByteRange.StartInclusive != 0 ||
             part.SegmentIdByteRange.Count < 0 ||

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -335,7 +335,7 @@ public class DavMultipartFileStream : FastReadOnlyStream
             {
                 _pendingInnerDispose = null;
                 pending.ContinueWith(
-                    static t => { _ = t.Exception; },
+                    t => { _ = t.Exception; },
                     TaskContinuationOptions.OnlyOnFaulted);
             }
         }

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -336,7 +336,9 @@ public class DavMultipartFileStream : FastReadOnlyStream
                 _pendingInnerDispose = null;
                 pending.ContinueWith(
                     t => { _ = t.Exception; },
-                    TaskContinuationOptions.OnlyOnFaulted);
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.Default);
             }
         }
         _disposed = true;

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -340,6 +340,7 @@ public class DavMultipartFileStream : FastReadOnlyStream
             }
         }
         _disposed = true;
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -357,5 +358,6 @@ public class DavMultipartFileStream : FastReadOnlyStream
         }
         if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/DisposableCallbackStream.cs
+++ b/backend/Streams/DisposableCallbackStream.cs
@@ -47,6 +47,7 @@ public class DisposableCallbackStream : Stream
             _onDispose?.Invoke();
 
         _disposed = true;
+        GC.SuppressFinalize(this);
         await base.DisposeAsync().ConfigureAwait(false);
     }
 

--- a/backend/Streams/LimitedLengthStream.cs
+++ b/backend/Streams/LimitedLengthStream.cs
@@ -41,6 +41,7 @@ public class LimitedLengthStream(Stream stream, long length) : FastReadOnlyNonSe
         if (_disposed) return;
         stream.Dispose();
         _disposed = true;
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -49,5 +50,6 @@ public class LimitedLengthStream(Stream stream, long length) : FastReadOnlyNonSe
         await stream.DisposeAsync().ConfigureAwait(false);
         _disposed = true;
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -407,9 +407,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     .ConfigureAwait(false);
 
                 await ThrowOnSegmentIdMismatchAsync(segmentId, bodyResponse).ConfigureAwait(false);
-                #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
+#pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                 var stream = await DrainSegmentAsync(
-                #pragma warning restore CA2000
+#pragma warning restore CA2000
                         bodyResponse.Stream!, segmentIndex, cancellationToken, lease, estimate)
                     .ConfigureAwait(false);
                 lease = null;
@@ -522,9 +522,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             var response = await responseTask.ConfigureAwait(false);
             await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
-            #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
+#pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
             var stream = await DrainSegmentAsync(
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
                     response.Stream!, segmentIndex, cancellationToken, lease, estimate)
                 .ConfigureAwait(false);
             lease = null; // owned by BudgetedStream / buffer
@@ -638,9 +638,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
                         .ConfigureAwait(false);
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
-                    #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
+#pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
-                    #pragma warning restore CA2000
+#pragma warning restore CA2000
                         response.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
                     lease = null;
                     return stream;
@@ -696,9 +696,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
                         .ConfigureAwait(false);
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
-                    #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
+#pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
-                    #pragma warning restore CA2000
+#pragma warning restore CA2000
                         response.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
                     lease = null;
                     return stream;
@@ -749,9 +749,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     Log.Debug(
                         "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
                         segmentIndex, fallbackId, _fileName);
-                    #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
+#pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
-                    #pragma warning restore CA2000
+#pragma warning restore CA2000
                         bodyResponse.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
                     lease = null;
                     return stream;
@@ -827,7 +827,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 fill, _fileName, segmentId);
         }
 
-        #pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
+#pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
         return SegmentDownloadResult.ZeroFill(
             CreateGapFillStream(fill, segmentIndex),
             messageTemplate,
@@ -835,7 +835,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             fill,
             exception,
             GetPlannedSegmentBytes(segmentIndex));
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
     }
 
     private Stream CreateGapFillStream(long fill, int segmentIndex)
@@ -1200,9 +1200,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         try
         {
-            #pragma warning disable CA1849 // synchronous Cancel is required -- teardown callbacks must run before _streamTasks.Writer completes; CancelAsync would race TryComplete
+#pragma warning disable CA1849 // synchronous Cancel is required -- teardown callbacks must run before _streamTasks.Writer completes; CancelAsync would race TryComplete
             _cts.Cancel();
-            #pragma warning restore CA1849
+#pragma warning restore CA1849
         }
         catch (ObjectDisposedException)
         {

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -130,14 +130,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 estimatedSegmentSize,
                 failFastOnFirstSegment,
                 usePipelinedBodyRequests,
-                cancellationToken,
                 fileName,
                 readBudget,
                 segmentFallbacks,
                 exactSegmentSizes,
                 inFlightArticleBudget,
                 useContainerAwareFill,
-                firstSegmentFileOffset);
+                firstSegmentFileOffset,
+                cancellationToken);
     }
 
     private MultiSegmentStream
@@ -148,14 +148,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         long estimatedSegmentSize,
         bool failFastOnFirstSegment,
         bool usePipelinedBodyRequests,
-        CancellationToken cancellationToken,
         string? fileName,
         long? readBudget,
         string[][]? segmentFallbacks,
         ReadOnlyMemory<long> exactSegmentSizes,
         InFlightArticleBudget? inFlightArticleBudget,
         bool useContainerAwareFill,
-        long? firstSegmentFileOffset
+        long? firstSegmentFileOffset,
+        CancellationToken cancellationToken
     )
     {
         _segmentIds = segmentIds;

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -407,7 +407,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     .ConfigureAwait(false);
 
                 await ThrowOnSegmentIdMismatchAsync(segmentId, bodyResponse).ConfigureAwait(false);
+                #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                 var stream = await DrainSegmentAsync(
+                #pragma warning restore CA2000
                         bodyResponse.Stream!, segmentIndex, cancellationToken, lease, estimate)
                     .ConfigureAwait(false);
                 lease = null;
@@ -520,7 +522,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             var response = await responseTask.ConfigureAwait(false);
             await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
+            #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
             var stream = await DrainSegmentAsync(
+            #pragma warning restore CA2000
                     response.Stream!, segmentIndex, cancellationToken, lease, estimate)
                 .ConfigureAwait(false);
             lease = null; // owned by BudgetedStream / buffer
@@ -634,7 +638,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
                         .ConfigureAwait(false);
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
+                    #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
+                    #pragma warning restore CA2000
                         response.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
                     lease = null;
                     return stream;
@@ -690,7 +696,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
                         .ConfigureAwait(false);
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
+                    #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
+                    #pragma warning restore CA2000
                         response.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
                     lease = null;
                     return stream;
@@ -741,7 +749,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     Log.Debug(
                         "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
                         segmentIndex, fallbackId, _fileName);
+                    #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
+                    #pragma warning restore CA2000
                         bodyResponse.Stream!, segmentIndex, cancellationToken, lease).ConfigureAwait(false);
                     lease = null;
                     return stream;
@@ -817,7 +827,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 fill, _fileName, segmentId);
         }
 
+        #pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
         return SegmentDownloadResult.ZeroFill(
+        #pragma warning restore CA2000
             CreateGapFillStream(fill, segmentIndex),
             messageTemplate,
             segmentId,

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -229,7 +229,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 segmentIds[index] = _segmentIds.Span[batchStart + index];
             }
 
-            await _streamTasks.Writer.WaitToWriteAsync(cancellationToken);
+            await _streamTasks.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
             var leases = new ArticleByteLease?[batchCount];
             Task<SegmentDownloadResult>[]? streamTasks = null;
             try
@@ -279,7 +279,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 {
                     var planned = GetPlannedSegmentBytes(batchStart + responseIndex);
                     await _streamTasks.Writer.WriteAsync(
-                        streamTasks[responseIndex], cancellationToken);
+                        streamTasks[responseIndex], cancellationToken).ConfigureAwait(false);
                     segmentsEnqueued++;
                     enqueuedBytes += planned;
                     Interlocked.Add(ref _inFlightPrefetchBytes, planned);
@@ -310,7 +310,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             await WaitForPrefetchCeilingAsync(cancellationToken).ConfigureAwait(false);
 
             var segmentId = _segmentIds.Span[index];
-            await _streamTasks.Writer.WaitToWriteAsync(cancellationToken);
+            await _streamTasks.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
             var lease = await LeaseSegmentBytesAsync(
                 GetPlannedSegmentBytes(index), cancellationToken).ConfigureAwait(false);
             var streamTask = DownloadSegment(
@@ -318,7 +318,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             var planned = GetPlannedSegmentBytes(index);
             try
             {
-                await _streamTasks.Writer.WriteAsync(streamTask, cancellationToken);
+                await _streamTasks.Writer.WriteAsync(streamTask, cancellationToken).ConfigureAwait(false);
                 enqueuedBytes += planned;
                 Interlocked.Add(ref _inFlightPrefetchBytes, planned);
             }
@@ -1072,7 +1072,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 var wasQueued = _streamTasks.Reader.TryRead(out var streamTask);
                 if (!wasQueued)
                 {
-                    if (!await _streamTasks.Reader.WaitToReadAsync(cancellationToken)) return 0;
+                    if (!await _streamTasks.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false)) return 0;
                     if (!_streamTasks.Reader.TryRead(out streamTask)) return 0;
                 }
 
@@ -1097,11 +1097,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
 
             // read from the stream
-            var read = await _stream.ReadAsync(buffer, cancellationToken);
+            var read = await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             if (read > 0) return read;
 
             // if the stream ended, continue to the next stream.
-            await _stream.DisposeAsync();
+            await _stream.DisposeAsync().ConfigureAwait(false);
             _stream = null;
         }
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -829,13 +829,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
         #pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
         return SegmentDownloadResult.ZeroFill(
-        #pragma warning restore CA2000
             CreateGapFillStream(fill, segmentIndex),
             messageTemplate,
             segmentId,
             fill,
             exception,
             GetPlannedSegmentBytes(segmentIndex));
+        #pragma warning restore CA2000
     }
 
     private Stream CreateGapFillStream(long fill, int segmentIndex)
@@ -1198,7 +1198,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         try
         {
+            #pragma warning disable CA1849 // synchronous Cancel is required -- teardown callbacks must run before _streamTasks.Writer completes; CancelAsync would race TryComplete
             _cts.Cancel();
+            #pragma warning restore CA1849
         }
         catch (ObjectDisposedException)
         {

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1176,11 +1176,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         base.Dispose(disposing);
     }
 
+#pragma warning disable CA2215 // base.DisposeAsync() would route through Close()/Dispose(true) back into EnsureDisposeAsync's sync-over-async teardown; the _disposeGate/_disposeTask pair already guarantees exactly-once cleanup (see Dispose(bool) recursion note)
     public override async ValueTask DisposeAsync()
     {
         await EnsureDisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }
+#pragma warning restore CA2215
 
     private Task EnsureDisposeAsync()
     {

--- a/backend/Streams/MultipartFileStream.cs
+++ b/backend/Streams/MultipartFileStream.cs
@@ -76,10 +76,12 @@ public class MultipartFileStream(MultipartFile multipartFile, INntpClient usenet
 
     protected override void Dispose(bool disposing)
     {
-        if (_isDisposed) return;
-        if (!disposing) return;
-        _currentStream?.Dispose();
-        _isDisposed = true;
+        if (!_isDisposed && disposing)
+        {
+            _currentStream?.Dispose();
+            _isDisposed = true;
+        }
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -88,5 +90,6 @@ public class MultipartFileStream(MultipartFile multipartFile, INntpClient usenet
         if (_currentStream != null) await _currentStream.DisposeAsync().ConfigureAwait(false);
         _isDisposed = true;
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -339,7 +339,9 @@ public class NzbFileStream(
                     await body.DiscardExactBytesAsync(rangeStart - start, ct).ConfigureAwait(false);
                     var tail = end - rangeStart;
                     var capacity = tail is > 0 and <= int.MaxValue ? (int)tail : 0;
+                    #pragma warning disable CA2000 // head is disposed in the outer finally on all non-transferred paths; on success ownership moves to the returned CombinedStream
                     head = new PooledBufferStream(capacity);
+                    #pragma warning restore CA2000
                     await body.CopyToAsync(head, ct).ConfigureAwait(false);
                     head.Position = 0;
                     // Do not relinquish the pooled head until body disposal succeeds.

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -339,9 +339,9 @@ public class NzbFileStream(
                     await body.DiscardExactBytesAsync(rangeStart - start, ct).ConfigureAwait(false);
                     var tail = end - rangeStart;
                     var capacity = tail is > 0 and <= int.MaxValue ? (int)tail : 0;
-                    #pragma warning disable CA2000 // head is disposed in the outer finally on all non-transferred paths; on success ownership moves to the returned CombinedStream
+#pragma warning disable CA2000 // head is disposed in the outer finally on all non-transferred paths; on success ownership moves to the returned CombinedStream
                     head = new PooledBufferStream(capacity);
-                    #pragma warning restore CA2000
+#pragma warning restore CA2000
                     await body.CopyToAsync(head, ct).ConfigureAwait(false);
                     head.Position = 0;
                     // Do not relinquish the pooled head until body disposal succeeds.

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -479,5 +479,6 @@ public class NzbFileStream(
         }
         if (_innerStream != null) await _innerStream.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -455,7 +455,9 @@ public class NzbFileStream(
                     _pendingInnerDispose = null;
                     pending.ContinueWith(
                         static t => { _ = t.Exception; },
-                        TaskContinuationOptions.OnlyOnFaulted);
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted,
+                        TaskScheduler.Default);
                 }
             }
             _disposed = true;

--- a/backend/Streams/PaddedLengthStream.cs
+++ b/backend/Streams/PaddedLengthStream.cs
@@ -122,11 +122,13 @@ public sealed class PaddedLengthStream(
 
     protected override void Dispose(bool disposing)
     {
-        if (_disposed || !disposing)
-            return;
+        if (!_disposed && disposing)
+        {
+            stream.Dispose();
+            _disposed = true;
+        }
 
-        stream.Dispose();
-        _disposed = true;
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -137,5 +139,6 @@ public sealed class PaddedLengthStream(
         await stream.DisposeAsync().ConfigureAwait(false);
         _disposed = true;
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -182,12 +182,12 @@ public sealed class PooledBufferStream : Stream
         base.Dispose(disposing);
     }
 
-    public override ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
         ReturnBuffer();
         _disposed = true;
         GC.SuppressFinalize(this);
-        return ValueTask.CompletedTask;
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     private void EnsureCapacity(int required)

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -19,8 +19,7 @@ public sealed class PooledBufferStream : Stream
         ISegmentBufferPool? pool = null,
         BufferPoolDiagnostics? diagnostics = null)
     {
-        if (capacityHint < 0)
-            throw new ArgumentOutOfRangeException(nameof(capacityHint));
+        ArgumentOutOfRangeException.ThrowIfNegative(capacityHint);
 
         _pool = pool ?? SharedArrayPoolAdapter.Instance;
         _diagnostics = diagnostics ?? BufferPoolDiagnostics.Shared;
@@ -59,8 +58,7 @@ public sealed class PooledBufferStream : Stream
         {
             ThrowIfDisposed();
             ArgumentOutOfRangeException.ThrowIfNegative(value);
-            if (value > int.MaxValue)
-                throw new ArgumentOutOfRangeException(nameof(value));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, int.MaxValue);
             _position = (int)value;
         }
     }
@@ -159,8 +157,7 @@ public sealed class PooledBufferStream : Stream
     {
         ThrowIfDisposed();
         ArgumentOutOfRangeException.ThrowIfNegative(value);
-        if (value > int.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(value));
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, int.MaxValue);
 
         var newLength = (int)value;
         if (newLength > _length)

--- a/backend/Streams/ProbingStream.cs
+++ b/backend/Streams/ProbingStream.cs
@@ -83,7 +83,7 @@ public class ProbingStream(Stream stream) : Stream
             return 1 + read;
         }
 
-        return await stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        return await stream.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)

--- a/backend/Streams/ProbingStream.cs
+++ b/backend/Streams/ProbingStream.cs
@@ -132,6 +132,7 @@ public class ProbingStream(Stream stream) : Stream
         if (_disposed) return;
         stream.Dispose();
         _disposed = true;
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -140,5 +141,6 @@ public class ProbingStream(Stream stream) : Stream
         await stream.DisposeAsync().ConfigureAwait(false);
         _disposed = true;
         GC.SuppressFinalize(this);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -53,11 +53,9 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
 
     public byte[] Rent(int minimumLength)
     {
-        if (minimumLength < 0)
-            throw new ArgumentOutOfRangeException(nameof(minimumLength));
+        ArgumentOutOfRangeException.ThrowIfNegative(minimumLength);
         if (minimumLength == 0) return [];
-        if (minimumLength > Array.MaxLength)
-            throw new ArgumentOutOfRangeException(nameof(minimumLength));
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(minimumLength, Array.MaxLength);
 
         var sizeClass = RoundToSizeClass(minimumLength);
         var now = _timeProvider.GetUtcNow();

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -75,7 +75,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 _openSegmentBytes = 0;
                 try
                 {
-                    var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken);
+                    var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken).ConfigureAwait(false);
                     await SegmentResponseValidator
                         .ThrowOnSegmentIdMismatchAsync(segmentId, body)
                         .ConfigureAwait(false);
@@ -128,7 +128,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             var destination = remainingExact > 0 && remainingExact < buffer.Length
                 ? buffer[..(int)remainingExact]
                 : buffer;
-            var read = await _stream.ReadAsync(destination, cancellationToken);
+            var read = await _stream.ReadAsync(destination, cancellationToken).ConfigureAwait(false);
             if (read > 0)
             {
                 _openSegmentBytes += read;

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -247,7 +247,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
     /// </summary>
     private static async Task<int> DeleteItemsByIdTextAsync(
         DavDatabaseContext dbContext,
-        IReadOnlyList<UnlinkedItemInfo> items,
+        List<UnlinkedItemInfo> items,
         CancellationToken cancellationToken = default)
     {
         var parameters = new SqliteParameter[items.Count];

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -50,7 +50,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         _progressObserver = progressObserver;
     }
 
-    private DavDatabaseContext CreateContext() => _createContext?.Invoke() ?? new DavDatabaseContext();
+    private DavDatabaseContext CreateContext() => DavDatabaseContexts.Create(_createContext);
 
     protected override async Task ExecuteInternal()
     {

--- a/backend/Tasks/RenameWindowsInvalidDavPathsTask.cs
+++ b/backend/Tasks/RenameWindowsInvalidDavPathsTask.cs
@@ -22,7 +22,7 @@ public class RenameWindowsInvalidDavPathsTask(
 {
     private static List<string> _auditLines = [];
 
-    private DavDatabaseContext CreateContext() => createContext?.Invoke() ?? new DavDatabaseContext();
+    private DavDatabaseContext CreateContext() => DavDatabaseContexts.Create(createContext);
 
     protected override async Task ExecuteInternal()
     {

--- a/backend/Tasks/StrmToSymlinksTask.cs
+++ b/backend/Tasks/StrmToSymlinksTask.cs
@@ -85,7 +85,7 @@ public class StrmToSymlinksTask(
             {
                 File.CreateSymbolicLink(symlinkPath, symlinkTarget);
                 File.Delete(item.Link.LinkPath);
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
             onItemCompleted?.Invoke();
         }
     }

--- a/backend/UsenetMigration/Provenance/AlreadyMigratedDetector.cs
+++ b/backend/UsenetMigration/Provenance/AlreadyMigratedDetector.cs
@@ -129,8 +129,8 @@ public sealed class AlreadyMigratedDetector
     /// </summary>
     private static List<DetectedFile>? MatchSidecar(
         AlreadyMigratedCandidate candidate,
-        IReadOnlyDictionary<Guid, ReleaseLeaf> liveById,
-        IReadOnlyDictionary<Guid, List<ReleaseLeaf>> liveByBlobId)
+        Dictionary<Guid, ReleaseLeaf> liveById,
+        Dictionary<Guid, List<ReleaseLeaf>> liveByBlobId)
     {
         if (candidate.Files.Count == 0)
             return null;
@@ -174,8 +174,8 @@ public sealed class AlreadyMigratedDetector
 
     private static List<DetectedFile>? MatchHistorical(
         AlreadyMigratedCandidate candidate,
-        IReadOnlyDictionary<string, MigratedFile> historicalFiles,
-        IReadOnlyDictionary<Guid, ReleaseLeaf> liveById)
+        Dictionary<string, MigratedFile> historicalFiles,
+        Dictionary<Guid, ReleaseLeaf> liveById)
     {
         if (candidate.Files.Count == 0 || historicalFiles.Count != candidate.Files.Count)
             return null;
@@ -195,7 +195,7 @@ public sealed class AlreadyMigratedDetector
 
     private static List<DetectedFile>? MatchLiveMount(
         AlreadyMigratedCandidate candidate,
-        IReadOnlyDictionary<string, List<ReleaseLeaf>> liveByMountPrefix)
+        Dictionary<string, List<ReleaseLeaf>> liveByMountPrefix)
     {
         if (candidate.Files.Count == 0)
             return null;

--- a/backend/UsenetMigration/Runner/AltmountScanRunner.cs
+++ b/backend/UsenetMigration/Runner/AltmountScanRunner.cs
@@ -158,7 +158,7 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
         string storeRef,
         List<WalkedMeta> metas,
         string? storeRoot,
-        IReadOnlyDictionary<string, MigrationCategoryMap> categoryMap,
+        Dictionary<string, MigrationCategoryMap> categoryMap,
         List<PendingScanError> scanErrors,
         CancellationToken ct)
     {
@@ -230,7 +230,7 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
     private static PendingRelease BuildV1Release(
         WalkedMeta v1,
         string? storeRoot,
-        IReadOnlyDictionary<string, MigrationCategoryMap> categoryMap)
+        Dictionary<string, MigrationCategoryMap> categoryMap)
     {
         var basename = DeriveBasename(v1.MetaPath);
         var storeRef = $"v1:{v1.MetaPath}";
@@ -347,7 +347,7 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
     }
 
     /// <summary>When every file carries the same NzbdavId, that GUID is the release provenance.</summary>
-    private static string? AgreedNzbdavId(IReadOnlyList<MigrationReleaseFile> files)
+    private static string? AgreedNzbdavId(List<MigrationReleaseFile> files)
     {
         if (files.Count == 0)
             return null;

--- a/backend/UsenetMigration/Runner/AltmountScanRunner.cs
+++ b/backend/UsenetMigration/Runner/AltmountScanRunner.cs
@@ -381,7 +381,7 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
             return;
 
         await using var migrationContext = store.NewContext();
-        await using var davContext = DavContextFactory?.Invoke() ?? new DavDatabaseContext();
+        await using var davContext = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
         var detected = await new AlreadyMigratedDetector()
             .DetectAndRecordAsync(candidates, migrationContext, davContext, ct)
             .ConfigureAwait(false);

--- a/backend/UsenetMigration/Runner/AltmountScanRunner.cs
+++ b/backend/UsenetMigration/Runner/AltmountScanRunner.cs
@@ -300,7 +300,7 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
     private static string DeriveTopLevelCategory(string virtualPath)
     {
         var normalised = virtualPath.Replace('\\', '/').Trim('/');
-        var slash = normalised.IndexOf('/');
+        var slash = normalised.IndexOf('/', StringComparison.Ordinal);
         return slash < 0 ? "" : normalised[..slash];
     }
 

--- a/backend/UsenetMigration/Runner/AltmountScanRunner.cs
+++ b/backend/UsenetMigration/Runner/AltmountScanRunner.cs
@@ -381,7 +381,7 @@ public sealed class AltmountScanRunner(UsenetMigrationStore store, ConfigManager
             return;
 
         await using var migrationContext = store.NewContext();
-        await using var davContext = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
+        await using var davContext = DavDatabaseContexts.Create(DavContextFactory);
         var detected = await new AlreadyMigratedDetector()
             .DetectAndRecordAsync(candidates, migrationContext, davContext, ct)
             .ConfigureAwait(false);

--- a/backend/UsenetMigration/Runner/LiveCollisions.cs
+++ b/backend/UsenetMigration/Runner/LiveCollisions.cs
@@ -31,7 +31,7 @@ public static class LiveCollisions
     public static (HashSet<string> queueKeys, HashSet<string> contentPaths) LoadSets(
         Func<DavDatabaseContext>? davContextFactory = null)
     {
-        using var ctx = davContextFactory?.Invoke() ?? new DavDatabaseContext();
+        using var ctx = DavDatabaseContexts.Create(davContextFactory);
         var queueKeys = ctx.QueueItems.AsNoTracking()
             .Select(q => new { q.Category, q.FileName })
             .AsEnumerable()

--- a/backend/UsenetMigration/Runner/MigrationHistoryCleaner.cs
+++ b/backend/UsenetMigration/Runner/MigrationHistoryCleaner.cs
@@ -48,7 +48,7 @@ public sealed class MigrationHistoryCleaner(UsenetMigrationStore store)
             };
         }
 
-        await using var davContext = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
+        await using var davContext = DavDatabaseContexts.Create(DavContextFactory);
         var davClient = new DavDatabaseClient(davContext);
         var removed = 0;
 

--- a/backend/UsenetMigration/Runner/MigrationHistoryCleaner.cs
+++ b/backend/UsenetMigration/Runner/MigrationHistoryCleaner.cs
@@ -48,7 +48,7 @@ public sealed class MigrationHistoryCleaner(UsenetMigrationStore store)
             };
         }
 
-        await using var davContext = DavContextFactory?.Invoke() ?? new DavDatabaseContext();
+        await using var davContext = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
         var davClient = new DavDatabaseClient(davContext);
         var removed = 0;
 

--- a/backend/UsenetMigration/Runner/SubmissionClaimRecovery.cs
+++ b/backend/UsenetMigration/Runner/SubmissionClaimRecovery.cs
@@ -33,7 +33,7 @@ internal static class SubmissionClaimRecovery
         if (claims.Count == 0)
             return new SubmissionRecoverySummary();
 
-        await using var davContext = (davContextFactory?.Invoke() ?? new DavDatabaseContext());
+        await using var davContext = DavDatabaseContexts.Create(davContextFactory);
         var adopted = 0;
         var retried = 0;
         var ambiguous = 0;

--- a/backend/UsenetMigration/Runner/SubmissionClaimRecovery.cs
+++ b/backend/UsenetMigration/Runner/SubmissionClaimRecovery.cs
@@ -33,7 +33,7 @@ internal static class SubmissionClaimRecovery
         if (claims.Count == 0)
             return new SubmissionRecoverySummary();
 
-        await using var davContext = davContextFactory?.Invoke() ?? new DavDatabaseContext();
+        await using var davContext = (davContextFactory?.Invoke() ?? new DavDatabaseContext());
         var adopted = 0;
         var retried = 0;
         var ambiguous = 0;

--- a/backend/UsenetMigration/Runner/SubmissionReconciler.cs
+++ b/backend/UsenetMigration/Runner/SubmissionReconciler.cs
@@ -42,7 +42,7 @@ public sealed class SubmissionReconciler(UsenetMigrationStore store)
         if (active.Count == 0)
             return new ReconcileSummary();
 
-        await using var davCtx = DavContextFactory?.Invoke() ?? new DavDatabaseContext();
+        await using var davCtx = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
         int completed = 0, failed = 0, processing = 0, evicted = 0;
         foreach (var sub in active)
         {

--- a/backend/UsenetMigration/Runner/SubmissionReconciler.cs
+++ b/backend/UsenetMigration/Runner/SubmissionReconciler.cs
@@ -42,7 +42,7 @@ public sealed class SubmissionReconciler(UsenetMigrationStore store)
         if (active.Count == 0)
             return new ReconcileSummary();
 
-        await using var davCtx = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
+        await using var davCtx = DavDatabaseContexts.Create(DavContextFactory);
         int completed = 0, failed = 0, processing = 0, evicted = 0;
         foreach (var sub in active)
         {

--- a/backend/UsenetMigration/Runner/SubmissionWorkerPool.cs
+++ b/backend/UsenetMigration/Runner/SubmissionWorkerPool.cs
@@ -361,6 +361,5 @@ public sealed class SubmissionWorkerPool(
         return await davCtx.QueueItems.AsNoTracking().CountAsync(ct).ConfigureAwait(false);
     }
 
-    private DavDatabaseContext NewDavContext() =>
-        DavContextFactory?.Invoke() ?? new DavDatabaseContext();
+    private DavDatabaseContext NewDavContext() => DavDatabaseContexts.Create(DavContextFactory);
 }

--- a/backend/UsenetMigration/Source/AltmountConfigReader.cs
+++ b/backend/UsenetMigration/Source/AltmountConfigReader.cs
@@ -141,7 +141,7 @@ public static class AltmountConfigReader
         ref string? name, ref string? dir, ref string? type,
         ref int? order, ref int? priority)
     {
-        var colon = keyValue.IndexOf(':');
+        var colon = keyValue.IndexOf(':', StringComparison.Ordinal);
         if (colon < 0) return;
         var key = keyValue[..colon].Trim();
         var value = ScalarValue(keyValue[(colon + 1)..]);

--- a/backend/UsenetMigration/Source/StorePathParser.cs
+++ b/backend/UsenetMigration/Source/StorePathParser.cs
@@ -107,7 +107,7 @@ public static class StorePathParser
     /// </summary>
     private static (long? queueId, string nzbBasename) SplitQueueId(string storeBasename)
     {
-        var dash = storeBasename.IndexOf('-');
+        var dash = storeBasename.IndexOf('-', StringComparison.Ordinal);
         if (dash <= 0) return (null, storeBasename);
 
         var left = storeBasename[..dash];

--- a/backend/UsenetMigration/Symlinks/SymlinkBackup.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkBackup.cs
@@ -52,7 +52,9 @@ public static class SymlinkBackup
             }
 
             await fs.FlushAsync(ct).ConfigureAwait(false);
+            #pragma warning disable CA1849 // FlushAsync does not flush to disk; backup durability requires the synchronous Flush(flushToDisk: true)
             fs.Flush(flushToDisk: true);
+            #pragma warning restore CA1849
         }
     }
 

--- a/backend/UsenetMigration/Symlinks/SymlinkBackup.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkBackup.cs
@@ -52,9 +52,9 @@ public static class SymlinkBackup
             }
 
             await fs.FlushAsync(ct).ConfigureAwait(false);
-            #pragma warning disable CA1849 // FlushAsync does not flush to disk; backup durability requires the synchronous Flush(flushToDisk: true)
+#pragma warning disable CA1849 // FlushAsync does not flush to disk; backup durability requires the synchronous Flush(flushToDisk: true)
             fs.Flush(flushToDisk: true);
-            #pragma warning restore CA1849
+#pragma warning restore CA1849
         }
     }
 

--- a/backend/UsenetMigration/Symlinks/SymlinkMatcher.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkMatcher.cs
@@ -68,7 +68,7 @@ public static class SymlinkMatcher
         Func<DavDatabaseContext>? davContextFactory = null,
         CancellationToken ct = default)
     {
-        await using var ctx = (davContextFactory?.Invoke() ?? new DavDatabaseContext());
+        await using var ctx = DavDatabaseContexts.Create(davContextFactory);
         return await ctx.Items.AsNoTracking()
             .Where(i => (i.NzbBlobId == nzoId || i.HistoryItemId == nzoId)
                         && i.Type == DavItem.ItemType.UsenetFile)

--- a/backend/UsenetMigration/Symlinks/SymlinkMatcher.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkMatcher.cs
@@ -68,7 +68,7 @@ public static class SymlinkMatcher
         Func<DavDatabaseContext>? davContextFactory = null,
         CancellationToken ct = default)
     {
-        await using var ctx = davContextFactory?.Invoke() ?? new DavDatabaseContext();
+        await using var ctx = (davContextFactory?.Invoke() ?? new DavDatabaseContext());
         return await ctx.Items.AsNoTracking()
             .Where(i => (i.NzbBlobId == nzoId || i.HistoryItemId == nzoId)
                         && i.Type == DavItem.ItemType.UsenetFile)

--- a/backend/UsenetMigration/Symlinks/SymlinkPlanner.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkPlanner.cs
@@ -416,7 +416,7 @@ public sealed class SymlinkPlanner(UsenetMigrationStore store, ConfigManager con
             return new List<CorrelatedFile>();
 
         var validIds = new HashSet<Guid>();
-        await using var davContext = DavContextFactory?.Invoke() ?? new DavDatabaseContext();
+        await using var davContext = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
         foreach (var batch in files.Select(f => f.DavItemId).Distinct().Chunk(500))
         {
             var found = await davContext.Items.AsNoTracking()

--- a/backend/UsenetMigration/Symlinks/SymlinkPlanner.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkPlanner.cs
@@ -416,7 +416,7 @@ public sealed class SymlinkPlanner(UsenetMigrationStore store, ConfigManager con
             return new List<CorrelatedFile>();
 
         var validIds = new HashSet<Guid>();
-        await using var davContext = (DavContextFactory?.Invoke() ?? new DavDatabaseContext());
+        await using var davContext = DavDatabaseContexts.Create(DavContextFactory);
         foreach (var batch in files.Select(f => f.DavItemId).Distinct().Chunk(500))
         {
             var found = await davContext.Items.AsNoTracking()

--- a/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
@@ -171,7 +171,7 @@ public sealed class SymlinkRewriter(UsenetMigrationStore store, ConfigManager co
             .ToList();
 
         HashSet<Guid> existing;
-        await using (var dav = (DavContextFactory?.Invoke() ?? new DavDatabaseContext()))
+        await using (var dav = DavDatabaseContexts.Create(DavContextFactory))
         {
             // Chunked IN queries keep SQLite parameter limits safe for large plans.
             existing = new HashSet<Guid>();

--- a/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
+++ b/backend/UsenetMigration/Symlinks/SymlinkRewriter.cs
@@ -171,7 +171,7 @@ public sealed class SymlinkRewriter(UsenetMigrationStore store, ConfigManager co
             .ToList();
 
         HashSet<Guid> existing;
-        await using (var dav = DavContextFactory?.Invoke() ?? new DavDatabaseContext())
+        await using (var dav = (DavContextFactory?.Invoke() ?? new DavDatabaseContext()))
         {
             // Chunked IN queries keep SQLite parameter limits safe for large plans.
             existing = new HashSet<Guid>();

--- a/backend/UsenetMigration/Triage/Verdict.cs
+++ b/backend/UsenetMigration/Triage/Verdict.cs
@@ -99,7 +99,7 @@ public static class VerdictReason
     /// <summary><c>{nzbBasename}</c> matches <c>PasswordRegex</c> — two password channels with unknown precedence.</summary>
     public const string FilenamePasswordMarker = "filename_password_marker";
 
-    private static readonly IReadOnlyDictionary<string, Verdict> Severity = new Dictionary<string, Verdict>
+    private static readonly Dictionary<string, Verdict> Severity = new Dictionary<string, Verdict>
     {
         [NoStoreRef] = Verdict.Red,
         [StoreMissing] = Verdict.Red,

--- a/backend/UsenetMigration/UsenetMigrationStore.cs
+++ b/backend/UsenetMigration/UsenetMigrationStore.cs
@@ -30,7 +30,7 @@ internal sealed record MigrationCategoryMappingChange(
 /// than resolving a scoped context, because the migration DB is separate from the
 /// request-scoped <see cref="DavDatabaseContext"/>.
 /// </summary>
-public sealed class UsenetMigrationStore
+public sealed class UsenetMigrationStore : IDisposable
 {
     /// <summary>The pinned singleton session id enforced by CK_SessionState_Singleton.</summary>
     public const int SessionId = 1;
@@ -895,4 +895,11 @@ public sealed class UsenetMigrationStore
 
     internal static int ClampSubmitWorkers(int value, int maxQueueDepth) =>
         Math.Clamp(value, 1, Math.Min(16, Math.Max(1, maxQueueDepth)));
+
+    public void Dispose()
+    {
+        _databaseInitialization.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
 }

--- a/backend/Utils/ContentHeaderUtil.cs
+++ b/backend/Utils/ContentHeaderUtil.cs
@@ -5,7 +5,7 @@ public static class ContentHeaderUtil
     public static string GetContentType(string fileName)
     {
         if (fileName == "README") return "text/plain";
-        var extension = Path.GetExtension(fileName).ToLower();
+        var extension = Path.GetExtension(fileName).ToLowerInvariant();
         // .mkv falls through to ContentTypeUtil → "video/x-matroska". WebM only
         // permits VP8/VP9 + Vorbis/Opus, while MKV releases commonly use other codecs.
         return extension == ".rclonelink" ? "text/plain"

--- a/backend/Utils/ContentTypeUtil.cs
+++ b/backend/Utils/ContentTypeUtil.cs
@@ -4,21 +4,22 @@ namespace NzbWebDAV.Utils;
 
 public static class ContentTypeUtil
 {
-    private static readonly FileExtensionContentTypeProvider ContentTypeProvider;
+    private static readonly FileExtensionContentTypeProvider ContentTypeProvider = CreateContentTypeProvider();
 
-    static ContentTypeUtil()
+    private static FileExtensionContentTypeProvider CreateContentTypeProvider()
     {
         // ReSharper disable once UseObjectOrCollectionInitializer
-        ContentTypeProvider = new FileExtensionContentTypeProvider();
-        ContentTypeProvider.Mappings[".flac"] = "audio/flac";
-        ContentTypeProvider.Mappings[".mkv"] = "video/x-matroska";
-        ContentTypeProvider.Mappings[".mk3d"] = "video/x-matroska";
-        ContentTypeProvider.Mappings[".m4v"] = "video/x-m4v";
-        ContentTypeProvider.Mappings[".ts"] = "video/mp2t";
-        ContentTypeProvider.Mappings[".m2ts"] = "video/mp2t";
-        ContentTypeProvider.Mappings[".mts"] = "video/mp2t";
-        ContentTypeProvider.Mappings[".divx"] = "video/divx";
-        ContentTypeProvider.Mappings[".rmvb"] = "application/vnd.rn-realmedia-vbr";
+        var provider = new FileExtensionContentTypeProvider();
+        provider.Mappings[".flac"] = "audio/flac";
+        provider.Mappings[".mkv"] = "video/x-matroska";
+        provider.Mappings[".mk3d"] = "video/x-matroska";
+        provider.Mappings[".m4v"] = "video/x-m4v";
+        provider.Mappings[".ts"] = "video/mp2t";
+        provider.Mappings[".m2ts"] = "video/mp2t";
+        provider.Mappings[".mts"] = "video/mp2t";
+        provider.Mappings[".divx"] = "video/divx";
+        provider.Mappings[".rmvb"] = "application/vnd.rn-realmedia-vbr";
+        return provider;
     }
 
     public static string GetContentType(string fileName)

--- a/backend/Utils/EmbeddedResourceUtil.cs
+++ b/backend/Utils/EmbeddedResourceUtil.cs
@@ -41,8 +41,8 @@ public static class EmbeddedResourceUtil
             .GetFrames()
             .Select(x => x.GetMethod()!)
             .Select(x => x.ReflectedType!)
-            .Where(x => !x.FullName!.StartsWith("NzbWebDAV.Utils.EmbeddedResourceUtil"))
-            .First(x => !x.FullName!.StartsWith("System"))
+            .Where(x => !x.FullName!.StartsWith("NzbWebDAV.Utils.EmbeddedResourceUtil", StringComparison.Ordinal))
+            .First(x => !x.FullName!.StartsWith("System", StringComparison.Ordinal))
             .Namespace + "." + resourcePath;
     }
 

--- a/backend/Utils/EnvironmentUtil.cs
+++ b/backend/Utils/EnvironmentUtil.cs
@@ -20,7 +20,7 @@ public static class EnvironmentUtil
 
     public static bool IsVariableTrue(string envVariable)
     {
-        var value = Environment.GetEnvironmentVariable(envVariable)?.ToLower();
+        var value = Environment.GetEnvironmentVariable(envVariable)?.ToLowerInvariant();
         return value is "y" or "yes" or "true";
     }
 }

--- a/backend/Utils/EnvironmentUtil.cs
+++ b/backend/Utils/EnvironmentUtil.cs
@@ -10,7 +10,7 @@ public static class EnvironmentUtil
     public static string GetRequiredVariable(string envVariable)
     {
         return Environment.GetEnvironmentVariable(envVariable) ??
-               throw new Exception($"The environment variable `{envVariable}` must be set.");
+               throw new InvalidOperationException($"The environment variable `{envVariable}` must be set.");
     }
 
     public static long? GetLongVariable(string envVariable)

--- a/backend/Utils/ExcludePatternParser.cs
+++ b/backend/Utils/ExcludePatternParser.cs
@@ -50,8 +50,8 @@ public static class ExcludePatternParser
             body = wrapper.Groups[1].Value;
             var flags = wrapper.Groups[2].Value;
             // Built in a fixed order so "/x/ms" and "/x/sm" yield the same dedup key.
-            if (flags.Contains('m')) { options |= RegexOptions.Multiline; extraFlags += "m"; }
-            if (flags.Contains('s')) { options |= RegexOptions.Singleline; extraFlags += "s"; }
+            if (flags.Contains('m', StringComparison.Ordinal)) { options |= RegexOptions.Multiline; extraFlags += "m"; }
+            if (flags.Contains('s', StringComparison.Ordinal)) { options |= RegexOptions.Singleline; extraFlags += "s"; }
         }
 
         if (body.Length == 0) return null;

--- a/backend/Utils/FileFilterUtil.cs
+++ b/backend/Utils/FileFilterUtil.cs
@@ -70,7 +70,7 @@ public static partial class FileFilterUtil
         {
             if (GlobCache.TryGetValue(glob, out var cached)) return cached;
             var pattern = "^" + Regex.Escape(glob)
-                .Replace("\\*", ".*")
+                .Replace("\\*", ".*", StringComparison.Ordinal)
                 .Replace("\\?", ".") + "$";
             var regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             GlobCache[glob] = regex;

--- a/backend/Utils/FileFilterUtil.cs
+++ b/backend/Utils/FileFilterUtil.cs
@@ -71,7 +71,7 @@ public static partial class FileFilterUtil
             if (GlobCache.TryGetValue(glob, out var cached)) return cached;
             var pattern = "^" + Regex.Escape(glob)
                 .Replace("\\*", ".*", StringComparison.Ordinal)
-                .Replace("\\?", ".") + "$";
+                .Replace("\\?", ".", StringComparison.Ordinal) + "$";
             var regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             GlobCache[glob] = regex;
             return regex;

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -2,7 +2,7 @@
 
 namespace NzbWebDAV.Utils;
 
-public partial class FilenameUtil
+public static partial class FilenameUtil
 {
     // Group `pw` contains the password,
     // Group `rm` contains the part of the filename that should be removed to create a clean job name

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -29,7 +29,7 @@ public static partial class FilenameUtil
 
     public static bool IsVideoFile(string filename)
     {
-        return VideoExtensions.Contains(Path.GetExtension(filename).ToLower());
+        return VideoExtensions.Contains(Path.GetExtension(filename).ToLowerInvariant());
     }
 
     public static bool IsRarFile(string? filename)

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -71,7 +71,7 @@ public static partial class FilenameUtil
         var passMatch = PasswordRegex.Match(filename);
         var jobName = Path.GetFileNameWithoutExtension(
             passMatch.Success ?
-            filename.Replace(passMatch.Groups["rm"].Value, "") :
+            filename.Replace(passMatch.Groups["rm"].Value, "", StringComparison.Ordinal) :
             filename
         );
         return PathSanitizer.SanitizeComponentWithLog(jobName);

--- a/backend/Utils/HttpContentReadUtil.cs
+++ b/backend/Utils/HttpContentReadUtil.cs
@@ -28,7 +28,7 @@ public static class HttpContentReadUtil
         {
             if (ms.Length + read > maxBytes)
                 throw new NzbResponseTooLargeException(maxBytes);
-            ms.Write(buf, 0, read);
+            await ms.WriteAsync(buf.AsMemory(0, read), ct).ConfigureAwait(false);
         }
 
         return ms.ToArray();

--- a/backend/Utils/ObfuscationUtil.cs
+++ b/backend/Utils/ObfuscationUtil.cs
@@ -34,7 +34,7 @@ public static class ObfuscationUtil
 
         // "[BlaBla] something [More] something 5937bc5e32146e.bef89a622e4a23f07b0d3757ad5e8a.a02b264e [Brrr]"
         // So: square brackets plus 30+ hex digit
-        if (Regex.IsMatch(fileBaseName, @"[a-f0-9]{30}") && Regex.Matches(fileBaseName, @"\[\w+\]").Count >= 2)
+        if (Regex.IsMatch(fileBaseName, @"[a-f0-9]{30}") && Regex.Count(fileBaseName, @"\[\w+\]") >= 2)
         {
             return true;
         }

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -104,10 +104,10 @@ public static class OrganizedLinksUtil
     internal static DavItemLink? GetDavItemLink(SymlinkAndStrmUtil.SymlinkInfo symlinkInfo, string mountDir)
     {
         var targetPath = symlinkInfo.TargetPath;
-        if (!targetPath.StartsWith(mountDir)) return null;
+        if (!targetPath.StartsWith(mountDir, StringComparison.Ordinal)) return null;
         targetPath = targetPath.RemovePrefix(mountDir);
         targetPath = targetPath.StartsWith('/') ? targetPath : $"/{targetPath}";
-        if (!targetPath.StartsWith("/.ids")) return null;
+        if (!targetPath.StartsWith("/.ids", StringComparison.Ordinal)) return null;
         var guid = Path.GetFileNameWithoutExtension(targetPath);
         // a foreign/hand-made symlink under the mount dir must not abort the library walk
         if (!Guid.TryParse(guid, out var davItemId)) return null;
@@ -125,7 +125,7 @@ public static class OrganizedLinksUtil
         // a malformed strm file must not abort the library walk
         if (!Uri.TryCreate(targetUrl, UriKind.Absolute, out var uri)) return null;
         var absolutePath = uri.AbsolutePath;
-        if (!absolutePath.StartsWith("/view/.ids")) return null;
+        if (!absolutePath.StartsWith("/view/.ids", StringComparison.Ordinal)) return null;
         var guid = Path.GetFileNameWithoutExtension(absolutePath);
         if (!Guid.TryParse(guid, out var davItemId)) return null;
         return new DavItemLink()

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -97,7 +97,7 @@ public static class OrganizedLinksUtil
         {
             SymlinkAndStrmUtil.SymlinkInfo symlinkInfo => GetDavItemLink(symlinkInfo, mountDir),
             SymlinkAndStrmUtil.StrmInfo strmInfo => GetDavItemLink(strmInfo),
-            _ => throw new Exception("Unknown link type")
+            _ => throw new InvalidOperationException("Unknown link type")
         };
     }
 

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -141,5 +141,14 @@ public static class OrganizedLinksUtil
         public string LinkPath; // Path to either a symlink or strm file.
         public Guid DavItemId;
         public SymlinkAndStrmUtil.ISymlinkOrStrmInfo SymlinkOrStrmInfo;
+        public static bool operator ==(DavItemLink left, DavItemLink right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(DavItemLink left, DavItemLink right)
+        {
+            return !(left == right);
+        }
     }
 }

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -141,14 +141,5 @@ public static class OrganizedLinksUtil
         public string LinkPath; // Path to either a symlink or strm file.
         public Guid DavItemId;
         public SymlinkAndStrmUtil.ISymlinkOrStrmInfo SymlinkOrStrmInfo;
-        public static bool operator ==(DavItemLink left, DavItemLink right)
-        {
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(DavItemLink left, DavItemLink right)
-        {
-            return !(left == right);
-        }
     }
 }

--- a/backend/Utils/PathUtil.cs
+++ b/backend/Utils/PathUtil.cs
@@ -1,6 +1,6 @@
 namespace NzbWebDAV.Utils;
 
-public class PathUtil
+public static class PathUtil
 {
     public static IEnumerable<string> GetAllParentDirectories(string path)
     {

--- a/backend/Utils/ProxyHttpClientPool.cs
+++ b/backend/Utils/ProxyHttpClientPool.cs
@@ -50,7 +50,9 @@ public static class ProxyHttpClientPool
             {
                 handler.SslOptions = new SslClientAuthenticationOptions
                 {
+#pragma warning disable CA5359 // behind the explicit per-provider SkipTlsVerification setting for providers with broken/self-signed certs
                     RemoteCertificateValidationCallback = static (_, _, _, _) => true,
+#pragma warning restore CA5359
                 };
             }
 

--- a/backend/Utils/ProxyHttpClientPool.cs
+++ b/backend/Utils/ProxyHttpClientPool.cs
@@ -78,9 +78,9 @@ public static class ProxyHttpClientPool
         for (var i = 0; i < addresses.Length; i++)
         {
             var isLast = i == addresses.Length - 1;
-            #pragma warning disable CA2000 // socket is disposed on connect failure; on success the pooled connection stream owns it
+#pragma warning disable CA2000 // socket is disposed on connect failure; on success the pooled connection stream owns it
             var socket = new Socket(addresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
             TrySetKeepAliveTuning(socket);
             try

--- a/backend/Utils/ProxyHttpClientPool.cs
+++ b/backend/Utils/ProxyHttpClientPool.cs
@@ -76,7 +76,9 @@ public static class ProxyHttpClientPool
         for (var i = 0; i < addresses.Length; i++)
         {
             var isLast = i == addresses.Length - 1;
+            #pragma warning disable CA2000 // socket is disposed on connect failure; on success the pooled connection stream owns it
             var socket = new Socket(addresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            #pragma warning restore CA2000
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
             TrySetKeepAliveTuning(socket);
             try

--- a/backend/Utils/RarUtil.cs
+++ b/backend/Utils/RarUtil.cs
@@ -148,7 +148,7 @@ public static class RarUtil
 
                 // TODO: support solid archives
                 if (fh.IsEncrypted && fh.IsSolid)
-                    throw new Exception("Password-protected rar archives cannot be solid.");
+                    throw new InvalidOperationException("Password-protected rar archives cannot be solid.");
 
                 // add the headers
                 headers.Add(header);

--- a/backend/Utils/SigtermUtil.cs
+++ b/backend/Utils/SigtermUtil.cs
@@ -5,7 +5,7 @@ namespace NzbWebDAV.Utils;
 public static class SigtermUtil
 {
     private static readonly CancellationTokenSource CancellationTokenSource = new();
-    private static bool _isInitialized = false;
+    private static bool _isInitialized;
 
     /// <summary>
     /// Gets a CancellationToken that will be cancelled when the application

--- a/backend/Utils/SymlinkAndStrmUtil.cs
+++ b/backend/Utils/SymlinkAndStrmUtil.cs
@@ -300,29 +300,11 @@ public static class SymlinkAndStrmUtil
     {
         public required string SymlinkPath;
         public required string TargetPath;
-        public static bool operator ==(SymlinkInfo left, SymlinkInfo right)
-        {
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(SymlinkInfo left, SymlinkInfo right)
-        {
-            return !(left == right);
-        }
     }
 
     public struct StrmInfo : ISymlinkOrStrmInfo
     {
         public required string StrmPath;
         public required string TargetUrl;
-        public static bool operator ==(StrmInfo left, StrmInfo right)
-        {
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(StrmInfo left, StrmInfo right)
-        {
-            return !(left == right);
-        }
     }
 }

--- a/backend/Utils/SymlinkAndStrmUtil.cs
+++ b/backend/Utils/SymlinkAndStrmUtil.cs
@@ -289,7 +289,7 @@ public static class SymlinkAndStrmUtil
     }
 
     private static bool IsStrm(FileInfo x) =>
-        x.Extension.Equals(".strm", StringComparison.CurrentCultureIgnoreCase);
+        x.Extension.Equals(".strm", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsSymLink(FileInfo x) =>
         x.Attributes.HasFlag(FileAttributes.ReparsePoint) && x.LinkTarget is not null;

--- a/backend/Utils/SymlinkAndStrmUtil.cs
+++ b/backend/Utils/SymlinkAndStrmUtil.cs
@@ -300,11 +300,29 @@ public static class SymlinkAndStrmUtil
     {
         public required string SymlinkPath;
         public required string TargetPath;
+        public static bool operator ==(SymlinkInfo left, SymlinkInfo right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(SymlinkInfo left, SymlinkInfo right)
+        {
+            return !(left == right);
+        }
     }
 
     public struct StrmInfo : ISymlinkOrStrmInfo
     {
         public required string StrmPath;
         public required string TargetUrl;
+        public static bool operator ==(StrmInfo left, StrmInfo right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(StrmInfo left, StrmInfo right)
+        {
+            return !(left == right);
+        }
     }
 }

--- a/backend/Utils/TrustedHostsMatcher.cs
+++ b/backend/Utils/TrustedHostsMatcher.cs
@@ -116,7 +116,7 @@ public sealed class TrustedHostsMatcher
         return false;
     }
 
-    private static IEnumerable<string> SplitEntries(string rawEntries)
+    private static string[] SplitEntries(string rawEntries)
     {
         return rawEntries
             .Split([',', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);

--- a/backend/Utils/TrustedHostsMatcher.cs
+++ b/backend/Utils/TrustedHostsMatcher.cs
@@ -52,7 +52,7 @@ public sealed class TrustedHostsMatcher
                 continue;
             }
 
-            if (part.Contains('/') && IPNetwork.TryParse(part, out var network))
+            if (part.Contains('/', StringComparison.Ordinal) && IPNetwork.TryParse(part, out var network))
             {
                 networks.Add(network);
                 continue;
@@ -65,7 +65,7 @@ public sealed class TrustedHostsMatcher
             }
 
             // Reject entries that look like broken CIDR/IP before treating as hostname.
-            if (part.Contains('/') || part.Any(char.IsWhiteSpace))
+            if (part.Contains('/', StringComparison.Ordinal) || part.Any(char.IsWhiteSpace))
             {
                 Log.Warning("Ignoring invalid trusted-hosts entry: {Entry}", part);
                 continue;

--- a/backend/Utils/WardenFingerprint.cs
+++ b/backend/Utils/WardenFingerprint.cs
@@ -25,7 +25,7 @@ public static class WardenFingerprint
     {
         if (string.IsNullOrWhiteSpace(host)) return "unknown";
         var h = host.Trim().ToLowerInvariant();
-        var colon = h.IndexOf(':');
+        var colon = h.IndexOf(':', StringComparison.Ordinal);
         if (colon > 0) h = h[..colon];
         return string.IsNullOrEmpty(h) ? "unknown" : h;
     }
@@ -34,7 +34,7 @@ public static class WardenFingerprint
     {
         if (string.IsNullOrWhiteSpace(host)) return "unknown";
         var h = host.Trim().ToLowerInvariant();
-        var colon = h.IndexOf(':');
+        var colon = h.IndexOf(':', StringComparison.Ordinal);
         if (colon > 0) h = h[..colon];
         h = h.Trim('.');
         if (h.Length == 0) return "unknown";

--- a/backend/WebDav/Base/BaseStoreCollection.cs
+++ b/backend/WebDav/Base/BaseStoreCollection.cs
@@ -84,9 +84,9 @@ public abstract class BaseStoreCollection : IStoreCollection
     )
     {
         var existingItem = await GetItemAsync(name, cancellationToken).ConfigureAwait(false);
-        #pragma warning disable CA2000 // wraps the framework-owned request body; on the write path ownership passes to CreateItemRequest
+#pragma warning disable CA2000 // wraps the framework-owned request body; on the write path ownership passes to CreateItemRequest
         var probingStream = new ProbingStream(stream);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
 
         // if the item doesn't already exist, create it
         //

--- a/backend/WebDav/Base/BaseStoreCollection.cs
+++ b/backend/WebDav/Base/BaseStoreCollection.cs
@@ -84,7 +84,9 @@ public abstract class BaseStoreCollection : IStoreCollection
     )
     {
         var existingItem = await GetItemAsync(name, cancellationToken).ConfigureAwait(false);
+        #pragma warning disable CA2000 // wraps the framework-owned request body; on the write path ownership passes to CreateItemRequest
         var probingStream = new ProbingStream(stream);
+        #pragma warning restore CA2000
 
         // if the item doesn't already exist, create it
         //

--- a/backend/WebDav/Base/BaseStoreStreamFile.cs
+++ b/backend/WebDav/Base/BaseStoreStreamFile.cs
@@ -23,14 +23,18 @@ public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager con
             Priority = SemaphorePriority.High,
             StreamSemaphore = streamSemaphore,
         };
+        #pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
         var scopedDownloadPriorityContext = cancellationToken.SetContext(downloadPriorityContext);
+        #pragma warning restore CA2000
 
         var streamingTimeoutContext = new StreamingTimeoutContext
         {
             PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
             MaxRetries = configManager.GetStreamingSegmentRetries(),
         };
+        #pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
         var scopedStreamingTimeoutContext = cancellationToken.SetContext(streamingTimeoutContext);
+        #pragma warning restore CA2000
 
         // Keep this stream's per-stream budget in sync with live config changes,
         // mirroring how DownloadingNntpClient resizes the shared streaming semaphore.

--- a/backend/WebDav/Base/BaseStoreStreamFile.cs
+++ b/backend/WebDav/Base/BaseStoreStreamFile.cs
@@ -23,18 +23,18 @@ public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager con
             Priority = SemaphorePriority.High,
             StreamSemaphore = streamSemaphore,
         };
-        #pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
+#pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
         var scopedDownloadPriorityContext = cancellationToken.SetContext(downloadPriorityContext);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
 
         var streamingTimeoutContext = new StreamingTimeoutContext
         {
             PerSegmentTimeout = configManager.GetStreamingSegmentTimeout(),
             MaxRetries = configManager.GetStreamingSegmentRetries(),
         };
-        #pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
+#pragma warning disable CA2000 // scoped context is disposed via Response.OnCompleted when the response completes
         var scopedStreamingTimeoutContext = cancellationToken.SetContext(streamingTimeoutContext);
-        #pragma warning restore CA2000
+#pragma warning restore CA2000
 
         // Keep this stream's per-stream budget in sync with live config changes,
         // mirroring how DownloadingNntpClient resizes the shared streaming semaphore.

--- a/backend/WebDav/Base/BaseStoreStreamFile.cs
+++ b/backend/WebDav/Base/BaseStoreStreamFile.cs
@@ -8,6 +8,11 @@ namespace NzbWebDAV.WebDav.Base;
 
 public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager configManager) : BaseStoreReadonlyItem
 {
+    // Derived stream files must use these properties instead of capturing
+    // the primary-constructor parameters (CS9107 double-capture).
+    protected HttpContext Context => context;
+    protected ConfigManager Config => configManager;
+
     protected abstract Task<Stream> GetStreamAsync(CancellationToken cancellationToken);
 
     public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)

--- a/backend/WebDav/DatabaseStore.cs
+++ b/backend/WebDav/DatabaseStore.cs
@@ -37,7 +37,7 @@ public class DatabaseStore(
     public async Task<IStoreItem?> GetItemAsync(string path, CancellationToken cancellationToken)
     {
         path = path.Trim('/');
-        if (path == "") return _root;
+        if (string.IsNullOrEmpty(path)) return _root;
 
         // Fast path: a single indexed lookup by absolute path. This handles the overwhelmingly
         // common case (streaming/serving a real, persisted file or directory) in one query

--- a/backend/WebDav/DatabaseStoreIdsCollection.cs
+++ b/backend/WebDav/DatabaseStoreIdsCollection.cs
@@ -43,7 +43,7 @@ public class DatabaseStoreIdsCollection(
         if (_currentPathParts.Length < DavItem.IdPrefixLength)
         {
             if (request.Name.Length != 1) return null;
-            if (!Alphabet.Contains(request.Name[0])) return null;
+            if (!Alphabet.Contains(request.Name[0], StringComparison.Ordinal)) return null;
             return new DatabaseStoreIdsCollection(
                 dir, Path.Join(currentPath, dir), ctx, db, usenet, config, lazy, budget);
         }

--- a/backend/WebDav/DatabaseStoreMultipartFile.cs
+++ b/backend/WebDav/DatabaseStoreMultipartFile.cs
@@ -30,7 +30,7 @@ public class DatabaseStoreMultipartFile(
     protected override async Task<Stream> GetStreamAsync(CancellationToken ct)
     {
         // store the DavItem being accessed in the http context
-        httpContext.Items["DavItem"] = davMultipartFile;
+        Context.Items["DavItem"] = davMultipartFile;
 
         var id = davMultipartFile.Id;
         var multipartFile = await dbClient.GetDavMultipartFileAsync(davMultipartFile, ct).ConfigureAwait(false);
@@ -51,9 +51,9 @@ public class DatabaseStoreMultipartFile(
         var packedStream = new DavMultipartFileStream(
             multipartFile,
             usenetClient,
-            configManager.GetArticleBufferSize(),
+            Config.GetArticleBufferSize(),
             lazyRarResolver,
-            configManager.IsPipelinedBodyRequestsEnabled(),
+            Config.IsPipelinedBodyRequestsEnabled(),
             davMultipartFile.Path,
             inFlightArticleBudget
         );

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -27,7 +27,7 @@ public class DatabaseStoreNzbFile(
     protected override async Task<Stream> GetStreamAsync(CancellationToken cancellationToken)
     {
         // store the DavItem being accessed in the http context
-        httpContext.Items["DavItem"] = davNzbFile;
+        Context.Items["DavItem"] = davNzbFile;
 
         var id = davNzbFile.Id;
         var file = await dbClient.GetDavNzbFileAsync(davNzbFile, cancellationToken).ConfigureAwait(false);
@@ -40,13 +40,13 @@ public class DatabaseStoreNzbFile(
         return usenetClient.GetFileStream(
             nzbFile.SegmentIds,
             FileSize,
-            configManager.GetArticleBufferSize(),
+            Config.GetArticleBufferSize(),
             nzbFile.SegmentByteRanges,
-            configManager.IsPipelinedBodyRequestsEnabled(),
+            Config.IsPipelinedBodyRequestsEnabled(),
             davNzbFile.Path,
             nzbFile.SegmentFallbackIds,
             inFlightArticleBudget,
-            useContainerAwareFill: configManager.IsContainerAwareFillEnabled()
+            useContainerAwareFill: Config.IsContainerAwareFillEnabled()
         );
     }
 }

--- a/backend/WebDav/DatabaseStoreRarFile.cs
+++ b/backend/WebDav/DatabaseStoreRarFile.cs
@@ -28,7 +28,7 @@ public class DatabaseStoreRarFile(
     protected override async Task<Stream> GetStreamAsync(CancellationToken ct)
     {
         // store the DavItem being accessed in the http context
-        httpContext.Items["DavItem"] = davRarFile;
+        Context.Items["DavItem"] = davRarFile;
 
         var id = davRarFile.Id;
         var rarFile = await dbClient.GetDavRarFileAsync(davRarFile, ct).ConfigureAwait(false);
@@ -50,9 +50,9 @@ public class DatabaseStoreRarFile(
         (
             transient,
             usenetClient,
-            configManager.GetArticleBufferSize(),
+            Config.GetArticleBufferSize(),
             resolver: null,
-            usePipelinedBodyRequests: configManager.IsPipelinedBodyRequestsEnabled(),
+            usePipelinedBodyRequests: Config.IsPipelinedBodyRequestsEnabled(),
             fileName: davRarFile.Path,
             inFlightArticleBudget: inFlightArticleBudget
         );

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -404,7 +404,7 @@ public class WebsocketManager
     private static string? GetMessageKey(WebsocketTopic topic, string message)
     {
         if (!topic.IsKeyed) return null;
-        var separator = message.IndexOf('|');
+        var separator = message.IndexOf('|', StringComparison.Ordinal);
         return separator > 0 ? message[..separator] : null;
     }
 

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -171,7 +171,7 @@ public class WebsocketManager
                     }
                     else
                     {
-                        messageBuffer.Write(buffer, 0, result.Count);
+                        await messageBuffer.WriteAsync(buffer.AsMemory(0, result.Count), SigtermUtil.GetCancellationToken()).ConfigureAwait(false);
                     }
                 }
 

--- a/libs/RapidYencSharp/.editorconfig
+++ b/libs/RapidYencSharp/.editorconfig
@@ -24,3 +24,46 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# ==========================================================================
+# Analyzer policy — mirrors the repository root .editorconfig (this file has
+# root = true, so the root policy does not flow in). Keep in sync with the
+# root "Analyzer policy" section. See CONTRIBUTING.md "Static analysis
+# policy".
+# ==========================================================================
+[*.cs]
+
+# Justification: P/Invoke declarations follow native symbol names and expose
+# interop structs directly by design; consumed only by this repo.
+dotnet_diagnostic.CA1002.severity = none
+dotnet_diagnostic.CA1819.severity = none
+dotnet_diagnostic.CA2227.severity = none
+dotnet_diagnostic.CA1051.severity = none
+dotnet_diagnostic.CA1034.severity = none
+dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.CA1008.severity = none
+dotnet_diagnostic.CA1024.severity = none
+dotnet_diagnostic.CA1040.severity = none
+dotnet_diagnostic.CA1054.severity = none
+dotnet_diagnostic.CA1055.severity = none
+dotnet_diagnostic.CA1056.severity = none
+dotnet_diagnostic.CA2234.severity = none
+dotnet_diagnostic.CA2225.severity = none
+dotnet_diagnostic.CA1031.severity = none
+dotnet_diagnostic.CA1032.severity = none
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
+# Justification: P/Invoke method names intentionally mirror the native C
+# symbols (snake_case) they bind to.
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1711.severity = none
+dotnet_diagnostic.CA1716.severity = none
+dotnet_diagnostic.CA1720.severity = none
+dotnet_diagnostic.CA1724.severity = none
+dotnet_diagnostic.CA1725.severity = none
+dotnet_diagnostic.CA1515.severity = none
+dotnet_diagnostic.CA1508.severity = none
+dotnet_diagnostic.CA1852.severity = none
+dotnet_diagnostic.CA2100.severity = none
+dotnet_diagnostic.CA3003.severity = none

--- a/libs/RapidYencSharp/.editorconfig
+++ b/libs/RapidYencSharp/.editorconfig
@@ -67,3 +67,9 @@ dotnet_diagnostic.CA1508.severity = none
 dotnet_diagnostic.CA1852.severity = none
 dotnet_diagnostic.CA2100.severity = none
 dotnet_diagnostic.CA3003.severity = none
+# Justification: NativeMethods registers a DllImportResolver that controls the
+# real load path (RAPIDYENC_LIBRARY_PATH, else runtimes/<rid>/native next to
+# the assembly); CA5393's "AssemblyDirectory is unsafe" classification targets
+# default-search-order loading, which the resolver preempts. The assembly-level
+# DefaultDllImportSearchPaths attribute stays as defense-in-depth.
+dotnet_diagnostic.CA5393.severity = none

--- a/libs/RapidYencSharp/Examples.cs
+++ b/libs/RapidYencSharp/Examples.cs
@@ -122,7 +122,9 @@ public static class Examples
     {
         // Simulate larger data
         byte[] largeData = new byte[10_000];
+        #pragma warning disable CA5394 // example/demo data generation; not security-sensitive
         Random.Shared.NextBytes(largeData);
+        #pragma warning restore CA5394
 
         // Calculate the maximum encoded size
         nuint maxEncodedSize = YencEncoder.GetMaxEncodedLength((nuint)largeData.Length);
@@ -199,7 +201,9 @@ public static class Examples
     {
         // Simulate reading data in chunks (e.g., from a network stream)
         byte[] sourceData = new byte[1000];
+        #pragma warning disable CA5394 // example/demo data generation; not security-sensitive
         Random.Shared.NextBytes(sourceData);
+        #pragma warning restore CA5394
 
         // Rent buffers from pool
         byte[] encodeBuffer =

--- a/libs/RapidYencSharp/Examples.cs
+++ b/libs/RapidYencSharp/Examples.cs
@@ -122,9 +122,9 @@ public static class Examples
     {
         // Simulate larger data
         byte[] largeData = new byte[10_000];
-        #pragma warning disable CA5394 // example/demo data generation; not security-sensitive
+#pragma warning disable CA5394 // example/demo data generation; not security-sensitive
         Random.Shared.NextBytes(largeData);
-        #pragma warning restore CA5394
+#pragma warning restore CA5394
 
         // Calculate the maximum encoded size
         nuint maxEncodedSize = YencEncoder.GetMaxEncodedLength((nuint)largeData.Length);
@@ -201,9 +201,9 @@ public static class Examples
     {
         // Simulate reading data in chunks (e.g., from a network stream)
         byte[] sourceData = new byte[1000];
-        #pragma warning disable CA5394 // example/demo data generation; not security-sensitive
+#pragma warning disable CA5394 // example/demo data generation; not security-sensitive
         Random.Shared.NextBytes(sourceData);
-        #pragma warning restore CA5394
+#pragma warning restore CA5394
 
         // Rent buffers from pool
         byte[] encodeBuffer =

--- a/libs/RapidYencSharp/NativeMethods.cs
+++ b/libs/RapidYencSharp/NativeMethods.cs
@@ -2,6 +2,11 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+// The native library always ships next to the managed assembly or is loaded
+// through the DllImportResolver below (RAPIDYENC_LIBRARY_PATH); never search
+// the application base directory / CWD for rapidyenc.dll-style lookups.
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.UseDllDirectoryForDependencies)]
+
 namespace RapidYencSharp;
 
 public enum RapidYencDecoderState

--- a/libs/SharpCompress/SharpCompress.csproj
+++ b/libs/SharpCompress/SharpCompress.csproj
@@ -18,7 +18,18 @@
     <IsAotCompatible>true</IsAotCompatible>
     <IsPackable>false</IsPackable>
     <!-- Keep local library builds usable without the upstream repo's Directory.Build.props. -->
-    <NoWarn>$(NoWarn);CS1591;IDE0051</NoWarn>
+    <!--
+      Vendored upstream code (adamhathcock/sharpcompress port): exempt from the
+      repo-wide latest-All analyzer policy (see root Directory.Build.props).
+      The CA list below is the union of every CA rule enabled by
+      Microsoft.CodeAnalysis.NetAnalyzers 10.0.302 under latest-All that fires
+      anywhere in the first-party solution; pinning the analyzer package keeps
+      this list stable. New rules appearing after a deliberate analyzer bump
+      should be triaged, not blanket-added. Do not fix these warnings in-tree
+      beyond this suppression — diverging from upstream complicates ports.
+      See CONTRIBUTING.md "Static analysis policy".
+    -->
+    <NoWarn>$(NoWarn);CS1591;IDE0051;CA1001;CA1002;CA1008;CA1024;CA1031;CA1032;CA1034;CA1040;CA1050;CA1051;CA1052;CA1054;CA1055;CA1056;CA1062;CA1063;CA1068;CA1303;CA1304;CA1305;CA1307;CA1308;CA1309;CA1310;CA1311;CA1508;CA1510;CA1512;CA1513;CA1515;CA1707;CA1711;CA1716;CA1720;CA1724;CA1725;CA1802;CA1805;CA1806;CA1810;CA1812;CA1813;CA1814;CA1815;CA1816;CA1819;CA1820;CA1822;CA1823;CA1826;CA1828;CA1835;CA1836;CA1844;CA1849;CA1851;CA1852;CA1859;CA1861;CA1862;CA1866;CA1869;CA1875;CA2000;CA2007;CA2008;CA2016;CA2022;CA2025;CA2100;CA2101;CA2201;CA2208;CA2213;CA2215;CA2225;CA2227;CA2234;CA2249;CA3003;CA5351;CA5359;CA5387;CA5392;CA5394;CA5398;CA5399;CA5401;CA1012;CA1027;CA1028;CA1033;CA1065;CA1066;CA1700;CA1721;CA2214</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Hashing" Version="10.0.10" />

--- a/libs/UsenetSharp/.editorconfig
+++ b/libs/UsenetSharp/.editorconfig
@@ -24,3 +24,58 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# ==========================================================================
+# Analyzer policy — mirrors the repository root .editorconfig (this file has
+# root = true, so the root policy does not flow in). Keep in sync with the
+# root "Analyzer policy" section. See CONTRIBUTING.md "Static analysis
+# policy".
+# ==========================================================================
+[*.cs]
+
+# Justification: protocol DTOs expose collections/arrays/fields directly by
+# design; this library's public surface is consumed only by this repo.
+dotnet_diagnostic.CA1002.severity = none
+dotnet_diagnostic.CA1819.severity = none
+dotnet_diagnostic.CA2227.severity = none
+dotnet_diagnostic.CA1051.severity = none
+dotnet_diagnostic.CA1034.severity = none
+# Justification: nullable reference types guard call sites; per-parameter
+# null re-validation duplicates that.
+dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.CA1008.severity = none
+dotnet_diagnostic.CA1024.severity = none
+dotnet_diagnostic.CA1040.severity = none
+# Justification: NNTP endpoints are configured as strings by design.
+dotnet_diagnostic.CA1054.severity = none
+dotnet_diagnostic.CA1055.severity = none
+dotnet_diagnostic.CA1056.severity = none
+dotnet_diagnostic.CA2234.severity = none
+# Justification: operator-overload alternate-method naming does not apply to
+# protocol value types.
+dotnet_diagnostic.CA2225.severity = none
+# Justification: connection/streaming code intentionally catches broadly at
+# layer boundaries; the AGENTS.md exception-logging policy governs.
+dotnet_diagnostic.CA1031.severity = none
+# Justification: exceptions define only the constructors they use (YAGNI).
+dotnet_diagnostic.CA1032.severity = none
+# Justification: no localization; NNTP/yEnc data is invariant ASCII.
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
+# Justification: identifiers follow protocol/field names (NNTP, yEnc).
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1711.severity = none
+dotnet_diagnostic.CA1716.severity = none
+dotnet_diagnostic.CA1720.severity = none
+dotnet_diagnostic.CA1724.severity = none
+dotnet_diagnostic.CA1725.severity = none
+# Justification: the public API is the repo-internal contract; hiding it adds
+# nothing.
+dotnet_diagnostic.CA1515.severity = none
+# Justification: repeated false positives under nullable flow analysis in
+# decoder state machines.
+dotnet_diagnostic.CA1508.severity = none
+dotnet_diagnostic.CA1852.severity = none
+dotnet_diagnostic.CA2100.severity = none
+dotnet_diagnostic.CA3003.severity = none

--- a/libs/UsenetSharp/.editorconfig
+++ b/libs/UsenetSharp/.editorconfig
@@ -73,6 +73,10 @@ dotnet_diagnostic.CA1725.severity = none
 # Justification: the public API is the repo-internal contract; hiding it adds
 # nothing.
 dotnet_diagnostic.CA1515.severity = none
+# Justification: C#-only consumers; positional record parameters deliberately
+# pair camelCase ctor parameters with PascalCase properties (SegmentId.value /
+# SegmentId.Value).
+dotnet_diagnostic.CA1708.severity = none
 # Justification: repeated false positives under nullable flow analysis in
 # decoder state machines.
 dotnet_diagnostic.CA1508.severity = none

--- a/libs/UsenetSharp/Clients/CoalescedReadTimeout.cs
+++ b/libs/UsenetSharp/Clients/CoalescedReadTimeout.cs
@@ -15,9 +15,9 @@ internal sealed class CoalescedReadTimeout : IDisposable
     private bool _disposed;
 
     public CoalescedReadTimeout(
-        CancellationToken operationToken,
         TimeSpan timeout,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        CancellationToken operationToken)
     {
         _operationToken = operationToken;
         _timeout = timeout;

--- a/libs/UsenetSharp/Clients/UsenetClient.ArticleAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.ArticleAsync.cs
@@ -39,9 +39,10 @@ public partial class UsenetClient
             ThrowIfDisposed();
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
+            #pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
             operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            #pragma warning restore CA2000
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,
@@ -68,8 +69,10 @@ public partial class UsenetClient
 
                 // Start background task to read the body and write to pipe
                 isReadBodyToPipeAsyncStarted = true;
+                #pragma warning disable CA2025 // the background body-read task owns and disposes the pipe writer and operationCts (see the streaming lifecycle invariants); the caller awaits/disposes the reader side
                 _ = ReadBodyToPipeAsync(
-                    pipe.Writer, operationCts, cancellationToken, onConnectionReadyAgain);
+                                    pipe.Writer, operationCts, onConnectionReadyAgain, cancellationToken);
+                #pragma warning restore CA2025
                 operationCts = null;
 
                 // Return immediately with the stream and headers
@@ -207,7 +210,7 @@ public partial class UsenetClient
                 CommitCurrentHeader();
 
                 // Parse new header: "Name: Value"
-                var colonIndex = line.IndexOf(':');
+                var colonIndex = line.IndexOf(':', StringComparison.Ordinal);
                 if (colonIndex > 0)
                 {
                     headerCount++;

--- a/libs/UsenetSharp/Clients/UsenetClient.ArticleAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.ArticleAsync.cs
@@ -39,9 +39,9 @@ public partial class UsenetClient
             ThrowIfDisposed();
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
-            #pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
+#pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
             operationCts = CreateOperationTokenSource(cancellationToken);
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
             using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
@@ -69,10 +69,10 @@ public partial class UsenetClient
 
                 // Start background task to read the body and write to pipe
                 isReadBodyToPipeAsyncStarted = true;
-                #pragma warning disable CA2025 // the background body-read task owns and disposes the pipe writer and operationCts (see the streaming lifecycle invariants); the caller awaits/disposes the reader side
+#pragma warning disable CA2025 // the background body-read task owns and disposes the pipe writer and operationCts (see the streaming lifecycle invariants); the caller awaits/disposes the reader side
                 _ = ReadBodyToPipeAsync(
                                     pipe.Writer, operationCts, onConnectionReadyAgain, cancellationToken);
-                #pragma warning restore CA2025
+#pragma warning restore CA2025
                 operationCts = null;
 
                 // Return immediately with the stream and headers

--- a/libs/UsenetSharp/Clients/UsenetClient.AuthenticateAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.AuthenticateAsync.cs
@@ -42,8 +42,7 @@ public partial class UsenetClient
             }
 
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (userResponseCode, userResponse) = await ExchangeSingleLineAsync(
                 ioTimeout,

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -47,9 +47,9 @@ public partial class UsenetClient
             ThrowIfDisposed();
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
-            #pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
+#pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
             operationCts = CreateOperationTokenSource(cancellationToken);
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
             using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
@@ -66,10 +66,10 @@ public partial class UsenetClient
 
                 // Start background task to read the body and write to pipe
                 isReadBodyToPipeAsyncStarted = true;
-                #pragma warning disable CA2025 // the background body-read task owns and disposes the pipe writer and operationCts; the caller awaits/disposes the reader side
+#pragma warning disable CA2025 // the background body-read task owns and disposes the pipe writer and operationCts; the caller awaits/disposes the reader side
                 _ = ReadBodyToPipeAsync(
                                     pipe.Writer, operationCts, onConnectionReadyAgain, cancellationToken);
-                #pragma warning restore CA2025
+#pragma warning restore CA2025
                 operationCts = null;
 
                 // Return immediately with the stream and headers
@@ -138,9 +138,9 @@ public partial class UsenetClient
             ThrowIfDisposed();
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
-            #pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
+#pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
             operationCts = CreateOperationTokenSource(cancellationToken);
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
             using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
@@ -159,7 +159,7 @@ public partial class UsenetClient
                         TaskCreationOptions.RunContinuationsAsynchronously);
 
                 isReadBodyToPipeAsyncStarted = true;
-                #pragma warning disable CA2025 // the background decode task owns and disposes the pipe writer, operationCts and decoded stream; completion is coordinated through headersCompletion and the response callbacks
+#pragma warning disable CA2025 // the background decode task owns and disposes the pipe writer, operationCts and decoded stream; completion is coordinated through headersCompletion and the response callbacks
                 _ = ReadDecodedBodyToPipeAsync(
                                     pipe.Writer,
                     headersCompletion,
@@ -167,7 +167,7 @@ public partial class UsenetClient
                     onConnectionReadyAgain,
                     decodedStream,
                     callerCancellationToken: cancellationToken);
-                #pragma warning restore CA2025
+#pragma warning restore CA2025
                 operationCts = null;
 
                 return new UsenetDecodedBodyResponse

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -47,9 +47,10 @@ public partial class UsenetClient
             ThrowIfDisposed();
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
+            #pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
             operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            #pragma warning restore CA2000
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,
@@ -65,8 +66,10 @@ public partial class UsenetClient
 
                 // Start background task to read the body and write to pipe
                 isReadBodyToPipeAsyncStarted = true;
+                #pragma warning disable CA2025 // the background body-read task owns and disposes the pipe writer and operationCts; the caller awaits/disposes the reader side
                 _ = ReadBodyToPipeAsync(
-                    pipe.Writer, operationCts, cancellationToken, onConnectionReadyAgain);
+                                    pipe.Writer, operationCts, onConnectionReadyAgain, cancellationToken);
+                #pragma warning restore CA2025
                 operationCts = null;
 
                 // Return immediately with the stream and headers
@@ -135,9 +138,10 @@ public partial class UsenetClient
             ThrowIfDisposed();
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
+            #pragma warning disable CA2000 // operationCts ownership transfers to the background body-read task (which disposes it on completion) via the `operationCts = null` handoff below; the finally disposes it only on non-transferred paths
             operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            #pragma warning restore CA2000
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,
@@ -155,13 +159,15 @@ public partial class UsenetClient
                         TaskCreationOptions.RunContinuationsAsynchronously);
 
                 isReadBodyToPipeAsyncStarted = true;
+                #pragma warning disable CA2025 // the background decode task owns and disposes the pipe writer, operationCts and decoded stream; completion is coordinated through headersCompletion and the response callbacks
                 _ = ReadDecodedBodyToPipeAsync(
-                    pipe.Writer,
+                                    pipe.Writer,
                     headersCompletion,
                     operationCts,
-                    cancellationToken,
                     onConnectionReadyAgain,
-                    decodedStream);
+                    decodedStream,
+                    callerCancellationToken: cancellationToken);
+                #pragma warning restore CA2025
                 operationCts = null;
 
                 return new UsenetDecodedBodyResponse
@@ -199,12 +205,12 @@ public partial class UsenetClient
         PipeWriter writer,
         TaskCompletionSource<UsenetYencHeader?> headersCompletion,
         CancellationTokenSource operationCts,
-        CancellationToken callerCancellationToken,
         ArticleBodyCompletionHandler? onConnectionReadyAgain,
         DecodedBodyReadStream decodedStream,
         bool releaseCommandLock = true,
         CoalescedReadTimeout? sharedReadTimeout = null,
-        BatchDecodeBuffer? sharedEncodedBuffer = null)
+        BatchDecodeBuffer? sharedEncodedBuffer = null,
+        CancellationToken callerCancellationToken = default)
     {
         Exception? failure = null;
         var connectionReusable = true;
@@ -242,8 +248,7 @@ public partial class UsenetClient
             var cancellationToken = operationCts.Token;
             if (sharedReadTimeout == null)
             {
-                ownedReadTimeout = new CoalescedReadTimeout(
-                    cancellationToken, _options.ReadTimeout, _timeProvider);
+                ownedReadTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, cancellationToken);
             }
 
             var readTimeout = sharedReadTimeout ?? ownedReadTimeout!;
@@ -291,8 +296,8 @@ public partial class UsenetClient
                             decoderState,
                             decodedCrc32,
                             _options.CrcValidation != YencCrcValidationMode.Off,
-                            cancellationToken,
-                            decodedStream).ConfigureAwait(false);
+                            decodedStream,
+                            cancellationToken).ConfigureAwait(false);
                         decoderState = flush.DecoderState;
                         decodedCrc32 = flush.Crc32;
                     }
@@ -379,8 +384,8 @@ public partial class UsenetClient
                             decoderState,
                             decodedCrc32,
                             _options.CrcValidation != YencCrcValidationMode.Off,
-                            cancellationToken,
-                            decodedStream).ConfigureAwait(false);
+                            decodedStream,
+                            cancellationToken).ConfigureAwait(false);
                         encodedLength = 0;
                         decoderState = flush.DecoderState;
                         decodedCrc32 = flush.Crc32;
@@ -406,8 +411,8 @@ public partial class UsenetClient
                         decoderState,
                         decodedCrc32,
                         _options.CrcValidation != YencCrcValidationMode.Off,
-                        cancellationToken,
-                        decodedStream).ConfigureAwait(false);
+                        decodedStream,
+                        cancellationToken).ConfigureAwait(false);
                     encodedLength = 0;
                     decoderState = flush.DecoderState;
                     decodedCrc32 = flush.Crc32;
@@ -441,8 +446,8 @@ public partial class UsenetClient
                         decoderState,
                         decodedCrc32,
                         _options.CrcValidation != YencCrcValidationMode.Off,
-                        cancellationToken,
-                        decodedStream).ConfigureAwait(false);
+                        decodedStream,
+                        cancellationToken).ConfigureAwait(false);
                     encodedLength = 0;
                     decoderState = flush.DecoderState;
                     decodedCrc32 = flush.Crc32;
@@ -543,8 +548,8 @@ public partial class UsenetClient
         RapidYencDecoderState? decoderState,
         uint crc32,
         bool computeCrc32,
-        CancellationToken cancellationToken,
-        DecodedBodyReadStream decodedStream)
+        DecodedBodyReadStream decodedStream,
+        CancellationToken cancellationToken)
     {
         var destination = writer.GetSpan(encoded.Length);
         var decodedLength = YencDecoder.DecodeEx(
@@ -664,8 +669,8 @@ public partial class UsenetClient
     private async Task ReadBodyToPipeAsync(
         PipeWriter writer,
         CancellationTokenSource operationCts,
-        CancellationToken callerCancellationToken,
-        ArticleBodyCompletionHandler? onConnectionReadyAgain)
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken callerCancellationToken)
     {
         Exception? failure = null;
         try
@@ -679,8 +684,7 @@ public partial class UsenetClient
             long drainedBytes = 0;
             var unflushed = 0;
             var cancellationToken = operationCts.Token;
-            using var readTimeout = new CoalescedReadTimeout(
-                cancellationToken, _options.ReadTimeout, _timeProvider);
+            using var readTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, cancellationToken);
 
             // Read lines until we encounter the termination sequence (single dot on a line)
             while (true)
@@ -802,8 +806,7 @@ public partial class UsenetClient
         try
         {
             using var drainCts = CreateOperationTokenSource(CancellationToken.None);
-            using var readTimeout = new CoalescedReadTimeout(
-                drainCts.Token, _options.ReadTimeout, _timeProvider);
+            using var readTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, drainCts.Token);
             long drainedBytes = 0;
 
             while (true)

--- a/libs/UsenetSharp/Clients/UsenetClient.CapabilitiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.CapabilitiesAsync.cs
@@ -27,8 +27,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,
@@ -94,8 +93,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,

--- a/libs/UsenetSharp/Clients/UsenetClient.ConnectAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.ConnectAsync.cs
@@ -50,13 +50,14 @@ public partial class UsenetClient
                 await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
                 {
                     TargetHost = host,
-                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 |
-                                          System.Security.Authentication.SslProtocols.Tls13,
+                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.None, // let the OS choose (TLS 1.2+ on all supported platforms; picks up future versions automatically)
                     CertificateRevocationCheckMode = _options.SkipTlsVerification
                         ? X509RevocationMode.NoCheck
                         : _options.CertificateRevocationCheckMode,
+#pragma warning disable CA5359 // deliberate: behind the explicit SkipTlsVerification option for providers with broken/self-signed certs
                     RemoteCertificateValidationCallback = _options.SkipTlsVerification
                         ? static (_, _, _, _) => true
+#pragma warning restore CA5359
                         : null
                 }, operationCts.Token).ConfigureAwait(false);
                 _stream = sslStream;
@@ -66,8 +67,7 @@ public partial class UsenetClient
             _reader = new NntpLineReader(_stream);
 
             // Read the server response
-            using var greetingTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var greetingTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
             var response = await ReadLineAsync(greetingTimeout).ConfigureAwait(false);
             var responseCode = ParseResponseCode(response);
 

--- a/libs/UsenetSharp/Clients/UsenetClient.DateAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DateAsync.cs
@@ -15,8 +15,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -81,8 +81,7 @@ public partial class UsenetClient
             ThrowIfNotConnected();
 
             using (var operationCts = CreateOperationTokenSource(cancellationToken))
-            using (var writeTimeout = new CoalescedReadTimeout(
-                       operationCts.Token, _options.ReadTimeout, _timeProvider))
+            using (var writeTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token))
             {
                 // Bytes may reach the wire from here on (RFC 3977 §3.5).
                 writeStarted = true;
@@ -103,8 +102,8 @@ public partial class UsenetClient
             var completion = ProcessDecodedBodyBatchAsync(
                 segments,
                 completions,
-                cancellationToken,
-                onConnectionReadyAgain);
+                onConnectionReadyAgain,
+                cancellationToken);
 
             return new UsenetDecodedBodyBatch
             {
@@ -217,11 +216,11 @@ public partial class UsenetClient
     }
 
     private async ValueTask WritePipelinedBodyCommandsAsync(
-        IReadOnlyList<SegmentId> segments,
+        SegmentId[] segments,
         CoalescedReadTimeout ioTimeout)
     {
         var totalLength = 0;
-        for (var index = 0; index < segments.Count; index++)
+        for (var index = 0; index < segments.Length; index++)
         {
             // "BODY <id>\r\n"
             totalLength += 4 + 1 + 1 + segments[index].Value.Length + 1 + 2;
@@ -231,7 +230,7 @@ public partial class UsenetClient
         try
         {
             var written = 0;
-            for (var index = 0; index < segments.Count; index++)
+            for (var index = 0; index < segments.Length; index++)
             {
                 written += FormatBodyCommand(buffer.AsSpan(written), segments[index]);
             }
@@ -256,18 +255,17 @@ public partial class UsenetClient
     }
 
     private async Task ProcessDecodedBodyBatchAsync(
-        IReadOnlyList<SegmentId> segmentIds,
-        IReadOnlyList<TaskCompletionSource<UsenetDecodedBodyResponse>> completions,
-        CancellationToken callerCancellationToken,
-        ArticleBodyCompletionHandler? onConnectionReadyAgain)
+        SegmentId[] segmentIds,
+        TaskCompletionSource<UsenetDecodedBodyResponse>[] completions,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken callerCancellationToken)
     {
         Exception? failure = null;
         var completionResult = ArticleBodyResult.Retrieved;
         string? completionReason = null;
         var nextResponseIndex = 0;
         using var operationCts = CreateOperationTokenSource(callerCancellationToken);
-        using var sharedReadTimeout = new CoalescedReadTimeout(
-            operationCts.Token, _options.ReadTimeout, _timeProvider);
+        using var sharedReadTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
         var sharedEncodedBuffer = new BatchDecodeBuffer
         {
             Buffer = ArrayPool<byte>.Shared.Rent(DecodedBodyChunkSize + 2)
@@ -275,7 +273,7 @@ public partial class UsenetClient
 
         try
         {
-            while (nextResponseIndex < segmentIds.Count)
+            while (nextResponseIndex < segmentIds.Length)
             {
                 var segmentId = segmentIds[nextResponseIndex];
                 var response = await ReadLineAsync(sharedReadTimeout).ConfigureAwait(false);
@@ -324,12 +322,12 @@ public partial class UsenetClient
                         pipe.Writer,
                         headersCompletion,
                         operationCts,
-                        callerCancellationToken,
                         onConnectionReadyAgain: null,
                         decodedStream: decodedStream,
                         releaseCommandLock: false,
                         sharedReadTimeout: sharedReadTimeout,
-                        sharedEncodedBuffer: sharedEncodedBuffer)
+                        sharedEncodedBuffer: sharedEncodedBuffer,
+                        callerCancellationToken: callerCancellationToken)
                     .ConfigureAwait(false);
                 if (bodyReadResult.Failure == null)
                 {
@@ -354,7 +352,7 @@ public partial class UsenetClient
                 }
 
                 var drainFailure = await TryDrainPipelinedBodiesAsync(
-                        segmentIds.Count - nextResponseIndex)
+                        segmentIds.Length - nextResponseIndex)
                     .ConfigureAwait(false);
                 if (drainFailure != null)
                 {
@@ -388,7 +386,7 @@ public partial class UsenetClient
             else
             {
                 var drainFailure = await TryDrainPipelinedBodiesAsync(
-                        segmentIds.Count - nextResponseIndex)
+                        segmentIds.Length - nextResponseIndex)
                     .ConfigureAwait(false);
                 if (drainFailure != null)
                 {
@@ -416,7 +414,7 @@ public partial class UsenetClient
             ArrayPool<byte>.Shared.Return(sharedEncodedBuffer.Buffer);
             if (failure != null)
             {
-                for (var index = nextResponseIndex; index < completions.Count; index++)
+                for (var index = nextResponseIndex; index < completions.Length; index++)
                 {
                     completions[index].TrySetException(failure);
                 }

--- a/libs/UsenetSharp/Clients/UsenetClient.HeadAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.HeadAsync.cs
@@ -16,8 +16,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,

--- a/libs/UsenetSharp/Clients/UsenetClient.QuitAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.QuitAsync.cs
@@ -19,8 +19,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
             var (code, line) = await ExchangeSingleLineAsync(
                 ioTimeout,
                 QuitCommand,

--- a/libs/UsenetSharp/Clients/UsenetClient.StatAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.StatAsync.cs
@@ -15,8 +15,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,

--- a/libs/UsenetSharp/Clients/UsenetClient.StatPipelinedAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.StatPipelinedAsync.cs
@@ -46,8 +46,7 @@ public partial class UsenetClient
             ThrowIfNotConnected();
 
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var depth = Math.Min(_options.MaxPipelineDepth, segments.Length);
             var results = new UsenetStatResponse[segments.Length];
@@ -139,7 +138,7 @@ public partial class UsenetClient
     }
 
     private async ValueTask WritePipelinedStatCommandsAsync(
-        IReadOnlyList<SegmentId> segments,
+        SegmentId[] segments,
         int start,
         int count,
         CoalescedReadTimeout ioTimeout)
@@ -181,7 +180,7 @@ public partial class UsenetClient
 
     private static void ThrowIfDesyncedStatEcho(string line, SegmentId expected)
     {
-        var open = line.IndexOf('<');
+        var open = line.IndexOf('<', StringComparison.Ordinal);
         if (open < 0)
         {
             return;

--- a/libs/UsenetSharp/Clients/UsenetClient.YencHeadersAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.YencHeadersAsync.cs
@@ -47,8 +47,7 @@ public partial class UsenetClient
             ThrowIfUnhealthy();
             ThrowIfNotConnected();
             using var operationCts = CreateOperationTokenSource(cancellationToken);
-            using var ioTimeout = new CoalescedReadTimeout(
-                operationCts.Token, _options.ReadTimeout, _timeProvider);
+            using var ioTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
 
             var (responseCode, response) = await ExchangeSingleLineAsync(
                 ioTimeout,
@@ -104,8 +103,7 @@ public partial class UsenetClient
         byte[]? ybeginBuffer = null;
         try
         {
-            using var readTimeout = new CoalescedReadTimeout(
-                cancellationToken, _options.ReadTimeout, _timeProvider);
+            using var readTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, cancellationToken);
             var ybeginLength = 0;
             long skippedBytes = 0;
 

--- a/libs/UsenetSharp/Clients/UsenetClient.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.cs
@@ -134,6 +134,13 @@ public partial class UsenetClient : IUsenetClient, IDisposable, IAsyncDisposable
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing) return;
         if (Interlocked.Exchange(ref _disposeState, 1) != 0)
         {
             return;
@@ -145,7 +152,6 @@ public partial class UsenetClient : IUsenetClient, IDisposable, IAsyncDisposable
         // Dispose the semaphore while still holding it so queued waiters are
         // faulted instead of being granted a lock that is about to be disposed.
         _commandLock.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     public async ValueTask DisposeAsync()

--- a/libs/UsenetSharp/Concurrency/AsyncSemaphore.cs
+++ b/libs/UsenetSharp/Concurrency/AsyncSemaphore.cs
@@ -125,6 +125,6 @@ public class AsyncSemaphore : IDisposable
         }
 
         foreach (var tcs in waitersToCancel)
-            tcs.TrySetException(new ObjectDisposedException(nameof(AsyncSemaphore)));
+            tcs.TrySetException(new ObjectDisposedException(typeof(AsyncSemaphore).FullName));
     }
 }

--- a/libs/UsenetSharp/Concurrency/AsyncSemaphore.cs
+++ b/libs/UsenetSharp/Concurrency/AsyncSemaphore.cs
@@ -4,12 +4,12 @@ public class AsyncSemaphore : IDisposable
 {
     private readonly LinkedList<TaskCompletionSource<bool>> _waiters = new();
     private int _currentCount;
-    private bool _disposed = false;
+    private bool _disposed;
     private readonly object _lock = new();
 
     public AsyncSemaphore(int initialCount)
     {
-        if (initialCount < 0) throw new ArgumentOutOfRangeException(nameof(initialCount));
+        ArgumentOutOfRangeException.ThrowIfNegative(initialCount);
         _currentCount = initialCount;
     }
 
@@ -33,8 +33,7 @@ public class AsyncSemaphore : IDisposable
     {
         lock (_lock)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(AsyncSemaphore));
+            ObjectDisposedException.ThrowIf(_disposed, this);
 
             if (_currentCount > 0)
             {
@@ -109,6 +108,13 @@ public class AsyncSemaphore : IDisposable
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing) return;
         List<TaskCompletionSource<bool>> waitersToCancel;
         lock (_lock)
         {

--- a/libs/UsenetSharp/Models/SegmentId.cs
+++ b/libs/UsenetSharp/Models/SegmentId.cs
@@ -1,8 +1,11 @@
+using System;
+
 namespace UsenetSharp.Models;
 
-public readonly struct SegmentId(string? value)
+public readonly record struct SegmentId(string? value)
 {
     private readonly string _value = value ?? string.Empty;
+
 
     public ReadOnlySpan<char> Value
     {

--- a/libs/UsenetSharp/Streams/YencStream.cs
+++ b/libs/UsenetSharp/Streams/YencStream.cs
@@ -82,7 +82,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
 
         if (!_headersRead)
         {
-            await ParseHeadersAsync(cancellationToken);
+            await ParseHeadersAsync(cancellationToken).ConfigureAwait(false);
             _headersRead = true;
         }
 
@@ -99,7 +99,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
         // Parse headers on first read
         if (!_headersRead)
         {
-            await ParseHeadersAsync(cancellationToken);
+            await ParseHeadersAsync(cancellationToken).ConfigureAwait(false);
             _headersRead = true;
         }
 
@@ -123,7 +123,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
             else
             {
                 // Need to decode next line
-                var lineMemory = await ReadNextLineAsync(cancellationToken);
+                var lineMemory = await ReadNextLineAsync(cancellationToken).ConfigureAwait(false);
 
                 if (!lineMemory.HasValue)
                 {
@@ -181,7 +181,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
             // Ensure we have data in read buffer
             if (_readBufferPosition >= _readBufferLength)
             {
-                bool hasMoreData = await FillReadBufferAsync(cancellationToken);
+                bool hasMoreData = await FillReadBufferAsync(cancellationToken).ConfigureAwait(false);
                 if (!hasMoreData && _lineAssemblyLength == 0)
                 {
                     return null;
@@ -283,7 +283,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
     private async ValueTask<bool> FillReadBufferAsync(CancellationToken cancellationToken)
     {
         _readBufferPosition = 0;
-        _readBufferLength = await _innerStream.ReadAsync(_readBuffer.AsMemory(0, ReadBufferSize), cancellationToken);
+        _readBufferLength = await _innerStream.ReadAsync(_readBuffer.AsMemory(0, ReadBufferSize), cancellationToken).ConfigureAwait(false);
         return _readBufferLength > 0;
     }
 
@@ -296,7 +296,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
             // Read lines until we find =ybegin (skip empty lines that may appear before it)
             while (true)
             {
-                var lineMemory = await ReadNextLineAsync(cancellationToken);
+                var lineMemory = await ReadNextLineAsync(cancellationToken).ConfigureAwait(false);
 
                 if (!lineMemory.HasValue)
                 {
@@ -319,7 +319,7 @@ public class YencStream : FastReadOnlyNonSeekableStream
             }
 
             // Check if next line is =ypart or encoded data
-            var nextLineMemory = await ReadNextLineAsync(cancellationToken);
+            var nextLineMemory = await ReadNextLineAsync(cancellationToken).ConfigureAwait(false);
             var nextLineSpan = nextLineMemory.HasValue
                 ? nextLineMemory.Value.Span
                 : ReadOnlySpan<byte>.Empty;

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,59 @@
+# Test-project analyzer policy — extends the repository root .editorconfig
+# (no `root = true` here on purpose). See CONTRIBUTING.md "Static analysis
+# policy". Compiler (CS) warnings are NOT relaxed: nullable and other compiler
+# warnings in tests must be fixed like anywhere else.
+
+[*.cs]
+
+# Justification: xUnit test methods use descriptive Snake_Case names.
+dotnet_diagnostic.CA1707.severity = none
+# Justification: ConfigureAwait adds no value inside test bodies; xUnit
+# controls the synchronization context.
+dotnet_diagnostic.CA2007.severity = none
+# Justification: test-scoped disposables are torn down by the test runner /
+# collection fixtures; per-local dispose tracking is noise.
+dotnet_diagnostic.CA2000.severity = none
+dotnet_diagnostic.CA2213.severity = none
+dotnet_diagnostic.CA1001.severity = none
+dotnet_diagnostic.CA1063.severity = none
+dotnet_diagnostic.CA1816.severity = none
+dotnet_diagnostic.CA2215.severity = none
+# Justification: culture/StringComparison correctness is a product-code
+# concern; tests assert on fixed English fixtures.
+dotnet_diagnostic.CA1307.severity = none
+dotnet_diagnostic.CA1308.severity = none
+dotnet_diagnostic.CA1309.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1311.severity = none
+# Justification: tests freely throw Exception/aggregate failures; reserved-type
+# and CancellationToken-plumbing rules target product code.
+dotnet_diagnostic.CA2201.severity = none
+dotnet_diagnostic.CA2016.severity = none
+dotnet_diagnostic.CA1849.severity = none
+dotnet_diagnostic.CA2025.severity = none
+# Justification: micro-performance rules (static members, concrete types,
+# cached arrays) are irrelevant in test code.
+dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1859.severity = none
+dotnet_diagnostic.CA1861.severity = none
+dotnet_diagnostic.CA1826.severity = none
+dotnet_diagnostic.CA1828.severity = none
+dotnet_diagnostic.CA1835.severity = none
+dotnet_diagnostic.CA1844.severity = none
+dotnet_diagnostic.CA1869.severity = none
+dotnet_diagnostic.CA1806.severity = none
+dotnet_diagnostic.CA1052.severity = none
+dotnet_diagnostic.CA1512.severity = none
+dotnet_diagnostic.CA1513.severity = none
+dotnet_diagnostic.CA1812.severity = none
+# Justification: test fixtures generate non-security random data, pin TLS
+# versions for compatibility matrix coverage, exercise P/Invoke marshaling,
+# and decrypt spec-mandated archive IVs on purpose.
+dotnet_diagnostic.CA5394.severity = none
+dotnet_diagnostic.CA5398.severity = none
+dotnet_diagnostic.CA5392.severity = none
+dotnet_diagnostic.CA5401.severity = none
+dotnet_diagnostic.CA2101.severity = none
+# Justification: Stream.Read exact-length checks are product-code concerns;
+# tests read in-memory buffers where short reads do not occur.
+dotnet_diagnostic.CA2022.severity = none

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
@@ -18,9 +18,9 @@ public class ArticleCachingNntpClientTests
         using var client = new ArticleCachingNntpClient(inner);
 
         var first = await client.DecodedBodyAsync("segment", CancellationToken.None);
-        var firstBytes = await ReadAllAsync(first.Stream);
+        var firstBytes = await ReadAllAsync(first.Stream!);
         var second = await client.DecodedBodyAsync("segment", CancellationToken.None);
-        var secondBytes = await ReadAllAsync(second.Stream);
+        var secondBytes = await ReadAllAsync(second.Stream!);
 
         Assert.Equal("cached payload", Encoding.ASCII.GetString(firstBytes));
         Assert.Equal(firstBytes, secondBytes);
@@ -38,14 +38,14 @@ public class ArticleCachingNntpClientTests
         });
         using var client = new ArticleCachingNntpClient(inner);
         var cached = await client.DecodedBodyAsync("one", CancellationToken.None);
-        await ReadAllAsync(cached.Stream);
+        await ReadAllAsync(cached.Stream!);
 
         var batch = await client.DecodedBodiesAsync(
             ["one", "two"], onConnectionReadyAgain: null, CancellationToken.None);
         var responses = await Task.WhenAll(batch.Responses);
         var bodies = new List<string>();
         foreach (var response in responses)
-            bodies.Add(Encoding.ASCII.GetString(await ReadAllAsync(response.Stream)));
+            bodies.Add(Encoding.ASCII.GetString(await ReadAllAsync(response.Stream!)));
 
         Assert.Equal(new[] { "one", "two" }, bodies);
         Assert.Equal(1, inner.BatchRequestCount);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -299,8 +299,9 @@ public class MultiProviderNntpClientTests
         var results = await CollectPipelinedAsync(client, ["segment"], 1);
         Assert.Single(results);
         Assert.True(results[0].Found);
-        if (results[0].Stream != null)
-            await results[0].Stream.DisposeAsync();
+        var firstStream = results[0].Stream;
+        if (firstStream != null)
+            await firstStream.DisposeAsync();
 
         // Exactly one fetch — must not double-count override metrics + DecodedBodiesAsync.
         Assert.Equal(1, writer.Stats.QueuedFetches);

--- a/tests/NzbWebDAV.Tests/Database/DeserializeOrFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DeserializeOrFallbackTests.cs
@@ -11,7 +11,7 @@ public class DeserializeOrFallbackTests
     public void DeserializeOrFallback_ReadsJsonArray()
     {
         var result = DavDatabaseContext.DeserializeOrFallback<string[]>("[\"a\",\"b\"]");
-        Assert.Equal(["a", "b"], result);
+        Assert.Equal(["a", "b"], result!);
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class DeserializeOrFallbackTests
         var encoded = EncodeBase64Brotli(json);
 
         var result = DavDatabaseContext.DeserializeOrFallback<string[]>(encoded);
-        Assert.Equal(["seg1", "seg2"], result);
+        Assert.Equal(["seg1", "seg2"], result!);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
+++ b/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
@@ -87,7 +87,7 @@ public class NzbDocumentTests
     {
         await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("<nzb><file>"));
 
-        var exception = await Assert.ThrowsAsync<Exception>(
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
             () => NzbDocument.LoadAsync(stream));
 
         Assert.Equal("Could not parse the nzb document (malformed nzb)", exception.Message);

--- a/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueFanOutTests.cs
@@ -45,14 +45,14 @@ public class QueueFanOutTests
     public void GetConcurrency_WithoutContext_UsesPrimaryFanOut()
     {
         var config = CreateConfig(maxQueueConnections: 8);
-        Assert.Equal(13, QueueFanOut.GetConcurrency(CancellationToken.None, config));
+        Assert.Equal(13, QueueFanOut.GetConcurrency(config, CancellationToken.None));
     }
 
     [Fact]
     public void GetExactQueueConcurrency_WithoutContext_UsesMaxQueue()
     {
         var config = CreateConfig(maxQueueConnections: 8);
-        Assert.Equal(8, QueueFanOut.GetExactQueueConcurrency(CancellationToken.None, config));
+        Assert.Equal(8, QueueFanOut.GetExactQueueConcurrency(config, CancellationToken.None));
     }
 
     [Fact]
@@ -66,8 +66,8 @@ public class QueueFanOutTests
             GetFanOutConcurrency = () => QueueFanOut.PrimaryFanOut(10),
         });
 
-        Assert.Equal(15, QueueFanOut.GetConcurrency(cts.Token, config));
-        Assert.Equal(10, QueueFanOut.GetExactQueueConcurrency(cts.Token, config));
+        Assert.Equal(15, QueueFanOut.GetConcurrency(config, cts.Token));
+        Assert.Equal(10, QueueFanOut.GetExactQueueConcurrency(config, cts.Token));
     }
 
     [Fact]
@@ -83,8 +83,8 @@ public class QueueFanOutTests
 
         using var linked = ContextualCancellationTokenSource.CreateLinkedTokenSource(parentCts.Token);
 
-        Assert.Equal(7, QueueFanOut.GetConcurrency(linked.Token, config));
-        Assert.Equal(7, QueueFanOut.GetExactQueueConcurrency(linked.Token, config));
+        Assert.Equal(7, QueueFanOut.GetConcurrency(config, linked.Token));
+        Assert.Equal(7, QueueFanOut.GetExactQueueConcurrency(config, linked.Token));
         Assert.Same(
             parentCts.Token.GetContext<QueueDownloadContext>(),
             linked.Token.GetContext<QueueDownloadContext>());

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -234,7 +234,7 @@ public class ArrLinkedRepairDecisionTests
         Func<Task<List<ArrRootFolder>>> rootFolders,
         Func<string, Guid, Task<ArrRepairOutcome>> removeAndBlocklist) : ArrClient(host, "test-key")
     {
-        public override Task<List<ArrRootFolder>> GetRootFolders() => rootFolders();
+        public override Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct) => rootFolders();
 
         public override Task<ArrRepairOutcome> RemoveAndBlocklist(
             string symlinkOrStrmPath,

--- a/tests/SharpCompress.Tests/SharpCompress.Tests.csproj
+++ b/tests/SharpCompress.Tests/SharpCompress.Tests.csproj
@@ -11,7 +11,12 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RestoreConfigFile>$(MSBuildThisFileDirectory)..\..\backend\nuget.config</RestoreConfigFile>
-    <NoWarn>$(NoWarn);CS1591;IDE0051</NoWarn>
+    <!--
+      Vendored upstream test suite (ported with libs/SharpCompress): exempt
+      from the repo-wide latest-All analyzer policy, same as the library it
+      tests. See libs/SharpCompress/SharpCompress.csproj for the rationale.
+    -->
+    <NoWarn>$(NoWarn);CS1591;IDE0051;CA1001;CA1002;CA1008;CA1024;CA1031;CA1032;CA1034;CA1040;CA1050;CA1051;CA1052;CA1054;CA1055;CA1056;CA1062;CA1063;CA1068;CA1303;CA1304;CA1305;CA1307;CA1308;CA1309;CA1310;CA1311;CA1508;CA1510;CA1512;CA1513;CA1515;CA1707;CA1711;CA1716;CA1720;CA1724;CA1725;CA1802;CA1805;CA1806;CA1810;CA1812;CA1813;CA1814;CA1815;CA1816;CA1819;CA1820;CA1822;CA1823;CA1826;CA1828;CA1835;CA1836;CA1844;CA1849;CA1851;CA1852;CA1859;CA1861;CA1862;CA1866;CA1869;CA1875;CA2000;CA2007;CA2008;CA2016;CA2022;CA2025;CA2100;CA2101;CA2201;CA2208;CA2213;CA2215;CA2225;CA2227;CA2234;CA2249;CA3003;CA5351;CA5359;CA5387;CA5392;CA5394;CA5398;CA5399;CA5401;CA1012;CA1027;CA1028;CA1033;CA1065;CA1066;CA1700;CA1721;CA2214</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>

--- a/tests/UsenetSharp.Tests/Clients/CoalescedReadTimeoutTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/CoalescedReadTimeoutTests.cs
@@ -10,10 +10,7 @@ public class CoalescedReadTimeoutTests
     public void BeginIo_AdvancePastTimeout_CancelsToken()
     {
         var timeProvider = new ManualTimeProvider();
-        using var timeout = new CoalescedReadTimeout(
-            CancellationToken.None,
-            TimeSpan.FromSeconds(1),
-            timeProvider);
+        using var timeout = new CoalescedReadTimeout(TimeSpan.FromSeconds(1), timeProvider, CancellationToken.None);
 
         timeout.BeginIo();
         timeProvider.Advance(TimeSpan.FromSeconds(1));
@@ -27,10 +24,7 @@ public class CoalescedReadTimeoutTests
     {
         var timeProvider = new ManualTimeProvider();
         CoalescedReadTimeout? timeout = null;
-        timeout = new CoalescedReadTimeout(
-            CancellationToken.None,
-            TimeSpan.FromSeconds(1),
-            timeProvider);
+        timeout = new CoalescedReadTimeout(TimeSpan.FromSeconds(1), timeProvider, CancellationToken.None);
 
         using var registration = timeout.Token.Register(() =>
         {
@@ -49,10 +43,7 @@ public class CoalescedReadTimeoutTests
     public void DisposeThenAdvance_CallbackIsSafeNoOp()
     {
         var timeProvider = new ManualTimeProvider();
-        var timeout = new CoalescedReadTimeout(
-            CancellationToken.None,
-            TimeSpan.FromSeconds(1),
-            timeProvider);
+        var timeout = new CoalescedReadTimeout(TimeSpan.FromSeconds(1), timeProvider, CancellationToken.None);
 
         timeout.BeginIo();
         timeout.Dispose();

--- a/tests/UsenetSharp.Tests/Concurrency/AsyncSemaphoreTests.cs
+++ b/tests/UsenetSharp.Tests/Concurrency/AsyncSemaphoreTests.cs
@@ -247,7 +247,7 @@ public class AsyncSemaphoreTests
 
         // Assert
         var ex = Assert.ThrowsAsync<ObjectDisposedException>(async () => await waitTask);
-        Assert.That(ex!.ObjectName, Is.EqualTo("AsyncSemaphore"));
+        Assert.That(ex!.ObjectName, Is.EqualTo(typeof(UsenetSharp.Concurrency.AsyncSemaphore).FullName));
     }
 
     [Test]
@@ -259,7 +259,7 @@ public class AsyncSemaphoreTests
 
         // Act & Assert
         var ex = Assert.Throws<ObjectDisposedException>(() => semaphore.WaitAsync());
-        Assert.That(ex!.ObjectName, Is.EqualTo("AsyncSemaphore"));
+        Assert.That(ex!.ObjectName, Is.EqualTo(typeof(UsenetSharp.Concurrency.AsyncSemaphore).FullName));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Phase 1 of #852: enables the full .NET analyzer set (pinned `Microsoft.CodeAnalysis.NetAnalyzers` 10.0.302, `AnalysisLevel=latest-All`, `EnforceCodeStyleInBuild`) for all first-party projects via a new repo-root `Directory.Build.props`, with the entire ~43k-warning backlog triaged to zero:

- **Rule policy in `.editorconfig`** — library-design/globalization/naming rules that don't fit an ASP.NET app are disabled with written justifications (CA1515, CA1062, CA1031, CA1002, CA1308, CA1861, CA1822, …); security rules (CA53xx) are never disabled rule-wide. Mirrored blocks in `libs/UsenetSharp` / `libs/RapidYencSharp` (they ship their own root editorconfigs); test noise scoped to `tests/.editorconfig`.
- **Vendored SharpCompress + its ported test suite** opt out via per-project `NoWarn` with justification.
- **Real fixes across the codebase**: ConfigureAwait on plain awaits, StringComparison.Ordinal everywhere, async-overloads-in-async-paths (CA1849), dispose-pattern completion (CA2215/CA1063/CA2213/CA2000), CS9107 double-capture refactor of the SAB controllers, concrete-type/perf fixes (CA1859/CA1865), and reserved-exception retypes (CA2201).
- **Justified per-site suppressions** for ownership transfers the analyzer cannot see (Response.OnCompleted scopes, InProgressQueueItem worker tokens, background body-read tasks, happy-eyeballs sockets), each with a written reason.
- **CONTRIBUTING.md** documents the suppression policy (fix-first ordering, when pragma/GlobalSuppressions/editorconfig apply).

Two pre-existing bugs surfaced and fixed along the way: a wrong-hook-dependency in queue-table (`onIsSelectedChanged` for `onIsRemovingChanged`) is in the phase-3 PR; here, `NzbDocument` parse failures now throw `InvalidDataException`.

Note for reviewers: `dotnet format analyzers` misbehaves while the analyzer package is referenced (applies each fix twice — documented in `Directory.Build.props` and CONTRIBUTING.md); bulk fix batches were run with the package temporarily removed, then restored.

## Test plan

- [x] All 9 projects build warning-free in Release (`dotnet build` / `dotnet publish`)
- [x] `dotnet test` NzbWebDAV.Tests (2384 pass), UsenetSharp.Tests (231), RapidYencSharp.Tests (39), SharpCompress.Tests (2124, `format!=stress`)
- [x] `dotnet format whitespace --verify-no-changes` clean on backend/tests/libs folders (CI gate)
- [x] Analyzer-driven behavior changes covered by updated tests (ArrLinkedRepairDecision scripted client, NzbDocument, AsyncSemaphore)

Part of #852. Stacked PR 1 of 6; merge order: this → warnings-as-errors → type-aware ESLint → strict tsconfig → warnings-zero → prettier.