### PR TITLE
feat(db): limit metrics database growth on high-throughput hosts

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -185,4 +185,5 @@ public static class ConfigKeys
     // database
     public const string DatabaseHealthcheckRetentionDays = "database.healthcheck-retention-days";
     public const string DatabaseHistoryRetentionDays = "database.history-retention-days";
+    public const string MetricsFetchRetentionHours = "metrics.fetch-retention-hours";
 }

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1689,7 +1689,8 @@ public class ConfigManager
     /// </summary>
     public int GetMetricsFetchRetentionHours()
     {
-        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.MetricsFetchRetentionHours));
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.MetricsFetchRetentionHours))
+                ?? EnvironmentUtil.GetEnvironmentVariable("METRICS_FETCH_RETENTION_HOURS");
         return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 8760) : 24;
     }
 

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -276,6 +276,7 @@ public class ConfigManager
             {
                 case ConfigKeys.QueueMaxItems:
                 case ConfigKeys.QueueResumeThreshold:
+                case ConfigKeys.MetricsFetchRetentionHours:
                     RequireNonNegativeInt(item.ConfigName, value);
                     break;
 
@@ -1679,6 +1680,17 @@ public class ConfigManager
             ConfigKeys.DatabaseHealthcheckRetentionDays,
             "DATABASE_HEALTHCHECK_RETENTION_DAYS",
             defaultValue: 30);
+    }
+
+    /// <summary>
+    /// Hours to keep raw per-fetch metrics rows (<c>SegmentFetches</c>, <c>FailoverMisses</c>).
+    /// Rollups retain aggregates longer. 0 requests rollup-only retention; the sweep enforces
+    /// a one-hour floor. Default is 24; max is 8760 (one year).
+    /// </summary>
+    public int GetMetricsFetchRetentionHours()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.MetricsFetchRetentionHours));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 8760) : 24;
     }
 
     private int GetRetentionDaysSetting(string configKey, string? environmentVariable, int defaultValue)

--- a/backend/Services/Metrics/MetricsRetentionService.cs
+++ b/backend/Services/Metrics/MetricsRetentionService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Extensions;
@@ -9,15 +10,16 @@ namespace NzbWebDAV.Services.Metrics;
 
 /// <summary>
 /// Enforces retention windows on the metrics database. Raw fetch events have
-/// the shortest TTL (24 h) since the rollups already carry the aggregate
-/// information; minute rollups keep a week; hour rollups stay a year; the
-/// daily catalogue snapshot is small enough to keep forever. Runs hourly,
+/// the shortest TTL (configurable, default 24 h) since the rollups already carry
+/// the aggregate information; minute rollups keep a week; hour rollups stay a year;
+/// the daily catalogue snapshot is small enough to keep forever. Runs hourly,
 /// re-claims free pages via incremental_vacuum on the same pass.
 /// </summary>
-public class MetricsRetentionService : BackgroundService
+public class MetricsRetentionService(ConfigManager configManager) : BackgroundService
 {
+    internal const int MinFetchRetentionHours = 1;
+
     private static readonly TimeSpan TickInterval = TimeSpan.FromHours(1);
-    private static readonly TimeSpan FetchTtl = TimeSpan.FromHours(24);
     private static readonly TimeSpan EventTtl = TimeSpan.FromDays(7);
     private static readonly TimeSpan MinuteRollupTtl = TimeSpan.FromDays(7);
     private static readonly TimeSpan SessionTtl = TimeSpan.FromDays(90);
@@ -42,13 +44,15 @@ public class MetricsRetentionService : BackgroundService
         }
     }
 
-    private static async Task SafeSweepAsync()
+    private async Task SafeSweepAsync()
     {
         try
         {
+            var fetchTtl = TimeSpan.FromHours(
+                Math.Max(configManager.GetMetricsFetchRetentionHours(), MinFetchRetentionHours));
             var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             await using var db = new MetricsDbContext();
-            await SweepAsync(db, nowMs).ConfigureAwait(false);
+            await SweepAsync(db, nowMs, fetchTtl).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
@@ -56,10 +60,10 @@ public class MetricsRetentionService : BackgroundService
         }
     }
 
