### PR TITLE
feat(webdav): allow clearing completed-symlinks via WebDAV delete and a new maintenance task

### DIFF
--- a/backend/Api/Controllers/PruneCompletedHistory/PruneCompletedHistoryController.cs
+++ b/backend/Api/Controllers/PruneCompletedHistory/PruneCompletedHistoryController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.PruneCompletedHistory;
+
+[ApiController]
+[Route("api/prune-completed-history")]
+public class PruneCompletedHistoryController(WebsocketManager websocketManager) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var category = HttpContext.Request.Query["category"].FirstOrDefault();
+        var olderThanDays = ParseOlderThanDays(HttpContext.Request.Query["older-than-days"].FirstOrDefault());
+        var task = new PruneCompletedHistoryTask(websocketManager, isDryRun: false, category, olderThanDays);
+        var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed) return Conflict(new { error = "A maintenance task is already running." });
+        return Ok(executed);
+    }
+
+    internal static int? ParseOlderThanDays(string? value) =>
+        int.TryParse(value, out var days) && days > 0 ? days : null;
+}

--- a/backend/Api/Controllers/PruneCompletedHistory/PruneCompletedHistoryDryRunController.cs
+++ b/backend/Api/Controllers/PruneCompletedHistory/PruneCompletedHistoryDryRunController.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers.PruneCompletedHistory;
+
+[ApiController]
+[Route("api/prune-completed-history/dry-run")]
+public class PruneCompletedHistoryDryRunController(WebsocketManager websocketManager) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var category = HttpContext.Request.Query["category"].FirstOrDefault();
+        var olderThanDays = PruneCompletedHistoryController.ParseOlderThanDays(
+            HttpContext.Request.Query["older-than-days"].FirstOrDefault());
+        var task = new PruneCompletedHistoryTask(websocketManager, isDryRun: true, category, olderThanDays);
+        var executed = await task.Execute().ConfigureAwait(false);
+        if (!executed) return Conflict(new { error = "A maintenance task is already running." });
+        return Ok(executed);
+    }
+}

--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -41,12 +41,9 @@ public class GetHistoryController(
         var historyItems = await historyItemsPromise.ConfigureAwait(false);
 
         // get download folders
-        var downloadFolderIds = historyItems.Select(x => x.DownloadDirId).ToHashSet();
-        var davItems = await dbClient.Ctx.Items
-            .Where(x => downloadFolderIds.Contains(x.Id))
-            .ToArrayAsync(request.CancellationToken).ConfigureAwait(false);
-        var davItemsDict = davItems
-            .ToDictionary(x => x.Id, x => x);
+        var downloadFolderIds = historyItems.Select(x => x.DownloadDirId).Where(x => x.HasValue).Select(x => x!.Value);
+        var davItems = await dbClient.GetItemsByIdsBatchedAsync(downloadFolderIds, ct: request.CancellationToken).ConfigureAwait(false);
+        var davItemsDict = davItems.ToDictionary(x => x.Id, x => x);
 
         // get slots (in-memory provider counts only survive until app restart)
         var providerUsages = providerUsageTracker.SnapshotMany(historyItems.Select(x => x.Id));

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Database;
@@ -44,6 +45,15 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         {
             yield return child;
         }
+    }
+
+    public async Task<List<DavItem>> GetItemsByIdsBatchedAsync(
+        IEnumerable<Guid> ids, int batchSize = 500, CancellationToken ct = default)
+    {
+        var result = new List<DavItem>();
+        foreach (var batch in ids.Distinct().ToBatches(batchSize))
+            result.AddRange(await Ctx.Items.AsNoTracking().Where(x => batch.Contains(x.Id)).ToListAsync(ct).ConfigureAwait(false));
+        return result;
     }
 
     public Task<DavItem?> GetDirectoryChildAsync(Guid dirId, string childName, CancellationToken ct = default)

--- a/backend/Tasks/PruneCompletedHistoryTask.cs
+++ b/backend/Tasks/PruneCompletedHistoryTask.cs
@@ -84,7 +84,11 @@ public class PruneCompletedHistoryTask : BaseTask
     {
         var query = dbContext.HistoryItems.AsNoTracking().Where(h => h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed);
         if (!string.IsNullOrWhiteSpace(category)) query = query.Where(h => h.Category == category);
-        if (olderThanDays is > 0) query = query.Where(h => h.CreatedAt < DateTime.UtcNow.AddDays(-olderThanDays.Value));
+        if (olderThanDays is > 0)
+        {
+            var days = olderThanDays.Value;
+            query = query.Where(h => h.CreatedAt < DateTime.UtcNow.AddDays(-days));
+        }
         return query;
     }
 

