### PR TITLE
chore(lint): zero ESLint warnings; enforce --max-warnings 0

### DIFF
--- a/frontend/app/components/tag-input/tag-input.tsx
+++ b/frontend/app/components/tag-input/tag-input.tsx
@@ -42,7 +42,7 @@ export function TagInput({
 
     const updateTags = useCallback((newTags: string[]) => {
         onChange(newTags.join(`${delimiter} `));
-    }, [onChange, delimiter]);
+    }, [onChange]);
 
     const addTag = useCallback((tag: string) => {
         const trimmed = tag.trim();

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -58,11 +58,11 @@ export default function handleRequest(
 
   return new Promise((resolve, reject) => {
     let shellRendered = false;
-    let userAgent = request.headers.get("user-agent");
+    const userAgent = request.headers.get("user-agent");
 
     // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
     // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-    let readyOption: keyof RenderToPipeableStreamOptions =
+    const readyOption: keyof RenderToPipeableStreamOptions =
       (userAgent && isbot(userAgent)) || routerContext.isSpaMode
         ? "onAllReady"
         : "onShellReady";

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -32,7 +32,7 @@ import { withUrlBase } from "~/utils/url-base";
 export async function loader({ request }: Route.LoaderArgs) {
   // Single-fetch navigation/revalidation uses internal `.data` URLs
   // (e.g. /login.data), so strip that suffix before the layout check.
-  let path = new URL(request.url).pathname.replace(/\.data$/, "");
+  const path = new URL(request.url).pathname.replace(/\.data$/, "");
   if (path === "/login" || path === "/onboarding") {
     return { useLayout: false, serviceProvider: null };
   }

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -294,7 +294,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         lifetime: staticLoaded
             ? <LifetimeBlock lifetime={stats.lifetime} />
             : <Skeleton height={120} />,
-    }), [liveTiles, stats, window, isLongWindow, windowLoaded, detailLoaded, staticLoaded, editMode, loaderData.hasConfiguredIndexers]);
+    }), [liveTiles, stats, window, isLongWindow, windowLoaded, detailLoaded, staticLoaded, loaderData.hasConfiguredIndexers]);
 
     const visibleOrder = useMemo(
         () => loaderData.hasConfiguredIndexers

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -80,7 +80,9 @@ export function HistoryTable({
                     return;
                 }
             }
-        } catch { }
+        } catch {
+            // network/API failure: history unchanged; removing state resets below
+        }
         onIsRemovingChanged(nzo_ids, false);
     }, [historySlots, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
@@ -182,7 +184,9 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
                     return;
                 }
             }
-        } catch { }
+        } catch {
+            // network/API failure: history unchanged; removing state resets below
+        }
         onIsRemovingChanged(slot.nzo_id, false);
     }, [slot.nzo_id, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
@@ -319,7 +323,7 @@ export function Actions({
                     isOpen={isMenuOpen}
                     onClose={() => setIsMenuOpen(false)}
                     options={[
-                        !!nzbDownloadUrl ? { option: <ExportNzb />, linkTo: nzbDownloadUrl } : undefined,
+                        nzbDownloadUrl ? { option: <ExportNzb />, linkTo: nzbDownloadUrl } : undefined,
                         !isReadOnly
                             ? { option: <Remove />, onSelect: onRemoveSelected, variant: "danger" }
                             : undefined,

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -84,7 +84,7 @@ export function QueueTable({
 
     const onRowIsRemovingChanged = useCallback((id: string, isRemoving: boolean) => {
         onIsRemovingChanged(new Set<string>([id]), isRemoving);
-    }, [onIsSelectedChanged]);
+    }, [onIsRemovingChanged]);
 
     const onRowRemoved = useCallback((id: string) => {
         onRemoved(new Set([id]));
@@ -134,7 +134,9 @@ export function QueueTable({
                     return;
                 }
             }
-        } catch { }
+        } catch {
+            // network/API failure: queue unchanged; removing state resets below
+        }
         onIsRemovingChanged(queued_nzo_ids, false);
     }, [queueSlots, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
@@ -261,7 +263,7 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
         }
 
         setIsConfirmingRemoval(true);
-    }, [setIsConfirmingRemoval]);
+    }, [slot.isUploading, slot.nzo_id, onRemoved, setIsConfirmingRemoval]);
 
     const onCancelRemoval = useCallback(() => {
         setIsConfirmingRemoval(false);
@@ -283,9 +285,11 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                     return;
                 }
             }
-        } catch { }
+        } catch {
+            // network/API failure: queue unchanged; removing state resets below
+        }
         onIsRemovingChanged(slot.nzo_id, false);
