### PR TITLE
fix(sab): queue and history no longer return empty when clients send limit=0

### DIFF
--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -16,7 +16,7 @@ public class GetHistoryController(
     ProviderUsageTracker providerUsageTracker
 ) : SabApiController.BaseController(httpContext, configManager)
 {
-    private async Task<GetHistoryResponse> GetHistoryAsync(GetHistoryRequest request)
+    internal async Task<GetHistoryResponse> GetHistoryAsync(GetHistoryRequest request)
     {
         // get query
         IQueryable<HistoryItem> query = dbClient.Ctx.HistoryItems;

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -42,7 +42,7 @@ public class GetHistoryRequest
         {
             var isValidLimit = int.TryParse(limitParam, out var limit);
             if (!isValidLimit) throw new BadHttpRequestException("Invalid limit parameter");
-            Limit = limit;
+            Limit = limit > 0 ? limit : int.MaxValue;
         }
 
         // Even though we may want to ignore the `limit` param from the Arrs, NzbDAV frontend
@@ -53,7 +53,7 @@ public class GetHistoryRequest
         {
             var isValidPageSize = int.TryParse(pageSizeParam, out var pageSize);
             if (!isValidPageSize) throw new BadHttpRequestException("Invalid pageSize parameter");
-            Limit = pageSize;
+            Limit = pageSize > 0 ? pageSize : int.MaxValue;
         }
 
         // Server-side ceiling: keep ignore-limit semantics for Arrs but never materialize

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -26,7 +26,7 @@ public class GetHistoryRequest
         {
             var isValidStartParam = int.TryParse(startParam, out int start);
             if (!isValidStartParam) throw new BadHttpRequestException("Invalid start parameter");
-            Start = start;
+            Start = Math.Max(0, start);
         }
 
         // The official Sabnzbd api uses the `limit` param to specify the number of history items
@@ -57,8 +57,7 @@ public class GetHistoryRequest
         }
 
         // Server-side ceiling: keep ignore-limit semantics for Arrs but never materialize
-        // an unbounded history response (default Limit is int.MaxValue). Clamp instead of
-        // Min because a negative Take() becomes a negative SQLite LIMIT, which is unbounded.
+        // an unbounded history response (default Limit is int.MaxValue when omitted or ≤ 0).
         Limit = Math.Clamp(Limit, 0, configManager.GetHistoryMaxPageSize());
 
         if (nzoIdsParam is not null)

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -36,7 +36,8 @@ public class GetQueueController(
         var totalCount = await dbClient.GetQueueItemsCount(request.Category, ct).ConfigureAwait(false);
 
         // get queued items, then merge active items ahead for the requested page
-        var getQueueItemsTask = dbClient.GetQueueItems(request.Category, 0, request.Start + request.Limit, ct);
+        var fetchCount = request.Start + Math.Min(request.Limit, int.MaxValue - request.Start);
+        var getQueueItemsTask = dbClient.GetQueueItems(request.Category, 0, fetchCount, ct);
         var queuedItems = (await getQueueItemsTask.ConfigureAwait(false))
             .Where(x => !inProgressIds.Contains(x.Id))
             .ToArray();

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -30,7 +30,7 @@ public class GetQueueRequest
         {
             var isValidLimit = int.TryParse(limitParam, out int limit);
             if (!isValidLimit) throw new BadHttpRequestException("Invalid limit parameter");
-            Limit = limit;
+            Limit = limit > 0 ? limit : int.MaxValue;
         }
     }
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -23,7 +23,7 @@ public class GetQueueRequest
         {
             var isValidStartParam = int.TryParse(startParam, out int start);
             if (!isValidStartParam) throw new BadHttpRequestException("Invalid start parameter");
-            Start = start;
+            Start = Math.Max(0, start);
         }
 
         if (limitParam is not null)

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -57,16 +57,73 @@ public class GetHistoryRequestTests
     }
 
     [Fact]