--- a/backend/Tasks/PruneCompletedHistoryTask.cs
+++ b/backend/Tasks/PruneCompletedHistoryTask.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+/// <remarks>
+/// <see cref="BaseTask"/> uses a single static semaphore shared by every subclass, so this task
+/// is mutually exclusive with <see cref="RemoveUnlinkedFilesTask"/> and other maintenance tasks.
+/// </remarks>
+public class PruneCompletedHistoryTask : BaseTask
+{
+    private const int BatchSize = 100;
+    private static readonly TimeSpan DefaultProgressHeartbeatInterval = TimeSpan.FromSeconds(2);
+    private readonly WebsocketManager _websocketManager;
+    private readonly bool _isDryRun;
+    private readonly string? _category;
+    private readonly int? _olderThanDays;
+    private readonly Func<DavDatabaseContext>? _createContext;
+    private readonly TimeSpan _progressHeartbeatInterval;
+    private readonly Action<string>? _progressObserver;
+    private ProgressHeartbeat? _progressHeartbeat;
+
+    public PruneCompletedHistoryTask(WebsocketManager websocketManager, bool isDryRun, string? category = null, int? olderThanDays = null)
+        : this(websocketManager, isDryRun, category, olderThanDays, null) { }
+
+    internal PruneCompletedHistoryTask(WebsocketManager websocketManager, bool isDryRun, string? category, int? olderThanDays,
+        Func<DavDatabaseContext>? createContext, TimeSpan? progressHeartbeatInterval = null, Action<string>? progressObserver = null)
+    {
+        _websocketManager = websocketManager;
+        _isDryRun = isDryRun;
+        _category = string.IsNullOrWhiteSpace(category) ? null : category.Trim();
+        _olderThanDays = olderThanDays is > 0 ? olderThanDays : null;
+        _createContext = createContext;
+        _progressHeartbeatInterval = progressHeartbeatInterval ?? DefaultProgressHeartbeatInterval;
+        _progressObserver = progressObserver;
+    }
+
+    private DavDatabaseContext CreateContext() => DavDatabaseContexts.Create(_createContext);
+
+    protected override async Task ExecuteInternal()
+    {
+        await using var progressHeartbeat = new ProgressHeartbeat(Report, _progressHeartbeatInterval);
+        _progressHeartbeat = progressHeartbeat;
+        try { await PruneCompletedHistory().ConfigureAwait(false); }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Complete($"Failed: {e.Message}");
+            if (TryGetKnownFailureReason(e, out var reason))
+            { Log.Warning("Could not prune completed history. Reason: {Reason}", reason); Log.Debug(e, "Prune completed history known failure stack"); }
+            else Log.Error(e, "Failed to prune completed history.");
+        }
+        finally { _progressHeartbeat = null; }
+    }
+
+    private async Task PruneCompletedHistory()
+    {
+        await using var dbContext = CreateContext();
+        var dbClient = new DavDatabaseClient(dbContext);
+        StartPhase("Counting completed history items...");
+        var totalCount = await CountMatchingItemsAsync(dbContext).ConfigureAwait(false);
+        UpdatePhase($"Counting completed history items...\nFound {totalCount} item(s) to prune.");
+        if (totalCount == 0)
+        {
+            Complete(_isDryRun ? "Done. Identified 0 completed history items." : "Done. Pruned 0 completed history items.");
+            return;
+        }
+        if (_isDryRun)
+        {
+            StartPhase("Identifying completed history items...");
+            Complete($"Done. Identified {await DryRunIdentifyAsync(dbContext).ConfigureAwait(false)} completed history item(s).");
+            return;
+        }
+        StartPhase("Pruning completed history items...");
+        Complete($"Done. Pruned {await PruneBatchesAsync(dbClient).ConfigureAwait(false)} completed history item(s).");
+    }
+
+    internal static IQueryable<HistoryItem> BuildFilterQuery(DavDatabaseContext dbContext, string? category, int? olderThanDays)
+    {
+        var query = dbContext.HistoryItems.AsNoTracking().Where(h => h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed);
+        if (!string.IsNullOrWhiteSpace(category)) query = query.Where(h => h.Category == category);
+        if (olderThanDays is > 0) query = query.Where(h => h.CreatedAt < DateTime.UtcNow.AddDays(-olderThanDays.Value));
+        return query;
+    }
+
+    private Task<int> CountMatchingItemsAsync(DavDatabaseContext dbContext) =>
+        BuildFilterQuery(dbContext, _category, _olderThanDays).CountAsync(CancellationToken);
+
+    private async Task<int> DryRunIdentifyAsync(DavDatabaseContext dbContext)
+    {
+        var identified = 0; var lastId = Guid.Empty;
+        while (true)
+        {
+            var filterQuery = BuildFilterQuery(dbContext, _category, _olderThanDays);
+            if (lastId != Guid.Empty) filterQuery = filterQuery.Where(h => h.Id > lastId);
+            var batch = await filterQuery.OrderBy(h => h.Id).Select(h => h.Id).Take(BatchSize).ToListAsync(CancellationToken).ConfigureAwait(false);
+            if (batch.Count == 0) break;
+            identified += batch.Count; lastId = batch[^1];
+            UpdatePhase($"Identifying completed history items...\nFound {identified}...");
+        }
+        return identified;
+    }
+
+    private async Task<int> PruneBatchesAsync(DavDatabaseClient dbClient)
+    {
+        var pruned = 0; string? lastStuckBatchKey = null;
+        while (true)
+        {
+            var ids = await BuildFilterQuery(dbClient.Ctx, _category, _olderThanDays).OrderBy(h => h.CreatedAt).Select(h => h.Id).Take(BatchSize).ToListAsync(CancellationToken).ConfigureAwait(false);
+            if (ids.Count == 0) break;
+            var existingCount = await dbClient.Ctx.HistoryItems.CountAsync(h => ids.Contains(h.Id), CancellationToken).ConfigureAwait(false);
+            await dbClient.RemoveHistoryItemsAsync(ids, deleteFiles: false, CancellationToken).ConfigureAwait(false);
+            await dbClient.Ctx.SaveChangesAsync(CancellationToken).ConfigureAwait(false);
+            dbClient.Ctx.ChangeTracker.Clear();
+            var remainingCount = await dbClient.Ctx.HistoryItems.CountAsync(h => ids.Contains(h.Id), CancellationToken).ConfigureAwait(false);
+            if (remainingCount == existingCount && existingCount > 0)
+            {
+                var batchKey = string.Join(",", ids);
+                if (batchKey == lastStuckBatchKey)
+                    throw new InvalidOperationException($"selected {ids.Count} completed history items but pruned 0 twice; aborting to avoid an infinite loop.");
+                lastStuckBatchKey = batchKey; continue;
+            }
+            lastStuckBatchKey = null; pruned += existingCount - remainingCount;
+            UpdatePhase($"Pruning completed history items...\nPruned {pruned}...");
+        }
+        return pruned;
+    }
+
+    private bool TryGetKnownFailureReason(Exception exception, out string reason)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current.IsCancellationException(CancellationToken)) { reason = "nzbdav is shutting down"; return true; }
+            if (current is SqliteException { SqliteErrorCode: 5 or 6 or 8 or 13 }) { reason = current.Message; return true; }
+        }
+        reason = string.Empty; return false;
+    }
+
+    private void StartPhase(string message) => _progressHeartbeat?.StartPhase(message);
+    private void UpdatePhase(string message) => _progressHeartbeat?.UpdatePhase(message);
+    private void Complete(string message) { if (_progressHeartbeat is not null) _progressHeartbeat.Complete(message); else Report(message); }
+    private void Report(string message) { var progress = $"{(_isDryRun ? "Dry Run - " : string.Empty)}{message}"; _progressObserver?.Invoke(progress); _ = _websocketManager.SendMessage(WebsocketTopic.CleanupTaskProgress, progress); }
+
+    internal sealed class ProgressHeartbeat : IAsyncDisposable
+    {
+        private readonly object _sync = new(); private readonly Action<string> _report; private readonly TimeSpan _interval; private readonly Timer _timer;
+        private string? _message; private long _runStartedAt; private bool _completed; private bool _disposed;
+        public ProgressHeartbeat(Action<string> report, TimeSpan interval)
+        { _report = report; _interval = interval; _timer = new Timer(static s => ((ProgressHeartbeat)s!).ReportHeartbeat(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); }
+        public void StartPhase(string message) { lock (_sync) { if (_disposed || _completed) return; if (_runStartedAt == 0) _runStartedAt = Stopwatch.GetTimestamp(); _message = message; ReportWithElapsed(); _timer.Change(_interval, _interval); } }
+        public void UpdatePhase(string message) { lock (_sync) { if (_disposed || _completed) return; _message = message; ReportWithElapsed(); } }
+        public void Complete(string message) { lock (_sync) { if (_disposed || _completed) return; _completed = true; _message = null; _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); _report(message); } }
+        private void ReportHeartbeat() { lock (_sync) { if (_disposed || _message is null) return; ReportWithElapsed(); } }
+        private void ReportWithElapsed() { if (_message is null) return; if (_runStartedAt == 0) _runStartedAt = Stopwatch.GetTimestamp(); _report($"{_message}\nElapsed: {FormatElapsed(Stopwatch.GetElapsedTime(_runStartedAt))}"); }
+        private static string FormatElapsed(TimeSpan elapsed) => elapsed.TotalMinutes >= 1 ? $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds}s" : $"{Math.Max(1, (int)elapsed.TotalSeconds)}s";
+        public async ValueTask DisposeAsync() { lock (_sync) { if (_disposed) return; _disposed = true; _message = null; _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); } await _timer.DisposeAsync().ConfigureAwait(false); }
+    }
+}

