### PR TITLE
fix(webdav): stop duplicate missing-article warnings for filenames with accented characters

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using NWebDav.Server.Helpers;
 using NzbWebDAV.Config;
@@ -436,6 +437,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         string key,
         Action<int> logAction)
     {
+        key = key.Normalize(NormalizationForm.FormC);
         var now = DateTime.UtcNow;
         var suppressed = 0;
         var shouldLog = false;

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -565,7 +565,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
     {
         return context.Items["DavItem"] is DavItem davItem
             ? davItem.Path
-            : context.Request.Path;
+            : context.Request.Path.Value ?? context.Request.Path.ToUriComponent();
     }
 
     private static bool IsDavItemRequest(HttpContext context)

--- a/backend/Streams/ThrottledSegmentWarning.cs
+++ b/backend/Streams/ThrottledSegmentWarning.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using Serilog;
 
 namespace NzbWebDAV.Streams;
@@ -21,7 +22,8 @@ internal static class ThrottledSegmentWarning
         params object?[] propertyValues)
     {
         var now = DateTime.UtcNow;
-        var state = Windows.GetOrAdd(key, static _ => new WindowState());
+        var dedupeKey = key.Normalize(NormalizationForm.FormC);
+        var state = Windows.GetOrAdd(dedupeKey, static _ => new WindowState());
         var shouldLog = false;
         var suppressed = 0;
 

--- a/backend/Streams/ZeroFillLogLimiter.cs
+++ b/backend/Streams/ZeroFillLogLimiter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using NzbWebDAV.Extensions;
 using Serilog;
 
@@ -29,7 +30,8 @@ internal static class ZeroFillLogLimiter
         string? context = null)
     {
         var now = DateTime.UtcNow;
-        var state = Windows.GetOrAdd(fileName, static _ => new WindowState());
+        var key = fileName.Normalize(NormalizationForm.FormC);
+        var state = Windows.GetOrAdd(key, static _ => new WindowState());
         var shouldLog = false;
         var suppressed = 0;
 

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -256,6 +256,29 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task MissingArticle_CoalescesUnicodePathVariants()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var baseName = $"unicode-{Guid.NewGuid():N}";
+        var pathNfc = $"/content/{baseName}\u00E9.mkv";
+        var pathNfd = $"/content/{baseName}e\u0301.mkv";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var contextNfc = CreateContext(hasStarted: false, lifetimeFeature);
+        contextNfc.Request.Path = pathNfc;
+        var contextNfd = CreateContext(hasStarted: false, lifetimeFeature);
+        contextNfd.Request.Path = pathNfd;
+        var middleware = CreateMiddleware(_ => throw new UsenetArticleNotFoundException(segmentId));
+        var events = await CaptureLogsAsync(async () =>
+        {
+            await middleware.InvokeAsync(contextNfc);
+            await middleware.InvokeAsync(contextNfd);
+        });
+        Assert.Single(events, e => e.Level == LogEventLevel.Error
+            && e.RenderMessage().Contains("missing articles", StringComparison.Ordinal)
+            && e.RenderMessage().Contains(segmentId, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task MissingArticleWithDavItem_RecordsSegmentForQueueFailFast()
     {
         // Re-grabs of the same release must fail the step-0 queue precheck pre-import

--- a/tests/NzbWebDAV.Tests/Streams/StreamHelperTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/StreamHelperTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Services.Metrics;
@@ -164,6 +165,67 @@ public class StreamHelperTests
                 logEvent.RenderMessage().Contains(fileName, StringComparison.Ordinal));
             Assert.Single(sink.Events, logEvent =>
                 logEvent.RenderMessage().Contains(otherFileName, StringComparison.Ordinal));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+
+    [Fact]
+    public async Task ZeroFillLogLimiter_CoalescesUnicodeFilenameVariants()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        var baseName = $"unicode-{Guid.NewGuid():N}";
+        var fileNameNfc = baseName + "\u00E9.bin";
+        var fileNameNfd = baseName + "e\u0301.bin";
+
+        try
+        {
+            ZeroFillLogLimiter.Write(
+                "Article {SegmentId} missing from {FileName}; filling {Bytes} bytes.",
+                "one", fileNameNfc, 100);
+            ZeroFillLogLimiter.Write(
+                "Article {SegmentId} missing from {FileName}; filling {Bytes} bytes.",
+                "two", fileNameNfd, 100);
+
+            await Task.Yield();
+
+            Assert.Single(sink.Events, logEvent =>
+                logEvent.RenderMessage().Contains(baseName, StringComparison.Ordinal));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ThrottledSegmentWarning_CoalescesUnicodeFilenameVariants()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        var baseName = $"unicode-{Guid.NewGuid():N}";
+        var keyNfc = $"provider|segment|{baseName}\u00E9.bin";
+        var keyNfd = $"provider|segment|{baseName}e\u0301.bin";
+
+        try
+        {
+            ThrottledSegmentWarning.Write(keyNfc, "Segment warning for {Key}", keyNfc);
+            ThrottledSegmentWarning.Write(keyNfd, "Segment warning for {Key}", keyNfd);
+            await Task.Yield();
+            Assert.Single(sink.Events, logEvent =>
+                logEvent.RenderMessage().Contains("Segment warning", StringComparison.Ordinal));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Streams/StreamHelperTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/StreamHelperTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Services.Metrics;


### PR DESCRIPTION
## Summary
- Normalize log-dedupe dictionary keys to Unicode NFC in `ZeroFillLogLimiter`, `ThrottledSegmentWarning`, and `ExceptionMiddleware.LogWithDedup` so filenames that differ only in composed vs decomposed form coalesce into a single warning stream.
- Add regression tests covering NFC/NFD filename variants for gap-fill warnings, throttled segment warnings, and missing-article middleware logging.

Fixes #890.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~CoalescesUnicode"` (3 new tests)
- [ ] Full backend suite via CI