### PR TITLE
chore(github): rename issue templates to InfiniDysk

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible problem in NzbDav
+description: Report a reproducible problem in InfiniDysk
 type: Bug
 body:
   - type: markdown
@@ -7,7 +7,7 @@ body:
       value: |
         Thanks for taking the time to report a problem.
 
-        Please do not include Usenet credentials, API keys, passwords, NZB contents, or other private data. NzbDav supports legally obtained content only; reports involving copyright infringement will be closed.
+        Please do not include Usenet credentials, API keys, passwords, NZB contents, or other private data. InfiniDysk supports legally obtained content only; reports involving copyright infringement will be closed.
 
   - type: checkboxes
     id: prerequisites
@@ -16,14 +16,14 @@ body:
       options:
         - label: I have searched existing issues and did not find a duplicate.
           required: true
-        - label: I am using NzbDav with legally obtained content.
+        - label: I am using InfiniDysk with legally obtained content.
           required: true
 
   - type: input
     id: version
     attributes:
-      label: NzbDav version
-      description: Enter the version shown in the NzbDav UI or the Docker image tag.
+      label: InfiniDysk version
+      description: Enter the version shown in the InfiniDysk UI or the Docker image tag.
       placeholder: "e.g. 0.6.4 or ghcr.io/infinidysk/infinidysk:0.6.4"
     validations:
       required: true
@@ -88,7 +88,7 @@ body:
     attributes:
       label: Technical support pack, relevant logs, or screenshots
       description: |
-        For the most useful diagnostics, open **Settings → Support** in NzbDav and select
+        For the most useful diagnostics, open **Settings → Support** in InfiniDysk and select
         **Generate & download**. Review the downloaded ZIP, then drag it into this field to upload it.
         The pack automatically redacts credentials, API keys, tokens, URL credentials, sensitive URL
         parameters, and IP addresses; it can still contain file names, paths, account usernames, and DNS

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,11 +1,11 @@
 name: Feature request
-description: Suggest an improvement to NzbDav
+description: Suggest an improvement to InfiniDysk
 type: Feature
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for sharing an idea. Feature requests should describe a legitimate use case for NzbDav; the project supports legally obtained content only.
+        Thanks for sharing an idea. Feature requests should describe a legitimate use case for InfiniDysk; the project supports legally obtained content only.
 
   - type: checkboxes
     id: prerequisites


### PR DESCRIPTION
## Summary
- Update the bug report and feature request issue templates to refer to the product as **InfiniDysk** instead of NzbDav
- Covers the description, legal notice, checkboxes, and field labels/descriptions
- The `<!-- nzbdav-votes-footer -->` marker in the feature template is intentionally unchanged; the votes sync workflow and template detection rely on it

## Test plan
- [ ] Open the new-issue chooser on a fork/branch and confirm both templates show InfiniDysk wording
- [ ] Confirm no workflow files were modified