--- a/backend/WebDav/DatabaseStoreItemFactory.cs
+++ b/backend/WebDav/DatabaseStoreItemFactory.cs
@@ -44,7 +44,7 @@ public static class DatabaseStoreItemFactory
                     lazyRarResolver, inFlightArticleBudget),
             DavItem.ItemSubType.SymlinkRoot =>
                 new DatabaseStoreSymlinkCollection(
-                    davItem, dbClient, configManager),
+                    davItem, dbClient, configManager, websocketManager),
             DavItem.ItemSubType.NzbFile =>
                 new DatabaseStoreNzbFile(
                     davItem, httpContext, dbClient, usenetClient, configManager, inFlightArticleBudget),

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -1,20 +1,24 @@
 ﻿using System.Text.RegularExpressions;
 using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.WebDav.Base;
 using NzbWebDAV.WebDav.Requests;
+using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.WebDav;
 
 public class DatabaseStoreSymlinkCollection(
     DavItem davDirectory,
     DavDatabaseClient dbClient,
-    ConfigManager configManager
+    ConfigManager configManager,
+    WebsocketManager websocketManager
 ) : BaseStoreReadonlyCollection
 {
     public override string Name => davDirectory.Name;
@@ -89,43 +93,25 @@ public class DatabaseStoreSymlinkCollection(
         }
     }
 