-    }, [slot.nzo_id, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
+    }, [slot.nzo_id, slot.isUploading, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
     const onMoveToTop = useCallback(async () => {
         if (slot.isUploading || isMoving) return;

--- a/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
+++ b/frontend/app/routes/queue/controllers/nzb-upload-controller.ts
@@ -20,7 +20,7 @@ export function useUploadController(
     useEffect(() => {
         // fire-and-forget: the queue processor runs in the background and updates state itself
         void processUploadQueue(isUploadingRef, uploadQueueRef, setUploadingFiles);
-    }, [uploadingFiles]);
+    }, [isUploadingRef, uploadQueueRef, uploadingFiles, setUploadingFiles]);
 }
 
 export function buildAddFileUploadUrl(category: string): string {

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -45,6 +45,7 @@ function parseArrConfig(value: string): ArrConfig {
             return parsed;
         }
     } catch {
+        // invalid stored JSON: fall through to the default config below
     }
 
     return {

--- a/frontend/app/routes/settings/migration/altmount/altmount-migration.tsx
+++ b/frontend/app/routes/settings/migration/altmount/altmount-migration.tsx
@@ -710,6 +710,7 @@ function CollisionPanel({ groups }: { groups: CollisionGroup[] }) {
 }
 
 function ReleaseGrid({ m, onChanged }: { m: Hook; onChanged: () => void }) {
+    const { loadReleases } = m;
     const [filters, setFilters] = useState<ReleaseFilters>({
         page: 1, pageSize: 50, verdict: "", included: "", q: "", sort: "",
     });
@@ -731,7 +732,7 @@ function ReleaseGrid({ m, onChanged }: { m: Hook; onChanged: () => void }) {
         try {
             await loadTableLatest(
                 loadGeneration,
-                () => m.loadReleases(f),
+                () => loadReleases(f),
                 (data) => {
                     setRows(data.releases);
                     setTotal(data.total);
@@ -742,7 +743,7 @@ function ReleaseGrid({ m, onChanged }: { m: Hook; onChanged: () => void }) {
         } finally {
             setLoading(false);
         }
-    }, [m.loadReleases]);
+    }, [loadReleases]);
 
     useEffect(() => { void load(filters); }, [load, filters]);
 
@@ -1084,6 +1085,7 @@ function SymlinkStep({ m }: { m: Hook }) {
 }
 
 function SymlinkResults({ m }: { m: Hook }) {
+    const { loadSymlinks } = m;
     const [filters, setFilters] = useState<SymlinkFilters>({ page: 1, pageSize: 100, status: "rewrite", q: "", sort: "" });
     const [searchDraft, setSearchDraft] = useState("");
     const debouncedSearch = useDebouncedValue(searchDraft, 300);
@@ -1103,7 +1105,7 @@ function SymlinkResults({ m }: { m: Hook }) {
         try {
             await loadTableLatest(
                 loadGeneration,
-                () => m.loadSymlinks(f),
+                () => loadSymlinks(f),
                 (res) => {
                     setData({ total: res.total, counts: res.counts, rows: res.rows });
                     setLoadError(null);
@@ -1113,7 +1115,7 @@ function SymlinkResults({ m }: { m: Hook }) {
         } finally {
             setLoading(false);
         }
-    }, [m.loadSymlinks]);
+    }, [loadSymlinks]);
 
     useEffect(() => { void load(filters); }, [load, filters]);
 
@@ -1314,6 +1316,7 @@ function SymlinkResults({ m }: { m: Hook }) {
 }
 
 function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => void }) {
+    const { loadSymlinkBackups, setError } = m;
     const [backups, setBackups] = useState<SymlinkBackupInfo[]>([]);
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState("");
@@ -1329,19 +1332,19 @@ function SymlinkRestoreAction({ m, onRestored }: { m: Hook; onRestored: () => vo
         try {
             await loadTableLatest(
                 loadGeneration,
-                m.loadSymlinkBackups,
+                loadSymlinkBackups,
                 (items) => {
                     setBackups(items);
                     setSelected((current) => items.some((item) => item.fileName === current)
                         ? current
                         : items.find((item) => item.isValid)?.fileName ?? items[0]?.fileName ?? "");
                 },
-                (message) => m.setError(message),
+                (message) => setError(message),
             );
         } finally {
             setLoading(false);
         }
-    }, [m.loadSymlinkBackups, m.setError]);
+    }, [loadSymlinkBackups, setError]);
 
     useEffect(() => { void load(); }, [load]);
 

--- a/frontend/app/routes/settings/profiles/profiles.tsx
+++ b/frontend/app/routes/settings/profiles/profiles.tsx
@@ -360,7 +360,9 @@ function AdapterRow({ token, origin, adapter, enabled, onToggle }: AdapterRowPro
             await navigator.clipboard.writeText(url);
             setCopied(true);
             setTimeout(() => setCopied(false), 1500);
-        } catch {}
+        } catch {
+            // clipboard write can fail without focus/permission; nothing to report
+        }
     }, [url]);
 
     return (

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -15,10 +15,13 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
     const [connectionState, setConnectionState] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
     const [testError, setTestError] = useState<string | null>(null);
 
+    const rcloneHost = config["rclone.host"];
+    const rcloneUser = config["rclone.user"];
+    const rclonePass = config["rclone.pass"];
     useEffect(() => {
         setConnectionState('idle');
         setTestError(null);
-    }, [config["rclone.host"], config["rclone.user"], config["rclone.pass"]]);
+    }, [rcloneHost, rcloneUser, rclonePass]);
 
     const testConnection = useCallback(async () => {
         const host = config["rclone.host"];

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -462,8 +462,8 @@ function getChangedConfig(
     config: Record<string, string>,
     newConfig: Record<string, string>
 ): Record<string, string> {
-    let changedConfig: Record<string, string> = {};
-    let configKeys = Object.keys(defaultConfig);
+    const changedConfig: Record<string, string> = {};
+    const configKeys = Object.keys(defaultConfig);
     for (const configKey of configKeys) {
         const newValue = newConfig[configKey];
         if (newValue !== undefined && config[configKey] !== newValue) {

--- a/frontend/app/routes/settings/warden/warden.tsx
+++ b/frontend/app/routes/settings/warden/warden.tsx
@@ -164,7 +164,9 @@ export function WardenSettings({ config, setNewConfig }: WardenSettingsProps) {
             const res = await fetch(withUrlBase("/api/warden-backup"));
             // GET /api/warden-backup → WardenBackupStatusResponse
             if (res.ok) setBackup((await res.json()) as BackupStatus);
-        } catch { }
+        } catch {
+            // backup status stays at its default when the fetch fails
+        }
     };
 
     // Initial load; both fetches catch internally and report via state.

--- a/frontend/app/routes/watchtower/route.tsx
+++ b/frontend/app/routes/watchtower/route.tsx
@@ -158,6 +158,7 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
         }
     }, [childFetcher.state, childFetcher.data]);
 
