### PR TITLE
fix(rclone): mounts no longer show stale files after a temporary rclone outage

### DIFF
--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
@@ -21,7 +21,8 @@ public class TestRcloneConnectionController(ConfigManager configManager) : BaseA
                 Status = true,
                 Connected = result.Success,
                 Error = result.Error,
-                LastInvalidationError = RcloneClient.LastForgetError?.Message
+                LastInvalidationError = RcloneClient.LastForgetError?.Message,
+                LastInvalidationErrorAt = RcloneClient.LastForgetError?.At
             };
         }
         catch (Exception e) when (e is HttpRequestException or IOException or TimeoutException or InvalidOperationException)

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
@@ -20,7 +20,8 @@ public class TestRcloneConnectionController(ConfigManager configManager) : BaseA
             {
                 Status = true,
                 Connected = result.Success,
-                Error = result.Error
+                Error = result.Error,
+                LastInvalidationError = RcloneClient.LastForgetError?.Message
             };
         }
         catch (Exception e) when (e is HttpRequestException or IOException or TimeoutException or InvalidOperationException)

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionResponse.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionResponse.cs
@@ -4,4 +4,5 @@ public class TestRcloneConnectionResponse : BaseApiResponse
 {
     public bool Connected { get; set; }
     public string? LastInvalidationError { get; set; }
+    public DateTimeOffset? LastInvalidationErrorAt { get; set; }
 }

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionResponse.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionResponse.cs
@@ -3,4 +3,5 @@ namespace NzbWebDAV.Api.Controllers.TestRcloneConnection;
 public class TestRcloneConnectionResponse : BaseApiResponse
 {
     public bool Connected { get; set; }
+    public string? LastInvalidationError { get; set; }
 }

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -17,6 +17,19 @@ namespace NzbWebDAV.Clients.Rclone;
 public static class RcloneClient
 {
     private static readonly HttpClient HttpClient = new();
+    private static ForgetErrorEntry? _lastForgetError;
+
+    internal static HttpMessageHandler? TestHandler { get; set; }
+    internal static Func<int, TimeSpan>? BackoffOverride { get; set; }
+
+    public static (string Message, DateTimeOffset At)? LastForgetError
+    {
+        get
+        {
+            var entry = Volatile.Read(ref _lastForgetError);
+            return entry is null ? null : (entry.Message, entry.At);
+        }
+    }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -96,8 +109,44 @@ public static class RcloneClient
         }
 
         Log.Debug("Rclone vfs/forget: {0}", paths.ToIndentedJson());
-        return await Post<VfsForgetResponse>("vfs/forget", request).ConfigureAwait(false);
+
+        const int maxAttempts = 4;
+        VfsForgetResponse? lastResponse = null;
+        var pathsDisplay = string.Join(", ", pathList);
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            lastResponse = await Post<VfsForgetResponse>("vfs/forget", request).ConfigureAwait(false);
+
+            if (lastResponse.Success)
+            {
+                Interlocked.Exchange(ref _lastForgetError, null);
+                return lastResponse;
+            }
+
+            if (lastResponse.Error == "Authentication failed")
+                return lastResponse;
+
+            if (attempt < maxAttempts)
+                await Task.Delay(GetBackoff(attempt)).ConfigureAwait(false);
+        }
+
+        var reason = lastResponse?.Error ?? "Unknown error";
+        Interlocked.Exchange(ref _lastForgetError, new ForgetErrorEntry(reason, DateTimeOffset.UtcNow));
+        Log.Warning(
+            "Rclone vfs/forget failed after {Attempts} attempts for paths {Paths}. Reason: {Reason}; mounted clients may show stale entries until rclone's dir-cache expires",
+            maxAttempts,
+            pathsDisplay,
+            reason);
+
+        return lastResponse!;
     }
+
+    private static TimeSpan GetForgetBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Min(60d, 5d * Math.Pow(2, attempt - 1)));
+
+    private static TimeSpan GetBackoff(int attempt) =>
+        BackoffOverride?.Invoke(attempt) ?? GetForgetBackoff(attempt);
 
     /// <summary>
     /// Get VFS statistics including cache information.