-    public void ClampsNegativePageSizeToZero()
+    public void TreatsNegativePageSizeAsUnlimitedCappedAtCeiling()
     {
-        // A negative Take() becomes a negative SQLite LIMIT (= unbounded); must clamp.
         var config = CreateConfig(ignoreLimit: true);
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?pageSize=-1");
 
         var request = new GetHistoryRequest(context, config);
 
-        Assert.Equal(0, request.Limit);
+        Assert.Equal(10_000, request.Limit);
+    }
+
+    [Fact]
+    public void TreatsLimitZeroAsUnlimitedCappedAtCeiling()
+    {
+        var config = CreateConfig(ignoreLimit: false);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=0");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(10_000, request.Limit);
+    }
+
+    [Fact]
+    public void TreatsPageSizeZeroAsUnlimitedCappedAtCeiling()
+    {
+        var config = CreateConfig(ignoreLimit: false);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?pageSize=0");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(10_000, request.Limit);
+    }
+
+    [Fact]
+    public void PageSizeZeroOverridesLimitWhenBothPresent()
+    {
+        var config = CreateConfig(ignoreLimit: false);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=60&pageSize=0");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(10_000, request.Limit);
+    }
+
+    [Fact]
+    public void RejectsNonIntegerLimit()
+    {
+        var config = CreateConfig(ignoreLimit: false);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=abc");
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        Assert.Equal("Invalid limit parameter", ex.Message);
+    }
+
+    [Fact]
+    public void RejectsNonIntegerPageSize()
+    {
+        var config = CreateConfig(ignoreLimit: true);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?pageSize=abc");
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        Assert.Equal("Invalid pageSize parameter", ex.Message);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -126,6 +126,22 @@ public class GetHistoryRequestTests
         Assert.Equal("Invalid pageSize parameter", ex.Message);
     }
 
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(-100, 0)]
+    [InlineData(0, 0)]
+    [InlineData(5, 5)]
+    public void ClampsNegativeStartToZero(int startParam, int expectedStart)
+    {
+        var config = CreateConfig(ignoreLimit: false);
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?start={startParam}");
+
+        var request = new GetHistoryRequest(context, config);
+
+        Assert.Equal(expectedStart, request.Start);
+    }
+
     [Fact]
     public void GetHistoryMaxPageSize_DefaultsAndClamps()
     {

--- a/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetQueueRequestTests
+{
+    [Fact]
+    public void OmittedLimitDefaultsToUnlimited()
+    {
+        var context = new DefaultHttpContext();
+        var request = new GetQueueRequest(context, new ConfigManager());
+
+        Assert.Equal(int.MaxValue, request.Limit);
+    }
+
+    [Theory]
+    [InlineData(50, 50)]
+    [InlineData(0, int.MaxValue)]
+    [InlineData(-5, int.MaxValue)]
+    public void ParsesLimitParameter(int limitParam, int expectedLimit)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?limit={limitParam}");
+
+        var request = new GetQueueRequest(context, new ConfigManager());
+
+        Assert.Equal(expectedLimit, request.Limit);
+    }
+
+    [Fact]
+    public void RejectsNonIntegerLimit()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=abc");
+
+        var ex = Assert.Throws<BadHttpRequestException>(() => new GetQueueRequest(context, new ConfigManager()));
+        Assert.Equal("Invalid limit parameter", ex.Message);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
@@ -29,6 +29,21 @@ public class GetQueueRequestTests
         Assert.Equal(expectedLimit, request.Limit);
     }
 
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(-100, 0)]
+    [InlineData(0, 0)]
+    [InlineData(5, 5)]
+    public void ClampsNegativeStartToZero(int startParam, int expectedStart)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?start={startParam}");
+
+        var request = new GetQueueRequest(context, new ConfigManager());
+
+        Assert.Equal(expectedStart, request.Start);
+    }
+
     [Fact]
     public void RejectsNonIntegerLimit()
     {

--- a/tests/NzbWebDAV.Tests/Api/SabLimitZeroTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabLimitZeroTests.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.GetHistory;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class SabLimitZeroTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-limit-zero-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        var websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task GetQueueAsync_LimitZero_ReturnsAllSeededItems()
+    {
+        var items = new[]
+        {
+            CreateQueueItem("first.nzb", DateTime.UtcNow.AddMinutes(-30)),
+            CreateQueueItem("second.nzb", DateTime.UtcNow.AddMinutes(-20)),
+            CreateQueueItem("third.nzb", DateTime.UtcNow.AddMinutes(-10)),
+        };
+        _context.QueueItems.AddRange(items);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=0");
+        var request = new GetQueueRequest(context, _configManager);
+
+        var response = await CreateGetQueueController().GetQueueAsync(request);
+
+        Assert.Equal(3, response.Queue.TotalCount);
+        Assert.Equal(3, response.Queue.Slots.Count);
+        Assert.Equal(
+            items.Select(i => i.Id.ToString()).OrderBy(x => x),
+            response.Queue.Slots.Select(s => s.NzoId).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_LimitZero_ReturnsAllSeededItems()
+    {
+        var items = new[]
+        {
+            CreateHistoryItem("first.nzb", DateTime.UtcNow.AddMinutes(-30)),
+            CreateHistoryItem("second.nzb", DateTime.UtcNow.AddMinutes(-20)),
+            CreateHistoryItem("third.nzb", DateTime.UtcNow.AddMinutes(-10)),
+        };
+        _context.HistoryItems.AddRange(items);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?limit=0");
+        var request = new GetHistoryRequest(context, _configManager);
+
+        var response = await CreateGetHistoryController().GetHistoryAsync(request);
+
+        Assert.Equal(3, response.History.TotalCount);
+        Assert.Equal(3, response.History.Slots.Count);
+        Assert.Equal(
+            items.Select(i => i.Id.ToString()).OrderBy(x => x),
+            response.History.Slots.Select(s => s.NzoId).OrderBy(x => x));
+    }
+
+    private GetQueueController CreateGetQueueController() =>
+        new(new DefaultHttpContext(), _dbClient, _queueManager, _configManager, new ProviderUsageTracker());
+
+    private GetHistoryController CreateGetHistoryController() =>
+        new(new DefaultHttpContext(), _dbClient, _configManager, new ProviderUsageTracker());
+
+    private static QueueItem CreateQueueItem(string fileName, DateTime createdAt) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            NzbFileSize = 100,
+            TotalSegmentBytes = 200,
+            Category = "movies",
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+
+    private static HistoryItem CreateHistoryItem(string fileName, DateTime createdAt) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = "movies",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+            TotalSegmentBytes = 100,
+            DownloadTimeSeconds = 5,
+        };
+}


### PR DESCRIPTION
## Summary
- Treat `limit=0` and `pageSize=0` as unlimited (mapped to `int.MaxValue`) for SAB queue and history requests, matching SABnzbd's "no limit" convention used by Sonarr/Radarr.
- History responses remain bounded by the configured `GetHistoryMaxPageSize` ceiling (default 10,000).
- Guard `GetQueueController` against `Start + Limit` integer overflow when limit is unlimited.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~GetQueueRequestTests|FullyQualifiedName~GetHistoryRequestTests|FullyQualifiedName~SabLimitZeroTests"` (18 tests passed)
- [ ] Verify Sonarr/Radarr queue and history polling with `limit=0` returns items instead of an empty slot list

Fixes #886