-    internal static async Task SweepAsync(MetricsDbContext db, long nowMs)
+    internal static async Task SweepAsync(MetricsDbContext db, long nowMs, TimeSpan fetchTtl)
     {
         await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM SegmentFetches WHERE At < {0}", Cutoff(nowMs, FetchTtl)).ConfigureAwait(false);
+            "DELETE FROM SegmentFetches WHERE At < {0}", Cutoff(nowMs, fetchTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
             "DELETE FROM MetricEvents WHERE At < {0}", Cutoff(nowMs, EventTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
@@ -70,7 +74,7 @@ public class MetricsRetentionService : BackgroundService
             "DELETE FROM ReadSessions WHERE EndedAt < {0}", Cutoff(nowMs, SessionTtl)).ConfigureAwait(false);
         await FoldAndPruneProviderHourlyAsync(db, Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM FailoverMisses WHERE At < {0}", Cutoff(nowMs, FetchTtl)).ConfigureAwait(false);
+            "DELETE FROM FailoverMisses WHERE At < {0}", Cutoff(nowMs, fetchTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
             "DELETE FROM FailoverHourly WHERE Hour < {0}", Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
 

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -16,6 +16,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | Vacuum on startup | `db.is-startup-vacuum-enabled` | off | Reclaim SQLite space; may slow start |
 | SAB history retention (days) | `database.history-retention-days` | `90` | Does not delete WebDAV; `0` = keep all |
 | Health-check retention (days) | `database.healthcheck-retention-days` | `30` | `0` = keep all |
+| Raw fetch-event retention (hours) [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since } | `metrics.fetch-retention-hours` | `24` | Raw `SegmentFetches` / `FailoverMisses`; rollups kept; `0` = rollup-only (~1 h floor) |
 | Enable daily orphan cleanup | `maintenance.remove-orphaned-schedule-enabled` | off | Remove Orphaned Files schedule |
 | Daily run time | `maintenance.remove-orphaned-schedule-time` | midnight (`0`) | Minutes from midnight; uses container `TZ` |
 

--- a/docs/operations/retention-cleanup.md
+++ b/docs/operations/retention-cleanup.md
@@ -10,6 +10,21 @@
 
 Configure in **Settings → Maintenance**.
 
+## Metrics database
+
+InfiniDysk stores streaming and provider metrics in a separate SQLite file (`metrics.sqlite` under `CONFIG_PATH`). Size grows with throughput because each article fetch writes a raw row to `SegmentFetches`.
+
+| Tier | Tables | Default retention |
+|------|--------|-------------------|
+| Raw fetch events | `SegmentFetches`, `FailoverMisses` | 24 hours (`metrics.fetch-retention-hours`) |
+| Events + minute rollups | `MetricEvents`, `ThroughputMinutes`, `ProviderMinutes` | 7 days |
+| Read sessions | `ReadSessions` | 90 days |
+| Hourly rollups | `ProviderHourly`, `FailoverHourly` | 365 days (folded into lifetime totals) |
+
+**Size expectations:** on high-throughput hosts, a few hundred MB per TB/day of sustained throughput is normal — proportional growth from raw fetch rows, not a leak. Shrinking `metrics.fetch-retention-hours` reduces raw-row depth; minute and hourly rollups still carry aggregate throughput and provider stats.
+
+Setting `metrics.fetch-retention-hours` to `0` requests rollup-only retention; the hourly sweep enforces a one-hour floor on raw rows. Configure in **Settings → Maintenance** or via `METRICS_FETCH_RETENTION_HOURS` (headless ENV).
+
 ## NZB blobs
 
 Blobs under `{CONFIG_PATH}/blobs/` remain while referenced by queue, history, or mounted `/content`. When the last reference drops, background cleanup removes them. History retention alone does not make mounts eligible for orphan deletion.

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -33,6 +33,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                     "db.is-startup-vacuum-enabled",
                     "database.history-retention-days",
                     "database.healthcheck-retention-days",
+                    "metrics.fetch-retention-hours",
                 ]}>
                 <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
                     <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
@@ -110,6 +111,32 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                                 <p className="text-[11px] leading-relaxed text-base-content/45" id="healthcheck-retention-days-help">
                                     Prunes old health-check results. Set to 0 to keep everything.
                                     Environment: <code className="break-all font-mono">DATABASE_HEALTHCHECK_RETENTION_DAYS</code>.
+                                </p>
+                            </div>
+
+                            <div className="space-y-2 sm:col-span-2">
+                                <label className="block text-sm font-medium text-base-content" htmlFor="metrics-fetch-retention-hours">
+                                    Raw fetch-event retention
+                                </label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        className="w-full max-w-xs"
+                                        id="metrics-fetch-retention-hours"
+                                        type="number"
+                                        min={0}
+                                        aria-describedby="metrics-fetch-retention-hours-help"
+                                        value={config["metrics.fetch-retention-hours"] ?? "24"}
+                                        onChange={e => setNewConfig({
+                                            ...config,
+                                            "metrics.fetch-retention-hours": e.target.value,
+                                        })}
+                                    />
+                                    <span className="text-xs text-base-content/45">hours</span>
+                                </div>
+                                <p className="text-[11px] leading-relaxed text-base-content/45" id="metrics-fetch-retention-hours-help">
+                                    Prunes raw per-fetch metrics rows. Minute and hourly rollups are kept regardless.
+                                    Set to 0 for rollup-only retention (one-hour floor). Environment:
+                                    <code className="break-all font-mono">METRICS_FETCH_RETENTION_HOURS</code>.
                                 </p>
                             </div>
                         </div>
@@ -283,6 +310,7 @@ export function isMaintenanceSettingsUpdated(config: Record<string, string>, new
     return config["db.is-startup-vacuum-enabled"] !== newConfig["db.is-startup-vacuum-enabled"]
         || config["database.history-retention-days"] !== newConfig["database.history-retention-days"]
         || config["database.healthcheck-retention-days"] !== newConfig["database.healthcheck-retention-days"]
+        || config["metrics.fetch-retention-hours"] !== newConfig["metrics.fetch-retention-hours"]
         || config["maintenance.remove-orphaned-schedule-enabled"] !== newConfig["maintenance.remove-orphaned-schedule-enabled"]
         || config["maintenance.remove-orphaned-schedule-time"] !== newConfig["maintenance.remove-orphaned-schedule-time"];
 }

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -124,6 +124,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
                                         id="metrics-fetch-retention-hours"
                                         type="number"
                                         min={0}
+                                        max={8760}
                                         aria-describedby="metrics-fetch-retention-hours-help"
                                         value={config["metrics.fetch-retention-hours"] ?? "24"}
                                         onChange={e => setNewConfig({

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -126,6 +126,7 @@ const defaultConfig = {
     "db.is-startup-vacuum-enabled": "false",
     "database.history-retention-days": "90",
     "database.healthcheck-retention-days": "30",
+    "metrics.fetch-retention-hours": "24",
     "maintenance.remove-orphaned-schedule-enabled": "false",
     "maintenance.remove-orphaned-schedule-time": "0",
     "backup.schedule-enabled": "false",

--- a/tests/NzbWebDAV.Tests/Config/MetricsFetchRetentionConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MetricsFetchRetentionConfigTests.cs
@@ -56,4 +56,47 @@ public class MetricsFetchRetentionConfigTests
             },
         ]);
     }
+
+    [Fact]
+    public void GetMetricsFetchRetentionHours_FallsBackToEnvironmentVariable()
+    {
+        const string envVar = "METRICS_FETCH_RETENTION_HOURS";
+        var previous = Environment.GetEnvironmentVariable(envVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(envVar, "6");
+            var config = new ConfigManager();
+
+            Assert.Equal(6, config.GetMetricsFetchRetentionHours());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVar, previous);
+        }
+    }
+
+    [Fact]
+    public void GetMetricsFetchRetentionHours_ConfigTakesPrecedenceOverEnvironmentVariable()
+    {
+        const string envVar = "METRICS_FETCH_RETENTION_HOURS";
+        var previous = Environment.GetEnvironmentVariable(envVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(envVar, "6");
+            var config = new ConfigManager();
+            config.UpdateValues([
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.MetricsFetchRetentionHours,
+                    ConfigValue = "48",
+                },
+            ]);
+
+            Assert.Equal(48, config.GetMetricsFetchRetentionHours());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVar, previous);
+        }
+    }
 }