@@ -178,7 +227,7 @@ public static class RcloneClient
 
         try
         {
-            using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
+            using var response = await SendRequest(request).ConfigureAwait(false);
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
@@ -229,6 +278,17 @@ public static class RcloneClient
     private static Task<T> Post<T>(string endpoint, object? body) where T : RcloneResponse, new()
         => Post<T>(Host!, User, Pass, endpoint, body);
 
+    private static async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request)
+    {
+        if (TestHandler != null)
+        {
+            using var client = new HttpClient(TestHandler, disposeHandler: false);
+            return await client.SendAsync(request).ConfigureAwait(false);
+        }
+
+        return await HttpClient.SendAsync(request).ConfigureAwait(false);
+    }
+
     private static void AddAuthHeader(HttpRequestMessage request, string? user, string? pass)
     {
         if (string.IsNullOrEmpty(user) && string.IsNullOrEmpty(pass))
@@ -237,5 +297,11 @@ public static class RcloneClient
         var credentials = $"{user ?? ""}:{pass ?? ""}";
         var encodedCredentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
         request.Headers.Authorization = new AuthenticationHeaderValue("Basic", encodedCredentials);
+    }
+
+    private sealed class ForgetErrorEntry(string message, DateTimeOffset at)
+    {
+        public string Message { get; } = message;
+        public DateTimeOffset At { get; } = at;
     }
 }

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -125,7 +125,10 @@ public static class RcloneClient
             }
 
             if (lastResponse.Error == "Authentication failed")
