### PR TITLE
fix(arr): reliably trigger Sonarr/Radarr replacement searches after repairing unplayable files

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -89,7 +89,7 @@ public class ArrClient(string host, string apiKey)
                 await operation(ct).ConfigureAwait(false);
                 return;
             }
-            catch (Exception ex) when (IsTransientArrFailure(ex) && attempt < maxAttempts)
+            catch (Exception ex) when (!ct.IsCancellationRequested && IsTransientArrFailure(ex) && attempt < maxAttempts)
             {
 #pragma warning disable CA5394 // retry backoff jitter is not security-sensitive
                 var delayMs = (int)Math.Pow(2, attempt - 1) * 1000 + Random.Shared.Next(0, 250);
@@ -107,7 +107,7 @@ public class ArrClient(string host, string apiKey)
 
     private static bool IsTransientArrFailure(Exception ex)
     {
-        if (ex is TaskCanceledException) return true;
+        if (ex is TaskCanceledException or OperationCanceledException) return true;
         if (ex is not HttpRequestException httpEx) return false;
         if (!httpEx.StatusCode.HasValue) return true;
         var statusCode = (int)httpEx.StatusCode.Value;

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -15,6 +15,9 @@ public class ArrClient(string host, string apiKey)
     private string ApiKey { get; } = apiKey;
     private const string BasePath = "/api/v3";
 
+    protected static bool Is2xx(HttpStatusCode statusCode) =>
+        (int)statusCode is >= 200 and < 300;
+
     public Task<ArrApiInfoResponse> GetApiInfo(CancellationToken ct = default) =>
         GetRoot<ArrApiInfoResponse>($"/api", ct);
 

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Config;
+using Serilog;
 
 namespace NzbWebDAV.Clients.RadarrSonarr;
 
@@ -70,6 +71,47 @@ public class ArrClient(string host, string apiKey)
     protected async Task MarkHistoryFailed(int historyId, CancellationToken ct = default)
     {
         _ = await Post<object>($"/history/failed/{historyId}", new { }, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Retries transient Arr API failures for repair search notifications.
+    /// Delete/blocklist steps rely on <see cref="NzbWebDAV.Services.HealthCheckService.DecideArrLinkedRepairAsync"/> fail-safe instead.
+    /// </summary>
+    protected async Task ExecuteWithTransientRetryAsync(
+        Func<CancellationToken, Task> operation,
+        CancellationToken ct)
+    {
+        const int maxAttempts = 3;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await operation(ct).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex) when (IsTransientArrFailure(ex) && attempt < maxAttempts)
+            {
+#pragma warning disable CA5394 // retry backoff jitter is not security-sensitive
+                var delayMs = (int)Math.Pow(2, attempt - 1) * 1000 + Random.Shared.Next(0, 250);
+#pragma warning restore CA5394
+                Log.Debug(
+                    ex,
+                    "Transient Arr API failure on attempt {Attempt}/{MaxAttempts}; retrying in {DelayMs}ms",
+                    attempt,
+                    maxAttempts,
+                    delayMs);
+                await Task.Delay(delayMs, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsTransientArrFailure(Exception ex)
+    {
+        if (ex is TaskCanceledException) return true;
+        if (ex is not HttpRequestException httpEx) return false;
+        if (!httpEx.StatusCode.HasValue) return true;
+        var statusCode = (int)httpEx.StatusCode.Value;
+        return statusCode is < 400 or >= 500;
     }
 
     protected Task<T> Get<T>(string path, CancellationToken ct = default) =>

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.RadarrSonarr.RadarrModels;
+using Serilog;
 
 namespace NzbWebDAV.Clients.RadarrSonarr;
 
@@ -30,20 +31,38 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         Guid downloadId,
         CancellationToken ct = default)
     {
-        var movieFileId = await GetMovieFileId(symlinkOrStrmPath, ct).ConfigureAwait(false);
-        if (movieFileId == null) return ArrRepairOutcome.MediaItemNotFound;
+        var movieIds = await GetMovieFileIds(symlinkOrStrmPath, ct).ConfigureAwait(false);
+        if (movieIds == null) return ArrRepairOutcome.MediaItemNotFound;
 
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
-        if (!Is2xx(await DeleteMovieFile(movieFileId.Value, ct).ConfigureAwait(false)))
+        if (!Is2xx(await DeleteMovieFile(movieIds.MovieFileId, ct).ConfigureAwait(false)))
             throw new InvalidOperationException($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+
+        try
+        {
+            await CommandAsync(
+                new { name = "MoviesSearch", movieIds = new[] { movieIds.MovieId } },
+                ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(
+                ex,
+                "Radarr repair on {Host}: failed to request MoviesSearch for movie {MovieId}",
+                Host,
+                movieIds.MovieId);
+        }
+
         return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
     }
 
-    private async Task<int?> GetMovieFileId(string symlinkOrStrmPath, CancellationToken ct)
+    private sealed record MovieFileIds(int MovieFileId, int MovieId);
+
+    private async Task<MovieFileIds?> GetMovieFileIds(string symlinkOrStrmPath, CancellationToken ct)
     {
         var cacheKey = (Host, symlinkOrStrmPath);
 
@@ -54,21 +73,21 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             var movie = await GetMovieOrNullAsync(movieId, ct).ConfigureAwait(false);
             var movieFile = movie?.MovieFile;
             if (movieFile is not null && movieFile.Path == symlinkOrStrmPath)
-                return movieFile.Id;
+                return new MovieFileIds(movieFile.Id, movieId);
             SymlinkOrStrmToMovieIdCache.TryRemove(cacheKey, out _);
         }
 
         // otherwise, let's fetch all movies, cache all movie files
         // and return the matching movie-id and movie-file-id
         var allMovies = await GetMoviesAsync(ct).ConfigureAwait(false);
-        int? result = null;
+        MovieFileIds? result = null;
         foreach (var movie in allMovies)
         {
             var movieFile = movie.MovieFile;
             if (movieFile?.Path != null)
                 SymlinkOrStrmToMovieIdCache[(Host, movieFile.Path)] = movie.Id;
             if (movieFile is not null && movieFile.Path == symlinkOrStrmPath)
-                result = movieFile.Id;
+                result = new MovieFileIds(movieFile.Id, movie.Id);
         }
 
         return result;

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -50,6 +50,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                     ct),
                 ct).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             Log.Warning(

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -44,8 +44,10 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 
         try
         {
-            await CommandAsync(
-                new { name = "MoviesSearch", movieIds = new[] { movieIds.MovieId } },
+            await ExecuteWithTransientRetryAsync(
+                ct => CommandAsync(
+                    new { name = "MoviesSearch", movieIds = new[] { movieIds.MovieId } },
+                    ct),
                 ct).ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -36,7 +36,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
-        if (await DeleteMovieFile(movieFileId.Value, ct).ConfigureAwait(false) != HttpStatusCode.OK)
+        if (!Is2xx(await DeleteMovieFile(movieFileId.Value, ct).ConfigureAwait(false)))
             throw new InvalidOperationException($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -53,7 +53,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
-        if (await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false) != HttpStatusCode.OK)
+        if (!Is2xx(await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false)))
             throw new InvalidOperationException($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -74,7 +74,9 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             }
             else
             {
-                await CommandAsync(new { name = "EpisodeSearch", episodeIds }, ct).ConfigureAwait(false);
+                await ExecuteWithTransientRetryAsync(
+                    ct => CommandAsync(new { name = "EpisodeSearch", episodeIds }, ct),
+                    ct).ConfigureAwait(false);
             }
         }
         catch (Exception ex)

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -54,9 +54,23 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
-        var episodeIds = (await GetEpisodesFromEpisodeFileId(episodeFileId.Value, ct).ConfigureAwait(false))
-            .Select(episode => episode.Id)
-            .ToList();
+        List<int> episodeIds;
+        try
+        {
+            episodeIds = (await GetEpisodesFromEpisodeFileId(episodeFileId.Value, ct).ConfigureAwait(false))
+                .Select(episode => episode.Id)
+                .ToList();
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            Log.Warning(
+                ex,
+                "Sonarr repair on {Host}: could not resolve episodes for episode file {EpisodeFileId}; repair will continue without explicit search",
+                Host,
+                episodeFileId.Value);
+            episodeIds = [];
+        }
 
         if (!Is2xx(await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false)))
             throw new InvalidOperationException($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
@@ -79,6 +93,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                     ct).ConfigureAwait(false);
             }
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             Log.Warning(

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -3,6 +3,7 @@ using System.Net;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.RadarrSonarr.SonarrModels;
 using NzbWebDAV.Utils;
+using Serilog;
 
 namespace NzbWebDAV.Clients.RadarrSonarr;
 
@@ -53,10 +54,38 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
+        var episodeIds = (await GetEpisodesFromEpisodeFileId(episodeFileId.Value, ct).ConfigureAwait(false))
+            .Select(episode => episode.Id)
+            .ToList();
+
         if (!Is2xx(await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false)))
             throw new InvalidOperationException($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+
+        try
+        {
+            if (episodeIds.Count == 0)
+            {
+                Log.Warning(
+                    "Sonarr repair on {Host}: no episodes linked to episode file {EpisodeFileId}; skipping EpisodeSearch",
+                    Host,
+                    episodeFileId.Value);
+            }
+            else
+            {
+                await CommandAsync(new { name = "EpisodeSearch", episodeIds }, ct).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(
+                ex,
+                "Sonarr repair on {Host}: failed to request EpisodeSearch for episode file {EpisodeFileId}",
+                Host,
+                episodeFileId.Value);
+        }
+
         return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
     }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1002,7 +1002,7 @@ public class HealthCheckService : BackgroundService
                         "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir.",
                         "Removed the Arr media file and blocklisted its original download.",
-                        "A replacement search was requested in Arr."
+                        "Arr was notified to search for a replacement."
                     ]), ct).ConfigureAwait(false);
                 return;
             }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1002,7 +1002,7 @@ public class HealthCheckService : BackgroundService
                         "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir.",
                         "Removed the Arr media file and blocklisted its original download.",
-                        "Arr will apply its configured failed-download redownload policy."
+                        "A replacement search was requested in Arr."
                     ]), ct).ConfigureAwait(false);
                 return;
             }

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -8,7 +8,7 @@ namespace NzbWebDAV.Tests.Clients;
 public class RadarrSonarrClientTests
 {
     [Fact]
-    public async Task SonarrRepair_BlocklistsHistoryWithoutDirectSearch()
+    public async Task SonarrRepair_RequestsEpisodeSearchAfterBlocklist()
     {
         const string seriesPath = "/library/tv/Stale Show";
         const string filePath = seriesPath + "/Stale Show S01E01.mkv";
@@ -18,8 +18,10 @@ public class RadarrSonarrClientTests
             ("GET /api/v3/episodefile?seriesId=101", JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
+            ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
             ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}")),
             ("GET /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/series/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/series", JsonResponse("[]"))));