--- a/tests/NzbWebDAV.Tests/Config/MetricsFetchRetentionConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MetricsFetchRetentionConfigTests.cs
@@ -1,0 +1,59 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class MetricsFetchRetentionConfigTests
+{
+    [Theory]
+    [InlineData(null, 24)]
+    [InlineData("", 24)]
+    [InlineData("abc", 24)]
+    [InlineData("24", 24)]
+    [InlineData("0", 0)]
+    [InlineData("12", 12)]
+    [InlineData("8760", 8760)]
+    [InlineData("10000", 8760)]
+    public void GetMetricsFetchRetentionHours_ClampsAndFallsBack(string? value, int expected)
+    {
+        var config = new ConfigManager();
+        if (value is not null)
+        {
+            config.UpdateValues([
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.MetricsFetchRetentionHours,
+                    ConfigValue = value,
+                },
+            ]);
+        }
+
+        Assert.Equal(expected, config.GetMetricsFetchRetentionHours());
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("not-a-number")]
+    public void ValidateConfigItems_RejectsInvalidMetricsFetchRetentionHours(string value)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.MetricsFetchRetentionHours,
+                ConfigValue = value,
+            },
+        ]));
+    }
+
+    [Fact]
+    public void ValidateConfigItems_AcceptsValidMetricsFetchRetentionHours()
+    {
+        ConfigManager.ValidateConfigItems([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.MetricsFetchRetentionHours,
+                ConfigValue = "48",
+            },
+        ]);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
@@ -11,6 +11,7 @@ namespace NzbWebDAV.Tests.Services.Metrics;
 public sealed class MetricsRetentionServiceTests
 {
     private const long OneDayMs = 24 * 60 * 60 * 1000L;
+    private const long OneHourMs = 60 * 60 * 1000L;
 
     [Fact]
     public async Task SweepAsync_FoldsPrunedProviderHourlyIntoLifetimeTotals()
@@ -58,7 +59,7 @@ public sealed class MetricsRetentionServiceTests
             });
         await db.SaveChangesAsync();
 