+    const childLoad = childFetcher.load;
     useEffect(() => {
         if (childFetcher.state !== "idle" || pendingChildRef.current) return;
         const keys = new Set(shows.map(s => s.key));
@@ -169,8 +170,8 @@ export default function Watchtower({ loaderData }: Route.ComponentProps) {
         if (stateFilter) sp.set("state", stateFilter);
         if (urlQuery) sp.set("q", urlQuery);
         sp.set("expander", next);
-        void childFetcher.load(`${location.pathname}?${sp.toString()}`); // fire-and-forget: result handled via fetcher state
-    }, [shows, expandedShows, childLoaded, childFetcher.state, stateFilter, urlQuery, location.pathname]);
+        void childLoad(`${location.pathname}?${sp.toString()}`); // fire-and-forget: result handled via fetcher state
+    }, [shows, expandedShows, childLoaded, childLoad, childFetcher.state, stateFilter, urlQuery, location.pathname]);
 
     useEffect(() => {
         if (statsFetcher.state === "idle" && statsFetcher.data) {

--- a/frontend/app/utils/path.ts
+++ b/frontend/app/utils/path.ts
@@ -1,6 +1,6 @@
 export function getLeafDirectoryName(fullPath: string): string {
     // Normalize the path by removing a trailing slash/backslash.
-    let normalizedPath = fullPath.replace(/[/\\]$/, '');
+    const normalizedPath = fullPath.replace(/[/\\]$/, '');
 
     // Find the index of the last separator.
     const lastSlash = normalizedPath.lastIndexOf('/');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "predev": "bash ../scripts/sync-dev-env.sh",
     "dev": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --import tsx server.ts",
     "start": "node dist-node/server.js",
-    "lint": "react-router typegen && eslint . --max-warnings 27",
+    "lint": "react-router typegen && eslint . --max-warnings 0",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "react-router typegen && tsc -b"


### PR DESCRIPTION
## Summary

Phase 3a of #853, stacked on the strict-tsconfig PR: the remaining 27-warning backlog is cleared and the lint ceiling drops from a budget to **zero** (`--max-warnings 0`).

- **react-hooks/exhaustive-deps (13)** — the risky class, reviewed per site: a copy-pasted wrong dep in queue-table (`onIsSelectedChanged` listed for a callback that calls `onIsRemovingChanged` — a real stale-closure bug), missing slot/fetcher deps added, module-constant and unused deps removed, member-expression deps destructured to stable hook members so memoization survives
- **no-empty (6)** — intentional catch-all blocks now carry a comment stating why nothing happens there
- **prefer-const (6), no-extra-boolean-cast (1)** — `eslint --fix`

The issue's "no rule disabled globally without justification" holds: only `no-undef` is off, TS-files-only, per the typescript-eslint FAQ, documented in `eslint.config.js`.

## Test plan

- [x] `npm run lint` — 0 problems under `--max-warnings 0`
- [x] `npm run typecheck` — clean
- [x] `npm test` — 519 pass
- [x] `npm run build && npm run build:server` — pass

Part of #853.