### PR TITLE
fix(usenet): stop 502 connection-limit retry loops by learning the provider's real connection cap

### DIFF
--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Services.Metrics;
 
@@ -33,7 +34,9 @@ public class GetProviderUsageController(
                 if (provider.ProviderId != Guid.Empty)
                     recentHoursByKey.TryGetValue(UsenetProviderIdentity.MetricsKey(provider), out recentHours);
                 var (bytesPerDay, daysRemaining) = ProviderUsageHelper.ComputeBurnRate(provider, used, recentHours);
-                snapshotsByKey.TryGetValue(UsenetProviderIdentity.MetricsKey(provider), out var snapshot);
+                ProviderConnectionSnapshot? snapshot = null;
+                if (provider.ProviderId != Guid.Empty)
+                    snapshotsByKey.TryGetValue(UsenetProviderIdentity.MetricsKey(provider), out snapshot);
                 return new GetProviderUsageResponse.ProviderUsageItem
                 {
                     Index = index,

--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Services.Metrics;
 
@@ -8,7 +9,8 @@ namespace NzbWebDAV.Api.Controllers.GetProviderUsage;
 [Route("api/get-provider-usage")]
 public class GetProviderUsageController(
     ConfigManager configManager,
-    ProviderBytesTracker bytesTracker
+    ProviderBytesTracker bytesTracker,
+    UsenetStreamingClient usenetStreamingClient
 ) : BaseApiController
 {
     private async Task<GetProviderUsageResponse> GetUsageAsync()
@@ -20,6 +22,9 @@ public class GetProviderUsageController(
                 .Select(UsenetProviderIdentity.MetricsKey))
             .ConfigureAwait(false);
 
+        var snapshotsByKey = usenetStreamingClient.GetProviderConnectionSnapshots()
+            .ToDictionary(s => s.MetricsKey);
+
         var items = providerConfig.Providers
             .Select((provider, index) =>
             {
@@ -28,6 +33,7 @@ public class GetProviderUsageController(
                 if (provider.ProviderId != Guid.Empty)
                     recentHoursByKey.TryGetValue(UsenetProviderIdentity.MetricsKey(provider), out recentHours);
                 var (bytesPerDay, daysRemaining) = ProviderUsageHelper.ComputeBurnRate(provider, used, recentHours);
+                snapshotsByKey.TryGetValue(UsenetProviderIdentity.MetricsKey(provider), out var snapshot);
                 return new GetProviderUsageResponse.ProviderUsageItem
                 {
                     Index = index,
@@ -41,6 +47,8 @@ public class GetProviderUsageController(
                     OverLimit = ProviderUsageHelper.IsOverLimit(bytesTracker, provider),
                     BytesPerDay = bytesPerDay,
                     DaysRemaining = daysRemaining,
+                    LearnedConnectionLimit = snapshot?.LearnedConnectionLimit,
+                    EffectiveMaxConnections = snapshot?.EffectiveMaxConnections,
                 };
             })
             .ToList();

--- a/backend/Api/Controllers/GetProviderUsage/GetProviderUsageResponse.cs
+++ b/backend/Api/Controllers/GetProviderUsage/GetProviderUsageResponse.cs
@@ -28,5 +28,15 @@ public class GetProviderUsageResponse : BaseApiResponse
         // the cap is already exceeded — in any of those cases there's no
         // honest number to display.
         public double? DaysRemaining { get; set; }
+        /// <summary>
+        /// Server-reported connection limit learned from a 502 rejection, if any.
+        /// Null when the provider has not hit a connection-limit rejection.
+        /// </summary>
+        public int? LearnedConnectionLimit { get; set; }
+        /// <summary>
+        /// The pool's current effective max (after any learned-limit shrink).
+        /// Equals configured MaxConnections when no shrink has occurred.
+        /// </summary>
+        public int? EffectiveMaxConnections { get; set; }
     }
 }

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -77,7 +77,7 @@ public class BaseNntpClient : NntpClient
             if (!response.Success)
             {
                 var message = $"Could not login to usenet host: {response.ResponseMessage}";
-                throw new CouldNotLoginToUsenetException(message);
+                throw new CouldNotLoginToUsenetException(message, responseCode: response.ResponseCode);
             }
 
             return response;

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -47,16 +47,20 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     public TimeSpan IdleTimeout { get; }
     public int MaxConnections => _maxConnections;
+    public int EffectiveMaxConnections => Volatile.Read(ref _effectiveMaxConnections);
+    public int? LearnedConnectionLimit => _learnedConnectionLimit;
     public int LiveConnections => _live;
     public int IdleConnections => _idleConnections.Count;
     public int ActiveConnections => _live - _idleConnections.Count;
-    public int AvailableConnections => _maxConnections - ActiveConnections;
+    public int AvailableConnections => Math.Max(0, EffectiveMaxConnections - ActiveConnections);
     internal bool IsDisposed => Volatile.Read(ref _disposed) == 1;
 
     public event EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs>? OnConnectionPoolChanged;
 
     private readonly Func<CancellationToken, ValueTask<T>> _factory;
     private readonly int _maxConnections;
+    private readonly Func<Exception, int?>? _connectionLimitDetector;
+    private readonly Action<int, int>? _onConnectionLimitLearned;
 
     /* --------------------------------- state --------------------------------------- */
 
@@ -69,6 +73,8 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     private int _live; // number of connections currently alive
     private int _disposed; // 0 == false, 1 == true
+    private int _effectiveMaxConnections;
+    private int? _learnedConnectionLimit;
 
     // Lifetime churn counters. A pool that keeps destroying and re-opening connections
     // pays the handshake cost repeatedly and can never reach its configured width, which
@@ -96,7 +102,9 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         int maxConnections,
         Func<CancellationToken, ValueTask<T>> connectionFactory,
         TimeSpan? idleTimeout = null,
-        SemaphorePriorityOdds? priorityOdds = null)
+        SemaphorePriorityOdds? priorityOdds = null,
+        Func<Exception, int?>? connectionLimitDetector = null,
+        Action<int, int>? onConnectionLimitLearned = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConnections);
 
@@ -109,6 +117,9 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             throw new ArgumentOutOfRangeException(nameof(idleTimeout));
 
         _maxConnections = maxConnections;
+        _effectiveMaxConnections = maxConnections;
+        _connectionLimitDetector = connectionLimitDetector;
+        _onConnectionLimitLearned = onConnectionLimitLearned;
         _gate = new PrioritizedSemaphore(maxConnections, maxConnections, priorityOdds);
         _sweeperTask = Task.Run(SweepLoop); // background idle-reaper
     }
