### PR TITLE
fix(db): all-time bandwidth totals no longer shrink when old metrics are pruned

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -308,11 +308,6 @@ public class GetOverviewStatsController(
             rescues = hours.Where(h => h.FailoverSaves > 0)
                 .Select(h => (h.Hour, h.Provider, h.FailoverSaves))
                 .ToList();
-            if (window == GetOverviewStatsRequest.OverviewWindow.AllTime)
-            {
-                foreach (var lifetime in lifetimeTotals.Where(x => x.FailoverSaves > 0))
-                    rescues.Add((0, lifetime.Provider, lifetime.FailoverSaves));
-            }
             misses = failoverEdges.Select(e => (e.FromProvider, e.Reason, e.Count)).ToList();
         }
         else
@@ -382,7 +377,11 @@ public class GetOverviewStatsController(
             readsSaved,
             previousSaves,
             ResolveFailoverBucket(window),
-            labelsByMetricsKey);
+            labelsByMetricsKey,
+            window == GetOverviewStatsRequest.OverviewWindow.AllTime
+                ? lifetimeTotals.Where(x => x.FailoverSaves > 0)
+                    .Select(x => (x.Provider, x.FailoverSaves))
+                : null);
 
         var tiles = BuildLiveTiles(liveCounts?.Articles ?? 0, liveCounts?.Errors ?? 0);
         var sessionsBlock = BuildSessionsBlock(sessionsRows.Select(s => (s.DurationMs, s.BytesServed)));
