### PR TITLE
fix(usenet): stop prefetch batch size from flapping during bursty reads

### DIFF
--- a/backend/Streams/AdaptiveBodyBatchSizer.cs
+++ b/backend/Streams/AdaptiveBodyBatchSizer.cs
@@ -6,17 +6,21 @@ namespace NzbWebDAV.Streams;
 /// Adapts BODY pipeline batch width from consumer readiness at segment boundaries.
 /// Narrows 4→2→1 when prefetch starves; recovers gradually after sustained readiness.
 /// </summary>
-internal sealed class AdaptiveBodyBatchSizer(int maximumBatchSize)
+internal sealed class AdaptiveBodyBatchSizer(int maximumBatchSize, TimeProvider? timeProvider = null)
 {
     private const int ObservationWindow = 8;
     private const int StarvedBoundariesToNarrow = 2;
     private const int ReadyBoundariesToRecover = 16;
 
+    internal const int RewidenHoldMilliseconds = 250;
+
     private readonly int _maximum = Math.Max(1, maximumBatchSize);
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private int _current = Math.Max(1, maximumBatchSize);
     private byte _starvationWindow;
     private int _observations;
     private int _ready;
+    private DateTimeOffset _lastTransition;
 
     public int Current => Volatile.Read(ref _current);
 
@@ -32,6 +36,7 @@ internal sealed class AdaptiveBodyBatchSizer(int maximumBatchSize)
             _ready = 0;
 
         int? next = null;
+        var isWiden = false;
         if (_observations == ObservationWindow
             && BitOperations.PopCount(_starvationWindow) >= StarvedBoundariesToNarrow)
         {
@@ -40,9 +45,18 @@ internal sealed class AdaptiveBodyBatchSizer(int maximumBatchSize)
         else if (_ready >= ReadyBoundariesToRecover)
         {
             next = Math.Min(_maximum, current * 2);
+            isWiden = true;
         }
 
         if (next is null) return null;
+
+        if (isWiden
+            && (_timeProvider.GetUtcNow() - _lastTransition).TotalMilliseconds < RewidenHoldMilliseconds)
+        {
+            return null;
+        }
+
+        _lastTransition = _timeProvider.GetUtcNow();
         _starvationWindow = 0;
         _observations = 0;
         _ready = 0;

--- a/backend/Streams/AdaptiveBodyBatchSizer.cs
+++ b/backend/Streams/AdaptiveBodyBatchSizer.cs
@@ -13,6 +13,7 @@ internal sealed class AdaptiveBodyBatchSizer(int maximumBatchSize, TimeProvider?
     private const int ReadyBoundariesToRecover = 16;
 
     internal const int RewidenHoldMilliseconds = 250;
+    private static readonly TimeSpan RewidenHold = TimeSpan.FromMilliseconds(RewidenHoldMilliseconds);
 
     private readonly int _maximum = Math.Max(1, maximumBatchSize);
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
@@ -50,13 +51,13 @@ internal sealed class AdaptiveBodyBatchSizer(int maximumBatchSize, TimeProvider?
 
         if (next is null) return null;
 
-        if (isWiden
-            && (_timeProvider.GetUtcNow() - _lastTransition).TotalMilliseconds < RewidenHoldMilliseconds)
+        var now = _timeProvider.GetUtcNow();
+        if (isWiden && (now - _lastTransition) < RewidenHold)
         {
             return null;
         }
 
-        _lastTransition = _timeProvider.GetUtcNow();
+        _lastTransition = now;
         _starvationWindow = 0;
         _observations = 0;
         _ready = 0;

--- a/tests/NzbWebDAV.Tests/Streams/AdaptiveBodyBatchSizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/AdaptiveBodyBatchSizerTests.cs
@@ -7,7 +7,8 @@ public class AdaptiveBodyBatchSizerTests
     [Fact]
     public void TwoNonAdjacentStarvedInEight_NarrowsFourToTwoThenTwoToOne()
     {
-        var sizer = new AdaptiveBodyBatchSizer(4);
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
         // S-R-R-R-S-R-R-R → two starved in eight → 4→2
         ObservePattern(sizer, "SRRRSRRR");
         Assert.Equal(2, sizer.Current);
@@ -28,14 +29,17 @@ public class AdaptiveBodyBatchSizerTests
     [Fact]
     public void SixteenConsecutiveReady_RecoversOneStepAtATime()
     {
-        var sizer = new AdaptiveBodyBatchSizer(4);
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
         ObservePattern(sizer, "SRRRSRRR"); // 4→2
         ObservePattern(sizer, "SRRRSRRR"); // 2→1
         Assert.Equal(1, sizer.Current);
 
+        AdvancePastHold(clock);
         ObservePattern(sizer, new string('R', 16));
         Assert.Equal(2, sizer.Current);
 
+        AdvancePastHold(clock);
         ObservePattern(sizer, new string('R', 16));
         Assert.Equal(4, sizer.Current);
     }
@@ -43,7 +47,8 @@ public class AdaptiveBodyBatchSizerTests
     [Fact]
     public void FifteenReadyThenStarved_DoesNotRecover()
     {
-        var sizer = new AdaptiveBodyBatchSizer(4);
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
         ObservePattern(sizer, "SRRRSRRR"); // 4→2
         ObservePattern(sizer, new string('R', 15) + "S");
         Assert.Equal(2, sizer.Current);
@@ -52,7 +57,8 @@ public class AdaptiveBodyBatchSizerTests
     [Fact]
     public void AlternatingObservations_ResizeOnlyOncePerClearedWindow()
     {
-        var sizer = new AdaptiveBodyBatchSizer(4);
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
         // Alternating fills the window with four starved → one narrow, then clear.
         ObservePattern(sizer, "SRSRSRSR");
         Assert.Equal(2, sizer.Current);
@@ -72,7 +78,8 @@ public class AdaptiveBodyBatchSizerTests
     [InlineData(3)]
     public void MaximumSizesStayWithinBounds(int maximum)
     {
-        var sizer = new AdaptiveBodyBatchSizer(maximum);
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(maximum, clock);
         Assert.Equal(maximum, sizer.Current);
 
         // Drive starvation until the floor.
@@ -82,10 +89,96 @@ public class AdaptiveBodyBatchSizerTests
 
         // Recover past the configured maximum must clamp.
         for (var i = 0; i < 8; i++)
+        {
+            AdvancePastHold(clock);
             ObservePattern(sizer, new string('R', 16));
+        }
         Assert.Equal(maximum, sizer.Current);
         Assert.InRange(sizer.Current, 1, maximum);
     }
+
+    [Fact]
+    public void ReadyBurstWithinHold_DoesNotRewiden()
+    {
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
+        ObservePattern(sizer, "SRRRSRRR"); // 4→2
+        Assert.Equal(2, sizer.Current);
+
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(2, sizer.Current);
+
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(2, sizer.Current);
+
+        AdvancePastHold(clock);
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(4, sizer.Current);
+    }
+
+    [Fact]
+    public void NarrowsAreNotTimeDampened()
+    {
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
+        ObservePattern(sizer, "SRRRSRRR");
+        Assert.Equal(2, sizer.Current);
+
+        ObservePattern(sizer, "SRRRSRRR");
+        Assert.Equal(1, sizer.Current);
+    }
+
+    [Fact]
+    public void WideningLadderIsSpacedByHold()
+    {
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
+        ObservePattern(sizer, "SRRRSRRR"); // 4→2
+        ObservePattern(sizer, "SRRRSRRR"); // 2→1
+        Assert.Equal(1, sizer.Current);
+
+        AdvancePastHold(clock);
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(2, sizer.Current);
+
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(2, sizer.Current);
+
+        AdvancePastHold(clock);
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(4, sizer.Current);
+    }
+
+    [Fact]
+    public void SuppressedWiden_KeepsStarvationWindowArmed()
+    {
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
+        ObservePattern(sizer, "SRRRSRRR"); // 4→2
+        Assert.Equal(2, sizer.Current);
+
+        ObservePattern(sizer, new string('R', 16)); // suppressed widen within hold
+        Assert.Equal(2, sizer.Current);
+
+        ObservePattern(sizer, "SRRRSRRR"); // narrows 2→1 immediately
+        Assert.Equal(1, sizer.Current);
+    }
+
+    [Fact]
+    public void FirstWidenAfterConstruction_NotSuppressed()
+    {
+        var clock = new ManualTimeProvider();
+        var sizer = new AdaptiveBodyBatchSizer(4, clock);
+        ObservePattern(sizer, "SRRRSRRR"); // 4→2
+        Assert.Equal(2, sizer.Current);
+
+        AdvancePastHold(clock);
+        ObservePattern(sizer, new string('R', 16));
+        Assert.Equal(4, sizer.Current);
+    }
+
+    private static void AdvancePastHold(ManualTimeProvider clock) =>
+        clock.Advance(TimeSpan.FromMilliseconds(AdaptiveBodyBatchSizer.RewidenHoldMilliseconds + 50));
 
     private static void ObservePattern(AdaptiveBodyBatchSizer sizer, string pattern)
     {
@@ -94,5 +187,14 @@ public class AdaptiveBodyBatchSizerTests
             var ready = c is 'R' or 'r';
             sizer.Observe(ready);
         }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UnixEpoch;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan duration) => _now += duration;
     }
 }


### PR DESCRIPTION
## Summary

- Adds a 250 ms wall-clock hold between re-widening transitions in `AdaptiveBodyBatchSizer`, preventing the 4→2→4→2 flapping observed in stream traces when segment completions arrive in bursts
- Narrowing (starvation response) remains immediate and undampened — only the recovery direction is time-gated
- Injects `TimeProvider` via the same optional-parameter pattern used by `SegmentBufferPool` and `ConcurrentReadTracker`

Closes #782

## Test plan

- [x] 5 new unit tests covering: burst within hold suppressed, narrows not dampened, widening ladder spacing, suppressed-widen starvation window preservation, first widen after construction
- [x] Existing tests updated with `ManualTimeProvider` clock injection and `AdvancePastHold` calls
- [ ] `dotnet test tests/NzbWebDAV.Tests` passes
- [ ] Manual: rclone sequential read produces ~10× fewer `PrefetchWidth` trace events
- [ ] Manual: `dotnet run --project backend.Benchmarks -c Release` shows no streaming regression