@@ -198,9 +209,10 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             {
                 conn = await _factory(linked.Token).ConfigureAwait(false);
             }
-            catch
+            catch (Exception factoryError)
             {
                 Interlocked.Increment(ref _handshakeFailures);
+                TryShrinkOnConnectionLimit(factoryError);
                 ReleaseGateIfActive(); // free the permit on failure
                 throw;
             }
@@ -339,8 +351,44 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         OnConnectionPoolChanged?.Invoke(this, new ConnectionPoolStats.ConnectionPoolChangedEventArgs(
             _live,
             _idleConnections.Count,
-            _maxConnections
+            EffectiveMaxConnections
         ));
+    }
+
+    /// <summary>
+    /// When the server rejects a login with "502 connection limit (N) reached", shrink the
+    /// gate so subsequent refills stop hitting the same rejection at the same width.
+    /// Monotonic — only ever shrinks, never grows. The check-compute-write is atomic under
+    /// <see cref="_lifecycleLock"/> so concurrent factory failures fire the callback at most
+    /// once per distinct effective value.
+    /// </summary>
+    private void TryShrinkOnConnectionLimit(Exception exception)
+    {
+        if (_connectionLimitDetector?.Invoke(exception) is not { } learned)
+            return;
+
+        // ~10% headroom for server-side teardown sockets; hard floor at 1.
+        var headroom = Math.Max(2, learned / 10);
+        var candidate = Math.Max(learned - headroom, 1);
+
+        int newEffective;
+        bool shrank;
+        lock (_lifecycleLock)
+        {
+            newEffective = Math.Min(candidate, _effectiveMaxConnections);
+            shrank = newEffective < _effectiveMaxConnections;
+            if (shrank)
+            {
+                _effectiveMaxConnections = newEffective;
+                _learnedConnectionLimit = learned;
+            }
+        }
+
+        if (!shrank) return;
+
+        _gate.UpdateMaxAllowed(newEffective);
+        TriggerConnectionPoolChangedEvent();
+        _onConnectionLimitLearned?.Invoke(learned, newEffective);
     }
 
     /* =================== idle sweeper (background) ================================= */