-        await MetricsRetentionService.SweepAsync(db, nowMs);
+        await MetricsRetentionService.SweepAsync(db, nowMs, TimeSpan.FromHours(24));
 
         var lifetimeA = await db.ProviderLifetimeTotals.SingleAsync(x => x.Provider == "provider-a");
         Assert.Equal(15, lifetimeA.Articles);
@@ -66,11 +67,73 @@ public sealed class MetricsRetentionServiceTests
         Assert.Equal(cutoff - 2 * OneDayMs, lifetimeA.FirstHour);
         Assert.Equal(1, await db.ProviderHourly.CountAsync());
 
-        await MetricsRetentionService.SweepAsync(db, nowMs);
+        await MetricsRetentionService.SweepAsync(db, nowMs, TimeSpan.FromHours(24));
         var lifetimeAAgain = await db.ProviderLifetimeTotals.SingleAsync(x => x.Provider == "provider-a");
         Assert.Equal(lifetimeA.Articles, lifetimeAAgain.Articles);
         Assert.Equal(lifetimeA.BytesFetched, lifetimeAAgain.BytesFetched);
         Assert.Equal(lifetimeA.FirstHour, lifetimeAAgain.FirstHour);
+    }
+
+    [Fact]
+    public async Task SweepAsync_PrunesSegmentFetchesOlderThanFetchTtl()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var nowMs = 100L * OneHourMs;
+        var fetchTtl = TimeSpan.FromHours(6);
+        var cutoff = MetricsRetentionService.Cutoff(nowMs, fetchTtl);
+
+        db.SegmentFetches.AddRange(
+            new SegmentFetch { At = cutoff - OneHourMs, Provider = "old" },
+            new SegmentFetch { At = cutoff + OneHourMs, Provider = "fresh" });
+        await db.SaveChangesAsync();
+
+        await MetricsRetentionService.SweepAsync(db, nowMs, fetchTtl);
+
+        Assert.Equal(1, await db.SegmentFetches.CountAsync());
+        Assert.Equal("fresh", await db.SegmentFetches.Select(x => x.Provider).SingleAsync());
+    }
+
+    [Fact]
+    public async Task SweepAsync_PrunesFailoverMissesWithSameFetchTtl()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var nowMs = 100L * OneHourMs;
+        var fetchTtl = TimeSpan.FromHours(3);
+        var cutoff = MetricsRetentionService.Cutoff(nowMs, fetchTtl);
+
+        db.FailoverMisses.AddRange(
+            new FailoverMiss { At = cutoff - OneHourMs, FromProvider = "old", ToProvider = "backup" },
+            new FailoverMiss { At = cutoff + OneHourMs, FromProvider = "fresh", ToProvider = "backup" });
+        await db.SaveChangesAsync();
+
+        await MetricsRetentionService.SweepAsync(db, nowMs, fetchTtl);
+
+        Assert.Equal(1, await db.FailoverMisses.CountAsync());
+        Assert.Equal("fresh", await db.FailoverMisses.Select(x => x.FromProvider).SingleAsync());
+    }
+
+    [Fact]
+    public async Task SweepAsync_UsesOneHourFloorWhenConfiguredRetentionIsZero()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var nowMs = 10L * OneHourMs;
+        var floorTtl = TimeSpan.FromHours(MetricsRetentionService.MinFetchRetentionHours);
+        var cutoff = MetricsRetentionService.Cutoff(nowMs, floorTtl);
+
+        db.SegmentFetches.AddRange(
+            new SegmentFetch { At = cutoff - OneHourMs, Provider = "old" },
+            new SegmentFetch { At = cutoff + OneHourMs, Provider = "fresh" });
+        await db.SaveChangesAsync();
+
+        var configuredHours = 0;
+        var effectiveHours = Math.Max(configuredHours, MetricsRetentionService.MinFetchRetentionHours);
+        await MetricsRetentionService.SweepAsync(db, nowMs, TimeSpan.FromHours(effectiveHours));
+
+        Assert.Equal(1, await db.SegmentFetches.CountAsync());
+        Assert.Equal("fresh", await db.SegmentFetches.Select(x => x.Provider).SingleAsync());
     }
 
     private sealed class MetricsHarness : IAsyncDisposable