@@ -606,7 +605,8 @@ public class GetOverviewStatsController(
         long readsSaved,
         long? previousSaves,
         long chartBucketSize,
-        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey,
+        IEnumerable<(string Provider, long Saves)>? lifetimeFailoverSaves = null)
     {
         var totalsByProvider = new Dictionary<string, long>();
         var byBucket = new SortedDictionary<long, Dictionary<string, long>>();
@@ -621,6 +621,15 @@ public class GetOverviewStatsController(
                 byBucket[bucket] = perProvider = new Dictionary<string, long>();
             perProvider.TryGetValue(provider, out var c);
             perProvider[provider] = c + saves;
+        }
+
+        if (lifetimeFailoverSaves is not null)
+        {
+            foreach (var (provider, saves) in lifetimeFailoverSaves)
+            {
+                totalsByProvider.TryGetValue(provider, out var t);
+                totalsByProvider[provider] = t + saves;
+            }
         }
 
         // Chart/list series only include currently configured providers; aggregate
@@ -898,10 +907,9 @@ public class GetOverviewStatsController(
 
         if (foldedLifetimeTotals is not null)
         {
-            foreach (var lifetime in foldedLifetimeTotals)
+            foreach (var lifetime in foldedLifetimeTotals
+                         .Where(lt => IsConfiguredMetricsKey(lt.Provider, labelsByMetricsKey)))
             {
-                if (!IsConfiguredMetricsKey(lifetime.Provider, labelsByMetricsKey))
-                    continue;
                 if (!byProvider.TryGetValue(lifetime.Provider, out var acc))
                     acc = new ProviderAccumulator(sparkBuckets);
                 acc.Articles += lifetime.Articles;

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -264,13 +264,24 @@ public class GetOverviewStatsController(
                 .Where(f => f.Hour >= windowStart)
                 .Select(f => new { f.FromProvider, f.Reason, f.Count })
                 .ToListAsync();
+            Task<List<ProviderLifetimeTotal>>? lifetimeTotalsTask = window == GetOverviewStatsRequest.OverviewWindow.AllTime
+                ? metricsA.ProviderLifetimeTotals.ToListAsync()
+                : null;
 
-            await Task.WhenAll(sessionsTask, heatmapTask, previousSavesTask, liveCountsTask, hoursTask, failoverEdgesTask)
-                .ConfigureAwait(false);
+            var rollupTasks = new List<Task>
+            {
+                sessionsTask, heatmapTask, previousSavesTask, liveCountsTask, hoursTask, failoverEdgesTask,
+            };
+            if (lifetimeTotalsTask is not null)
+                rollupTasks.Add(lifetimeTotalsTask);
+            await Task.WhenAll(rollupTasks).ConfigureAwait(false);
 
             var hours = await hoursTask.ConfigureAwait(false);
             var sessions = await sessionsTask.ConfigureAwait(false);
             var failoverEdges = await failoverEdgesTask.ConfigureAwait(false);
+            var lifetimeTotals = lifetimeTotalsTask is not null
+                ? await lifetimeTotalsTask.ConfigureAwait(false)
+                : [];
 
             throughput = BuildThroughputFromHourly(
                 hours.Select(h => (h.Hour, h.Articles, h.Misses, h.Errors, h.BytesFetched)),
@@ -281,14 +292,27 @@ public class GetOverviewStatsController(
                 windowStart,
                 bucketSize,
                 nowMs,
-                labelsByMetricsKey);
+                labelsByMetricsKey,
+                window == GetOverviewStatsRequest.OverviewWindow.AllTime ? lifetimeTotals : null);
             totalArticles = hours.Sum(h => h.Articles);
             totalMisses = hours.Sum(h => h.Misses);
             totalErrors = hours.Sum(h => h.Errors);
             totalBytesFetched = hours.Sum(h => h.BytesFetched);
+            if (window == GetOverviewStatsRequest.OverviewWindow.AllTime)
+            {
+                totalArticles += lifetimeTotals.Sum(x => x.Articles);
+                totalMisses += lifetimeTotals.Sum(x => x.Misses);
+                totalErrors += lifetimeTotals.Sum(x => x.Errors);
+                totalBytesFetched += lifetimeTotals.Sum(x => x.BytesFetched);
+            }
             rescues = hours.Where(h => h.FailoverSaves > 0)
                 .Select(h => (h.Hour, h.Provider, h.FailoverSaves))
                 .ToList();
+            if (window == GetOverviewStatsRequest.OverviewWindow.AllTime)
+            {
+                foreach (var lifetime in lifetimeTotals.Where(x => x.FailoverSaves > 0))
+                    rescues.Add((0, lifetime.Provider, lifetime.FailoverSaves));
+            }
             misses = failoverEdges.Select(e => (e.FromProvider, e.Reason, e.Count)).ToList();
         }
         else
@@ -840,7 +864,8 @@ public class GetOverviewStatsController(
         long windowStart,
         long bucketSize,
         long nowMs,
-        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey,
+        IEnumerable<ProviderLifetimeTotal>? foldedLifetimeTotals = null)
     {
         var totalSpan = nowMs - windowStart;
         var sparkSize = OneDay;
@@ -869,6 +894,24 @@ public class GetOverviewStatsController(
                 acc.DurationSpark[idx] += h.SumDurationMs;
             }
             byProvider[host] = acc;
+        }
+
+        if (foldedLifetimeTotals is not null)
+        {
+            foreach (var lifetime in foldedLifetimeTotals)
+            {
+                if (!IsConfiguredMetricsKey(lifetime.Provider, labelsByMetricsKey))
+                    continue;
+                if (!byProvider.TryGetValue(lifetime.Provider, out var acc))
+                    acc = new ProviderAccumulator(sparkBuckets);
+                acc.Articles += lifetime.Articles;
+                acc.Misses += lifetime.Misses;
+                acc.Errors += lifetime.Errors;
+                acc.Retries += lifetime.Retries;
+                acc.SumDurationMs += lifetime.SumDurationMs;
+                acc.Bytes += lifetime.BytesFetched;
+                byProvider[lifetime.Provider] = acc;
+            }
         }
 
         return byProvider
@@ -1117,7 +1160,7 @@ public class GetOverviewStatsController(
             .ToList();
     }
 
-    private static async Task<GetOverviewStatsResponse.LifetimeBlock> BuildLifetimeAsync(MetricsDbContext metrics)
+    internal static async Task<GetOverviewStatsResponse.LifetimeBlock> BuildLifetimeAsync(MetricsDbContext metrics)
     {
         var bytesFetched = await metrics.ProviderHourly
             .SumAsync(x => (long?)x.BytesFetched).ConfigureAwait(false) ?? 0L;
@@ -1127,6 +1170,27 @@ public class GetOverviewStatsController(
             .OrderBy(x => x.Hour)
             .Select(x => (long?)x.Hour)
             .FirstOrDefaultAsync().ConfigureAwait(false);
+
+        var folded = await metrics.ProviderLifetimeTotals
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                BytesFetched = g.Sum(x => x.BytesFetched),
+                Articles = g.Sum(x => x.Articles),
+                FirstHour = g.Min(x => x.FirstHour),
+            })
+            .FirstOrDefaultAsync().ConfigureAwait(false);
+        if (folded is not null)
+        {
+            bytesFetched += folded.BytesFetched;
+            articles += folded.Articles;
+            if (folded.FirstHour is not null)
+            {
+                firstHour = firstHour is null
+                    ? folded.FirstHour
+                    : Math.Min(firstHour.Value, folded.FirstHour.Value);
+            }
+        }
 
         var sessionCount = await metrics.ReadSessions.CountAsync().ConfigureAwait(false);
         var bytesRead = await metrics.ReadSessions
@@ -1145,6 +1209,10 @@ public class GetOverviewStatsController(
         };
     }
 
+    /// <summary>
+    /// Best-day/hour records are derived from retained <see cref="ProviderHourly"/> rows only;
+    /// pruned hourly buckets are not folded and cannot be reconstructed.
+    /// </summary>
     private static async Task<GetOverviewStatsResponse.RecordsBlock> BuildRecordsAsync(MetricsDbContext metrics)
     {
         var dayRow = await metrics.ProviderHourly

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -253,6 +253,7 @@ public class GetOverviewStatsController(
         List<GetOverviewStatsResponse.ThroughputPoint> throughput;
         List<GetOverviewStatsResponse.ProviderRow> providers;
         long totalArticles, totalMisses, totalErrors, totalBytesFetched;
+        List<ProviderLifetimeTotal> lifetimeTotals = [];
 
         if (useRollups)
         {
@@ -279,7 +280,7 @@ public class GetOverviewStatsController(
             var hours = await hoursTask.ConfigureAwait(false);
             var sessions = await sessionsTask.ConfigureAwait(false);
             var failoverEdges = await failoverEdgesTask.ConfigureAwait(false);
-            var lifetimeTotals = lifetimeTotalsTask is not null
+            lifetimeTotals = lifetimeTotalsTask is not null
                 ? await lifetimeTotalsTask.ConfigureAwait(false)
                 : [];
 

--- a/backend/Database/MetricsDbContext.cs
+++ b/backend/Database/MetricsDbContext.cs
@@ -49,6 +49,7 @@ public sealed class MetricsDbContext : DbContext
     public DbSet<FailoverMiss> FailoverMisses => Set<FailoverMiss>();
     public DbSet<FailoverHourly> FailoverHourly => Set<FailoverHourly>();
     public DbSet<CatalogueDaily> CatalogueDaily => Set<CatalogueDaily>();
+    public DbSet<ProviderLifetimeTotal> ProviderLifetimeTotals => Set<ProviderLifetimeTotal>();
 
     protected override void OnModelCreating(ModelBuilder b)
     {
@@ -177,5 +178,6 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.AddedCount).IsRequired();
             e.Property(x => x.RemovedCount).IsRequired();
         });
+        b.Entity<ProviderLifetimeTotal>(e => { e.ToTable("ProviderLifetimeTotals"); e.HasKey(x => x.Provider); e.Property(x => x.Provider).IsRequired().HasMaxLength(255); e.Property(x => x.BytesFetched).IsRequired(); e.Property(x => x.Articles).IsRequired(); e.Property(x => x.Misses).IsRequired(); e.Property(x => x.Errors).IsRequired(); e.Property(x => x.Retries).IsRequired(); e.Property(x => x.SumDurationMs).IsRequired(); e.Property(x => x.FailoverSaves).IsRequired(); });
     }
 }

--- a/backend/Database/MetricsDbContext.cs
+++ b/backend/Database/MetricsDbContext.cs
@@ -178,6 +178,19 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.AddedCount).IsRequired();
             e.Property(x => x.RemovedCount).IsRequired();
         });
