### PR TITLE
fix(webdav): directory listings no longer appear empty in rclone v1.74+

### DIFF
--- a/backend/Logging/NWebDavLogFilter.cs
+++ b/backend/Logging/NWebDavLogFilter.cs
@@ -15,4 +15,17 @@ internal static class NWebDavLogFilter
                && string.Equals(source, PropFindHandlerSource, StringComparison.Ordinal)
                && logEvent.MessageTemplate.Text.StartsWith(PropertyErrorPrefix, StringComparison.Ordinal);
     }
+
+    // NWebDav.Server 0.2.0-beta.2 logs every unsupported PROPFIND property as a
+    // Warning ("Property {Name} is not supported"). Prefix matching survives minor
+    // template wording changes across NWebDav releases.
+    internal static bool IsUnsupportedPropFindPropertyWarning(LogEvent logEvent)
+    {
+        return logEvent.Level == LogEventLevel.Warning
+               && logEvent.Properties.TryGetValue("SourceContext", out var sourceContext)
+               && sourceContext is ScalarValue { Value: string source }
+               && string.Equals(source, PropFindHandlerSource, StringComparison.Ordinal)
+               && logEvent.MessageTemplate.Text.StartsWith(PropertyErrorPrefix, StringComparison.Ordinal)
+               && logEvent.MessageTemplate.Text.Contains("is not supported", StringComparison.Ordinal);
+    }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -79,6 +79,8 @@ public partial class Program
             // NWebDav logs every remaining property as an Error after a
             // PROPFIND client disconnects. Suppress only that known event.
             .Filter.ByExcluding(NWebDavLogFilter.IsCancelledPropFindPropertyError)
