### PR TITLE
fix(sharpcompress): resolve CodeQL findings in zstd unsafe code and buffer pool tests

### DIFF
--- a/libs/SharpCompress/Compressors/ZStandard/Unsafe/ZstdOpt.cs
+++ b/libs/SharpCompress/Compressors/ZStandard/Unsafe/ZstdOpt.cs
@@ -1928,7 +1928,7 @@ public static unsafe partial class Methods
                                 {
                                     last_pos++;
                                     opt[last_pos].price = 1 << 30;
-                                    opt[last_pos].litlen = 0 == 0 ? 1U : 0U;
+                                    opt[last_pos].litlen = 1U; // upstream: litlen = !0, "not an end of match"
                                 }
 
                                 opt[pos].mlen = mlen;

--- a/libs/SharpCompress/Compressors/ZStandard/Unsafe/ZstdPresplit.cs
+++ b/libs/SharpCompress/Compressors/ZStandard/Unsafe/ZstdPresplit.cs
@@ -142,7 +142,9 @@ public static unsafe partial class Methods
             fpstats->pastEvents.events[n] = fpstats->newEvents.events[n];
         }
 
-        fpstats->pastEvents.nbEvents = fpstats->newEvents.nbEvents;
+        // Read via local to avoid CodeQL false-positive self-assignment on pointer paths.
+        var nbEvents = fpstats->newEvents.nbEvents;
+        fpstats->pastEvents.nbEvents = nbEvents;
         fpstats->newEvents = new Fingerprint();
     }
 

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -111,9 +111,11 @@ public class SegmentBufferPoolTests
         var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);
         var weakBuffer = RentAndDropBuffer(pool);
 
+#pragma warning disable CA2001 // forced GC is the standard pattern for weak-reference leak tests
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
+#pragma warning restore CA2001
 
         Assert.False(weakBuffer.IsAlive);
         // The leak stays visible in diagnostics even though nothing is rooted.


### PR DESCRIPTION
## Summary
- **ZstdOpt.cs**: Replace `0 == 0 ? 1U : 0U` with `1U` — this was a mechanical port of C's `!0` (confirmed against [upstream zstd](https://github.com/facebook/zstd/blob/dev/lib/compress/zstd_opt.c)); CodeQL flagged it as a comparison of identical values
- **ZstdPresplit.cs**: Break false-positive self-assignment (`fpstats->pastEvents.nbEvents = fpstats->newEvents.nbEvents`) by reading through a local variable; CodeQL's pointer alias analysis can't distinguish the two struct field paths
- **SegmentBufferPoolTests.cs**: Add `#pragma warning disable CA2001` around the intentional `GC.Collect()` triple — this is the standard .NET pattern for weak-reference leak verification tests

## Test plan
- [x] `dotnet build libs/SharpCompress` — 0 warnings, 0 errors
- [x] `dotnet test tests/NzbWebDAV.Tests --filter SegmentBufferPoolTests` — 13/13 passed
- [x] `dotnet test tests/SharpCompress.Tests --filter "format!=stress"` — 2124/2124 passed
- [ ] Verify CodeQL alerts close on next analysis run