-    protected override Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)
+    protected override async Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)
     {
-        // Cannot delete from symlink root folder
         var isSymlinkFolder = davDirectory.Id == DavItem.SymlinkFolder.Id;
-        if (isSymlinkFolder) return base.DeleteItemAsync(request);
-
-        // Items cannot be deleted from the '/completed-symlinks' folder.
-        // This path simply mirrors the '/content' folder, except with symlinks.
-        // This allows radarr/sonarr to import the lightweight symlink, instead
-        // of trying to import large-sized media.
-        //
-        // However, when radarr attempts to import the symlink, it does so by moving
-        // it to the media library. But since the symlinks lives in a separate
-        // file-system (rclone-mounted webdav), the operating system will instead
-        // perform a copy-and-delete operation. For the import to succeed, we must
-        // trick the OS into thinking that the "delete" worked.
-        //
-        // The symlink doesn't actually exist anywhere. It takes zero storage and
-        // just gets created in memory, as needed, for webdav requests. The only
-        // thing that exists is the underlying data within the '/content' directory
-        // But in this request, we only want to "delete" the symlink. We don't want
-        // to delete the underlying media within the '/content' directory.
-        //
-        // Instead, we store the filename in a temporary cache (for 30 seconds).
-        // While the filename is in the cache, we will no longer create that
-        // symlink on-the-fly in subsequent webdav requests. It essentially
-        // mimics a deletion even though there was nothing to delete in the first
-        // place, since everything is created on the fly, mirroring the '/content'
-        // directory.
-        //
-        // (204 No Content) is the correct status code to return for a successful
-        // deletion of a file. This status code means the server has successfully
-        // processed the request, and there is no additional content to send in the
-        // response body. (200 OK) is also acceptable, but more appropriate for when
-        // the server also returns a response body with the status of the operation.
+        if (isSymlinkFolder) return await base.DeleteItemAsync(request).ConfigureAwait(false);
+        if (configManager.IsEnforceReadonlyWebdavEnabled()) return DavStatusCode.Forbidden;
+        var child = await dbClient.GetDirectoryChildAsync(TargetId, request.Name, request.CancellationToken).ConfigureAwait(false);
+        if (child is { Type: DavItem.ItemType.Directory } && !child.IsProtected() && davDirectory.ParentId == DavItem.ContentFolder.Id)
+        {
+            var historyIds = await dbClient.Ctx.HistoryItems.AsNoTracking()
+                .Where(h => h.DownloadDirId == child.Id && h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed)
+                .Select(h => h.Id).ToListAsync(request.CancellationToken).ConfigureAwait(false);
+            if (historyIds.Count == 0) return DavStatusCode.NotFound;
+            await dbClient.RemoveHistoryItemsAsync(historyIds, deleteFiles: false, request.CancellationToken).ConfigureAwait(false);
+            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+            _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", historyIds));
+            return DavStatusCode.NoContent;
+        }
         DeletedFiles.AddDeletedFile(request.Name, TimeSpan.FromSeconds(30));
-        return Task.FromResult(DavStatusCode.NoContent);
+        return DavStatusCode.NoContent;
     }
 
     private IStoreItem GetItem(DavItem davItem)