+            // Unsupported PROPFIND properties are expected for clients like rclone.
+            .Filter.ByExcluding(NWebDavLogFilter.IsUnsupportedPropFindPropertyWarning)
             .WriteTo.Console(new ExpressionTemplate(
                 "[{@t:HH:mm:ss} {@l:u3}] " +
                 "{#if SourceContext is not null}" +

--- a/backend/WebDav/Base/PropFindHandlerPatch.cs
+++ b/backend/WebDav/Base/PropFindHandlerPatch.cs
@@ -64,7 +64,7 @@ public class PropFindHandlerPatch(PropFindHandler inner) : IRequestHandler
     // RFC 4918 allows 404 propstats inside a 207 Multi-Status, but rclone v1.74+
     // treats them as fatal and shows an empty directory. Real clients only need the
     // 200 propstat blocks, so strip the 404 entries before serializing the response.
-    internal static byte[] SanitizePropFindMultiStatus(Stream body)
+    internal static byte[] SanitizePropFindMultiStatus(MemoryStream body)
     {
         body.Position = 0;
         var document = XDocument.Load(body, LoadOptions.PreserveWhitespace);
@@ -84,7 +84,7 @@ public class PropFindHandlerPatch(PropFindHandler inner) : IRequestHandler
         if (!removed)
         {
             body.Position = 0;
-            return ((MemoryStream)body).ToArray();
+            return body.ToArray();
         }
 
         return Encoding.UTF8.GetBytes(document.ToString(SaveOptions.DisableFormatting));

--- a/backend/WebDav/Base/PropFindHandlerPatch.cs
+++ b/backend/WebDav/Base/PropFindHandlerPatch.cs
@@ -1,4 +1,7 @@
+using System.Text;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Http;
+using NWebDav.Server;
 using NWebDav.Server.Handlers;
 
 namespace NzbWebDAV.WebDav.Base;
@@ -8,11 +11,83 @@ public class PropFindHandlerPatch(PropFindHandler inner) : IRequestHandler
     internal const string FiniteDepthErrorBody =
         """<?xml version="1.0" encoding="utf-8"?><D:error xmlns:D="DAV:"><D:propfind-finite-depth/></D:error>""";
 
+    private static readonly XName PropStatName = WebDavNamespaces.DavNs + "propstat";
+    private static readonly XName StatusName = WebDavNamespaces.DavNs + "status";
+    private const string NotFoundStatusPrefix = "HTTP/1.1 404";
+
     public async Task<bool> HandleRequestAsync(HttpContext httpContext)
     {
-        var handled = await inner.HandleRequestAsync(httpContext).ConfigureAwait(false);
-        await TryWriteFiniteDepthErrorAsync(httpContext).ConfigureAwait(false);
+        var response = httpContext.Response;
+        var originalBody = response.Body;
+        await using var buffer = new MemoryStream();
+        response.Body = buffer;
+
+        bool handled;
+        try
+        {
+            handled = await inner.HandleRequestAsync(httpContext).ConfigureAwait(false);
+            await TryWriteFiniteDepthErrorAsync(httpContext).ConfigureAwait(false);
+        }
+        finally
+        {
+            response.Body = originalBody;
+        }
+
+        if (response.HasStarted)
+        {
+            buffer.Position = 0;
+            await CopyBufferAsync(buffer, originalBody, httpContext.RequestAborted).ConfigureAwait(false);
+            return handled;
+        }
+
+        if (ShouldSanitizeMultiStatus(response))
+        {
+            var sanitized = SanitizePropFindMultiStatus(buffer);
+            response.ContentLength = sanitized.Length;
+            await originalBody.WriteAsync(sanitized, httpContext.RequestAborted).ConfigureAwait(false);
+        }
+        else
+        {
+            buffer.Position = 0;
+            await CopyBufferAsync(buffer, originalBody, httpContext.RequestAborted).ConfigureAwait(false);
+        }
+
         return handled;
+    }
+
+    internal static bool ShouldSanitizeMultiStatus(HttpResponse response)
+    {
+        return response.StatusCode == StatusCodes.Status207MultiStatus
+               && IsXmlContentType(response.ContentType);
+    }
+
+    // RFC 4918 allows 404 propstats inside a 207 Multi-Status, but rclone v1.74+
+    // treats them as fatal and shows an empty directory. Real clients only need the
+    // 200 propstat blocks, so strip the 404 entries before serializing the response.
+    internal static byte[] SanitizePropFindMultiStatus(Stream body)
+    {
+        body.Position = 0;
+        var document = XDocument.Load(body, LoadOptions.PreserveWhitespace);
+        var removed = false;
+
+        foreach (var propStat in document.Descendants(PropStatName).ToList())
+        {
+            var status = propStat.Element(StatusName)?.Value;
+            if (status is not null
+                && status.StartsWith(NotFoundStatusPrefix, StringComparison.Ordinal))
+            {
+                propStat.Remove();
+                removed = true;
+            }
+        }
+
+        if (!removed)
+        {
+            body.Position = 0;
+            return ((MemoryStream)body).ToArray();
+        }
+
+        return Encoding.UTF8.GetBytes(document.ToString(SaveOptions.DisableFormatting));
     }
 
     internal static async Task<bool> TryWriteFiniteDepthErrorAsync(HttpContext httpContext)
@@ -24,5 +99,29 @@ public class PropFindHandlerPatch(PropFindHandler inner) : IRequestHandler
         response.ContentType = "application/xml; charset=utf-8";
         await response.WriteAsync(FiniteDepthErrorBody, httpContext.RequestAborted).ConfigureAwait(false);
         return true;
+    }
+
+    private static bool IsXmlContentType(string? contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        return contentType.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase)
+               || contentType.StartsWith("text/xml", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task CopyBufferAsync(
+        MemoryStream buffer,
+        Stream destination,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await buffer.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected before the PROPFIND body was fully written.
+        }
     }
 }

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -65,7 +65,7 @@ function logProxyFailure(message: string, error: unknown) {
 // `timeout` option, which leaks socket listeners under keep-alive (#486).
 const forwardToBackend = createProxyMiddleware({
   target: process.env["BACKEND_URL"]!,
-  changeOrigin: true,
+  changeOrigin: false,
   selfHandleResponse: true,
   ...backendProxyTimeoutOptions,
   on: {

--- a/frontend/server/backend-proxy-options.test.ts
+++ b/frontend/server/backend-proxy-options.test.ts
@@ -85,7 +85,7 @@ describe("backend proxy keep-alive timeout listeners", () => {
 
     const proxy = createProxyMiddleware({
       target: `http://127.0.0.1:${backendPort}`,
-      changeOrigin: true,
+      changeOrigin: false,
       ...backendProxyTimeoutOptions,
     });
 

--- a/frontend/server/backend-proxy-response.test.ts
+++ b/frontend/server/backend-proxy-response.test.ts
@@ -119,7 +119,7 @@ describe("handleBackendProxyResponse", () => {
 
     const proxy = createProxyMiddleware({
       target: `http://127.0.0.1:${backendPort}`,
-      changeOrigin: true,
+      changeOrigin: false,
       selfHandleResponse: true,
       on: { proxyRes: handleBackendProxyResponse },
     });

--- a/tests/NzbWebDAV.Tests/NWebDavLogFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/NWebDavLogFilterTests.cs
@@ -47,6 +47,39 @@ public class NWebDavLogFilterTests
         Assert.Single(events);
     }
 
+    [Fact]
+    public void UnsupportedPropFindPropertyWarning_IsExcluded()
+    {
+        var events = CaptureUnsupportedWarningFilteredLogs(logger =>
+            logger
+                .ForContext("SourceContext", PropFindHandlerSource)
+                .Warning("Property {PropertyName} is not supported.", "{DAV:}quota-available-bytes"));
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void UnsupportedPropFindPropertyWarningFromAnotherSource_IsRetained()
+    {
+        var events = CaptureUnsupportedWarningFilteredLogs(logger =>
+            logger
+                .ForContext("SourceContext", "NzbWebDAV.SomeComponent")
+                .Warning("Property {PropertyName} is not supported.", "{DAV:}quota-available-bytes"));
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void OtherPropFindWarning_IsRetained()
+    {
+        var events = CaptureUnsupportedWarningFilteredLogs(logger =>
+            logger
+                .ForContext("SourceContext", PropFindHandlerSource)
+                .Warning("PROPFIND depth exceeded"));
+
+        Assert.Single(events);
+    }
+
     private static void WritePropertyError(ILogger logger, string source, Exception exception)
     {
         logger
@@ -64,6 +97,19 @@ public class NWebDavLogFilterTests
         using var logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()
             .Filter.ByExcluding(NWebDavLogFilter.IsCancelledPropFindPropertyError)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        write(logger);
+        return sink.Events;
+    }
+
+    private static IReadOnlyList<LogEvent> CaptureUnsupportedWarningFilteredLogs(Action<ILogger> write)
+    {
+        var sink = new CollectingSink();
+        using var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .Filter.ByExcluding(NWebDavLogFilter.IsUnsupportedPropFindPropertyWarning)
             .WriteTo.Sink(sink)
             .CreateLogger();
 

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
@@ -33,7 +33,7 @@ public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactor
         Assert.All(
             document.Descendants(Dav + "response"),
             response => Assert.Contains(response.Elements(Dav + "propstat"), propStat =>
-                propStat.Element(Dav + "status")?.Value.StartsWith("HTTP/1.1 200", StringComparison.Ordinal) == true));
+                propStat.Element(Dav + "status")?.Value.StartsWith("HTTP/1.1 200", StringComparison.Ordinal) is true));
 
         var hrefs = ReadHrefs(document);
         Assert.Contains(hrefs, href => href.EndsWith("/nzbs", StringComparison.Ordinal));

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreHttpIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Xml.Linq;
+using NWebDav.Server;
 using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Tests.TestUtils;
@@ -11,6 +12,7 @@ namespace NzbWebDAV.Tests.WebDav;
 public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactory factory)
 {
     private static readonly HttpMethod PropFind = new("PROPFIND");
+    private static readonly XNamespace Dav = WebDavNamespaces.DavNs;
 
     [Fact]
     public async Task PropFindRoot_RequiresBasicAuthenticationAndListsCoreMounts()
@@ -26,7 +28,14 @@ public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactor
         using var accepted = await client.SendAsync(acceptedRequest);
         Assert.Equal((HttpStatusCode)207, accepted.StatusCode);
 
-        var hrefs = await ReadHrefsAsync(accepted);
+        var document = await ReadMultiStatusDocumentAsync(accepted);
+        AssertNoNotFoundPropStats(document);
+        Assert.All(
+            document.Descendants(Dav + "response"),
+            response => Assert.Contains(response.Elements(Dav + "propstat"), propStat =>
+                propStat.Element(Dav + "status")?.Value.StartsWith("HTTP/1.1 200", StringComparison.Ordinal) == true));
+
+        var hrefs = ReadHrefs(document);
         Assert.Contains(hrefs, href => href.EndsWith("/nzbs", StringComparison.Ordinal));
         Assert.Contains(hrefs, href => href.EndsWith("/content", StringComparison.Ordinal));
         Assert.Contains(hrefs, href => href.EndsWith("/completed-symlinks", StringComparison.Ordinal));
@@ -69,7 +78,9 @@ public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactor
         using var response = await client.SendAsync(request);
 
         Assert.Equal((HttpStatusCode)207, response.StatusCode);
-        var hrefs = await ReadHrefsAsync(response);
+        var document = await ReadMultiStatusDocumentAsync(response);
+        AssertNoNotFoundPropStats(document);
+        var hrefs = ReadHrefs(document);
         Assert.Contains(
             hrefs,
             href => href.EndsWith(
@@ -151,16 +162,26 @@ public sealed class DatabaseStoreHttpIntegrationTests(NzbDavWebApplicationFactor
         return item;
     }
 
-    private static async Task<string[]> ReadHrefsAsync(HttpResponseMessage response)
+    private static async Task<XDocument> ReadMultiStatusDocumentAsync(HttpResponseMessage response)
     {
-        var document = await XDocument.LoadAsync(
+        return await XDocument.LoadAsync(
             await response.Content.ReadAsStreamAsync(),
             LoadOptions.None,
             CancellationToken.None);
+    }
+
+    private static string[] ReadHrefs(XDocument document)
+    {
         return document
-            .Descendants()
-            .Where(element => element.Name.LocalName == "href")
+            .Descendants(Dav + "href")
             .Select(element => Uri.UnescapeDataString(element.Value))
             .ToArray();
+    }
+
+    private static void AssertNoNotFoundPropStats(XDocument document)
+    {
+        Assert.DoesNotContain(
+            document.Descendants(Dav + "status"),
+            status => status.Value.StartsWith("HTTP/1.1 404", StringComparison.Ordinal));
     }
 }

--- a/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
@@ -120,7 +120,7 @@ public class PropFindHandlerPatchTests
         var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(body);
         var document = XDocument.Parse(Encoding.UTF8.GetString(sanitized));
 
-        Assert.Equal(2, document.Descendants(Dav + "propstat").Count());
+        Assert.Single(document.Descendants(Dav + "propstat"));
         Assert.Contains(
             document.Descendants(Dav + "status").Select(element => element.Value),
             status => status.StartsWith("HTTP/1.1 500", StringComparison.Ordinal));

--- a/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
@@ -1,12 +1,16 @@
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using NWebDav.Server;
 using NzbWebDAV.WebDav.Base;
 
 namespace NzbWebDAV.Tests.WebDav;
 
 public class PropFindHandlerPatchTests
 {
+    private static readonly XNamespace Dav = WebDavNamespaces.DavNs;
+
     [Fact]
     public async Task ForbiddenResponse_GetsFiniteDepthErrorBody()
     {
@@ -48,6 +52,188 @@ public class PropFindHandlerPatchTests
         Assert.False(written);
         Assert.Equal("text/plain", context.Response.ContentType);
         Assert.Equal("existing", Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Status207MultiStatus, "application/xml; charset=utf-8", true)]
+    [InlineData(StatusCodes.Status207MultiStatus, "text/xml", true)]
+    [InlineData(StatusCodes.Status207MultiStatus, "text/plain", false)]
+    [InlineData(StatusCodes.Status403Forbidden, "application/xml; charset=utf-8", false)]
+    [InlineData(StatusCodes.Status404NotFound, "application/xml; charset=utf-8", false)]
+    public void ShouldSanitizeMultiStatus_GatesOnStatusAndContentType(
+        int statusCode,
+        string contentType,
+        bool expected)
+    {
+        var context = new DefaultHttpContext();
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = contentType;
+
+        Assert.Equal(expected, PropFindHandlerPatch.ShouldSanitizeMultiStatus(context.Response));
+    }
+
+    [Fact]
+    public void SanitizePropFindMultiStatus_Removes404PropstatsAndPreserves200Blocks()
+    {
+        var body = CreateMultiStatusStream(
+            """
+            <D:response>
+              <D:href>/content/</D:href>
+              <D:propstat>
+                <D:prop><D:displayname>content</D:displayname></D:prop>
+                <D:status>HTTP/1.1 200 OK</D:status>
+              </D:propstat>
+              <D:propstat>
+                <D:prop><D:quota-available-bytes/></D:prop>
+                <D:status>HTTP/1.1 404 Not Found</D:status>
+              </D:propstat>
+            </D:response>
+            """);
+
+        var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(body);
+        var document = XDocument.Parse(Encoding.UTF8.GetString(sanitized));
+
+        Assert.Single(document.Descendants(Dav + "propstat"));
+        Assert.Equal("HTTP/1.1 200 OK", document.Descendants(Dav + "status").Single().Value);
+        Assert.Equal("/content/", document.Descendants(Dav + "href").Single().Value);
+        Assert.Equal("content", document.Descendants(Dav + "displayname").Single().Value);
+    }
+
+    [Fact]
+    public void SanitizePropFindMultiStatus_Preserves500Propstats()
+    {
+        var body = CreateMultiStatusStream(
+            """
+            <D:response>
+              <D:href>/locked/</D:href>
+              <D:propstat>
+                <D:prop><D:displayname>locked</D:displayname></D:prop>
+                <D:status>HTTP/1.1 500 Internal Server Error</D:status>
+              </D:propstat>
+              <D:propstat>
+                <D:prop><D:quota-available-bytes/></D:prop>
+                <D:status>HTTP/1.1 404 Not Found</D:status>
+              </D:propstat>
+            </D:response>
+            """);
+
+        var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(body);
+        var document = XDocument.Parse(Encoding.UTF8.GetString(sanitized));
+
+        Assert.Equal(2, document.Descendants(Dav + "propstat").Count());
+        Assert.Contains(
+            document.Descendants(Dav + "status").Select(element => element.Value),
+            status => status.StartsWith("HTTP/1.1 500", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SanitizePropFindMultiStatus_LeavesResponseSkeletonWhenOnly404PropstatsRemoved()
+    {
+        var body = CreateMultiStatusStream(
+            """
+            <D:response>
+              <D:href>/missing-prop-only/</D:href>
+              <D:propstat>
+                <D:prop><D:quota-available-bytes/></D:prop>
+                <D:status>HTTP/1.1 404 Not Found</D:status>
+              </D:propstat>
+            </D:response>
+            """);
+
+        var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(body);
+        var document = XDocument.Parse(Encoding.UTF8.GetString(sanitized));
+
+        Assert.Empty(document.Descendants(Dav + "propstat"));
+        Assert.Equal("/missing-prop-only/", document.Descendants(Dav + "href").Single().Value);
+    }
+
+    [Fact]
+    public void SanitizePropFindMultiStatus_PreservesElementOrderAcrossResponses()
+    {
+        var body = CreateMultiStatusStream(
+            """
+            <D:response>
+              <D:href>/first/</D:href>
+              <D:propstat>
+                <D:prop><D:displayname>first</D:displayname></D:prop>
+                <D:status>HTTP/1.1 200 OK</D:status>
+              </D:propstat>
+            </D:response>
+            <D:response>
+              <D:href>/second/</D:href>
+              <D:propstat>
+                <D:prop><D:displayname>second</D:displayname></D:prop>
+                <D:status>HTTP/1.1 200 OK</D:status>
+              </D:propstat>
+              <D:propstat>
+                <D:prop><D:quota-available-bytes/></D:prop>
+                <D:status>HTTP/1.1 404 Not Found</D:status>
+              </D:propstat>
+            </D:response>
+            """);
+
+        var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(body);
+        var document = XDocument.Parse(Encoding.UTF8.GetString(sanitized));
+
+        Assert.Equal(["/first/", "/second/"], document.Descendants(Dav + "href").Select(element => element.Value));
+        Assert.Equal(2, document.Descendants(Dav + "propstat").Count());
+    }
+
+    [Fact]
+    public void SanitizePropFindMultiStatus_ReturnsOriginalBytesWhenNo404Propstats()
+    {
+        var original = CreateMultiStatusStream(
+            """
+            <D:response>
+              <D:href>/unchanged/</D:href>
+              <D:propstat>
+                <D:prop><D:displayname>unchanged</D:displayname></D:prop>
+                <D:status>HTTP/1.1 200 OK</D:status>
+              </D:propstat>
+            </D:response>
+            """);
+
+        var expected = original.ToArray();
+        var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(original);
+
+        Assert.Equal(expected, sanitized);
+    }
+
+    [Fact]
+    public void SanitizePropFindMultiStatus_RecomputesContentLength()
+    {
+        var body = CreateMultiStatusStream(
+            """
+            <D:response>
+              <D:href>/content/</D:href>
+              <D:propstat>
+                <D:prop><D:displayname>content</D:displayname></D:prop>
+                <D:status>HTTP/1.1 200 OK</D:status>
+              </D:propstat>
+              <D:propstat>
+                <D:prop><D:quota-available-bytes/></D:prop>
+                <D:status>HTTP/1.1 404 Not Found</D:status>
+              </D:propstat>
+            </D:response>
+            """);
+
+        var originalLength = body.Length;
+        var sanitized = PropFindHandlerPatch.SanitizePropFindMultiStatus(body);
+
+        Assert.True(sanitized.Length < originalLength);
+        Assert.Equal(sanitized.Length, Encoding.UTF8.GetByteCount(Encoding.UTF8.GetString(sanitized)));
+    }
+
+    private static MemoryStream CreateMultiStatusStream(string responsesXml)
+    {
+        var xml =
+            $"""
+             <?xml version="1.0" encoding="utf-8"?>
+             <D:multistatus xmlns:D="DAV:">
+             {responsesXml}
+             </D:multistatus>
+             """;
+        return new MemoryStream(Encoding.UTF8.GetBytes(xml));
     }
 
     private static (DefaultHttpContext Context, MemoryStream Body) CreateContext(


### PR DESCRIPTION
## Summary
- Strip `HTTP/1.1 404` propstat blocks from PROPFIND 207 Multi-Status XML responses before they reach clients; rclone v1.74+ treats these as fatal and shows empty directories.
- Suppress expected NWebDav "Property … is not supported" warnings that PROPFIND clients like rclone trigger.
- Set `changeOrigin: false` on the frontend backend proxy as defense-in-depth for Host header forwarding (the forwarded-headers pipeline already handles this correctly).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~PropFindHandlerPatchTests`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~DatabaseStoreHttpIntegrationTests`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~NWebDavLogFilterTests`
- [x] `cd frontend && npm run typecheck && npm test`
- [ ] Manual: mount with rclone v1.74+ and confirm directory listings show children

Closes #888