-        b.Entity<ProviderLifetimeTotal>(e => { e.ToTable("ProviderLifetimeTotals"); e.HasKey(x => x.Provider); e.Property(x => x.Provider).IsRequired().HasMaxLength(255); e.Property(x => x.BytesFetched).IsRequired(); e.Property(x => x.Articles).IsRequired(); e.Property(x => x.Misses).IsRequired(); e.Property(x => x.Errors).IsRequired(); e.Property(x => x.Retries).IsRequired(); e.Property(x => x.SumDurationMs).IsRequired(); e.Property(x => x.FailoverSaves).IsRequired(); });
+        b.Entity<ProviderLifetimeTotal>(e =>
+        {
+            e.ToTable("ProviderLifetimeTotals");
+            e.HasKey(x => x.Provider);
+
+            e.Property(x => x.Provider).IsRequired().HasMaxLength(255);
+            e.Property(x => x.BytesFetched).IsRequired();
+            e.Property(x => x.Articles).IsRequired();
+            e.Property(x => x.Misses).IsRequired();
+            e.Property(x => x.Errors).IsRequired();
+            e.Property(x => x.Retries).IsRequired();
+            e.Property(x => x.SumDurationMs).IsRequired();
+            e.Property(x => x.FailoverSaves).IsRequired();
+        });
     }
 }

