### PR TITLE
chore(lint): enable type-aware ESLint rules and clear all errors

### DIFF
--- a/frontend/app/auth/auth-middleware.server.test.ts
+++ b/frontend/app/auth/auth-middleware.server.test.ts
@@ -17,7 +17,7 @@ function mockReq(path: string): express.Request {
 function mockRes() {
   return {
     redirect: vi.fn(),
-  } as unknown as express.Response & { redirect: ReturnType<typeof vi.fn> };
+  } as unknown as Omit<express.Response, "redirect"> & { redirect: ReturnType<typeof vi.fn> };
 }
 
 beforeEach(() => {
@@ -37,7 +37,7 @@ describe("authMiddleware", () => {
     const next = vi.fn();
     const res = mockRes();
 
-    await authMiddleware(mockReq(path), res, next);
+    await authMiddleware(mockReq(path), res as unknown as express.Response, next);
 
     expect(next).toHaveBeenCalledOnce();
     expect(res.redirect).not.toHaveBeenCalled();
@@ -49,7 +49,7 @@ describe("authMiddleware", () => {
     const next = vi.fn();
     const res = mockRes();
 
-    await authMiddleware(mockReq("/settings"), res, next);
+    await authMiddleware(mockReq("/settings"), res as unknown as express.Response, next);
 
     expect(isAuthenticatedMock).toHaveBeenCalledOnce();
     expect(next).toHaveBeenCalledOnce();
@@ -61,7 +61,7 @@ describe("authMiddleware", () => {
     const next = vi.fn();
     const res = mockRes();
 
-    await authMiddleware(mockReq("/queue"), res, next);
+    await authMiddleware(mockReq("/queue"), res as unknown as express.Response, next);
 
     expect(res.redirect).toHaveBeenCalledWith(302, "/login");
     expect(next).not.toHaveBeenCalled();
@@ -71,7 +71,7 @@ describe("authMiddleware", () => {
     const next = vi.fn();
     const res = mockRes();
 
-    await authMiddleware(mockReq("/%6Fnboarding"), res, next);
+    await authMiddleware(mockReq("/%6Fnboarding"), res as unknown as express.Response, next);
 
     expect(next).toHaveBeenCalledOnce();
     expect(isAuthenticatedMock).not.toHaveBeenCalled();
@@ -82,7 +82,7 @@ describe("authMiddleware", () => {
     const next = vi.fn();
     const res = mockRes();
 
-    await authMiddleware(mockReq("/%E0%A4%A"), res, next);
+    await authMiddleware(mockReq("/%E0%A4%A"), res as unknown as express.Response, next);
 
     expect(res.redirect).toHaveBeenCalledWith(302, "/login");
     expect(next).not.toHaveBeenCalled();

--- a/frontend/app/auth/authentication.server.ts
+++ b/frontend/app/auth/authentication.server.ts
@@ -170,9 +170,11 @@ export async function clearOidcFlowState(
 
 async function authenticate(request: Request): Promise<User> {
   const formData = await request.formData();
-  const username = formData.get("username")?.toString();
-  const password = formData.get("password")?.toString();
-  if (!username || !password) throw new Error("username and password required");
+  const username = formData.get("username");
+  const password = formData.get("password");
+  if (typeof username !== "string" || typeof password !== "string" || !username || !password) {
+    throw new Error("username and password required");
+  }
   if (await backendClient.authenticate(username, password)) {
     return { username, role: "admin" };
   }

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -62,7 +62,7 @@ function form(...entries: [string, string | Blob, string?][]): FormData {
  * shared api key, and converts a non-2xx response into an Error whose message is
  * prefixed with `errorPrefix` and suffixed with the backend's reported error.
  */
-async function call(path: string, errorPrefix: string, init?: RequestInit): Promise<any> {
+async function call<T = unknown>(path: string, errorPrefix: string, init?: RequestInit): Promise<T> {
     let response: Response;
     try {
         response = await fetch(process.env.BACKEND_URL + path, {
@@ -84,7 +84,7 @@ async function call(path: string, errorPrefix: string, init?: RequestInit): Prom
 
     if (!response.ok) {
         const body = await response.json().catch(() => null) as
-            | { error?: unknown; status?: unknown }
+            | { error?: string; status?: string }
             | null;
         if (response.status === 503 || body?.status === "migrating") {
             throw new BackendUnavailableError(
@@ -95,17 +95,19 @@ async function call(path: string, errorPrefix: string, init?: RequestInit): Prom
 
         const backendError =
             body && typeof body === "object" && "error" in body
-                ? String(body.error ?? "unknown error")
+                ? (body.error ?? "unknown error")
                 : `HTTP ${response.status}`;
         throw new Error(`${errorPrefix}: ${backendError}`);
     }
 
-    return response.json();
+    // The type parameter is the caller's declared contract for the backend
+    // response shape; the assertion is centralized here.
+    return (await response.json()) as T;
 }
 
 class BackendClient {
     public async isOnboarding(): Promise<boolean> {
-        const data = await call("/api/is-onboarding", "Failed to fetch onboarding status", {
+        const data = await call<{ isOnboarding: boolean }>("/api/is-onboarding", "Failed to fetch onboarding status", {
             method: "GET",
             headers: { "Content-Type": "application/json" },
         });
@@ -113,7 +115,7 @@ class BackendClient {
     }
 
     public async createAccount(username: string, password: string): Promise<boolean> {
-        const data = await call("/api/create-account", "Failed to create account", {
+        const data = await call<{ status: boolean }>("/api/create-account", "Failed to create account", {
             method: "POST",
             body: form(["username", username], ["password", password], ["type", "admin"]),
         });
@@ -121,7 +123,7 @@ class BackendClient {
     }
 
     public async authenticate(username: string, password: string): Promise<boolean> {
-        const data = await call("/api/authenticate", "Failed to authenticate", {
+        const data = await call<{ authenticated: boolean }>("/api/authenticate", "Failed to authenticate", {
             method: "POST",
             body: form(["username", username], ["password", password], ["type", "admin"]),
         });
@@ -129,12 +131,12 @@ class BackendClient {
     }
 
     public async getQueue(limit: number, start: number = 0): Promise<QueueResponse> {
-        const data = await call(`/api?mode=queue&start=${start}&limit=${limit}`, "Failed to get queue");
+        const data = await call<{ queue: QueueResponse }>(`/api?mode=queue&start=${start}&limit=${limit}`, "Failed to get queue");
         return data.queue;
     }
 
     public async getHistory(limit: number, start: number = 0): Promise<HistoryResponse> {
-        const data = await call(`/api?mode=history&start=${start}&pageSize=${limit}`, "Failed to get history");
+        const data = await call<{ history: HistoryResponse }>(`/api?mode=history&start=${start}&pageSize=${limit}`, "Failed to get history");
         return data.history;
     }
 
@@ -147,7 +149,7 @@ class BackendClient {
             priority: "0",
             pp: "0",
         });
-        const data = await call(`/api?${params.toString()}`, "Failed to add nzb file", {
+        const data = await call<{ nzo_ids?: string[] }>(`/api?${params.toString()}`, "Failed to add nzb file", {
             method: "POST",
             body: form(["nzbFile", nzbFile, nzbFile.name]),
         });
@@ -158,7 +160,7 @@ class BackendClient {
     }
 
     public async searchIndexers(q: string, limit: number = 100): Promise<SearchIndexersResponse> {
-        return await call("/api/search-indexers", "Failed to search indexers", {
+        return await call<SearchIndexersResponse>("/api/search-indexers", "Failed to search indexers", {
             method: "POST",
             body: form(["q", q], ["limit", String(limit)]),
         });
@@ -175,7 +177,7 @@ class BackendClient {
             name: nzbUrl,
             nzbname: nzbName,
         });
-        const data = await call(`/api?${params.toString()}`, "Failed to add nzb url", {
+        const data = await call<{ nzo_ids?: string[] }>(`/api?${params.toString()}`, "Failed to add nzb url", {
             method: "POST",
         });
         if (!data.nzo_ids || data.nzo_ids.length !== 1) {
@@ -186,7 +188,7 @@ class BackendClient {
 
     public async listWebdavDirectory(directory: string): Promise<DirectoryItem[]> {
         try {
-            const data = await call("/api/list-webdav-directory", "Failed to list webdav directory", {
+            const data = await call<{ items: DirectoryItem[] }>("/api/list-webdav-directory", "Failed to list webdav directory", {
                 method: "POST",
                 body: form(["directory", directory]),
             });
@@ -200,7 +202,7 @@ class BackendClient {
     }
 
     public async getConfig(keys: string[]): Promise<ConfigItem[]> {
-        const data = await call("/api/get-config", "Failed to get config items", {
+        const data = await call<{ configItems?: ConfigItem[] }>("/api/get-config", "Failed to get config items", {
             method: "POST",
             body: form(...keys.map(key => ["config-keys", key] as [string, string])),
         });
@@ -208,7 +210,7 @@ class BackendClient {
     }
 
     public async updateConfig(configItems: ConfigItem[]): Promise<boolean> {
-        const data = await call("/api/update-config", "Failed to update config items", {
+        const data = await call<{ status: boolean }>("/api/update-config", "Failed to update config items", {
             method: "POST",
             body: form(...configItems.map(item => [item.configName, item.configValue] as [string, string])),
         });
@@ -217,41 +219,41 @@ class BackendClient {
 
     public async getHealthCheckQueue(pageSize?: number): Promise<HealthCheckQueueResponse> {
         const query = pageSize !== undefined ? `?pageSize=${pageSize}` : "";
-        return await call(`/api/get-health-check-queue${query}`, "Failed to get health check queue", {
+        return await call<HealthCheckQueueResponse>(`/api/get-health-check-queue${query}`, "Failed to get health check queue", {
             method: "GET",
         });
     }
 
     public async getWatchdogEntries(limit: number = 200): Promise<WatchdogEntry[]> {
-        const data = await call(`/api/get-watchdog-entries?limit=${limit}`, "Failed to get watchdog entries", {
+        const data = await call<{ entries?: WatchdogEntry[] }>(`/api/get-watchdog-entries?limit=${limit}`, "Failed to get watchdog entries", {
             method: "GET",
         });
         return data.entries ?? [];
     }
 
     public async getExcludeSyncStatus(): Promise<ExcludeSyncUrlStatus[]> {
-        const data = await call("/api/exclude-sync", "Failed to get exclude-sync status", {
+        const data = await call<{ urls?: ExcludeSyncUrlStatus[] }>("/api/exclude-sync", "Failed to get exclude-sync status", {
             method: "GET",
         });
         return data.urls || [];
     }
 
     public async refreshExcludeSync(): Promise<ExcludeSyncUrlStatus[]> {
-        const data = await call("/api/exclude-sync", "Failed to refresh exclude-sync", {
+        const data = await call<{ urls?: ExcludeSyncUrlStatus[] }>("/api/exclude-sync", "Failed to refresh exclude-sync", {
             method: "POST",
         });
         return data.urls || [];
     }
 
     public async clearWatchdogEntries(): Promise<number> {
-        const data = await call(`/api/clear-watchdog-entries`, "Failed to clear watchdog entries", {
+        const data = await call<{ deleted?: number }>(`/api/clear-watchdog-entries`, "Failed to clear watchdog entries", {
             method: "POST",
         });
         return data.deleted ?? 0;
     }
 
     public async clearHealthCheckHistory(): Promise<{ deletedResults: number; deletedStats: number }> {
-        const data = await call(`/api/clear-health-check-history`, "Failed to clear health-check history", {
+        const data = await call<{ deletedResults?: number; deletedStats?: number }>(`/api/clear-health-check-history`, "Failed to clear health-check history", {
             method: "POST",
         });
         return {
@@ -262,7 +264,7 @@ class BackendClient {
 
     public async clearOverviewStats(providerId?: string): Promise<number> {
         const query = providerId ? `?provider=${encodeURIComponent(providerId)}` : "";
-        const data = await call(`/api/clear-overview-stats${query}`, "Failed to clear overview statistics", {
+        const data = await call<{ deletedRows?: number }>(`/api/clear-overview-stats${query}`, "Failed to clear overview statistics", {
             method: "POST",
         });
         return data.deletedRows ?? 0;
@@ -270,7 +272,7 @@ class BackendClient {
 
     public async getHealthCheckHistory(pageSize?: number): Promise<HealthCheckHistoryResponse> {
         const query = pageSize !== undefined ? `?pageSize=${pageSize}` : "";
-        return await call(`/api/get-health-check-history${query}`, "Failed to get health check history", {
+        return await call<HealthCheckHistoryResponse>(`/api/get-health-check-history${query}`, "Failed to get health check history", {
             method: "GET",
         });
     }
@@ -279,7 +281,7 @@ class BackendClient {
         window: OverviewWindow = "24h",
         sections: OverviewSections = "all",
     ): Promise<OverviewStatsResponse> {
-        return await call(
+        return await call<OverviewStatsResponse>(
             `/api/get-overview-stats?window=${window}&sections=${sections}`,
             "Failed to get overview stats",
             { method: "GET" },
@@ -294,13 +296,13 @@ class BackendClient {
         if (params.search) qs.set("search", params.search);
         if (params.beforeSequence !== undefined) qs.set("beforeSequence", String(params.beforeSequence));
         const query = qs.toString();
-        return await call(`/api/get-logs${query ? `?${query}` : ""}`, "Failed to get logs", {
+        return await call<GetLogsResponse>(`/api/get-logs${query ? `?${query}` : ""}`, "Failed to get logs", {
             method: "GET",
         });
     }
 
     public async getStreamTracingStatus(): Promise<StreamTracingStatus> {
-        const data = await call("/api/get-stream-traces?limit=1", "Failed to get stream tracing status", {
+        const data = await call<Record<string, unknown>>("/api/get-stream-traces?limit=1", "Failed to get stream tracing status", {
             method: "GET",
         });
         return toStreamTracingStatus(data);
@@ -311,7 +313,7 @@ class BackendClient {
         minutes: number = 30,
         capacity: number = 100_000,
     ): Promise<StreamTracingStatus> {
-        const data = await call("/api/set-stream-tracing", "Failed to update stream tracing", {
+        const data = await call<Record<string, unknown>>("/api/set-stream-tracing", "Failed to update stream tracing", {
             method: "POST",
             body: form(
                 ["enabled", enabled ? "true" : "false"],
@@ -323,7 +325,7 @@ class BackendClient {
     }
 
     public async discardStreamTraces(): Promise<StreamTracingStatus> {
-        const data = await call("/api/discard-stream-traces", "Failed to discard stream traces", {
+        const data = await call<Record<string, unknown>>("/api/discard-stream-traces", "Failed to discard stream traces", {
             method: "POST",
         });
         return toStreamTracingStatus(data);
@@ -339,13 +341,13 @@ class BackendClient {
         if (params.expander) qs.set("expander", params.expander);
         if (params.statsOnly) qs.set("statsOnly", "1");
         const query = qs.toString();
-        return await call(`/api/get-watchtower${query ? `?${query}` : ""}`, "Failed to get watchtower", {
+        return await call<WatchtowerData>(`/api/get-watchtower${query ? `?${query}` : ""}`, "Failed to get watchtower", {
             method: "GET",
         });
     }
 
     public async watchtowerMutate(fields: Record<string, string>): Promise<boolean> {
-        const data = await call("/api/watchtower-mutate", "Watchtower action failed", {
+        const data = await call<{ status: boolean }>("/api/watchtower-mutate", "Watchtower action failed", {
             method: "POST",
             body: form(...Object.entries(fields).map(([k, v]) => [k, v] as [string, string])),
         });
@@ -353,7 +355,7 @@ class BackendClient {
     }
 
     public async discoverStremioCatalogs(manifestUrl: string): Promise<DiscoverCatalogsResponse> {
-        return await call("/api/watchtower-discover-catalogs", "Failed to discover catalogs", {
+        return await call<DiscoverCatalogsResponse>("/api/watchtower-discover-catalogs", "Failed to discover catalogs", {
             method: "POST",
             body: form(["url", manifestUrl]),
         });
@@ -615,7 +617,7 @@ export enum RepairAction {
 }
 
 export type OverviewWindow = "1h" | "24h" | "7d" | "30d" | "all";
-export type OverviewSections = "all" | "window" | "detail" | "static" | string;
+export type OverviewSections = "all" | "window" | "detail" | "static" | (string & {});
 
 export type OverviewStatsResponse = {
     window: OverviewWindow,

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -120,7 +120,7 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
         });
         if (cancelled) return;
 
-        const body = res.ok ? await res.json().catch(() => null) : null;
+        const body: unknown = res.ok ? await res.json().catch(() => null) : null;
         if (cancelled) return;
 
         const decision = decideMigrationStatusPoll(res.status, body);
@@ -148,8 +148,9 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
       }
     };
 
-    poll();
-    interval = window.setInterval(poll, 2000);
+    // fire-and-forget: polling errors are handled inside poll()
+    void poll();
+    interval = window.setInterval(() => void poll(), 2000);
     return () => {
       cancelled = true;
       stopPolling();

--- a/frontend/app/components/service-provider-gate.tsx
+++ b/frontend/app/components/service-provider-gate.tsx
@@ -40,7 +40,7 @@ export function ServiceProviderGate({
     <ServiceProviderNotice
       open
       serviceProvider={serviceProvider}
-      onClose={() => navigate("/overview", { replace: true })}
+      onClose={() => { void navigate("/overview", { replace: true }); }}
     />
   );
 }

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -101,7 +101,7 @@ export default function handleRequest(
           );
         },
         onShellError(error: unknown) {
-          reject(error);
+          reject(error instanceof Error ? error : new Error("Unknown shell rendering error"));
         },
         onError(error: unknown) {
           responseStatusCode = 500;

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -102,8 +102,12 @@ function hasConfiguredUsenetProviders(configValue?: string): boolean {
   if (!configValue) return false;
 
   try {
-    const config = JSON.parse(configValue);
-    return Array.isArray(config?.Providers) && config.Providers.length > 0;
+    const config: unknown = JSON.parse(configValue);
+    return typeof config === "object"
+      && config !== null
+      && "Providers" in config
+      && Array.isArray(config.Providers)
+      && config.Providers.length > 0;
   } catch {
     return false;
   }

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -66,7 +66,7 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
         <button
           type="button"
           className="btn btn-ghost gap-3 px-2"
-          onClick={() => navigate("/")}
+          onClick={() => { void navigate("/"); }}
         >
           <img
             className="h-10 w-10 rounded-xl bg-gradient-to-br from-primary via-info to-success p-0.5 shadow-md shadow-primary/20"

--- a/frontend/app/routes/_index/route.test.ts
+++ b/frontend/app/routes/_index/route.test.ts
@@ -3,7 +3,7 @@ import { action } from "./route";
 
 describe("_index route action", () => {
   it("returns 405 for POST requests", async () => {
-    const response = await action();
+    const response = action();
 
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(405);

--- a/frontend/app/routes/_index/route.tsx
+++ b/frontend/app/routes/_index/route.tsx
@@ -1,11 +1,10 @@
 import { redirect } from "react-router";
-import type { Route } from "./+types/route";
 
-export async function loader({ request }: Route.LoaderArgs) {
+export function loader() {
     return redirect("/overview")
 }
 
-export async function action() {
+export function action() {
     return new Response("Method Not Allowed", {
         status: 405,
         headers: { Allow: "GET, HEAD" },

--- a/frontend/app/routes/explore/breadcrumbs/breadcrumbs.tsx
+++ b/frontend/app/routes/explore/breadcrumbs/breadcrumbs.tsx
@@ -11,7 +11,7 @@ export type BreadcrumbProps = {
 export function Breadcrumbs({ parentDirectories }: BreadcrumbProps): ReactNode {
     const navigate = useNavigate();
     const onClick = useCallback((index: number) => {
-        navigate(getExploreBreadcrumbHref(parentDirectories, index));
+        void navigate(getExploreBreadcrumbHref(parentDirectories, index));
     }, [parentDirectories, navigate]);
 
     return (

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -113,7 +113,7 @@ function Body(props: ExplorePageData) {
     useEffect(() => {
         const revalidateWhenVisible = () => {
             if (document.visibilityState === "visible" && revalidator.state === "idle") {
-                revalidator.revalidate();
+                void revalidator.revalidate(); // fire-and-forget refresh
             }
         };
 
@@ -136,7 +136,7 @@ function Body(props: ExplorePageData) {
 
     const visibleNames = useMemo(() => visibleItems.map(i => i.name), [visibleItems]);
     const selectableNames = useMemo(
-        () => visibleNames.filter(n => canDelete),
+        () => visibleNames.filter(() => canDelete),
         [visibleNames, canDelete]
     );
     const selectedVisibleCount = useMemo(
@@ -192,11 +192,12 @@ function Body(props: ExplorePageData) {
             try {
                 const resp = await fetch(withUrlBase('/api/delete-webdav-item'), { method: 'POST', body: fd });
                 if (!resp.ok) {
-                    const data = await resp.json().catch(() => ({} as any));
+                    // /api/delete-webdav-item returns BaseApiResponse { status, error? }
+                    const data = await resp.json().catch(() => ({})) as { error?: string };
                     failures.push(`${name}: ${data.error || resp.statusText}`);
                 }
-            } catch (err: any) {
-                failures.push(`${name}: ${err?.message || 'network error'}`);
+            } catch (err: unknown) {
+                failures.push(`${name}: ${err instanceof Error && err.message ? err.message : 'network error'}`);
             }
         }
         setIsDeleting(false);
@@ -210,7 +211,7 @@ function Body(props: ExplorePageData) {
             return next;
         });
         setPendingDelete(null);
-        revalidator.revalidate();
+        void revalidator.revalidate(); // fire-and-forget refresh after delete
     }, [pendingDelete, location.pathname, revalidator]);
 
     const toggleSelect = useCallback((name: string, shiftKey: boolean) => {
@@ -315,7 +316,7 @@ function Body(props: ExplorePageData) {
                 sortKey={sortKey}
                 sortDir={sortDir}
                 onSortChange={(k, d) => { setSortKey(k); setSortDir(d); }}
-                onRefresh={() => revalidator.revalidate()}
+                onRefresh={() => void revalidator.revalidate()}
                 isRefreshing={isRefreshing}
                 stats={stats}
                 totalCount={items.length}
@@ -411,7 +412,7 @@ function Body(props: ExplorePageData) {
                 cancelText="Cancel"
                 errorMessage={deleteError ?? undefined}
                 onCancel={cancelDelete}
-                onConfirm={performDelete}
+                onConfirm={() => void performDelete()}
             />
         </div>
     );

--- a/frontend/app/routes/health/components/health-stats/health-stats.tsx
+++ b/frontend/app/routes/health/components/health-stats/health-stats.tsx
@@ -1,33 +1,27 @@
-import type { HealthCheckStats } from "~/clients/backend-client.server";
+import type { HealthCheckStats, HealthResult, RepairAction } from "~/clients/backend-client.server";
 import { Badge, Icon } from "~/components/ui";
 
 export type HealthStatsProps = {
     stats: HealthCheckStats[];
 }
 
-enum HealthResult {
-    Healthy = 0,
-    Unhealthy = 1,
-}
-
-enum RepairAction {
-    None = 0,
-    Repaired = 1,
-    Deleted = 2,
-    ActionNeeded = 3,
-}
+// Numeric values mirror the backend HealthResult / RepairAction enums declared in
+// ~/clients/backend-client.server (a .server module, so its enums cannot be value-imported here).
+const HealthResultHealthy: HealthResult = 0;
+const RepairActionRepaired: RepairAction = 1;
+const RepairActionDeleted: RepairAction = 2;
 
 export function HealthStats({ stats }: HealthStatsProps) {
     const totalChecked = stats
         .reduce((sum, stat) => sum + stat.count, 0);
     const healthy = stats
-        .filter(stat => stat.result === HealthResult.Healthy)
+        .filter(stat => stat.result === HealthResultHealthy)
         .reduce((sum, stat) => sum + stat.count, 0);
     const repaired = stats
-        .filter(stat => stat.repairStatus === RepairAction.Repaired)
+        .filter(stat => stat.repairStatus === RepairActionRepaired)
         .reduce((sum, stat) => sum + stat.count, 0);
     const deleted = stats
-        .filter(stat => stat.repairStatus === RepairAction.Deleted)
+        .filter(stat => stat.repairStatus === RepairActionDeleted)
         .reduce((sum, stat) => sum + stat.count, 0);
 
     const getPercentage = (count: number) => {

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -5,7 +5,7 @@ import { HealthStats } from "./components/health-stats/health-stats";
 import { useCallback, useEffect, useState } from "react";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
 import { Alert, Icon } from "~/components/ui";
-import type { HealthCheckQueueResponse } from "~/clients/backend-client.server";
+import type { HealthCheckQueueResponse, HealthResult, RepairAction } from "~/clients/backend-client.server";
 import { completeHealthCheck, type HealthQueueState } from "./health-queue-state";
 import { withUrlBase } from "~/utils/url-base";
 
@@ -53,23 +53,25 @@ export default function Health({ loaderData }: Route.ComponentProps) {
         const refetchData = async () => {
             const response = await fetch(withUrlBase('/api/get-health-check-queue?pageSize=30'));
             if (response.ok) {
-                const healthCheckQueue: HealthCheckQueueResponse = await response.json();
+                // /api/get-health-check-queue returns HealthCheckQueueResponse
+                const healthCheckQueue = await response.json() as HealthCheckQueueResponse;
                 setQueueState({
                     items: healthCheckQueue.items,
                     uncheckedCount: healthCheckQueue.uncheckedCount,
                 });
             }
         };
-        refetchData();
+        void refetchData(); // fire-and-forget queue refill
     }, [queueItems, setQueueState]);
 
     // events
-    const onHealthItemStatus = useCallback(async (message: string) => {
+    const onHealthItemStatus = useCallback((message: string) => {
         const [davItemId, healthResult, repairAction] = message.split('|');
         setQueueState(x => completeHealthCheck(x, davItemId));
         setHistoryStats(x => {
-            const healthResultNum = Number(healthResult);
-            const repairActionNum = Number(repairAction);
+            // 'hs' websocket payload carries numeric HealthResult / RepairAction enum values
+            const healthResultNum: HealthResult = Number(healthResult);
+            const repairActionNum: RepairAction = Number(repairAction);
 
             // attempt to find and update a matching statistic
             let updated = false;

--- a/frontend/app/routes/logout/route.tsx
+++ b/frontend/app/routes/logout/route.tsx
@@ -5,7 +5,7 @@ import { redirect } from "react-router";
 export async function action({ request }: Route.ActionArgs) {
     // if we logout intent is not confirmed, redirect to landing page
     const formData = await request.formData();
-    const confirm = formData.get("confirm")?.toString();
+    const confirm = formData.get("confirm");
     if (confirm !== "true") return redirect("/");
 
     // otherwise, proceed to log out!

--- a/frontend/app/routes/logs/route.tsx
+++ b/frontend/app/routes/logs/route.tsx
@@ -8,7 +8,7 @@ import {
     useRef,
     useState,
 } from "react";
-import { backendClient, type LogEntry, type LogLevel } from "~/clients/backend-client.server";
+import { backendClient, type GetLogsResponse, type LogEntry, type LogLevel } from "~/clients/backend-client.server";
 import { useLogsWebsocket, type ConnectionStatus } from "./controllers/websocket-controller";
 import { Alert, Badge, Icon } from "~/components/ui";
 import { Input } from "~/components/ui/form";
@@ -111,9 +111,10 @@ export default function Logs({ loaderData }: Route.ComponentProps) {
         if (search) params.set("search", search);
         if (source) params.set("source", source);
         fetch(withUrlBase(`/api/get-logs?${params.toString()}`))
-            .then(async r => {
+            .then(r => {
                 if (!r.ok) throw new Error(`HTTP ${r.status}`);
-                return r.json();
+                // /api/get-logs returns GetLogsResponse
+                return r.json() as Promise<GetLogsResponse>;
             })
             .then(data => {
                 if (cancelled) return;
@@ -122,9 +123,9 @@ export default function Logs({ loaderData }: Route.ComponentProps) {
                 setErrorText(null);
                 if (followTailRef.current) requestAnimationFrame(scrollToBottom);
             })
-            .catch(e => {
+            .catch((e: unknown) => {
                 if (cancelled) return;
-                setErrorText(String(e?.message ?? e));
+                setErrorText(e instanceof Error ? e.message : String(e));
             });
         return () => {
             cancelled = true;
@@ -200,7 +201,6 @@ export default function Logs({ loaderData }: Route.ComponentProps) {
     // when the entries list mounts/first-loads, scroll to bottom
     useEffect(() => {
         requestAnimationFrame(scrollToBottom);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // keyboard shortcuts

--- a/frontend/app/routes/onboarding/route.tsx
+++ b/frontend/app/routes/onboarding/route.tsx
@@ -6,10 +6,6 @@ import { isAuthenticated, setSessionUser } from "~/auth/authentication.server";
 import { Alert, Button, Input, Spinner } from "~/components/ui";
 import { withUrlBase } from "~/utils/url-base";
 
-type OnboardingPageData = {
-    error: string
-}
-
 export async function loader({ request }: Route.LoaderArgs) {
     if (await isAuthenticated(request)) return redirect("/")
 
@@ -149,9 +145,9 @@ export async function action({ request }: Route.ActionArgs) {
         if (!isOnboarding) return redirect("/login");
 
         const formData = await request.formData();
-        const username = formData.get("username")?.toString();
-        const password = formData.get("password")?.toString();
-        if (!username || !password) throw new Error("username and password required");
+        const username = formData.get("username");
+        const password = formData.get("password");
+        if (typeof username !== "string" || typeof password !== "string" || !username || !password) throw new Error("username and password required");
         const isSuccess = await backendClient.createAccount(username, password);
         if (!isSuccess) throw new Error("Unknown error creating account");
         const responseInit = await setSessionUser(request, username);

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -19,7 +19,8 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
 
     useWebsocketTopic(TOPIC_ACTIVE_READS, "state", (message) => {
         try {
-            const payload: ActiveReadsMessage = JSON.parse(message);
+            // ActiveReads websocket topic payload shape (backend contract)
+            const payload = JSON.parse(message) as ActiveReadsMessage;
             const now = Date.now();
             const prev = prevRef.current;
             const next = new Map<string, { bytes: number, at: number, rate: number }>();

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -115,14 +115,15 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
             try {
                 const res = await fetch(withUrlBase(`/api/get-overview-stats?window=${window}&sections=window`));
                 if (!res.ok || cancelled) return;
-                const data: OverviewStatsResponse = await res.json();
+                // /api/get-overview-stats returns OverviewStatsResponse
+                const data = await res.json() as OverviewStatsResponse;
                 if (cancelled) return;
                 setStats(s => mergeOverviewStats(s, data));
                 setWindowLoaded(true);
             } catch { /* network blip, retry next tick */ }
         };
 
-        fetchWindow();
+        void fetchWindow(); // fire-and-forget: polled on interval below
         const interval = setInterval(() => {
             if (editModeRef.current) return;
             void fetchWindow();
@@ -143,11 +144,12 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     useEffect(() => {
         if (isLongWindow) return;
         let cancelled = false;
-        (async () => {
+        void (async () => {
             try {
                 const res = await fetch(withUrlBase(`/api/get-overview-stats?window=${window}&sections=detail`));
                 if (!res.ok || cancelled) return;
-                const data: OverviewStatsResponse = await res.json();
+                // /api/get-overview-stats returns OverviewStatsResponse
+                const data = await res.json() as OverviewStatsResponse;
                 if (cancelled) return;
                 setStats(s => mergeOverviewStats(s, data));
                 setDetailLoaded(true);
@@ -159,11 +161,12 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     // Static blocks: once per page visit.
     useEffect(() => {
         let cancelled = false;
-        (async () => {
+        void (async () => {
             try {
                 const res = await fetch(withUrlBase(`/api/get-overview-stats?window=${window}&sections=static`));
                 if (!res.ok || cancelled) return;
-                const data: OverviewStatsResponse = await res.json();
+                // /api/get-overview-stats returns OverviewStatsResponse
+                const data = await res.json() as OverviewStatsResponse;
                 if (cancelled) return;
                 setStats(s => mergeOverviewStats(s, data));
                 setStaticLoaded(true);
@@ -175,7 +178,8 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     const onWsMessage = useCallback((topic: string, message: string) => {
         if (topic !== topicNames.liveStats) return;
         try {
-            const live: LiveStatsMessage = JSON.parse(message);
+            // live-stats websocket message ('ls' topic) carries LiveStatsMessage
+            const live = JSON.parse(message) as LiveStatsMessage;
             setStats(s => ({
                 ...s,
                 tiles: {

--- a/frontend/app/routes/overview/utils/has-configured-indexers.ts
+++ b/frontend/app/routes/overview/utils/has-configured-indexers.ts
@@ -2,8 +2,12 @@ export function hasConfiguredIndexers(configValue?: string): boolean {
     if (!configValue) return false;
 
     try {
-        const config = JSON.parse(configValue);
-        return Array.isArray(config?.Indexers) && config.Indexers.length > 0;
+        const config: unknown = JSON.parse(configValue);
+        return typeof config === "object"
+            && config !== null
+            && "Indexers" in config
+            && Array.isArray(config.Indexers)
+            && config.Indexers.length > 0;
     } catch {
         return false;
     }

--- a/frontend/app/routes/overview/utils/use-row-order.ts
+++ b/frontend/app/routes/overview/utils/use-row-order.ts
@@ -9,7 +9,7 @@ export function useRowOrder(defaultOrder: readonly string[]) {
         try {
             const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
             if (!raw) return;
-            const saved = JSON.parse(raw);
+            const saved: unknown = JSON.parse(raw);
             if (!Array.isArray(saved)) return;
             const known = new Set(defaultOrder);
             const kept = saved.filter((id: unknown): id is string => typeof id === "string" && known.has(id));

--- a/frontend/app/routes/queue/components/history-table/history-retry.test.ts
+++ b/frontend/app/routes/queue/components/history-table/history-retry.test.ts
@@ -34,7 +34,7 @@ describe("retryHistoryItem", () => {
     it("posts to the retry endpoint and returns success", async () => {
         const fetchImpl = vi.fn().mockResolvedValue({
             ok: true,
-            json: async () => ({ status: true, nzo_id: "new-id" }),
+            json: () => Promise.resolve({ status: true, nzo_id: "new-id" }),
         });
 
         const result = await retryHistoryItem("old-id", fetchImpl as typeof fetch);
@@ -46,7 +46,7 @@ describe("retryHistoryItem", () => {
     it("returns the API error when retry fails", async () => {
         const fetchImpl = vi.fn().mockResolvedValue({
             ok: false,
-            json: async () => ({ status: false, error: "The NZB file could not be found." }),
+            json: () => Promise.resolve({ status: false, error: "The NZB file could not be found." }),
         });
 
         const result = await retryHistoryItem("old-id", fetchImpl as typeof fetch);

--- a/frontend/app/routes/queue/components/history-table/history-retry.ts
+++ b/frontend/app/routes/queue/components/history-table/history-retry.ts
@@ -19,15 +19,22 @@ export type HistoryRetryResult =
     | { ok: true; nzoId?: string }
     | { ok: false; error: string };
 
+// SABnzbd API (`/api?mode=retry`) response shape
+type HistoryRetryResponse = {
+    status?: boolean;
+    error?: string;
+    nzo_id?: string;
+};
+
 export async function retryHistoryItem(
     nzoId: string,
     fetchImpl: typeof fetch = fetch,
 ): Promise<HistoryRetryResult> {
     try {
         const response = await fetchImpl(buildHistoryRetryUrl(nzoId), { method: "POST" });
-        let data: { status?: boolean; error?: string; nzo_id?: string } | null = null;
+        let data: HistoryRetryResponse | null = null;
         try {
-            data = await response.json();
+            data = await response.json() as HistoryRetryResponse;
         } catch {
             data = null;
         }

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -73,7 +73,8 @@ export function HistoryTable({
                 body: JSON.stringify({ nzo_ids: Array.from(nzo_ids) }),
             });
             if (response.ok) {
-                const data = await response.json();
+                // SABnzbd API (`/api?mode=history&name=delete`) response shape
+                const data = await response.json() as { status?: boolean };
                 if (data.status === true) {
                     onRemoved(nzo_ids);
                     return;
@@ -135,7 +136,7 @@ export function HistoryTable({
                 title="Remove From History?"
                 message={`${selectedCount} item(s) will be removed`}
                 checkboxMessage="Delete mounted files"
-                onConfirm={onConfirmRemoval}
+                onConfirm={(isChecked) => void onConfirmRemoval(isChecked)}
                 onCancel={onCancelRemoval} />
         </PageSection>
     );
@@ -174,7 +175,8 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                 + `&del_completed_files=${deleteCompletedFiles ? 1 : 0}`;
             const response = await fetch(url);
             if (response.ok) {
-                const data = await response.json();
+                // SABnzbd API (`/api?mode=history&name=delete`) response shape
+                const data = await response.json() as { status?: boolean };
                 if (data.status === true) {
                     onRemoved(slot.nzo_id);
                     return;
@@ -222,7 +224,7 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                                 slot={slot}
                                 isRetrying={isRetrying}
                                 onRemove={onRemove}
-                                onRetry={onRetry}
+                                onRetry={() => void onRetry()}
                             />
                         </div>
                         {retryError &&
@@ -243,7 +245,7 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                 message={slot.nzb_name}
                 checkboxMessage={!slot.fail_message ? "Delete mounted files" : undefined}
                 errorMessage={slot.fail_message}
-                onConfirm={onConfirmRemoval}
+                onConfirm={(isChecked) => void onConfirmRemoval(isChecked)}
                 onCancel={onCancelRemoval} />
         </>
     );

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -42,7 +42,8 @@ async function moveQueueItemsToTop(nzoIds: string[]): Promise<boolean> {
             body: JSON.stringify({ nzo_ids: nzoIds }),
         });
         if (!response.ok) return false;
-        const data = await response.json();
+        // SABnzbd API (`/api?mode=queue&name=move`) response shape
+        const data = await response.json() as { status?: boolean };
         return data.status === true;
     } catch {
         return false;
@@ -126,7 +127,8 @@ export function QueueTable({
                 body: JSON.stringify({ nzo_ids: Array.from(queued_nzo_ids) }),
             });
             if (response.ok) {
-                const data = await response.json();
+                // SABnzbd API (`/api?mode=queue&name=delete`) response shape
+                const data = await response.json() as { status?: boolean };
                 if (data.status === true) {
                     onRemoved(queued_nzo_ids);
                     return;
@@ -164,7 +166,7 @@ export function QueueTable({
                 <>
                     {selectedMovableIds.length > 0 &&
                         <Tooltip content="Move selected to top of queue">
-                            <ActionButton type="move-top" onClick={onMoveSelectedToTop} />
+                            <ActionButton type="move-top" onClick={() => void onMoveSelectedToTop()} />
                         </Tooltip>
                     }
                     <ActionButton type="delete" onClick={onRemove} />
@@ -229,7 +231,7 @@ export function QueueTable({
                 show={isConfirmingRemoval}
                 title="Remove From Queue?"
                 message={`${selectedCount} item(s) will be removed`}
-                onConfirm={onConfirmRemoval}
+                onConfirm={() => void onConfirmRemoval()}
                 onCancel={onCancelRemoval} />
         </PageSection>
     );
@@ -274,7 +276,8 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                 + `&value=${encodeURIComponent(slot.nzo_id)}`;
             const response = await fetch(url);
             if (response.ok) {
-                const data = await response.json();
+                // SABnzbd API (`/api?mode=queue&name=delete`) response shape
+                const data = await response.json() as { status?: boolean };
                 if (data.status === true) {
                     onRemoved(slot.nzo_id);
                     return;
@@ -314,7 +317,7 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                                 <ActionButton
                                     type="move-top"
                                     disabled={!!slot.isRemoving || isMoving}
-                                    onClick={onMoveToTop}
+                                    onClick={() => void onMoveToTop()}
                                 />
                             </Tooltip>
                         }
@@ -331,7 +334,7 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                 show={isConfirmingRemoval}
                 title="Remove From Queue?"
                 message={slot.filename}
-                onConfirm={onConfirmRemoval}
+                onConfirm={() => void onConfirmRemoval()}
                 onCancel={onCancelRemoval} />
         </>
     )

--- a/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
+++ b/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
@@ -18,7 +18,8 @@ export function useUploadController(
     setUploadingFiles: (value: React.SetStateAction<UploadingFile[]>) => void,
 ) {
     useEffect(() => {
-        processUploadQueue(isUploadingRef, uploadQueueRef, setUploadingFiles);
+        // fire-and-forget: the queue processor runs in the background and updates state itself
+        void processUploadQueue(isUploadingRef, uploadQueueRef, setUploadingFiles);
     }, [uploadingFiles]);
 }
 
@@ -33,14 +34,15 @@ export function buildAddFileUploadUrl(category: string): string {
 }
 
 export function getXhrErrorMessage(xhr: XhrErrorResponse): string {
+    const response: unknown = xhr.response;
     if (
-        typeof xhr.response === "object" &&
-        xhr.response !== null &&
-        "error" in xhr.response &&
-        typeof xhr.response.error === "string" &&
-        xhr.response.error.trim() !== ""
+        typeof response === "object" &&
+        response !== null &&
+        "error" in response &&
+        typeof response.error === "string" &&
+        response.error.trim() !== ""
     ) {
-        return xhr.response.error;
+        return response.error;
     }
 
     if (xhr.statusText.trim() !== "") return xhr.statusText;

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { HistoryEvents, QueueEvents } from "./events-controller";
 import { adjustTotalCount } from "./events-controller";
+import type { HistorySlot, QueueSlot } from "~/clients/backend-client.server";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
 
 const topicNames = {
@@ -39,7 +40,8 @@ export function useQueueHistoryWebsocket(
             // Count updates live here (not in UI handlers) so optimistic UI remove + qr
             // do not double-decrement.
             setTotalQueueCount(count => adjustTotalCount(count, 1));
-            if (isQueueLive) queueEvents.onAddQueueSlot(JSON.parse(message));
+            // 'qa' websocket payload carries a JSON-serialized QueueSlot (backend contract)
+            if (isQueueLive) queueEvents.onAddQueueSlot(JSON.parse(message) as QueueSlot);
         }
         else if (topic == topicNames.queueItemRemoved) {
             const ids = message.split(',').filter(Boolean);
@@ -57,7 +59,8 @@ export function useQueueHistoryWebsocket(
             queueEvents.onChangeQueueSlotProviders(message);
         else if (topic == topicNames.historyItemAdded) {
             setTotalHistoryCount(count => adjustTotalCount(count, 1));
-            if (isHistoryLive) historyEvents.onAddHistorySlot(JSON.parse(message));
+            // 'ha' websocket payload carries a JSON-serialized HistorySlot (backend contract)
+            if (isHistoryLive) historyEvents.onAddHistorySlot(JSON.parse(message) as HistorySlot);
         }
         else if (topic == topicNames.historyItemRemoved) {
             const ids = message.split(',').filter(Boolean);

--- a/frontend/app/routes/search/route.tsx
+++ b/frontend/app/routes/search/route.tsx
@@ -13,16 +13,22 @@ export async function loader({ request }: Route.LoaderArgs) {
     return { q, data };
 }
 
-export async function action({ request }: Route.ActionArgs) {
+type SearchActionResult =
+    | { ok: true; nzoId: string }
+    | { ok: false; error: string };
+
+export async function action({ request }: Route.ActionArgs): Promise<SearchActionResult> {
     const formData = await request.formData();
-    const nzbUrl = formData.get("nzbUrl")?.toString() ?? "";
-    const nzbName = formData.get("nzbName")?.toString() ?? "";
+    const nzbUrlEntry = formData.get("nzbUrl");
+    const nzbNameEntry = formData.get("nzbName");
+    const nzbUrl = typeof nzbUrlEntry === "string" ? nzbUrlEntry : "";
+    const nzbName = typeof nzbNameEntry === "string" ? nzbNameEntry : "";
     if (!nzbUrl || !nzbName) return { ok: false, error: "Missing nzbUrl or nzbName" };
     try {
         const nzoId = await backendClient.addNzbFromUrl(nzbUrl, nzbName);
         return { ok: true, nzoId };
-    } catch (e: any) {
-        return { ok: false, error: e?.message ?? "Failed to add" };
+    } catch (e: unknown) {
+        return { ok: false, error: e instanceof Error ? e.message : "Failed to add" };
     }
 }
 
@@ -117,7 +123,7 @@ function ResultRow({ result }: { result: { indexer: string; title: string; nzbUr
                     variant={done ? "success" : failed ? "danger" : "primary"}
                     disabled={submitting || done}
                     className="whitespace-nowrap"
-                    title={failed ? fetcher.data?.error : undefined}
+                    title={fetcher.data && !fetcher.data.ok ? fetcher.data.error : undefined}
                 >
                     {submitting ? <Spinner size="sm" />
                         : done ? "Mounted"

--- a/frontend/app/routes/settings.stream-tracing/route.tsx
+++ b/frontend/app/routes/settings.stream-tracing/route.tsx
@@ -9,13 +9,15 @@ export async function loader() {
 
 export async function action({ request }: { request: Request }) {
     const formData = await request.formData();
-    if (formData.get("intent")?.toString() === "discard") {
+    if (formData.get("intent") === "discard") {
         return Response.json(await backendClient.discardStreamTraces());
     }
-    const enabled = formData.get("enabled")?.toString() === "true";
-    const minutesRaw = Number(formData.get("minutes")?.toString() ?? "30");
+    const enabled = formData.get("enabled") === "true";
+    const minutesEntry = formData.get("minutes");
+    const minutesRaw = Number(typeof minutesEntry === "string" ? minutesEntry : "30");
     const minutes = [15, 30, 60].includes(minutesRaw) ? minutesRaw : 30;
-    const capacityRaw = Number(formData.get("capacity")?.toString() ?? "100000");
+    const capacityEntry = formData.get("capacity");
+    const capacityRaw = Number(typeof capacityEntry === "string" ? capacityEntry : "100000");
     const capacity = (ALLOWED_CAPACITIES as readonly number[]).includes(capacityRaw)
         ? capacityRaw
         : 100_000;

--- a/frontend/app/routes/settings.update/route.tsx
+++ b/frontend/app/routes/settings.update/route.tsx
@@ -4,8 +4,10 @@ import { backendClient, type ConfigItem } from "~/clients/backend-client.server"
 export async function action({ request }: Route.ActionArgs) {
     // get the ConfigItems to update
     const formData = await request.formData();
-    const configJson = formData.get("config")!.toString();
-    const config = JSON.parse(configJson);
+    const configJson = formData.get("config");
+    if (typeof configJson !== "string") throw new Error("config required");
+    // settings.update posts a JSON object mapping config names to string values (backend contract)
+    const config = JSON.parse(configJson) as Record<string, string>;
     const configItems: ConfigItem[] = [];
     for (const [key, value] of Object.entries<string>(config)) {
         configItems.push({

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -21,6 +21,13 @@ interface QueueRule {
     Action: number;
 }
 
+// Mirrors backend TestArrConnectionResponse (BaseApiResponse + Connected), camelCase JSON.
+interface TestConnectionResult {
+    status?: boolean;
+    connected?: boolean;
+    error?: string | null;
+}
+
 interface ArrConfig {
     RadarrInstances: ConnectionDetails[];
     SonarrInstances: ConnectionDetails[];
@@ -29,7 +36,8 @@ interface ArrConfig {
 
 function parseArrConfig(value: string): ArrConfig {
     try {
-        const parsed = JSON.parse(value);
+        // Config key "arr.instances" holds the backend ArrConfig JSON.
+        const parsed = JSON.parse(value) as ArrConfig | null;
         if (parsed &&
             Array.isArray(parsed.RadarrInstances) &&
             Array.isArray(parsed.SonarrInstances) &&
@@ -130,7 +138,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
         updateConfig({
             ...arrConfig,
             RadarrInstances: arrConfig.RadarrInstances
-                .filter((_: any, i: number) => i !== index)
+                .filter((_, i) => i !== index)
         });
     }, [arrConfig, updateConfig]);
 
@@ -138,7 +146,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
         updateConfig({
             ...arrConfig,
             RadarrInstances: arrConfig.RadarrInstances
-                .map((instance: any, i: number) =>
+                .map((instance, i) =>
                     i === index ? { ...instance, [field]: value } : instance
                 )
         });
@@ -158,7 +166,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
         updateConfig({
             ...arrConfig,
             SonarrInstances: arrConfig.SonarrInstances
-                .filter((_: any, i: number) => i !== index)
+                .filter((_, i) => i !== index)
         });
     }, [arrConfig, updateConfig]);
 
@@ -166,7 +174,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
         updateConfig({
             ...arrConfig,
             SonarrInstances: arrConfig.SonarrInstances
-                .map((instance: any, i: number) =>
+                .map((instance, i) =>
                     i === index ? { ...instance, [field]: value } : instance
                 )
         });
@@ -218,7 +226,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                 {arrConfig.RadarrInstances.length === 0 ? (
                     <div role="alert" className="alert alert-info alert-soft text-sm">No Radarr instances configured. Click on the "Add" button to get started.</div>
                 ) : (
-                    arrConfig.RadarrInstances.map((instance: any, index: number) =>
+                    arrConfig.RadarrInstances.map((instance, index) =>
                         <InstanceForm
                             key={index}
                             instance={instance}
@@ -245,7 +253,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                 {arrConfig.SonarrInstances.length === 0 ? (
                     <div role="alert" className="alert alert-info alert-soft text-sm">No Sonarr instances configured. Click on the "Add" button to get started.</div>
                 ) : (
-                    arrConfig.SonarrInstances.map((instance: any, index: number) =>
+                    arrConfig.SonarrInstances.map((instance, index) =>
                         <InstanceForm
                             key={index}
                             instance={instance}
@@ -337,7 +345,8 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
                 body: formData
             });
 
-            const result = await response.json();
+            // Response of POST /api/test-arr-connection (backend TestArrConnectionResponse).
+            const result = await response.json() as TestConnectionResult;
 
             if (result.status && result.connected) {
                 setConnectionState('success');
@@ -375,7 +384,7 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
                                 <Button
                                     variant={connectionState === 'success' ? 'success' :
                                         connectionState === 'error' ? 'danger' : 'secondary'}
-                                    onClick={() => testConnection(instance.Host, instance.ApiKey)}
+                                    onClick={() => void testConnection(instance.Host, instance.ApiKey)}
                                     disabled={connectionState === 'testing'}
                                     className={'shrink-0'}
                                 >
@@ -424,7 +433,8 @@ export function isArrsSettingsUpdated(config: Record<string, string>, newConfig:
 
 export function isArrsSettingsValid(newConfig: Record<string, string>) {
     try {
-        const arrConfig: ArrConfig = JSON.parse(newConfig["arr.instances"] || "{}");
+        // Config key "arr.instances" holds the backend ArrConfig JSON.
+        const arrConfig = JSON.parse(newConfig["arr.instances"] || "{}") as ArrConfig;
 
         // Validate all Radarr instances
         for (const instance of arrConfig.RadarrInstances || []) {

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -48,6 +48,9 @@ type BackupListResponse = {
     error?: string;
 };
 
+// Error body shared by the /api/db-backup-* and /api/db-restore endpoints (BaseApiResponse).
+type BackupErrorResponse = { error?: string };
+
 export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
     const [backups, setBackups] = useState<BackupManifest[]>([]);
     const [taskRunning, setTaskRunning] = useState(false);
@@ -124,7 +127,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                     cache: "no-store",
                 });
                 if (cancelled) return;
-                const body = res.ok ? await res.json().catch(() => null) : null;
+                const body: unknown = res.ok ? await res.json().catch(() => null) : null;
                 const decision = decideMigrationStatusPoll(res.status, body);
                 if (decision.action === "migrating") {
                     setMigrationStatus(decision.status);
@@ -144,7 +147,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         };
 
         void poll();
-        const interval = window.setInterval(poll, 2000);
+        const interval = window.setInterval(() => void poll(), 2000);
         return () => {
             cancelled = true;
             window.clearInterval(interval);
@@ -164,7 +167,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
                 return;
             }
             if (!res.ok) {
-                const data = await res.json().catch(() => null);
+                const data = (await res.json().catch(() => null)) as BackupErrorResponse | null;
                 setMessage({ text: data?.error || `Backup failed (${res.status})`, variant: "danger" });
                 return;
             }
@@ -185,7 +188,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         if (patch.notes !== undefined) form.append("notes", patch.notes);
         const res = await fetch(withUrlBase("/api/db-backup-update"), { method: "POST", body: form });
         if (!res.ok) {
-            const data = await res.json().catch(() => null);
+            const data = (await res.json().catch(() => null)) as BackupErrorResponse | null;
             setMessage({ text: data?.error || `Update failed (${res.status})`, variant: "danger" });
             return;
         }
@@ -200,7 +203,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
             form.append("id", id);
             const res = await fetch(withUrlBase("/api/db-backup-delete"), { method: "POST", body: form });
             if (!res.ok) {
-                const data = await res.json().catch(() => null);
+                const data = (await res.json().catch(() => null)) as BackupErrorResponse | null;
                 setMessage({ text: data?.error || `Delete failed (${res.status})`, variant: "danger" });
                 return;
             }
@@ -219,7 +222,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
         try {
             const res = await fetch(withUrlBase(`/api/db-backup-download?id=${encodeURIComponent(id)}`));
             if (!res.ok) {
-                const data = await res.json().catch(() => null);
+                const data = (await res.json().catch(() => null)) as BackupErrorResponse | null;
                 setMessage({ text: data?.error || `Download failed (${res.status})`, variant: "danger" });
                 return;
             }
@@ -246,7 +249,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
             const form = new FormData();
             form.append("file", file);
             const res = await fetch(withUrlBase("/api/db-backup-upload"), { method: "POST", body: form });
-            const data = await res.json().catch(() => null);
+            const data = (await res.json().catch(() => null)) as BackupErrorResponse | null;
             if (!res.ok) {
                 setMessage({ text: data?.error || `Upload failed (${res.status})`, variant: "danger" });
                 return;
@@ -276,7 +279,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
             const form = new FormData();
             form.append("id", id);
             const res = await fetch(withUrlBase("/api/db-restore"), { method: "POST", body: form });
-            const data = await res.json().catch(() => null);
+            const data = (await res.json().catch(() => null)) as BackupErrorResponse | null;
             if (res.status === 409) {
                 setMessage({ text: "A backup or restore task is already running.", variant: "warning" });
                 setRestoring(false);

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -19,6 +19,7 @@ import {
     useIsAnyManaged,
 } from "~/components/ui";
 import { withUrlBase } from "~/utils/url-base";
+import type { ExcludeSyncUrlStatus } from "~/clients/backend-client.server";
 
 type IndexersSettingsProps = {
     config: Record<string, string>
@@ -79,6 +80,12 @@ interface IndexerConfig {
     Indexers: ConnectionDetails[];
 }
 
+// Mirrors backend TestIndexerConnectionResponse (BaseApiResponse + Connected), camelCase JSON.
+interface TestIndexerConnectionResult {
+    status?: boolean;
+    connected?: boolean;
+}
+
 // Hard fallback when neither the indexer nor the global override sets a timeout.
 // Mirrors IndexerConfig.DefaultTimeoutSeconds in the backend.
 const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -97,19 +104,16 @@ function validateExcludePatterns(raw: string): PatternIssue[] {
         if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
         try {
             new RegExp(trimmed, "i");
-        } catch (e: any) {
-            issues.push({ line: i + 1, pattern: trimmed, error: e?.message ?? "invalid regex" });
+        } catch (e) {
+            issues.push({ line: i + 1, pattern: trimmed, error: e instanceof Error ? e.message : "invalid regex" });
         }
     }
     return issues;
 }
 
-type ExcludeSyncUrlStatus = {
-    url: string,
-    count: number,
-    fetchedAt: number | null,
-    lastChecked: number | null,
-    error: string | null,
+// Response shape of /settings/exclude-sync (backend ExcludeSyncResponse).
+type ExcludeSyncResponse = {
+    urls?: ExcludeSyncUrlStatus[];
 };
 
 type SyncUrlIssue = { line: number, value: string, error: string };
@@ -153,7 +157,8 @@ function syncRelativeTime(unixSeconds: number): string {
 
 function parseConfig(raw: string): IndexerConfig {
     try {
-        const parsed = JSON.parse(raw || "{}");
+        // Config key "indexers.instances" holds the backend IndexerConfig JSON.
+        const parsed = JSON.parse(raw || "{}") as Partial<IndexerConfig>;
         return {
             ProxyUrl: parsed.ProxyUrl ?? "",
             TimeoutSeconds: typeof parsed.TimeoutSeconds === "number" ? parsed.TimeoutSeconds : undefined,
@@ -288,7 +293,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
     const loadSyncStatus = useCallback(async () => {
         try {
             const res = await fetch(withUrlBase("/settings/exclude-sync"));
-            if (res.ok) setSyncStatus((await res.json()).urls ?? []);
+            if (res.ok) setSyncStatus((await res.json() as ExcludeSyncResponse).urls ?? []);
         } catch {
             // status is best-effort; ignore transient failures
         }
@@ -310,7 +315,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
         setIsSyncing(true);
         try {
             const res = await fetch(withUrlBase("/settings/exclude-sync"), { method: "POST" });
-            if (res.ok) setSyncStatus((await res.json()).urls ?? []);
+            if (res.ok) setSyncStatus((await res.json() as ExcludeSyncResponse).urls ?? []);
         } catch {
             // ignore; the row shows the backend-reported error on the next status load
         } finally {
@@ -512,7 +517,7 @@ export function IndexersSettings({ config, setNewConfig, savedConfig }: Indexers
                             <Button
                                 variant="primary"
                                 size="small"
-                                onClick={handleSyncNow}
+                                onClick={() => void handleSyncNow()}
                                 disabled={isSyncing || excludeSyncManaged}
                                 title={excludeSyncManaged
                                     ? "Synced exclude URLs are managed by NZBDAV_CONFIG__... — change the container environment and restart"
@@ -948,7 +953,8 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             if (timeoutSeconds.trim()) fd.append('timeoutSeconds', timeoutSeconds);
             fd.append('skipTlsVerification', skipTlsVerification.toString());
             const r = await fetch(withUrlBase('/api/test-indexer-connection'), { method: 'POST', body: fd });
-            const data = await r.json();
+            // Response of POST /api/test-indexer-connection (backend TestIndexerConnectionResponse).
+            const data = await r.json() as TestIndexerConnectionResult;
             setTestState(data.status && data.connected ? 'success' : 'error');
         } catch {
             setTestState('error');
@@ -1053,7 +1059,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
                 <>
                     <Button
                         variant={testState === 'success' ? 'success' : testState === 'error' ? 'danger' : 'secondary'}
-                        onClick={handleTest}
+                        onClick={() => void handleTest()}
                         disabled={!isUrlValid || !apiKey.trim() || testState === 'testing'}
                     >
                         {testState === 'testing'

--- a/frontend/app/routes/settings/library/library.tsx
+++ b/frontend/app/routes/settings/library/library.tsx
@@ -7,7 +7,7 @@ type LibrarySettingsProps = {
     setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
 };
 
-export function LibrarySettings({ savedConfig, config, setNewConfig }: LibrarySettingsProps) {
+export function LibrarySettings({ config, setNewConfig }: LibrarySettingsProps) {
     return (
         <div className={'space-y-6'}>
             <div className="space-y-2">

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -117,7 +117,7 @@ export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
                         <Button
                             className="shrink-0"
                             variant={runButtonVariant}
-                            onClick={onRun}
+                            onClick={() => void onRun()}
                             disabled={!isRunButtonEnabled}
                         >
                             <Icon

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -109,7 +109,7 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
                             <Button
                                 className={'shrink-0'}
                                 variant={runButtonVariant}
-                                onClick={onRun}
+                                onClick={() => void onRun()}
                                 disabled={!isRunButtonEnabled}
                             >
                                 <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
@@ -118,7 +118,7 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
                             <Button
                                 className="shrink-0"
                                 disabled={!isRunButtonEnabled}
-                                onClick={onDryRun}
+                                onClick={() => void onDryRun()}
                                 variant="outline"
                                 size="small"
                             >

--- a/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
+++ b/frontend/app/routes/settings/maintenance/rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths.tsx
@@ -105,7 +105,7 @@ export function RenameWindowsInvalidDavPaths({ savedConfig }: RenameWindowsInval
                             <Button
                                 className="shrink-0"
                                 variant={runButtonVariant}
-                                onClick={onApply}
+                                onClick={() => void onApply()}
                                 disabled={!isRunButtonEnabled}
                             >
                                 <Icon name={isRunning ? "progress_activity" : "drive_file_rename_outline"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />
@@ -114,7 +114,7 @@ export function RenameWindowsInvalidDavPaths({ savedConfig }: RenameWindowsInval
                             <Button
                                 className="shrink-0"
                                 disabled={!isRunButtonEnabled}
-                                onClick={onDryRun}
+                                onClick={() => void onDryRun()}
                                 variant="outline"
                                 size="small"
                             >

--- a/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-stats/reset-health-check-stats.tsx
@@ -22,10 +22,12 @@ export function ResetHealthCheckStats() {
         try {
             const response = await fetch(withUrlBase("/api/clear-health-check-history"), { method: "POST" });
             if (!response.ok) {
-                const body = await response.json().catch(() => ({}));
+                // Error body from POST /api/clear-health-check-history (BaseApiResponse).
+                const body = await response.json().catch(() => ({})) as { error?: string };
                 throw new Error(body.error || `Request failed (${response.status})`);
             }
-            const data = await response.json();
+            // Success body from POST /api/clear-health-check-history (ClearHealthCheckHistoryResponse).
+            const data = await response.json() as { deletedResults?: number; deletedStats?: number };
             setMessage(
                 `Reset complete. Removed ${data.deletedResults ?? 0} result row(s) and ${data.deletedStats ?? 0} stat row(s).`
             );
@@ -59,7 +61,7 @@ export function ResetHealthCheckStats() {
                         variant={isRunning ? "secondary" : "danger"}
                         disabled={isRunning}
                         className="shrink-0"
-                        onClick={onReset}
+                        onClick={() => void onReset()}
                     >
                         <Icon
                             name={isRunning ? "progress_activity" : "delete_sweep"}

--- a/frontend/app/routes/settings/maintenance/reset-overview-stats/reset-overview-stats.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-overview-stats/reset-overview-stats.tsx
@@ -7,6 +7,17 @@ import { withUrlBase } from "~/utils/url-base";
 
 type ProviderOption = { providerId: string; label: string };
 
+// Response shape of GET /api/get-provider-usage (GetProviderUsageResponse).
+type ProviderUsageItem = {
+    providerId?: string | null;
+    host: string;
+    nickname?: string | null;
+};
+
+type ProviderUsageResponse = {
+    providers?: ProviderUsageItem[];
+};
+
 export function ResetOverviewStats() {
     const [isRunning, setIsRunning] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
@@ -17,13 +28,13 @@ export function ResetOverviewStats() {
     useEffect(() => {
         let cancelled = false;
         fetch(withUrlBase("/api/get-provider-usage"))
-            .then(r => (r.ok ? r.json() : Promise.reject()))
+            .then(r => (r.ok ? r.json() as Promise<ProviderUsageResponse> : Promise.reject(new Error("Failed to load provider usage"))))
             .then(data => {
                 if (cancelled) return;
                 setProviders(
                     (data.providers ?? [])
-                        .filter((p: { providerId?: string }) => p.providerId)
-                        .map((p: { providerId: string; host: string; nickname?: string }) => ({
+                        .filter((p): p is ProviderUsageItem & { providerId: string } => Boolean(p.providerId))
+                        .map((p) => ({
                             providerId: p.providerId,
                             label: p.nickname?.trim() || p.host,
                         }))
@@ -59,10 +70,12 @@ export function ResetOverviewStats() {
                 : "/api/clear-overview-stats";
             const response = await fetch(url, { method: "POST" });
             if (!response.ok) {
-                const body = await response.json().catch(() => ({}));
+                // Error body from POST /api/clear-overview-stats (BaseApiResponse).
+                const body = await response.json().catch(() => ({})) as { error?: string };
                 throw new Error(body.error || `Request failed (${response.status})`);
             }
-            const data = await response.json();
+            // Success body from POST /api/clear-overview-stats (ClearOverviewStatsResponse).
+            const data = await response.json() as { deletedRows?: number };
             setMessage(`Reset complete. Removed ${data.deletedRows ?? 0} metric row(s).`);
         } catch (e) {
             setError(e instanceof Error ? e.message : "Failed to reset Overview statistics.");
@@ -117,7 +130,7 @@ export function ResetOverviewStats() {
                         variant={isRunning ? "secondary" : "danger"}
                         disabled={isRunning}
                         className="shrink-0"
-                        onClick={onReset}
+                        onClick={() => void onReset()}
                     >
                         <Icon
                             name={isRunning ? "progress_activity" : "delete_sweep"}

--- a/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
+++ b/frontend/app/routes/settings/maintenance/strm-to-symlinks/strm-to-symlinks.tsx
@@ -71,7 +71,7 @@ export function ConvertStrmToSymlinks({ savedConfig }: ConvertStrmToSymlinksProp
                         <Button
                             className="shrink-0"
                             variant={runButtonVariant}
-                            onClick={onRun}
+                            onClick={() => void onRun()}
                             disabled={!isRunButtonEnabled}
                         >
                             <Icon name={isRunning ? "progress_activity" : "play_arrow"} className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`} />

--- a/frontend/app/routes/settings/migration/altmount/use-altmount-migration.test.ts
+++ b/frontend/app/routes/settings/migration/altmount/use-altmount-migration.test.ts
@@ -20,6 +20,12 @@ import {
     type SessionStatus,
 } from "./use-altmount-migration";
 
+function parseRequestJsonBody(init: RequestInit | undefined): unknown {
+    const body = init?.body;
+    if (typeof body !== "string") throw new Error("Expected request body to be a JSON string");
+    return JSON.parse(body);
+}
+
 describe("requestAltmountPathDetection", () => {
     it("asks the backend to inspect the trimmed container path", async () => {
         const originalFetch = globalThis.fetch;
@@ -46,7 +52,7 @@ describe("requestAltmountPathDetection", () => {
             const [url, init] = fetchMock.mock.calls[0];
             expect(url).toBe("/api/migration/altmount/detect");
             expect(init?.method).toBe("POST");
-            expect(JSON.parse(String(init?.body))).toEqual({ root: "/altmount-data/config" });
+            expect(parseRequestJsonBody(init)).toEqual({ root: "/altmount-data/config" });
         } finally {
             globalThis.fetch = originalFetch;
         }
@@ -72,7 +78,7 @@ describe("requestAltmountPathDetection", () => {
             await requestAltmountPathDetection();
 
             const [, init] = fetchMock.mock.calls[0];
-            expect(JSON.parse(String(init?.body))).toEqual({ root: null });
+            expect(parseRequestJsonBody(init)).toEqual({ root: null });
         } finally {
             globalThis.fetch = originalFetch;
         }
@@ -183,7 +189,7 @@ describe("requestSymlinkApply", () => {
             const [url, init] = fetchMock.mock.calls[0];
             expect(url).toBe("/api/migration/altmount/symlinks/apply");
             expect(init?.method).toBe("POST");
-            expect(JSON.parse(String(init?.body))).toEqual({
+            expect(parseRequestJsonBody(init)).toEqual({
                 confirm: true,
                 acknowledgeUnreadable: expected,
             });
@@ -210,7 +216,7 @@ describe("requestOrphanSymlinkRemoval", () => {
             const [url, init] = fetchMock.mock.calls[0];
             expect(url).toBe("/api/migration/altmount/symlinks/orphans/remove");
             expect(init?.method).toBe("POST");
-            expect(JSON.parse(String(init?.body))).toEqual({ confirm: true });
+            expect(parseRequestJsonBody(init)).toEqual({ confirm: true });
         } finally {
             globalThis.fetch = originalFetch;
         }

--- a/frontend/app/routes/settings/profiles/profiles.tsx
+++ b/frontend/app/routes/settings/profiles/profiles.tsx
@@ -57,7 +57,8 @@ const ALL_ADAPTER_KEYS: AdapterKey[] = ADAPTERS.map(a => a.key);
 
 function parseProfileConfig(raw: string): ProfileConfig {
     try {
-        const parsed = JSON.parse(raw || "{}");
+        // The profiles.instances config value stores a serialized ProfileConfig.
+        const parsed = JSON.parse(raw || "{}") as Partial<ProfileConfig>;
         return { Profiles: parsed.Profiles ?? [] };
     } catch {
         return { Profiles: [] };
@@ -66,7 +67,8 @@ function parseProfileConfig(raw: string): ProfileConfig {
 
 function parseIndexerNames(raw: string): string[] {
     try {
-        const parsed = JSON.parse(raw || "{}");
+        // The indexers.instances config value stores a serialized { Indexers: IndexerSummary[] }.
+        const parsed = JSON.parse(raw || "{}") as { Indexers?: IndexerSummary[] };
         const list: IndexerSummary[] = parsed.Indexers ?? [];
         return list.filter(i => i.Enabled && i.Name?.trim()).map(i => i.Name);
     } catch {
@@ -385,7 +387,7 @@ function AdapterRow({ token, origin, adapter, enabled, onToggle }: AdapterRowPro
                         value={url}
                         onFocus={e => e.currentTarget.select()}
                     />
-                    <Button variant={copied ? "success" : "secondary"} size="xsmall" onClick={onCopy}>
+                    <Button variant={copied ? "success" : "secondary"} size="xsmall" onClick={() => void onCopy()}>
                         {copied ? "Copied" : "Copy"}
                     </Button>
                 </div>

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -40,7 +40,8 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 body: formData
             });
 
-            const result = await response.json();
+            // `/api/test-rclone-connection` response shape (backend contract)
+            const result = await response.json() as { status?: boolean; connected?: boolean; error?: string };
 
             if (result.status && result.connected) {
                 setConnectionState('success');
@@ -103,7 +104,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                             <Button
                                 variant={connectionState === 'success' ? 'success' :
                                     connectionState === 'error' ? 'danger' : 'secondary'}
-                                onClick={testConnection}
+                                onClick={() => void testConnection()}
                                 disabled={connectionState === 'testing'}
                                 className={'shrink-0'}
                             >

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -15,7 +15,8 @@ function isNonNegativeInteger(value: string) {
 
 export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) {
     const libraryDirConfig = config["media.library-dir"];
-    const arrConfig = JSON.parse(config["arr.instances"]);
+    // `arr.instances` config value shape (backend contract)
+    const arrConfig = JSON.parse(config["arr.instances"]) as { RadarrInstances: unknown[]; SonarrInstances: unknown[] };
     const areArrInstancesConfigured =
         arrConfig.RadarrInstances.length > 0 ||
         arrConfig.SonarrInstances.length > 0;

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -166,7 +166,7 @@ const defaultConfig = {
     "warden.backbone-scope": "true",
 }
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader() {
     const configItems = await backendClient.getConfig(Object.keys(defaultConfig));
 
     const config: Record<string, string> = { ...defaultConfig };
@@ -199,7 +199,7 @@ export default function Settings(props: Route.ComponentProps) {
             <ServiceProviderNotice
                 open
                 serviceProvider={serviceProvider}
-                onClose={() => navigate("/overview", { replace: true })}
+                onClose={() => { void navigate("/overview", { replace: true }); }}
             />
         );
     }
@@ -435,7 +435,7 @@ function Body(props: BodyProps) {
                     className="min-w-28"
                     variant={saveButtonVariant}
                     disabled={isSaveButtonDisabled}
-                    onClick={onSave}>
+                    onClick={() => void onSave()}>
                     <Icon name={isSaving ? "progress_activity" : saveButtonLabel === "Saved" ? "check" : "save"} className={`!text-[18px] ${isSaving ? "animate-spin" : ""}`} />
                     {saveButtonLabel}
                 </Button>

--- a/frontend/app/routes/settings/support/support.tsx
+++ b/frontend/app/routes/settings/support/support.tsx
@@ -95,7 +95,8 @@ export function SupportSettings() {
         try {
             const response = await fetch(withUrlBase("/api/download-support-pack"), { cache: "no-store" });
             if (!response.ok) {
-                const body = await response.json().catch(() => null);
+                // Error body from /api/download-support-pack (BaseApiResponse).
+                const body = await response.json().catch(() => null) as { error?: string } | null;
                 throw new Error(body?.error || `Support pack failed (${response.status})`);
             }
 
@@ -142,7 +143,8 @@ export function SupportSettings() {
             form.append("capacity", String(capacity));
             const response = await fetch(withUrlBase("/settings/stream-tracing"), { method: "POST", body: form });
             if (!response.ok) {
-                const body = await response.json().catch(() => null);
+                // Error body from POST /settings/stream-tracing (BaseApiResponse).
+                const body = await response.json().catch(() => null) as { error?: string } | null;
                 throw new Error(body?.error || `Could not update stream tracing (${response.status})`);
             }
             const next = toStreamTracingStatus(await response.json() as Record<string, unknown>);
@@ -176,7 +178,8 @@ export function SupportSettings() {
             form.append("intent", "discard");
             const response = await fetch(withUrlBase("/settings/stream-tracing"), { method: "POST", body: form });
             if (!response.ok) {
-                const body = await response.json().catch(() => null);
+                // Error body from POST /settings/stream-tracing (BaseApiResponse).
+                const body = await response.json().catch(() => null) as { error?: string } | null;
                 throw new Error(body?.error || `Could not discard stream traces (${response.status})`);
             }
             const next = toStreamTracingStatus(await response.json() as Record<string, unknown>);

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -6,6 +6,8 @@ import { shouldWarnCleartextCredentials } from "./cleartext-credentials";
 import {
     DndContext,
     type DragEndEvent,
+    type DraggableAttributes,
+    type DraggableSyntheticListeners,
     closestCenter,
     KeyboardSensor,
     PointerSensor,
@@ -67,6 +69,20 @@ type BenchmarkProgress = {
     error?: string | null;
 };
 type BenchmarkIntensity = "quick" | "thorough";
+
+// Mirrors backend TestUsenetConnectionResponse (BaseApiResponse + Connected), camelCase JSON.
+type TestConnectionResult = {
+    status?: boolean;
+    connected?: boolean;
+    error?: string | null;
+};
+
+// Mirrors backend BenchmarkUsenetConnectionResponse (BaseApiResponse + Result), camelCase JSON.
+type BenchmarkPostResult = {
+    status?: boolean;
+    result?: BenchmarkResult | null;
+    error?: string | null;
+};
 
 type UsenetSettingsProps = {
     config: Record<string, string>
@@ -360,7 +376,8 @@ function parseProviderConfig(jsonString: string): UsenetProviderConfig {
         if (!jsonString || jsonString.trim() === "") {
             return { Providers: [] };
         }
-        const parsed = JSON.parse(jsonString);
+        // Config key "usenet.providers" holds the backend UsenetProviderConfig JSON.
+        const parsed = JSON.parse(jsonString) as UsenetProviderConfig | null;
         return parsed && Array.isArray(parsed.Providers)
             ? parsed
             : { Providers: [] };
@@ -414,8 +431,8 @@ function generateProviderId(): string {
 type DragBits = {
     setNodeRef: (node: HTMLElement | null) => void;
     setActivatorNodeRef: (node: HTMLElement | null) => void;
-    attributes: any;
-    listeners: any;
+    attributes: DraggableAttributes;
+    listeners: DraggableSyntheticListeners;
     style: CSSProperties;
     isDragging: boolean;
 };
@@ -587,7 +604,7 @@ export function UsenetSettings({ config, savedConfig, setNewConfig, persistConfi
 
     const handleConnectionsMessage = useCallback((message: string) => {
         const parts = (message || "0|0|0|0|1|0").split("|");
-        const [index, live, idle, _0, _1, _2] = parts.map((x: any) => Number(x));
+        const [index, live, idle, _0, _1, _2] = parts.map((x) => Number(x));
         if (showModal) return;
         const savedProvider = savedProviderConfig.Providers[index];
         if (!savedProvider) return;
@@ -613,7 +630,8 @@ export function UsenetSettings({ config, savedConfig, setNewConfig, persistConfi
             try {
                 const response = await fetch(withUrlBase('/api/get-provider-usage'));
                 if (!response.ok || disposed) return;
-                const data: { providers?: ProviderUsage[] } = await response.json();
+                // Response of GET /api/get-provider-usage (backend GetProviderUsageResponse).
+                const data = await response.json() as { providers?: ProviderUsage[] };
                 if (disposed || !data.providers) return;
                 const next: Record<string, ProviderUsage> = {};
                 for (const p of data.providers) {
@@ -624,9 +642,9 @@ export function UsenetSettings({ config, savedConfig, setNewConfig, persistConfi
                 // network blips are fine — next tick retries.
             }
         }
-        fetchUsage();
+        void fetchUsage(); // fire-and-forget: fetchUsage swallows its own errors
         if (showModal) return () => { disposed = true; };
-        const id = setInterval(fetchUsage, USAGE_POLL_INTERVAL_MS);
+        const id = setInterval(() => void fetchUsage(), USAGE_POLL_INTERVAL_MS);
         return () => { disposed = true; clearInterval(id); };
     }, [showModal, providerConfig.Providers]);
 
@@ -1024,7 +1042,7 @@ function UsageRow({ provider, usage, onReset, resetDisabled = false }: UsageRowP
     const limit = provider.ByteLimit ?? null;
     const used = usage?.bytesUsed ?? 0;
     const hasLimit = limit !== null && limit > 0;
-    const pct = hasLimit ? Math.min(100, (used / (limit as number)) * 100) : 0;
+    const pct = hasLimit ? Math.min(100, (used / limit) * 100) : 0;
     // Thresholds match the soft-warning levels the backend would alert on if
     // we wired notifications. Keeping the same numbers here means the colors
     // tell the same story as any future alert email or webhook.
@@ -1049,7 +1067,7 @@ function UsageRow({ provider, usage, onReset, resetDisabled = false }: UsageRowP
                 </span>
                 <span className={`min-w-0 flex-1 text-xs font-semibold tabular-nums ${valueToneClass}`}>
                     {hasLimit
-                        ? `${formatBytes(used)} / ${formatBytes(limit as number)} · ${pct.toFixed(1)}%`
+                        ? `${formatBytes(used)} / ${formatBytes(limit)} · ${pct.toFixed(1)}%`
                         : formatBytes(used)}
                 </span>
                 {hasLimit && usage && usage.daysRemaining !== null && usage.daysRemaining !== undefined && !usage.overLimit && (
@@ -1218,7 +1236,8 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
             });
 
             if (response.ok) {
-                const data = await response.json();
+                // Response of POST /api/test-usenet-connection (backend TestUsenetConnectionResponse).
+                const data = await response.json() as TestConnectionResult;
                 if (data.connected) {
                     setConnectionTested(true);
                     setTestError(null);
@@ -1226,7 +1245,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
                     setTestError("Connection test failed");
                 }
             } else {
-                const data = await response.json().catch(() => null);
+                const data = await response.json().catch(() => null) as TestConnectionResult | null;
                 setTestError(data?.error || "Failed to test connection");
             }
         } catch (error) {
@@ -1308,11 +1327,12 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
             const response = await fetch(withUrlBase('/api/benchmark-usenet-connection'), {
                 method: 'POST', body: formData, signal: controller.signal,
             });
-            const data = await response.json().catch(() => null);
+            // Response of POST /api/benchmark-usenet-connection (backend BenchmarkUsenetConnectionResponse).
+            const data = await response.json().catch(() => null) as BenchmarkPostResult | null;
             if (finished) return;
 
             if (response.ok && data?.status && data.result) {
-                finish(data.result as BenchmarkResult, null);
+                finish(data.result, null);
                 return;
             }
             if (data?.error) {
@@ -1445,7 +1465,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
                     {canSave && type !== ProviderType.Disabled && (
                         <Button
                             variant="outline"
-                            onClick={handleTestConnection}
+                            onClick={() => void handleTestConnection()}
                             disabled={!isFormValid || isTestingConnection || isSaving}
                         >
                             {isTestingConnection ? "Testing..." : "Test Connection"}
@@ -1454,13 +1474,13 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
                     {!canSave ? (
                         <Button
                             variant="primary"
-                            onClick={handleTestConnection}
+                            onClick={() => void handleTestConnection()}
                             disabled={!isFormValid || isTestingConnection || isSaving}
                         >
                             {isTestingConnection ? "Testing..." : "Test Connection"}
                         </Button>
                     ) : (
-                        <Button variant="primary" onClick={handleSave} disabled={!canSave || isSaving}>
+                        <Button variant="primary" onClick={() => void handleSave()} disabled={!canSave || isSaving}>
                             {isSaving ? "Saving..." : "Save Provider"}
                         </Button>
                     )}
@@ -1658,7 +1678,7 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
                                 id="provider-type"
                                 className="w-full"
                                 value={type}
-                                onChange={(e) => setType(parseInt(e.target.value, 10) as ProviderType)}
+                                onChange={(e) => setType(parseInt(e.target.value, 10))}
                             >
                                 <option value={ProviderType.Disabled}>Disabled</option>
                                 <option value={ProviderType.Pooled}>Pool Connections</option>
@@ -1714,8 +1734,8 @@ function ProviderModal({ show, provider, existingStorageGroups, onClose, onSave,
                         progress={benchmarkProgress}
                         result={benchmarkResult}
                         error={benchmarkError}
-                        onRun={() => handleAutoTune()}
-                        onVerify={(connections) => handleAutoTune(connections)}
+                        onRun={() => void handleAutoTune()}
+                        onVerify={(connections) => void handleAutoTune(connections)}
                         onCancel={handleCancelBenchmark}
                         onApply={handleApplyRecommendation}
                     />

--- a/frontend/app/routes/settings/warden/warden.tsx
+++ b/frontend/app/routes/settings/warden/warden.tsx
@@ -47,6 +47,30 @@ type BackupStatus = {
     rawUrl?: string | null;
 };
 
+// Backend response contracts, mirroring backend/Api/Controllers/Warden/*.cs
+type WardenImportResponse = {
+    added: number;
+    total: number;
+    cleared: number;
+    sourceId?: string | null;
+};
+
+type WardenSourceMutateResponse = {
+    sourceId?: string | null;
+    message?: string | null;
+    removed: number;
+};
+
+type WardenSourcesImportResponse = {
+    added: number;
+    skipped: number;
+    invalid: number;
+};
+
+type WardenBackupMutateResponse = {
+    message: string;
+};
+
 const TRUST_HELP: Record<Trust, string> = {
     full: "Filters on its own",
     corroborate: "Filters only when enough sources agree",
@@ -66,6 +90,16 @@ function kindMeta(kind: Source["kind"]) {
     if (kind === "local") return { label: "Local", cls: "text-success border-success/30 bg-success/10" };
     if (kind === "remote") return { label: "Remote", cls: "text-info border-info/30 bg-info/10" };
     return { label: "Imported", cls: "" };
+}
+
+function apiError(data: unknown) {
+    return typeof data === "object" && data !== null && "error" in data && typeof data.error === "string"
+        ? data.error
+        : null;
+}
+
+function errorText(err: unknown, fallback: string) {
+    return err instanceof Error && err.message ? err.message : fallback;
 }
 
 export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
@@ -120,18 +154,21 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
     const refresh = async () => {
         try {
             const res = await fetch(withUrlBase("/api/warden-sources"));
-            if (res.ok) setSnap(await res.json());
+            // GET /api/warden-sources → WardenSourcesResponse
+            if (res.ok) setSnap((await res.json()) as Snapshot);
         } catch { /* ignore */ }
     };
 
     const loadBackup = async () => {
         try {
             const res = await fetch(withUrlBase("/api/warden-backup"));
-            if (res.ok) setBackup(await res.json());
+            // GET /api/warden-backup → WardenBackupStatusResponse
+            if (res.ok) setBackup((await res.json()) as BackupStatus);
         } catch { }
     };
 
-    useEffect(() => { refresh(); loadBackup(); }, []);
+    // Initial load; both fetches catch internally and report via state.
+    useEffect(() => { void refresh(); void loadBackup(); }, []);
 
     useEffect(() => {
         if (message?.variant !== "success") return;
@@ -139,11 +176,12 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
         return () => clearTimeout(t);
     }, [message]);
 
-    const post = async (url: string, form: FormData): Promise<any> => {
+    const post = async <T = unknown>(url: string, form: FormData): Promise<T> => {
         const res = await fetch(url, { method: "POST", body: form });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(data.error || "Request failed.");
-        return data;
+        const data: unknown = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(apiError(data) || "Request failed.");
+        // The caller names the endpoint's response contract (see the Warden controllers).
+        return data as T;
     };
 
     const submitImport = async () => {
@@ -158,14 +196,14 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 form.append("name", importName);
                 form.append("trust", importTrust);
             }
-            const data = await post("/api/warden-import", form);
+            const data = await post<WardenImportResponse>("/api/warden-import", form);
             setMessage({ text: `Imported ${(data.added ?? 0).toLocaleString()} fingerprint${data.added === 1 ? "" : "s"}.`, variant: "success" });
             setShowImport(false);
             setPendingFile(null);
             setImportName("");
             await refresh();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Import failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Import failed."), variant: "danger" });
         } finally {
             setBusy(null);
             if (fileRef.current) fileRef.current.value = "";
@@ -215,7 +253,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             form.append("name", remoteName.trim());
             form.append("trust", remoteTrust);
             form.append("refreshHours", remoteInterval);
-            const data = await post("/api/warden-source-add", form);
+            const data = await post<WardenSourceMutateResponse>("/api/warden-source-add", form);
             const failed = (data.message ?? "").startsWith("error");
             setMessage(failed
                 ? { text: `Added, but the first fetch failed: ${data.message}`, variant: "danger" }
@@ -224,8 +262,8 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             setRemoteUrl("");
             setRemoteName("");
             await refresh();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Could not add the remote list.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Could not add the remote list."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -240,7 +278,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             if (bulkText.trim()) form.append("text", bulkText);
             form.append("trust", bulkTrust);
             form.append("refreshHours", bulkInterval);
-            const data = await post("/api/warden-sources-import", form);
+            const data = await post<WardenSourcesImportResponse>("/api/warden-sources-import", form);
             const parts = [`Added ${(data.added ?? 0).toLocaleString()}`];
             if (data.skipped) parts.push(`${data.skipped.toLocaleString()} already present`);
             if (data.invalid) parts.push(`${data.invalid.toLocaleString()} invalid`);
@@ -250,8 +288,8 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             setBulkFile(null);
             if (bulkFileRef.current) bulkFileRef.current.value = "";
             await refresh();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Import failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Import failed."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -274,8 +312,8 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             for (const [k, v] of Object.entries(fields)) form.append(k, v);
             await post("/api/warden-source-update", form);
             await refresh();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Update failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Update failed."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -287,12 +325,12 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
         try {
             const form = new FormData();
             form.append("id", id);
-            const data = await post("/api/warden-source-refresh", form);
+            const data = await post<WardenSourceMutateResponse>("/api/warden-source-refresh", form);
             const failed = (data.message ?? "").startsWith("error");
             setMessage({ text: `Refresh: ${data.message}`, variant: failed ? "danger" : "success" });
             await refresh();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Refresh failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Refresh failed."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -308,7 +346,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             const form = new FormData();
             form.append("id", source.id);
             if (kind === "clear") form.append("action", "clear");
-            const data = await post("/api/warden-source-remove", form);
+            const data = await post<WardenSourceMutateResponse>("/api/warden-source-remove", form);
             setMessage({
                 text: kind === "clear"
                     ? `Cleared ${(data.removed ?? 0).toLocaleString()} fingerprint${data.removed === 1 ? "" : "s"}.`
@@ -316,8 +354,8 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 variant: "success",
             });
             await refresh();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Action failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Action failed."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -346,13 +384,13 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             form.append("scope", bScope);
             form.append("intervalHours", bInterval);
             if (bToken) form.append("token", bToken);
-            const data = await post("/api/warden-backup", form);
+            const data = await post<BackupStatus>("/api/warden-backup", form);
             setBackup(data);
             setMessage({ text: "Backup settings saved.", variant: "success" });
             setShowBackup(false);
             setBToken("");
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Could not save backup settings.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Could not save backup settings."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -362,12 +400,12 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
         setBusy("backup-now");
         setMessage(null);
         try {
-            const data = await post("/api/warden-backup-now", new FormData());
+            const data = await post<WardenBackupMutateResponse>("/api/warden-backup-now", new FormData());
             const failed = (data.message ?? "").startsWith("error");
             setMessage({ text: `Backup: ${data.message}`, variant: failed ? "danger" : "success" });
             await loadBackup();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Backup failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Backup failed."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -378,12 +416,12 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
         setBusy("backup-restore");
         setMessage(null);
         try {
-            const data = await post("/api/warden-backup-restore", new FormData());
+            const data = await post<WardenBackupMutateResponse>("/api/warden-backup-restore", new FormData());
             setMessage({ text: data.message || "Restored.", variant: "success" });
             await refresh();
             await loadBackup();
-        } catch (err: any) {
-            setMessage({ text: err?.message || "Restore failed.", variant: "danger" });
+        } catch (err: unknown) {
+            setMessage({ text: errorText(err, "Restore failed."), variant: "danger" });
         } finally {
             setBusy(null);
         }
@@ -504,14 +542,14 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                             ? <span className={"truncate text-sm font-semibold text-base-content"}>{s.name}</span>
                                             : <input className={"min-w-0 max-w-[240px] rounded-md border border-transparent bg-transparent px-1.5 py-0.5 text-sm font-semibold text-base-content hover:border-base-content/10 focus:border-base-content/10 focus:bg-base-200 focus:outline-none"} defaultValue={s.name} disabled={rowBusy}
                                                 key={`nm-${s.id}-${s.name}`}
-                                                onBlur={e => { const v = e.target.value.trim(); if (v && v !== s.name) updateSource(s.id, { name: v }); }}
+                                                onBlur={e => { const v = e.target.value.trim(); if (v && v !== s.name) void updateSource(s.id, { name: v }); /* failures surface via setMessage */ }}
                                                 onKeyDown={e => { if (e.key === "Enter") e.currentTarget.blur(); }} />}
                                         <span className={`${"shrink-0 rounded-md border border-base-content/10 bg-base-200 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-base-content/80"} ${km.cls}`}>{km.label}</span>
                                         {rowBusy && <Spinner size="sm" />}
                                     </div>
                                     <div className={"ml-auto flex shrink-0 items-center gap-1.5"}>
                                         {s.kind === "remote" &&
-                                            <Button variant="primary" size="xsmall" disabled={rowBusy} onClick={() => refreshSource(s.id)}>
+                                            <Button variant="primary" size="xsmall" disabled={rowBusy} onClick={() => void refreshSource(s.id)}>
                                                 <Icon name="refresh" className="!text-[16px]" />
                                                 Refresh
                                             </Button>}
@@ -538,7 +576,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                         : <div className={"flex items-center gap-1.5"}>
                                             <span className={"text-xs text-base-content/80"}>Trust</span>
                                             <Form.Select className={"w-[123px] shrink-0 text-xs"} value={s.trust} disabled={rowBusy}
-                                                onChange={e => updateSource(s.id, { trust: e.target.value })}>
+                                                onChange={e => void updateSource(s.id, { trust: e.target.value })}>
                                                 <option value="full">full</option>
                                                 <option value="corroborate">corroborate</option>
                                                 <option value="observe">observe</option>
@@ -551,7 +589,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                             <Form.Check type="switch" id={`enabled-${s.id}`} label="Enabled"
                                                 className="cursor-pointer gap-2 p-0"
                                                 checked={s.enabled} disabled={rowBusy}
-                                                onChange={e => updateSource(s.id, { enabled: String(e.target.checked) })} />
+                                                onChange={e => void updateSource(s.id, { enabled: String(e.target.checked) })} />
                                         </Tooltip>}
 
                                     {s.kind === "remote" &&
@@ -559,7 +597,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                                             <span className={"text-xs text-base-content/80"}>Refresh (h)</span>
                                             <Form.Control type="number" min={1} max={720} className={"w-[72px] shrink-0 text-xs"}
                                                 key={`rh-${s.id}-${s.refreshHours}`} defaultValue={s.refreshHours} disabled={rowBusy}
-                                                onBlur={e => { const v = parseInt(e.target.value, 10); if (v && v !== s.refreshHours) updateSource(s.id, { refreshHours: String(v) }); }}
+                                                onBlur={e => { const v = parseInt(e.target.value, 10); if (v && v !== s.refreshHours) void updateSource(s.id, { refreshHours: String(v) }); /* failures surface via setMessage */ }}
                                                 onKeyDown={e => { if (e.key === "Enter") e.currentTarget.blur(); }} />
                                         </div>}
 
@@ -596,7 +634,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                             Settings
                         </Button>
                         <Button variant="primary" size="xsmall" disabled={!backup?.hasToken || busy !== null}
-                            onClick={backupNow}>
+                            onClick={() => void backupNow()}>
                             {busy === "backup-now"
                                 ? <><Spinner size="sm" /> Backing up…</>
                                 : <><Icon name="cloud_upload" className="!text-[16px]" /> Back up now</>}
@@ -636,7 +674,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 onClose={() => setShowAddRemote(false)}
                 footer={<>
                     <Button variant="outline" onClick={() => setShowAddRemote(false)}>Cancel</Button>
-                    <Button disabled={busy === "add-remote" || !remoteUrl.trim()} onClick={addRemoteSource}>
+                    <Button disabled={busy === "add-remote" || !remoteUrl.trim()} onClick={() => void addRemoteSource()}>
                         {busy === "add-remote" ? <><Spinner size="sm" /> Adding…</> : "Add & fetch"}
                     </Button>
                 </>}
@@ -675,7 +713,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 onClose={() => setShowBulk(false)}
                 footer={<>
                     <Button variant="outline" onClick={() => setShowBulk(false)}>Cancel</Button>
-                    <Button disabled={busy === "bulk" || (!bulkText.trim() && !bulkFile)} onClick={submitBulk}>
+                    <Button disabled={busy === "bulk" || (!bulkText.trim() && !bulkFile)} onClick={() => void submitBulk()}>
                         {busy === "bulk" ? <><Spinner size="sm" /> Importing…</> : "Import"}
                     </Button>
                 </>}
@@ -730,7 +768,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 onClose={() => setShowImport(false)}
                 footer={<>
                     <Button variant="outline" onClick={() => setShowImport(false)}>Cancel</Button>
-                    <Button disabled={busy === "import" || !pendingFile} onClick={submitImport}>
+                    <Button disabled={busy === "import" || !pendingFile} onClick={() => void submitImport()}>
                         {busy === "import" ? <><Spinner size="sm" /> Importing…</> : "Import"}
                     </Button>
                 </>}
@@ -814,7 +852,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 onClose={() => setShowBackup(false)}
                 footer={<>
                     <Button variant="outline" onClick={() => setShowBackup(false)}>Cancel</Button>
-                    <Button disabled={busy === "backup-save" || !bRepo.trim()} onClick={saveBackup}>
+                    <Button disabled={busy === "backup-save" || !bRepo.trim()} onClick={() => void saveBackup()}>
                         {busy === "backup-save" ? <><Spinner size="sm" /> Saving…</> : "Save"}
                     </Button>
                 </>}
@@ -872,7 +910,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 cancelText="Cancel"
                 confirmText="Restore"
                 onCancel={() => setConfirmRestore(false)}
-                onConfirm={doRestore} />
+                onConfirm={() => void doRestore()} />
 
             <ConfirmModal
                 show={confirm !== null}
@@ -883,7 +921,7 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
                 cancelText="Cancel"
                 confirmText={confirm?.kind === "remove" ? "Remove" : "Clear"}
                 onCancel={() => setConfirm(null)}
-                onConfirm={runConfirm} />
+                onConfirm={() => void runConfirm()} />
         </SettingsPage>
     );
 }

--- a/frontend/app/routes/settings/watchtower/watchtower.tsx
+++ b/frontend/app/routes/settings/watchtower/watchtower.tsx
@@ -7,7 +7,9 @@ type ProfileOption = { token: string; name: string };
 
 function parseProfiles(raw?: string): ProfileOption[] {
     try {
-        const list = (JSON.parse(raw || "{}").Profiles ?? []) as Array<{ Token?: string; Name?: string }>;
+        // `profiles.instances` config value shape (backend contract)
+        const parsed = JSON.parse(raw || "{}") as { Profiles?: Array<{ Token?: string; Name?: string }> };
+        const list = parsed.Profiles ?? [];
         return list
             .filter(p => p?.Token)
             .map(p => ({ token: String(p.Token), name: String(p.Name ?? "").trim() }));

--- a/frontend/app/routes/watchdog/route.tsx
+++ b/frontend/app/routes/watchdog/route.tsx
@@ -47,12 +47,13 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
         try {
             const r = await fetch(withUrlBase("/settings/watchdog-attempts?limit=200"));
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
-            const data = await r.json();
+            // /settings/watchdog-attempts resource route returns { entries: WatchdogEntry[] }
+            const data = await r.json() as { entries?: WatchdogEntry[] };
             const next: WatchdogEntry[] = data.entries ?? [];
             setAttempts(prev => attemptsEqual(prev, next) ? prev : next);
             setError(null);
-        } catch (e: any) {
-            setError(e?.message ?? String(e));
+        } catch (e: unknown) {
+            setError(e instanceof Error ? e.message : String(e));
         } finally {
             if (!silent) setRefreshing(false);
         }
@@ -66,8 +67,8 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             setAttempts([]);
             setError(null);
-        } catch (e: any) {
-            setError(e?.message ?? String(e));
+        } catch (e: unknown) {
+            setError(e instanceof Error ? e.message : String(e));
         } finally {
             setClearing(false);
         }
@@ -81,9 +82,9 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
             if (cancelled) return;
             await refresh(true);
             if (cancelled) return;
-            timer = setTimeout(loop, POLL_INTERVAL_MS);
+            timer = setTimeout(() => { void loop(); }, POLL_INTERVAL_MS);
         };
-        timer = setTimeout(loop, POLL_INTERVAL_MS);
+        timer = setTimeout(() => { void loop(); }, POLL_INTERVAL_MS);
         return () => {
             cancelled = true;
             if (timer) clearTimeout(timer);
@@ -125,7 +126,7 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
                             <button
                                 type="button"
                                 className="btn btn-sm btn-primary join-item gap-2"
-                                onClick={() => refresh()}
+                                onClick={() => void refresh()}
                                 disabled={refreshing || clearing}
                                 title="Refresh now.">
                                 <Icon
@@ -194,7 +195,7 @@ export default function Watchdog({ loaderData }: Route.ComponentProps) {
                 confirmText="Clear log"
                 cancelText="Cancel"
                 onCancel={() => setShowClearConfirm(false)}
-                onConfirm={performClear}
+                onConfirm={() => void performClear()}
             />
         </div>
     );

--- a/frontend/app/routes/watchtower/route.tsx
+++ b/frontend/app/routes/watchtower/route.tsx
@@ -35,7 +35,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 export async function action({ request }: Route.ActionArgs) {
     const form = await request.formData();
     const fields: Record<string, string> = {};
-    for (const [k, v] of form.entries()) fields[k] = String(v);
+    for (const [k, v] of form.entries()) fields[k] = typeof v === "string" ? v : v.name;
     try {
         if (fields.action === "discover-catalogs") {
             const discovered = await backendClient.discoverStremioCatalogs(fields.url ?? "");
@@ -48,8 +48,8 @@ export async function action({ request }: Route.ActionArgs) {
         }
         await backendClient.watchtowerMutate(fields);
         return { ok: true as const };
-    } catch (e: any) {
-        return { ok: false as const, error: e?.message ?? String(e) };
+    } catch (e: unknown) {
+        return { ok: false as const, error: e instanceof Error ? e.message : String(e) };
     }
 }
 
@@ -165,7 +165,7 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
         if (stateFilter) sp.set("state", stateFilter);
         if (urlQuery) sp.set("q", urlQuery);
         sp.set("expander", next);
-        childFetcher.load(`${location.pathname}?${sp.toString()}`);
+        void childFetcher.load(`${location.pathname}?${sp.toString()}`); // fire-and-forget: result handled via fetcher state
     }, [shows, expandedShows, childLoaded, childFetcher.state, stateFilter, urlQuery, location.pathname]);
 
     useEffect(() => {
@@ -187,11 +187,11 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
         if (urlQuery) sp.set("q", urlQuery);
         if (sortKey !== "default") sp.set("sort", sortKey);
         sp.set("offset", String(offset));
-        moreFetcher.load(`${location.pathname}?${sp.toString()}`);
+        void moreFetcher.load(`${location.pathname}?${sp.toString()}`); // fire-and-forget: result handled via fetcher state
     };
     const pollRef = useRef<() => void>(() => {});
     pollRef.current = () => {
-        if (statsFetcher.state === "idle") statsFetcher.load(`${location.pathname}?statsOnly=1`);
+        if (statsFetcher.state === "idle") void statsFetcher.load(`${location.pathname}?statsOnly=1`); // fire-and-forget poll
     };
 
     useEffect(() => {
@@ -301,7 +301,8 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
 
     const handleConfirmRemove = useCallback(() => {
         if (pendingRemove === "bulk") {
-            bulkItemFetcher.submit(
+            // fire-and-forget: result handled via fetcher state
+            void bulkItemFetcher.submit(
                 { action: "bulk-remove", keys: bulkKeysValue },
                 { method: "post" },
             );
@@ -309,7 +310,7 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
             const formData: Record<string, string> = { action: "remove-by-filter" };
             if (stateFilter) formData.state = stateFilter;
             if (urlQuery) formData.q = urlQuery;
-            filterFetcher.submit(formData, { method: "post" });
+            void filterFetcher.submit(formData, { method: "post" }); // fire-and-forget: result handled via fetcher state
         }
         setPendingRemove(null);
     }, [pendingRemove, bulkKeysValue, bulkItemFetcher, filterFetcher, stateFilter, urlQuery]);

--- a/frontend/app/utils/update-check.server.test.ts
+++ b/frontend/app/utils/update-check.server.test.ts
@@ -23,6 +23,12 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+function firstCalledUrl(): string {
+  const input = fetchMock.mock.calls[0]?.[0];
+  if (typeof input !== "string") throw new Error("Expected fetch to be called with a string URL");
+  return input;
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   resetUpdateCheckCache();
@@ -198,7 +204,7 @@ describe("checkForUpdate", () => {
 
     expect(getBuildCommitMock).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/releases/latest");
+    expect(firstCalledUrl()).toContain("/releases/latest");
   });
 
   it("returns commits behind for an up-to-date source checkout on main", async () => {
@@ -247,7 +253,7 @@ describe("checkForUpdate", () => {
 
     await expect(checkForUpdate("0.7.5")).resolves.toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/releases/latest");
+    expect(firstCalledUrl()).toContain("/releases/latest");
   });
 
   it("does not compare release builds using version-embedded SHAs", async () => {
@@ -265,7 +271,7 @@ describe("checkForUpdate", () => {
 
     await expect(checkForUpdate("0.7.5")).resolves.toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/releases/latest");
+    expect(firstCalledUrl()).toContain("/releases/latest");
   });
 
   it("notifies main-<sha> builds when main is ahead", async () => {
@@ -289,7 +295,7 @@ describe("checkForUpdate", () => {
       trackRef: "main",
     });
     expect(getBuildCommitMock).toHaveBeenCalledWith({ version: "main-e0eef520" });
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/compare/e0eef520...main");
+    expect(firstCalledUrl()).toContain("/compare/e0eef520...main");
   });
 });
 
@@ -319,7 +325,7 @@ describe("checkForUpdate (dev builds)", () => {
       compareUrl: `https://github.com/infinidysk/infinidysk/compare/${buildSha}...dev`,
       trackRef: "dev",
     });
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+    expect(firstCalledUrl()).toContain(
       `/compare/${encodeURIComponent(buildSha)}...dev`,
     );
   });
@@ -334,7 +340,7 @@ describe("checkForUpdate (dev builds)", () => {
     );
 
     await expect(checkForUpdate("dev-e0eef52")).resolves.toBeNull();
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+    expect(firstCalledUrl()).toContain(
       `/compare/${encodeURIComponent(buildSha)}...dev`,
     );
   });

--- a/frontend/app/utils/websocket-util.ts
+++ b/frontend/app/utils/websocket-util.ts
@@ -2,7 +2,8 @@ export function receiveMessage(
     onMessage: (topic: string, message: string) => void
 ): (event: MessageEvent) => void {
     return (event) => {
-        const parsed = JSON.parse(event.data);
+        // Websocket text frames carry the backend envelope shape { Topic, Message }
+        const parsed = JSON.parse(event.data as string) as { Topic: string; Message: string };
         onMessage(parsed.Topic, parsed.Message);
     }
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,12 +18,19 @@ export default tseslint.config(
     ],
   },
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  // Type-aware rules: catch floating/misused promises and unsafe `any` flows.
+  // Requires generated route types (`react-router typegen`) — the lint script
+  // runs typegen first.
+  ...tseslint.configs.recommendedTypeChecked,
   {
     plugins: {
       "react-hooks": reactHooks,
     },
     languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
       globals: {
         console: "readonly",
         process: "readonly",
@@ -65,16 +72,28 @@ export default tseslint.config(
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
 
-      // Existing backlog — the npm lint script locks its 163-warning baseline;
-      // follow-ups must reduce it before the budget can be lowered.
-      "@typescript-eslint/no-explicit-any": "warn",
+      // Type-aware strictness (#853 phase 1). The four promise rules per the
+      // issue; no-unsafe-* come from recommendedTypeChecked.
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/await-thenable": "error",
+      "@typescript-eslint/require-await": "error",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": [
-        "warn",
+        "error",
         {
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
         },
       ],
+
+      // no-undef is meaningless for TypeScript (the compiler owns undefined-name
+      // detection) and misfires on type-only imports; typescript-eslint FAQ
+      // recommends turning it off for TS files.
+      "no-undef": "off",
+
+      // Remaining warning budget — driven to zero in phase 3 (kept as warn so
+      // the type-aware rollout stays reviewable; the lint script caps the count).
       "@typescript-eslint/no-empty-object-type": "warn",
       "@typescript-eslint/no-unused-expressions": "warn",
       "no-unused-expressions": "off",
@@ -82,7 +101,12 @@ export default tseslint.config(
       "no-extra-boolean-cast": "warn",
       "no-useless-assignment": "warn",
       "prefer-const": "warn",
-      "no-undef": "warn",
     },
+  },
+  {
+    // Root config files are not part of any tsconfig project; lint them
+    // without type information.
+    files: ["*.js", "*.ts", "*.mjs"],
+    ...tseslint.configs.disableTypeChecked,
   },
 );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "predev": "bash ../scripts/sync-dev-env.sh",
     "dev": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --import tsx server.ts",
     "start": "node dist-node/server.js",
-    "lint": "eslint . --max-warnings 163",
+    "lint": "react-router typegen && eslint . --max-warnings 27",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "react-router typegen && tsc -b"

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -113,14 +113,20 @@ const router = express.Router();
 router.use(securityHeadersMiddleware);
 
 // Initialize the websocket server as soon as both it and the server-module are ready
-let _serverModule: any = null;
+interface ServerBuildModule {
+    app: express.Express;
+    bakedUrlBase?: string;
+    initializeWebsocketServer(websocketServer: WebSocketServer): void;
+}
+
+let _serverModule: ServerBuildModule | null = null;
 let _websocketServer: WebSocketServer | null = null;
 const setWebsocketServer = (websocketServer: WebSocketServer) => {
   if (_websocketServer != null) return;
   if (_serverModule != null) _serverModule.initializeWebsocketServer(websocketServer);
   _websocketServer = websocketServer;
 };
-const setServerModule = (serverModule: any) => {
+const setServerModule = (serverModule: ServerBuildModule) => {
   if (_serverModule != null) return;
   if (_websocketServer != null) serverModule.initializeWebsocketServer(_websocketServer);
   _serverModule = serverModule;
@@ -139,7 +145,8 @@ if (DEVELOPMENT) {
   app.use(viteDevServer.middlewares);
   router.use(async (req, res, next) => {
     try {
-      const serverModule = await viteDevServer.ssrLoadModule("./server/app.ts");
+      // The dev SSR module fulfills the same contract as the production build.
+      const serverModule = (await viteDevServer.ssrLoadModule("./server/app.ts")) as ServerBuildModule;
       assertUrlBaseMatchesBuild(serverModule.bakedUrlBase);
       setServerModule(serverModule);
       return await serverModule.app(req, res, next);

--- a/frontend/server/backend-proxy-options.test.ts
+++ b/frontend/server/backend-proxy-options.test.ts
@@ -120,7 +120,7 @@ describe("backend proxy keep-alive timeout listeners", () => {
 
     // Same TCP connection reused for every request.
     expect(inboundSocket).toBeDefined();
-    const first = listenerCounts[0]!;
+    const first = listenerCounts[0];
     for (const count of listenerCounts) {
       expect(count).toBe(first);
     }

--- a/frontend/server/oidc-routes.integration.test.ts
+++ b/frontend/server/oidc-routes.integration.test.ts
@@ -107,7 +107,7 @@ describe("OIDC callback integration", () => {
     );
     const res = mockResponse();
 
-    await oidcCallbackHandler(req, res);
+    await oidcCallbackHandler(req, res as unknown as Response);
 
     expect(fixture.tokenRequest()).toEqual(expect.any(URLSearchParams));
     expect(fixture.tokenRequest()?.get("client_id")).toBe(CLIENT_ID);
@@ -128,7 +128,7 @@ describe("OIDC callback integration", () => {
     );
     const res = mockResponse();
 
-    await oidcCallbackHandler(req, res);
+    await oidcCallbackHandler(req, res as unknown as Response);
 
     expect(mocks.setSessionUser).not.toHaveBeenCalled();
     expect(mocks.clearOidcFlowState).toHaveBeenCalledWith(req);
@@ -280,15 +280,14 @@ function mockRequest(originalUrl: string): Request {
   } as unknown as Request;
 }
 
-function mockResponse(): Response & {
+type MockResponse = Omit<Response, "redirect" | "setHeader"> & {
   redirect: ReturnType<typeof vi.fn>;
   setHeader: ReturnType<typeof vi.fn>;
-} {
+};
+
+function mockResponse(): MockResponse {
   return {
     redirect: vi.fn(),
     setHeader: vi.fn(),
-  } as unknown as Response & {
-    redirect: ReturnType<typeof vi.fn>;
-    setHeader: ReturnType<typeof vi.fn>;
-  };
+  } as unknown as MockResponse;
 }

--- a/frontend/server/oidc-routes.test.ts
+++ b/frontend/server/oidc-routes.test.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from "express";
 
 const mocks = vi.hoisted(() => ({
   randomPKCECodeVerifier: vi.fn(() => "verifier"),
-  calculatePKCECodeChallenge: vi.fn(async () => "challenge"),
+  calculatePKCECodeChallenge: vi.fn(() => Promise.resolve("challenge")),
   randomNonce: vi.fn(() => "nonce"),
   randomState: vi.fn(() => "state"),
   buildAuthorizationUrl: vi.fn(() => new URL("https://identity.example.com/authorize")),
@@ -68,17 +68,19 @@ function mockRequest(originalUrl: string): Request {
   } as unknown as Request;
 }
 
-function mockResponse(): Response & {
+// Omit<> keeps the mock members lint-clean (pure vi.fn, no `this`); callers cast
+// back to express.Response at the handler boundary (the mock only implements the
+// surface the handlers exercise).
+type MockResponse = Omit<Response, "redirect" | "setHeader"> & {
   redirect: ReturnType<typeof vi.fn>;
   setHeader: ReturnType<typeof vi.fn>;
-} {
+};
+
+function mockResponse(): MockResponse {
   return {
     redirect: vi.fn(),
     setHeader: vi.fn(),
-  } as unknown as Response & {
-    redirect: ReturnType<typeof vi.fn>;
-    setHeader: ReturnType<typeof vi.fn>;
-  };
+  } as unknown as MockResponse;
 }
 
 beforeEach(() => {
@@ -106,7 +108,7 @@ describe("OIDC Express routes", () => {
     const req = mockRequest("/auth/oidc/login");
     const res = mockResponse();
 
-    await oidcLoginHandler(req, res);
+    await oidcLoginHandler(req, res as unknown as Response);
 
     expect(mocks.setOidcFlowState).toHaveBeenCalledWith(req, {
       codeVerifier: "verifier",
@@ -149,7 +151,7 @@ describe("OIDC Express routes", () => {
       headers: { "Set-Cookie": "__session=user" },
     });
 
-    await oidcCallbackHandler(req, res);
+    await oidcCallbackHandler(req, res as unknown as Response);
 
     expect(mocks.authorizationCodeGrant).toHaveBeenCalledWith(
       {},
@@ -170,7 +172,7 @@ describe("OIDC Express routes", () => {
     const res = mockResponse();
     mocks.getOidcFlowState.mockResolvedValue(null);
 
-    await oidcCallbackHandler(req, res);
+    await oidcCallbackHandler(req, res as unknown as Response);
 
     expect(mocks.clearOidcFlowState).toHaveBeenCalledWith(req);
     expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", "__session=cleared");

--- a/frontend/server/request-log-throttle.ts
+++ b/frontend/server/request-log-throttle.ts
@@ -17,7 +17,11 @@ const throttleState = process as typeof process & {
 };
 
 function getState(): Map<string, ThrottleEntry> {
-  return throttleState.__nzbdavClientErrorLogState ??= new Map();
+  const existing = throttleState.__nzbdavClientErrorLogState;
+  if (existing) return existing;
+  const created = new Map<string, ThrottleEntry>();
+  throttleState.__nzbdavClientErrorLogState = created;
+  return created;
 }
 
 /**

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -131,7 +131,7 @@ describe("UpstreamSubscriptionForwarder", () => {
         forwarder.sendFullSubscriptionSet();
 
         expect(sent).toHaveLength(1);
-        const parsed = JSON.parse(sent[0]);
+        const parsed = JSON.parse(sent[0]) as { sub: string[] };
         expect(parsed.sub.sort()).toEqual(["cxs", "ls"]);
     });
 

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -1,7 +1,17 @@
 import WebSocket, { WebSocketServer } from 'ws';
+import { Buffer } from "node:buffer";
 import { isAuthenticated } from "../app/auth/authentication.server";
 import type { IncomingMessage } from 'http';
 import { logger } from "./logger";
+
+// ws types MessageEvent.data as any; decode explicitly.
+function messageEventDataToString(data: unknown): string {
+    if (typeof data === "string") return data;
+    if (data instanceof Buffer) return data.toString("utf8");
+    if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+    if (Array.isArray(data)) return Buffer.concat(data as Buffer[]).toString("utf8");
+    return String(data);
+}
 
 export const MAX_WEBSOCKET_PAYLOAD_BYTES = 64 * 1024;
 export const MAX_TOPICS_PER_SOCKET = 100;
@@ -99,7 +109,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
         });
 
         const applySubscription = (event: WebSocket.MessageEvent) => {
-            const topics = parseSubscriptionTopics(event.data.toString());
+            const topics = parseSubscriptionTopics(messageEventDataToString(event.data));
             if (!topics) {
                 ws.close(1003, "Could not process topic subscription. If recently updated, try refreshing the page.");
                 return;
@@ -241,7 +251,7 @@ export function initializeWebsocketClient(
 
         socket.onmessage = (event: WebSocket.MessageEvent) => {
             try {
-                const rawMessage = event.data.toString();
+                const rawMessage = messageEventDataToString(event.data);
                 const topicMessage: unknown = JSON.parse(rawMessage);
                 if (!topicMessage || typeof topicMessage !== "object") return;
 


### PR DESCRIPTION
## Summary

Phase 1 of #853: `frontend/eslint.config.js` moves from `typescript-eslint` recommended to **recommendedTypeChecked** (via `projectService`), with `no-floating-promises`, `no-misused-promises`, `await-thenable`, `require-await` as errors and `no-explicit-any`/`no-unused-vars` promoted to error.

**513 → 0 errors.** Highlights:

- `backend-client.server.ts`: `call()` is now generic over a per-endpoint response contract instead of returning `any` — one documented assertion at the JSON boundary replaces 76 unsafe-flow errors; error body typed so the `String()` cast is gone
- Route pages (warden/usenet/arrs/indexers/backup/watchtower/watchdog/explore/…) get real payload types at their loaders/fetchers instead of `any` flows
- Promise discipline: fire-and-forget calls use explicit `void` + comment; event handlers wrap async handlers (`onClick={() => void h()}`); Express 5 async handlers kept
- `no-undef` is off for TS files per the typescript-eslint FAQ (the compiler owns undefined-name detection) — documented in the config
- Root config files (`eslint.config.js`, `react-router.config.ts`) lint without type info via `disableTypeChecked`
- Lint script runs `react-router typegen` first so type-aware rules always see generated route types (CI lints before typecheck)
- Warning budget ratcheted 163 → 27 (measured; the remaining warn-level backlog is cleared in the follow-up phase)

Lint time: ~6s full tree (budget was 90s).

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm test` — 519 pass
- [x] `npm run build && npm run build:server` — pass

Part of #853. Stacked on the warnings-as-errors PR (merge order maintained by the stack).