@@ -34,7 +36,31 @@ public class RadarrSonarrClientTests
     }
 
     [Fact]
-    public async Task RadarrRepair_BlocklistsHistoryWithoutDirectSearch()
+    public async Task SonarrRepair_SeasonPackEpisodeSearchIncludesAllLinkedEpisodes()
+    {
+        const string seriesPath = "/library/tv/Season Pack Show";
+        const string filePath = seriesPath + "/Season Pack Show S01.mkv";
+        var downloadId = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":105,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=105",
+                JsonResponse($"[{{\"id\":205,\"seriesId\":105,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":405}]}""")),
+            ("GET /api/v3/episode?episodeFileId=205",
+                JsonResponse("""[{"id":305,"seriesId":105},{"id":306,"seriesId":105}]""")),
+            ("DELETE /api/v3/episodefile/205", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/405", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+    }
+
+    [Fact]
+    public async Task RadarrRepair_RequestsMoviesSearchAfterBlocklist()
     {
         const string filePath = "/library/movies/Stale Movie/Stale Movie.mkv";
         var downloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
@@ -44,6 +70,7 @@ public class RadarrSonarrClientTests
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}")),
             ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/movie", JsonResponse("[]"))));
         var client = new TestRadarrClient(httpClient);
@@ -73,10 +100,14 @@ public class RadarrSonarrClientTests
                 JsonResponse("""{"records":[{"id":403}]}""")),
             ($"GET /api/v3/history?downloadId={secondDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":404}]}""")),