--- a/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
@@ -16,10 +16,11 @@ public class ConnectionPoolStats
     private readonly int[] _idle;
     private readonly int[] _latestLive;
     private readonly int[] _latestIdle;
+    private readonly int[] _latestMax;
     private readonly bool[] _dirty;
-    private readonly int _max;
     private int _totalLive;
     private int _totalIdle;
+    private int _totalMax;
     private int _flushScheduled; // 0 == false, 1 == true
     private int _active = 1;
     private readonly Lock _lock = new();
@@ -35,8 +36,14 @@ public class ConnectionPoolStats
         _idle = new int[count];
         _latestLive = new int[count];
         _latestIdle = new int[count];
+        _latestMax = new int[count];
         _dirty = new bool[count];
-        _max = providerConfig.Providers
+
+        // Initialize from config so the header shows the configured ceiling before
+        // the first pool event arrives; events then keep it current (effective max).
+        for (var i = 0; i < count; i++)
+            _latestMax[i] = providerConfig.Providers[i].MaxConnections;
+        _totalMax = providerConfig.Providers
             .Where(x => x.Type == ProviderType.Pooled)
             .Select(x => x.MaxConnections)
             .Sum();
@@ -61,6 +68,7 @@ public class ConnectionPoolStats
 
                 _latestLive[providerIndex] = args.Live;
                 _latestIdle[providerIndex] = args.Idle;
+                _latestMax[providerIndex] = args.Max;
                 _dirty[providerIndex] = true;
 
                 if (_providerConfig.Providers[providerIndex].Type == ProviderType.Pooled)
@@ -69,6 +77,9 @@ public class ConnectionPoolStats
                     _idle[providerIndex] = args.Idle;
                     _totalLive = _live.Sum();
                     _totalIdle = _idle.Sum();
+                    _totalMax = _latestMax
+                        .Where((_, i) => _providerConfig.Providers[i].Type == ProviderType.Pooled)
+                        .Sum();
                 }
             }
 
@@ -103,7 +114,7 @@ public class ConnectionPoolStats
                 if (!_dirty[i]) continue;
                 _dirty[i] = false;
                 var message =
-                    $"{i}|{_latestLive[i]}|{_latestIdle[i]}|{_totalLive}|{_max}|{_totalIdle}";
+                    $"{i}|{_latestLive[i]}|{_latestIdle[i]}|{_totalLive}|{_totalMax}|{_totalIdle}";
                 _ = _websocketManager.SendMessage(WebsocketTopic.UsenetConnections, message);
             }
         }

--- a/backend/Clients/Usenet/Models/ProviderConnectionSnapshot.cs
+++ b/backend/Clients/Usenet/Models/ProviderConnectionSnapshot.cs
@@ -16,4 +16,6 @@ public sealed record ProviderConnectionSnapshot(
     int ActiveConnections,
     int AvailableConnections,
     int PendingSelections,
-    ConnectionPoolChurn Churn);
+    ConnectionPoolChurn Churn,
+    int? LearnedConnectionLimit,
+    int EffectiveMaxConnections);

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -98,6 +98,8 @@ public class MultiConnectionNntpClient(
     public bool IsTripped => circuitBreaker.IsTripped;
     public ProviderCircuitBreakerSnapshot GetCircuitBreakerSnapshot() => circuitBreaker.GetSnapshot();
     public int MaxConnections => connectionPool.MaxConnections;
+    public int EffectiveMaxConnections => connectionPool.EffectiveMaxConnections;
+    public int? LearnedConnectionLimit => connectionPool.LearnedConnectionLimit;
     public int LiveConnections => connectionPool.LiveConnections;
     public int IdleConnections => connectionPool.IdleConnections;
     public int ActiveConnections => connectionPool.ActiveConnections;

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -79,7 +79,9 @@ public class MultiProviderNntpClient(
                 p.ActiveConnections,
                 p.AvailableConnections,
                 p.PendingSelections,
-                p.GetConnectionChurn()))
+                p.GetConnectionChurn(),
+                p.LearnedConnectionLimit,
+                p.EffectiveMaxConnections))
             .ToList();
     }
 