@@ -133,7 +119,7 @@ public class DatabaseStoreSymlinkCollection(
         return davItem.SubType switch
         {
             DavItem.ItemSubType.Directory =>
-                new DatabaseStoreSymlinkCollection(davItem, dbClient, configManager),
+                new DatabaseStoreSymlinkCollection(davItem, dbClient, configManager, websocketManager),
             DavItem.ItemSubType.NzbFile =>
                 new DatabaseStoreSymlinkFile(davItem, configManager),
             DavItem.ItemSubType.RarFile =>

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -2,6 +2,7 @@ import { ManagedSetting, SettingsIntro, SettingsPage, Tooltip } from "~/componen
 import { Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
+import { PruneCompletedHistory } from "./prune-completed-history/prune-completed-history";
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
 import { RenameWindowsInvalidDavPaths } from "./rename-windows-invalid-dav-paths/rename-windows-invalid-dav-paths";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
@@ -232,11 +233,14 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                             Run repair, migration, and destructive cleanup tools on demand.
                         </p>
                     </div>
-                    <span className="badge badge-ghost badge-sm shrink-0">7 tools</span>
+                    <span className="badge badge-ghost badge-sm shrink-0">8 tools</span>
                 </div>
                 <div className="space-y-3">
                     <MaintenanceTaskDetails title="Remove Orphaned Files">
                         <RemoveUnlinkedFiles savedConfig={savedConfig} />
+                    </MaintenanceTaskDetails>
+                    <MaintenanceTaskDetails title="Prune Completed History">
+                        <PruneCompletedHistory savedConfig={savedConfig} />
                     </MaintenanceTaskDetails>
                     <MaintenanceTaskDetails title="Rename Windows-Invalid Paths">
                         <RenameWindowsInvalidDavPaths savedConfig={savedConfig} />

--- a/frontend/app/routes/settings/maintenance/prune-completed-history/prune-completed-history.tsx
+++ b/frontend/app/routes/settings/maintenance/prune-completed-history/prune-completed-history.tsx
@@ -1,0 +1,68 @@
+import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/feedback";
+import { Input, Select } from "~/components/ui/form";
+import { Icon } from "~/components/ui/icon";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
+
+type PruneCompletedHistoryProps = { savedConfig: Record<string, string> };
+
+export function PruneCompletedHistory({ savedConfig }: PruneCompletedHistoryProps) {
+    const [connected, setConnected] = useState(false);
+    const [progress, setProgress] = useState<string | null>(null);
+    const [isFetching, setIsFetching] = useState(false);
+    const [runStarted, setRunStarted] = useState(false);
+    const [statusError, setStatusError] = useState<string | null>(null);
+    const [category, setCategory] = useState("");
+    const [olderThanDays, setOlderThanDays] = useState("");
+    const categories = useMemo(() => (savedConfig["api.categories"] ?? "").split(",").map(c => c.trim()).filter(Boolean), [savedConfig]);
+    const progressMessage = progress?.replace("Dry Run - ", "");
+    const isFinished = progressMessage?.startsWith("Done") || progressMessage?.startsWith("Failed") || progressMessage?.startsWith("Aborted");
+    const isRunning = !isFinished && (isFetching || runStarted);
+    useWebsocketTopic("ctp", "state", setProgress, { onOpen: () => setConnected(true), onClose: () => setProgress(null) });
+    useEffect(() => { if (isFinished) setRunStarted(false); }, [isFinished]);
+    const buildQueryString = useCallback(() => {
+        const params = new URLSearchParams();
+        if (category) params.set("category", category);
+        const days = parseInt(olderThanDays, 10);
+        if (!Number.isNaN(days) && days > 0) params.set("older-than-days", String(days));
+        const qs = params.toString();
+        return qs ? `?${qs}` : "";
+    }, [category, olderThanDays]);
+    const startTask = useCallback(async (url: string) => {
+        setStatusError(null); setProgress(null); setRunStarted(true); setIsFetching(true);
+        try {
+            const response = await fetch(withUrlBase(`${url}${buildQueryString()}`));
+            if (response.status === 409) { setStatusError("Task already running."); setRunStarted(false); return; }
+            if (!response.ok) { setStatusError(`Request failed (${response.status}).`); setRunStarted(false); }
+        } catch { setStatusError("Request failed."); setRunStarted(false); }
+        finally { setIsFetching(false); }
+    }, [buildQueryString]);
+    return (
+        <>
+            <Alert className="alert-soft mb-4 items-start py-3 text-sm" variant="warning">
+                <Icon name="backup" className="!text-[20px]" />
+                <div><p className="font-semibold">Back up before cleanup</p><p className="mt-0.5 text-xs opacity-80">Pruning SAB history is permanent. WebDAV files are preserved.</p></div>
+            </Alert>
+            <div className="space-y-4">
+                <p className="text-sm text-base-content/70">Remove completed SAB history rows in bulk without deleting mounted WebDAV content.</p>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <label className="space-y-1.5"><span className="block text-xs font-medium text-base-content/70">Category</span>
+                        <Select className="w-full" value={category} onChange={e => setCategory(e.target.value)} disabled={isRunning}>
+                            <option value="">All categories</option>{categories.map(cat => <option key={cat} value={cat}>{cat}</option>)}
+                        </Select></label>
+                    <label className="space-y-1.5"><span className="block text-xs font-medium text-base-content/70">Older than (days)</span>
+                        <Input className="w-full" type="number" min={0} placeholder="Any age" value={olderThanDays} onChange={e => setOlderThanDays(e.target.value)} disabled={isRunning} /></label>
+                </div>
+                <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3 flex flex-wrap gap-2 items-center justify-between">
+                    <div className="flex gap-2">
+                        <Button variant={connected && !isRunning ? "danger" : "secondary"} disabled={!connected || isRunning} onClick={() => startTask("/api/prune-completed-history")}>{isRunning ? "Running..." : "Run Task"}</Button>
+                        <Button variant="outline" size="small" disabled={!connected || isRunning} onClick={() => startTask("/api/prune-completed-history/dry-run")}>Dry Run</Button>
+                    </div>
+                    <div aria-live="polite" className="font-mono text-xs text-base-content/70 whitespace-pre-line">{statusError ?? progress ?? "Ready to prune."}</div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -154,6 +154,18 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetItemsByIdsBatchedAsync_ReturnsAllItemsAcrossLargeIdSets()
+    {
+        var ids = Enumerable.Range(0, 600).Select(_ => Guid.NewGuid()).ToList();
+        _context.Items.AddRange(ids.Select(id => DavItem.New(id, DavItem.Root, $"{id:N}.mkv", 10,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile, null, null, null, null)));
+        await _context.SaveChangesAsync(); _context.ChangeTracker.Clear();
+        var found = await _client.GetItemsByIdsBatchedAsync(ids, batchSize: 500);
+        Assert.Equal(600, found.Count);
+        Assert.Equal(ids.OrderBy(x => x).ToList(), found.Select(x => x.Id).OrderBy(x => x).ToList());
+    }
+
+    [Fact]
     public async Task GetFileById_NonGuidName_ReturnsNull()
     {
         Assert.Null(await _client.GetFileById("not-a-guid"));

--- a/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Tasks;
+
+[Collection(nameof(BaseTaskCollection))]
+public class PruneCompletedHistoryTaskTests
+{
+    [Fact]
+    public async Task Execute_PrunesOnlyCompletedMatchingCategoryAndAge()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            var oldMoviesId = Guid.NewGuid(); var recentMoviesId = Guid.NewGuid(); var oldTvId = Guid.NewGuid(); var failedId = Guid.NewGuid();
+            ctx.HistoryItems.AddRange(
+                CreateHistory(oldMoviesId, "old-movies.nzb", "movies", DateTime.UtcNow.AddDays(-120)),
+                CreateHistory(recentMoviesId, "recent-movies.nzb", "movies", DateTime.UtcNow.AddDays(-5)),
+                CreateHistory(oldTvId, "old-tv.nzb", "tv", DateTime.UtcNow.AddDays(-120)),
+                CreateHistory(failedId, "failed.nzb", "movies", DateTime.UtcNow.AddDays(-120), HistoryItem.DownloadStatusOption.Failed));
+            await ctx.SaveChangesAsync(); ctx.ChangeTracker.Clear();
+            Assert.True(await new PruneCompletedHistoryTask(new WebsocketManager(), false, "movies", 90, () => harness.CreateContext()).Execute());
+            Assert.Null(await ctx.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == oldMoviesId));
+            Assert.NotNull(await ctx.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == recentMoviesId));
+            Assert.NotNull(await ctx.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == oldTvId));
+            Assert.NotNull(await ctx.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == failedId));
+        }
+        finally { await BaseTask.ResetRunningTaskForTestsAsync(); }
+    }
+
+    [Fact]
+    public async Task DryRun_DoesNotModifyDatabase()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            ctx.HistoryItems.Add(CreateHistory(Guid.NewGuid(), "dry-run.nzb", "movies", DateTime.UtcNow.AddDays(-200)));
+            await ctx.SaveChangesAsync(); ctx.ChangeTracker.Clear();
+            Assert.True(await new PruneCompletedHistoryTask(new WebsocketManager(), true, null, 90, () => harness.CreateContext()).Execute());
+            Assert.Equal(1, await ctx.HistoryItems.CountAsync());
+            Assert.Empty(await ctx.HistoryCleanupItems.AsNoTracking().ToListAsync());
+        }
+        finally { await BaseTask.ResetRunningTaskForTestsAsync(); }
+    }
+
+    [Fact]
+    public async Task Execute_PrunesInBatches_WhenMoreThanBatchSize()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            for (var i = 0; i < 150; i++) ctx.HistoryItems.Add(CreateHistory(Guid.NewGuid(), $"batch-{i}.nzb", "movies", DateTime.UtcNow.AddDays(-200)));
+            await ctx.SaveChangesAsync(); ctx.ChangeTracker.Clear();
+            Assert.True(await new PruneCompletedHistoryTask(new WebsocketManager(), false, "movies", 90, () => harness.CreateContext()).Execute());
+            Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            Assert.Equal(150, await ctx.HistoryCleanupItems.CountAsync());
+        }
+        finally { await BaseTask.ResetRunningTaskForTestsAsync(); }
+    }
+
+    [Fact]
+    public async Task BuildFilterQuery_OnlyIncludesCompletedStatus()
+    {
+        await using var harness = await TempDb.CreateAsync();
+        var ctx = harness.Context;
+        var completedId = Guid.NewGuid(); var failedId = Guid.NewGuid();
+        ctx.HistoryItems.AddRange(
+            CreateHistory(completedId, "ok.nzb", "movies", DateTime.UtcNow.AddDays(-10)),
+            CreateHistory(failedId, "bad.nzb", "movies", DateTime.UtcNow.AddDays(-10), HistoryItem.DownloadStatusOption.Failed));
+        await ctx.SaveChangesAsync();
+        Assert.Equal([completedId], PruneCompletedHistoryTask.BuildFilterQuery(ctx, null, null).Select(h => h.Id).ToList());
+    }
+
+    private static HistoryItem CreateHistory(Guid id, string fileName, string category, DateTime createdAt,
+        HistoryItem.DownloadStatusOption status = HistoryItem.DownloadStatusOption.Completed) => new()
+    {
+        Id = id, CreatedAt = createdAt, FileName = fileName, JobName = Path.GetFileNameWithoutExtension(fileName),
+        Category = category, DownloadStatus = status, TotalSegmentBytes = 100, DownloadTimeSeconds = 1,
+    };
+
+    private sealed class TempDb : IAsyncDisposable
+    {
+        private readonly string _path;
+        private TempDb(string path, DavDatabaseContext context) { _path = path; Context = context; }
+        public DavDatabaseContext Context { get; }
+        public DavDatabaseContext CreateContext() => new(new DbContextOptionsBuilder<DavDatabaseContext>().UseSqlite($"Data Source={_path}")
+            .AddInterceptors(new SqliteMainDbPragmas()).ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>().Options);
+        public static async Task<TempDb> CreateAsync()
+        {
+            var path = Path.Join(Path.GetTempPath(), $"nzbdav-prune-{Guid.NewGuid():N}.sqlite");
+            var ctx = new DavDatabaseContext(new DbContextOptionsBuilder<DavDatabaseContext>().UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMainDbPragmas()).ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>().Options);
+            await ctx.Database.MigrateAsync();
+            return new TempDb(path, ctx);
+        }
+        public async ValueTask DisposeAsync() { await Context.DisposeAsync(); try { File.Delete(_path); } catch (IOException) { } }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
@@ -85,10 +85,16 @@ public class PruneCompletedHistoryTaskTests
 
     private static HistoryItem CreateHistory(Guid id, string fileName, string category, DateTime createdAt,
         HistoryItem.DownloadStatusOption status = HistoryItem.DownloadStatusOption.Completed) => new()