+            ("GET /api/v3/episode?episodeFileId=203", JsonResponse("""[{"id":303,"seriesId":103}]""")),
+            ("GET /api/v3/episode?episodeFileId=204", JsonResponse("""[{"id":304,"seriesId":103}]""")),
             ("DELETE /api/v3/episodefile/203", new HttpResponseMessage(HttpStatusCode.OK)),
             ("DELETE /api/v3/episodefile/204", new HttpResponseMessage(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/403", JsonResponse("{}")),
             ("POST /api/v3/history/failed/404", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}")),
             ("GET /api/v3/episodefile/203", new HttpResponseMessage(HttpStatusCode.NotFound)),
             ("GET /api/v3/series/103", JsonResponse($"{{\"id\":103,\"path\":\"{seriesPath}\"}}"))));
         var client = new TestSonarrClient(httpClient);
@@ -122,14 +153,16 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={firstDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
         using var secondHttpClient = new HttpClient(CreateHandler(
             ("GET /api/v3/movie", JsonResponse(
                 $"[{{\"id\":102,\"movieFile\":{{\"id\":202,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={secondDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":402}]}""")),
             ("DELETE /api/v3/moviefile/202", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/402", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/402", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
         var firstClient = new TestRadarrClient(firstHost, firstHttpClient);
         var secondClient = new TestRadarrClient(secondHost, secondHttpClient);
 
@@ -156,16 +189,20 @@ public class RadarrSonarrClientTests
                 JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
             ($"GET /api/v3/history?downloadId={firstDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
+            ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
             ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
         using var secondHttpClient = new HttpClient(CreateHandler(
             ("GET /api/v3/series", JsonResponse($"[{{\"id\":102,\"path\":\"{seriesPath}\"}}]")),
             ("GET /api/v3/episodefile?seriesId=102",
                 JsonResponse($"[{{\"id\":202,\"seriesId\":102,\"path\":\"{filePath}\"}}]")),
             ($"GET /api/v3/history?downloadId={secondDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":402}]}""")),
