### PR TITLE
chore(test): resolve all CodeQL cs/path-combine findings by replacing Path.Combine with Path.Join

### DIFF
--- a/libs/SharpCompress/Archives/ArchiveVolumeFactory.cs
+++ b/libs/SharpCompress/Archives/ArchiveVolumeFactory.cs
@@ -16,7 +16,7 @@ internal abstract class ArchiveVolumeFactory
         if (m.Success)
         {
             item = new FileInfo(
-                Path.Combine(
+                Path.Join(
                     part1.DirectoryName!,
                     String.Concat(
                         m.Groups[1].Value,

--- a/libs/SharpCompress/Archives/Rar/RarArchiveVolumeFactory.cs
+++ b/libs/SharpCompress/Archives/Rar/RarArchiveVolumeFactory.cs
@@ -16,7 +16,7 @@ internal static class RarArchiveVolumeFactory
         if (m.Success)
         {
             item = new FileInfo(
-                Path.Combine(
+                Path.Join(
                     part1.DirectoryName!,
                     String.Concat(
                         m.Groups[1].Value,
@@ -35,7 +35,7 @@ internal static class RarArchiveVolumeFactory
             if (m.Success)
             {
                 item = new FileInfo(
-                    Path.Combine(
+                    Path.Join(
                         part1.DirectoryName!,
                         String.Concat(
                             m.Groups[1].Value,

--- a/libs/SharpCompress/Archives/Zip/ZipArchiveVolumeFactory.cs
+++ b/libs/SharpCompress/Archives/Zip/ZipArchiveVolumeFactory.cs
@@ -17,7 +17,7 @@ internal static class ZipArchiveVolumeFactory
         if (m.Success)
         {
             item = new FileInfo(
-                Path.Combine(
+                Path.Join(
                     part1.DirectoryName!,
                     String.Concat(
                         m.Groups[1].Value,

--- a/libs/SharpCompress/Common/IEntryExtensions.cs
+++ b/libs/SharpCompress/Common/IEntryExtensions.cs
@@ -92,7 +92,7 @@ internal static partial class IEntryExtensions
             {
                 var folder = Path.GetDirectoryName(entry.Key.NotNull("Entry Key is null"))
                     .NotNull("Directory is null");
-                var destdir = Path.GetFullPath(Path.Combine(fullDestinationDirectoryPath, folder));
+                var destdir = Path.GetFullPath(Path.Join(fullDestinationDirectoryPath, folder));
 
                 DirectoryManagement.EnsurePathInDestinationDirectory(
                     destdir,
@@ -107,10 +107,10 @@ internal static partial class IEntryExtensions
                     Directory.CreateDirectory(destdir);
                 }
 
-                return Path.Combine(destdir, file);
+                return Path.Join(destdir, file);
             }
 
-            return Path.Combine(fullDestinationDirectoryPath, file);
+            return Path.Join(fullDestinationDirectoryPath, file);
         }
 
         public void WriteEntryToFile(

--- a/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
@@ -23,7 +23,7 @@ namespace NzbWebDAV.Tests.Api;
 public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-addfile-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-addfile-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private DavDatabaseContext _context = null!;

--- a/tests/NzbWebDAV.Tests/Api/CreateAccountControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/CreateAccountControllerTests.cs
@@ -16,7 +16,7 @@ namespace NzbWebDAV.Tests.Api;
 public sealed class CreateAccountControllerTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-createaccount-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-createaccount-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private DavDatabaseContext _context = null!;
@@ -135,7 +135,7 @@ public sealed class CreateAccountControllerTests : IAsyncLifetime
     [Fact]
     public async Task SingleAdminMigration_ExistingDuplicates_KeepsEarliestAdmin()
     {
-        var migrationDbPath = Path.Combine(_configRoot, "duplicate-admin-migration.sqlite");
+        var migrationDbPath = Path.Join(_configRoot, "duplicate-admin-migration.sqlite");
         var migrationOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
             .UseSqlite($"Data Source={migrationDbPath}")
             .AddInterceptors(new SqliteForeignKeyEnabler())

--- a/tests/NzbWebDAV.Tests/Api/DbBackupDownloadZipTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DbBackupDownloadZipTests.cs
@@ -76,14 +76,14 @@ public class DbBackupDownloadZipTests
 
     private static string CreateStagingBackup()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "nzbdav-backup-zip-test-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-backup-zip-test-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
-        Directory.CreateDirectory(Path.Combine(dir, DatabaseBackupStore.RollbackFolderName));
+        Directory.CreateDirectory(Path.Join(dir, DatabaseBackupStore.RollbackFolderName));
 
-        File.WriteAllText(Path.Combine(dir, "db.sql"), "SELECT 1;");
-        File.WriteAllText(Path.Combine(dir, "manifest.json"), """{"id":"test"}""");
+        File.WriteAllText(Path.Join(dir, "db.sql"), "SELECT 1;");
+        File.WriteAllText(Path.Join(dir, "manifest.json"), """{"id":"test"}""");
         File.WriteAllText(
-            Path.Combine(dir, DatabaseBackupStore.RollbackFolderName, "db.sql"),
+            Path.Join(dir, DatabaseBackupStore.RollbackFolderName, "db.sql"),
             "SHOULD_NOT_BE_IN_ZIP");
 
         return dir;

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -23,7 +23,7 @@ namespace NzbWebDAV.Tests.Api;
 public sealed class RetryHistoryControllerTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-retry-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-retry-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private DavDatabaseContext _context = null!;

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -26,7 +26,7 @@ namespace NzbWebDAV.Tests.Api;
 public sealed class SabPauseResumeTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-pause-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-pause-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private DavDatabaseContext _context = null!;

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DeleteCacheDirTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DeleteCacheDirTests.cs
@@ -7,7 +7,7 @@ public class DeleteCacheDirTests
     [Fact]
     public async Task DeleteCacheDir_NonexistentPath_ReturnsPromptly()
     {
-        var path = Path.Combine(Path.GetTempPath(), "nzbdav-missing-" + Guid.NewGuid().ToString("N"));
+        var path = Path.Join(Path.GetTempPath(), "nzbdav-missing-" + Guid.NewGuid().ToString("N"));
         var sw = System.Diagnostics.Stopwatch.StartNew();
         await ArticleCachingNntpClient.DeleteCacheDir(path);
         sw.Stop();
@@ -19,7 +19,7 @@ public class DeleteCacheDirTests
     {
         var previous = ArticleCachingNntpClient.DeleteCacheDirInitialDelayMs;
         ArticleCachingNntpClient.DeleteCacheDirInitialDelayMs = 1;
-        var blocker = Path.Combine(Path.GetTempPath(), "nzbdav-block-" + Guid.NewGuid().ToString("N"));
+        var blocker = Path.Join(Path.GetTempPath(), "nzbdav-block-" + Guid.NewGuid().ToString("N"));
         try
         {
             // A file at the target path makes Directory.Delete throw IOException.

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -12,7 +12,7 @@ public sealed class SegmentCacheNntpClientTests
     [Fact]
     public async Task CatalogHydration_DoesNotBlockConstruction_AndServesEntriesAfterLoad()
     {
-        var cacheDir = Path.Combine(
+        var cacheDir = Path.Join(
             Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
         var loadStarted = new ManualResetEventSlim();
         var allowLoad = new ManualResetEventSlim();
@@ -71,7 +71,7 @@ public sealed class SegmentCacheNntpClientTests
     [Fact]
     public async Task CatalogHydration_DoesNotDoubleCountEntryFinalizedDuringLoad()
     {
-        var cacheDir = Path.Combine(
+        var cacheDir = Path.Join(
             Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
         var loadStarted = new ManualResetEventSlim();
         var allowLoad = new ManualResetEventSlim();
@@ -122,9 +122,9 @@ public sealed class SegmentCacheNntpClientTests
     private static void WriteCacheEntry(string cacheDir, string segmentId, byte[] content)
     {
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
-        var directory = Path.Combine(cacheDir, hash[..2]);
+        var directory = Path.Join(cacheDir, hash[..2]);
         Directory.CreateDirectory(directory);
-        File.WriteAllBytes(Path.Combine(directory, hash), content);
+        File.WriteAllBytes(Path.Join(directory, hash), content);
 
         var header = new UsenetYencHeader
         {
@@ -137,7 +137,7 @@ public sealed class SegmentCacheNntpClientTests
             TotalParts = 1,
         };
         File.WriteAllText(
-            Path.Combine(directory, hash) + ".h",
+            Path.Join(directory, hash) + ".h",
             JsonSerializer.Serialize(header, new JsonSerializerOptions { IncludeFields = true }));
     }
 }

--- a/tests/NzbWebDAV.Tests/Database/DatabaseMigrationLeaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseMigrationLeaseTests.cs
@@ -107,7 +107,7 @@ public sealed class DatabaseMigrationLeaseTests
     }
 
     private static string TempDatabasePath() =>
-        Path.Combine(Path.GetTempPath(), $"nzbdav-migration-lease-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-migration-lease-{Guid.NewGuid():N}.sqlite");
 
     private static void DeleteDatabaseFiles(string path)
     {

--- a/tests/NzbWebDAV.Tests/Database/DatabaseStartupGuardsTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseStartupGuardsTests.cs
@@ -11,7 +11,7 @@ public class DatabaseStartupGuardsTests
     [Fact]
     public async Task ConfigItemsTableExistsAsync_ReturnsFalse_OnEmptySqliteFile()
     {
-        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-startup-{Guid.NewGuid():N}.sqlite");
+        var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-startup-{Guid.NewGuid():N}.sqlite");
         try
         {
             // Mimic a WAL-created empty file: open and close without migrating.
@@ -38,7 +38,7 @@ public class DatabaseStartupGuardsTests
     [Fact]
     public async Task ConfigItemsTableExistsAsync_ReturnsTrue_AfterMigrate()
     {
-        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-startup-{Guid.NewGuid():N}.sqlite");
+        var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-startup-{Guid.NewGuid():N}.sqlite");
         try
         {
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -14,7 +14,7 @@ namespace NzbWebDAV.Tests.Database;
 public sealed class DavDatabaseClientTests : IAsyncLifetime
 {
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-tests-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-tests-{Guid.NewGuid():N}.sqlite");
     private DavDatabaseContext _context = null!;
     private DavDatabaseClient _client = null!;
 

--- a/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
@@ -230,7 +230,7 @@ public sealed class FixEmptyCategoriesMigrationTests
 
         public static async Task<MigrationHarness> CreateAsync()
         {
-            var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-empty-cat-{Guid.NewGuid():N}.sqlite");
+            var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-empty-cat-{Guid.NewGuid():N}.sqlite");
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()
                 .UseSqlite($"Data Source={databasePath}")
                 .AddInterceptors(new SqliteForeignKeyEnabler())

--- a/tests/NzbWebDAV.Tests/Database/HealthyTreePathMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/HealthyTreePathMigrationTests.cs
@@ -132,7 +132,7 @@ public sealed class HealthyTreePathMigrationTests
 
         public static async Task<MigrationHarness> CreateAsync()
         {
-            var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-healthy-tree-{Guid.NewGuid():N}.sqlite");
+            var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-healthy-tree-{Guid.NewGuid():N}.sqlite");
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()
                 .UseSqlite($"Data Source={databasePath}")
                 .AddInterceptors(new SqliteForeignKeyEnabler())

--- a/tests/NzbWebDAV.Tests/Database/MetricsMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/MetricsMigrationTests.cs
@@ -13,7 +13,7 @@ public sealed class MetricsMigrationTests
     [Fact]
     public async Task AddMissesCounters_MovesExistingErrorsWithoutScanningRawFetches()
     {
-        var databasePath = Path.Combine(
+        var databasePath = Path.Join(
             Path.GetTempPath(),
             $"nzbdav-metrics-migration-{Guid.NewGuid():N}.sqlite");
         var options = new DbContextOptionsBuilder<MetricsDbContext>()

--- a/tests/NzbWebDAV.Tests/Database/PreExistingPathIndexMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PreExistingPathIndexMigrationTests.cs
@@ -127,7 +127,7 @@ public sealed class PreExistingPathIndexMigrationTests
 
         public static async Task<MigrationHarness> CreateAsync()
         {
-            var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-preexisting-path-index-{Guid.NewGuid():N}.sqlite");
+            var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-preexisting-path-index-{Guid.NewGuid():N}.sqlite");
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()
                 .UseSqlite($"Data Source={databasePath}")
                 .AddInterceptors(new SqliteForeignKeyEnabler())

--- a/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteDumpImportTests.cs
@@ -13,14 +13,14 @@ public sealed class SqliteDumpImportTests
     [Fact]
     public async Task DumpAndImport_RoundTripsRepresentativeContent()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-dump-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-dump-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
         try
         {
-            var sourcePath = Path.Combine(root, "source.sqlite");
-            var dumpPath = Path.Combine(root, "dump.sql");
-            var restoredPath = Path.Combine(root, "restored.sqlite");
-            var redumpPath = Path.Combine(root, "redump.sql");
+            var sourcePath = Path.Join(root, "source.sqlite");
+            var dumpPath = Path.Join(root, "dump.sql");
+            var restoredPath = Path.Join(root, "restored.sqlite");
+            var redumpPath = Path.Join(root, "redump.sql");
 
             await CreateRepresentativeDatabaseAsync(sourcePath);
 
@@ -96,12 +96,12 @@ public sealed class SqliteDumpImportTests
     [Fact]
     public async Task Importer_HandlesSemicolonsCommentsAndMultilineStatements()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-import-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-import-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
         try
         {
-            var sqlPath = Path.Combine(root, "special.sql");
-            var dbPath = Path.Combine(root, "special.sqlite");
+            var sqlPath = Path.Join(root, "special.sql");
+            var dbPath = Path.Join(root, "special.sqlite");
             await File.WriteAllTextAsync(sqlPath, """
                 PRAGMA foreign_keys=OFF;
                 BEGIN TRANSACTION;
@@ -143,13 +143,13 @@ public sealed class SqliteDumpImportTests
     [Fact]
     public async Task Importer_RejectsAttachedDatabaseAndLeavesItUnchanged()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-import-authorizer-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-import-authorizer-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
         try
         {
-            var sqlPath = Path.Combine(root, "malicious.sql");
-            var stagedPath = Path.Combine(root, "staged.sqlite");
-            var livePath = Path.Combine(root, "live.sqlite");
+            var sqlPath = Path.Join(root, "malicious.sql");
+            var stagedPath = Path.Join(root, "staged.sqlite");
+            var livePath = Path.Join(root, "live.sqlite");
             await File.WriteAllTextAsync(sqlPath, $"""
                 CREATE TABLE Safe(Value TEXT);
                 aTtAcH DATABASE '{livePath.Replace("'", "''", StringComparison.Ordinal)}' AS live;
@@ -185,11 +185,11 @@ public sealed class SqliteDumpImportTests
     [Fact]
     public async Task DumpAndImport_RoundTripsRealDavSchema()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-schema-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-schema-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
-        var sourceDb = Path.Combine(root, "source.sqlite");
-        var dumpPath = Path.Combine(root, "db.sql");
-        var restoredDb = Path.Combine(root, "restored-db.sqlite");
+        var sourceDb = Path.Join(root, "source.sqlite");
+        var dumpPath = Path.Join(root, "db.sql");
+        var restoredDb = Path.Join(root, "restored-db.sqlite");
         try
         {
             var sourceOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
@@ -323,7 +323,7 @@ public sealed class DatabaseBackupStoreTests
     [Fact]
     public void Retention_RespectsPreservedAndZeroDisablesPruning()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-store-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-store-{Guid.NewGuid():N}");
         var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
         Environment.SetEnvironmentVariable("CONFIG_PATH", root);
         try
@@ -362,7 +362,7 @@ public sealed class DatabaseBackupStoreTests
     [Fact]
     public void IncompletePendingRestore_IsReadableAndClearable()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-intent-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-intent-{Guid.NewGuid():N}");
         var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
         Environment.SetEnvironmentVariable("CONFIG_PATH", root);
         try
@@ -391,7 +391,7 @@ public sealed class DatabaseBackupStoreTests
     private static void CreateCommittedBackup(DatabaseBackupStore store, string kind, bool preserved)
     {
         var staging = store.CreateStaging(kind);
-        File.WriteAllText(Path.Combine(staging, DatabaseBackupStore.DbSqlName), "PRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\nCOMMIT;\n");
+        File.WriteAllText(Path.Join(staging, DatabaseBackupStore.DbSqlName), "PRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\nCOMMIT;\n");
         store.CommitStaging(staging, kind, notes: null, preserved: preserved, appVersion: "test", lastMainMigration: null);
     }
 
@@ -415,7 +415,7 @@ public sealed class DatabaseRestoreRunnerTests
     [Fact]
     public async Task ApplyPendingRestore_DiscardsMissingStagingFiles()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-restore-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-restore-{Guid.NewGuid():N}");
         var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
         Environment.SetEnvironmentVariable("CONFIG_PATH", root);
         try
@@ -457,7 +457,7 @@ public sealed class DatabaseRestoreRunnerTests
     [Fact]
     public async Task ApplyPendingRestore_SwapsStagedDatabaseAndWritesReport()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"nzbdav-swap-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-swap-{Guid.NewGuid():N}");
         var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
         Environment.SetEnvironmentVariable("CONFIG_PATH", root);
         try
@@ -477,12 +477,12 @@ public sealed class DatabaseRestoreRunnerTests
 
             // Pre-restore backup folder for rollback target
             var preStaging = store.CreateStaging(DatabaseBackupKinds.PreRestore);
-            File.WriteAllText(Path.Combine(preStaging, DatabaseBackupStore.DbSqlName), "PRAGMA foreign_keys=OFF;\nBEGIN;\nCOMMIT;\n");
+            File.WriteAllText(Path.Join(preStaging, DatabaseBackupStore.DbSqlName), "PRAGMA foreign_keys=OFF;\nBEGIN;\nCOMMIT;\n");
             var pre = store.CommitStaging(preStaging, DatabaseBackupKinds.PreRestore, "safety", preserved: true, "test", null);
 
             // Staged restored DB
             store.PrepareRestoreStaging();
-            var stagedPath = Path.Combine(store.RestoreStagingRoot, "db.sqlite");
+            var stagedPath = Path.Join(store.RestoreStagingRoot, "db.sqlite");
             await using (var staged = new SqliteConnection($"Data Source={stagedPath};Pooling=False"))
             {
                 await staged.OpenAsync();
@@ -517,7 +517,7 @@ public sealed class DatabaseRestoreRunnerTests
                 Assert.Equal("restored", (string)(await cmd.ExecuteScalarAsync())!);
             }
 
-            var rollbackDb = Path.Combine(store.GetBackupDirectory(pre.Id), DatabaseBackupStore.RollbackFolderName, "db.sqlite");
+            var rollbackDb = Path.Join(store.GetBackupDirectory(pre.Id), DatabaseBackupStore.RollbackFolderName, "db.sqlite");
             Assert.True(File.Exists(rollbackDb));
 
             var report = store.ReadLastRestoreReport();

--- a/tests/NzbWebDAV.Tests/Database/SqliteMainDbPragmasTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SqliteMainDbPragmasTests.cs
@@ -24,7 +24,7 @@ public class SqliteMainDbPragmasTests
     [Fact]
     public async Task ConnectionOpened_AppliesMemoryAndJournalPragmas()
     {
-        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-main-pragmas-{Guid.NewGuid():N}.sqlite");
+        var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-main-pragmas-{Guid.NewGuid():N}.sqlite");
         try
         {
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()
@@ -49,10 +49,10 @@ public class SqliteMainDbPragmasTests
     [Fact]
     public async Task MaintenanceSweep_PopulatesSqliteStat1()
     {
-        var configPath = Path.Combine(Path.GetTempPath(), $"nzbdav-maint-{Guid.NewGuid():N}");
+        var configPath = Path.Join(Path.GetTempPath(), $"nzbdav-maint-{Guid.NewGuid():N}");
         Directory.CreateDirectory(configPath);
-        var mainPath = Path.Combine(configPath, "db.sqlite");
-        var metricsPath = Path.Combine(configPath, "metrics.sqlite");
+        var mainPath = Path.Join(configPath, "db.sqlite");
+        var metricsPath = Path.Join(configPath, "metrics.sqlite");
 
         try
         {
@@ -115,7 +115,7 @@ public class SqliteMetricsPragmasTests
     [Fact]
     public async Task ConnectionOpened_AppliesBusyTimeout()
     {
-        var databasePath = Path.Combine(Path.GetTempPath(), $"nzbdav-metrics-pragmas-{Guid.NewGuid():N}.sqlite");
+        var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-metrics-pragmas-{Guid.NewGuid():N}.sqlite");
         try
         {
             var options = new DbContextOptionsBuilder<MetricsDbContext>()

--- a/tests/NzbWebDAV.Tests/Database/StartupDatabaseMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/StartupDatabaseMigrationTests.cs
@@ -71,7 +71,7 @@ public sealed class StartupDatabaseMigrationTests
     }
 
     private static string TempDatabasePath(string name) =>
-        Path.Combine(Path.GetTempPath(), $"nzbdav-startup-{name}-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-startup-{name}-{Guid.NewGuid():N}.sqlite");
 
     private static void DeleteDatabaseFiles(string path)
     {

--- a/tests/NzbWebDAV.Tests/MetricsWriterTests.cs
+++ b/tests/NzbWebDAV.Tests/MetricsWriterTests.cs
@@ -14,7 +14,7 @@ public class MetricsWriterTests
         try
         {
             var options = new DbContextOptionsBuilder<MetricsDbContext>()
-                .UseSqlite($"Data Source={Path.Combine(invalidParent, "metrics.sqlite")}")
+                .UseSqlite($"Data Source={Path.Join(invalidParent, "metrics.sqlite")}")
                 .Options;
             var writer = new MetricsWriter(() => new MetricsDbContext(options));
             writer.RecordFetch(new SegmentFetch

--- a/tests/NzbWebDAV.Tests/Queue/BlocklistedFilePostProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/BlocklistedFilePostProcessorTests.cs
@@ -15,7 +15,7 @@ public class BlocklistedFilePostProcessorTests : IDisposable
 
     public BlocklistedFilePostProcessorTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"blocklist-test-{Guid.NewGuid():N}.sqlite");
+        _dbPath = Path.Join(Path.GetTempPath(), $"blocklist-test-{Guid.NewGuid():N}.sqlite");
         var options = new DbContextOptionsBuilder<DavDatabaseContext>()
             .UseSqlite($"Data Source={_dbPath}")
             .Options;

--- a/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
@@ -20,7 +20,7 @@ namespace NzbWebDAV.Tests.Queue;
 public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-qworkers-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-qworkers-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private ConfigManager _configManager = null!;

--- a/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
@@ -17,8 +17,8 @@ public class CreateStrmFilesPostProcessorTests : IDisposable
 
     public CreateStrmFilesPostProcessorTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"strm-test-{Guid.NewGuid():N}.sqlite");
-        _strmDir = Path.Combine(Path.GetTempPath(), $"strm-out-{Guid.NewGuid():N}");
+        _dbPath = Path.Join(Path.GetTempPath(), $"strm-test-{Guid.NewGuid():N}.sqlite");
+        _strmDir = Path.Join(Path.GetTempPath(), $"strm-out-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_strmDir);
 
         var options = new DbContextOptionsBuilder<DavDatabaseContext>()

--- a/tests/NzbWebDAV.Tests/Services/DavCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/DavCleanupServiceTests.cs
@@ -12,7 +12,7 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class DavCleanupServiceTests : IAsyncLifetime
 {
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-dav-cleanup-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-dav-cleanup-{Guid.NewGuid():N}.sqlite");
     private DavDatabaseContext _context = null!;
 
     public async Task InitializeAsync()

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -11,7 +11,7 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
 {
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-health-queue-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-health-queue-{Guid.NewGuid():N}.sqlite");
     private DavDatabaseContext _context = null!;
     private DavDatabaseClient _dbClient = null!;
 

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckRetentionServiceTests.cs
@@ -11,7 +11,7 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class HealthCheckRetentionServiceTests : IAsyncLifetime
 {
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-health-retention-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-health-retention-{Guid.NewGuid():N}.sqlite");
     private DavDatabaseContext _context = null!;
 
     public async Task InitializeAsync()

--- a/tests/NzbWebDAV.Tests/Services/HistoryRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HistoryRetentionServiceTests.cs
@@ -11,7 +11,7 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class HistoryRetentionServiceTests : IAsyncLifetime
 {
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-history-retention-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-history-retention-{Guid.NewGuid():N}.sqlite");
     private DavDatabaseContext _context = null!;
     private DavDatabaseClient _client = null!;
 

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -104,7 +104,7 @@ public class LazyRarResolverTests
         var reconcileSawPersistedBlob = false;
 
         var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
-        var configRoot = Path.Combine(Path.GetTempPath(), $"nzbdav-lazy-reconcile-{Guid.NewGuid():N}");
+        var configRoot = Path.Join(Path.GetTempPath(), $"nzbdav-lazy-reconcile-{Guid.NewGuid():N}");
         Directory.CreateDirectory(configRoot);
         Environment.SetEnvironmentVariable("CONFIG_PATH", configRoot);
         try

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
@@ -118,7 +118,7 @@ public sealed class MetricsRollupFailoverSavesTests
 
     private static async Task withMetricsDb(Func<MetricsDbContext, Task> body)
     {
-        var databasePath = Path.Combine(
+        var databasePath = Path.Join(
             Path.GetTempPath(),
             $"nzbdav-metrics-rollup-{Guid.NewGuid():N}.sqlite");
         var options = new DbContextOptionsBuilder<MetricsDbContext>()

--- a/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
@@ -335,7 +335,7 @@ public class OverviewStatsResetTests
         try
         {
             var options = new DbContextOptionsBuilder<MetricsDbContext>()
-                .UseSqlite($"Data Source={Path.Combine(invalidParent, "metrics.sqlite")}")
+                .UseSqlite($"Data Source={Path.Join(invalidParent, "metrics.sqlite")}")
                 .Options;
             var writer = new MetricsWriter(() => new MetricsDbContext(options));
             writer.RecordFetch(new SegmentFetch
@@ -372,7 +372,7 @@ public class OverviewStatsResetTests
         try
         {
             var options = new DbContextOptionsBuilder<MetricsDbContext>()
-                .UseSqlite($"Data Source={Path.Combine(invalidParent, "metrics.sqlite")}")
+                .UseSqlite($"Data Source={Path.Join(invalidParent, "metrics.sqlite")}")
                 .Options;
             var writer = new MetricsWriter(() => new MetricsDbContext(options));
             writer.RecordFetch(new SegmentFetch
@@ -562,9 +562,9 @@ public class OverviewStatsResetTests
 
         public static async Task<MetricsHarness> CreateAsync()
         {
-            var dir = Path.Combine(Path.GetTempPath(), $"nzbdav-overview-reset-{Guid.NewGuid():N}");
+            var dir = Path.Join(Path.GetTempPath(), $"nzbdav-overview-reset-{Guid.NewGuid():N}");
             Directory.CreateDirectory(dir);
-            var path = Path.Combine(dir, "metrics.sqlite");
+            var path = Path.Join(dir, "metrics.sqlite");
             var options = new DbContextOptionsBuilder<MetricsDbContext>()
                 .UseSqlite($"Data Source={path}")
                 .AddInterceptors(new SqliteMetricsPragmas())

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
@@ -197,12 +197,12 @@ public class ProviderMetricsKeyTests
     {
         // Un-migrated database: every table query throws "no such table". The remap
         // must contain the failure — throwing here used to crash backend startup.
-        var dir = Path.Combine(Path.GetTempPath(), $"nzbdav-metrics-broken-{Guid.NewGuid():N}");
+        var dir = Path.Join(Path.GetTempPath(), $"nzbdav-metrics-broken-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dir);
         try
         {
             var options = new DbContextOptionsBuilder<MetricsDbContext>()
-                .UseSqlite($"Data Source={Path.Combine(dir, "metrics.sqlite")}")
+                .UseSqlite($"Data Source={Path.Join(dir, "metrics.sqlite")}")
                 .Options;
             await using var context = new MetricsDbContext(options);
 
@@ -307,9 +307,9 @@ public class ProviderMetricsKeyTests
 
         public static async Task<MetricsHarness> CreateAsync()
         {
-            var dir = Path.Combine(Path.GetTempPath(), $"nzbdav-metrics-key-{Guid.NewGuid():N}");
+            var dir = Path.Join(Path.GetTempPath(), $"nzbdav-metrics-key-{Guid.NewGuid():N}");
             Directory.CreateDirectory(dir);
-            var path = Path.Combine(dir, "metrics.sqlite");
+            var path = Path.Join(dir, "metrics.sqlite");
             var options = new DbContextOptionsBuilder<MetricsDbContext>()
                 .UseSqlite($"Data Source={path}")
                 .AddInterceptors(new SqliteMetricsPragmas())

--- a/tests/NzbWebDAV.Tests/Services/MultipartFileSizeRepairServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/MultipartFileSizeRepairServiceTests.cs
@@ -15,7 +15,7 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class MultipartFileSizeRepairServiceTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-filesize-repair-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-filesize-repair-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
     private DavDatabaseContext _context = null!;
 

--- a/tests/NzbWebDAV.Tests/Services/NzbBackupRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbBackupRetentionServiceTests.cs
@@ -5,11 +5,11 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class NzbBackupRetentionServiceTests : IDisposable
 {
     private readonly string _backupRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-nzb-backup-retention-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-nzb-backup-retention-{Guid.NewGuid():N}");
 
     public NzbBackupRetentionServiceTests()
     {
-        Directory.CreateDirectory(Path.Combine(_backupRoot, "tv"));
+        Directory.CreateDirectory(Path.Join(_backupRoot, "tv"));
     }
 
     public void Dispose()
@@ -20,9 +20,9 @@ public sealed class NzbBackupRetentionServiceTests : IDisposable
     [Fact]
     public void SweepDirectory_DeletesAgedNzbFiles_KeepsRecent()
     {
-        var oldPath = Path.Combine(_backupRoot, "tv", "old.nzb");
-        var recentPath = Path.Combine(_backupRoot, "tv", "recent.nzb");
-        var otherPath = Path.Combine(_backupRoot, "tv", "notes.txt");
+        var oldPath = Path.Join(_backupRoot, "tv", "old.nzb");
+        var recentPath = Path.Join(_backupRoot, "tv", "recent.nzb");
+        var otherPath = Path.Join(_backupRoot, "tv", "notes.txt");
         File.WriteAllText(oldPath, "old");
         File.WriteAllText(recentPath, "recent");
         File.WriteAllText(otherPath, "keep");
@@ -40,7 +40,7 @@ public sealed class NzbBackupRetentionServiceTests : IDisposable
     [Fact]
     public void SweepDirectory_WithZeroRetention_DeletesNothing()
     {
-        var path = Path.Combine(_backupRoot, "tv", "old.nzb");
+        var path = Path.Join(_backupRoot, "tv", "old.nzb");
         File.WriteAllText(path, "old");
         File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-400));
 

--- a/tests/NzbWebDAV.Tests/Services/NzbBlobCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbBlobCleanupServiceTests.cs
@@ -13,9 +13,9 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class NzbBlobCleanupServiceTests : IAsyncLifetime
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-nzb-blob-cleanup-cfg-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-nzb-blob-cleanup-cfg-{Guid.NewGuid():N}");
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-nzb-blob-cleanup-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-nzb-blob-cleanup-{Guid.NewGuid():N}.sqlite");
     private string? _previousConfigPath;
     private DavDatabaseContext _context = null!;
 

--- a/tests/NzbWebDAV.Tests/Services/NzbResolutionCachePersistenceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbResolutionCachePersistenceTests.cs
@@ -11,7 +11,7 @@ namespace NzbWebDAV.Tests.Services;
 public sealed class NzbResolutionCachePersistenceTests : IAsyncLifetime
 {
     private readonly string _databasePath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-resolution-cache-{Guid.NewGuid():N}.sqlite");
+        Path.Join(Path.GetTempPath(), $"nzbdav-resolution-cache-{Guid.NewGuid():N}.sqlite");
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private DavDatabaseContext _context = null!;
 

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -25,7 +25,7 @@ namespace NzbWebDAV.Tests.Services.SupportPack;
 public sealed class SupportPackContentsTests : IDisposable
 {
     private readonly string _configRoot =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-support-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-support-{Guid.NewGuid():N}");
 
     private readonly string? _previousConfigPath;
 

--- a/tests/NzbWebDAV.Tests/Tasks/RecreateStrmFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RecreateStrmFilesTaskTests.cs
@@ -11,8 +11,8 @@ namespace NzbWebDAV.Tests.Tasks;
 [Collection(nameof(BaseTaskCollection))]
 public class RecreateStrmFilesTaskTests : IAsyncLifetime
 {
-    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"recreate-strm-{Guid.NewGuid():N}.sqlite");
-    private readonly string _strmDir = Path.Combine(Path.GetTempPath(), $"recreate-strm-out-{Guid.NewGuid():N}");
+    private readonly string _dbPath = Path.Join(Path.GetTempPath(), $"recreate-strm-{Guid.NewGuid():N}.sqlite");
+    private readonly string _strmDir = Path.Join(Path.GetTempPath(), $"recreate-strm-out-{Guid.NewGuid():N}");
     private DavDatabaseContext _context = null!;
     private DavDatabaseClient _dbClient = null!;
     private ConfigManager _config = null!;

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -219,7 +219,7 @@ public class RemoveUnlinkedFilesTaskTests
     public async Task DryRun_DoesNotTreatLowercaseLinkedIdAsUnlinked()
     {
         await BaseTask.ResetRunningTaskForTestsAsync();
-        var libraryDir = Path.Combine(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
         Directory.CreateDirectory(libraryDir);
         await using var harness = await TempDb.CreateAsync();
         try
@@ -266,7 +266,7 @@ public class RemoveUnlinkedFilesTaskTests
             foreach (var id in linkedIds.Append(lowercaseId))
             {
                 await File.WriteAllTextAsync(
-                    Path.Combine(libraryDir, $"{id:N}.strm"),
+                    Path.Join(libraryDir, $"{id:N}.strm"),
                     $"http://localhost/view/.ids/{id}.mkv");
             }
 
@@ -326,7 +326,7 @@ public class RemoveUnlinkedFilesTaskTests
     public async Task DryRun_ReportsDone_WithTerminalProgress()
     {
         await BaseTask.ResetRunningTaskForTestsAsync();
-        var libraryDir = Path.Combine(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
         Directory.CreateDirectory(libraryDir);
         await using var harness = await TempDb.CreateAsync();
         try
@@ -356,7 +356,7 @@ public class RemoveUnlinkedFilesTaskTests
             foreach (var id in linkedIds)
             {
                 await File.WriteAllTextAsync(
-                    Path.Combine(libraryDir, $"{id:N}.strm"),
+                    Path.Join(libraryDir, $"{id:N}.strm"),
                     $"http://localhost/view/.ids/{id}.mkv");
             }
 
@@ -401,7 +401,7 @@ public class RemoveUnlinkedFilesTaskTests
     public async Task DryRun_Succeeds_WhenPreviousRunLeftUniqueTempTableBehind()
     {
         await BaseTask.ResetRunningTaskForTestsAsync();
-        var libraryDir = Path.Combine(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
         Directory.CreateDirectory(libraryDir);
         await using var harness = await TempDb.CreateAsync();
         try
@@ -431,7 +431,7 @@ public class RemoveUnlinkedFilesTaskTests
             foreach (var id in linkedIds)
             {
                 await File.WriteAllTextAsync(
-                    Path.Combine(libraryDir, $"{id:N}.strm"),
+                    Path.Join(libraryDir, $"{id:N}.strm"),
                     $"http://localhost/view/.ids/{id}.mkv");
             }
 
@@ -599,7 +599,7 @@ public class RemoveUnlinkedFilesTaskTests
 
         public static async Task<TempDb> CreateAsync()
         {
-            var path = Path.Combine(Path.GetTempPath(), $"nzbdav-unlinked-{Guid.NewGuid():N}.sqlite");
+            var path = Path.Join(Path.GetTempPath(), $"nzbdav-unlinked-{Guid.NewGuid():N}.sqlite");
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()
                 .UseSqlite($"Data Source={path}")
                 .AddInterceptors(new SqliteMainDbPragmas())

--- a/tests/NzbWebDAV.Tests/Tasks/RenameWindowsInvalidDavPathsTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RenameWindowsInvalidDavPathsTaskTests.cs
@@ -386,7 +386,7 @@ public class RenameWindowsInvalidDavPathsTaskTests
 
         public static async Task<TempDb> CreateAsync()
         {
-            var path = Path.Combine(Path.GetTempPath(), $"nzbdav-winrename-{Guid.NewGuid():N}.sqlite");
+            var path = Path.Join(Path.GetTempPath(), $"nzbdav-winrename-{Guid.NewGuid():N}.sqlite");
             var options = new DbContextOptionsBuilder<DavDatabaseContext>()
                 .UseSqlite($"Data Source={path}")
                 .AddInterceptors(new SqliteMainDbPragmas())

--- a/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
@@ -20,7 +20,7 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
     public const string WebDavPassword = "integration-password";
 
     private readonly string _configPath =
-        Path.Combine(Path.GetTempPath(), $"nzbdav-http-tests-{Guid.NewGuid():N}");
+        Path.Join(Path.GetTempPath(), $"nzbdav-http-tests-{Guid.NewGuid():N}");
     private readonly Dictionary<string, string?> _previousEnvironment = new();
     private int _disposed;
 
@@ -107,7 +107,7 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
     private void InitializeDatabases()
     {
         var databaseOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
-            .UseSqlite($"Data Source={Path.Combine(_configPath, "db.sqlite")}")
+            .UseSqlite($"Data Source={Path.Join(_configPath, "db.sqlite")}")
             .AddInterceptors(new SqliteMainDbPragmas())
             .ReplaceService<
                 IMigrationsSqlGenerator,
@@ -117,7 +117,7 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
         databaseContext.Database.Migrate();
 
         var metricsOptions = new DbContextOptionsBuilder<MetricsDbContext>()
-            .UseSqlite($"Data Source={Path.Combine(_configPath, "metrics.sqlite")}")
+            .UseSqlite($"Data Source={Path.Join(_configPath, "metrics.sqlite")}")
             .AddInterceptors(new SqliteMetricsPragmas())
             .ReplaceService<
                 IMigrationsSqlGenerator,

--- a/tests/NzbWebDAV.Tests/UsenetMigration/AltmountPathDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/AltmountPathDetectorTests.cs
@@ -10,8 +10,8 @@ public sealed class AltmountPathDetectorTests
         var root = Directory.CreateTempSubdirectory("altmig-detect-");
         try
         {
-            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
-            var configPath = Path.Combine(root.FullName, "config.yaml");
+            var metadataRoot = Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
+            var configPath = Path.Join(root.FullName, "config.yaml");
             await File.WriteAllTextAsync(
                 configPath,
                 "sabnzbd:\n  categories:\n  - name: 'movies'\n    dir: 'movies'\n");
@@ -35,7 +35,7 @@ public sealed class AltmountPathDetectorTests
     [Fact]
     public async Task Detect_ReportsMissingRoot()
     {
-        var root = Path.Combine(
+        var root = Path.Join(
             Path.GetTempPath(),
             $"missing-altmig-detect-{Guid.NewGuid():N}");
 
@@ -44,8 +44,8 @@ public sealed class AltmountPathDetectorTests
         Assert.False(result.Detected);
         Assert.Equal(AltmountPathDetector.FailureReason, result.Reason);
         Assert.DoesNotContain(root, result.Reason);
-        Assert.Equal(Path.Combine(Path.GetFullPath(root), "metadata"), result.MetadataRoot);
-        Assert.Equal(Path.Combine(Path.GetFullPath(root), "config.yaml"), result.ConfigPath);
+        Assert.Equal(Path.Join(Path.GetFullPath(root), "metadata"), result.MetadataRoot);
+        Assert.Equal(Path.Join(Path.GetFullPath(root), "config.yaml"), result.ConfigPath);
         Assert.Equal(Path.GetFullPath(root), result.StoreRoot);
     }
 
@@ -75,7 +75,7 @@ public sealed class AltmountPathDetectorTests
         var root = Directory.CreateTempSubdirectory("altmig-detect-");
         try
         {
-            Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
 
             var result = await AltmountPathDetector.DetectAsync(root.FullName);
 
@@ -100,9 +100,9 @@ public sealed class AltmountPathDetectorTests
     [Fact]
     public async Task Detect_RejectsNavigationSegmentsBeforeCanonicalization()
     {
-        var parent = Path.Combine(Path.GetTempPath(), $"altmig-parent-{Guid.NewGuid():N}");
-        var withParentTraversal = Path.Combine(parent, "child", "..", "altmount");
-        var withCurrentTraversal = Path.Combine(parent, ".", "altmount");
+        var parent = Path.Join(Path.GetTempPath(), $"altmig-parent-{Guid.NewGuid():N}");
+        var withParentTraversal = Path.Join(parent, "child", "..", "altmount");
+        var withCurrentTraversal = Path.Join(parent, ".", "altmount");
 
         await Assert.ThrowsAsync<ArgumentException>(
             () => AltmountPathDetector.DetectAsync(withParentTraversal));
@@ -126,9 +126,9 @@ public sealed class AltmountPathDetectorTests
         var root = Directory.CreateTempSubdirectory("altmig-detect-");
         try
         {
-            Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
             await File.WriteAllTextAsync(
-                Path.Combine(root.FullName, "config.yaml"),
+                Path.Join(root.FullName, "config.yaml"),
                 "sabnzbd:\n  categories:\n");
 
             var result = await AltmountPathDetector.DetectAsync(root.FullName);
@@ -149,9 +149,9 @@ public sealed class AltmountPathDetectorTests
         var root = Directory.CreateTempSubdirectory("altmig-detect-");
         try
         {
-            Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
             await File.WriteAllTextAsync(
-                Path.Combine(root.FullName, "config.yaml"),
+                Path.Join(root.FullName, "config.yaml"),
                 "sabnzbd:\n  categories: [{ name: 'movies' }]\n");
 
             var result = await AltmountPathDetector.DetectAsync(root.FullName);

--- a/tests/NzbWebDAV.Tests/UsenetMigration/MetadataTreeWalkerTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/MetadataTreeWalkerTests.cs
@@ -4,7 +4,7 @@ namespace NzbWebDAV.Tests.UsenetMigration;
 
 public class MetadataTreeWalkerTests : IDisposable
 {
-    private readonly string _root = Path.Combine(Path.GetTempPath(), $"meta-walk-{Guid.NewGuid():N}");
+    private readonly string _root = Path.Join(Path.GetTempPath(), $"meta-walk-{Guid.NewGuid():N}");
 
     public MetadataTreeWalkerTests() => Directory.CreateDirectory(_root);
 
@@ -16,17 +16,17 @@ public class MetadataTreeWalkerTests : IDisposable
     [Fact]
     public void EnumerateMetaFiles_SkipsIdsAndCorruptedMetadataDirs()
     {
-        var keep = Path.Combine(_root, "tv", "Show.mkv.meta");
+        var keep = Path.Join(_root, "tv", "Show.mkv.meta");
         Directory.CreateDirectory(Path.GetDirectoryName(keep)!);
         File.WriteAllText(keep, "ok");
 
-        var ids = Path.Combine(_root, ".ids", "a", "b", "c", "d", "e");
+        var ids = Path.Join(_root, ".ids", "a", "b", "c", "d", "e");
         Directory.CreateDirectory(ids);
-        File.WriteAllText(Path.Combine(ids, $"{Guid.NewGuid()}.meta"), "id");
+        File.WriteAllText(Path.Join(ids, $"{Guid.NewGuid()}.meta"), "id");
 
-        var corrupted = Path.Combine(_root, "corrupted_metadata", "tv");
+        var corrupted = Path.Join(_root, "corrupted_metadata", "tv");
         Directory.CreateDirectory(corrupted);
-        File.WriteAllText(Path.Combine(corrupted, "bad.mkv.meta"), "bad");
+        File.WriteAllText(Path.Join(corrupted, "bad.mkv.meta"), "bad");
 
         var found = MetadataTreeWalker.EnumerateMetaFiles(_root).ToList();
         Assert.Single(found);
@@ -39,9 +39,9 @@ public class MetadataTreeWalkerTests : IDisposable
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
             return;
 
-        var real = Path.Combine(_root, "real.mkv.meta");
+        var real = Path.Join(_root, "real.mkv.meta");
         File.WriteAllText(real, "ok");
-        var link = Path.Combine(_root, "link.mkv.meta");
+        var link = Path.Join(_root, "link.mkv.meta");
         File.CreateSymbolicLink(link, real);
 
         var found = MetadataTreeWalker.EnumerateMetaFiles(_root).ToList();
@@ -55,15 +55,15 @@ public class MetadataTreeWalkerTests : IDisposable
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
             return;
 
-        var outside = Path.Combine(Path.GetTempPath(), $"meta-walk-out-{Guid.NewGuid():N}");
+        var outside = Path.Join(Path.GetTempPath(), $"meta-walk-out-{Guid.NewGuid():N}");
         Directory.CreateDirectory(outside);
         try
         {
-            File.WriteAllText(Path.Combine(outside, "escaped.mkv.meta"), "x");
-            var linkDir = Path.Combine(_root, "linked");
+            File.WriteAllText(Path.Join(outside, "escaped.mkv.meta"), "x");
+            var linkDir = Path.Join(_root, "linked");
             Directory.CreateSymbolicLink(linkDir, outside);
 
-            File.WriteAllText(Path.Combine(_root, "local.mkv.meta"), "ok");
+            File.WriteAllText(Path.Join(_root, "local.mkv.meta"), "ok");
             var found = MetadataTreeWalker.EnumerateMetaFiles(_root).ToList();
             Assert.Single(found);
             Assert.EndsWith("local.mkv.meta", found[0]);
@@ -80,9 +80,9 @@ public class MetadataTreeWalkerTests : IDisposable
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
             return;
 
-        var locked = Path.Combine(_root, "locked");
+        var locked = Path.Join(_root, "locked");
         Directory.CreateDirectory(locked);
-        File.WriteAllText(Path.Combine(locked, "x.meta"), "x");
+        File.WriteAllText(Path.Join(locked, "x.meta"), "x");
         // Remove all permissions so GetFiles/GetDirectories fail.
         File.SetUnixFileMode(locked, (UnixFileMode)0);
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/MigrationSymlinkUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/MigrationSymlinkUtilTests.cs
@@ -8,7 +8,7 @@ public sealed class MigrationSymlinkUtilTests
     [Fact]
     public void LinuxFindStartInfo_PassesHostileRootAsOneOpaqueArgument()
     {
-        var hostileRoot = Path.Combine(
+        var hostileRoot = Path.Join(
             Path.GetTempPath(),
             "library-\"-'-$()-; touch injected-line1\nline2");
 
@@ -27,11 +27,11 @@ public sealed class MigrationSymlinkUtilTests
     {
         Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
 
-        var root = Path.Combine(
+        var root = Path.Join(
             Path.GetTempPath(),
             $"library-\"-'-$()-; touch injected-line1\nline2-{Guid.NewGuid():N}");
-        var strmPath = Path.Combine(root, "movie.strm");
-        var symlinkPath = Path.Combine(root, "episode-\nlink.mkv");
+        var strmPath = Path.Join(root, "movie.strm");
+        var symlinkPath = Path.Join(root, "episode-\nlink.mkv");
         const string targetUrl = "http://localhost:8080/content/movie.mkv?token=a&part=1";
         const string linkTarget = "missing-target.mkv";
 
@@ -61,7 +61,7 @@ public sealed class MigrationSymlinkUtilTests
     [Fact]
     public void Enumeration_MissingRootFailsWithoutReturningPartialResults()
     {
-        var missingRoot = Path.Combine(
+        var missingRoot = Path.Join(
             Path.GetTempPath(),
             $"missing-altmount-library-{Guid.NewGuid():N}");
 
@@ -83,7 +83,7 @@ public sealed class MigrationSymlinkUtilTests
     {
         Skip.IfNot(OperatingSystem.IsLinux(), "Linux filenames may contain arbitrary non-UTF-8 bytes.");
 
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-nonutf8-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-nonutf8-{Guid.NewGuid():N}");
         try
         {
             Directory.CreateDirectory(root);
@@ -107,13 +107,13 @@ public sealed class MigrationSymlinkUtilTests
     {
         Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
 
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-census-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-census-{Guid.NewGuid():N}");
         try
         {
             Directory.CreateDirectory(root);
-            File.WriteAllText(Path.Combine(root, "present.mkv"), "fixture");
-            File.CreateSymbolicLink(Path.Combine(root, "readable.mkv"), "present.mkv");
-            File.CreateSymbolicLink(Path.Combine(root, "dangling.mkv"), "missing.mkv");
+            File.WriteAllText(Path.Join(root, "present.mkv"), "fixture");
+            File.CreateSymbolicLink(Path.Join(root, "readable.mkv"), "present.mkv");
+            File.CreateSymbolicLink(Path.Join(root, "dangling.mkv"), "missing.mkv");
             CreateNonUtf8Symlink(root);
 
             var result = MigrationSymlinkUtil.GetAllSymlinks(root);

--- a/tests/NzbWebDAV.Tests/UsenetMigration/MigrationTestHarness.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/MigrationTestHarness.cs
@@ -32,8 +32,8 @@ internal sealed class MigrationTestHarness : IAsyncDisposable
 
     private MigrationTestHarness()
     {
-        _migPath = Path.Combine(Path.GetTempPath(), $"altmig-tests-{Guid.NewGuid():N}.db");
-        _davPath = Path.Combine(Path.GetTempPath(), $"altmig-dav-{Guid.NewGuid():N}.sqlite");
+        _migPath = Path.Join(Path.GetTempPath(), $"altmig-tests-{Guid.NewGuid():N}.db");
+        _davPath = Path.Join(Path.GetTempPath(), $"altmig-dav-{Guid.NewGuid():N}.sqlite");
 
         MigOptions = new DbContextOptionsBuilder<UsenetMigrationDbContext>()
             .UseSqlite($"Data Source={_migPath}")

--- a/tests/NzbWebDAV.Tests/UsenetMigration/Step6LifecycleTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/Step6LifecycleTests.cs
@@ -51,12 +51,12 @@ public sealed class Step6LifecycleTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var root = Directory.CreateTempSubdirectory("altmig-library-");
         var backups = Directory.CreateTempSubdirectory("altmig-backups-");
-        var link = Path.Combine(root.FullName, "movie.mkv");
+        var link = Path.Join(root.FullName, "movie.mkv");
         var original = "/mnt/altmount/movie.mkv";
         var replacement = "/mnt/nzbdav/.ids/x";
         var archiveName = "altmount-symlink-backup-20260721-120000.tar.gz";
         await SymlinkBackup.WriteAsync(
-            Path.Combine(backups.FullName, archiveName),
+            Path.Join(backups.FullName, archiveName),
             [new SymlinkBackup.Entry(link, original, replacement)]);
         await h.Store.UpdateSessionAsync(s =>
         {
@@ -352,11 +352,11 @@ public sealed class Step6LifecycleTests
                     await controller.PlanSymlinks(new SymlinkPlanRequest(configDir.FullName, backups.FullName)));
                 Assert.Contains("config directory", Assert.IsType<BaseApiResponse>(configRejected.Value).Error!);
 
-                var nestedBackup = Path.Combine(configDir.FullName, "nested-backup");
+                var nestedBackup = Path.Join(configDir.FullName, "nested-backup");
                 Directory.CreateDirectory(nestedBackup);
                 // Use a valid library that is not config, but put backup inside it.
                 var library = Directory.CreateTempSubdirectory("altmig-lib-");
-                var inside = Path.Combine(library.FullName, "backups");
+                var inside = Path.Join(library.FullName, "backups");
                 var insideRejected = Assert.IsType<BadRequestObjectResult>(
                     await controller.PlanSymlinks(new SymlinkPlanRequest(library.FullName, inside)));
                 Assert.Contains("inside libraryRoot", Assert.IsType<BaseApiResponse>(insideRejected.Value).Error!);
@@ -391,7 +391,7 @@ public sealed class Step6LifecycleTests
         {
             migration.SymlinkRewrites.Add(new MigrationSymlinkRewrite
             {
-                SymlinkPath = Path.Combine(library.FullName, "orphan.mkv"),
+                SymlinkPath = Path.Join(library.FullName, "orphan.mkv"),
                 OldTarget = "/mnt/altmount/orphan.mkv",
                 Status = "orphan",
                 UpdatedAt = DateTime.UtcNow,
@@ -442,7 +442,7 @@ public sealed class Step6LifecycleTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var library = Directory.CreateTempSubdirectory("altmig-library-");
         var backups = Directory.CreateTempSubdirectory("altmig-backups-");
-        var link = Path.Combine(library.FullName, "orphan.mkv");
+        var link = Path.Join(library.FullName, "orphan.mkv");
         const string target = "/mnt/altmount/orphan.mkv";
         await h.Store.UpdateSessionAsync(s =>
         {

--- a/tests/NzbWebDAV.Tests/UsenetMigration/StoreLocatorTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/StoreLocatorTests.cs
@@ -7,11 +7,11 @@ public class StoreLocatorTests
     [Fact]
     public void ResolveSourceNzb_FindsRecordedPath()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "nzbdav-storeloc-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-storeloc-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         try
         {
-            var nzb = Path.Combine(dir, "Show.nzb");
+            var nzb = Path.Join(dir, "Show.nzb");
             File.WriteAllText(nzb, "<nzb/>");
             Assert.Equal(nzb, StoreLocator.ResolveSourceNzb(nzb, storeRoot: null));
         }
@@ -24,11 +24,11 @@ public class StoreLocatorTests
     [Fact]
     public void ResolveSourceNzb_AppendsGzWhenPlainMissing()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "nzbdav-storeloc-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-storeloc-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         try
         {
-            var plain = Path.Combine(dir, "Show.nzb");
+            var plain = Path.Join(dir, "Show.nzb");
             var gz = plain + ".gz";
             File.WriteAllBytes(gz, [0x1f, 0x8b]);
             Assert.Equal(gz, StoreLocator.ResolveSourceNzb(plain, storeRoot: null));
@@ -42,12 +42,12 @@ public class StoreLocatorTests
     [Fact]
     public void ResolveSourceNzb_RemapsUnderStoreRootViaNzbsSuffix()
     {
-        var root = Path.Combine(Path.GetTempPath(), "nzbdav-storeloc-" + Guid.NewGuid().ToString("N"));
-        var nzbs = Path.Combine(root, ".nzbs", "tv");
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-storeloc-" + Guid.NewGuid().ToString("N"));
+        var nzbs = Path.Join(root, ".nzbs", "tv");
         Directory.CreateDirectory(nzbs);
         try
         {
-            var local = Path.Combine(nzbs, "Show.nzb.gz");
+            var local = Path.Join(nzbs, "Show.nzb.gz");
             File.WriteAllBytes(local, [0x1f, 0x8b]);
             var foreign = "/other/host/.nzbs/tv/Show.nzb";
             Assert.Equal(local, StoreLocator.ResolveSourceNzb(foreign, root));

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SubmissionWorkerPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SubmissionWorkerPoolTests.cs
@@ -323,9 +323,9 @@ public sealed class SubmissionWorkerPoolTests
     public async Task BuildNzb_V1Release_LoadsOriginalNzbGzFromDisk()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var root = Path.Combine(Path.GetTempPath(), "nzbdav-v1sub-" + Guid.NewGuid().ToString("N"));
-        var metaDir = Path.Combine(root, "meta", "tv");
-        var nzbsDir = Path.Combine(root, ".nzbs", "tv");
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-v1sub-" + Guid.NewGuid().ToString("N"));
+        var metaDir = Path.Join(root, "meta", "tv");
+        var nzbsDir = Path.Join(root, ".nzbs", "tv");
         Directory.CreateDirectory(metaDir);
         Directory.CreateDirectory(nzbsDir);
 
@@ -333,7 +333,7 @@ public sealed class SubmissionWorkerPoolTests
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<nzb xmlns=\"http://www.newzbin.com/DTD/2003/nzb\">\n" +
             "  <file poster=\"p\" date=\"1\" subject=\"s\">\n  </file>\n</nzb>\n";
-        var nzbPath = Path.Combine(nzbsDir, "Show.nzb.gz");
+        var nzbPath = Path.Join(nzbsDir, "Show.nzb.gz");
         await using (var fs = File.Create(nzbPath))
         await using (var gz = new System.IO.Compression.GZipStream(fs, System.IO.Compression.CompressionLevel.Optimal))
         {
@@ -341,7 +341,7 @@ public sealed class SubmissionWorkerPoolTests
             await gz.WriteAsync(bytes);
         }
 
-        var metaPath = Path.Combine(metaDir, "Show.meta");
+        var metaPath = Path.Join(metaDir, "Show.meta");
         var metaBytes = new TestProtoWriter()
             .Varint(1, 100)
             .String(2, "/foreign/.nzbs/tv/Show.nzb")

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkBackupAndCsvTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkBackupAndCsvTests.cs
@@ -84,7 +84,7 @@ public class SymlinkBackupAndCsvTests
     [Fact]
     public async Task WriteAsync_RoundTripsAndSurvivesReadBackVerification()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"altmig-bak-{Guid.NewGuid():N}.tar.gz");
+        var path = Path.Join(Path.GetTempPath(), $"altmig-bak-{Guid.NewGuid():N}.tar.gz");
         try
         {
             var entries = new[]
@@ -110,14 +110,14 @@ public class SymlinkBackupAndCsvTests
         Skip.If(OperatingSystem.IsLinux(), "Linux path uses find(1); this covers the managed walker.");
         Skip.If(OperatingSystem.IsWindows(), "Directory symlink recursion is validated on macOS.");
 
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-walk-{Guid.NewGuid():N}");
-        var nested = Path.Combine(root, "real");
-        var linked = Path.Combine(root, "linked-dir");
-        var outside = Path.Combine(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-walk-{Guid.NewGuid():N}");
+        var nested = Path.Join(root, "real");
+        var linked = Path.Join(root, "linked-dir");
+        var outside = Path.Join(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}");
         Directory.CreateDirectory(nested);
         Directory.CreateDirectory(outside);
-        File.CreateSymbolicLink(Path.Combine(nested, "file.link"), "/tmp/target");
-        File.CreateSymbolicLink(Path.Combine(outside, "hidden.link"), "/tmp/hidden");
+        File.CreateSymbolicLink(Path.Join(nested, "file.link"), "/tmp/target");
+        File.CreateSymbolicLink(Path.Join(outside, "hidden.link"), "/tmp/hidden");
         Directory.CreateSymbolicLink(linked, outside);
 
         try

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkOrphanRemoverTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkOrphanRemoverTests.cs
@@ -52,8 +52,8 @@ public sealed class SymlinkOrphanRemoverTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
         var backups = Directory.CreateTempSubdirectory("altmig-orphan-backups-");
-        var orphan = Path.Combine(library.FullName, "orphan.mkv");
-        var rewrite = Path.Combine(library.FullName, "rewrite.mkv");
+        var orphan = Path.Join(library.FullName, "orphan.mkv");
+        var rewrite = Path.Join(library.FullName, "rewrite.mkv");
         const string orphanTarget = "/mnt/altmount/orphan.mkv";
         const string rewriteTarget = "/mnt/altmount/rewrite.mkv";
         var ops = new FakeSymlinkOps
@@ -71,7 +71,7 @@ public sealed class SymlinkOrphanRemoverTests
             await SeedPlanAsync(h,
                 Row(orphan, orphanTarget, "orphan"),
                 Row(rewrite, rewriteTarget, "rewrite"),
-                Row(Path.Combine(library.FullName, "unreadable.mkv"), "", "unreadable"));
+                Row(Path.Join(library.FullName, "unreadable.mkv"), "", "unreadable"));
 
             var remover = new SymlinkOrphanRemover(h.Store)
             {
@@ -86,7 +86,7 @@ public sealed class SymlinkOrphanRemoverTests
             Assert.DoesNotContain(orphan, ops.Links.Keys);
             Assert.Equal(rewriteTarget, ops.Links[rewrite]);
             Assert.Equal(
-                Path.Combine(backups.FullName, "altmount-orphan-symlink-backup-20260802-123456.tar.gz"),
+                Path.Join(backups.FullName, "altmount-orphan-symlink-backup-20260802-123456.tar.gz"),
                 result.BackupPath);
 
             var entries = await SymlinkBackup.ReadAsync(result.BackupPath!);
@@ -112,7 +112,7 @@ public sealed class SymlinkOrphanRemoverTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
         var backupPathThatIsAFile = Path.GetTempFileName();
-        var orphan = Path.Combine(library.FullName, "orphan.mkv");
+        var orphan = Path.Join(library.FullName, "orphan.mkv");
         const string target = "/mnt/altmount/orphan.mkv";
         var ops = new FakeSymlinkOps { Links = { [orphan] = target } };
 
@@ -142,7 +142,7 @@ public sealed class SymlinkOrphanRemoverTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
         var backups = Directory.CreateTempSubdirectory("altmig-orphan-backups-");
-        var orphan = Path.Combine(library.FullName, "orphan.mkv");
+        var orphan = Path.Join(library.FullName, "orphan.mkv");
         const string planned = "/mnt/altmount/original.mkv";
         const string current = "/mnt/elsewhere/replaced.mkv";
         var ops = new FakeSymlinkOps { Links = { [orphan] = current } };
@@ -176,8 +176,8 @@ public sealed class SymlinkOrphanRemoverTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var library = Directory.CreateTempSubdirectory("altmig-orphan-library-");
         var backups = Directory.CreateTempSubdirectory("altmig-orphan-backups-");
-        var first = Path.Combine(library.FullName, "a.mkv");
-        var second = Path.Combine(library.FullName, "b.mkv");
+        var first = Path.Join(library.FullName, "a.mkv");
+        var second = Path.Join(library.FullName, "b.mkv");
         using var cancel = new CancellationTokenSource();
         var ops = new FakeSymlinkOps
         {
@@ -209,7 +209,7 @@ public sealed class SymlinkOrphanRemoverTests
             Assert.Equal(1, ops.DeleteCalls);
             Assert.False(ops.Links.ContainsKey(first));
             Assert.True(ops.Links.ContainsKey(second));
-            var archive = Path.Combine(
+            var archive = Path.Join(
                 backups.FullName, "altmount-orphan-symlink-backup-20260802-130000.tar.gz");
             Assert.Equal(2, (await SymlinkBackup.ReadAsync(archive)).Count);
 
@@ -229,8 +229,8 @@ public sealed class SymlinkOrphanRemoverTests
     {
         Skip.If(OperatingSystem.IsWindows(), "Creating symlinks may require Windows developer mode.");
         var root = Directory.CreateTempSubdirectory("altmig-real-delete-");
-        var target = Path.Combine(root.FullName, "target.mkv");
-        var link = Path.Combine(root.FullName, "link.mkv");
+        var target = Path.Join(root.FullName, "target.mkv");
+        var link = Path.Join(root.FullName, "link.mkv");
         File.WriteAllText(target, "precious content");
         File.CreateSymbolicLink(link, target);
 
@@ -251,7 +251,7 @@ public sealed class SymlinkOrphanRemoverTests
     public void RealOps_DeleteRefusesRealFile()
     {
         var root = Directory.CreateTempSubdirectory("altmig-real-delete-");
-        var path = Path.Combine(root.FullName, "real.mkv");
+        var path = Path.Join(root.FullName, "real.mkv");
         File.WriteAllText(path, "precious content");
 
         try
@@ -272,7 +272,7 @@ public sealed class SymlinkOrphanRemoverTests
     {
         Skip.If(OperatingSystem.IsWindows(), "Creating symlinks may require Windows developer mode.");
         var root = Directory.CreateTempSubdirectory("altmig-delete-race-");
-        var link = Path.Combine(root.FullName, "movie.mkv");
+        var link = Path.Join(root.FullName, "movie.mkv");
         const string target = "/mnt/altmount/movie.mkv";
         File.CreateSymbolicLink(link, target);
 
@@ -303,7 +303,7 @@ public sealed class SymlinkOrphanRemoverTests
     public void RealOps_DeleteRejectsPathOutsideLibraryRoot()
     {
         var root = Directory.CreateTempSubdirectory("altmig-delete-root-");
-        var outside = Path.Combine(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}.mkv");
+        var outside = Path.Join(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}.mkv");
         try
         {
             var error = Assert.Throws<IOException>(() =>

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkPlannerTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkPlannerTests.cs
@@ -312,8 +312,8 @@ public class SymlinkPlannerTests
         Skip.IfNot(OperatingSystem.IsLinux(), "Directory symlink behavior is validated on the Linux deployment platform.");
 
         await using var h = await MigrationTestHarness.CreateAsync();
-        var realRoot = Path.Combine(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
-        var linkedRoot = Path.Combine(Path.GetTempPath(), $"altmig-library-link-{Guid.NewGuid():N}");
+        var realRoot = Path.Join(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
+        var linkedRoot = Path.Join(Path.GetTempPath(), $"altmig-library-link-{Guid.NewGuid():N}");
         Directory.CreateDirectory(realRoot);
         Directory.CreateSymbolicLink(linkedRoot, realRoot);
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRestoreServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRestoreServiceTests.cs
@@ -40,12 +40,12 @@ public class SymlinkRestoreServiceTests
     public async Task Restore_LeavesDriftedAndOutOfRootLinksUntouched()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
-        var inRoot = Path.Combine(root, "movie.mkv");
-        var outsideRoot = Path.Combine(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.mkv");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
+        var inRoot = Path.Join(root, "movie.mkv");
+        var outsideRoot = Path.Join(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.mkv");
         var archiveName = "altmount-symlink-backup-20260720-120000.tar.gz";
-        var archivePath = Path.Combine(backupDir, archiveName);
+        var archivePath = Path.Join(backupDir, archiveName);
         await h.Store.UpdateSessionAsync(s =>
         {
             s.Status = "linked";
@@ -82,9 +82,9 @@ public class SymlinkRestoreServiceTests
     public async Task Restore_LegacyArchiveUsesCurrentPlanForDriftGuard()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
-        var link = Path.Combine(root, "episode.mkv");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
+        var link = Path.Join(root, "episode.mkv");
         var archiveName = "altmount-symlink-backup-20260720-120001.tar.gz";
         await h.Store.UpdateSessionAsync(s =>
         {
@@ -105,7 +105,7 @@ public class SymlinkRestoreServiceTests
             await ctx.SaveChangesAsync();
         }
         await SymlinkBackup.WriteAsync(
-            Path.Combine(backupDir, archiveName),
+            Path.Join(backupDir, archiveName),
             [new SymlinkBackup.Entry(link, "/alt/original.mkv")]);
         var ops = new FakeSymlinkOps { Links = { [link] = "/nzbdav/replacement.mkv" } };
 
@@ -124,9 +124,9 @@ public class SymlinkRestoreServiceTests
     public async Task Restore_CurrentArchiveRecreatesMissingRewritePlanRow()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
-        var link = Path.Combine(root, "movie.mkv");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
+        var link = Path.Join(root, "movie.mkv");
         var archiveName = "altmount-symlink-backup-20260720-120002.tar.gz";
         await h.Store.UpdateSessionAsync(s =>
         {
@@ -135,7 +135,7 @@ public class SymlinkRestoreServiceTests
             s.SymlinkBackupDir = backupDir;
         });
         await SymlinkBackup.WriteAsync(
-            Path.Combine(backupDir, archiveName),
+            Path.Join(backupDir, archiveName),
             [new SymlinkBackup.Entry(link, "/alt/original.mkv", "/nzbdav/replacement.mkv")]);
         var ops = new FakeSymlinkOps { Links = { [link] = "/nzbdav/replacement.mkv" } };
 
@@ -157,10 +157,10 @@ public class SymlinkRestoreServiceTests
     public async Task Restore_RecreatesEntirelyMissingSymlink()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
-        var link = Path.Combine(root, "movie.mkv");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
+        var link = Path.Join(root, "movie.mkv");
         var archiveName = "altmount-symlink-backup-20260720-120003.tar.gz";
         await h.Store.UpdateSessionAsync(s =>
         {
@@ -169,7 +169,7 @@ public class SymlinkRestoreServiceTests
             s.SymlinkBackupDir = backupDir;
         });
         await SymlinkBackup.WriteAsync(
-            Path.Combine(backupDir, archiveName),
+            Path.Join(backupDir, archiveName),
             [new SymlinkBackup.Entry(link, "/alt/original.mkv", "/nzbdav/replacement.mkv")]);
         var ops = new FakeSymlinkOps(); // link absent
 
@@ -186,10 +186,10 @@ public class SymlinkRestoreServiceTests
     public async Task Restore_RefusesRealFileAtPath()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-library-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
-        var link = Path.Combine(root, "movie.mkv");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-backups-{Guid.NewGuid():N}");
+        var link = Path.Join(root, "movie.mkv");
         File.WriteAllText(link, "precious");
         var archiveName = "altmount-symlink-backup-20260720-120004.tar.gz";
         await h.Store.UpdateSessionAsync(s =>
@@ -199,7 +199,7 @@ public class SymlinkRestoreServiceTests
             s.SymlinkBackupDir = backupDir;
         });
         await SymlinkBackup.WriteAsync(
-            Path.Combine(backupDir, archiveName),
+            Path.Join(backupDir, archiveName),
             [new SymlinkBackup.Entry(link, "/alt/original.mkv", "/nzbdav/replacement.mkv")]);
         var ops = new FakeSymlinkOps();
 
@@ -221,7 +221,7 @@ public class SymlinkRestoreServiceTests
         await using var h = await MigrationTestHarness.CreateAsync();
         var root = Directory.CreateTempSubdirectory("altmig-library-");
         var backupDir = Directory.CreateTempSubdirectory("altmig-backups-");
-        var link = Path.Combine(root.FullName, "orphan.mkv");
+        var link = Path.Join(root.FullName, "orphan.mkv");
         const string target = "/mnt/altmount/orphan.mkv";
         var archiveName = "altmount-orphan-symlink-backup-20260720-120005.tar.gz";
         try
@@ -244,7 +244,7 @@ public class SymlinkRestoreServiceTests
                 await migration.SaveChangesAsync();
             }
             await SymlinkBackup.WriteAsync(
-                Path.Combine(backupDir.FullName, archiveName),
+                Path.Join(backupDir.FullName, archiveName),
                 [new SymlinkBackup.Entry(
                     link,
                     target,
@@ -279,10 +279,10 @@ public class SymlinkRestoreServiceTests
         {
             await h.Store.UpdateSessionAsync(s => s.SymlinkBackupDir = backupDir.FullName);
             await SymlinkBackup.WriteAsync(
-                Path.Combine(backupDir.FullName, "altmount-symlink-backup-20260720-120006.tar.gz"),
+                Path.Join(backupDir.FullName, "altmount-symlink-backup-20260720-120006.tar.gz"),
                 [new SymlinkBackup.Entry("/lib/rewrite.mkv", "/alt/rewrite.mkv", "/nzbdav/rewrite.mkv")]);
             await SymlinkBackup.WriteAsync(
-                Path.Combine(backupDir.FullName, "altmount-orphan-symlink-backup-20260720-120007.tar.gz"),
+                Path.Join(backupDir.FullName, "altmount-orphan-symlink-backup-20260720-120007.tar.gz"),
                 [new SymlinkBackup.Entry(
                     "/lib/orphan.mkv",
                     "/alt/orphan.mkv",
@@ -311,7 +311,7 @@ public class SymlinkRestoreServiceTests
         {
             await h.Store.UpdateSessionAsync(s => s.SymlinkBackupDir = backupDir.FullName);
             await SymlinkBackup.WriteAsync(
-                Path.Combine(backupDir.FullName, archiveName),
+                Path.Join(backupDir.FullName, archiveName),
                 [new SymlinkBackup.Entry(
                     "/lib/orphan.mkv",
                     "/alt/orphan.mkv",
@@ -333,7 +333,7 @@ public class SymlinkRestoreServiceTests
     {
         const string name = "altmount-orphan-symlink-backup-20260720-120008.tar.gz";
         Assert.Equal(
-            Path.GetFullPath(Path.Combine(Path.GetTempPath(), name)),
+            Path.GetFullPath(Path.Join(Path.GetTempPath(), name)),
             SymlinkRestoreService.ResolveArchivePath(Path.GetTempPath(), name));
     }
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRewriterTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SymlinkRewriterTests.cs
@@ -80,7 +80,7 @@ public class SymlinkRewriterTests
     public async Task Apply_RetargetsRewrites_LeavesOrphansAndOthersUntouched_AndBacksUpFirst()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-backup-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-backup-{Guid.NewGuid():N}");
         var (_, newTarget) = await SeedDavTargetAsync(h);
         await h.Store.UpdateSessionAsync(s =>
         {
@@ -150,7 +150,7 @@ public class SymlinkRewriterTests
         await h.Store.UpdateSessionAsync(s =>
         {
             s.SymlinkLibraryRoot = "/lib";
-            s.SymlinkBackupDir = Path.Combine(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
+            s.SymlinkBackupDir = Path.Join(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
         });
         await SeedPlanAsync(h, Row("rewrite", "/lib/a.mkv", "/mnt/altmount/tv/a.mkv", newTarget));
 
@@ -182,7 +182,7 @@ public class SymlinkRewriterTests
         await h.Store.UpdateSessionAsync(s =>
         {
             s.SymlinkLibraryRoot = "/lib";
-            s.SymlinkBackupDir = Path.Combine(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
+            s.SymlinkBackupDir = Path.Join(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
         });
         await SeedPlanAsync(h, Row("rewrite", "/lib/a.mkv", "/mnt/altmount/tv/a.mkv", newTarget));
 
@@ -204,7 +204,7 @@ public class SymlinkRewriterTests
     public async Task Apply_DriftGuard_UsesOperatingSystemCaseSemantics()
     {
         await using var h = await MigrationTestHarness.CreateAsync();
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
         var (_, newTarget) = await SeedDavTargetAsync(h);
         await h.Store.UpdateSessionAsync(s =>
         {
@@ -249,7 +249,7 @@ public class SymlinkRewriterTests
     {
         await using var h = await MigrationTestHarness.CreateAsync();
         var (id, newTarget) = await SeedDavTargetAsync(h);
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
         await h.Store.UpdateSessionAsync(s =>
         {
             s.SymlinkLibraryRoot = "/lib";
@@ -282,7 +282,7 @@ public class SymlinkRewriterTests
     {
         await using var h = await MigrationTestHarness.CreateAsync();
         var (_, newTarget) = await SeedDavTargetAsync(h, mountDir: "/mnt/nzbdav");
-        var backupDir = Path.Combine(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
+        var backupDir = Path.Join(Path.GetTempPath(), $"altmig-{Guid.NewGuid():N}");
         await h.Store.UpdateSessionAsync(s =>
         {
             s.SymlinkLibraryRoot = "/lib";
@@ -312,9 +312,9 @@ public class SymlinkRewriterTests
     {
         // The never-delete invariant, tested on the real filesystem without needing
         // symlink privileges: a real file at the path must not be replaced.
-        var dir = Path.Combine(Path.GetTempPath(), $"altmig-realops-{Guid.NewGuid():N}");
+        var dir = Path.Join(Path.GetTempPath(), $"altmig-realops-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dir);
-        var realFile = Path.Combine(dir, "real.mkv");
+        var realFile = Path.Join(dir, "real.mkv");
         File.WriteAllText(realFile, "precious content");
 
         try
@@ -335,9 +335,9 @@ public class SymlinkRewriterTests
     {
         Skip.IfNot(OperatingSystem.IsLinux(), "Symlink race behavior is validated on the Linux deployment platform.");
 
-        var dir = Path.Combine(Path.GetTempPath(), $"altmig-leaf-race-{Guid.NewGuid():N}");
+        var dir = Path.Join(Path.GetTempPath(), $"altmig-leaf-race-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dir);
-        var link = Path.Combine(dir, "movie.mkv");
+        var link = Path.Join(dir, "movie.mkv");
         File.CreateSymbolicLink(link, "/mnt/altmount/movie.mkv");
 
         try
@@ -366,11 +366,11 @@ public class SymlinkRewriterTests
     [Fact]
     public void RealOps_RejectsPathsOutsideLibraryRoot()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-root-{Guid.NewGuid():N}");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-root-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
         try
         {
-            var outside = Path.Combine(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.mkv");
+            var outside = Path.Join(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.mkv");
             var ex = Assert.Throws<IOException>(() => RealSymlinkOps.Instance.ReadLink(root, outside));
             Assert.Contains("outside the configured Library Root", ex.Message);
         }
@@ -385,18 +385,18 @@ public class SymlinkRewriterTests
     {
         Skip.IfNot(OperatingSystem.IsLinux(), "Directory symlink behavior is validated on the Linux deployment platform.");
 
-        var root = Path.Combine(Path.GetTempPath(), $"altmig-root-{Guid.NewGuid():N}");
-        var outside = Path.Combine(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}");
-        var escape = Path.Combine(root, "escape");
+        var root = Path.Join(Path.GetTempPath(), $"altmig-root-{Guid.NewGuid():N}");
+        var outside = Path.Join(Path.GetTempPath(), $"altmig-outside-{Guid.NewGuid():N}");
+        var escape = Path.Join(root, "escape");
         Directory.CreateDirectory(root);
         Directory.CreateDirectory(outside);
         Directory.CreateSymbolicLink(escape, outside);
-        var outsideFile = Path.Combine(outside, "movie.mkv");
+        var outsideFile = Path.Join(outside, "movie.mkv");
         File.WriteAllText(outsideFile, "precious content");
 
         try
         {
-            var escapedPath = Path.Combine(escape, "movie.mkv");
+            var escapedPath = Path.Join(escape, "movie.mkv");
             var ex = Assert.Throws<IOException>(() => RealSymlinkOps.Instance.ReplaceSymlink(
                 root,
                 escapedPath,
@@ -418,9 +418,9 @@ public class SymlinkRewriterTests
     {
         Skip.If(OperatingSystem.IsWindows(), "Symbolic link create/recreate is validated on Unix.");
 
-        var dir = Path.Combine(Path.GetTempPath(), $"altmig-recreate-{Guid.NewGuid():N}");
+        var dir = Path.Join(Path.GetTempPath(), $"altmig-recreate-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dir);
-        var link = Path.Combine(dir, "movie.mkv");
+        var link = Path.Join(dir, "movie.mkv");
         const string oldTarget = "/mnt/altmount/movie.mkv";
         File.CreateSymbolicLink(link, oldTarget);
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationControllerAuthTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationControllerAuthTests.cs
@@ -81,8 +81,8 @@ public sealed class UsenetMigrationControllerAuthTests
         var root = Directory.CreateTempSubdirectory("altmig-connect-");
         try
         {
-            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
-            var configPath = Path.Combine(root.FullName, "config.yaml");
+            var metadataRoot = Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
+            var configPath = Path.Join(root.FullName, "config.yaml");
             await File.WriteAllTextAsync(configPath, string.Join('\n',
             [
                 "sabnzbd:",
@@ -121,8 +121,8 @@ public sealed class UsenetMigrationControllerAuthTests
         var root = Directory.CreateTempSubdirectory("altmig-connect-");
         try
         {
-            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
-            var configPath = Path.Combine(root.FullName, "config.yaml");
+            var metadataRoot = Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
+            var configPath = Path.Join(root.FullName, "config.yaml");
             await File.WriteAllTextAsync(configPath, "sabnzbd:\n  categories:\n");
 
             await WithAuthorizedControllerAsync(h, async controller =>
@@ -152,8 +152,8 @@ public sealed class UsenetMigrationControllerAuthTests
         var root = Directory.CreateTempSubdirectory("altmig-connect-");
         try
         {
-            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
-            var configPath = Path.Combine(root.FullName, "config.yaml");
+            var metadataRoot = Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
+            var configPath = Path.Join(root.FullName, "config.yaml");
             await File.WriteAllTextAsync(
                 configPath,
                 "sabnzbd:\n  categories: [{ name: 'movies' }]\n");
@@ -182,7 +182,7 @@ public sealed class UsenetMigrationControllerAuthTests
         var root = Directory.CreateTempSubdirectory("altmig-connect-");
         try
         {
-            var metadataRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "metadata"));
+            var metadataRoot = Directory.CreateDirectory(Path.Join(root.FullName, "metadata"));
 
             await WithAuthorizedControllerAsync(h, async controller =>
             {
@@ -276,7 +276,7 @@ public sealed class UsenetMigrationControllerAuthTests
     [Fact]
     public void EveryHttpAction_DelegatesThroughGuardedAsync()
     {
-        var source = File.ReadAllText(Path.Combine(
+        var source = File.ReadAllText(Path.Join(
             FindRepoRoot(),
             "backend",
             "Api",
@@ -319,7 +319,7 @@ public sealed class UsenetMigrationControllerAuthTests
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null)
         {
-            if (File.Exists(Path.Combine(dir.FullName, "backend", "NzbWebDAV.csproj")))
+            if (File.Exists(Path.Join(dir.FullName, "backend", "NzbWebDAV.csproj")))
                 return dir.FullName;
             dir = dir.Parent;
         }

--- a/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationStoreTests.cs
@@ -25,7 +25,7 @@ public class UsenetMigrationStoreTests
     [Fact]
     public async Task ConcurrentFirstRequests_CreateDatabaseAndOneSingletonSession()
     {
-        var databasePath = Path.Combine(Path.GetTempPath(), $"altmig-first-use-{Guid.NewGuid():N}.db");
+        var databasePath = Path.Join(Path.GetTempPath(), $"altmig-first-use-{Guid.NewGuid():N}.db");
         var options = new DbContextOptionsBuilder<UsenetMigrationDbContext>()
             .UseSqlite($"Data Source={databasePath}")
             .Options;
@@ -63,7 +63,7 @@ public class UsenetMigrationStoreTests
     [Fact]
     public async Task EnsureDatabase_RecreatesIncompatiblePreSquashLedger()
     {
-        var databasePath = Path.Combine(Path.GetTempPath(), $"altmig-stale-{Guid.NewGuid():N}.db");
+        var databasePath = Path.Join(Path.GetTempPath(), $"altmig-stale-{Guid.NewGuid():N}.db");
         await CreatePreSquashStaleLedgerAsync(databasePath);
 
         var options = new DbContextOptionsBuilder<UsenetMigrationDbContext>()

--- a/tests/NzbWebDAV.Tests/Utils/SymlinkAndStrmUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/SymlinkAndStrmUtilTests.cs
@@ -9,7 +9,7 @@ public sealed class SymlinkAndStrmUtilTests
     [Fact]
     public void LinuxFindStartInfo_PassesHostileRootAsOneOpaqueArgument()
     {
-        var hostileRoot = Path.Combine(
+        var hostileRoot = Path.Join(
             Path.GetTempPath(),
             "-library-\"-'-$()-; touch injected-line1\nline2-ユニコード");
 
@@ -44,23 +44,23 @@ public sealed class SymlinkAndStrmUtilTests
         var root = CreateTempDirectory();
         try
         {
-            var multiLine = Path.Combine(root, "multi.strm");
+            var multiLine = Path.Join(root, "multi.strm");
             File.WriteAllText(multiLine, "\n\r\nhttp://localhost/view/.ids/a.mkv?extension=mkv\nsecond-line\n");
 
-            var withBom = Path.Combine(root, "bom.strm");
+            var withBom = Path.Join(root, "bom.strm");
             File.WriteAllBytes(
                 withBom,
                 new byte[] { 0xEF, 0xBB, 0xBF }
                     .Concat(Encoding.UTF8.GetBytes("http://localhost/view/.ids/b.mkv\r\n"))
                     .ToArray());
 
-            var empty = Path.Combine(root, "empty.strm");
+            var empty = Path.Join(root, "empty.strm");
             File.WriteAllText(empty, "");
 
-            var oversized = Path.Combine(root, "oversized.strm");
+            var oversized = Path.Join(root, "oversized.strm");
             File.WriteAllText(oversized, new string('a', SymlinkAndStrmUtil.MaxStrmTargetBytes + 1));
 
-            var hugeLaterLine = Path.Combine(root, "huge-later.strm");
+            var hugeLaterLine = Path.Join(root, "huge-later.strm");
             File.WriteAllText(
                 hugeLaterLine,
                 "http://localhost/view/.ids/c.mkv\n" + new string('b', SymlinkAndStrmUtil.MaxStrmTargetBytes * 4));
@@ -95,7 +95,7 @@ public sealed class SymlinkAndStrmUtilTests
     public void ReadLinuxFindEntry_FailsClosedWhenSymlinkTargetDisappears()
     {
         var root = CreateTempDirectory();
-        var path = Path.Combine(root, "victim.mkv");
+        var path = Path.Join(root, "victim.mkv");
         try
         {
             File.CreateSymbolicLink(path, "original-target.mkv");
@@ -117,13 +117,13 @@ public sealed class SymlinkAndStrmUtilTests
     {
         Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
 
-        var root = Path.Combine(
+        var root = Path.Join(
             Path.GetTempPath(),
             $"-library-\"-'-$()-; touch injected-line1\nline2-ユニコード-{Guid.NewGuid():N}");
         var newlineName = "file\nwith\nnewlines.mkv";
-        var symlinkPath = Path.Combine(root, newlineName);
-        var strmPath = Path.Combine(root, "movie.strm");
-        var trailingSymlinkPath = Path.Combine(root, "trailing.mkv");
+        var symlinkPath = Path.Join(root, newlineName);
+        var strmPath = Path.Join(root, "movie.strm");
+        var trailingSymlinkPath = Path.Join(root, "trailing.mkv");
         const string targetUrl = "http://localhost:8080/view/.ids/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.mkv?extension=mkv";
         const string linkTarget = "missing-target\nwith\nnewlines.mkv";
         const string trailingTarget = "next-target.mkv";
@@ -164,10 +164,10 @@ public sealed class SymlinkAndStrmUtilTests
         Skip.IfNot(OperatingSystem.IsLinux(), "Linux find traversal is only used on Linux.");
 
         var parent = CreateTempDirectory();
-        var realRoot = Path.Combine(parent, "real-root");
-        var linkRoot = Path.Combine(parent, "link-root");
-        var nestedReal = Path.Combine(parent, "nested-real");
-        var nestedLink = Path.Combine(realRoot, "nested-link");
+        var realRoot = Path.Join(parent, "real-root");
+        var linkRoot = Path.Join(parent, "link-root");
+        var nestedReal = Path.Join(parent, "nested-real");
+        var nestedLink = Path.Join(realRoot, "nested-link");
 
         try
         {
@@ -176,8 +176,8 @@ public sealed class SymlinkAndStrmUtilTests
             File.CreateSymbolicLink(linkRoot, realRoot);
             Directory.CreateSymbolicLink(nestedLink, nestedReal);
 
-            File.WriteAllText(Path.Combine(realRoot, "root.strm"), "http://localhost/view/.ids/root.mkv");
-            File.WriteAllText(Path.Combine(nestedReal, "nested.strm"), "http://localhost/view/.ids/nested.mkv");
+            File.WriteAllText(Path.Join(realRoot, "root.strm"), "http://localhost/view/.ids/root.mkv");
+            File.WriteAllText(Path.Join(nestedReal, "nested.strm"), "http://localhost/view/.ids/nested.mkv");
 
             var results = SymlinkAndStrmUtil.GetAllSymlinksAndStrms(linkRoot).ToList();
             var strmPaths = results.OfType<SymlinkAndStrmUtil.StrmInfo>()
@@ -186,18 +186,18 @@ public sealed class SymlinkAndStrmUtilTests
 
             // find -H may report the strm under the symlink root path or the real path.
             Assert.True(
-                strmPaths.Contains(Path.Combine(realRoot, "root.strm")) ||
-                strmPaths.Contains(Path.Combine(linkRoot, "root.strm")),
+                strmPaths.Contains(Path.Join(realRoot, "root.strm")) ||
+                strmPaths.Contains(Path.Join(linkRoot, "root.strm")),
                 $"Expected root.strm under the followed symlink root. Found: {string.Join(", ", strmPaths)}");
-            Assert.DoesNotContain(Path.Combine(nestedReal, "nested.strm"), strmPaths);
-            Assert.DoesNotContain(Path.Combine(nestedLink, "nested.strm"), strmPaths);
+            Assert.DoesNotContain(Path.Join(nestedReal, "nested.strm"), strmPaths);
+            Assert.DoesNotContain(Path.Join(nestedLink, "nested.strm"), strmPaths);
 
             // The nested directory symlink itself is still a -type l match.
             Assert.Contains(
                 results.OfType<SymlinkAndStrmUtil.SymlinkInfo>(),
                 x =>
                     (x.SymlinkPath == nestedLink ||
-                     x.SymlinkPath == Path.Combine(linkRoot, "nested-link")) &&
+                     x.SymlinkPath == Path.Join(linkRoot, "nested-link")) &&
                     (x.TargetPath == nestedReal ||
                      Path.GetFullPath(x.TargetPath, Path.GetDirectoryName(x.SymlinkPath)!) == nestedReal));
         }
@@ -217,14 +217,14 @@ public sealed class SymlinkAndStrmUtilTests
         var deniedDirs = new List<string>();
         try
         {
-            File.WriteAllText(Path.Combine(root, "ok.strm"), "http://localhost/view/.ids/ok.mkv");
+            File.WriteAllText(Path.Join(root, "ok.strm"), "http://localhost/view/.ids/ok.mkv");
 
             // Enough denied subtrees to exceed MaxStderrChars when find reports each one.
             for (var i = 0; i < 80; i++)
             {
-                var denied = Path.Combine(root, $"denied-{i:D3}");
+                var denied = Path.Join(root, $"denied-{i:D3}");
                 Directory.CreateDirectory(denied);
-                File.WriteAllText(Path.Combine(denied, $"hidden-{i}.strm"), "http://localhost/view/.ids/hidden.mkv");
+                File.WriteAllText(Path.Join(denied, $"hidden-{i}.strm"), "http://localhost/view/.ids/hidden.mkv");
                 chmod(denied, 0);
                 deniedDirs.Add(denied);
             }
@@ -256,7 +256,7 @@ public sealed class SymlinkAndStrmUtilTests
 
     private static string CreateTempDirectory()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"nzbdav-symlink-tests-{Guid.NewGuid():N}");
+        var path = Path.Join(Path.GetTempPath(), $"nzbdav-symlink-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
     }

--- a/tests/SharpCompress.Tests/ADCTest.cs
+++ b/tests/SharpCompress.Tests/ADCTest.cs
@@ -39,11 +39,11 @@ public class AdcTest : TestBase
     [Fact]
     public void TestBuffer()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
         var decompressed = new byte[decFs.Length];
         decFs.Read(decompressed, 0, decompressed.Length);
 
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
         var compressed = new byte[cmpFs.Length];
         cmpFs.Read(compressed, 0, compressed.Length);
 
@@ -55,11 +55,11 @@ public class AdcTest : TestBase
     [Fact]
     public void TestBaseStream()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
         var decompressed = new byte[decFs.Length];
         decFs.Read(decompressed, 0, decompressed.Length);
 
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
 
         ADCBase.Decompress(cmpFs, out var test);
 
@@ -69,11 +69,11 @@ public class AdcTest : TestBase
     [Fact]
     public void TestAdcStreamWholeChunk()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
         var decompressed = new byte[decFs.Length];
         decFs.Read(decompressed, 0, decompressed.Length);
 
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
         using var decStream = new ADCStream(cmpFs);
         var test = new byte[262144];
 
@@ -85,11 +85,11 @@ public class AdcTest : TestBase
     [Fact]
     public void TestAdcStream()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
         var decompressed = new byte[decFs.Length];
         decFs.Read(decompressed, 0, decompressed.Length);
 
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
         using var decStream = new ADCStream(cmpFs);
         using var decMs = new MemoryStream();
         var test = new byte[512];
@@ -107,7 +107,7 @@ public class AdcTest : TestBase
     [Fact]
     public void TestCrc32Stream()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var crc32 = new CRC32().GetCrc32(decFs);
         decFs.Seek(0, SeekOrigin.Begin);
 
@@ -128,7 +128,7 @@ public class AdcTest : TestBase
     [Fact]
     public async Task TestCrc32StreamWriteAsync()
     {
-        var buffer = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var buffer = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var crc32 = Crc32Stream.Compute(buffer);
 
         using var memory = new MemoryStream();
@@ -143,7 +143,7 @@ public class AdcTest : TestBase
     [Fact]
     public async Task TestCrc32StreamWriteMemoryAsync()
     {
-        var buffer = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var buffer = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var crc32 = Crc32Stream.Compute(buffer);
 
         using var memory = new MemoryStream();

--- a/tests/SharpCompress.Tests/Ace/AceReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Ace/AceReaderAsyncTests.cs
@@ -69,7 +69,7 @@ public class AceReaderAsyncTests : ReaderTests
 
     private async Task ReadAsync(string testArchive, CompressionType expectedCompression)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
@@ -91,7 +91,7 @@ public class AceReaderAsyncTests : ReaderTests
         CompressionType expectedCompression
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
@@ -109,8 +109,8 @@ public class AceReaderAsyncTests : ReaderTests
             }
         }
         CompareFilesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "alice29.txt"),
-            Path.Combine(MISC_TEST_FILES_PATH, "alice29.txt")
+            Path.Join(SCRATCH_FILES_PATH, "alice29.txt"),
+            Path.Join(MISC_TEST_FILES_PATH, "alice29.txt")
         );
     }
 
@@ -120,7 +120,7 @@ public class AceReaderAsyncTests : ReaderTests
     )
     {
         await using var reader = readerFactory(
-            archives.Select(s => Path.Combine(TEST_ARCHIVES_PATH, s)).Select(File.OpenRead)
+            archives.Select(s => Path.Join(TEST_ARCHIVES_PATH, s)).Select(File.OpenRead)
         );
 
         while (await reader.MoveToNextEntryAsync())

--- a/tests/SharpCompress.Tests/AdcAsyncTest.cs
+++ b/tests/SharpCompress.Tests/AdcAsyncTest.cs
@@ -10,11 +10,11 @@ public class AdcAsyncTest : TestBase
     [Fact]
     public async ValueTask TestAdcStreamAsyncWholeChunk()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
         var decompressed = new byte[decFs.Length];
         decFs.Read(decompressed, 0, decompressed.Length);
 
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
         using var decStream = new ADCStream(cmpFs);
         var test = new byte[262144];
 
@@ -26,11 +26,11 @@ public class AdcAsyncTest : TestBase
     [Fact]
     public async ValueTask TestAdcStreamAsync()
     {
-        using var decFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
+        using var decFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_decompressed.bin"));
         var decompressed = new byte[decFs.Length];
         decFs.Read(decompressed, 0, decompressed.Length);
 
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
         using var decStream = new ADCStream(cmpFs);
         using var decMs = new MemoryStream();
         var test = new byte[512];
@@ -48,7 +48,7 @@ public class AdcAsyncTest : TestBase
     [Fact]
     public async ValueTask TestAdcStreamAsyncWithCancellation()
     {
-        using var cmpFs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
+        using var cmpFs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "adc_compressed.bin"));
         using var decStream = new ADCStream(cmpFs);
         var test = new byte[512];
         using var cts = new System.Threading.CancellationTokenSource();

--- a/tests/SharpCompress.Tests/ArchiveFactoryTests.cs
+++ b/tests/SharpCompress.Tests/ArchiveFactoryTests.cs
@@ -24,7 +24,7 @@ public class ArchiveFactoryTests : TestBase
     )
     {
         var factory = await ArchiveFactory.FindFactoryAsync<IArchiveFactory>(
-            Path.Combine(TEST_ARCHIVES_PATH, archiveName)
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
         );
 
         Assert.IsType(expectedFactoryType, factory);
@@ -41,7 +41,7 @@ public class ArchiveFactoryTests : TestBase
     )
     {
         var factory = await ArchiveFactory.FindFactoryAsync<IArchiveFactory>(
-            new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, archiveName))
+            new FileInfo(Path.Join(TEST_ARCHIVES_PATH, archiveName))
         );
 
         Assert.IsType(expectedFactoryType, factory);
@@ -134,7 +134,7 @@ public class ArchiveFactoryTests : TestBase
     public void IsArchive_String_ReturnsExpectedType(string archiveName, ArchiveType expectedType)
     {
         var result = ArchiveFactory.IsArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, archiveName),
+            Path.Join(TEST_ARCHIVES_PATH, archiveName),
             out var type
         );
 
@@ -203,7 +203,7 @@ public class ArchiveFactoryTests : TestBase
     )
     {
         var result = await ArchiveFactory.IsArchiveAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, archiveName)
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
         );
 
         Assert.True(result.IsArchive);
@@ -254,7 +254,7 @@ public class ArchiveFactoryTests : TestBase
     )
     {
         var info = ArchiveFactory.GetArchiveInformation(
-            Path.Combine(TEST_ARCHIVES_PATH, archiveName)
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
         );
 
         Assert.NotNull(info);
@@ -295,7 +295,7 @@ public class ArchiveFactoryTests : TestBase
     )
     {
         var info = await ArchiveFactory.GetArchiveInformationAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, archiveName)
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
         );
 
         Assert.NotNull(info);
@@ -774,12 +774,12 @@ public class ArchiveFactoryTests : TestBase
 
     private static string GetTestArchivePath(string archiveName)
     {
-        var archivesPath = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var archivesPath = Path.Join(TEST_ARCHIVES_PATH, archiveName);
         if (File.Exists(archivesPath))
         {
             return archivesPath;
         }
 
-        return Path.GetFullPath(Path.Combine(TEST_ARCHIVES_PATH, "..", archiveName));
+        return Path.GetFullPath(Path.Join(TEST_ARCHIVES_PATH, "..", archiveName));
     }
 }

--- a/tests/SharpCompress.Tests/ArchiveTests.cs
+++ b/tests/SharpCompress.Tests/ArchiveTests.cs
@@ -21,7 +21,7 @@ public class ArchiveTests : ReaderTests
 {
     protected void ArchiveGetParts(IEnumerable<string> testArchives)
     {
-        var arcs = testArchives.Select(a => Path.Combine(TEST_ARCHIVES_PATH, a)).ToArray();
+        var arcs = testArchives.Select(a => Path.Join(TEST_ARCHIVES_PATH, a)).ToArray();
         var found = ArchiveFactory.GetFileParts(arcs[0]).ToArray();
         Assert.Equal(arcs.Length, found.Length);
         for (var i = 0; i < arcs.Length; i++)
@@ -32,7 +32,7 @@ public class ArchiveTests : ReaderTests
 
     protected void ArchiveStreamReadExtractAll(string testArchive, CompressionType compression)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         ArchiveStreamReadExtractAll(new[] { testArchive }, compression);
     }
 
@@ -77,10 +77,10 @@ public class ArchiveTests : ReaderTests
 
     protected void ArchiveStreamRead(string testArchive, ReaderOptions? readerOptions = null)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        var fullPath = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         ArchiveStreamRead(
-            ArchiveFactory.FindFactory<IArchiveFactory>(testArchive),
-            Path.GetExtension(testArchive),
+            ArchiveFactory.FindFactory<IArchiveFactory>(fullPath),
+            Path.GetExtension(fullPath),
             readerOptions,
             testArchive
         );
@@ -92,10 +92,10 @@ public class ArchiveTests : ReaderTests
         ReaderOptions? readerOptions = null
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        var fullPath = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         ArchiveStreamRead(
             archiveFactory,
-            Path.GetExtension(testArchive),
+            Path.GetExtension(fullPath),
             readerOptions,
             testArchive
         );
@@ -107,7 +107,7 @@ public class ArchiveTests : ReaderTests
         params string[] testArchives
     )
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchives[0]);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchives[0]);
         ArchiveStreamRead(
             ArchiveFactory.FindFactory<IArchiveFactory>(testArchive),
             extension,
@@ -125,7 +125,7 @@ public class ArchiveTests : ReaderTests
         ArchiveStreamRead(
             archiveFactory,
             readerOptions,
-            testArchives.Select(x => Path.Combine(TEST_ARCHIVES_PATH, x)),
+            testArchives.Select(x => Path.Join(TEST_ARCHIVES_PATH, x)),
             extension
         );
 
@@ -166,7 +166,7 @@ public class ArchiveTests : ReaderTests
     ) =>
         ArchiveStreamMultiRead(
             readerOptions,
-            testArchives.Select(x => Path.Combine(TEST_ARCHIVES_PATH, x))
+            testArchives.Select(x => Path.Join(TEST_ARCHIVES_PATH, x))
         );
 
     protected void ArchiveStreamMultiRead(
@@ -195,7 +195,7 @@ public class ArchiveTests : ReaderTests
     ) =>
         ArchiveOpenStreamRead(
             readerOptions,
-            testArchives.Select(x => Path.Combine(TEST_ARCHIVES_PATH, x))
+            testArchives.Select(x => Path.Join(TEST_ARCHIVES_PATH, x))
         );
 
     protected void ArchiveOpenStreamRead(
@@ -226,7 +226,7 @@ public class ArchiveTests : ReaderTests
         ArchiveOpenEntryVolumeIndexTest(
             results,
             readerOptions,
-            testArchives.Select(x => Path.Combine(TEST_ARCHIVES_PATH, x))
+            testArchives.Select(x => Path.Join(TEST_ARCHIVES_PATH, x))
         );
 
     private void ArchiveOpenEntryVolumeIndexTest(
@@ -263,7 +263,7 @@ public class ArchiveTests : ReaderTests
         ReaderOptions? readerOptions = null
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using (var archive = ArchiveFactory.OpenArchive(new FileInfo(testArchive), readerOptions))
         {
             archive.WriteToDirectory(SCRATCH_FILES_PATH);
@@ -277,7 +277,7 @@ public class ArchiveTests : ReaderTests
         IArchiveFactory? archiveFactory = null
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         archiveFactory ??= ArchiveFactory.FindFactory<IArchiveFactory>(testArchive);
         ExtensionTest(testArchive, archiveFactory);
         using (var archive = archiveFactory.OpenArchive(new FileInfo(testArchive), readerOptions))
@@ -310,7 +310,7 @@ public class ArchiveTests : ReaderTests
             fileOrder = fileOrder.Replace('\\', '/');
         }
         var expected = new Stack<string>(fileOrder.Split(' '));
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using var archive = ArchiveFactory.OpenArchive(testArchive, readerOptions);
         foreach (var entry in archive.Entries)
         {
@@ -323,7 +323,7 @@ public class ArchiveTests : ReaderTests
     /// </summary>
     protected void ArchiveFileReadEx(string testArchive)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using (var archive = ArchiveFactory.OpenArchive(testArchive))
         {
             foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
@@ -336,7 +336,7 @@ public class ArchiveTests : ReaderTests
 
     protected void ArchiveDeltaDistanceRead(string testArchive)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using var archive = ArchiveFactory.OpenArchive(testArchive);
         foreach (var entry in archive.Entries)
         {
@@ -594,7 +594,7 @@ public class ArchiveTests : ReaderTests
         ReaderOptions? readerOptions = null
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         await ArchiveStreamReadAsync(
             ArchiveFactory.FindFactory<IArchiveFactory>(testArchive),
             readerOptions,

--- a/tests/SharpCompress.Tests/Arj/ArjReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Arj/ArjReaderAsyncTests.cs
@@ -90,7 +90,7 @@ public class ArjReaderAsyncTests : ReaderTests
 
     private async Task ReadAsync(string testArchive, CompressionType? expectedCompression = null)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
@@ -115,7 +115,7 @@ public class ArjReaderAsyncTests : ReaderTests
         CompressionType expectedCompression
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
@@ -133,8 +133,8 @@ public class ArjReaderAsyncTests : ReaderTests
             }
         }
         CompareFilesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "alice29.txt"),
-            Path.Combine(MISC_TEST_FILES_PATH, "alice29.txt")
+            Path.Join(SCRATCH_FILES_PATH, "alice29.txt"),
+            Path.Join(MISC_TEST_FILES_PATH, "alice29.txt")
         );
     }
 
@@ -143,7 +143,7 @@ public class ArjReaderAsyncTests : ReaderTests
         Func<IEnumerable<Stream>, ValueTask<IAsyncReader>> openReader
     )
     {
-        var testArchives = archiveNames.Select(s => Path.Combine(TEST_ARCHIVES_PATH, s)).ToList();
+        var testArchives = archiveNames.Select(s => Path.Join(TEST_ARCHIVES_PATH, s)).ToList();
         var streams = testArchives.Select(File.OpenRead).ToList();
         try
         {

--- a/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
+++ b/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
@@ -23,7 +23,7 @@ public class AsyncParityAndCancellationTests : TestBase
     [InlineData("7Zip.nonsolid.7z")]
     public async Task ArchiveAsyncEntries_ShouldMatchSyncEntries(string archiveName)
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, archiveName);
 
         var syncEntries = ReadArchiveEntries(archivePath);
         var asyncEntries = await ReadArchiveEntriesAsync(archivePath);
@@ -38,7 +38,7 @@ public class AsyncParityAndCancellationTests : TestBase
     [InlineData("Rar.rar")]
     public async Task ReaderAsyncEntries_ShouldMatchSyncEntries(string archiveName)
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, archiveName);
 
         var syncEntries = ReadReaderEntries(archivePath);
         var asyncEntries = await ReadReaderEntriesAsync(archivePath);
@@ -49,7 +49,7 @@ public class AsyncParityAndCancellationTests : TestBase
     [Fact]
     public async Task AsyncReaderExtraction_ShouldRespectCancellationBeforeStart()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
         await using var stream = File.OpenRead(archivePath);
         await using var reader = await ReaderFactory.OpenAsyncReader(stream);
         using var cts = new CancellationTokenSource();
@@ -63,7 +63,7 @@ public class AsyncParityAndCancellationTests : TestBase
     [Fact]
     public async Task AsyncArchiveExtraction_ShouldRespectCancellationBeforeStart()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
         await using var archive = await ArchiveFactory.OpenAsyncArchive(archivePath);
         using var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -76,7 +76,7 @@ public class AsyncParityAndCancellationTests : TestBase
     [Fact]
     public async Task TarArchiveOpenAsyncArchive_ShouldRespectCancellationBeforeValidationAsync()
     {
-        await using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        await using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -125,7 +125,7 @@ public class AsyncParityAndCancellationTests : TestBase
     public async Task SevenZip_AsyncExtraction_ShouldRespectCancellationDuringRead()
     {
         var archiveBytes = await File.ReadAllBytesAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
         );
         using var cts = new CancellationTokenSource();
         await using var stream = new CancelAfterBytesReadStream(
@@ -148,7 +148,7 @@ public class AsyncParityAndCancellationTests : TestBase
     public async Task Zip_AsyncExtraction_ShouldRespectCancellationDuringRead()
     {
         var archiveBytes = await File.ReadAllBytesAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip")
         );
         using var cts = new CancellationTokenSource();
         await using var stream = new CancelAfterBytesReadStream(
@@ -171,7 +171,7 @@ public class AsyncParityAndCancellationTests : TestBase
     public async Task OpenAsyncReader_CallerProvidedStream_ShouldRemainOpenByDefault()
     {
         var archiveBytes = await File.ReadAllBytesAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip")
         );
         var stream = new TestStream(new MemoryStream(archiveBytes));
 
@@ -194,7 +194,7 @@ public class AsyncParityAndCancellationTests : TestBase
     public async Task OpenAsyncArchive_CallerProvidedStream_ShouldRemainOpenByDefault()
     {
         var archiveBytes = await File.ReadAllBytesAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip")
         );
         var stream = new TestStream(new MemoryStream(archiveBytes));
 

--- a/tests/SharpCompress.Tests/CompressionProviderTests.cs
+++ b/tests/SharpCompress.Tests/CompressionProviderTests.cs
@@ -669,7 +669,7 @@ public class CompressionProviderTests
     [Fact]
     public void LzwReader_OpenReader_UsesCustomLzwProvider()
     {
-        var archivePath = Path.Combine(TestBase.TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var archivePath = Path.Join(TestBase.TEST_ARCHIVES_PATH, "Tar.tar.Z");
         var trackingProvider = new TrackingCompressionProvider(new LzwCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
         var options = ReaderOptions.ForExternalStream.WithProviders(registry);

--- a/tests/SharpCompress.Tests/ExtractAll.cs
+++ b/tests/SharpCompress.Tests/ExtractAll.cs
@@ -20,7 +20,7 @@ public class ExtractAllTests : TestBase
     [InlineData("7Zip.LZMA.7z")]
     public async ValueTask ExtractAllEntriesAsync(string archivePath)
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, archivePath);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, archivePath);
 
         await using var archive = await ArchiveFactory.OpenAsyncArchive(testArchive);
         await archive.WriteToDirectoryAsync(SCRATCH_FILES_PATH);
@@ -36,7 +36,7 @@ public class ExtractAllTests : TestBase
     [InlineData("7Zip.LZMA.7z")]
     public void ExtractAllEntriesSync(string archivePath)
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, archivePath);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, archivePath);
 
         using var archive = ArchiveFactory.OpenArchive(testArchive);
         archive.WriteToDirectory(SCRATCH_FILES_PATH);

--- a/tests/SharpCompress.Tests/ExtractAllEntriesTests.cs
+++ b/tests/SharpCompress.Tests/ExtractAllEntriesTests.cs
@@ -16,7 +16,7 @@ public class ExtractAllEntriesTests : TestBase
     [Fact]
     public void ExtractAllEntries_WithProgressReporting_NonSolidArchive()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
 
         using var archive = ArchiveFactory.OpenArchive(archivePath);
         Assert.Throws<SharpCompressException>(() =>
@@ -28,7 +28,7 @@ public class ExtractAllEntriesTests : TestBase
     [Fact]
     public void ExtractAllEntries_WithProgressReporting_SolidArchive()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Rar.solid.rar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Rar.solid.rar");
 
         using var archive = ArchiveFactory.OpenArchive(archivePath);
         Assert.True(archive.IsSolid);

--- a/tests/SharpCompress.Tests/ExtractionTests.cs
+++ b/tests/SharpCompress.Tests/ExtractionTests.cs
@@ -20,7 +20,7 @@ public class ExtractionTests : TestBase
         // Windows file systems are case-insensitive. On Unix-like systems, this test
         // verifies that the case-sensitive comparison is used correctly.
 
-        var testArchive = Path.Combine(SCRATCH2_FILES_PATH, "test-extraction.zip");
+        var testArchive = Path.Join(SCRATCH2_FILES_PATH, "test-extraction.zip");
         var extractPath = SCRATCH_FILES_PATH;
 
         // Create a simple test archive with a single file
@@ -34,7 +34,7 @@ public class ExtractionTests : TestBase
                 );
 
             // Create a test file to add to the archive
-            var testFilePath = Path.Combine(SCRATCH2_FILES_PATH, "testfile.txt");
+            var testFilePath = Path.Join(SCRATCH2_FILES_PATH, "testfile.txt");
             File.WriteAllText(testFilePath, "Test content");
 
             writer.Write("testfile.txt", testFilePath);
@@ -58,7 +58,7 @@ public class ExtractionTests : TestBase
         }
 
         // Verify the file was extracted successfully
-        var extractedFile = Path.Combine(extractPath, "testfile.txt");
+        var extractedFile = Path.Join(extractPath, "testfile.txt");
         Assert.True(File.Exists(extractedFile));
         Assert.Equal("Test content", File.ReadAllText(extractedFile));
     }
@@ -69,7 +69,7 @@ public class ExtractionTests : TestBase
         // This test ensures that the security check still works to prevent
         // path traversal attacks (e.g., using "../" to escape the destination directory)
 
-        var testArchive = Path.Combine(SCRATCH2_FILES_PATH, "test-traversal.zip");
+        var testArchive = Path.Join(SCRATCH2_FILES_PATH, "test-traversal.zip");
         var extractPath = SCRATCH_FILES_PATH;
 
         // Create a test archive with a path traversal attempt
@@ -82,7 +82,7 @@ public class ExtractionTests : TestBase
                     new WriterOptions(CompressionType.Deflate)
                 );
 
-            var testFilePath = Path.Combine(SCRATCH2_FILES_PATH, "testfile2.txt");
+            var testFilePath = Path.Join(SCRATCH2_FILES_PATH, "testfile2.txt");
             File.WriteAllText(testFilePath, "Test content");
 
             // Try to write with a path that attempts to escape the destination directory

--- a/tests/SharpCompress.Tests/GZip/AsyncTests.cs
+++ b/tests/SharpCompress.Tests/GZip/AsyncTests.cs
@@ -21,7 +21,7 @@ public class AsyncTests : TestBase
     [Fact]
     public async ValueTask Reader_Async_Extract_All()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
         await using var stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
 
@@ -39,7 +39,7 @@ public class AsyncTests : TestBase
     [Fact]
     public async ValueTask Reader_Async_Extract_Single_Entry()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
         await using var stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
 
@@ -47,7 +47,7 @@ public class AsyncTests : TestBase
         {
             if (!reader.Entry.IsDirectory)
             {
-                var outputPath = Path.Combine(SCRATCH_FILES_PATH, reader.Entry.Key!);
+                var outputPath = Path.Join(SCRATCH_FILES_PATH, reader.Entry.Key!);
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
                 await using var outputStream = File.Create(outputPath);
                 await reader.WriteEntryToAsync(outputStream);
@@ -59,7 +59,7 @@ public class AsyncTests : TestBase
     [Fact]
     public async ValueTask Archive_Entry_Async_Open_Stream()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
         await using var archive = await GZipArchive.OpenAsyncArchive(
             new AsyncOnlyStream(File.OpenRead(testArchive))
         );
@@ -80,7 +80,7 @@ public class AsyncTests : TestBase
     [Fact]
     public async ValueTask Writer_Async_Write_Single_File()
     {
-        var outputPath = Path.Combine(SCRATCH_FILES_PATH, "async_test.zip");
+        var outputPath = Path.Join(SCRATCH_FILES_PATH, "async_test.zip");
 
         await using (var stream = File.Create(outputPath))
         await using (
@@ -91,7 +91,7 @@ public class AsyncTests : TestBase
             )
         )
         {
-            var testFile = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+            var testFile = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
 
             await using var fileStream = File.OpenRead(testFile);
             await writer.WriteAsync("test_entry.bin", fileStream, new DateTime(2023, 1, 1));
@@ -109,7 +109,7 @@ public class AsyncTests : TestBase
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(10000); // 10 seconds should be plenty
 
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
         await using var stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
@@ -130,8 +130,8 @@ public class AsyncTests : TestBase
     [Fact]
     public async ValueTask Stream_Extensions_Async()
     {
-        var testFile = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
-        var outputPath = Path.Combine(SCRATCH_FILES_PATH, "async_copy.bin");
+        var testFile = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+        var outputPath = Path.Join(SCRATCH_FILES_PATH, "async_copy.bin");
         await using var inputStream = File.OpenRead(testFile);
         await using var outputStream = File.Create(outputPath);
 
@@ -150,7 +150,7 @@ public class AsyncTests : TestBase
     [Fact]
     public async ValueTask EntryStream_ReadAsync_Works()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz");
         await using var stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
 
@@ -181,7 +181,7 @@ public class AsyncTests : TestBase
         var testData = new byte[1024];
         new Random(42).NextBytes(testData);
 
-        var compressedPath = Path.Combine(SCRATCH_FILES_PATH, "async_compressed.gz");
+        var compressedPath = Path.Join(SCRATCH_FILES_PATH, "async_compressed.gz");
 
         // Test async write with GZipStream
         await using (var fileStream = File.Create(compressedPath))

--- a/tests/SharpCompress.Tests/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipArchiveAsyncTests.cs
@@ -21,63 +21,63 @@ public class GZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask GZip_Archive_Generic_Async()
     {
-        await using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
+        await using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
         await using (var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream)))
         {
             var entry = await archive.EntriesAsync.FirstAsync();
-            await entry.WriteToFileAsync(Path.Combine(SCRATCH_FILES_PATH, entry.Key.NotNull()));
+            await entry.WriteToFileAsync(Path.Join(SCRATCH_FILES_PATH, entry.Key.NotNull()));
 
             var size = entry.Size;
-            var scratch = new FileInfo(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"));
-            var test = new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            var scratch = new FileInfo(Path.Join(SCRATCH_FILES_PATH, "Tar.tar"));
+            var test = new FileInfo(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
 
             Assert.Equal(size, scratch.Length);
             Assert.Equal(size, test.Length);
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar")
         );
     }
 
     [Fact]
     public async ValueTask GZip_Archive_Async()
     {
-        await using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
+        await using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
         {
             await using (
                 var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream))
             )
             {
                 var entry = await archive.EntriesAsync.FirstAsync();
-                await entry.WriteToFileAsync(Path.Combine(SCRATCH_FILES_PATH, entry.Key.NotNull()));
+                await entry.WriteToFileAsync(Path.Join(SCRATCH_FILES_PATH, entry.Key.NotNull()));
 
                 var size = entry.Size;
-                var scratch = new FileInfo(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"));
-                var test = new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+                var scratch = new FileInfo(Path.Join(SCRATCH_FILES_PATH, "Tar.tar"));
+                var test = new FileInfo(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
 
                 Assert.Equal(size, scratch.Length);
                 Assert.Equal(size, test.Length);
             }
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar")
         );
     }
 
     [Fact]
     public async ValueTask GZip_Archive_NoAdd_Async()
     {
-        var jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-        await using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        var jpg = Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
+        await using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         await using (var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream)))
         {
             await Assert.ThrowsAsync<NotSupportedException>(async () =>
                 await archive.AddEntryAsync("jpg\\test.jpg", File.OpenRead(jpg), closeStream: true)
             );
             await archive.SaveToAsync(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 new GZipWriterOptions()
             );
         }
@@ -87,7 +87,7 @@ public class GZipArchiveAsyncTests : ArchiveTests
     public async ValueTask GZip_Archive_Multiple_Reads_Async()
     {
         var inputStream = new MemoryStream();
-        await using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
+        await using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
         {
             await stream.CopyToAsync(inputStream);
             inputStream.Position = 0;
@@ -130,7 +130,7 @@ public class GZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task TestGzCrcWithMostSignificantBitNotNegative_Async()
     {
-        await using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        await using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         await using var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
         await foreach (var entry in archive.EntriesAsync.Where(entry => !entry.IsDirectory))
         {
@@ -141,7 +141,7 @@ public class GZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task TestGzArchiveTypeGzip_Async()
     {
-        await using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        await using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         await using var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
         Assert.Equal(archive.Type, ArchiveType.GZip);
     }
@@ -149,18 +149,18 @@ public class GZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask GZip_Create_New_Async()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
-        var filePath = Path.Combine(scratchPath, "test.gz");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var filePath = Path.Join(scratchPath, "test.gz");
         if (!Directory.Exists(scratchPath))
         {
             Directory.CreateDirectory(scratchPath);
         }
         await using (var archive = (GZipArchive)await GZipArchive.CreateAsyncArchive())
         {
-            await archive.AddEntryAsync("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            await archive.AddEntryAsync("Tar.tar", Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
             await archive.SaveToAsync(filePath, new GZipWriterOptions(CompressionLevel.BestSpeed));
         }
-        var scratchPath2 = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var scratchPath2 = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
         if (!Directory.Exists(scratchPath2))
         {
             Directory.CreateDirectory(scratchPath2);
@@ -175,8 +175,8 @@ public class GZipArchiveAsyncTests : ArchiveTests
             await entry.WriteToDirectoryAsync(scratchPath2);
         }
         CompareFilesByPath(
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"),
-            Path.Combine(scratchPath2, "Tar.tar")
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"),
+            Path.Join(scratchPath2, "Tar.tar")
         );
     }
 

--- a/tests/SharpCompress.Tests/GZip/GZipArchiveTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipArchiveTests.cs
@@ -18,62 +18,62 @@ public class GZipArchiveTests : ArchiveTests
     [Fact]
     public void GZip_Archive_Generic()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
         using (var archive = GZipArchive.OpenArchive(stream))
         {
             var entry = archive.Entries.First();
-            entry.WriteToFile(Path.Combine(SCRATCH_FILES_PATH, entry.Key.NotNull()));
+            entry.WriteToFile(Path.Join(SCRATCH_FILES_PATH, entry.Key.NotNull()));
 
             var size = entry.Size;
-            var scratch = new FileInfo(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"));
-            var test = new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            var scratch = new FileInfo(Path.Join(SCRATCH_FILES_PATH, "Tar.tar"));
+            var test = new FileInfo(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
 
             Assert.Equal(size, scratch.Length);
             Assert.Equal(size, test.Length);
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar")
         );
     }
 
     [Fact]
     public void GZip_Archive()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
         using (var archive = GZipArchive.OpenArchive(stream))
         {
             var entry = archive.Entries.First();
-            entry.WriteToFile(Path.Combine(SCRATCH_FILES_PATH, entry.Key.NotNull()));
+            entry.WriteToFile(Path.Join(SCRATCH_FILES_PATH, entry.Key.NotNull()));
 
             var size = entry.Size;
-            var scratch = new FileInfo(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"));
-            var test = new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            var scratch = new FileInfo(Path.Join(SCRATCH_FILES_PATH, "Tar.tar"));
+            var test = new FileInfo(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
 
             Assert.Equal(size, scratch.Length);
             Assert.Equal(size, test.Length);
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar")
         );
     }
 
     [Fact]
     public void GZip_Archive_NoAdd()
     {
-        var jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        var jpg = Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var archive = GZipArchive.OpenArchive(stream);
         Assert.Throws<InvalidFormatException>(() => archive.AddEntry("jpg\\test.jpg", jpg));
-        archive.SaveTo(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"), new GZipWriterOptions());
+        archive.SaveTo(Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"), new GZipWriterOptions());
     }
 
     [Fact]
     public void GZip_Archive_Multiple_Reads()
     {
         var inputStream = new MemoryStream();
-        using (var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
+        using (var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")))
         {
             fileStream.CopyTo(inputStream);
             inputStream.Position = 0;
@@ -113,7 +113,7 @@ public class GZipArchiveTests : ArchiveTests
     [Fact]
     public void TestGzCrcWithMostSignificantBitNotNegative()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var archive = GZipArchive.OpenArchive(stream);
         //process all entries in solid archive until the one we want to test
         foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
@@ -125,7 +125,7 @@ public class GZipArchiveTests : ArchiveTests
     [Fact]
     public void TestGzArchiveTypeGzip()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var archive = GZipArchive.OpenArchive(stream);
         Assert.Equal(archive.Type, ArchiveType.GZip);
     }
@@ -151,7 +151,7 @@ public class GZipArchiveTests : ArchiveTests
     public void GZip_Archive_NonSeekableStream()
     {
         // Test that GZip extraction works with non-seekable streams (like HttpBaseStream)
-        using var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         var buffer = new MemoryStream();
         fileStream.CopyTo(buffer);
         buffer.Position = 0;

--- a/tests/SharpCompress.Tests/GZip/GZipCrcExtractionTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipCrcExtractionTests.cs
@@ -21,7 +21,7 @@ public class GZipCrcExtractionTests : TestBase
         using var stream = new MemoryStream(ReadCorruptedGZipTrailer(corruptCrc: true));
         using var archive = GZipArchive.OpenArchive(stream);
         var entry = archive.Entries.Single();
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
 
         Assert.Throws<InvalidFormatException>(() => entry.WriteToFile(destination));
     }
@@ -32,7 +32,7 @@ public class GZipCrcExtractionTests : TestBase
         using var stream = new MemoryStream(ReadCorruptedGZipTrailer(corruptCrc: false));
         using var archive = GZipArchive.OpenArchive(stream);
         var entry = archive.Entries.Single();
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
 
         Assert.Throws<InvalidFormatException>(() => entry.WriteToFile(destination));
     }
@@ -43,7 +43,7 @@ public class GZipCrcExtractionTests : TestBase
         using var stream = new MemoryStream(ReadCorruptedGZipTrailer(corruptCrc: true));
         using var nonSeekableStream = new ForwardOnlyStream(stream);
         using var reader = GZipReader.OpenReader(nonSeekableStream);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
 
         Assert.True(reader.MoveToNextEntry());
         Assert.Throws<InvalidFormatException>(() => reader.WriteEntryToFile(destination));
@@ -55,12 +55,12 @@ public class GZipCrcExtractionTests : TestBase
         using var stream = new MemoryStream(ReadCorruptedGZipTrailer(corruptCrc: true));
         using var archive = GZipArchive.OpenArchive(stream);
         var entry = archive.Entries.Single();
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
 
         entry.WriteToFile(destination, new ExtractionOptions { CheckCrc = false });
 
         Assert.Equal(
-            new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")).Length,
+            new FileInfo(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar")).Length,
             new FileInfo(destination).Length
         );
     }
@@ -71,7 +71,7 @@ public class GZipCrcExtractionTests : TestBase
         await using var stream = new MemoryStream(ReadCorruptedGZipTrailer(corruptCrc: true));
         await using var archive = await GZipArchive.OpenAsyncArchive(stream);
         var entry = await archive.EntriesAsync.SingleAsync();
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
 
         await Assert.ThrowsAsync<InvalidFormatException>(async () =>
             await entry.WriteToFileAsync(destination)
@@ -80,7 +80,7 @@ public class GZipCrcExtractionTests : TestBase
 
     private static byte[] ReadCorruptedGZipTrailer(bool corruptCrc)
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         var trailer = bytes.AsSpan(bytes.Length - 8);
         var offset = corruptCrc ? 0 : 4;
         var value = BinaryPrimitives.ReadUInt32LittleEndian(trailer[offset..]);

--- a/tests/SharpCompress.Tests/GZip/GZipReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipReaderAsyncTests.cs
@@ -21,7 +21,7 @@ public class GZipReaderAsyncTests : ReaderTests
     public async ValueTask GZip_Reader_Generic2_Async()
     {
         //read only as GZip item
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         await using var reader = await GZipReader.OpenAsyncReader(new AsyncOnlyStream(stream));
         while (await reader.MoveToNextEntryAsync())
         {

--- a/tests/SharpCompress.Tests/GZip/GZipReaderTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipReaderTests.cs
@@ -17,7 +17,7 @@ public class GZipReaderTests : ReaderTests
     public void GZip_Reader_Generic2()
     {
         //read only as GZip itme
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var reader = GZipReader.OpenReader(SharpCompressStream.CreateNonDisposing(stream));
         while (reader.MoveToNextEntry()) // Crash here
         {

--- a/tests/SharpCompress.Tests/GZip/GZipWriterAsyncTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipWriterAsyncTests.cs
@@ -18,7 +18,7 @@ public class GZipWriterAsyncTests : WriterTests
     {
         using (
             Stream stream = File.Open(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 FileMode.OpenOrCreate,
                 FileAccess.Write
             )
@@ -31,11 +31,11 @@ public class GZipWriterAsyncTests : WriterTests
             )
         )
         {
-            await writer.WriteAsync("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            await writer.WriteAsync("Tar.tar", Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")
         );
     }
 
@@ -44,18 +44,18 @@ public class GZipWriterAsyncTests : WriterTests
     {
         using (
             Stream stream = File.Open(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 FileMode.OpenOrCreate,
                 FileAccess.Write
             )
         )
         await using (var writer = new GZipWriter(new AsyncOnlyStream(stream)))
         {
-            await writer.WriteAsync("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            await writer.WriteAsync("Tar.tar", Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")
         );
     }
 
@@ -63,7 +63,7 @@ public class GZipWriterAsyncTests : WriterTests
     public void GZip_Writer_Generic_Bad_Compression_Async() =>
         Assert.Throws<InvalidFormatException>(() =>
         {
-            using Stream stream = File.OpenWrite(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"));
+            using Stream stream = File.OpenWrite(Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"));
             using var writer = WriterFactory.OpenWriter(
                 new AsyncOnlyStream(stream),
                 ArchiveType.GZip,
@@ -76,19 +76,19 @@ public class GZipWriterAsyncTests : WriterTests
     {
         using (
             Stream stream = File.Open(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 FileMode.OpenOrCreate,
                 FileAccess.Write
             )
         )
         await using (var writer = new GZipWriter(new AsyncOnlyStream(stream)))
         {
-            var path = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar");
+            var path = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar");
             await writer.WriteAsync(path, path);
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")
         );
     }
 }

--- a/tests/SharpCompress.Tests/GZip/GZipWriterTests.cs
+++ b/tests/SharpCompress.Tests/GZip/GZipWriterTests.cs
@@ -16,7 +16,7 @@ public class GZipWriterTests : WriterTests
     {
         using (
             Stream stream = File.Open(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 FileMode.OpenOrCreate,
                 FileAccess.Write
             )
@@ -29,11 +29,11 @@ public class GZipWriterTests : WriterTests
             )
         )
         {
-            writer.Write("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            writer.Write("Tar.tar", Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")
         );
     }
 
@@ -42,18 +42,18 @@ public class GZipWriterTests : WriterTests
     {
         using (
             Stream stream = File.Open(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 FileMode.OpenOrCreate,
                 FileAccess.Write
             )
         )
         using (var writer = new GZipWriter(stream))
         {
-            writer.Write("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            writer.Write("Tar.tar", Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")
         );
     }
 
@@ -61,7 +61,7 @@ public class GZipWriterTests : WriterTests
     public void GZip_Writer_Generic_Bad_Compression() =>
         Assert.Throws<InvalidFormatException>(() =>
         {
-            using Stream stream = File.OpenWrite(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"));
+            using Stream stream = File.OpenWrite(Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"));
             using var writer = WriterFactory.OpenWriter(
                 stream,
                 ArchiveType.GZip,
@@ -74,19 +74,19 @@ public class GZipWriterTests : WriterTests
     {
         using (
             Stream stream = File.Open(
-                Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+                Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
                 FileMode.OpenOrCreate,
                 FileAccess.Write
             )
         )
         using (var writer = new GZipWriter(stream))
         {
-            var path = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar");
+            var path = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar");
             writer.Write(path, path); //covers issue #532
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz")
+            Path.Join(SCRATCH_FILES_PATH, "Tar.tar.gz"),
+            Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz")
         );
     }
 }

--- a/tests/SharpCompress.Tests/LazyReadOnlyCollectionTests.cs
+++ b/tests/SharpCompress.Tests/LazyReadOnlyCollectionTests.cs
@@ -419,7 +419,7 @@ public class LazyReadOnlyCollectionTests
     [Fact]
     public async Task ArchiveConcurrentEntriesEnumeration_IsSafe()
     {
-        var archivePath = Path.Combine(TestBase.TEST_ARCHIVES_PATH, "WinZip26.nocomp.multi.zip");
+        var archivePath = Path.Join(TestBase.TEST_ARCHIVES_PATH, "WinZip26.nocomp.multi.zip");
         using var archive = ArchiveFactory.OpenArchive(archivePath);
         const int taskCount = 8;
 

--- a/tests/SharpCompress.Tests/Lzw/LzwReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Lzw/LzwReaderAsyncTests.cs
@@ -20,7 +20,7 @@ public class LzwReaderAsyncTests : ReaderTests
     public async System.Threading.Tasks.Task Lzw_Reader_Plain_Z_File_Async()
     {
         // Test async reading of a plain .Z file (not tar-wrapped) using LzwReader directly
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "large_test.txt.Z"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "large_test.txt.Z"));
         using var reader = LzwReader.OpenReader(stream);
 
         Assert.Equal(ArchiveType.Lzw, reader.Type);

--- a/tests/SharpCompress.Tests/Lzw/LzwReaderTests.cs
+++ b/tests/SharpCompress.Tests/Lzw/LzwReaderTests.cs
@@ -18,7 +18,7 @@ public class LzwReaderTests : ReaderTests
     public void Lzw_Reader_Generic2()
     {
         //read only as Lzw item
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z"));
         using var reader = LzwReader.OpenReader(SharpCompressStream.CreateNonDisposing(stream));
         while (reader.MoveToNextEntry())
         {
@@ -34,7 +34,7 @@ public class LzwReaderTests : ReaderTests
         // 1. LzwStream only supports decompression, not compression
         // 2. This tests the important tar wrapper detection code path in LzwFactory.TryOpenReader
         // 3. Verifies that tar.Z files correctly return TarReader with CompressionType.Lzw
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z"));
         using var reader = ReaderFactory.OpenReader(
             stream,
             ReaderOptions.ForExternalStream with
@@ -54,7 +54,7 @@ public class LzwReaderTests : ReaderTests
     public void Lzw_Reader_Plain_Z_File()
     {
         // Test with a plain .Z file (not tar-wrapped) using LzwReader directly
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "large_test.txt.Z"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "large_test.txt.Z"));
         using var reader = LzwReader.OpenReader(stream);
 
         Assert.True(reader.MoveToNextEntry());
@@ -79,7 +79,7 @@ public class LzwReaderTests : ReaderTests
     public void Lzw_Reader_Factory_Detects_Plain_Z_File()
     {
         // Test that ReaderFactory correctly identifies a plain .Z file (not tar-wrapped)
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "large_test.txt.Z"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "large_test.txt.Z"));
         using var reader = ReaderFactory.OpenReader(stream);
 
         // Should detect as Lzw archive (not Tar)

--- a/tests/SharpCompress.Tests/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Tests/OptionsUsabilityTests.cs
@@ -22,7 +22,7 @@ public class OptionsUsabilityTests : TestBase
     [Fact]
     public void ReaderFactory_Stream_Default_Leaves_Stream_Open()
     {
-        using var file = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip"));
+        using var file = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip"));
         using var testStream = new TestStream(file);
 
         using (var reader = ReaderFactory.OpenReader(testStream))
@@ -36,7 +36,7 @@ public class OptionsUsabilityTests : TestBase
     [Fact]
     public void ArchiveFactory_Stream_Default_Leaves_Stream_Open()
     {
-        using var file = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip"));
+        using var file = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip"));
         using var testStream = new TestStream(file);
 
         using (var archive = ArchiveFactory.OpenArchive(testStream))
@@ -50,7 +50,7 @@ public class OptionsUsabilityTests : TestBase
     [Fact]
     public async Task ReaderFactory_Stream_Default_Leaves_Stream_Open_Async()
     {
-        using var file = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip"));
+        using var file = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip"));
         using var testStream = new TestStream(file);
 
         await using (
@@ -312,7 +312,7 @@ public class OptionsUsabilityTests : TestBase
     public void Reader_WriteEntryToFile_Uses_ExtractionOptions_BufferSize()
     {
         using var reader = new TrackingReader();
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "reader-buffer-size.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "reader-buffer-size.txt");
 
         reader.WriteEntryToFile(destination, new ExtractionOptions { BufferSize = 11 });
 
@@ -323,7 +323,7 @@ public class OptionsUsabilityTests : TestBase
     public async Task Reader_WriteEntryToFileAsync_Uses_ExtractionOptions_BufferSize()
     {
         await using var reader = new TrackingReader();
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "reader-buffer-size-async.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "reader-buffer-size-async.txt");
 
         await reader.WriteEntryToFileAsync(destination, new ExtractionOptions { BufferSize = 13 });
 

--- a/tests/SharpCompress.Tests/Rar/RarAdversarialStreamTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarAdversarialStreamTests.cs
@@ -61,7 +61,7 @@ public class RarAdversarialStreamTests : ArchiveTests
         int chunkSize
     )
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var options = ReaderOptions.ForExternalStream with { Password = password };
 
         var baseline = ExtractRarEntryBytes(new MemoryStream(bytes, writable: false), options);
@@ -83,7 +83,7 @@ public class RarAdversarialStreamTests : ArchiveTests
     public void Rar_Encrypted_AlternatingOddReads_MatchBaseline(string archiveName, string password)
     {
         int[] pattern = [1, 7, 15, 16, 17, 8192];
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var options = ReaderOptions.ForExternalStream with { Password = password };
 
         var baseline = ExtractRarEntryBytes(new MemoryStream(bytes, writable: false), options);
@@ -109,7 +109,7 @@ public class RarAdversarialStreamTests : ArchiveTests
         int chunkSize
     )
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var options = ReaderOptions.ForExternalStream with { Password = password };
 
         var baseline = await ExtractRarEntryBytesAsync(
@@ -134,7 +134,7 @@ public class RarAdversarialStreamTests : ArchiveTests
         // RarArchive.OpenAsyncArchive still sync-reads headers, so CancelAfterBytesReadStream
         // (sync Read unsupported) cannot wrap the archive source. Cancel after the first entry chunk.
         var archiveBytes = await File.ReadAllBytesAsync(
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar")
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.rar")
         );
         await using var archive = await RarArchive.OpenAsyncArchive(new MemoryStream(archiveBytes));
         using var cts = new CancellationTokenSource();
@@ -160,7 +160,7 @@ public class RarAdversarialStreamTests : ArchiveTests
     [Fact(Timeout = 30_000)]
     public void SevenZip_Truncated_Throws()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         using var fileStream = File.OpenRead(path);
         using var truncated = TruncatedStream.AtPercent(fileStream, 50, leaveOpen: false);
 
@@ -180,7 +180,7 @@ public class RarAdversarialStreamTests : ArchiveTests
     [Fact(Timeout = 30_000)]
     public void Zip_Truncated_Throws()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
         using var fileStream = File.OpenRead(path);
         using var truncated = TruncatedStream.AtPercent(fileStream, 50, leaveOpen: false);
 
@@ -203,7 +203,7 @@ public class RarAdversarialStreamTests : ArchiveTests
     [InlineData("Zip.deflate.zip", null, 1)]
     public void Zip_ChunkyReads_MatchBaseline(string archiveName, string? password, int chunkSize)
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var options = ReaderOptions.ForExternalStream;
         if (password is not null)
         {
@@ -233,7 +233,7 @@ public class RarAdversarialStreamTests : ArchiveTests
         int chunkSize
     )
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var options = ReaderOptions.ForExternalStream;
         if (password is not null)
         {
@@ -368,7 +368,7 @@ public class RarAdversarialStreamTests : ArchiveTests
         var streams = new List<Stream>();
         for (var i = 0; i < MultiVolumeParts.Length; i++)
         {
-            var path = Path.Combine(TEST_ARCHIVES_PATH, MultiVolumeParts[i]);
+            var path = Path.Join(TEST_ARCHIVES_PATH, MultiVolumeParts[i]);
             var bytes = File.ReadAllBytes(path);
             if (i == MultiVolumeParts.Length - 1)
             {

--- a/tests/SharpCompress.Tests/Rar/RarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarArchiveAsyncTests.cs
@@ -24,7 +24,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     {
         var extractedEntries = 0;
         await using var archive = await RarArchive.OpenAsyncArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, filename),
+            Path.Join(TEST_ARCHIVES_PATH, filename),
             new ReaderOptions { LookForHeader = true }
         );
 
@@ -92,7 +92,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private async ValueTask ReadRarPasswordAsync(string testArchive, string? password)
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testArchive)))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, testArchive)))
         await using (
             var archive = await RarArchive.OpenAsyncArchive(
                 stream,
@@ -126,7 +126,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     {
         using (
             var archive = RarArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, archiveName),
+                Path.Join(TEST_ARCHIVES_PATH, archiveName),
                 ReaderOptions.ForFilePath with
                 {
                     Password = password,
@@ -164,7 +164,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private async ValueTask DoRar_test_invalid_exttime_ArchiveStreamReadAsync(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = ArchiveFactory.OpenArchive(stream);
         foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
         {
@@ -175,7 +175,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Rar_Jpg_ArchiveStreamRead_Async()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"));
         using (
             var archive = RarArchive.OpenArchive(
                 stream,
@@ -204,7 +204,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private async ValueTask DoRar_IsSolidArchiveCheckAsync(string filename)
     {
-        using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
+        using (var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename)))
         {
             using var archive = RarArchive.OpenArchive(stream);
             Assert.False(archive.IsSolid);
@@ -222,7 +222,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private async ValueTask DoRar_IsSolidEntryStreamCheckAsync(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = RarArchive.OpenArchive(stream);
         Assert.True(archive.IsSolid);
         IArchiveEntry[] entries = archive.Entries.Where(a => !a.IsDirectory).ToArray();
@@ -296,7 +296,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     {
         using var archive = RarArchive.OpenArchive(
             archives
-                .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                .Select(s => Path.Join(TEST_ARCHIVES_PATH, s))
                 .Select(File.OpenRead)
                 .ToArray()
         );
@@ -345,7 +345,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private Task DoRar_ArchiveFileRead_HasDirectoriesAsync(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = RarArchive.OpenArchive(stream);
         Assert.False(archive.IsSolid);
         Assert.Contains(true, archive.Entries.Select(entry => entry.IsDirectory));
@@ -357,7 +357,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     {
         using (
             var archive = RarArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
+                Path.Join(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
                 ReaderOptions.ForFilePath with
                 {
                     LookForHeader = true,
@@ -414,7 +414,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     [Fact]
     public void Rar15_ArchiveVersionTest_Async()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar15.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar15.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(1, archive.MinVersion);
@@ -424,7 +424,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     [Fact]
     public void Rar2_ArchiveVersionTest_Async()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar2.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar2.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(2, archive.MinVersion);
@@ -434,7 +434,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     [Fact]
     public void Rar4_ArchiveVersionTest_Async()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar4.multi.part01.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar4.multi.part01.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(3, archive.MinVersion);
@@ -444,7 +444,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     [Fact]
     public void Rar5_ArchiveVersionTest_Async()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.solid.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar5.solid.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(5, archive.MinVersion);
@@ -603,7 +603,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private void DoRar_IsFirstVolume_True(string firstFilename)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, firstFilename));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, firstFilename));
         Assert.True(archive.IsMultipartVolume());
         Assert.True(archive.IsFirstVolume());
     }
@@ -619,7 +619,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     private void DoRar_IsFirstVolume_False(string notFirstFilename)
     {
         using var archive = RarArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, notFirstFilename)
+            Path.Join(TEST_ARCHIVES_PATH, notFirstFilename)
         );
         Assert.True(archive.IsMultipartVolume());
         Assert.False(archive.IsFirstVolume());
@@ -661,7 +661,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private async ValueTask ArchiveStreamReadAsync(string testArchive)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using var stream = File.OpenRead(testArchive);
         using var archive = ArchiveFactory.OpenArchive(stream);
         foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
@@ -676,7 +676,7 @@ public class RarArchiveAsyncTests : ArchiveTests
         CompressionType compression
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -704,7 +704,7 @@ public class RarArchiveAsyncTests : ArchiveTests
 
     private async ValueTask ArchiveFileReadAsync(string testArchive)
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using var archive = ArchiveFactory.OpenArchive(testArchive);
         foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
         {
@@ -718,7 +718,7 @@ public class RarArchiveAsyncTests : ArchiveTests
         params string[] testArchives
     )
     {
-        var paths = testArchives.Select(x => Path.Combine(TEST_ARCHIVES_PATH, x));
+        var paths = testArchives.Select(x => Path.Join(TEST_ARCHIVES_PATH, x));
         using var archive = ArchiveFactory.OpenArchive(
             paths.Select(a => new FileInfo(a)).ToArray(),
             readerOptions
@@ -738,7 +738,7 @@ public class RarArchiveAsyncTests : ArchiveTests
     public async ValueTask Rar_Issue1050_WriteToDirectoryAsync_ExtractsToSubdirectories()
     {
         var testFile = "Rar.issue1050.rar";
-        using var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testFile));
+        using var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, testFile));
         await using var archive = await RarArchive.OpenAsyncArchive(fileStream);
 
         // Extract using archive.WriteToDirectoryAsync without explicit options
@@ -746,23 +746,23 @@ public class RarArchiveAsyncTests : ArchiveTests
 
         // Verify files are in their subdirectories, not at the root
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "PhysicsBraid", "263825.tr11dtp")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "PhysicsBraid", "263825.tr11dtp")),
             "File should be in PhysicsBraid subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "Animations", "15441.tr11anim")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "Animations", "15441.tr11anim")),
             "File should be in Animations subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "Braid", "766728.tr11dtp")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "Braid", "766728.tr11dtp")),
             "File should be in Braid subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "Braid", "766832.tr11dtp")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "Braid", "766832.tr11dtp")),
             "File should be in Braid subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "HeadBraid", "321353.tr11modeldata")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "HeadBraid", "321353.tr11modeldata")),
             "File should be in HeadBraid subdirectory"
         );
 
@@ -776,7 +776,7 @@ public class RarArchiveAsyncTests : ArchiveTests
         params string[] testArchives
     )
     {
-        var paths = testArchives.Select(x => Path.Combine(TEST_ARCHIVES_PATH, x));
+        var paths = testArchives.Select(x => Path.Join(TEST_ARCHIVES_PATH, x));
         using var archive = ArchiveFactory.OpenArchive(
             paths.Select(f => new FileInfo(f)).ToArray(),
             readerOptions

--- a/tests/SharpCompress.Tests/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarArchiveTests.cs
@@ -23,7 +23,7 @@ public class RarArchiveTests : ArchiveTests
     public void Rar_Archive_Recently_Changed_Unpackers_Sync(string filename)
     {
         var extractedEntries = 0;
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = RarArchive.OpenArchive(
             stream,
             new ReaderOptions { LookForHeader = true }
@@ -45,7 +45,7 @@ public class RarArchiveTests : ArchiveTests
     public void RarArchive_Entry_Attrib_ReturnsValueWithoutThrowing(string filename)
     {
         using var archive = RarArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, filename),
+            Path.Join(TEST_ARCHIVES_PATH, filename),
             ReaderOptions.ForExternalStream
         );
 
@@ -105,7 +105,7 @@ public class RarArchiveTests : ArchiveTests
 
     private void ReadRarPassword(string testArchive, string? password)
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testArchive)))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, testArchive)))
         using (
             var archive = RarArchive.OpenArchive(
                 stream,
@@ -139,7 +139,7 @@ public class RarArchiveTests : ArchiveTests
     {
         using (
             var archive = RarArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, archiveName),
+                Path.Join(TEST_ARCHIVES_PATH, archiveName),
                 ReaderOptions.ForFilePath with
                 {
                     Password = password,
@@ -191,7 +191,7 @@ public class RarArchiveTests : ArchiveTests
 
     private void DoRar_test_invalid_exttime_ArchiveStreamRead(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = ArchiveFactory.OpenArchive(stream);
         foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
         {
@@ -202,7 +202,7 @@ public class RarArchiveTests : ArchiveTests
     [Fact]
     public void Rar_Jpg_ArchiveStreamRead()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"));
         using (
             var archive = RarArchive.OpenArchive(
                 stream,
@@ -229,7 +229,7 @@ public class RarArchiveTests : ArchiveTests
 
     private void DoRar_IsSolidArchiveCheck(string filename)
     {
-        using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
+        using (var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename)))
         {
             using var archive = RarArchive.OpenArchive(stream);
             Assert.False(archive.IsSolid);
@@ -247,7 +247,7 @@ public class RarArchiveTests : ArchiveTests
     //Extract the 2nd file in a solid archive to check that the first file is skipped properly
     private void DoRar_IsSolidEntryStreamCheck(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = RarArchive.OpenArchive(stream);
         Assert.True(archive.IsSolid);
         IArchiveEntry[] entries = archive.Entries.Where(a => !a.IsDirectory).ToArray();
@@ -320,7 +320,7 @@ public class RarArchiveTests : ArchiveTests
     {
         using var archive = RarArchive.OpenArchive(
             archives
-                .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                .Select(s => Path.Join(TEST_ARCHIVES_PATH, s))
                 .Select(File.OpenRead)
                 .ToArray()
         );
@@ -367,7 +367,7 @@ public class RarArchiveTests : ArchiveTests
 
     private void DoRar_ArchiveFileRead_HasDirectories(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var archive = RarArchive.OpenArchive(stream);
         Assert.False(archive.IsSolid);
         Assert.Contains(true, archive.Entries.Select(entry => entry.IsDirectory));
@@ -378,7 +378,7 @@ public class RarArchiveTests : ArchiveTests
     {
         using (
             var archive = RarArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
+                Path.Join(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
                 ReaderOptions.ForFilePath with
                 {
                     LookForHeader = true,
@@ -432,7 +432,7 @@ public class RarArchiveTests : ArchiveTests
     [Fact]
     public void Rar15_ArchiveVersionTest()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar15.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar15.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(1, archive.MinVersion);
@@ -442,7 +442,7 @@ public class RarArchiveTests : ArchiveTests
     [Fact]
     public void Rar2_ArchiveVersionTest()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar2.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar2.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(2, archive.MinVersion);
@@ -452,7 +452,7 @@ public class RarArchiveTests : ArchiveTests
     [Fact]
     public void Rar4_ArchiveVersionTest()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar4.multi.part01.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar4.multi.part01.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(3, archive.MinVersion);
@@ -462,7 +462,7 @@ public class RarArchiveTests : ArchiveTests
     [Fact]
     public void Rar5_ArchiveVersionTest()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.solid.rar");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Rar5.solid.rar");
 
         using var archive = RarArchive.OpenArchive(testArchive);
         Assert.Equal(5, archive.MinVersion);
@@ -645,7 +645,7 @@ public class RarArchiveTests : ArchiveTests
 
     private void DoRar_IsFirstVolume_True(string firstFilename)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, firstFilename));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, firstFilename));
         Assert.True(archive.IsMultipartVolume());
         Assert.True(archive.IsFirstVolume());
     }
@@ -659,7 +659,7 @@ public class RarArchiveTests : ArchiveTests
     private void DoRar_IsFirstVolume_False(string notFirstFilename)
     {
         using var archive = RarArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, notFirstFilename)
+            Path.Join(TEST_ARCHIVES_PATH, notFirstFilename)
         );
         Assert.True(archive.IsMultipartVolume());
         Assert.False(archive.IsFirstVolume());
@@ -702,7 +702,7 @@ public class RarArchiveTests : ArchiveTests
     public void Rar_TestEncryptedDetection()
     {
         using var passwordProtectedFilesArchive = RarArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
         );
         Assert.True(passwordProtectedFilesArchive.IsEncrypted);
     }
@@ -723,7 +723,7 @@ public class RarArchiveTests : ArchiveTests
 
         foreach (var testFile in testFiles)
         {
-            using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testFile));
+            using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, testFile));
             using var archive = RarArchive.OpenArchive(stream);
 
             // Extract all entries and read them completely
@@ -756,7 +756,7 @@ public class RarArchiveTests : ArchiveTests
         // This test verifies the exception is thrown when decompression ends prematurely
         // by using a truncated stream that stops reading after a small number of bytes
         var testFile = "Rar.rar";
-        using var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testFile));
+        using var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, testFile));
 
         // Wrap the file stream with a truncated stream that will stop reading early
         // This simulates a corrupted or truncated RAR file
@@ -791,7 +791,7 @@ public class RarArchiveTests : ArchiveTests
     public void Rar_Issue1050_WriteToDirectory_ExtractsToSubdirectories()
     {
         var testFile = "Rar.issue1050.rar";
-        using var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testFile));
+        using var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, testFile));
         using var archive = RarArchive.OpenArchive(fileStream);
 
         // Extract using archive.WriteToDirectory without explicit options
@@ -799,28 +799,28 @@ public class RarArchiveTests : ArchiveTests
 
         // Verify files are in their subdirectories, not at the root
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "PhysicsBraid", "263825.tr11dtp")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "PhysicsBraid", "263825.tr11dtp")),
             "File should be in PhysicsBraid subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "Animations", "15441.tr11anim")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "Animations", "15441.tr11anim")),
             "File should be in Animations subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "Braid", "766728.tr11dtp")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "Braid", "766728.tr11dtp")),
             "File should be in Braid subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "Braid", "766832.tr11dtp")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "Braid", "766832.tr11dtp")),
             "File should be in Braid subdirectory"
         );
         Assert.True(
-            File.Exists(Path.Combine(SCRATCH_FILES_PATH, "HeadBraid", "321353.tr11modeldata")),
+            File.Exists(Path.Join(SCRATCH_FILES_PATH, "HeadBraid", "321353.tr11modeldata")),
             "File should be in HeadBraid subdirectory"
         );
 
         // Verify the exact file size of 766832.tr11dtp matches the archive entry size
-        var fileInfo = new FileInfo(Path.Combine(SCRATCH_FILES_PATH, "Braid", "766832.tr11dtp"));
+        var fileInfo = new FileInfo(Path.Join(SCRATCH_FILES_PATH, "Braid", "766832.tr11dtp"));
         Assert.Equal(4867620, fileInfo.Length); // Expected: 4,867,620 bytes
     }
 
@@ -840,7 +840,7 @@ public class RarArchiveTests : ArchiveTests
         var exception = Assert.Throws<ArchiveOperationException>(() =>
         {
             using var fileStream = File.Open(
-                Path.Combine(TEST_ARCHIVES_PATH, testFile),
+                Path.Join(TEST_ARCHIVES_PATH, testFile),
                 FileMode.Open
             );
             using var archive = RarArchive.OpenArchive(fileStream, readerOptions);

--- a/tests/SharpCompress.Tests/Rar/RarConcurrentEntryStreamTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarConcurrentEntryStreamTests.cs
@@ -14,7 +14,7 @@ public class RarConcurrentEntryStreamTests : ArchiveTests
     [Fact]
     public void NonSolid_InterleavedEntryStreams_MatchReference()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Rar.rar");
         using var archive = RarArchive.OpenArchive(archivePath);
         Assert.False(archive.IsSolid);
 
@@ -68,7 +68,7 @@ public class RarConcurrentEntryStreamTests : ArchiveTests
     [Fact]
     public async Task NonSolid_InterleavedEntryStreams_MatchReference_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Rar.rar");
         await using var archive = await RarArchive.OpenAsyncArchive(archivePath);
         Assert.False(await archive.IsSolidAsync());
 
@@ -138,7 +138,7 @@ public class RarConcurrentEntryStreamTests : ArchiveTests
     [Fact]
     public void Solid_ConcurrentOpenEntryStream_Throws()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Rar.solid.rar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Rar.solid.rar");
         using var archive = RarArchive.OpenArchive(archivePath);
         Assert.True(archive.IsSolid);
 
@@ -156,7 +156,7 @@ public class RarConcurrentEntryStreamTests : ArchiveTests
     [Fact]
     public async Task Solid_ConcurrentOpenEntryStream_Throws_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Rar.solid.rar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Rar.solid.rar");
         await using var archive = await RarArchive.OpenAsyncArchive(archivePath);
         Assert.True(await archive.IsSolidAsync());
 
@@ -186,7 +186,7 @@ public class RarConcurrentEntryStreamTests : ArchiveTests
     [Fact]
     public void Solid_SequentialOpenAfterDispose_Succeeds()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Rar.solid.rar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Rar.solid.rar");
         using var archive = RarArchive.OpenArchive(archivePath);
         Assert.True(archive.IsSolid);
 

--- a/tests/SharpCompress.Tests/Rar/RarCrcExtractionTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarCrcExtractionTests.cs
@@ -14,9 +14,9 @@ public class RarCrcExtractionTests : ArchiveTests
     [InlineData("Rar5.rar")]
     public void Rar_Archive_WriteToFile_Throws_On_Crc_Mismatch(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = CorruptFirstFileCrc(archive);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, $"{archiveName}-crc-mismatch.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, $"{archiveName}-crc-mismatch.txt");
 
         Assert.Throws<InvalidFormatException>(() => entry.WriteToFile(destination));
     }

--- a/tests/SharpCompress.Tests/Rar/RarEncryptedStoredEntryStreamTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarEncryptedStoredEntryStreamTests.cs
@@ -77,7 +77,7 @@ public class RarEncryptedStoredEntryStreamTests : ArchiveTests
     public void EncryptedStored_WrongPassword_Throws()
     {
         using var archive = RarArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar"),
             new ReaderOptions { Password = "wrong" }
         );
         var entry = archive.Entries.First(e => !e.IsDirectory && e.Size > 0);
@@ -109,7 +109,7 @@ public class RarEncryptedStoredEntryStreamTests : ArchiveTests
     {
         await using var archive = (RarArchive)
             await RarArchive.OpenAsyncArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar"),
+                Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar"),
                 new ReaderOptions { Password = Password }
             );
         var entry = (RarArchiveEntry)archive.Entries.First(e => !e.IsDirectory && e.Size > 0);
@@ -141,14 +141,14 @@ public class RarEncryptedStoredEntryStreamTests : ArchiveTests
     private static RarArchive OpenEncrypted(string archiveName) =>
         (RarArchive)
             RarArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, archiveName),
+                Path.Join(TEST_ARCHIVES_PATH, archiveName),
                 new ReaderOptions { Password = Password }
             );
 
     private static RarArchive OpenEncryptedMulti()
     {
         var streams = MultiEncryptedParts
-            .Select(p => (Stream)File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, p)))
+            .Select(p => (Stream)File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, p)))
             .ToArray();
         return (RarArchive)
             RarArchive.OpenArchive(streams, new ReaderOptions { Password = Password });

--- a/tests/SharpCompress.Tests/Rar/RarHeaderFactoryDeferredSkipTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarHeaderFactoryDeferredSkipTests.cs
@@ -31,7 +31,7 @@ public class RarHeaderFactoryDeferredSkipTests : TestBase
     [InlineData("Rar5.none.rar")]
     public void StopAfterFirstFileHeader_PerformsNoDataSeek(string archiveName)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var factory = NewFactory();
 
         IRarFileHeader? first = null;
@@ -59,7 +59,7 @@ public class RarHeaderFactoryDeferredSkipTests : TestBase
     [InlineData("Rar5.none.rar")]
     public void FullWalk_StoredEntries_DataStartPositionsSliceExactPayload(string archiveName)
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var path = Path.Join(TEST_ARCHIVES_PATH, archiveName);
 
         Dictionary<string, byte[]> expected;
         using (var archive = RarArchive.OpenArchive(path))
@@ -100,7 +100,7 @@ public class RarHeaderFactoryDeferredSkipTests : TestBase
     [Fact]
     public void CommentVolume_FullEnumeration_Succeeds_WithoutManualDrain()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar5.comment.rar"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar5.comment.rar"));
         var factory = NewFactory();
 
         var sawComment = false;
@@ -138,7 +138,7 @@ public class RarHeaderFactoryDeferredSkipTests : TestBase
     public void CommentVolume_ArchiveStillReadsComment()
     {
         using var archive = RarArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar5.comment.rar")
+            Path.Join(TEST_ARCHIVES_PATH, "Rar5.comment.rar")
         );
         // Comment is populated while enumerating volume file parts (on the CMT service
         // header); force that load before reading Volumes.Comment.

--- a/tests/SharpCompress.Tests/Rar/RarHeaderFactoryTest.cs
+++ b/tests/SharpCompress.Tests/Rar/RarHeaderFactoryTest.cs
@@ -39,7 +39,7 @@ public class RarHeaderFactoryTest : TestBase
     private void ReadEncryptedFlag(string testArchive, bool isEncrypted)
     {
         using var stream = new FileStream(
-            Path.Combine(TEST_ARCHIVES_PATH, testArchive),
+            Path.Join(TEST_ARCHIVES_PATH, testArchive),
             FileMode.Open,
             FileAccess.Read
         );

--- a/tests/SharpCompress.Tests/Rar/RarHeaderReadExceptionTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarHeaderReadExceptionTests.cs
@@ -67,7 +67,7 @@ public class RarHeaderReadExceptionTests : TestBase
     [Fact]
     public void SuccessfulParse_Unchanged()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.rar"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.rar"));
         var factory = NewFactory();
 
         var count = 0;
@@ -83,7 +83,7 @@ public class RarHeaderReadExceptionTests : TestBase
     [Fact]
     public void SeekPastEnd_OnDeferredSkip_ThrowsTruncated()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Rar.none.rar");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Rar.none.rar");
         var bytes = File.ReadAllBytes(path);
 
         long skipTarget = 0;

--- a/tests/SharpCompress.Tests/Rar/RarKeyDerivationTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarKeyDerivationTests.cs
@@ -51,7 +51,7 @@ public class RarKeyDerivationTests : TestBase
         // Round-trip through the Archive API (which uses CryptKey5 internally) and assert the
         // public DeriveKey material matches that path. Full CBC decrypt of packed bytes is
         // covered by EncryptedStoredRarEntryStream tests; here we only validate the public API.
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar");
 
         using (
             var archive = RarArchive.OpenArchive(path, new ReaderOptions { Password = Password })
@@ -81,7 +81,7 @@ public class RarKeyDerivationTests : TestBase
     [Fact]
     public void DeriveKey_Rar5_MatchesInternalCryptKey()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar");
         using var stream = File.OpenRead(path);
         var factory = NewFactory();
         var fh = (FileHeader)FirstEncryptedFileHeader(stream, factory);
@@ -99,7 +99,7 @@ public class RarKeyDerivationTests : TestBase
     [Fact]
     public void DeriveKey_Rar5_WrongPassword_Throws()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.encrypted.rar");
         using var stream = File.OpenRead(path);
         var factory = NewFactory();
         var fh = FirstEncryptedFileHeader(stream, factory);

--- a/tests/SharpCompress.Tests/Rar/RarReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarReaderAsyncTests.cs
@@ -23,7 +23,7 @@ public class RarReaderAsyncTests : ReaderTests
     [InlineData("Rar5.solid.rar")]
     public async ValueTask Rar_Reader_Async_Uses_Only_Async_Stream_Operations(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
             new ReaderOptions { LookForHeader = true }
@@ -66,7 +66,7 @@ public class RarReaderAsyncTests : ReaderTests
         using (
             IReader baseReader = RarReader.OpenReader(
                 archives
-                    .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                    .Select(s => Path.Join(TEST_ARCHIVES_PATH, s))
                     .Select(p => File.OpenRead(p))
             )
         )
@@ -96,7 +96,7 @@ public class RarReaderAsyncTests : ReaderTests
             using (
                 IReader baseReader = RarReader.OpenReader(
                     archives
-                        .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                        .Select(s => Path.Join(TEST_ARCHIVES_PATH, s))
                         .Select(p => File.OpenRead(p)),
                     ReaderOptions.ForExternalStream with
                     {
@@ -141,12 +141,12 @@ public class RarReaderAsyncTests : ReaderTests
         foreach (var file in archives)
         {
             File.Copy(
-                Path.Combine(TEST_ARCHIVES_PATH, file),
-                Path.Combine(SCRATCH2_FILES_PATH, file)
+                Path.Join(TEST_ARCHIVES_PATH, file),
+                Path.Join(SCRATCH2_FILES_PATH, file)
             );
         }
         var streams = archives
-            .Select(s => Path.Combine(SCRATCH2_FILES_PATH, s))
+            .Select(s => Path.Join(SCRATCH2_FILES_PATH, s))
             .Select(File.OpenRead)
             .ToList();
         using (IReader baseReader = RarReader.OpenReader(streams))
@@ -163,7 +163,7 @@ public class RarReaderAsyncTests : ReaderTests
         }
         VerifyFiles();
 
-        foreach (var file in archives.Select(s => Path.Combine(SCRATCH2_FILES_PATH, s)))
+        foreach (var file in archives.Select(s => Path.Join(SCRATCH2_FILES_PATH, s)))
         {
             File.Delete(file);
         }
@@ -183,7 +183,7 @@ public class RarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Rar_Reader_Async_Reads_Into_Native_Memory()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.rar"));
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
             ReaderOptions.ForExternalStream with
@@ -264,7 +264,7 @@ public class RarReaderAsyncTests : ReaderTests
 
     private async ValueTask DoRar_Entry_Stream_Async(string filename)
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename)))
         await using (var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream)))
         {
             while (await reader.MoveToNextEntryAsync())
@@ -281,12 +281,12 @@ public class RarReaderAsyncTests : ReaderTests
                             ?? throw new InvalidOperationException(
                                 "Entry key must have a directory name."
                             );
-                        var destdir = Path.Combine(SCRATCH_FILES_PATH, folder);
+                        var destdir = Path.Join(SCRATCH_FILES_PATH, folder);
                         if (!Directory.Exists(destdir))
                         {
                             Directory.CreateDirectory(destdir);
                         }
-                        var destinationFileName = Path.Combine(destdir, file);
+                        var destinationFileName = Path.Join(destdir, file);
 
                         using var fs = File.OpenWrite(destinationFileName);
                         await entryStream.CopyToAsync(fs);
@@ -305,7 +305,7 @@ public class RarReaderAsyncTests : ReaderTests
     public async ValueTask Rar_Reader_Audio_program_Async()
     {
         using (
-            var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.Audio_program.rar"))
+            var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.Audio_program.rar"))
         )
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
@@ -324,15 +324,15 @@ public class RarReaderAsyncTests : ReaderTests
             }
         }
         CompareFilesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "test.dat"),
-            Path.Combine(MISC_TEST_FILES_PATH, "test.dat")
+            Path.Join(SCRATCH_FILES_PATH, "test.dat"),
+            Path.Join(MISC_TEST_FILES_PATH, "test.dat")
         );
     }
 
     [Fact]
     public async ValueTask Rar_Jpg_Reader_Async()
     {
-        using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
+        using (var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
         using (
             IReader baseReader = RarReader.OpenReader(
                 stream,
@@ -379,7 +379,7 @@ public class RarReaderAsyncTests : ReaderTests
 
     private async ValueTask DoRar_Solid_Skip_Reader_Async(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
             ReaderOptions.ForExternalStream with
@@ -405,7 +405,7 @@ public class RarReaderAsyncTests : ReaderTests
 
     private async ValueTask DoRar_Reader_Skip_Async(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
             ReaderOptions.ForExternalStream with
@@ -429,7 +429,7 @@ public class RarReaderAsyncTests : ReaderTests
         ReaderOptions? readerOptions = null
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),

--- a/tests/SharpCompress.Tests/Rar/RarReaderDisposeAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarReaderDisposeAsyncTests.cs
@@ -12,7 +12,7 @@ public class RarReaderDisposeAsyncTests : ReaderTests
     [Fact]
     public async ValueTask RarReader_AwaitUsing_DisposesUnpackV1_AfterEntryExtract()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.rar"));
         RarReader rarReader;
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
@@ -39,7 +39,7 @@ public class RarReaderDisposeAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Rar5Reader_AwaitUsing_DisposesUnpackV2017_AfterEntryExtract()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar5.rar"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar5.rar"));
         RarReader rarReader;
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(

--- a/tests/SharpCompress.Tests/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarReaderTests.cs
@@ -39,7 +39,7 @@ public class RarReaderTests : ReaderTests
         using (
             var reader = RarReader.OpenReader(
                 archives
-                    .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                    .Select(s => Path.Join(TEST_ARCHIVES_PATH, s))
                     .Select(p => File.OpenRead(p))
             )
         )
@@ -69,7 +69,7 @@ public class RarReaderTests : ReaderTests
             using (
                 var reader = RarReader.OpenReader(
                     archives
-                        .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                        .Select(s => Path.Join(TEST_ARCHIVES_PATH, s))
                         .Select(p => File.OpenRead(p)),
                     ReaderOptions.ForExternalStream with
                     {
@@ -113,12 +113,12 @@ public class RarReaderTests : ReaderTests
         foreach (var file in archives)
         {
             File.Copy(
-                Path.Combine(TEST_ARCHIVES_PATH, file),
-                Path.Combine(SCRATCH2_FILES_PATH, file)
+                Path.Join(TEST_ARCHIVES_PATH, file),
+                Path.Join(SCRATCH2_FILES_PATH, file)
             );
         }
         var streams = archives
-            .Select(s => Path.Combine(SCRATCH2_FILES_PATH, s))
+            .Select(s => Path.Join(SCRATCH2_FILES_PATH, s))
             .Select(File.OpenRead)
             .ToList();
         using (var reader = RarReader.OpenReader(streams))
@@ -134,7 +134,7 @@ public class RarReaderTests : ReaderTests
         }
         VerifyFiles();
 
-        foreach (var file in archives.Select(s => Path.Combine(SCRATCH2_FILES_PATH, s)))
+        foreach (var file in archives.Select(s => Path.Join(SCRATCH2_FILES_PATH, s)))
         {
             File.Delete(file);
         }
@@ -193,7 +193,7 @@ public class RarReaderTests : ReaderTests
 
     private void DoRar_Entry_Stream(string filename)
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename)))
         using (var reader = ReaderFactory.OpenReader(stream))
         {
             while (reader.MoveToNextEntry())
@@ -208,12 +208,12 @@ public class RarReaderTests : ReaderTests
                         ?? throw new InvalidOperationException(
                             "Entry key must have a directory name."
                         );
-                    var destdir = Path.Combine(SCRATCH_FILES_PATH, folder);
+                    var destdir = Path.Join(SCRATCH_FILES_PATH, folder);
                     if (!Directory.Exists(destdir))
                     {
                         Directory.CreateDirectory(destdir);
                     }
-                    var destinationFileName = Path.Combine(destdir, file);
+                    var destinationFileName = Path.Join(destdir, file);
 
                     using var fs = File.OpenWrite(destinationFileName);
                     entryStream.CopyTo(fs);
@@ -227,7 +227,7 @@ public class RarReaderTests : ReaderTests
     public void Rar_Reader_Audio_program()
     {
         using (
-            var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.Audio_program.rar"))
+            var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.Audio_program.rar"))
         )
         using (
             var reader = ReaderFactory.OpenReader(
@@ -246,15 +246,15 @@ public class RarReaderTests : ReaderTests
             }
         }
         CompareFilesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "test.dat"),
-            Path.Combine(MISC_TEST_FILES_PATH, "test.dat")
+            Path.Join(SCRATCH_FILES_PATH, "test.dat"),
+            Path.Join(MISC_TEST_FILES_PATH, "test.dat")
         );
     }
 
     [Fact]
     public void Rar_Jpg_Reader()
     {
-        using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
+        using (var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
         using (
             var reader = RarReader.OpenReader(
                 stream,
@@ -294,7 +294,7 @@ public class RarReaderTests : ReaderTests
 
     private void DoRar_Solid_Skip_Reader(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var reader = ReaderFactory.OpenReader(
             stream,
             ReaderOptions.ForExternalStream with
@@ -320,7 +320,7 @@ public class RarReaderTests : ReaderTests
 
     private void DoRar_Reader_Skip(string filename)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, filename));
         using var reader = ReaderFactory.OpenReader(
             stream,
             ReaderOptions.ForExternalStream with
@@ -342,7 +342,7 @@ public class RarReaderTests : ReaderTests
     public void Rar_SkipEncryptedFilesWithoutPassword()
     {
         using var stream = File.OpenRead(
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
         );
         using var reader = ReaderFactory.OpenReader(
             stream,
@@ -418,17 +418,17 @@ public class RarReaderTests : ReaderTests
                 "exe",
                 "Empty",
                 "тест.txt",
-                Path.Combine("jpg", "test.jpg"),
-                Path.Combine("exe", "test.exe"),
+                Path.Join("jpg", "test.jpg"),
+                Path.Join("exe", "test.exe"),
             }
         );
         using var reader = RarReader.OpenReader([
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part01.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part02.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part03.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part04.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part05.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part06.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.multi.part01.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.multi.part02.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.multi.part03.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.multi.part04.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.multi.part05.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar.multi.part06.rar"),
         ]);
         while (reader.MoveToNextEntry())
         {

--- a/tests/SharpCompress.Tests/Rar/RarStoredEntryStreamTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarStoredEntryStreamTests.cs
@@ -24,7 +24,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar5.none.rar")]
     public void Stored_SingleVolume_CanSeek_And_MatchesFullRead(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = archive.Entries.First(e => !e.IsDirectory && e.Size > 0);
         var full = ReadFully(entry);
 
@@ -41,7 +41,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar5.none.rar")]
     public void Stored_SingleVolume_SeekRead_MatchesSlice(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = archive.Entries.First(e => !e.IsDirectory && e.Size > 0);
         var full = ReadFully(entry);
         long[] offsets = [0, 1, full.Length / 4, full.Length / 2, Math.Max(0, full.Length - 16)];
@@ -64,7 +64,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar5.none.rar")]
     public void Stored_SequentialEof_Throws_On_CrcMismatch(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = archive
             .Entries.OfType<RarArchiveEntry>()
             .First(e => !e.IsDirectory && e.Size > 0);
@@ -81,7 +81,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar5.none.rar")]
     public void Stored_AfterSeek_DoesNotValidateCrc(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = archive
             .Entries.OfType<RarArchiveEntry>()
             .First(e => !e.IsDirectory && e.Size > 0);
@@ -97,7 +97,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar5.none.rar")]
     public void Stored_EofAtLength_ReturnsZero(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = archive.Entries.First(e => !e.IsDirectory && e.Size > 0);
         using var stream = entry.OpenEntryStream();
         Assert.IsType<StoredRarEntryStream>(stream);
@@ -110,7 +110,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar5.none.rar")]
     public void Stored_InterleavedConcurrentStreams_MatchReference(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entries = archive.Entries.Where(e => !e.IsDirectory && e.Size > 0).Take(2).ToList();
         Assert.True(entries.Count >= 2);
 
@@ -208,7 +208,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     [InlineData("Rar.solid.rar")]
     public void NonStored_Or_Solid_Uses_NonSeekable_SlowPath(string archiveName)
     {
-        using var archive = RarArchive.OpenArchive(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var archive = RarArchive.OpenArchive(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var entry = archive.Entries.First(e => !e.IsDirectory && e.Size > 0);
         using var stream = entry.OpenEntryStream();
         Assert.False(stream.CanSeek);
@@ -221,7 +221,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     public async Task Stored_Async_SeekRead_MatchesSlice(string archiveName)
     {
         await using var archive = await RarArchive.OpenAsyncArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, archiveName)
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
         );
         SharpCompress.Archives.IArchiveEntry? entry = null;
         await foreach (var e in archive.EntriesAsync)
@@ -253,7 +253,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     public async Task Stored_MultiVolume_Async_FullRead()
     {
         var streams = MultiNoneParts
-            .Select(p => (Stream)File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, p)))
+            .Select(p => (Stream)File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, p)))
             .ToArray();
         try
         {
@@ -287,7 +287,7 @@ public class RarStoredEntryStreamTests : ArchiveTests
     private static IRarArchive OpenMultiNone()
     {
         var streams = MultiNoneParts
-            .Select(p => (Stream)File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, p)))
+            .Select(p => (Stream)File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, p)))
             .ToArray();
         return RarArchive.OpenArchive(streams);
     }

--- a/tests/SharpCompress.Tests/Rar/RarUncompressedSizeUnknownTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarUncompressedSizeUnknownTests.cs
@@ -61,7 +61,7 @@ public class RarUncompressedSizeUnknownTests
     [Fact]
     public void ExistingRar5Fixture_KnownSize_IsNotUnknown()
     {
-        var path = Path.Combine(TestBase.TEST_ARCHIVES_PATH, "Rar5.none.rar");
+        var path = Path.Join(TestBase.TEST_ARCHIVES_PATH, "Rar5.none.rar");
         using var stream = File.OpenRead(path);
         var factory = new RarHeaderFactory(
             StreamingMode.Seekable,

--- a/tests/SharpCompress.Tests/ReaderTests.cs
+++ b/tests/SharpCompress.Tests/ReaderTests.cs
@@ -31,7 +31,7 @@ public abstract class ReaderTests : TestBase
         Action<string, ReaderOptions> readImpl
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         options ??= ReaderOptions.ForFilePath.WithBufferSize(0x20000);
 
         var optionsWithStreamOpen = options.WithLeaveStreamOpen(true);
@@ -98,7 +98,7 @@ public abstract class ReaderTests : TestBase
         CancellationToken cancellationToken = default
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         var factory = new TarFactory();
         (
             await factory.IsArchiveAsync(
@@ -127,7 +127,7 @@ public abstract class ReaderTests : TestBase
         CancellationToken cancellationToken = default
     )
     {
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
 
         options ??= ReaderOptions.ForExternalStream.WithBufferSize(0x20000);
 
@@ -205,7 +205,7 @@ public abstract class ReaderTests : TestBase
 
     protected void ReadForBufferBoundaryCheck(string fileName, CompressionType compressionType)
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, fileName));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, fileName));
         using var reader = ReaderFactory.OpenReader(
             stream,
             ReaderOptions.ForExternalStream with
@@ -222,8 +222,8 @@ public abstract class ReaderTests : TestBase
         }
 
         CompareFilesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "alice29.txt"),
-            Path.Combine(MISC_TEST_FILES_PATH, "alice29.txt")
+            Path.Join(SCRATCH_FILES_PATH, "alice29.txt"),
+            Path.Join(MISC_TEST_FILES_PATH, "alice29.txt")
         );
     }
 
@@ -240,7 +240,7 @@ public abstract class ReaderTests : TestBase
         }
         var expected = new Stack<string>(fileOrder.Split(' '));
 
-        testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
+        testArchive = Path.Join(TEST_ARCHIVES_PATH, testArchive);
         using var file = File.OpenRead(testArchive);
         using var forward = new ForwardOnlyStream(file);
         using var reader = ReaderFactory.OpenReader(forward, options);
@@ -257,7 +257,7 @@ public abstract class ReaderTests : TestBase
     )
     {
         using var reader = readerFactory(
-            archives.Select(s => Path.Combine(TEST_ARCHIVES_PATH, s)).Select(File.OpenRead)
+            archives.Select(s => Path.Join(TEST_ARCHIVES_PATH, s)).Select(File.OpenRead)
         );
 
         while (reader.MoveToNextEntry())

--- a/tests/SharpCompress.Tests/Readers/EntryStreamDisposeTests.cs
+++ b/tests/SharpCompress.Tests/Readers/EntryStreamDisposeTests.cs
@@ -59,7 +59,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public void ZeroLengthRead_DoesNotMarkEntryCompleted()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         string expectedContent;
         using (
             var reader = ReaderFactory.OpenReader(
@@ -94,7 +94,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public void ZeroLengthSpanRead_DoesNotMarkEntryCompleted()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         string expectedContent;
         using (
             var reader = ReaderFactory.OpenReader(
@@ -128,7 +128,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public async Task ZeroLengthReadAsync_DoesNotMarkEntryCompleted()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         string expectedContent;
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
@@ -163,7 +163,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public void Dispose_Default_DrainsRemainingEntryBytes()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var counting = new CountingReadStream(
             new ForwardOnlyStream(new MemoryStream(archiveBytes)),
             leaveOpen: false
@@ -192,7 +192,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public void Dispose_Default_SeekableSourceSeeksPastRemainingEntryBytes()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var counting = new CountingReadStream(new MemoryStream(archiveBytes), leaveOpen: false);
         using var reader = ReaderFactory.OpenReader(counting, ReaderOptions.ForExternalStream);
 
@@ -218,7 +218,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public async Task DisposeAsync_Default_SeekableSourceSeeksPastRemainingEntryBytes()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var counting = new CountingReadStream(new MemoryStream(archiveBytes), leaveOpen: false);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             counting,
@@ -247,7 +247,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public void Dispose_CancelOnEntryStreamDispose_DoesNotDrain()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var counting = new CountingReadStream(new MemoryStream(archiveBytes), leaveOpen: false);
         using var reader = ReaderFactory.OpenReader(
             counting,
@@ -277,7 +277,7 @@ public class EntryStreamDisposeTests : TestBase
     [Fact]
     public async Task DisposeAsync_CancelOnEntryStreamDispose_DoesNotDrain()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"));
         var counting = new CountingReadStream(new MemoryStream(archiveBytes), leaveOpen: false);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             counting,

--- a/tests/SharpCompress.Tests/RemainingCrcExtractionTests.cs
+++ b/tests/SharpCompress.Tests/RemainingCrcExtractionTests.cs
@@ -20,7 +20,7 @@ public class RemainingCrcExtractionTests : TestBase
     {
         using var stream = new MemoryStream(ReadCorruptedArchive(archiveName, payloadMarker));
         using var reader = ReaderFactory.OpenReader(stream);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
         Directory.CreateDirectory(destination);
 
         Assert.Throws<InvalidFormatException>(() => reader.WriteAllToDirectory(destination));
@@ -37,7 +37,7 @@ public class RemainingCrcExtractionTests : TestBase
     {
         using var stream = new MemoryStream(ReadCorruptedArchive(archiveName, payloadMarker));
         using var reader = ReaderFactory.OpenReader(stream);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var destination = Path.Join(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
         Directory.CreateDirectory(destination);
 
         reader.WriteAllToDirectory(destination, new ExtractionOptions { CheckCrc = false });
@@ -48,7 +48,7 @@ public class RemainingCrcExtractionTests : TestBase
     [Fact]
     public void LZipStream_Throws_On_Trailer_Crc_Mismatch()
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.lz"));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.lz"));
         bytes[^20] ^= 1;
         using var stream = LZipStream.Create(
             new MemoryStream(bytes),
@@ -61,7 +61,7 @@ public class RemainingCrcExtractionTests : TestBase
 
     private static byte[] ReadCorruptedArchive(string archiveName, string payloadMarker)
     {
-        var bytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        var bytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var marker = System.Text.Encoding.ASCII.GetBytes(payloadMarker);
         var offset = bytes.AsSpan().IndexOf(marker);
         if (offset < 0)

--- a/tests/SharpCompress.Tests/Security/ExtractionPathTraversalTests.cs
+++ b/tests/SharpCompress.Tests/Security/ExtractionPathTraversalTests.cs
@@ -23,7 +23,6 @@ public class ExtractionPathTraversalTests : TestBase
         {
             { "ReaderAll", "zip", "../escape.txt" },
             { "ReaderAll", "zip", "a/../../escape.txt" },
-            { "ReaderAll", "zip", "/abs.txt" },
         };
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -41,7 +40,6 @@ public class ExtractionPathTraversalTests : TestBase
         {
             { "ReaderAll", "tar", "../escape.txt" },
             { "ReaderAll", "tar", "a/../../escape.txt" },
-            { "ReaderAll", "tar", "/abs.txt" },
         };
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -62,12 +60,12 @@ public class ExtractionPathTraversalTests : TestBase
         string entryName
     )
     {
-        var parentDir = Path.Combine(SCRATCH_FILES_PATH, $"traversal_{Path.GetRandomFileName()}");
-        var extractDir = Path.Combine(parentDir, "extract");
+        var parentDir = Path.Join(SCRATCH_FILES_PATH, $"traversal_{Path.GetRandomFileName()}");
+        var extractDir = Path.Join(parentDir, "extract");
         Directory.CreateDirectory(extractDir);
-        var siblingDir = Path.Combine(parentDir, "sibling");
+        var siblingDir = Path.Join(parentDir, "sibling");
         Directory.CreateDirectory(siblingDir);
-        var archivePath = Path.Combine(
+        var archivePath = Path.Join(
             SCRATCH2_FILES_PATH,
             $"{api}_{archiveFormat}_{Guid.NewGuid():N}.archive"
         );
@@ -86,7 +84,39 @@ public class ExtractionPathTraversalTests : TestBase
         var extractionException = Assert.IsType<ExtractionException>(exception);
         Assert.Contains("outside of the destination", extractionException.Message);
         AssertNothingEscaped(parentDir, extractDir);
-        Assert.False(File.Exists(Path.Combine(siblingDir, "escape.txt")));
+        Assert.False(File.Exists(Path.Join(siblingDir, "escape.txt")));
+    }
+
+    [Theory]
+    [InlineData("zip")]
+    [InlineData("tar")]
+    public async Task AbsolutePathEntry_IsSafelyExtractedInsideDestination(string archiveFormat)
+    {
+        var parentDir = Path.Join(SCRATCH_FILES_PATH, $"abs_{Path.GetRandomFileName()}");
+        var extractDir = Path.Join(parentDir, "extract");
+        Directory.CreateDirectory(extractDir);
+        var archivePath = Path.Join(
+            SCRATCH2_FILES_PATH,
+            $"abs_{archiveFormat}_{Guid.NewGuid():N}.archive"
+        );
+
+        if (archiveFormat == "zip")
+        {
+            BuildZip(archivePath, "/abs.txt");
+        }
+        else
+        {
+            BuildTar(archivePath, "/abs.txt");
+        }
+
+        var exception = await RecordExtractionExceptionAsync(
+            "ReaderAll",
+            archivePath,
+            extractDir
+        );
+
+        Assert.Null(exception);
+        AssertNothingEscaped(parentDir, extractDir);
     }
 
     [Theory]
@@ -100,11 +130,11 @@ public class ExtractionPathTraversalTests : TestBase
     [InlineData("AsyncArchiveEntry")]
     public async Task DirectoryTraversalToExistingOutsideDirectory_ShouldThrow(string api)
     {
-        var extractDir = Path.Combine(SCRATCH_FILES_PATH, "extract");
+        var extractDir = Path.Join(SCRATCH_FILES_PATH, "extract");
         Directory.CreateDirectory(extractDir);
-        var escapedDirectory = Path.GetFullPath(Path.Combine(extractDir, "../../escaped_existing"));
+        var escapedDirectory = Path.GetFullPath(Path.Join(extractDir, "../../escaped_existing"));
         Directory.CreateDirectory(escapedDirectory);
-        var archivePath = Path.Combine(SCRATCH2_FILES_PATH, $"{api}.zip");
+        var archivePath = Path.Join(SCRATCH2_FILES_PATH, $"{api}.zip");
         BuildZip(archivePath, "../../escaped_existing/");
 
         var exception = await RecordExtractionExceptionAsync(api, archivePath, extractDir);
@@ -124,18 +154,18 @@ public class ExtractionPathTraversalTests : TestBase
     [InlineData("AsyncArchiveEntry")]
     public async Task FileTraversalToSiblingDirectory_ShouldThrow(string api)
     {
-        var extractDir = Path.Combine(SCRATCH_FILES_PATH, "extract");
+        var extractDir = Path.Join(SCRATCH_FILES_PATH, "extract");
         Directory.CreateDirectory(extractDir);
-        var siblingDirectory = Path.Combine(SCRATCH_FILES_PATH, "extract2");
+        var siblingDirectory = Path.Join(SCRATCH_FILES_PATH, "extract2");
         Directory.CreateDirectory(siblingDirectory);
-        var archivePath = Path.Combine(SCRATCH2_FILES_PATH, $"{api}.zip");
+        var archivePath = Path.Join(SCRATCH2_FILES_PATH, $"{api}.zip");
         BuildZip(archivePath, "../extract2/evil.txt");
 
         var exception = await RecordExtractionExceptionAsync(api, archivePath, extractDir);
 
         var extractionException = Assert.IsType<ExtractionException>(exception);
         Assert.Contains("outside of the destination", extractionException.Message);
-        Assert.False(File.Exists(Path.Combine(siblingDirectory, "evil.txt")));
+        Assert.False(File.Exists(Path.Join(siblingDirectory, "evil.txt")));
     }
 
     private static void BuildZip(string path, string entryName)

--- a/tests/SharpCompress.Tests/Security/ZipSlip.cs
+++ b/tests/SharpCompress.Tests/Security/ZipSlip.cs
@@ -18,7 +18,7 @@ public class ZipSlip : TestBase
         Console.WriteLine("--- Sync: archive.WriteToDirectory() ---");
         var (extractDir, parentDir) = SetupDirs("sync");
         Directory.CreateDirectory(extractDir);
-        var archivePath = Path.Combine(parentDir, "malicious.zip");
+        var archivePath = Path.Join(parentDir, "malicious.zip");
 
         BuildMaliciousZip(archivePath);
 
@@ -45,7 +45,7 @@ public class ZipSlip : TestBase
         Console.WriteLine("--- Async: archive.WriteToDirectoryAsync() ---");
         var (extractDir, parentDir) = SetupDirs("async");
         Directory.CreateDirectory(extractDir);
-        var archivePath = Path.Combine(parentDir, "malicious.zip");
+        var archivePath = Path.Join(parentDir, "malicious.zip");
 
         BuildMaliciousZip(archivePath);
 
@@ -77,7 +77,7 @@ public class ZipSlip : TestBase
         // 1. Relative traversal: two levels up, then "escaped_relative/"
         zip.CreateEntry("../../escaped_relative/");
 
-        // 2. Absolute Unix path (Path.Combine discards the base when second arg is rooted)
+        // 2. Absolute Unix path (Path.Join discards the base when second arg is rooted)
         zip.CreateEntry("/tmp/escaped_absolute/");
 
         // 3. A legitimate entry for contrast
@@ -86,12 +86,12 @@ public class ZipSlip : TestBase
 
     private (string extractDir, string parentDir) SetupDirs(string label)
     {
-        var parentDir = Path.Combine(
+        var parentDir = Path.Join(
             SCRATCH_FILES_PATH,
             $"sc_poc_{label}_{Path.GetRandomFileName()}"
         );
         Directory.CreateDirectory(parentDir);
-        var extractDir = Path.Combine(parentDir, "extract_target");
+        var extractDir = Path.Join(parentDir, "extract_target");
 
         Console.WriteLine($"  Parent  : {parentDir}");
         Console.WriteLine($"  Target  : {extractDir}");
@@ -110,7 +110,7 @@ public class ZipSlip : TestBase
 
         // Relative traversal "../../escaped_relative/" escapes two levels above extractDir
         // (which is parentDir/extract_target), landing in Path.GetTempPath()
-        var relTarget = Path.GetFullPath(Path.Combine(extractDir, "../../escaped_relative"));
+        var relTarget = Path.GetFullPath(Path.Join(extractDir, "../../escaped_relative"));
         if (Directory.Exists(relTarget))
         {
             Console.WriteLine($"    [ESCAPED] relative traversal created: {relTarget}");

--- a/tests/SharpCompress.Tests/SevenZip/Aes7zKeyCacheTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/Aes7zKeyCacheTests.cs
@@ -20,7 +20,7 @@ public class Aes7zKeyCacheTests : TestBase
     [Fact]
     public void SevenZip_LZMAAES_ExtractTwice_ProducesIdenticalOutput()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, EncryptedArchive);
+        var path = Path.Join(TEST_ARCHIVES_PATH, EncryptedArchive);
         var options = ReaderOptions.ForFilePath with { Password = Password };
 
         var first = ExtractAllEntryBytes(path, options);
@@ -36,7 +36,7 @@ public class Aes7zKeyCacheTests : TestBase
     [Fact]
     public void SevenZip_LZMAAES_WrongPassword_DoesNotContaminateCorrectExtraction()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, EncryptedArchive);
+        var path = Path.Join(TEST_ARCHIVES_PATH, EncryptedArchive);
         var correctOptions = ReaderOptions.ForFilePath with { Password = Password };
         var wrongOptions = ReaderOptions.ForFilePath with { Password = "wrongpassword" };
 

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipArchiveAsyncTests.cs
@@ -18,7 +18,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task SevenZipArchive_LZMA_AsyncStreamExtraction()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z");
         await using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -26,7 +26,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
 
         await foreach (var entry in archive.EntriesAsync.Where(entry => !entry.IsDirectory))
         {
-            var targetPath = Path.Combine(SCRATCH_FILES_PATH, entry.Key!);
+            var targetPath = Path.Join(SCRATCH_FILES_PATH, entry.Key!);
             var targetDir = Path.GetDirectoryName(targetPath);
 
             if (!string.IsNullOrEmpty(targetDir) && !Directory.Exists(targetDir))
@@ -45,7 +45,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     //[Fact]
     public async Task SevenZipArchive_LZMA2_AsyncStreamExtraction()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA2.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA2.7z");
         await using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -53,7 +53,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
 
         await foreach (var entry in archive.EntriesAsync.Where(entry => !entry.IsDirectory))
         {
-            var targetPath = Path.Combine(SCRATCH_FILES_PATH, entry.Key!);
+            var targetPath = Path.Join(SCRATCH_FILES_PATH, entry.Key!);
             var targetDir = Path.GetDirectoryName(targetPath);
 
             if (!string.IsNullOrEmpty(targetDir) && !Directory.Exists(targetDir))
@@ -72,7 +72,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task SevenZipArchive_Solid_AsyncStreamExtraction()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         await using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -80,7 +80,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
 
         await foreach (var entry in archive.EntriesAsync.Where(entry => !entry.IsDirectory))
         {
-            var targetPath = Path.Combine(SCRATCH_FILES_PATH, entry.Key!);
+            var targetPath = Path.Join(SCRATCH_FILES_PATH, entry.Key!);
             var targetDir = Path.GetDirectoryName(targetPath);
 
             if (!string.IsNullOrEmpty(targetDir) && !Directory.Exists(targetDir))
@@ -103,7 +103,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
         var progress = new SynchronousProgress<ProgressReport>(report =>
             progressReports.Add(report)
         );
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         await using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -118,7 +118,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task SevenZipArchive_BZip2_AsyncStreamExtraction()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.BZip2.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.BZip2.7z");
         await using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -126,7 +126,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
 
         await foreach (var entry in archive.EntriesAsync.Where(entry => !entry.IsDirectory))
         {
-            var targetPath = Path.Combine(SCRATCH_FILES_PATH, entry.Key!);
+            var targetPath = Path.Join(SCRATCH_FILES_PATH, entry.Key!);
             var targetDir = Path.GetDirectoryName(targetPath);
 
             if (!string.IsNullOrEmpty(targetDir) && !Directory.Exists(targetDir))
@@ -145,7 +145,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task SevenZipArchive_PPMd_AsyncStreamExtraction()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.PPMd.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.PPMd.7z");
         await using var stream = File.OpenRead(testArchive);
         await using var archive = await ArchiveFactory.OpenAsyncArchive(
             new AsyncOnlyStream(stream)
@@ -153,7 +153,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
 
         await foreach (var entry in archive.EntriesAsync.Where(entry => !entry.IsDirectory))
         {
-            var targetPath = Path.Combine(SCRATCH_FILES_PATH, entry.Key!);
+            var targetPath = Path.Join(SCRATCH_FILES_PATH, entry.Key!);
             var targetDir = Path.GetDirectoryName(targetPath);
 
             if (!string.IsNullOrEmpty(targetDir) && !Directory.Exists(targetDir))
@@ -173,17 +173,17 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     public async Task SevenZipArchive_TestSolidDetectionAsync()
     {
         await using var oneBlockSolidArchive = await SevenZipArchive.OpenAsyncArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.1block.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.1block.7z")
         );
         Assert.True(await oneBlockSolidArchive.IsSolidAsync());
 
         await using var solidArchive = await SevenZipArchive.OpenAsyncArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z")
         );
         Assert.True(await solidArchive.IsSolidAsync());
 
         await using var nonSolidArchive = await SevenZipArchive.OpenAsyncArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.nonsolid.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.nonsolid.7z")
         );
         Assert.False(await nonSolidArchive.IsSolidAsync());
     }
@@ -193,7 +193,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     {
         // This test verifies that solid archives iterate entries as contiguous streams
         // rather than recreating the decompression stream for each entry
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         await using var archive = await SevenZipArchive.OpenAsyncArchive(testArchive);
         Assert.True(await archive.IsSolidAsync());
 
@@ -214,7 +214,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     {
         // This test verifies that the folder stream is reused within each folder
         // and not recreated for each entry in solid archives
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         await using var archive = await SevenZipArchive.OpenAsyncArchive(testArchive);
         Assert.True(await archive.IsSolidAsync());
 
@@ -282,7 +282,7 @@ public class SevenZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async Task SevenZipArchive_ExtractAllEntriesAsync_Dispose_DoesNotDisposeVolumeStream()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         await using var archive = (SevenZipArchive)
             await SevenZipArchive.OpenAsyncArchive(testArchive);
         var volumeStream = ((SevenZipVolume)archive.Volumes.Single()).Stream;

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipArchiveTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipArchiveTests.cs
@@ -138,7 +138,7 @@ public class SevenZipArchiveTests : ArchiveTests
     public void SevenZipArchive_Entry_Attrib_ReturnsNullOrValueWithoutThrowing()
     {
         using var archive = ArchiveFactory.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
         );
 
         Assert.NotEmpty(archive.Entries);
@@ -206,7 +206,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_Copy_CompressionType()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "7Zip.Copy.7z")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "7Zip.Copy.7z")))
         using (var archive = SevenZipArchive.OpenArchive(stream))
         {
             foreach (var entry in archive.Entries.Where(e => !e.IsDirectory))
@@ -277,23 +277,23 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_Tar_PathRead()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "7Zip.Tar.tar.7z")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "7Zip.Tar.tar.7z")))
         using (var archive = SevenZipArchive.OpenArchive(stream))
         {
             var entry = archive.Entries.First();
-            entry.WriteToFile(Path.Combine(SCRATCH_FILES_PATH, entry.Key.NotNull()));
+            entry.WriteToFile(Path.Join(SCRATCH_FILES_PATH, entry.Key.NotNull()));
 
             var size = entry.Size;
-            var scratch = new FileInfo(Path.Combine(SCRATCH_FILES_PATH, "7Zip.Tar.tar"));
-            var test = new FileInfo(Path.Combine(TEST_ARCHIVES_PATH, "7Zip.Tar.tar"));
+            var scratch = new FileInfo(Path.Join(SCRATCH_FILES_PATH, "7Zip.Tar.tar"));
+            var test = new FileInfo(Path.Join(TEST_ARCHIVES_PATH, "7Zip.Tar.tar"));
 
             Assert.Equal(size, scratch.Length);
             Assert.Equal(size, test.Length);
         }
 
         CompareArchivesByPath(
-            Path.Combine(SCRATCH_FILES_PATH, "7Zip.Tar.tar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.Tar.tar")
+            Path.Join(SCRATCH_FILES_PATH, "7Zip.Tar.tar"),
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.Tar.tar")
         );
     }
 
@@ -301,7 +301,7 @@ public class SevenZipArchiveTests : ArchiveTests
     public void SevenZipArchive_TestEncryptedDetection()
     {
         using var passwordProtectedFilesArchive = SevenZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.encryptedFiles.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.encryptedFiles.7z")
         );
         Assert.True(passwordProtectedFilesArchive.IsEncrypted);
     }
@@ -330,17 +330,17 @@ public class SevenZipArchiveTests : ArchiveTests
     public void SevenZipArchive_TestSolidDetection()
     {
         using var oneBlockSolidArchive = SevenZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.1block.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.1block.7z")
         );
         Assert.True(oneBlockSolidArchive.IsSolid);
 
         using var solidArchive = SevenZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z")
         );
         Assert.True(solidArchive.IsSolid);
 
         using var nonSolidArchive = SevenZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.nonsolid.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.nonsolid.7z")
         );
         Assert.False(nonSolidArchive.IsSolid);
     }
@@ -350,7 +350,7 @@ public class SevenZipArchiveTests : ArchiveTests
     {
         // This test verifies that solid archives iterate entries as contiguous streams
         // rather than recreating the decompression stream for each entry
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         using var archive = SevenZipArchive.OpenArchive(testArchive);
         Assert.True(archive.IsSolid);
 
@@ -371,7 +371,7 @@ public class SevenZipArchiveTests : ArchiveTests
     {
         // This test verifies that the folder stream is reused within each folder
         // and not recreated for each entry in solid archives
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         using var archive = SevenZipArchive.OpenArchive(testArchive);
         Assert.True(archive.IsSolid);
 
@@ -439,7 +439,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_Solid_ArchiveApi_SequentialMatchesExtractAllEntries()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         var expected = ReadSolidEntriesViaExtractAllEntries(testArchive);
 
         using var archive = SevenZipArchive.OpenArchive(testArchive);
@@ -457,7 +457,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_Solid_ArchiveApi_OutOfOrderOpen_StillCorrect()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         var expected = ReadSolidEntriesViaExtractAllEntries(testArchive);
 
         using var archive = SevenZipArchive.OpenArchive(testArchive);
@@ -477,7 +477,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_Solid_ArchiveApi_EarlyDispose_ThenNextEntryCorrect()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         var expected = ReadSolidEntriesViaExtractAllEntries(testArchive);
 
         using var archive = SevenZipArchive.OpenArchive(testArchive);
@@ -499,7 +499,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_Solid_ArchiveApi_ReOpenSameEntry_UsesDecodedCache()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.solid.7z");
         var expected = ReadSolidEntriesViaExtractAllEntries(testArchive);
 
         using var archive = SevenZipArchive.OpenArchive(testArchive);
@@ -544,7 +544,7 @@ public class SevenZipArchiveTests : ArchiveTests
         // (files with size 0 and no compressed data) can be extracted without throwing
         // NullReferenceException. This was previously failing because the folder was null
         // for empty-stream entries.
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.EmptyStream.7z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "7Zip.EmptyStream.7z");
         using var archive = SevenZipArchive.OpenArchive(testArchive);
 
         var emptyStreamFileCount = 0;
@@ -589,7 +589,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_LookForHeader_FindsSignatureAfterLargeStub()
     {
-        var archiveBytes = File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z"));
+        var archiveBytes = File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z"));
         const int stubSize = 5 * 1024;
         using var stream = new MemoryStream(stubSize + archiveBytes.Length);
         stream.Write(new byte[stubSize]);

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipAsyncStressTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipAsyncStressTests.cs
@@ -46,7 +46,7 @@ public class SevenZipAsyncStressTests : TestBase
     [InlineData("7Zip.solid.7z")]
     public async Task SevenZip_OpenAsyncArchive_OddBuffers(string archiveName)
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, archiveName);
         foreach (var bufferSize in BufferSizes)
         {
             CleanScratch();
@@ -57,7 +57,7 @@ public class SevenZipAsyncStressTests : TestBase
 
             await foreach (var entry in archive.EntriesAsync.Where(e => !e.IsDirectory))
             {
-                var targetPath = Path.Combine(SCRATCH_FILES_PATH, entry.Key!);
+                var targetPath = Path.Join(SCRATCH_FILES_PATH, entry.Key!);
                 var targetDir = Path.GetDirectoryName(targetPath);
                 if (!string.IsNullOrEmpty(targetDir))
                 {
@@ -79,7 +79,7 @@ public class SevenZipAsyncStressTests : TestBase
     [InlineData("7Zip.solid.7z")]
     public async Task SevenZip_ExtractAllEntriesAsync_OddBuffers(string archiveName)
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, archiveName);
         foreach (var bufferSize in BufferSizes)
         {
             CleanScratch();
@@ -96,7 +96,7 @@ public class SevenZipAsyncStressTests : TestBase
                     continue;
                 }
 
-                var targetPath = Path.Combine(SCRATCH_FILES_PATH, reader.Entry.Key!);
+                var targetPath = Path.Join(SCRATCH_FILES_PATH, reader.Entry.Key!);
                 var targetDir = Path.GetDirectoryName(targetPath);
                 if (!string.IsNullOrEmpty(targetDir))
                 {

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipCrcExtractionTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipCrcExtractionTests.cs
@@ -15,10 +15,10 @@ public class SevenZipCrcExtractionTests : ArchiveTests
     public void SevenZip_Archive_WriteToFile_Throws_On_Crc_Mismatch()
     {
         using var archive = SevenZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
         );
         var entry = CorruptFirstFileCrc(archive);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "7zip-crc-mismatch.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "7zip-crc-mismatch.txt");
 
         var exception = Assert.Throws<InvalidFormatException>(() => entry.WriteToFile(destination));
 
@@ -29,10 +29,10 @@ public class SevenZipCrcExtractionTests : ArchiveTests
     public void SevenZip_Archive_WriteToFile_Skips_Crc_Mismatch_When_Disabled()
     {
         using var archive = SevenZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
         );
         var entry = CorruptFirstFileCrc(archive);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "7zip-crc-disabled.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "7zip-crc-disabled.txt");
 
         entry.WriteToFile(destination, new ExtractionOptions { CheckCrc = false });
 
@@ -43,11 +43,11 @@ public class SevenZipCrcExtractionTests : ArchiveTests
     public async Task SevenZip_Archive_WriteToFileAsync_Throws_On_Crc_Mismatch()
     {
         await using var archive = await SevenZipArchive.OpenAsyncArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
+            Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z")
         );
         var entries = await archive.EntriesAsync.ToListAsync();
         var entry = CorruptFirstFileCrc(entries);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "7zip-crc-mismatch-async.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "7zip-crc-mismatch-async.txt");
 
         var exception = await Assert.ThrowsAsync<InvalidFormatException>(async () =>
             await entry.WriteToFileAsync(destination)

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipHeaderValidationTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipHeaderValidationTests.cs
@@ -11,7 +11,7 @@ namespace SharpCompress.Test.SevenZip;
 public class SevenZipHeaderValidationTests : TestBase
 {
     private static byte[] ReadArchiveBytes(string fileName) =>
-        File.ReadAllBytes(Path.Combine(TEST_ARCHIVES_PATH, fileName));
+        File.ReadAllBytes(Path.Join(TEST_ARCHIVES_PATH, fileName));
 
     [Fact]
     public void OpenArchive_Throws_On_Invalid_Signature()

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipMetadataApiTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipMetadataApiTests.cs
@@ -18,7 +18,7 @@ public class SevenZipMetadataApiTests : TestBase
     [Fact]
     public void StoredCopy_TryGetPackedByteRange_SlicesExactPayload()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.Copy.7z");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "7Zip.Copy.7z");
         using var archive = (SevenZipArchive)SevenZipArchive.OpenArchive(path);
 
         var any = false;
@@ -42,7 +42,7 @@ public class SevenZipMetadataApiTests : TestBase
     [Fact]
     public void AesCopy_ReportsNoneAndWholeFolderRange()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.Copy.Aes.7z");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "7Zip.Copy.Aes.7z");
         using var archive = (SevenZipArchive)
             SevenZipArchive.OpenArchive(
                 path,
@@ -71,7 +71,7 @@ public class SevenZipMetadataApiTests : TestBase
     [InlineData("7Zip.LZMA2.Aes.7z")]
     public void AesLzma_ReportsLzma_And_NoContiguousRange(string archiveName)
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var path = Path.Join(TEST_ARCHIVES_PATH, archiveName);
         using var archive = (SevenZipArchive)
             SevenZipArchive.OpenArchive(
                 path,
@@ -94,7 +94,7 @@ public class SevenZipMetadataApiTests : TestBase
     [InlineData("7Zip.solid.7z")]
     public void Compressed_HasNoContiguousRange(string archiveName)
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, archiveName);
+        var path = Path.Join(TEST_ARCHIVES_PATH, archiveName);
         using var archive = (SevenZipArchive)SevenZipArchive.OpenArchive(path);
 
         foreach (var entry in archive.Entries.Where(e => !e.IsDirectory && e.Size > 0))

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipWritableArchiveTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipWritableArchiveTests.cs
@@ -51,7 +51,7 @@ public class SevenZipWritableArchiveTests : TestBase
     [Fact]
     public void SevenZipWritableArchive_ModifyExisting_RemoveAndAdd_RoundTrip()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, FixtureArchive);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, FixtureArchive);
         var newContent = "Freshly added entry during modify-existing test."u8.ToArray();
 
         using var outputStream = new MemoryStream();
@@ -130,7 +130,7 @@ public class SevenZipWritableArchiveTests : TestBase
     [Fact]
     public async ValueTask SevenZipWritableArchive_ModifyExisting_RemoveAndAdd_RoundTrip_Async()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, FixtureArchive);
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, FixtureArchive);
         var newContent = "Async freshly added entry during modify-existing test."u8.ToArray();
 
         using var outputStream = new MemoryStream();

--- a/tests/SharpCompress.Tests/StreamContractTests.cs
+++ b/tests/SharpCompress.Tests/StreamContractTests.cs
@@ -52,9 +52,9 @@ public class StreamContractTests : TestBase
     {
         var paths = new[]
         {
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar5.multi.none.part01.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar5.multi.none.part02.rar"),
-            Path.Combine(TEST_ARCHIVES_PATH, "Rar5.multi.none.part03.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar5.multi.none.part01.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar5.multi.none.part02.rar"),
+            Path.Join(TEST_ARCHIVES_PATH, "Rar5.multi.none.part03.rar"),
         };
         var streams = paths.Select(p => (Stream)File.OpenRead(p)).ToArray();
         try
@@ -80,7 +80,7 @@ public class StreamContractTests : TestBase
     [Fact]
     public void SharpCompressStream_NonSeekableReader_Contract()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.rar");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.rar");
         var bytes = File.ReadAllBytes(path);
         using var nonSeekable = new NonSeekableStream(new MemoryStream(bytes));
         using var reader = ReaderFactory.OpenReader(nonSeekable);
@@ -99,7 +99,7 @@ public class StreamContractTests : TestBase
     [Fact]
     public async Task EntryStream_DisposeAsync_AfterDispose_DoesNotThrow()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.rar");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.rar");
         await using var archive = (RarArchive)await RarArchive.OpenAsyncArchive(path);
         var entry = archive.Entries.First(e => !e.IsDirectory);
         var entryStream = await entry.OpenEntryStreamAsync();
@@ -139,12 +139,12 @@ public class StreamContractTests : TestBase
     private static string GetArchivePath(string caseName) =>
         caseName switch
         {
-            "Zip.deflate" => Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip"),
-            "Rar4" => Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar"),
-            "Rar5.stored" => Path.Combine(TEST_ARCHIVES_PATH, "Rar5.none.rar"),
-            "Rar5.compressed" => Path.Combine(TEST_ARCHIVES_PATH, "Rar5.rar"),
-            "7z" => Path.Combine(TEST_ARCHIVES_PATH, "7Zip.nonsolid.7z"),
-            "Tar.gz" => Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"),
+            "Zip.deflate" => Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip"),
+            "Rar4" => Path.Join(TEST_ARCHIVES_PATH, "Rar.rar"),
+            "Rar5.stored" => Path.Join(TEST_ARCHIVES_PATH, "Rar5.none.rar"),
+            "Rar5.compressed" => Path.Join(TEST_ARCHIVES_PATH, "Rar5.rar"),
+            "7z" => Path.Join(TEST_ARCHIVES_PATH, "7Zip.nonsolid.7z"),
+            "Tar.gz" => Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"),
             _ => throw new ArgumentOutOfRangeException(nameof(caseName)),
         };
 

--- a/tests/SharpCompress.Tests/Streams/LzmaStreamAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Streams/LzmaStreamAsyncTests.cs
@@ -15,7 +15,7 @@ public class LzmaStreamAsyncTests : TestBase
     [Fact]
     public async ValueTask TestLzma2Decompress()
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "bad-1-lzma2-7.xz"));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "bad-1-lzma2-7.xz"));
 
         using var xz = new XZStream(stream);
         await Assert.ThrowsAnyAsync<SharpCompressException>(async () =>

--- a/tests/SharpCompress.Tests/Streams/LzwStreamAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Streams/LzwStreamAsyncTests.cs
@@ -13,7 +13,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_ByteArray()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 
@@ -26,7 +26,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_Memory()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 
@@ -39,7 +39,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_ProducesSameResultAsSync()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
 
         byte[] syncResult;
         byte[] asyncResult;
@@ -62,7 +62,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_MultipleReads()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 
@@ -87,7 +87,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_Cancellation()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 
@@ -104,7 +104,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_EmptyBuffer()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 
@@ -117,7 +117,7 @@ public class LzwStreamAsyncTests : TestBase
     [Fact]
     public async Task LzwStream_ReadAsync_ReturnsZeroAtEndOfStream()
     {
-        var testArchive = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z");
+        var testArchive = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.Z");
         using var stream = File.OpenRead(testArchive);
         using var lzwStream = new LzwStream(stream);
 

--- a/tests/SharpCompress.Tests/Streams/SharpCompressStreamReleaseTest.cs
+++ b/tests/SharpCompress.Tests/Streams/SharpCompressStreamReleaseTest.cs
@@ -14,7 +14,7 @@ public class SharpCompressStreamReleaseTest
     [Fact]
     public void RarFactory_OpenReader_ReleasesRingBufferAfterDetection()
     {
-        var path = Path.Combine(TestBase.TEST_ARCHIVES_PATH, "Rar5.none.rar");
+        var path = Path.Join(TestBase.TEST_ARCHIVES_PATH, "Rar5.none.rar");
         var data = File.ReadAllBytes(path);
         var inner = new MemoryStream(data);
         var nonSeekable = new ForwardOnlyStream(inner);

--- a/tests/SharpCompress.Tests/Streams/StreamSpanReadParityTests.cs
+++ b/tests/SharpCompress.Tests/Streams/StreamSpanReadParityTests.cs
@@ -58,7 +58,7 @@ public class StreamSpanReadParityTests : TestBase
     {
         AssertArrayAndSpanReadsMatch(() =>
         {
-            var reader = ReaderFactory.OpenReader(Path.Combine(TEST_ARCHIVES_PATH, "Rar.rar"));
+            var reader = ReaderFactory.OpenReader(Path.Join(TEST_ARCHIVES_PATH, "Rar.rar"));
             reader.MoveToNextEntry();
             return reader.OpenEntryStream();
         });
@@ -67,7 +67,7 @@ public class StreamSpanReadParityTests : TestBase
     [Fact]
     public void SevenZipEntryStream_SpanRead_MatchesArrayRead()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "7Zip.LZMA.7z");
 
         byte[] arrayResult;
         using (var archive = SevenZipArchive.OpenArchive(path))
@@ -98,7 +98,7 @@ public class StreamSpanReadParityTests : TestBase
         AssertArrayAndSpanReadsMatch(() =>
         {
             var reader = ReaderFactory.OpenReader(
-                Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip")
+                Path.Join(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip")
             );
             reader.MoveToNextEntry();
             return reader.OpenEntryStream();

--- a/tests/SharpCompress.Tests/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarArchiveAsyncTests.cs
@@ -26,7 +26,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     public async ValueTask TarArchiveOpenAsyncStream_Throws_On_NonSeekable_Stream()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"))
         );
 
         await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -43,7 +43,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     [InlineData("Tar.tar.Z")]
     public async ValueTask TarArchiveOpenAsyncArchive_RejectsCompressedTar(string archiveName)
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
 
         await Assert.ThrowsAsync<InvalidFormatException>(async () =>
             await TarArchive.OpenAsyncArchive(stream)
@@ -59,7 +59,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     [InlineData("Tar.tar.Z")]
     public async ValueTask ArchiveFactoryOpenAsyncArchive_RejectsCompressedTar(string archiveName)
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
 
         await Assert.ThrowsAsync<ArchiveOperationException>(async () =>
             await ArchiveFactory.OpenAsyncArchive(stream)
@@ -86,7 +86,7 @@ public class TarArchiveAsyncTests : ArchiveTests
             "filename_with_exactly_100_characters_______________________________________________________________X";
 
         // Step 1: create a tar file containing a file with the test name
-        using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenWrite(Path.Join(SCRATCH2_FILES_PATH, archive)))
         {
             await using (
                 var writer = await WriterFactory.OpenAsyncWriter(
@@ -107,7 +107,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         }
 
         // Step 2: check if the written tar file can be read correctly
-        var unmodified = Path.Combine(SCRATCH2_FILES_PATH, archive);
+        var unmodified = Path.Join(SCRATCH2_FILES_PATH, archive);
         await using (
             var archive2 = await TarArchive.OpenAsyncArchive(
                 new AsyncOnlyStream(File.OpenRead(unmodified)),
@@ -146,7 +146,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         longFilename += ".txt";
 
         // Step 1: create a tar file containing a file with a long name
-        using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenWrite(Path.Join(SCRATCH2_FILES_PATH, archive)))
         await using (
             var writer = await WriterFactory.OpenAsyncWriter(
                 new AsyncOnlyStream(stream),
@@ -165,7 +165,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         }
 
         // Step 2: check if the written tar file can be read correctly
-        var unmodified = Path.Combine(SCRATCH2_FILES_PATH, archive);
+        var unmodified = Path.Join(SCRATCH2_FILES_PATH, archive);
         await using (
             var archive2 = await TarArchive.OpenAsyncArchive(
                 new AsyncOnlyStream(File.OpenRead(unmodified)),
@@ -192,8 +192,8 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_Create_New_Async()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.tar");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Tar.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
         await using (var archive = await TarArchive.CreateAsyncArchive())
         {
@@ -233,10 +233,10 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_Random_Write_Add_Async()
     {
-        var jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.mod.tar");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.mod.tar");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
+        var jpg = Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Tar.mod.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Tar.mod.tar");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
         await using (var archive = await TarArchive.OpenAsyncArchive(unmodified))
         {
@@ -252,9 +252,9 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_Random_Write_Remove_Async()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.mod.tar");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.mod.tar");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Tar.mod.tar");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Tar.mod.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
         await using (var archive = await TarArchive.OpenAsyncArchive(unmodified))
         {
@@ -348,7 +348,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_PaxLocalHeader_Archive_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
         await using var archive = await TarArchive.OpenAsyncArchive(
             new AsyncOnlyStream(File.OpenRead(archivePath))
         );
@@ -374,7 +374,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_PaxLocalHeader_Link_Archive_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
         await using var archive = await TarArchive.OpenAsyncArchive(
             new AsyncOnlyStream(File.OpenRead(archivePath))
         );
@@ -387,7 +387,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_PaxGlobalHeader_Archive_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
         await using var archive = await TarArchive.OpenAsyncArchive(
             new AsyncOnlyStream(File.OpenRead(archivePath))
         );
@@ -422,7 +422,7 @@ public class TarArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Tar_PaxGlobalHeader_Link_Archive_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
         await using var archive = await TarArchive.OpenAsyncArchive(
             new AsyncOnlyStream(File.OpenRead(archivePath))
         );

--- a/tests/SharpCompress.Tests/Tar/TarArchiveDirectoryTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarArchiveDirectoryTests.cs
@@ -61,7 +61,7 @@ public class TarArchiveDirectoryTests : TestBase
     [Fact]
     public void TarArchive_AddDirectoryEntry_SaveAndReload()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "tar-directory-test.tar");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "tar-directory-test.tar");
 
         using (var archive = TarArchive.CreateArchive())
         {

--- a/tests/SharpCompress.Tests/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarArchiveTests.cs
@@ -29,7 +29,7 @@ public class TarArchiveTests : ArchiveTests
     public void TarArchiveStreamRead_Throws_On_NonSeekable_Stream()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"))
         );
 
         Assert.Throws<ArgumentException>(() => ArchiveFactory.OpenArchive(stream));
@@ -39,7 +39,7 @@ public class TarArchiveTests : ArchiveTests
     public void TarArchiveStreamRead_Throws_On_Unreadable_Stream()
     {
         using var unreadable = new TestStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")),
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar")),
             false,
             true,
             true
@@ -67,7 +67,7 @@ public class TarArchiveTests : ArchiveTests
             "filename_with_exactly_100_characters_______________________________________________________________X";
 
         // Step 1: create a tar file containing a file with the test name
-        using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenWrite(Path.Join(SCRATCH2_FILES_PATH, archive)))
         using (
             var writer = WriterFactory.OpenWriter(
                 stream,
@@ -86,7 +86,7 @@ public class TarArchiveTests : ArchiveTests
         }
 
         // Step 2: check if the written tar file can be read correctly
-        var unmodified = Path.Combine(SCRATCH2_FILES_PATH, archive);
+        var unmodified = Path.Join(SCRATCH2_FILES_PATH, archive);
         using (var archive2 = ArchiveFactory.OpenArchive(unmodified))
         {
             Assert.Equal(1, archive2.Entries.Count());
@@ -105,7 +105,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_NonUstarArchiveWithLongNameDoesNotSkipEntriesAfterTheLongOne()
     {
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "very long filename.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "very long filename.tar");
         using var archive = ArchiveFactory.OpenArchive(unmodified);
         Assert.Equal(5, archive.Entries.Count());
         Assert.Contains("very long filename/", archive.Entries.Select(entry => entry.Key));
@@ -133,7 +133,7 @@ public class TarArchiveTests : ArchiveTests
         longFilename += ".txt";
 
         // Step 1: create a tar file containing a file with a long name
-        using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenWrite(Path.Join(SCRATCH2_FILES_PATH, archive)))
         using (
             var writer = WriterFactory.OpenWriter(
                 stream,
@@ -152,7 +152,7 @@ public class TarArchiveTests : ArchiveTests
         }
 
         // Step 2: check if the written tar file can be read correctly
-        var unmodified = Path.Combine(SCRATCH2_FILES_PATH, archive);
+        var unmodified = Path.Join(SCRATCH2_FILES_PATH, archive);
         using (var archive2 = ArchiveFactory.OpenArchive(unmodified))
         {
             Assert.Equal(1, archive2.Entries.Count());
@@ -171,7 +171,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_UstarArchivePathReadLongName()
     {
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "ustar with long names.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "ustar with long names.tar");
         using var archive = ArchiveFactory.OpenArchive(unmodified);
         Assert.Equal(6, archive.Entries.Count());
         Assert.Contains("Directory/", archive.Entries.Select(entry => entry.Key));
@@ -200,7 +200,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_PaxLocalHeader_Archive()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
         using var archive = TarArchive.OpenArchive(archivePath);
 
         var firstEntry = (TarArchiveEntry)
@@ -224,7 +224,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_PaxLocalHeader_Link_Archive()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
         using var archive = TarArchive.OpenArchive(archivePath);
 
         var entry = (TarArchiveEntry)archive.Entries.Single();
@@ -235,7 +235,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_PaxGlobalHeader_Archive()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
         using var archive = TarArchive.OpenArchive(archivePath);
 
         var globalTime = DateTimeOffset.FromUnixTimeSeconds(1700000100).LocalDateTime;
@@ -266,7 +266,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_PaxGlobalHeader_Link_Archive()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
         using var archive = TarArchive.OpenArchive(archivePath);
 
         var globalLink = (TarArchiveEntry)
@@ -287,8 +287,8 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_Create_New()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.tar");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Tar.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
         // var aropt = new Ar
 
@@ -307,10 +307,10 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_Random_Write_Add()
     {
-        var jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.mod.tar");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.mod.tar");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
+        var jpg = Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Tar.mod.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Tar.mod.tar");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
         using (var archive = TarArchive.OpenArchive(unmodified))
         {
@@ -323,9 +323,9 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_Random_Write_Remove()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.mod.tar");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.mod.tar");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Tar.mod.tar");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Tar.mod.tar");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
         using (var archive = TarArchive.OpenArchive(unmodified))
         {
@@ -341,7 +341,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_Containing_Rar_Archive()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.ContainsRar.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.ContainsRar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var archive = ArchiveFactory.OpenArchive(stream);
         Assert.True(archive.Type == ArchiveType.Tar);
@@ -350,7 +350,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_Empty_Archive()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.Empty.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.Empty.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var archive = ArchiveFactory.OpenArchive(stream);
         Assert.True(archive.Type == ArchiveType.Tar);
@@ -484,7 +484,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void Tar_Detect_Test()
     {
-        var isTar = TarArchive.IsTarFile(Path.Combine(TEST_ARCHIVES_PATH, "false.positive.tar"));
+        var isTar = TarArchive.IsTarFile(Path.Join(TEST_ARCHIVES_PATH, "false.positive.tar"));
 
         Assert.False(isTar);
     }
@@ -498,7 +498,7 @@ public class TarArchiveTests : ArchiveTests
     [InlineData("Tar.tar.Z")]
     public void ArchiveFactoryStreamRead_Autodetect_RejectsCompressedTar(string archiveName)
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
 
         Assert.Throws<ArchiveOperationException>(() => ArchiveFactory.OpenArchive(stream));
     }
@@ -512,7 +512,7 @@ public class TarArchiveTests : ArchiveTests
     [InlineData("Tar.tar.Z")]
     public void TarArchiveOpenArchive_RejectsCompressedTar(string archiveName)
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
 
         Assert.Throws<InvalidFormatException>(() => TarArchive.OpenArchive(stream));
     }
@@ -525,7 +525,7 @@ public class TarArchiveTests : ArchiveTests
         bool expectedDisposed
     )
     {
-        using var file = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using var file = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         var stream = new TestStream(file);
         var options = ReaderOptions.ForExternalStream.WithLeaveStreamOpen(leaveStreamOpen);
 
@@ -541,7 +541,7 @@ public class TarArchiveTests : ArchiveTests
     [Fact]
     public void TarReaderStreamRead_Autodetect_CompressedTar()
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var reader = ReaderFactory.OpenReader(stream);
 
         Assert.Equal(ArchiveType.Tar, reader.Type);

--- a/tests/SharpCompress.Tests/Tar/TarReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarReaderAsyncTests.cs
@@ -25,7 +25,7 @@ public class TarReaderAsyncTests : ReaderTests
     public async ValueTask Tar_Skip_Async()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"))
         );
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
         var x = 0;
@@ -55,7 +55,7 @@ public class TarReaderAsyncTests : ReaderTests
         CompressionType compressionType
     )
     {
-        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, archiveName));
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
         var options = ReaderOptions.ForExternalStream.WithExtensionHint(extensionHint);
 
         await using var reader = await ReaderFactory.OpenAsyncReader(stream, options);
@@ -95,7 +95,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_BZip2_Entry_Stream_Async()
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
         await using var reader = await TarReader.OpenAsyncReader(stream);
         while (await reader.MoveToNextEntryAsync())
         {
@@ -106,12 +106,12 @@ public class TarReaderAsyncTests : ReaderTests
                 var file = Path.GetFileName(reader.Entry.Key);
                 var folder =
                     Path.GetDirectoryName(reader.Entry.Key) ?? throw new ArgumentNullException();
-                var destdir = Path.Combine(SCRATCH_FILES_PATH, folder);
+                var destdir = Path.Join(SCRATCH_FILES_PATH, folder);
                 if (!Directory.Exists(destdir))
                 {
                     Directory.CreateDirectory(destdir);
                 }
-                var destinationFileName = Path.Combine(destdir, file.NotNull());
+                var destinationFileName = Path.Join(destdir, file.NotNull());
 
                 using var fs = File.OpenWrite(destinationFileName);
                 await entryStream.CopyToAsync(fs);
@@ -127,7 +127,7 @@ public class TarReaderAsyncTests : ReaderTests
 
         using (
             Stream stream = File.OpenRead(
-                Path.Combine(TEST_ARCHIVES_PATH, "Tar.LongPathsWithLongNameExtension.tar")
+                Path.Join(TEST_ARCHIVES_PATH, "Tar.LongPathsWithLongNameExtension.tar")
             )
         )
         using (var reader = TarReader.OpenReader(stream))
@@ -156,7 +156,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_BZip2_Skip_Entry_Stream_Async()
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
         await using var reader = await TarReader.OpenAsyncReader(stream);
         var names = new List<string>();
         while (await reader.MoveToNextEntryAsync())
@@ -175,7 +175,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_PaxLocalHeader_Reader_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         await using var reader = await TarReader.OpenAsyncReader(stream);
@@ -212,7 +212,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_PaxLocalHeader_Link_Reader_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         await using var reader = await TarReader.OpenAsyncReader(stream);
@@ -227,7 +227,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_PaxGlobalHeader_Reader_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         await using var reader = await TarReader.OpenAsyncReader(stream);
@@ -265,7 +265,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_PaxGlobalHeader_Link_Reader_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         await using var reader = await TarReader.OpenAsyncReader(stream);
@@ -292,7 +292,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_WithSymlink_Reader_SurfacesLinkTargets_Async()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "TarWithSymlink.tar.gz");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "TarWithSymlink.tar.gz");
 
         using Stream stream = File.OpenRead(archivePath);
         await using var reader = await TarReader.OpenAsyncReader(stream);
@@ -322,7 +322,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public void Tar_Containing_Rar_Reader_Async()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.ContainsRar.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.ContainsRar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
         Assert.True(reader.Type == ArchiveType.Tar);
@@ -331,7 +331,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_With_TarGz_With_Flushed_EntryStream_Async()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.ContainsTarGz.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.ContainsTarGz.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         await using var reader = await ReaderFactory.OpenAsyncReader(stream);
         Assert.True(await reader.MoveToNextEntryAsync());
@@ -349,7 +349,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_Broken_Stream_Async()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
         using var memoryStream = new MemoryStream();
@@ -425,7 +425,7 @@ public class TarReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Tar_Corrupted_Async()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "TarCorrupted.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "TarCorrupted.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
         using var memoryStream = new MemoryStream();

--- a/tests/SharpCompress.Tests/Tar/TarReaderTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarReaderTests.cs
@@ -25,7 +25,7 @@ public class TarReaderTests : ReaderTests
     public void Tar_Skip()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar"))
         );
         using var reader = ReaderFactory.OpenReader(stream);
         var x = 0;
@@ -69,7 +69,7 @@ public class TarReaderTests : ReaderTests
         // Regression test for: Dynamic default RingBuffer for BZip2
         // Opening a .tar.bz2 from a non-seekable stream should succeed
         // because the ring buffer is sized to hold the BZip2 block before calling IsTarFile.
-        using var fs = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
+        using var fs = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
         using var nonSeekable = new ForwardOnlyStream(fs);
         using var reader = ReaderFactory.OpenReader(nonSeekable);
         var entryCount = 0;
@@ -112,7 +112,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_BZip2_Entry_Stream()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.bz2")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.bz2")))
         using (var reader = TarReader.OpenReader(stream))
         {
             while (reader.MoveToNextEntry())
@@ -125,12 +125,12 @@ public class TarReaderTests : ReaderTests
                     var folder =
                         Path.GetDirectoryName(reader.Entry.Key)
                         ?? throw new ArgumentNullException();
-                    var destdir = Path.Combine(SCRATCH_FILES_PATH, folder);
+                    var destdir = Path.Join(SCRATCH_FILES_PATH, folder);
                     if (!Directory.Exists(destdir))
                     {
                         Directory.CreateDirectory(destdir);
                     }
-                    var destinationFileName = Path.Combine(destdir, file.NotNull());
+                    var destinationFileName = Path.Join(destdir, file.NotNull());
 
                     using var fs = File.OpenWrite(destinationFileName);
                     entryStream.CopyTo(fs);
@@ -147,7 +147,7 @@ public class TarReaderTests : ReaderTests
 
         using (
             Stream stream = File.OpenRead(
-                Path.Combine(TEST_ARCHIVES_PATH, "Tar.LongPathsWithLongNameExtension.tar")
+                Path.Join(TEST_ARCHIVES_PATH, "Tar.LongPathsWithLongNameExtension.tar")
             )
         )
         using (var reader = TarReader.OpenReader(stream))
@@ -176,7 +176,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_PaxLocalHeader_Reader()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         using var reader = TarReader.OpenReader(stream);
@@ -213,7 +213,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_PaxLocalHeader_Link_Reader()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxLocalHeader.Link.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         using var reader = TarReader.OpenReader(stream);
@@ -228,7 +228,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_PaxGlobalHeader_Reader()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         using var reader = TarReader.OpenReader(stream);
@@ -266,7 +266,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_PaxGlobalHeader_Link_Reader()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "Tar.PaxGlobalHeader.Link.tar");
 
         using Stream stream = File.OpenRead(archivePath);
         using var reader = TarReader.OpenReader(stream);
@@ -293,7 +293,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_WithSymlink_Reader_SurfacesLinkTargets()
     {
-        var archivePath = Path.Combine(TEST_ARCHIVES_PATH, "TarWithSymlink.tar.gz");
+        var archivePath = Path.Join(TEST_ARCHIVES_PATH, "TarWithSymlink.tar.gz");
 
         using Stream stream = File.OpenRead(archivePath);
         using var reader = TarReader.OpenReader(stream);
@@ -323,7 +323,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_BZip2_Skip_Entry_Stream()
     {
-        using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
+        using Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Tar.tar.bz2"));
         using var reader = TarReader.OpenReader(stream);
         var names = new List<string>();
         while (reader.MoveToNextEntry())
@@ -342,7 +342,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_Containing_Rar_Reader()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.ContainsRar.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.ContainsRar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
         Assert.True(reader.Type == ArchiveType.Tar);
@@ -351,7 +351,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_With_TarGz_With_Flushed_EntryStream()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.ContainsTarGz.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.ContainsTarGz.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
         Assert.True(reader.MoveToNextEntry());
@@ -369,7 +369,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_Broken_Stream()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "Tar.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
         using var memoryStream = new MemoryStream();
@@ -441,7 +441,7 @@ public class TarReaderTests : ReaderTests
     [Fact]
     public void Tar_Corrupted()
     {
-        var archiveFullPath = Path.Combine(TEST_ARCHIVES_PATH, "TarCorrupted.tar");
+        var archiveFullPath = Path.Join(TEST_ARCHIVES_PATH, "TarCorrupted.tar");
         using Stream stream = File.OpenRead(archiveFullPath);
         using var reader = ReaderFactory.OpenReader(stream);
         using var memoryStream = new MemoryStream();

--- a/tests/SharpCompress.Tests/Tar/TarWriterAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarWriterAsyncTests.cs
@@ -80,7 +80,7 @@ public class TarWriterAsyncTests : WriterTests
     public async ValueTask Tar_Finalize_Archive_Async(bool finalizeArchive)
     {
         using var stream = new MemoryStream();
-        using Stream content = File.OpenRead(Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg"));
+        using Stream content = File.OpenRead(Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg"));
         await using (
             var writer = new TarWriter(
                 new AsyncOnlyStream(stream, false),

--- a/tests/SharpCompress.Tests/Tar/TarWriterTests.cs
+++ b/tests/SharpCompress.Tests/Tar/TarWriterTests.cs
@@ -68,7 +68,7 @@ public class TarWriterTests : WriterTests
     public void Tar_Finalize_Archive(bool finalizeArchive)
     {
         using var stream = new MemoryStream();
-        using Stream content = File.OpenRead(Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg"));
+        using Stream content = File.OpenRead(Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg"));
         using (
             var writer = new TarWriter(
                 stream,

--- a/tests/SharpCompress.Tests/TempDirectory.cs
+++ b/tests/SharpCompress.Tests/TempDirectory.cs
@@ -11,7 +11,7 @@ internal sealed class TempDirectory : IAsyncDisposable
 
     public TempDirectory(string prefix)
     {
-        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{prefix}.{Guid.NewGuid():N}");
+        Path = System.IO.Path.Join(System.IO.Path.GetTempPath(), $"{prefix}.{Guid.NewGuid():N}");
         Directory.CreateDirectory(Path);
     }
 
@@ -19,22 +19,22 @@ internal sealed class TempDirectory : IAsyncDisposable
 
     public string GetDirectory(string name)
     {
-        var path = System.IO.Path.Combine(Path, name);
+        var path = System.IO.Path.Join(Path, name);
         Directory.CreateDirectory(path);
         return path;
     }
 
     public string CreateDirectory(string name)
     {
-        var path = System.IO.Path.Combine(Path, name, System.IO.Path.GetRandomFileName());
+        var path = System.IO.Path.Join(Path, name, System.IO.Path.GetRandomFileName());
         Directory.CreateDirectory(path);
         return path;
     }
 
     public void ResetDirectory(string name)
     {
-        DeleteDirectory(System.IO.Path.Combine(Path, name));
-        Directory.CreateDirectory(System.IO.Path.Combine(Path, name));
+        DeleteDirectory(System.IO.Path.Join(Path, name));
+        Directory.CreateDirectory(System.IO.Path.Join(Path, name));
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/SharpCompress.Tests/TestBase.cs
+++ b/tests/SharpCompress.Tests/TestBase.cs
@@ -23,7 +23,7 @@ public class TestBase : IAsyncDisposable
         var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
         while (
             dir != null
-            && !Directory.Exists(Path.Combine(dir.FullName, "TestArchives"))
+            && !Directory.Exists(Path.Join(dir.FullName, "TestArchives"))
         )
         {
             dir = dir.Parent;
@@ -35,9 +35,9 @@ public class TestBase : IAsyncDisposable
                 "Could not locate TestArchives relative to the SharpCompress test output directory."
             );
 
-        TEST_ARCHIVES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "Archives");
-        ORIGINAL_FILES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "Original");
-        MISC_TEST_FILES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "MiscTest");
+        TEST_ARCHIVES_PATH = Path.Join(SOLUTION_BASE_PATH, "TestArchives", "Archives");
+        ORIGINAL_FILES_PATH = Path.Join(SOLUTION_BASE_PATH, "TestArchives", "Original");
+        MISC_TEST_FILES_PATH = Path.Join(SOLUTION_BASE_PATH, "TestArchives", "MiscTest");
     }
 
     private readonly TempDirectory _tempDirectory;
@@ -61,10 +61,10 @@ public class TestBase : IAsyncDisposable
     }
 
     protected string CreateScratchDirectory(string name) =>
-        _tempDirectory.CreateDirectory(Path.Combine("Scratch", name));
+        _tempDirectory.CreateDirectory(Path.Join("Scratch", name));
 
     protected string CreateScratch2Directory(string name) =>
-        _tempDirectory.CreateDirectory(Path.Combine("Scratch2", name));
+        _tempDirectory.CreateDirectory(Path.Join("Scratch2", name));
 
     protected string GetScratchPath(params string[] parts) =>
         CombinePath(SCRATCH_FILES_PATH, parts);
@@ -73,7 +73,7 @@ public class TestBase : IAsyncDisposable
         CombinePath(SCRATCH2_FILES_PATH, parts);
 
     private static string CombinePath(string root, string[] parts) =>
-        parts.Length == 0 ? root : Path.Combine(root, Path.Combine(parts));
+        parts.Length == 0 ? root : Path.Join(root, Path.Join(parts));
 
     public void VerifyFiles()
     {

--- a/tests/SharpCompress.Tests/WriterTests.cs
+++ b/tests/SharpCompress.Tests/WriterTests.cs
@@ -23,7 +23,7 @@ public class WriterTests : TestBase
         Encoding? encoding = null
     )
     {
-        using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenWrite(Path.Join(SCRATCH2_FILES_PATH, archive)))
         {
             var writerOptions = new WriterOptions(compressionType) { LeaveStreamOpen = true };
 
@@ -33,11 +33,11 @@ public class WriterTests : TestBase
             writer.WriteAll(ORIGINAL_FILES_PATH, "*", SearchOption.AllDirectories);
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH2_FILES_PATH, archive),
-            Path.Combine(TEST_ARCHIVES_PATH, archiveToVerifyAgainst)
+            Path.Join(SCRATCH2_FILES_PATH, archive),
+            Path.Join(TEST_ARCHIVES_PATH, archiveToVerifyAgainst)
         );
 
-        using (Stream stream = File.OpenRead(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenRead(Path.Join(SCRATCH2_FILES_PATH, archive)))
         {
             var readerOptions = ReaderOptions.ForExternalStream;
 
@@ -62,7 +62,7 @@ public class WriterTests : TestBase
     {
         using (
             Stream stream = new AsyncOnlyStream(
-                File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive))
+                File.OpenWrite(Path.Join(SCRATCH2_FILES_PATH, archive))
             )
         )
         {
@@ -84,11 +84,11 @@ public class WriterTests : TestBase
             );
         }
         CompareArchivesByPath(
-            Path.Combine(SCRATCH2_FILES_PATH, archive),
-            Path.Combine(TEST_ARCHIVES_PATH, archiveToVerifyAgainst)
+            Path.Join(SCRATCH2_FILES_PATH, archive),
+            Path.Join(TEST_ARCHIVES_PATH, archiveToVerifyAgainst)
         );
 
-        using (Stream stream = File.OpenRead(Path.Combine(SCRATCH2_FILES_PATH, archive)))
+        using (Stream stream = File.OpenRead(Path.Join(SCRATCH2_FILES_PATH, archive)))
         {
             var readerOptions = ReaderOptions.ForExternalStream;
 

--- a/tests/SharpCompress.Tests/Zip/Zip64AsyncTests.cs
+++ b/tests/SharpCompress.Tests/Zip/Zip64AsyncTests.cs
@@ -104,7 +104,7 @@ public class Zip64AsyncTests : WriterTests
     [Trait("format", "zip64")]
     public async ValueTask Zip64_Large_File_Then_Small_File_NonSeekable_Async()
     {
-        var filename = Path.Combine(SCRATCH2_FILES_PATH, "zip64-nonseekable-async.zip");
+        var filename = Path.Join(SCRATCH2_FILES_PATH, "zip64-nonseekable-async.zip");
 
         // A small trailing entry with recognizable content. Its bytes can only be read back
         // correctly if the reader stays byte-aligned after the preceding >=4GB Zip64 entry.
@@ -223,7 +223,7 @@ public class Zip64AsyncTests : WriterTests
         string filename = "zip64-test-async.zip"
     )
     {
-        filename = Path.Combine(SCRATCH2_FILES_PATH, filename);
+        filename = Path.Join(SCRATCH2_FILES_PATH, filename);
 
         try
         {

--- a/tests/SharpCompress.Tests/Zip/Zip64Tests.cs
+++ b/tests/SharpCompress.Tests/Zip/Zip64Tests.cs
@@ -100,7 +100,7 @@ public class Zip64Tests : WriterTests
         string filename = "zip64-test.zip"
     )
     {
-        filename = Path.Combine(SCRATCH2_FILES_PATH, filename);
+        filename = Path.Join(SCRATCH2_FILES_PATH, filename);
 
         if (File.Exists(filename))
         {

--- a/tests/SharpCompress.Tests/Zip/Zip64VersionConsistencyTests.cs
+++ b/tests/SharpCompress.Tests/Zip/Zip64VersionConsistencyTests.cs
@@ -24,7 +24,7 @@ public class Zip64VersionConsistencyTests : WriterTests
     public void Zip64_Small_File_With_UseZip64_Should_Have_Matching_Versions()
     {
         // Create a zip with UseZip64=true but with a small file
-        var filename = Path.Combine(SCRATCH2_FILES_PATH, "zip64_version_test.zip");
+        var filename = Path.Join(SCRATCH2_FILES_PATH, "zip64_version_test.zip");
 
         if (File.Exists(filename))
         {
@@ -129,7 +129,7 @@ public class Zip64VersionConsistencyTests : WriterTests
     public void Zip64_Small_File_Without_UseZip64_Should_Have_Version_20()
     {
         // Create a zip without UseZip64
-        var filename = Path.Combine(SCRATCH2_FILES_PATH, "no_zip64_version_test.zip");
+        var filename = Path.Join(SCRATCH2_FILES_PATH, "no_zip64_version_test.zip");
 
         if (File.Exists(filename))
         {
@@ -182,7 +182,7 @@ public class Zip64VersionConsistencyTests : WriterTests
     public void LZMA_Compression_Should_Use_Version_63()
     {
         // Create a zip with LZMA compression
-        var filename = Path.Combine(SCRATCH2_FILES_PATH, "lzma_version_test.zip");
+        var filename = Path.Join(SCRATCH2_FILES_PATH, "lzma_version_test.zip");
 
         if (File.Exists(filename))
         {
@@ -236,7 +236,7 @@ public class Zip64VersionConsistencyTests : WriterTests
     public void PPMd_Compression_Should_Use_Version_63()
     {
         // Create a zip with PPMd compression
-        var filename = Path.Combine(SCRATCH2_FILES_PATH, "ppmd_version_test.zip");
+        var filename = Path.Join(SCRATCH2_FILES_PATH, "ppmd_version_test.zip");
 
         if (File.Exists(filename))
         {
@@ -290,7 +290,7 @@ public class Zip64VersionConsistencyTests : WriterTests
     public void Zip64_Multiple_Small_Files_With_UseZip64_Should_Have_Matching_Versions()
     {
         // Create a zip with UseZip64=true but with multiple small files
-        var filename = Path.Combine(SCRATCH2_FILES_PATH, "zip64_version_multiple_test.zip");
+        var filename = Path.Join(SCRATCH2_FILES_PATH, "zip64_version_multiple_test.zip");
 
         if (File.Exists(filename))
         {

--- a/tests/SharpCompress.Tests/Zip/ZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipArchiveAsyncTests.cs
@@ -122,9 +122,9 @@ public class ZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Zip_Random_Write_Remove_Async()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
 
         await using (var archive = await ZipArchive.OpenAsyncArchive(unmodified))
         {
@@ -146,10 +146,10 @@ public class ZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Zip_Random_Write_Add_Async()
     {
-        var jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var jpg = Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
         await using (var archive = await ZipArchive.OpenAsyncArchive(unmodified))
         {
@@ -168,8 +168,8 @@ public class ZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Zip_Create_New_Async()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Zip.deflate.noEmptyDirs.zip");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
         await using (var archive = (ZipArchive)await ZipArchive.CreateAsyncArchive())
         {
@@ -212,7 +212,7 @@ public class ZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Zip_Deflate_Entry_Stream_Async()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip")))
         {
             IAsyncArchive archive = await ZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
             try
@@ -233,7 +233,7 @@ public class ZipArchiveAsyncTests : ArchiveTests
     [Fact]
     public async ValueTask Zip_Deflate_Archive_WriteToDirectoryAsync()
     {
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip")))
         {
             IAsyncArchive archive = await ZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
             try
@@ -255,7 +255,7 @@ public class ZipArchiveAsyncTests : ArchiveTests
         var progress = new Progress<ProgressReport>(report => progressReports.Add(report));
 
         await using (
-            Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip"))
+            Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip"))
         )
         {
             await using IAsyncArchive archive = await ZipArchive.OpenAsyncArchive(

--- a/tests/SharpCompress.Tests/Zip/ZipArchiveDirectoryTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipArchiveDirectoryTests.cs
@@ -61,7 +61,7 @@ public class ZipArchiveDirectoryTests : TestBase
     [Fact]
     public void ZipArchive_AddDirectoryEntry_SaveAndReload()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "zip-directory-test.zip");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "zip-directory-test.zip");
 
         using (var archive = ZipArchive.CreateArchive())
         {

--- a/tests/SharpCompress.Tests/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipArchiveTests.cs
@@ -104,7 +104,7 @@ public class ZipArchiveTests : ArchiveTests
     public void WinZip27_X_XZ_Reports_CompressionType_Xz()
     {
         using var archive = ArchiveFactory.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "WinZip27_XZ.zipx")
+            Path.Join(TEST_ARCHIVES_PATH, "WinZip27_XZ.zipx")
         );
 
         foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
@@ -264,9 +264,9 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Random_Write_Remove()
     {
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
 
         using (var archive = ZipArchive.OpenArchive(unmodified))
         {
@@ -288,10 +288,10 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Random_Write_Add()
     {
-        var jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
-        var modified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod2.zip");
+        var jpg = Path.Join(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
+        var scratchPath = Path.Join(SCRATCH_FILES_PATH, "Zip.deflate.mod.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
+        var modified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.mod2.zip");
 
         using (var archive = ZipArchive.OpenArchive(unmodified))
         {
@@ -310,8 +310,8 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Save_Twice()
     {
-        var scratchPath1 = Path.Combine(SCRATCH_FILES_PATH, "a.zip");
-        var scratchPath2 = Path.Combine(SCRATCH_FILES_PATH, "b.zip");
+        var scratchPath1 = Path.Join(SCRATCH_FILES_PATH, "a.zip");
+        var scratchPath2 = Path.Join(SCRATCH_FILES_PATH, "b.zip");
 
         using (var arc = ZipArchive.CreateArchive())
         {
@@ -328,7 +328,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Removal_Poly()
     {
-        var scratchPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var scratchPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
         using var vfs = (ZipArchive)ArchiveFactory.OpenArchive(scratchPath);
         var e = vfs.Entries.First(v =>
@@ -360,8 +360,8 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Create_Same_Stream()
     {
-        var scratchPath1 = Path.Combine(SCRATCH_FILES_PATH, "a.zip");
-        var scratchPath2 = Path.Combine(SCRATCH_FILES_PATH, "b.zip");
+        var scratchPath1 = Path.Join(SCRATCH_FILES_PATH, "a.zip");
+        var scratchPath2 = Path.Join(SCRATCH_FILES_PATH, "b.zip");
 
         using (var arc = ZipArchive.CreateArchive())
         {
@@ -398,7 +398,7 @@ public class ZipArchiveTests : ArchiveTests
             {
                 newFileName = newFileName.Substring(1);
             }
-            newFileName = Path.Combine(SCRATCH_FILES_PATH, newFileName);
+            newFileName = Path.Join(SCRATCH_FILES_PATH, newFileName);
             var newDir = Path.GetDirectoryName(newFileName) ?? throw new ArgumentNullException();
             if (!Directory.Exists(newDir))
             {
@@ -406,8 +406,8 @@ public class ZipArchiveTests : ArchiveTests
             }
             File.Copy(file, newFileName);
         }
-        var scratchPath = Path.Combine(SCRATCH2_FILES_PATH, "Zip.deflate.noEmptyDirs.zip");
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var scratchPath = Path.Join(SCRATCH2_FILES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
         using (var archive = ZipArchive.CreateArchive())
         {
@@ -466,7 +466,7 @@ public class ZipArchiveTests : ArchiveTests
             {
                 newFileName = newFileName.Substring(1);
             }
-            newFileName = Path.Combine(SCRATCH_FILES_PATH, newFileName);
+            newFileName = Path.Join(SCRATCH_FILES_PATH, newFileName);
             var newDir = Path.GetDirectoryName(newFileName) ?? throw new ArgumentNullException();
             if (!Directory.Exists(newDir))
             {
@@ -474,7 +474,7 @@ public class ZipArchiveTests : ArchiveTests
             }
             File.Copy(file, newFileName);
         }
-        var scratchPath = Path.Combine(SCRATCH2_FILES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var scratchPath = Path.Join(SCRATCH2_FILES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
         using (var archive = ZipArchive.CreateArchive())
         {
@@ -497,7 +497,7 @@ public class ZipArchiveTests : ArchiveTests
     {
         using (
             var reader = ZipArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"),
+                Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"),
                 ReaderOptions.ForFilePath with
                 {
                     Password = "test",
@@ -517,7 +517,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Deflate_WinzipAES_MultiOpenEntryStream()
     {
         using var reader = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES2.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES2.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -537,7 +537,7 @@ public class ZipArchiveTests : ArchiveTests
     {
         // Test that WinZip AES encrypted entries correctly report their compression type
         using var deflateArchive = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -550,7 +550,7 @@ public class ZipArchiveTests : ArchiveTests
         }
 
         using var lzmaArchive = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -567,7 +567,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Zstandard_WinzipAES_Mixed_ArchiveFileRead()
     {
         using var archive = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.zstd.WinzipAES.mixed.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.zstd.WinzipAES.mixed.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -581,7 +581,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Zstandard_WinzipAES_Mixed_ArchiveStreamRead()
     {
         using var stream = File.OpenRead(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.zstd.WinzipAES.mixed.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.zstd.WinzipAES.mixed.zip")
         );
         using var archive = ZipArchive.OpenArchive(
             stream,
@@ -598,7 +598,7 @@ public class ZipArchiveTests : ArchiveTests
     [Trait("zip64", "generated")]
     public void Zip_Zip64_GeneratedArchive_StreamIsBoundedToEntryLength()
     {
-        var zipPath = Path.Combine(SCRATCH2_FILES_PATH, "generated.zip64.large.zip");
+        var zipPath = Path.Join(SCRATCH2_FILES_PATH, "generated.zip64.large.zip");
         CreateZip64Archive(zipPath);
 
         using var archive = ZipArchive.OpenArchive(zipPath);
@@ -624,7 +624,7 @@ public class ZipArchiveTests : ArchiveTests
     {
         // Test that Pkware encrypted entries correctly report their compression type
         using var deflateArchive = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.pkware.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.pkware.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -637,7 +637,7 @@ public class ZipArchiveTests : ArchiveTests
         }
 
         using var bzip2Archive = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -654,7 +654,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Read_Volume_Comment()
     {
         using var reader = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.zip64.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.zip64.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -673,7 +673,7 @@ public class ZipArchiveTests : ArchiveTests
     {
         using (
             var reader = ZipArchive.OpenArchive(
-                Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"),
+                Path.Join(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"),
                 ReaderOptions.ForFilePath with
                 {
                     Password = "test",
@@ -692,7 +692,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Random_Entry_Access()
     {
-        var unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
+        var unmodified = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
         var a = ZipArchive.OpenArchive(unmodified);
         var count = 0;
@@ -734,7 +734,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Deflate_PKWear_Multipy_Entry_Access()
     {
-        var zipFile = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.pkware.zip");
+        var zipFile = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.pkware.zip");
 
         using var fileStream = File.OpenRead(zipFile);
         using var archive = ArchiveFactory.OpenArchive(
@@ -760,7 +760,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Evil_Throws_Exception_Windows()
     {
-        var zipFile = Path.Combine(TEST_ARCHIVES_PATH, "Zip.Evil.zip");
+        var zipFile = Path.Join(TEST_ARCHIVES_PATH, "Zip.Evil.zip");
 
         Assert.ThrowsAny<Exception>(() =>
         {
@@ -798,7 +798,7 @@ public class ZipArchiveTests : ArchiveTests
         }
 
         stream = new MemoryStream(stream.ToArray());
-        File.WriteAllBytes(Path.Combine(SCRATCH_FILES_PATH, "foo.zip"), stream.ToArray());
+        File.WriteAllBytes(Path.Join(SCRATCH_FILES_PATH, "foo.zip"), stream.ToArray());
 
         using (var zipArchive = ZipArchive.OpenArchive(stream))
         {
@@ -820,7 +820,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_BadLocalExtra_Read()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.badlocalextra.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.badlocalextra.zip");
 
         using var za = ZipArchive.OpenArchive(zipPath);
         var ex = Record.Exception(() =>
@@ -840,7 +840,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_NoCompression_DataDescriptors_Read()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip");
 
         using var za = ZipArchive.OpenArchive(zipPath);
         var firstEntry = za.Entries.First(x => x.Key == "first.txt");
@@ -877,7 +877,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_LongComment_Read()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.LongComment.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.LongComment.zip");
 
         using var za = ZipArchive.OpenArchive(zipPath);
         var count = za.Entries.Count();
@@ -887,7 +887,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Zip64_CompressedSizeExtraOnly_Read()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.zip64.compressedonly.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.zip64.compressedonly.zip");
 
         using var za = ZipArchive.OpenArchive(zipPath);
         var firstEntry = za.Entries.First(x => x.Key == "test/test.txt");
@@ -901,7 +901,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Uncompressed_Read_All()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
         using var stream = File.OpenRead(zipPath);
         var reader = ReaderFactory.OpenReader(stream);
         var entries = 0;
@@ -929,7 +929,7 @@ public class ZipArchiveTests : ArchiveTests
             "Folder2/File2.txt",
             "DEADBEEF",
         };
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
         using var stream = File.OpenRead(zipPath);
         var reader = ReaderFactory.OpenReader(stream);
         var x = 0;
@@ -945,7 +945,7 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void Zip_Forced_Ignores_UnicodePathExtra()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.UnicodePathExtra.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.UnicodePathExtra.zip");
         using (var stream = File.OpenRead(zipPath))
         {
             var reader = ReaderFactory.OpenReader(
@@ -982,7 +982,7 @@ public class ZipArchiveTests : ArchiveTests
     public void TestDataDescriptorRead()
     {
         using var archive = ArchiveFactory.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip")
         );
         var firstEntry = archive.Entries.First();
         Assert.Equal(199, firstEntry.Size);
@@ -994,7 +994,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_EntryCommentAfterEntryRead()
     {
         using var archive = ZipArchive.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.EntryComment.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.EntryComment.zip")
         );
         var firstEntry = (ZipArchiveEntry)archive.Entries.First();
         Assert.Equal(29, firstEntry.Comment!.Length);
@@ -1006,7 +1006,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_FilePermissions()
     {
         using var archive = ArchiveFactory.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.644.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.644.zip")
         );
 
         var firstEntry = archive.Entries.First();
@@ -1019,7 +1019,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_LZMA_ZeroSizeEntry_CanExtract()
     {
         using var archive = ArchiveFactory.OpenArchive(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.empty.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.empty.zip")
         );
         var entries = archive.Entries.Where(x => !x.IsDirectory).ToList();
         Assert.Single(entries);

--- a/tests/SharpCompress.Tests/Zip/ZipCrcExtractionTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipCrcExtractionTests.cs
@@ -25,7 +25,7 @@ public class ZipCrcExtractionTests : ArchiveTests
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: false);
         using var archive = ZipArchive.OpenArchive(zipStream);
         var entry = archive.Entries.Single(e => !e.IsDirectory);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-crc-mismatch.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-crc-mismatch.txt");
 
         var exception = Assert.Throws<InvalidFormatException>(() => entry.WriteToFile(destination));
 
@@ -38,7 +38,7 @@ public class ZipCrcExtractionTests : ArchiveTests
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: false);
         using var archive = ZipArchive.OpenArchive(zipStream);
         var entry = archive.Entries.Single(e => !e.IsDirectory);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-crc-disabled.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-crc-disabled.txt");
 
         entry.WriteToFile(destination, new ExtractionOptions { CheckCrc = false });
 
@@ -78,7 +78,7 @@ public class ZipCrcExtractionTests : ArchiveTests
     {
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: false);
         using var reader = ReaderFactory.OpenReader(zipStream);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-reader-crc-mismatch.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-reader-crc-mismatch.txt");
 
         Assert.True(reader.MoveToNextEntry());
         var exception = Assert.Throws<InvalidFormatException>(() =>
@@ -93,7 +93,7 @@ public class ZipCrcExtractionTests : ArchiveTests
     {
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: false);
         using var reader = ReaderFactory.OpenReader(zipStream);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-reader-crc-disabled.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-reader-crc-disabled.txt");
 
         Assert.True(reader.MoveToNextEntry());
         reader.WriteEntryToFile(destination, new ExtractionOptions { CheckCrc = false });
@@ -107,7 +107,7 @@ public class ZipCrcExtractionTests : ArchiveTests
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: false);
         using var archive = ZipArchive.OpenArchive(zipStream);
         var entry = archive.Entries.Single(e => !e.IsDirectory);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-crc-mismatch-async.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-crc-mismatch-async.txt");
 
         var exception = await Assert.ThrowsAsync<InvalidFormatException>(async () =>
             await entry.WriteToFileAsync(destination)
@@ -149,7 +149,7 @@ public class ZipCrcExtractionTests : ArchiveTests
     {
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: false);
         await using var reader = await ReaderFactory.OpenAsyncReader(zipStream);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-reader-crc-mismatch-async.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-reader-crc-mismatch-async.txt");
 
         Assert.True(await reader.MoveToNextEntryAsync());
         var exception = await Assert.ThrowsAsync<InvalidFormatException>(async () =>
@@ -165,7 +165,7 @@ public class ZipCrcExtractionTests : ArchiveTests
         using var zipStream = CreateZipWithInvalidCrc(useDataDescriptor: true);
         using var archive = ZipArchive.OpenArchive(zipStream);
         var entry = archive.Entries.Single(e => !e.IsDirectory);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "zip-dd-crc-mismatch.txt");
+        var destination = Path.Join(SCRATCH_FILES_PATH, "zip-dd-crc-mismatch.txt");
 
         var exception = Assert.Throws<InvalidFormatException>(() => entry.WriteToFile(destination));
 

--- a/tests/SharpCompress.Tests/Zip/ZipReaderAsyncTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipReaderAsyncTests.cs
@@ -19,7 +19,7 @@ public class ZipReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask Issue_269_Double_Skip_Async()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
         using Stream stream = new ForwardOnlyStream(File.OpenRead(path));
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
         var count = 0;
@@ -39,7 +39,7 @@ public class ZipReaderAsyncTests : ReaderTests
     [Fact]
     public async ValueTask SkipUnreadEntryAsync_SeekableSourceDoesNotReadEntryPayload()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
         await using var stream = new ReadGuardStream(File.OpenRead(path));
         await using var reader = await ReaderFactory.OpenAsyncReader(stream);
 
@@ -82,7 +82,7 @@ public class ZipReaderAsyncTests : ReaderTests
     public async ValueTask Zip_Deflate_Streamed_Skip_Async()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
         );
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
         var x = 0;
@@ -103,7 +103,7 @@ public class ZipReaderAsyncTests : ReaderTests
     public async ValueTask Zip_Deflate_Streamed2_Skip_Async()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd-.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd-.zip"))
         );
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
         var x = 0;
@@ -156,7 +156,7 @@ public class ZipReaderAsyncTests : ReaderTests
     public async ValueTask Zip_BZip2_PkwareEncryption_Read_Async()
     {
         using (
-            Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"))
+            Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"))
         )
         using (
             IReader baseReader = ZipReader.OpenReader(
@@ -185,7 +185,7 @@ public class ZipReaderAsyncTests : ReaderTests
     public async ValueTask Zip_Reader_Disposal_Test_Async()
     {
         using var stream = new TestStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
         );
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
@@ -210,7 +210,7 @@ public class ZipReaderAsyncTests : ReaderTests
     {
         using var stream = new TestStream(
             new AsyncOnlyStream(
-                File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
+                File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
             )
         );
         await using var reader = await ReaderFactory.OpenAsyncReader(stream);
@@ -230,7 +230,7 @@ public class ZipReaderAsyncTests : ReaderTests
         {
             using (
                 Stream stream = new AsyncOnlyStream(
-                    File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip"))
+                    File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip"))
                 )
             )
             using (
@@ -261,7 +261,7 @@ public class ZipReaderAsyncTests : ReaderTests
     {
         using (
             Stream stream = new AsyncOnlyStream(
-                File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"))
+                File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"))
             )
         )
 
@@ -293,7 +293,7 @@ public class ZipReaderAsyncTests : ReaderTests
         var count = 0;
         using (
             Stream stream = new AsyncOnlyStream(
-                File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "zipcrypto.zip"))
+                File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "zipcrypto.zip"))
             )
         )
         await using (
@@ -324,7 +324,7 @@ public class ZipReaderAsyncTests : ReaderTests
     {
         // Since version 0.41.0: EntryStream.DisposeAsync() should not throw NotSupportedException
         // when FlushAsync() fails on non-seekable streams (Deflate compression)
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
         using Stream stream = new ForwardOnlyStream(File.OpenRead(path));
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
 
@@ -347,7 +347,7 @@ public class ZipReaderAsyncTests : ReaderTests
     {
         // Since version 0.41.0: EntryStream.DisposeAsync() should not throw NotSupportedException
         // when FlushAsync() fails on non-seekable streams (LZMA compression)
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
         using Stream stream = new ForwardOnlyStream(File.OpenRead(path));
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
 
@@ -371,7 +371,7 @@ public class ZipReaderAsyncTests : ReaderTests
         // Regression test: since 0.41.0, archive iteration would silently break
         // when the input stream throws NotSupportedException in Flush().
         // Only the first entry would be returned, then iteration would stop without exception.
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
         using var fileStream = File.OpenRead(path);
         using Stream stream = new ThrowOnFlushStream(fileStream);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));
@@ -395,7 +395,7 @@ public class ZipReaderAsyncTests : ReaderTests
         // Regression test: since 0.41.0, archive iteration would silently break
         // when the input stream throws NotSupportedException in Flush().
         // Only the first entry would be returned, then iteration would stop without exception.
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
         using var fileStream = File.OpenRead(path);
         using Stream stream = new ThrowOnFlushStream(fileStream);
         await using var reader = await ReaderFactory.OpenAsyncReader(new AsyncOnlyStream(stream));

--- a/tests/SharpCompress.Tests/Zip/ZipReaderTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipReaderTests.cs
@@ -21,7 +21,7 @@ public class ZipReaderTests : ReaderTests
     [Fact]
     public void Issue_269_Double_Skip()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
         using Stream stream = new ForwardOnlyStream(File.OpenRead(path));
         using var reader = ReaderFactory.OpenReader(stream);
         var count = 0;
@@ -41,7 +41,7 @@ public class ZipReaderTests : ReaderTests
     [Fact]
     public void SkipUnreadEntry_SeekableSourceDoesNotReadEntryPayload()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
         using var stream = new ReadGuardStream(File.OpenRead(path));
         using var reader = ReaderFactory.OpenReader(stream);
 
@@ -79,7 +79,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Deflate_Streamed_Skip()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
         );
         using var reader = ReaderFactory.OpenReader(stream);
         var x = 0;
@@ -100,7 +100,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Deflate_Streamed2_Skip()
     {
         using Stream stream = new ForwardOnlyStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd-.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd-.zip"))
         );
         using var reader = ReaderFactory.OpenReader(stream);
         var x = 0;
@@ -146,7 +146,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_BZip2_PkwareEncryption_Read()
     {
         using (
-            Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"))
+            Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"))
         )
         using (
             var reader = ZipReader.OpenReader(
@@ -174,7 +174,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Reader_Disposal_Test()
     {
         using var stream = new TestStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
         );
         using (
             var reader = ReaderFactory.OpenReader(
@@ -198,7 +198,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Reader_Disposal_Test2()
     {
         using var stream = new TestStream(
-            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
+            File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))
         );
         var reader = ReaderFactory.OpenReader(stream);
         while (reader.MoveToNextEntry())
@@ -217,7 +217,7 @@ public class ZipReaderTests : ReaderTests
         {
             using (
                 Stream stream = File.OpenRead(
-                    Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip")
+                    Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip")
                 )
             )
             using (
@@ -247,7 +247,7 @@ public class ZipReaderTests : ReaderTests
     {
         using (
             Stream stream = File.OpenRead(
-                Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip")
+                Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip")
             )
         )
         using (
@@ -276,7 +276,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Deflate_ZipCrypto_Read()
     {
         var count = 0;
-        using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "zipcrypto.zip")))
+        using (Stream stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "zipcrypto.zip")))
         using (
             var reader = ZipReader.OpenReader(
                 stream,
@@ -327,7 +327,7 @@ public class ZipReaderTests : ReaderTests
         }
 
         stream = new MemoryStream(memory.ToArray());
-        File.WriteAllBytes(Path.Combine(SCRATCH_FILES_PATH, "foo.zip"), memory.ToArray());
+        File.WriteAllBytes(Path.Join(SCRATCH_FILES_PATH, "foo.zip"), memory.ToArray());
 
         using IReader zipReader = ZipReader.OpenReader(
             SharpCompressStream.CreateNonDisposing(stream)
@@ -359,7 +359,7 @@ public class ZipReaderTests : ReaderTests
         var keys = new[] { "Empty1", "Empty2", "Dir1/", "Dir2/", "Fake1", "Fake2", "Internal.zip" };
 
         using Stream stream = File.OpenRead(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.issue86.zip")
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.none.issue86.zip")
         );
         using var reader = ZipReader.OpenReader(stream);
         foreach (var key in keys)
@@ -382,7 +382,7 @@ public class ZipReaderTests : ReaderTests
     {
         var keys = new[] { "version", "sizehint", "data/0/metadata", "data/0/records" };
 
-        using var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "test_477.zip"));
+        using var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "test_477.zip"));
         using var reader = ZipReader.OpenReader(fileStream);
         foreach (var key in keys)
         {
@@ -396,7 +396,7 @@ public class ZipReaderTests : ReaderTests
     public void Issue_685()
     {
         var count = 0;
-        using var fileStream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Issue_685.zip"));
+        using var fileStream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, "Issue_685.zip"));
         using var reader = ZipReader.OpenReader(fileStream);
         while (reader.MoveToNextEntry())
         {
@@ -412,7 +412,7 @@ public class ZipReaderTests : ReaderTests
         // Regression for #42: partially reading a Deflate entry and then disposing its
         // EntryStream must return the decompressor's over-read (rewind the buffered
         // underlying stream) so the following entry starts at the correct position.
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.zip");
 
         var expected = new Dictionary<string, byte[]>();
         using (var archive = ZipArchive.OpenArchive(File.OpenRead(path)))
@@ -461,7 +461,7 @@ public class ZipReaderTests : ReaderTests
     [Fact]
     public void Zip_ReaderFactory_Uncompressed_Read_All()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
         using var stream = File.OpenRead(zipPath);
         using var reader = ReaderFactory.OpenReader(stream);
         while (reader.MoveToNextEntry())
@@ -474,7 +474,7 @@ public class ZipReaderTests : ReaderTests
     [Fact]
     public void Zip_ReaderFactory_Uncompressed_Skip_All()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
         using var stream = File.OpenRead(zipPath);
         using var reader = ReaderFactory.OpenReader(stream);
         while (reader.MoveToNextEntry()) { }
@@ -485,7 +485,7 @@ public class ZipReaderTests : ReaderTests
     [Fact]
     public void Zip_Uncompressed_64bit()
     {
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "64bitstream.zip.7z");
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, "64bitstream.zip.7z");
         using var stream = File.OpenRead(zipPath);
         var archive = ArchiveFactory.OpenArchive(stream);
         var reader = archive.ExtractAllEntries();
@@ -504,7 +504,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Uncompressed_Encrypted_Read()
     {
         using var reader = ReaderFactory.OpenReader(
-            Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.encrypted.zip"),
+            Path.Join(TEST_ARCHIVES_PATH, "Zip.none.encrypted.zip"),
             ReaderOptions.ForFilePath with
             {
                 Password = "test",
@@ -530,7 +530,7 @@ public class ZipReaderTests : ReaderTests
 
         foreach (var testFile in testFiles)
         {
-            var path = Path.Combine(TEST_ARCHIVES_PATH, testFile);
+            var path = Path.Join(TEST_ARCHIVES_PATH, testFile);
 
             var readerKeys = new List<string>();
             using (var stream = File.OpenRead(path))
@@ -561,7 +561,7 @@ public class ZipReaderTests : ReaderTests
     {
         // Since version 0.41.0: EntryStream.Dispose() should not throw NotSupportedException
         // when Flush() fails on non-seekable streams (Deflate compression)
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
         using Stream stream = new ForwardOnlyStream(File.OpenRead(path));
         using var reader = ReaderFactory.OpenReader(stream);
 
@@ -584,7 +584,7 @@ public class ZipReaderTests : ReaderTests
     {
         // Since version 0.41.0: EntryStream.Dispose() should not throw NotSupportedException
         // when Flush() fails on non-seekable streams (LZMA compression)
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
         using Stream stream = new ForwardOnlyStream(File.OpenRead(path));
         using var reader = ReaderFactory.OpenReader(stream);
 
@@ -608,7 +608,7 @@ public class ZipReaderTests : ReaderTests
         // Regression test: since 0.41.0, archive iteration would silently break
         // when the input stream throws NotSupportedException in Flush().
         // Only the first entry would be returned, then iteration would stop without exception.
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip");
         using var fileStream = File.OpenRead(path);
         using Stream stream = new ThrowOnFlushStream(fileStream);
         using var reader = ReaderFactory.OpenReader(stream);
@@ -632,7 +632,7 @@ public class ZipReaderTests : ReaderTests
         // Regression test: since 0.41.0, archive iteration would silently break
         // when the input stream throws NotSupportedException in Flush().
         // Only the first entry would be returned, then iteration would stop without exception.
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.dd.zip");
         using var fileStream = File.OpenRead(path);
         using Stream stream = new ThrowOnFlushStream(fileStream);
         using var reader = ReaderFactory.OpenReader(stream);
@@ -653,7 +653,7 @@ public class ZipReaderTests : ReaderTests
     [Fact]
     public void Zip_LZMA_ZeroSizeEntry_CanExtract_Streaming()
     {
-        var path = Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.empty.zip");
+        var path = Path.Join(TEST_ARCHIVES_PATH, "Zip.lzma.empty.zip");
         using var fileStream = File.OpenRead(path);
         using Stream stream = new ForwardOnlyStream(fileStream);
         using var reader = ReaderFactory.OpenReader(stream);

--- a/tests/SharpCompress.Tests/Zip/ZipShortReadTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipShortReadTests.cs
@@ -29,7 +29,7 @@ public class ZipShortReadTests : ReaderTests
     public void Zip_Reader_Handles_Short_Reads(string zipFile, int firstReadSize, int chunkSize)
     {
         // Use an existing test ZIP file
-        var zipPath = Path.Combine(TEST_ARCHIVES_PATH, zipFile);
+        var zipPath = Path.Join(TEST_ARCHIVES_PATH, zipFile);
         if (!File.Exists(zipPath))
         {
             return; // Skip if file doesn't exist


### PR DESCRIPTION
## Summary

- Replaced all ~907 `Path.Combine` calls with `Path.Join` across `libs/SharpCompress/` and `tests/`
- Fixed double-join bugs in `ArchiveTests.cs` where already-absolute paths were being re-joined with the base path
- Updated path-traversal security tests: absolute-path archive entries (e.g. `/abs.txt`) are now safely extracted inside the destination directory (previously they escaped via `Path.Combine`'s absolute-path drop behavior and triggered an exception)
- Zero instances existed in `backend/` application code

## Test plan

- [x] `dotnet build` succeeds with 0 warnings, 0 errors for both test projects
- [x] `dotnet test tests/SharpCompress.Tests` — 2124 passed, 0 failed (2 new tests added for absolute-path extraction)
- [x] `dotnet test tests/NzbWebDAV.Tests` — 2405 passed, 0 failed
- [x] Zero remaining `Path.Combine` in any `.cs` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)