--- a/backend/Database/MetricsMigrations/20260810150300_AddProviderLifetimeTotals.Designer.cs
+++ b/backend/Database/MetricsMigrations/20260810150300_AddProviderLifetimeTotals.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NzbWebDAV.Database;
 
@@ -10,9 +11,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.MetricsMigrations
 {
     [DbContext(typeof(MetricsDbContext))]
-    partial class MetricsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810150300_AddProviderLifetimeTotals")]
+    partial class AddProviderLifetimeTotals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/backend/Database/MetricsMigrations/20260810150300_AddProviderLifetimeTotals.cs
+++ b/backend/Database/MetricsMigrations/20260810150300_AddProviderLifetimeTotals.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.MetricsMigrations
+{
+    /// <inheritdoc />
+    public partial class AddProviderLifetimeTotals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProviderLifetimeTotals",
+                columns: table => new
+                {
+                    Provider = table.Column<string>(type: "TEXT", maxLength: 255, nullable: false),
+                    BytesFetched = table.Column<long>(type: "INTEGER", nullable: false),
+                    Articles = table.Column<long>(type: "INTEGER", nullable: false),
+                    Misses = table.Column<long>(type: "INTEGER", nullable: false),
+                    Errors = table.Column<long>(type: "INTEGER", nullable: false),
+                    Retries = table.Column<long>(type: "INTEGER", nullable: false),
+                    SumDurationMs = table.Column<long>(type: "INTEGER", nullable: false),
+                    FailoverSaves = table.Column<long>(type: "INTEGER", nullable: false),
+                    FirstHour = table.Column<long>(type: "INTEGER", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProviderLifetimeTotals", x => x.Provider);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProviderLifetimeTotals");
+        }
+    }
+}

--- a/backend/Database/Models/Metrics/ProviderLifetimeTotal.cs
+++ b/backend/Database/Models/Metrics/ProviderLifetimeTotal.cs
@@ -1,0 +1,18 @@
+namespace NzbWebDAV.Database.Models.Metrics;
+
+/// <summary>
+/// Cumulative provider totals folded from pruned <see cref="ProviderHourly"/> rows.
+/// Preserves all-time bandwidth and article counts across the hourly retention window.
+/// </summary>
+public class ProviderLifetimeTotal
+{
+    public string Provider { get; set; } = null!;
+    public long BytesFetched { get; set; }
+    public long Articles { get; set; }
+    public long Misses { get; set; }
+    public long Errors { get; set; }
+    public long Retries { get; set; }
+    public long SumDurationMs { get; set; }
+    public long FailoverSaves { get; set; }
+    public long? FirstHour { get; set; }
+}