+            ("GET /api/v3/episode?episodeFileId=202", JsonResponse("""[{"id":302,"seriesId":102}]""")),
             ("DELETE /api/v3/episodefile/202", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/402", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/402", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
         var firstClient = new TestSonarrClient(firstHost, firstHttpClient);
         var secondClient = new TestSonarrClient(secondHost, secondHttpClient);
 
@@ -189,7 +226,8 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={seedDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
         var seedClient = new TestRadarrClient(host, seedHttpClient);
         Assert.Equal(
             ArrRepairOutcome.RemoveAndBlocklistSucceeded,
@@ -209,6 +247,29 @@ public class RadarrSonarrClientTests
             secondClient.RemoveAndBlocklist(filePath, Guid.NewGuid()));
 
         Assert.All(outcomes, outcome => Assert.Equal(ArrRepairOutcome.MediaItemNotFound, outcome));
+    }
+
+    [Fact]
+    public async Task SonarrRepair_AcceptsNonOk2xxDeleteResponse()
+    {
+        const string seriesPath = "/library/tv/No Content Show";
+        const string filePath = seriesPath + "/No Content Show S01E01.mkv";
+        var downloadId = Guid.Parse("99999999-9999-9999-9999-999999999999");
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":106,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=106",
+                JsonResponse($"[{{\"id\":206,\"seriesId\":106,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":406}]}""")),
+            ("GET /api/v3/episode?episodeFileId=206", JsonResponse("""[{"id":306,"seriesId":106}]""")),
+            ("DELETE /api/v3/episodefile/206", new HttpResponseMessage(HttpStatusCode.NoContent)),
+            ("POST /api/v3/history/failed/406", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}"))));
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
     }
 
     private static HttpResponseMessage JsonResponse(string json) =>

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -272,6 +272,51 @@ public class RadarrSonarrClientTests
             await client.RemoveAndBlocklist(filePath, downloadId));
     }
 
+    [Fact]
+    public async Task RadarrRepair_RetriesTransientSearchCommandFailures()
+    {
+        const string filePath = "/library/movies/Retry Movie/Retry Movie.mkv";
+        var downloadId = Guid.Parse("88888888-8888-8888-8888-888888888888");
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie", JsonResponse($"[{{\"id\":107,\"movieFile\":{{\"id\":207,\"path\":\"{filePath}\"}}}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":407}]}""")),
+            ("DELETE /api/v3/moviefile/207", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/407", JsonResponse("{}")),
+            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
+            ("POST /api/v3/command", JsonResponse("{}"))));
+        var client = new TestRadarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+    }
+
+    [Fact]
+    public async Task SonarrRepair_SearchCommandFailureStillReturnsSuccess()
+    {
+        const string seriesPath = "/library/tv/Search Fail Show";
+        const string filePath = seriesPath + "/Search Fail Show S01E01.mkv";
+        var downloadId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":108,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=108",
+                JsonResponse($"[{{\"id\":208,\"seriesId\":108,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":408}]}""")),
+            ("GET /api/v3/episode?episodeFileId=208", JsonResponse("""[{"id":308,"seriesId":108}]""")),
+            ("DELETE /api/v3/episodefile/208", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/408", JsonResponse("{}")),
+            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
+            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
+            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))));
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+    }
+
     private static HttpResponseMessage JsonResponse(string json) =>
         new(HttpStatusCode.OK)
         {


### PR DESCRIPTION
## Summary
- Accept any 2xx response from Sonarr/Radarr file-delete endpoints during health repair.
- After blocklisting a failed download, explicitly request `EpisodeSearch` / `MoviesSearch` (with pre-delete episode resolution for season packs).
- Retry transient Arr search-command failures with bounded exponential backoff; repair still succeeds if search notification fails.

Fixes #892.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~RadarrSonarrClientTests|FullyQualifiedName~ArrLinkedRepairDecisionTests"`