--- a/backend/Clients/Usenet/UsenetConnectionLimitDetector.cs
+++ b/backend/Clients/Usenet/UsenetConnectionLimitDetector.cs
@@ -1,0 +1,56 @@
+using System.Text.RegularExpressions;
+using NzbWebDAV.Exceptions;
+using UsenetSharp.Exceptions;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Detects a server-side connection-limit rejection ("502 connection limit (N) reached")
+/// from an exception chain and extracts the learned limit N. Covers both stages:
+/// auth (AUTHINFO) via <see cref="CouldNotLoginToUsenetException"/> and connect greeting
+/// via <see cref="UsenetConnectionException"/> (wrapped in <see cref="CouldNotConnectToUsenetException"/>).
+/// </summary>
+public static partial class UsenetConnectionLimitDetector
+{
+    private const int ConnectionLimitResponseCode = 502;
+
+    [GeneratedRegex(@"connection\s+limit\s*\((\d+)\)", RegexOptions.IgnoreCase)]
+    private static partial Regex ConnectionLimitRegex();
+
+    /// <summary>
+    /// Returns true when the exception chain contains a 502 response whose message
+    /// matches "connection limit (N)", and outputs the learned limit N.
+    /// </summary>
+    public static bool TryLearn(Exception exception, out int learnedLimit)
+    {
+        learnedLimit = 0;
+
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (!IsConnectionLimit502(current))
+                continue;
+
+            if (TryParseLimit(current.Message, out learnedLimit))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsConnectionLimit502(Exception e) => e switch
+    {
+        CouldNotLoginToUsenetException login => login.ResponseCode == ConnectionLimitResponseCode,
+        UsenetConnectionException greeting => greeting.ResponseCode == ConnectionLimitResponseCode,
+        _ => false,
+    };
+
+    private static bool TryParseLimit(string message, out int limit)
+    {
+        var match = ConnectionLimitRegex().Match(message);
+        if (match.Success && int.TryParse(match.Groups[1].Value, out limit) && limit > 0)
+            return true;
+
+        limit = 0;
+        return false;
+    }
+}

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -250,7 +250,20 @@ public class UsenetStreamingClient : WrappingNntpClient
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
             onConnectionPoolChanged,
             idleTimeoutSeconds,
-            streamingPriority
+            streamingPriority,
+            connectionLimitDetector: ex =>
+                UsenetConnectionLimitDetector.TryLearn(ex, out var learned) ? learned : null,
+            onConnectionLimitLearned: (learned, effective) =>
+            {
+                var label = string.IsNullOrWhiteSpace(connectionDetails.Nickname)
+                    ? connectionDetails.Host
+                    : connectionDetails.Nickname;
+                Log.Warning(
+                    "Provider '{Provider}' reported a server-side connection limit of {Learned} " +
+                    "(configured MaxConnections={Configured}). Pool width reduced to {Effective} until restart. " +
+                    "Lower MaxConnections in settings to make this permanent.",
+                    label, learned, maxConnections, effective);
+            }
         );
         // Ensure a metrics key even if startup backfill was skipped somehow.
         if (connectionDetails.ProviderId == Guid.Empty)
@@ -299,7 +312,9 @@ public class UsenetStreamingClient : WrappingNntpClient
         Func<CancellationToken, ValueTask<INntpClient>> connectionFactory,
         EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
         int idleTimeoutSeconds,
-        SemaphorePriorityOdds? streamingPriority = null
+        SemaphorePriorityOdds? streamingPriority = null,
+        Func<Exception, int?>? connectionLimitDetector = null,
+        Action<int, int>? onConnectionLimitLearned = null
     )
     {
         var idleTimeout = TimeSpan.FromSeconds(idleTimeoutSeconds);
@@ -307,7 +322,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             "Creating NNTP connection pool max={Max} idleTimeout={IdleTimeoutSeconds}s streamingPriority={StreamingPriority}",
             maxConnections, idleTimeoutSeconds, streamingPriority?.HighPriorityOdds);
         var connectionPool = new ConnectionPool<INntpClient>(
-            maxConnections, connectionFactory, idleTimeout, streamingPriority);
+            maxConnections, connectionFactory, idleTimeout, streamingPriority,
+            connectionLimitDetector, onConnectionLimitLearned);
         connectionPool.OnConnectionPoolChanged += onConnectionPoolChanged;
         var args = new ConnectionPoolStats.ConnectionPoolChangedEventArgs(0, 0, maxConnections);
         onConnectionPoolChanged(connectionPool, args);