+            {
+                Interlocked.Exchange(ref _lastForgetError, null);
                 return lastResponse;
+            }
 
             if (attempt < maxAttempts)
                 await Task.Delay(GetBackoff(attempt)).ConfigureAwait(false);

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -14,10 +14,12 @@ type RcloneSettingsProps = {
 export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
     const [connectionState, setConnectionState] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
     const [testError, setTestError] = useState<string | null>(null);
+    const [invalidationError, setInvalidationError] = useState<string | null>(null);
 
     useEffect(() => {
         setConnectionState('idle');
         setTestError(null);
+        setInvalidationError(null);
     }, [config["rclone.host"], config["rclone.user"], config["rclone.pass"]]);
 
     const testConnection = useCallback(async () => {
@@ -28,6 +30,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
 
         setConnectionState('testing');
         setTestError(null);
+        setInvalidationError(null);
 
         try {
             const formData = new FormData();
@@ -45,6 +48,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
             if (result.status && result.connected) {
                 setConnectionState('success');
                 setTestError(null);
+                setInvalidationError(result.lastInvalidationError ?? null);
             } else {
                 setConnectionState('error');
                 setTestError(result.error || "Connection test failed");
@@ -130,6 +134,12 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 {connectionState === 'success' && (
                     <Alert variant="success" className="text-xs py-2">
                         Connection test successful
+                    </Alert>
+                )}
+                {connectionState === 'success' && invalidationError && (
+                    <Alert variant="warning" className="text-xs py-2">
+                        Recent VFS cache invalidation failed: {invalidationError}. Mounted clients may show stale
+                        entries until rclone&apos;s dir-cache expires.
                     </Alert>
                 )}
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="rclone-host-help">

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -6,6 +6,16 @@ import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
 import { withUrlBase } from "~/utils/url-base";
 
+function formatTimeAgo(isoDate: string): string {
+    const seconds = Math.floor((Date.now() - new Date(isoDate).getTime()) / 1000);
+    if (seconds < 60) return "just now";
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+}
+
 type RcloneSettingsProps = {
     config: Record<string, string>
     setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
@@ -15,11 +25,13 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
     const [connectionState, setConnectionState] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
     const [testError, setTestError] = useState<string | null>(null);
     const [invalidationError, setInvalidationError] = useState<string | null>(null);
+    const [invalidationErrorAt, setInvalidationErrorAt] = useState<string | null>(null);
 
     useEffect(() => {
         setConnectionState('idle');
         setTestError(null);
         setInvalidationError(null);
+        setInvalidationErrorAt(null);
     }, [config["rclone.host"], config["rclone.user"], config["rclone.pass"]]);
 
     const testConnection = useCallback(async () => {
@@ -31,6 +43,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
         setConnectionState('testing');
         setTestError(null);
         setInvalidationError(null);
+        setInvalidationErrorAt(null);
 
         try {
             const formData = new FormData();
@@ -49,6 +62,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 setConnectionState('success');
                 setTestError(null);
                 setInvalidationError(result.lastInvalidationError ?? null);
+                setInvalidationErrorAt(result.lastInvalidationErrorAt ?? null);
             } else {
                 setConnectionState('error');
                 setTestError(result.error || "Connection test failed");
@@ -138,7 +152,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 )}
                 {connectionState === 'success' && invalidationError && (
                     <Alert variant="warning" className="text-xs py-2">
-                        Recent VFS cache invalidation failed: {invalidationError}. Mounted clients may show stale
+                        VFS cache invalidation failed{invalidationErrorAt ? ` ${formatTimeAgo(invalidationErrorAt)}` : ''}: {invalidationError}. Mounted clients may show stale
                         entries until rclone&apos;s dir-cache expires.
                     </Alert>
                 )}

--- a/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Text;
+using NzbWebDAV.Clients.Rclone;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Clients;
+
+public class RcloneClientTests : IDisposable
+{
+    public RcloneClientTests()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://rclone.test" },
+        ]);
+        RcloneClient.Initialize(config);
+        RcloneClient.BackoffOverride = _ => TimeSpan.Zero;
+    }
+
+    [Fact]
+    public async Task ForgetVfsPaths_RetriesUntilSuccess()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/forget", FailResponse("transient failure")),
+            ("POST /vfs/forget", FailResponse("transient failure")),
+            ("POST /vfs/forget", SuccessResponse()));
+
+        var result = await RcloneClient.ForgetVfsPaths(["/content/test"]);
+
+        Assert.True(result.Success);
+        Assert.Null(RcloneClient.LastForgetError);
+    }
+
+    [Fact]
+    public async Task ForgetVfsPaths_DoesNotRetryAuthenticationFailure()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/forget", UnauthorizedResponse()));
+
+        var result = await RcloneClient.ForgetVfsPaths(["/content/test"]);
+
+        Assert.False(result.Success);
+        Assert.Equal("Authentication failed", result.Error);
+        Assert.Null(RcloneClient.LastForgetError);
+    }
+
+    [Fact]
+    public async Task ForgetVfsPaths_SetsLastForgetErrorAfterAllAttemptsFail()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/forget", FailResponse("persistent failure")),
+            ("POST /vfs/forget", FailResponse("persistent failure")),
+            ("POST /vfs/forget", FailResponse("persistent failure")),
+            ("POST /vfs/forget", FailResponse("persistent failure")));
+
+        var result = await RcloneClient.ForgetVfsPaths(["/content/test"]);
+
+        Assert.False(result.Success);
+        Assert.NotNull(RcloneClient.LastForgetError);
+        Assert.Equal("persistent failure", RcloneClient.LastForgetError!.Value.Message);
+    }
+
+    [Fact]
+    public async Task ForgetVfsPaths_EmptyPathList_DoesNotCallHttp()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/forget", SuccessResponse()));
+
+        var result = await RcloneClient.ForgetVfsPaths([]);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Forgotten ?? []);
+    }
+
+    public void Dispose()
+    {
+        RcloneClient.TestHandler = null;
+        RcloneClient.BackoffOverride = null;
+    }
+
+    private static HttpResponseMessage SuccessResponse() =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage FailResponse(string error) =>
+        new(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent($"{{\"error\":\"{error}\"}}", Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage UnauthorizedResponse() =>
+        new(HttpStatusCode.Unauthorized);
+
+    private static ResponseQueueHandler CreateHandler(
+        params (string request, HttpResponseMessage response)[] responses) =>
+        new(responses
+            .GroupBy(x => x.request)
+            .ToDictionary(
+                x => x.Key,
+                x => new Queue<HttpResponseMessage>(x.Select(y => y.response))));
+
+    private sealed class ResponseQueueHandler(
+        Dictionary<string, Queue<HttpResponseMessage>> responses) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var key = $"{request.Method} {request.RequestUri!.PathAndQuery}";
+            if (!responses.TryGetValue(key, out var queuedResponses) || !queuedResponses.TryDequeue(out var response))
+                throw new InvalidOperationException($"Unexpected request: {key}");
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
@@ -47,6 +47,26 @@ public class RcloneClientTests : IDisposable
     }
 
     [Fact]
+    public async Task ForgetVfsPaths_AuthenticationFailureClearsPriorError()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/forget", FailResponse("transient failure")),
+            ("POST /vfs/forget", FailResponse("transient failure")),
+            ("POST /vfs/forget", FailResponse("transient failure")),
+            ("POST /vfs/forget", FailResponse("transient failure")),
+            ("POST /vfs/forget", UnauthorizedResponse()));
+
+        await RcloneClient.ForgetVfsPaths(["/content/seed-error"]);
+        Assert.NotNull(RcloneClient.LastForgetError);
+
+        var result = await RcloneClient.ForgetVfsPaths(["/content/test"]);
+
+        Assert.False(result.Success);
+        Assert.Equal("Authentication failed", result.Error);
+        Assert.Null(RcloneClient.LastForgetError);
+    }
+
+    [Fact]
     public async Task ForgetVfsPaths_SetsLastForgetErrorAfterAllAttemptsFail()
     {
         RcloneClient.TestHandler = CreateHandler(


### PR DESCRIPTION
Closes #891

## Summary
- Retry failed `vfs/forget` RC calls up to 4 times with exponential backoff (5s → 10s → 20s, capped at 60s), skipping retries on authentication failures
- Track the last persistent invalidation failure in `RcloneClient.LastForgetError` and surface it via the rclone connection test API
- Show a warning on the rclone settings page when the connection test succeeds but a recent cache invalidation failed

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~RcloneClientTests"`
- [ ] Manually trigger a file add/remove with rclone RC briefly unavailable, confirm retries in logs and mount updates after recovery
- [ ] Run rclone connection test after a failed invalidation and confirm the warning appears beneath the success alert