### PR DESCRIPTION
## Summary

- Adds `metrics.fetch-retention-hours` setting (default 24, clamped 0–8760) so operators on high-throughput hosts can shrink the raw fetch-event retention window and reduce metrics DB size
- `MetricsRetentionService` reads the configured value each sweep, enforcing a 1-hour floor so at least one full tick of raw rows is always available
- Surfaces the setting in **Settings → Maintenance** with dirty detection, and documents retention tiers and size expectations in the published docs

Closes #784

## Notes

- **Back up `/config` before upgrading** — this is an additive config change; no schema migration, but the new setting takes effect on the next hourly retention sweep
- During review I caught a missing env var fallback: the getter didn't read `METRICS_FETCH_RETENTION_HOURS` for headless Docker configs despite the docs/UI advertising it — fixed in the final commit

## Test plan

- [x] `MetricsFetchRetentionConfigTests`: clamping, default fallback, validation rejection of negatives/non-numeric, acceptance of valid values
- [x] `MetricsRetentionServiceTests`: sweep prunes `SegmentFetches` and `FailoverMisses` by configured TTL; 0-hour config uses 1-hour floor; existing fold+prune test updated for new `SweepAsync` signature
- [ ] Verify `METRICS_FETCH_RETENTION_HOURS=6` env var is respected in Docker
- [ ] Set value in UI → confirm save → verify sweep prunes at configured window
- [ ] Confirm docs render `since 1.1.0` pill on maintenance table row