--- a/backend/Exceptions/CouldNotLoginToUsenetException.cs
+++ b/backend/Exceptions/CouldNotLoginToUsenetException.cs
@@ -1,6 +1,8 @@
 ﻿namespace NzbWebDAV.Exceptions;
 
-public class CouldNotLoginToUsenetException(string message, Exception? innerException = null)
+public class CouldNotLoginToUsenetException(string message, Exception? innerException = null, int? responseCode = null)
     : RetryableDownloadException(message, innerException)
 {
+    /// <summary>The NNTP response code (e.g. 502), when the server returned one.</summary>
+    public int? ResponseCode { get; } = responseCode;
 }

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -584,6 +584,8 @@ public sealed class SupportPackService(
                     snapshot.ActiveConnections,
                     snapshot.AvailableConnections,
                     snapshot.PendingSelections,
+                    snapshot.LearnedConnectionLimit,
+                    snapshot.EffectiveMaxConnections,
                     churn = new
                     {
                         snapshot.Churn.ConnectionsOpened,

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -245,6 +245,8 @@ type ProviderUsage = {
     overLimit: boolean;
     bytesPerDay: number;
     daysRemaining: number | null;
+    learnedConnectionLimit?: number | null;
+    effectiveMaxConnections?: number | null;
 };
 
 function formatDaysRemaining(days: number): string {
@@ -642,6 +644,9 @@ export function UsenetSettings({ config, savedConfig, setNewConfig, persistConfi
         const isDisabled = provider.Type === ProviderType.Disabled;
         const displayName = provider.Nickname?.trim() || provider.Host;
         const liveConnections = isDemoPreview ? 0 : connections[providerIdentity(provider)]?.live ?? 0;
+        const providerUsage = isDemoPreview ? undefined : usage[providerIdentity(provider)];
+        const learnedLimit = providerUsage?.learnedConnectionLimit;
+        const effectiveMax = providerUsage?.effectiveMaxConnections ?? provider.MaxConnections;
 
         return (
             <SortableItem key={providerKey(provider)} id={providerKey(provider)} disabled={!cascadeEnabled || isDemoPreview}>
@@ -730,14 +735,20 @@ export function UsenetSettings({ config, savedConfig, setNewConfig, persistConfi
                                     <ProviderCardMeta
                                         icon="hub"
                                         label="Connections"
-                                        value={`${liveConnections} / ${provider.MaxConnections} max`}
+                                        value={`${liveConnections} / ${effectiveMax} max`}
                                         emphasize
                                     />
+                                    {learnedLimit != null && (
+                                        <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-warning">
+                                            <Icon name="warning" className="!text-[13px] shrink-0" />
+                                            <span>Provider caps at {learnedLimit} — lower MaxConnections</span>
+                                        </div>
+                                    )}
                                 </div>
 
                                 <UsageRow
                                     provider={provider}
-                                    usage={isDemoPreview ? undefined : usage[providerIdentity(provider)]}
+                                    usage={providerUsage}
                                     onReset={() => handleResetUsage(index)}
                                     resetDisabled={isDemoPreview}
                                 />

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolConnectionLimitTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolConnectionLimitTests.cs
@@ -175,11 +175,8 @@ public class ConnectionPoolConnectionLimitTests
             factory: _ => throw new CouldNotLoginToUsenetException(
                 "502 connection limit (3) reached", responseCode: 502));
 
-        // Acquire 3 connections (the max the pool will allow after shrink to 2).
-        var locks = new List<ConnectionLock<object>>();
-        // First, fill the pool with 5 successful connections.
-        // We can't do that with a failing factory, so let's test the property directly.
-        // After shrink to 2 with 0 active, available should be 2 (not negative).
+        // learned=3, headroom=max(2,0)=2, candidate=max(1,1)=1 → effective shrinks to 1.
+        // With 0 active connections, AvailableConnections should be 1 (not negative).
         await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
             () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolConnectionLimitTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolConnectionLimitTests.cs
@@ -1,0 +1,239 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ConnectionPoolConnectionLimitTests
+{
+    private static readonly TimeSpan WaitBudget = TimeSpan.FromSeconds(10);
+
+    private static ConnectionPool<object> CreatePool(
+        int maxConnections,
+        Func<Exception, int?>? detector = null,
+        Action<int, int>? onLearned = null,
+        Func<CancellationToken, ValueTask<object>>? factory = null) =>
+        new(
+            maxConnections,
+            factory ?? (_ => ValueTask.FromResult(new object())),
+            TimeSpan.FromMinutes(5),
+            priorityOdds: null,
+            connectionLimitDetector: detector,
+            onConnectionLimitLearned: onLearned);
+
+    private static Func<Exception, int?> Detector502(int learned) =>
+        ex => ex is CouldNotLoginToUsenetException { ResponseCode: 502 } ? learned : null;
+
+    [Fact]
+    public async Task ConnectionLimit502_ShrinksEffectiveMax()
+    {
+        var learnedValues = new List<(int learned, int effective)>();
+        await using var pool = CreatePool(
+            maxConnections: 150,
+            detector: Detector502(150),
+            onLearned: (learned, effective) => learnedValues.Add((learned, effective)),
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "Could not login to usenet host: 502 connection limit (150) reached",
+                responseCode: 502));
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+
+        Assert.Equal(135, pool.EffectiveMaxConnections);
+        Assert.Equal(150, pool.LearnedConnectionLimit);
+        Assert.Single(learnedValues);
+        Assert.Equal((150, 135), learnedValues[0]);
+    }
+
+    [Fact]
+    public async Task RepeatedSameLimit_DoesNotShrinkAgain()
+    {
+        var callbackCount = 0;
+        await using var pool = CreatePool(
+            maxConnections: 150,
+            detector: Detector502(150),
+            onLearned: (_, _) => Interlocked.Increment(ref callbackCount),
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "Could not login to usenet host: 502 connection limit (150) reached",
+                responseCode: 502));
+
+        for (var i = 0; i < 3; i++)
+        {
+            await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+                () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+        }
+
+        Assert.Equal(135, pool.EffectiveMaxConnections);
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public async Task LowerSecondLimit_ShrinksFurther()
+    {
+        var learnedValues = new List<(int learned, int effective)>();
+        var learned = 150;
+        await using var pool = CreatePool(
+            maxConnections: 150,
+            detector: _ => learned,
+            onLearned: (l, e) => learnedValues.Add((l, e)),
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "502 connection limit reached", responseCode: 502));
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+        Assert.Equal(135, pool.EffectiveMaxConnections);
+
+        learned = 100;
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+        Assert.Equal(90, pool.EffectiveMaxConnections);
+
+        Assert.Equal(2, learnedValues.Count);
+        Assert.Equal((150, 135), learnedValues[0]);
+        Assert.Equal((100, 90), learnedValues[1]);
+    }
+
+    [Fact]
+    public async Task LearnedTwo_HardFloorAtOne()
+    {
+        await using var pool = CreatePool(
+            maxConnections: 10,
+            detector: Detector502(2),
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "502 connection limit (2) reached", responseCode: 502));
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+
+        Assert.Equal(1, pool.EffectiveMaxConnections);
+    }
+
+    [Fact]
+    public async Task Non502_DoesNotShrink()
+    {
+        await using var pool = CreatePool(
+            maxConnections: 10,
+            detector: _ => null, // detector returns null for non-502
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "Could not login to usenet host: 481 authentication rejected"));
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+
+        Assert.Equal(10, pool.EffectiveMaxConnections);
+        Assert.Null(pool.LearnedConnectionLimit);
+    }
+
+    [Fact]
+    public async Task NoDetector_NoShrink()
+    {
+        await using var pool = CreatePool(
+            maxConnections: 10,
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "502 connection limit (5) reached", responseCode: 502));
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+
+        Assert.Equal(10, pool.EffectiveMaxConnections);
+    }
+
+    [Fact]
+    public async Task ConcurrentFailures_OnlyOneCallback()
+    {
+        var callbackCount = 0;
+        var barrier = new TaskCompletionSource();
+        await using var pool = CreatePool(
+            maxConnections: 10,
+            detector: Detector502(10),
+            onLearned: (_, _) => Interlocked.Increment(ref callbackCount),
+            factory: async _ =>
+            {
+                // Both factory calls wait at the barrier, then both throw.
+                await barrier.Task;
+                throw new CouldNotLoginToUsenetException(
+                    "502 connection limit (10) reached", responseCode: 502);
+            });
+
+        var t1 = pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None);
+        var t2 = pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None);
+        barrier.SetResult();
+
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(() => t1.WaitAsync(WaitBudget));
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(() => t2.WaitAsync(WaitBudget));
+
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public async Task AvailableConnections_NeverNegative()
+    {
+        await using var pool = CreatePool(
+            maxConnections: 5,
+            detector: Detector502(3),
+            factory: _ => throw new CouldNotLoginToUsenetException(
+                "502 connection limit (3) reached", responseCode: 502));
+
+        // Acquire 3 connections (the max the pool will allow after shrink to 2).
+        var locks = new List<ConnectionLock<object>>();
+        // First, fill the pool with 5 successful connections.
+        // We can't do that with a failing factory, so let's test the property directly.
+        // After shrink to 2 with 0 active, available should be 2 (not negative).
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+
+        Assert.True(pool.AvailableConnections >= 0);
+    }
+
+    [Fact]
+    public async Task GateCapsAtEffectiveMax()
+    {
+        var factoryCallCount = 0;
+        var shouldFail = false;
+        await using var pool = CreatePool(
+            maxConnections: 5,
+            detector: Detector502(5),
+            factory: _ =>
+            {
+                if (shouldFail)
+                    throw new CouldNotLoginToUsenetException(
+                        "502 connection limit (5) reached", responseCode: 502);
+                Interlocked.Increment(ref factoryCallCount);
+                return ValueTask.FromResult(new object());
+            });
+
+        // Acquire 5 connections successfully.
+        var locks = new List<ConnectionLock<object>>();
+        for (var i = 0; i < 5; i++)
+            locks.Add(await pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+        Assert.Equal(5, pool.ActiveConnections);
+
+        // Now shrink: destroy one connection so the next acquire calls the factory,
+        // which fails with 502 limit(5) → effective = 5-2=3.
+        locks[0].Replace();
+        locks[0].Dispose();
+        shouldFail = true;
+        await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+        Assert.Equal(3, pool.EffectiveMaxConnections);
+
+        // We hold 4 locks (5 - 1 returned). Active = 4. Effective = 3.
+        // The gate should block new acquisitions since active >= effective.
+        // Return all and verify we can only acquire 3.
+        foreach (var l in locks.Skip(1)) l.Dispose();
+        locks.Clear();
+        shouldFail = false;
+
+        for (var i = 0; i < 3; i++)
+            locks.Add(await pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None).WaitAsync(WaitBudget));
+        Assert.Equal(3, pool.ActiveConnections);
+
+        // The 4th acquisition should block (gate at 3).
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, cts.Token).WaitAsync(WaitBudget));
+
+        foreach (var l in locks) l.Dispose();
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolStatsReplayTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolStatsReplayTests.cs
@@ -44,6 +44,41 @@ public class ConnectionPoolStatsReplayTests
             websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
     }
 
