### PR TITLE
fix(sab): malformed IDs in SAB history requests now return a client error instead of HTTP 500

### DIFF
--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -63,11 +63,34 @@ public class GetHistoryRequest
 
         if (nzoIdsParam is not null)
         {
-            NzoIds = nzoIdsParam
-                .Split(',')
-                .Select(nzoId => nzoId.Trim())
-                .Select(Guid.Parse)
-                .ToList();
+            var nzoIds = new List<Guid>();
+            var badTokens = new List<string>();
+            foreach (var token in nzoIdsParam.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (Guid.TryParse(token, out var nzoId))
+                {
+                    nzoIds.Add(nzoId);
+                }
+                else
+                {
+                    badTokens.Add(token);
+                }
+            }
+
+            if (badTokens.Count > 0)
+            {
+                const int maxBadTokensShown = 5;
+                var shown = badTokens.Take(maxBadTokensShown).Select(t => $"'{t}'");
+                var bad = string.Join(", ", shown);
+                if (badTokens.Count > maxBadTokensShown)
+                {
+                    bad += $", ... ({badTokens.Count - maxBadTokensShown} more)";
+                }
+
+                throw new BadHttpRequestException($"Invalid nzo_ids parameter: {bad}");
+            }
+
+            NzoIds = nzoIds;
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -70,6 +70,56 @@ public class GetHistoryRequestTests
     }
 
     [Fact]
+    public void MalformedNzoId_ThrowsBadRequest()
+    {
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?nzo_ids=not-a-guid");
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        Assert.Contains("not-a-guid", ex.Message);
+    }
+
+    [Fact]
+    public void MixedValidAndInvalidNzoIds_ThrowsBadRequestNamingOnlyInvalidTokens()
+    {
+        var validId = Guid.NewGuid();
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?nzo_ids={validId},bad-one,also-bad");
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        Assert.Contains("bad-one", ex.Message);
+        Assert.Contains("also-bad", ex.Message);
+        Assert.DoesNotContain(validId.ToString(), ex.Message);
+    }
+
+    [Fact]
+    public void ValidNzoIdsWithWhitespaceAndEmptyEntries_ParsesExpectedGuids()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?nzo_ids= {id1} ,,{id2} ");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal([id1, id2], request.NzoIds);
+    }
+
+    [Fact]
+    public void MissingNzoIds_KeepsEmptyList()
+    {
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Empty(request.NzoIds);
+    }
+
+    [Fact]
     public void GetHistoryMaxPageSize_DefaultsAndClamps()
     {
         Assert.Equal(10_000, new ConfigManager().GetHistoryMaxPageSize());


### PR DESCRIPTION
## Summary
- Parse `nzo_ids` on SAB `mode=history` requests with `Guid.TryParse` instead of `Guid.Parse`
- Return HTTP 400 with a clear message naming invalid tokens (capped at five) instead of HTTP 500 with a stack dump
- Add request-parser tests for malformed, mixed, whitespace, and absent `nzo_ids`

Fixes #887

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~GetHistoryRequestTests"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~SabDeleteRequestTests"`
- [x] Full backend suite (one unrelated flaky `CorrelatedTripDetectorTests` failure on first run; passed on re-run)