-    {
-        Id = id, CreatedAt = createdAt, FileName = fileName, JobName = Path.GetFileNameWithoutExtension(fileName),
-        Category = category, DownloadStatus = status, TotalSegmentBytes = 100, DownloadTimeSeconds = 1,
-    };
+        {
+            Id = id,
+            CreatedAt = createdAt,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = category,
+            DownloadStatus = status,
+            TotalSegmentBytes = 100,
+            DownloadTimeSeconds = 1,
+        };
 
     private sealed class TempDb : IAsyncDisposable
     {

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
@@ -91,9 +91,15 @@ public sealed class DatabaseStoreSymlinkCollectionTests : IAsyncLifetime
 
     private static HistoryItem CreateHistory(Guid id, string fileName, string category, Guid downloadDirId) => new()
     {
-        Id = id, CreatedAt = DateTime.UtcNow, FileName = fileName, JobName = Path.GetFileNameWithoutExtension(fileName),
-        Category = category, DownloadStatus = HistoryItem.DownloadStatusOption.Completed, DownloadDirId = downloadDirId,
-        TotalSegmentBytes = 100, DownloadTimeSeconds = 1,
+        Id = id,
+        CreatedAt = DateTime.UtcNow,
+        FileName = fileName,
+        JobName = Path.GetFileNameWithoutExtension(fileName),
+        Category = category,
+        DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+        DownloadDirId = downloadDirId,
+        TotalSegmentBytes = 100,
+        DownloadTimeSeconds = 1,
     };
 
     public async Task DisposeAsync() { await _context.DisposeAsync(); try { File.Delete(_databasePath); } catch (IOException) { } }

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
@@ -1,0 +1,100 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NWebDav.Server;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.WebDav;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+public sealed class DatabaseStoreSymlinkCollectionTests : IAsyncLifetime
+{
+    private readonly string _databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-symlink-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _client = null!;
+    private ConfigManager _config = null!;
+    private WebsocketManager _websocket = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>().UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>().Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _client = new DavDatabaseClient(_context);
+        _config = new ConfigManager();
+        _config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.WebdavEnforceReadonly, ConfigValue = "false" }]);
+        _websocket = new WebsocketManager();
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_FromSymlinkRoot_ReturnsForbidden()
+    {
+        var status = await new DatabaseStoreSymlinkCollection(DavItem.SymlinkFolder, _client, _config, _websocket)
+            .DeleteItemAsync("movies", CancellationToken.None);
+        Assert.Equal(DavStatusCode.Forbidden, status);
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_FileDelete_DoesNotRemoveHistory()
+    {
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "movies");
+        var release = NewDir(Guid.NewGuid(), category, "Show.S01E01");
+        var historyId = Guid.NewGuid();
+        _context.Items.AddRange(category, release);
+        _context.HistoryItems.Add(CreateHistory(historyId, "episode.nzb", category.Name, release.Id));
+        await _context.SaveChangesAsync();
+        var status = await new DatabaseStoreSymlinkCollection(release, _client, _config, _websocket)
+            .DeleteItemAsync("episode.mkv", CancellationToken.None);
+        Assert.Equal(DavStatusCode.NoContent, status);
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == historyId));
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_ReleaseDirectory_PrunesHistoryAndPreservesDavItems()
+    {
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "movies");
+        var release = NewDir(Guid.NewGuid(), category, "Show.S01E01");
+        var historyId = Guid.NewGuid();
+        _context.Items.AddRange(category, release);
+        _context.HistoryItems.Add(CreateHistory(historyId, "episode.nzb", category.Name, release.Id));
+        await _context.SaveChangesAsync();
+        var status = await new DatabaseStoreSymlinkCollection(category, _client, _config, _websocket)
+            .DeleteItemAsync(release.Name, CancellationToken.None);
+        Assert.Equal(DavStatusCode.NoContent, status);
+        Assert.Null(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == historyId));
+        Assert.NotNull(await _context.Items.AsNoTracking().FirstOrDefaultAsync(x => x.Id == release.Id));
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_WhenReadonlyWebdavEnabled_ReturnsForbiddenForReleaseDirectory()
+    {
+        _config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.WebdavEnforceReadonly, ConfigValue = "true" }]);
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "tv");
+        var release = NewDir(Guid.NewGuid(), category, "Show.S01E01");
+        var historyId = Guid.NewGuid();
+        _context.Items.AddRange(category, release);
+        _context.HistoryItems.Add(CreateHistory(historyId, "episode.nzb", category.Name, release.Id));
+        await _context.SaveChangesAsync();
+        var status = await new DatabaseStoreSymlinkCollection(category, _client, _config, _websocket)
+            .DeleteItemAsync(release.Name, CancellationToken.None);
+        Assert.Equal(DavStatusCode.Forbidden, status);
+    }
+
+    private static DavItem NewDir(Guid id, DavItem parent, string name) =>
+        DavItem.New(id, parent, name, null, DavItem.ItemType.Directory, DavItem.ItemSubType.Directory, null, null, null, null);
+
+    private static HistoryItem CreateHistory(Guid id, string fileName, string category, Guid downloadDirId) => new()
+    {
+        Id = id, CreatedAt = DateTime.UtcNow, FileName = fileName, JobName = Path.GetFileNameWithoutExtension(fileName),
+        Category = category, DownloadStatus = HistoryItem.DownloadStatusOption.Completed, DownloadDirId = downloadDirId,
+        TotalSegmentBytes = 100, DownloadTimeSeconds = 1,
+    };
+
+    public async Task DisposeAsync() { await _context.DisposeAsync(); try { File.Delete(_databasePath); } catch (IOException) { } }
+}


### PR DESCRIPTION
Closes #133

## Summary
- WebDAV DELETE on a release directory under `/completed-symlinks/<category>` prunes the matching completed SAB history row without deleting mounted WebDAV content; files still use the existing fake-delete cache path.
- Adds a **Prune Completed History** maintenance task (run + dry-run API endpoints) with optional category and age filters, sharing `BaseTask`'s single-flight semaphore with Remove Orphaned Files.
- Batches `mode=history` download-folder lookups to avoid SQLite "too many SQL variables" 500s when history backlogs are large.

## Test plan
- [x] `DatabaseStoreSymlinkCollectionTests` — root forbidden, file fake-delete, release-dir history prune, readonly forbidden
- [x] `PruneCompletedHistoryTaskTests` — category/age filters, Completed-only, batching, dry-run, DavItems preserved
- [x] `GetItemsByIdsBatchedAsync` — 600-id batched lookup
- [x] Frontend typecheck, build, and vitest (519 tests)
- [ ] Manual: DELETE a release folder under `/completed-symlinks/tv` via rclone/WebDAV client; confirm entry disappears from history UI and symlink listing
- [ ] Manual: run Prune Completed History dry-run + real run from Settings → Maintenance