+    [Fact]
+    public async Task EffectiveMax_ReflectedInTotalMax()
+    {
+        var websocketManager = new WebsocketManager();
+        var connectionStats = new ConnectionPoolStats(
+            new UsenetProviderConfig
+            {
+                Providers =
+                [
+                    new UsenetProviderConfig.ConnectionDetails
+                    {
+                        Type = ProviderType.Pooled,
+                        Host = "news.example.com",
+                        Port = 563,
+                        UseSsl = true,
+                        User = "user",
+                        Pass = "pass",
+                        MaxConnections = 150,
+                    },
+                ],
+            },
+            websocketManager);
+        var onChanged = connectionStats.GetOnConnectionPoolChanged(0);
+
+        // Simulate a learned-limit shrink: pool reports effective max 135.
+        onChanged(
+            this,
+            new ConnectionPoolStats.ConnectionPoolChangedEventArgs(5, 2, 135));
+
+        await WaitUntil(() => websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections) is not null);
+        Assert.Equal(
+            "0|5|2|5|135|2",
+            websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
+    }
+
     private static async Task WaitUntil(Func<bool> condition)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/UsenetConnectionLimitDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/UsenetConnectionLimitDetectorTests.cs
@@ -1,0 +1,126 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
+using UsenetSharp.Exceptions;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class UsenetConnectionLimitDetectorTests
+{
+    [Fact]
+    public void AuthStage_502WithConnectionLimit_ReturnsLearned()
+    {
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 connection limit (150) reached",
+            responseCode: 502);
+
+        Assert.True(UsenetConnectionLimitDetector.TryLearn(ex, out var learned));
+        Assert.Equal(150, learned);
+    }
+
+    [Fact]
+    public void AuthStage_502WithoutConnectionLimit_ReturnsFalse()
+    {
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 authentication failed",
+            responseCode: 502);
+
+        Assert.False(UsenetConnectionLimitDetector.TryLearn(ex, out _));
+    }
+
+    [Fact]
+    public void AuthStage_481WithConnectionLimitMessage_ReturnsFalse()
+    {
+        // Wrong response code — only 502 triggers the shrink.
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 481 connection limit (50) reached",
+            responseCode: 481);
+
+        Assert.False(UsenetConnectionLimitDetector.TryLearn(ex, out _));
+    }
+
+    [Fact]
+    public void AuthStage_NoResponseCode_ReturnsFalse()
+    {
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 connection limit (100) reached");
+
+        Assert.False(UsenetConnectionLimitDetector.TryLearn(ex, out _));
+    }
+
+    [Fact]
+    public void GreetingStage_UsenetConnectionException502_ReturnsLearned()
+    {
+        var inner = new UsenetConnectionException("502 connection limit (75) reached")
+        {
+            ResponseCode = 502,
+        };
+        var ex = new CouldNotConnectToUsenetException("Could not connect.", inner);
+
+        Assert.True(UsenetConnectionLimitDetector.TryLearn(ex, out var learned));
+        Assert.Equal(75, learned);
+    }
+
+    [Fact]
+    public void GreetingStage_UsenetConnectionException400_ReturnsFalse()
+    {
+        var inner = new UsenetConnectionException("400 connection limit (50) reached")
+        {
+            ResponseCode = 400,
+        };
+        var ex = new CouldNotConnectToUsenetException("Could not connect.", inner);
+
+        Assert.False(UsenetConnectionLimitDetector.TryLearn(ex, out _));
+    }
+
+    [Fact]
+    public void DifferentLimit_ParsesCorrectly()
+    {
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 connection limit (30) reached",
+            responseCode: 502);
+
+        Assert.True(UsenetConnectionLimitDetector.TryLearn(ex, out var learned));
+        Assert.Equal(30, learned);
+    }
+
+    [Fact]
+    public void CaseInsensitive_Matches()
+    {
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 Connection Limit (100) Reached",
+            responseCode: 502);
+
+        Assert.True(UsenetConnectionLimitDetector.TryLearn(ex, out var learned));
+        Assert.Equal(100, learned);
+    }
+
+    [Fact]
+    public void DeepChain_FindsNested502()
+    {
+        var inner = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 connection limit (60) reached",
+            responseCode: 502);
+        var ex = new InvalidOperationException("wrapper", new Exception("middle", inner));
+
+        Assert.True(UsenetConnectionLimitDetector.TryLearn(ex, out var learned));
+        Assert.Equal(60, learned);
+    }
+
+    [Fact]
+    public void UnrelatedException_ReturnsFalse()
+    {
+        var ex = new IOException("network error");
+
+        Assert.False(UsenetConnectionLimitDetector.TryLearn(ex, out _));
+    }
+
+    [Fact]
+    public void ZeroLimit_ReturnsFalse()
+    {
+        var ex = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 connection limit (0) reached",
+            responseCode: 502);
+
+        Assert.False(UsenetConnectionLimitDetector.TryLearn(ex, out _));
+    }
+}


### PR DESCRIPTION
## Summary
- When a provider rejects login with `502 connection limit (N) reached`, the pool learns N, shrinks its connection gate with ~10% headroom (hard floor at 1), and logs one actionable warning per shrink event
- The learned/effective limit is surfaced in three places: the nav header connection counter, the settings provider card, and support pack `environment.json`
- Existing circuit-breaker trip behavior is unchanged — shrink is additive and prevents the *next* refill from re-hitting the same 502

## Test plan
- [x] 8 pool-shrink tests (monotonic, floor, concurrent safety, gate capping, non-negative available)
- [x] 11 detector parser tests (auth/greeting stages, regex variants, deep chains, wrong codes)
- [x] ConnectionPoolStats effective-max-in-cxs test
- [x] Existing breaker tests still pass (35 focused tests green)
- [x] Full backend suite: 2405 passed, 0 failed
- [x] SharpCompress: 2124 passed
- [x] Frontend typecheck + build + 519 tests passing
- [ ] Manual: configure a provider with MaxConnections above its account limit, stream under load, verify warning + header + card + support pack

Closes #913