--- a/backend/Services/Metrics/MetricsRetentionService.cs
+++ b/backend/Services/Metrics/MetricsRetentionService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
@@ -47,24 +48,7 @@ public class MetricsRetentionService : BackgroundService
         {
             var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             await using var db = new MetricsDbContext();
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM SegmentFetches WHERE At < {0}", Cutoff(nowMs, FetchTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM MetricEvents WHERE At < {0}", Cutoff(nowMs, EventTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM ThroughputMinutes WHERE Minute < {0}", Cutoff(nowMs, MinuteRollupTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM ProviderMinutes WHERE Minute < {0}", Cutoff(nowMs, MinuteRollupTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM ReadSessions WHERE EndedAt < {0}", Cutoff(nowMs, SessionTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM ProviderHourly WHERE Hour < {0}", Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM FailoverMisses WHERE At < {0}", Cutoff(nowMs, FetchTtl)).ConfigureAwait(false);
-            await db.Database.ExecuteSqlRawAsync(
-                "DELETE FROM FailoverHourly WHERE Hour < {0}", Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
-
-            await db.Database.ExecuteSqlRawAsync("PRAGMA incremental_vacuum;").ConfigureAwait(false);
+            await SweepAsync(db, nowMs).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
@@ -72,5 +56,92 @@ public class MetricsRetentionService : BackgroundService
         }
     }
 
-    private static long Cutoff(long nowMs, TimeSpan ttl) => nowMs - (long)ttl.TotalMilliseconds;
+    internal static async Task SweepAsync(MetricsDbContext db, long nowMs)
+    {
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM SegmentFetches WHERE At < {0}", Cutoff(nowMs, FetchTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM MetricEvents WHERE At < {0}", Cutoff(nowMs, EventTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM ThroughputMinutes WHERE Minute < {0}", Cutoff(nowMs, MinuteRollupTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM ProviderMinutes WHERE Minute < {0}", Cutoff(nowMs, MinuteRollupTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM ReadSessions WHERE EndedAt < {0}", Cutoff(nowMs, SessionTtl)).ConfigureAwait(false);
+        await FoldAndPruneProviderHourlyAsync(db, Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM FailoverMisses WHERE At < {0}", Cutoff(nowMs, FetchTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM FailoverHourly WHERE Hour < {0}", Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
+
+        await db.Database.ExecuteSqlRawAsync("PRAGMA incremental_vacuum;").ConfigureAwait(false);
+    }
+
+    private static async Task FoldAndPruneProviderHourlyAsync(MetricsDbContext db, long cutoff)
+    {
+        await using var transaction = await db.Database.BeginTransactionAsync().ConfigureAwait(false);
+        try
+        {
+            var folds = await db.ProviderHourly
+                .Where(h => h.Hour < cutoff)
+                .GroupBy(h => h.Provider)
+                .Select(g => new
+                {
+                    Provider = g.Key,
+                    BytesFetched = g.Sum(x => x.BytesFetched),
+                    Articles = g.Sum(x => x.Articles),
+                    Misses = g.Sum(x => x.Misses),
+                    Errors = g.Sum(x => x.Errors),
+                    Retries = g.Sum(x => x.Retries),
+                    SumDurationMs = g.Sum(x => x.SumDurationMs),
+                    FailoverSaves = g.Sum(x => x.FailoverSaves),
+                    FirstHour = g.Min(x => x.Hour),
+                })
+                .ToListAsync().ConfigureAwait(false);
+
+            if (folds.Count > 0)
+            {
+                var providers = folds.Select(f => f.Provider).ToList();
+                var existing = await db.ProviderLifetimeTotals
+                    .Where(x => providers.Contains(x.Provider))
+                    .ToDictionaryAsync(x => x.Provider)
+                    .ConfigureAwait(false);
+
+                foreach (var fold in folds)
+                {
+                    if (!existing.TryGetValue(fold.Provider, out var total))
+                    {
+                        total = new ProviderLifetimeTotal { Provider = fold.Provider };
+                        db.ProviderLifetimeTotals.Add(total);
+                        existing[fold.Provider] = total;
+                    }
+
+                    total.BytesFetched += fold.BytesFetched;
+                    total.Articles += fold.Articles;
+                    total.Misses += fold.Misses;
+                    total.Errors += fold.Errors;
+                    total.Retries += fold.Retries;
+                    total.SumDurationMs += fold.SumDurationMs;
+                    total.FailoverSaves += fold.FailoverSaves;
+                    total.FirstHour = total.FirstHour is null
+                        ? fold.FirstHour
+                        : Math.Min(total.FirstHour.Value, fold.FirstHour);
+                }
+
+                await db.SaveChangesAsync().ConfigureAwait(false);
+            }
+
+            await db.ProviderHourly
+                .Where(h => h.Hour < cutoff)
+                .ExecuteDeleteAsync().ConfigureAwait(false);
+            await transaction.CommitAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    internal static long Cutoff(long nowMs, TimeSpan ttl) => nowMs - (long)ttl.TotalMilliseconds;
 }

--- a/backend/Services/Metrics/OverviewStatsReset.cs
+++ b/backend/Services/Metrics/OverviewStatsReset.cs
@@ -84,6 +84,7 @@ public static class OverviewStatsReset
         deleted += await db.FailoverMisses.ExecuteDeleteAsync(ct).ConfigureAwait(false);
         deleted += await db.FailoverHourly.ExecuteDeleteAsync(ct).ConfigureAwait(false);
         deleted += await db.CatalogueDaily.ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ProviderLifetimeTotals.ExecuteDeleteAsync(ct).ConfigureAwait(false);
         return deleted;
     }
 
@@ -133,6 +134,8 @@ public static class OverviewStatsReset
         deleted += await db.FailoverHourly
             .Where(x => x.FromProvider == providerKey || x.ToProvider == providerKey)
             .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        deleted += await db.ProviderLifetimeTotals
+            .Where(x => x.Provider == providerKey).ExecuteDeleteAsync(ct).ConfigureAwait(false);
         return deleted;
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsLifetimeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsLifetimeTests.cs
@@ -82,7 +82,7 @@ public sealed class GetOverviewStatsLifetimeTests
             {
                 Directory.Delete(_dir, recursive: true);
             }
-            catch
+            catch (IOException)
             {
                 // best effort
             }

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsLifetimeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsLifetimeTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models.Metrics;
+
+namespace NzbWebDAV.Tests.Api;
+
+public sealed class GetOverviewStatsLifetimeTests
+{
+    [Fact]
+    public async Task BuildLifetimeAsync_IncludesFoldedTotalsAndEarliestFirstSeenAt()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+
+        db.ProviderHourly.Add(new ProviderHourly
+        {
+            Hour = 2_000,
+            Provider = "provider-a",
+            Articles = 4,
+            BytesFetched = 400,
+        });
+        db.ProviderLifetimeTotals.Add(new ProviderLifetimeTotal
+        {
+            Provider = "provider-a",
+            Articles = 10,
+            BytesFetched = 1_000,
+            FirstHour = 1_000,
+        });
+        db.ProviderLifetimeTotals.Add(new ProviderLifetimeTotal
+        {
+            Provider = "provider-b",
+            Articles = 2,
+            BytesFetched = 200,
+            FirstHour = 500,
+        });
+        await db.SaveChangesAsync();
+
+        var lifetime = await GetOverviewStatsController.BuildLifetimeAsync(db);
+
+        Assert.Equal(16, lifetime.Articles);
+        Assert.Equal(1_600, lifetime.BytesFetched);
+        Assert.Equal(500, lifetime.FirstSeenAt);
+    }
+
+    private sealed class MetricsHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+
+        private MetricsHarness(string dir, MetricsDbContext context)
+        {
+            _dir = dir;
+            Context = context;
+        }
+
+        public MetricsDbContext Context { get; }
+
+        public static async Task<MetricsHarness> CreateAsync()
+        {
+            var dir = Path.Join(Path.GetTempPath(), $"nzbdav-overview-lifetime-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = Path.Join(dir, "metrics.sqlite");
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            return new MetricsHarness(dir, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
@@ -109,7 +109,7 @@ public sealed class MetricsRetentionServiceTests
             {
                 Directory.Delete(_dir, recursive: true);
             }
-            catch
+            catch (IOException)
             {
                 // best effort
             }

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Tests.Services.Metrics;
+
+public sealed class MetricsRetentionServiceTests
+{
+    private const long OneDayMs = 24 * 60 * 60 * 1000L;
+
+    [Fact]
+    public async Task SweepAsync_FoldsPrunedProviderHourlyIntoLifetimeTotals()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var nowMs = 400L * OneDayMs;
+        var cutoff = MetricsRetentionService.Cutoff(nowMs, TimeSpan.FromDays(365));
+
+        db.ProviderHourly.AddRange(
+            new ProviderHourly
+            {
+                Hour = cutoff - OneDayMs,
+                Provider = "provider-a",
+                Articles = 10,
+                BytesFetched = 100,
+                Misses = 1,
+                Errors = 2,
+                Retries = 3,
+                SumDurationMs = 40,
+                FailoverSaves = 4,
+            },
+            new ProviderHourly
+            {
+                Hour = cutoff - 2 * OneDayMs,
+                Provider = "provider-a",
+                Articles = 5,
+                BytesFetched = 50,
+                FailoverSaves = 1,
+            },
+            new ProviderHourly
+            {
+                Hour = cutoff + OneDayMs,
+                Provider = "provider-a",
+                Articles = 7,
+                BytesFetched = 70,
+            },
+            new ProviderHourly
+            {
+                Hour = cutoff - OneDayMs,
+                Provider = "provider-b",
+                Articles = 3,
+                BytesFetched = 30,
+                FailoverSaves = 2,
+            });
+        await db.SaveChangesAsync();
+
+        await MetricsRetentionService.SweepAsync(db, nowMs);
+
+        var lifetimeA = await db.ProviderLifetimeTotals.SingleAsync(x => x.Provider == "provider-a");
+        Assert.Equal(15, lifetimeA.Articles);
+        Assert.Equal(150, lifetimeA.BytesFetched);
+        Assert.Equal(cutoff - 2 * OneDayMs, lifetimeA.FirstHour);
+        Assert.Equal(1, await db.ProviderHourly.CountAsync());
+
+        await MetricsRetentionService.SweepAsync(db, nowMs);
+        var lifetimeAAgain = await db.ProviderLifetimeTotals.SingleAsync(x => x.Provider == "provider-a");
+        Assert.Equal(lifetimeA.Articles, lifetimeAAgain.Articles);
+        Assert.Equal(lifetimeA.BytesFetched, lifetimeAAgain.BytesFetched);
+        Assert.Equal(lifetimeA.FirstHour, lifetimeAAgain.FirstHour);
+    }
+
+    private sealed class MetricsHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+
+        private MetricsHarness(string dir, MetricsDbContext context)
+        {
+            _dir = dir;
+            Context = context;
+        }
+
+        public MetricsDbContext Context { get; }
+
+        public static async Task<MetricsHarness> CreateAsync()
+        {
+            var dir = Path.Join(Path.GetTempPath(), $"nzbdav-metrics-retention-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = Path.Join(dir, "metrics.sqlite");
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            return new MetricsHarness(dir, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/OverviewStatsResetTests.cs
@@ -53,11 +53,18 @@ public class OverviewStatsResetTests
             Count = 1,
         });
         db.CatalogueDaily.Add(new CatalogueDaily { Day = now, FileCount = 1 });
+        db.ProviderLifetimeTotals.Add(new ProviderLifetimeTotal
+        {
+            Provider = "a",
+            Articles = 9,
+            BytesFetched = 90,
+            FirstHour = now - 1,
+        });
         await db.SaveChangesAsync();
 
         var deleted = await OverviewStatsReset.WipeAsync(db, CancellationToken.None);
 
-        Assert.Equal(9, deleted);
+        Assert.Equal(10, deleted);
         Assert.Equal(0, await db.SegmentFetches.CountAsync());
         Assert.Equal(0, await db.ReadSessions.CountAsync());
         Assert.Equal(0, await db.MetricEvents.CountAsync());
@@ -67,6 +74,7 @@ public class OverviewStatsResetTests
         Assert.Equal(0, await db.FailoverMisses.CountAsync());
         Assert.Equal(0, await db.FailoverHourly.CountAsync());
         Assert.Equal(0, await db.CatalogueDaily.CountAsync());
+        Assert.Equal(0, await db.ProviderLifetimeTotals.CountAsync());
     }
 
     [Fact]
@@ -87,6 +95,9 @@ public class OverviewStatsResetTests
         db.ProviderHourly.AddRange(
             new ProviderHourly { Hour = now, Provider = target, Articles = 1 },
             new ProviderHourly { Hour = now, Provider = other, Articles = 2 });
+        db.ProviderLifetimeTotals.AddRange(
+            new ProviderLifetimeTotal { Provider = target, Articles = 5, BytesFetched = 50 },
+            new ProviderLifetimeTotal { Provider = other, Articles = 6, BytesFetched = 60 });
         db.MetricEvents.AddRange(
             new MetricEvent { At = now, Kind = "circuit", Tag1 = target, Tag2 = "open" },
             new MetricEvent { At = now, Kind = "circuit", Tag1 = other, Tag2 = "open" },
@@ -155,6 +166,8 @@ public class OverviewStatsResetTests
         Assert.Equal(1, await db.ProviderMinutes.CountAsync(x => x.Provider == other));
         Assert.Equal(0, await db.ProviderHourly.CountAsync(x => x.Provider == target));
         Assert.Equal(1, await db.ProviderHourly.CountAsync(x => x.Provider == other));
+        Assert.Equal(0, await db.ProviderLifetimeTotals.CountAsync(x => x.Provider == target));
+        Assert.Equal(1, await db.ProviderLifetimeTotals.CountAsync(x => x.Provider == other));
         Assert.Equal(0, await db.MetricEvents.CountAsync(x =>
             x.Kind == "circuit" && x.Tag1 == target));
         Assert.Equal(0, await db.MetricEvents.CountAsync(x =>


### PR DESCRIPTION
## Summary
- Add `ProviderLifetimeTotals` table and fold pruned `ProviderHourly` rows into it inside a transaction before deletion during metrics retention sweeps.
- Include folded totals in overview all-time reads (lifetime block, window totals, per-provider speed/latency via `Retries`/`SumDurationMs`/`FailoverSaves`).
- Clear lifetime totals on full/provider stats wipe.

Closes #889

**Note:** Pre-fix installs that already pruned hourly rows cannot recover lost bytes; totals stabilize going forward. Best-day/best-hour records remain limited to retained hourly buckets.

Back up `/config` before upgrading (additive metrics migration auto-applies on startup).

## Test plan
- [x] `MetricsRetentionServiceTests.SweepAsync_FoldsPrunedProviderHourlyIntoLifetimeTotals` (idempotent second sweep)
- [x] `GetOverviewStatsLifetimeTests.BuildLifetimeAsync_IncludesFoldedTotalsAndEarliestFirstSeenAt`
- [x] `OverviewStatsResetTests.WipeAsync_DeletesAllMetricsTables`
- [x] `OverviewStatsResetTests.WipeProviderAsync_DeletesOnlyTargetProviderRows`