### PR TITLE
feat(queue): automatically recover queue items that stop making progress

### DIFF
--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
@@ -38,10 +39,18 @@ public sealed class QueueManager : IDisposable
     private int _pendingAdmissions;
     private bool _admissionPaused;
 
+    private static readonly TimeSpan DefaultStuckItemThreshold =
+        EnvironmentUtil.GetLongVariable("QUEUE_ITEM_STUCK_MINUTES") is long minutes and > 0
+            ? TimeSpan.FromMinutes(minutes)
+            : TimeSpan.FromMinutes(5);
+
     // Overridable in tests so persistent-failure / idle-sleep behaviour can be
     // exercised without a real database.
     internal TimeSpan ErrorBackoffDelay { get; set; } = TimeSpan.FromSeconds(5);
     internal TimeSpan IdleDelay { get; set; } = TimeSpan.FromMinutes(1);
+    internal TimeSpan StuckItemThreshold { get; set; } = DefaultStuckItemThreshold;
+    internal TimeSpan StuckItemCheckInterval { get; set; } = TimeSpan.FromSeconds(30);
+    internal TimeSpan StuckItemPauseWriteTimeout { get; set; } = TimeSpan.FromSeconds(10);
     internal Func<IReadOnlyCollection<Guid>, CancellationToken, Task<(QueueItem? queueItem, Stream? queueNzbStream)>>?
         GetTopQueueItemOverride
     { get; set; }
@@ -635,9 +644,14 @@ public sealed class QueueManager : IDisposable
             _finalizeLock, cts.Token
         ).ProcessAsync();
 
+        var watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+
         _ = task.ContinueWith(
             t =>
             {
+                try { watchdogCts.Cancel(); }
+                catch (ObjectDisposedException) { /* already disposed */ }
+
                 if (t.IsFaulted)
                     Log.Error(t.Exception!.GetBaseException(),
                         "Unhandled queue processor fault for {QueueItemId}", queueItem.Id);
@@ -660,7 +674,10 @@ public sealed class QueueManager : IDisposable
             QueueNzbStream = queueNzbStream,
             CachingUsenetClient = cachingUsenetClient,
             StartedAt = DateTime.UtcNow,
+            WatchdogCts = watchdogCts,
         };
+        inProgressQueueItem.WatchdogTask =
+            WatchForStuckProgressAsync(inProgressQueueItem, watchdogCts.Token);
 
         var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
         var providersDebounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(500));
@@ -703,6 +720,95 @@ public sealed class QueueManager : IDisposable
         };
         return inProgressQueueItem;
     }
+
+    private async Task WatchForStuckProgressAsync(InProgressQueueItem item, CancellationToken ct)
+    {
+        var lastProgress = item.ProgressPercentage;
+        var lastChangeTick = Environment.TickCount64;
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(StuckItemCheckInterval, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var currentProgress = item.ProgressPercentage;
+            if (currentProgress != lastProgress)
+            {
+                lastProgress = currentProgress;
+                lastChangeTick = Environment.TickCount64;
+                continue;
+            }
+
+            var idleMs = Environment.TickCount64 - lastChangeTick;
+            if (idleMs < StuckItemThreshold.TotalMilliseconds)
+                continue;
+
+            await HandleStuckItemAsync(item, idleMs).ConfigureAwait(false);
+            return;
+        }
+    }
+
+    private async Task HandleStuckItemAsync(InProgressQueueItem item, long idleMs)
+    {
+        var queueItem = item.QueueItem;
+        var progress = item.ProgressPercentage;
+        var idleMinutes = idleMs / 60000d;
+        var phase = DescribeProgressPhase(progress);
+#pragma warning disable CA5394 // pause jitter is not security-sensitive
+        var jitterSeconds = Random.Shared.Next(0, 301);
+#pragma warning restore CA5394
+        var pauseUntil = DateTime.Now + TimeSpan.FromMinutes(15) + TimeSpan.FromSeconds(jitterSeconds);
+
+        try
+        {
+            await using var ctx = CreateDbContext();
+            using var writeCts = new CancellationTokenSource(StuckItemPauseWriteTimeout);
+            await ctx.QueueItems
+                .Where(q => q.Id == queueItem.Id)
+                .ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, pauseUntil), writeCts.Token)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+        {
+            Log.Warning(e,
+                "Failed to persist PauseUntil for stuck queue item {QueueItemId} ({JobName})",
+                queueItem.Id,
+                queueItem.JobName);
+        }
+
+        Log.Warning(
+            "Queue item stuck with no progress; pausing and cancelling. JobName={JobName} QueueItemId={QueueItemId} " +
+            "IdleMinutes={IdleMinutes:F1} ProgressPhase={ProgressPhase} ProgressPercentage={ProgressPercentage} " +
+            "PauseUntil={PauseUntil}",
+            queueItem.JobName,
+            queueItem.Id,
+            idleMinutes,
+            phase,
+            progress,
+            pauseUntil);
+
+        try
+        {
+            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Worker may have finished and disposed the CTS concurrently.
+        }
+    }
+
+    private static string DescribeProgressPhase(int progress) =>
+        progress < 50 ? "fetch first segments"
+        : progress < 100 ? "file processing"
+        : "full health check";
 
     private string BuildProvidersMessage(Guid queueItemId)
     {
@@ -822,10 +928,23 @@ public sealed class QueueManager : IDisposable
         public Stream? QueueNzbStream { get; init; }
         public ArticleCachingNntpClient CachingUsenetClient { get; init; } = null!;
         public DateTime StartedAt { get; init; }
+        public CancellationTokenSource WatchdogCts { get; init; } = null!;
+        public Task WatchdogTask { get; set; } = Task.CompletedTask;
         public bool IsPrimary => QueueDownloadContext.IsPrimary;
 
         public async ValueTask DisposeAsync()
         {
+            try { await WatchdogCts.CancelAsync().ConfigureAwait(false); }
+            catch (ObjectDisposedException) { /* already disposed */ }
+
+            try { await WatchdogTask.ConfigureAwait(false); }
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+            {
+                // Watchdog may fault after the worker is torn down; ignore during cleanup.
+            }
+
             QueueContextRegistration.Dispose();
             CancellationTokenSource.Dispose();
             CachingUsenetClient.Dispose();

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -774,8 +774,16 @@ public sealed class QueueManager : IDisposable
                 .ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, pauseUntil), writeCts.Token)
                 .ConfigureAwait(false);
         }
-#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
-        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+        catch (OperationCanceledException)
+        {
+            Log.Warning(
+                "Timed out persisting PauseUntil for stuck queue item {QueueItemId} ({JobName}); " +
+                "proceeding with worker cancellation",
+                queueItem.Id,
+                queueItem.JobName);
+        }
+#pragma warning disable CA2016
+        catch (Exception e) when (e is not OutOfMemoryException)
 #pragma warning restore CA2016
         {
             Log.Warning(e,
@@ -945,6 +953,7 @@ public sealed class QueueManager : IDisposable
                 // Watchdog may fault after the worker is torn down; ignore during cleanup.
             }
 
+            WatchdogCts.Dispose();
             QueueContextRegistration.Dispose();
             CancellationTokenSource.Dispose();
             CachingUsenetClient.Dispose();

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -95,6 +95,7 @@ or restrict backend capabilities when enforcement is required.
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |
 | `MAX_REQUEST_BODY_SIZE` | 100 MiB | Max request body bytes |
+| `QUEUE_ITEM_STUCK_MINUTES` | `5` | Minutes without queue progress before the stuck-item watchdog pauses and cancels the worker |
 | `NZBDAV_VERSION` | `0.0.0` | Reported app version |
 | `DOTNET_DbgEnableMiniDump` | off | Opt-in crash dumps — [Logs](../operations/logs-crash-dumps.md) |
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -95,7 +95,7 @@ or restrict backend capabilities when enforcement is required.
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |
 | `MAX_REQUEST_BODY_SIZE` | 100 MiB | Max request body bytes |
-| `QUEUE_ITEM_STUCK_MINUTES` | `5` | Minutes without queue progress before the stuck-item watchdog pauses and cancels the worker |
+| `QUEUE_ITEM_STUCK_MINUTES` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since } | `5` | Minutes without queue progress before the stuck-item watchdog pauses and cancels the worker |
 | `NZBDAV_VERSION` | `0.0.0` | Reported app version |
 | `DOTNET_DbgEnableMiniDump` | off | Opt-in crash dumps — [Logs](../operations/logs-crash-dumps.md) |
 

--- a/docs/configuration/queue.md
+++ b/docs/configuration/queue.md
@@ -44,4 +44,15 @@ The resume threshold adds hysteresis after the maximum is reached. Set it to
 submissions that replace an existing queue item remain allowed because they do
 not increase queue depth.
 
+## Stuck-item watchdog
+
+Each active queue worker runs a progress watchdog. If `ProgressPercentage` does not
+increase for `QUEUE_ITEM_STUCK_MINUTES` (default **5**), InfiniDysk pauses the item
+(`PauseUntil` ≈ 15–20 minutes with jitter) and cancels the worker so the queue can
+move on. The item is **not** failed into history — it retries after the pause
+expires.
+
+Tune the stall budget with `QUEUE_ITEM_STUCK_MINUTES` when long phases legitimately
+hold progress (large archives, full article-existence health checks).
+
 [SABnzbd settings](sabnzbd.md) · [Streaming settings](streaming.md)

--- a/docs/configuration/queue.md
+++ b/docs/configuration/queue.md
@@ -44,7 +44,7 @@ The resume threshold adds hysteresis after the maximum is reached. Set it to
 submissions that replace an existing queue item remain allowed because they do
 not increase queue depth.
 
-## Stuck-item watchdog
+## Stuck-item watchdog [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 
 Each active queue worker runs a progress watchdog. If `ProgressPercentage` does not
 increase for `QUEUE_ITEM_STUCK_MINUTES` (default **5**), InfiniDysk pauses the item

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -1,0 +1,434 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Queue;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class QueueStuckWatchdogTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-stuck-wd-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private ConfigManager _configManager = null!;
+    private QueueManager _queueManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+
+        await using (var ctx = new DavDatabaseContext(_options))
+            await ctx.Database.MigrateAsync();
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            ProviderId = Guid.NewGuid(),
+                            Type = NzbWebDAV.Models.ProviderType.Pooled,
+                            Host = "nntp.example",
+                            Port = 563,
+                            UseSsl = true,
+                            User = "u",
+                            Pass = "p",
+                            MaxConnections = 20,
+                        },
+                    ],
+                }),
+            },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = "10" },
+            new ConfigItem { ConfigName = ConfigKeys.QueueWorkerCount, ConfigValue = "1" },
+        ]);
+
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false)
+        {
+            CreateDbContextOverride = () => new DavDatabaseContext(_options),
+            StuckItemCheckInterval = TimeSpan.FromMilliseconds(50),
+            StuckItemThreshold = TimeSpan.FromMilliseconds(250),
+        };
+    }
+
+    public Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try
+        {
+            if (Directory.Exists(_configRoot))
+                Directory.Delete(_configRoot, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task StuckProgress_CancelsWorkerAndSetsPauseUntil()
+    {
+        var stall = new StallStream();
+        var item = CreateQueueItem("stuck.nzb", "movies", "StuckJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, stall);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        object? inProgress = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            inProgress = FindInProgressItem(item.Id);
+            if (inProgress is not null) break;
+            await Task.Delay(20);
+        }
+
+        Assert.NotNull(inProgress);
+        stall.BindWorker(GetWorkerCts(inProgress!));
+
+        deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        DateTime? pauseUntil = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            pauseUntil = await ctx.QueueItems.AsNoTracking()
+                .Where(q => q.Id == item.Id)
+                .Select(q => q.PauseUntil)
+                .FirstOrDefaultAsync();
+            if (pauseUntil is not null) break;
+            await Task.Delay(20);
+        }
+
+        Assert.NotNull(pauseUntil);
+        var now = DateTime.Now;
+        Assert.InRange(pauseUntil!.Value, now + TimeSpan.FromMinutes(14), now + TimeSpan.FromMinutes(21));
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            Assert.Equal(1, await ctx.QueueItems.CountAsync());
+        }
+
+        Assert.True(GetWorkerCts(inProgress!).IsCancellationRequested);
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ProgressingItem_IsNotCancelledByWatchdog()
+    {
+        var stall = new StallStream();
+        var item = CreateQueueItem("progress.nzb", "movies", "ProgressJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, stall);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        object? inProgress = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            inProgress = FindInProgressItem(item.Id);
+            if (inProgress is not null) break;
+            await Task.Delay(20);
+        }
+
+        Assert.NotNull(inProgress);
+        stall.BindWorker(GetWorkerCts(inProgress!));
+
+        using var progressCts = new CancellationTokenSource();
+        var bumpTask = Task.Run(async () =>
+        {
+            var value = 1;
+            while (!progressCts.Token.IsCancellationRequested)
+            {
+                SetProgressPercentage(inProgress!, value);
+                value = value >= 90 ? 1 : value + 10;
+                await Task.Delay(80, progressCts.Token);
+            }
+        }, progressCts.Token);
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        Assert.False(GetWorkerCts(inProgress!).IsCancellationRequested);
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            var pauseUntil = await ctx.QueueItems.AsNoTracking()
+                .Where(q => q.Id == item.Id)
+                .Select(q => q.PauseUntil)
+                .FirstAsync();
+            Assert.Null(pauseUntil);
+        }
+
+        await progressCts.CancelAsync();
+        try { await bumpTask; }
+        catch (OperationCanceledException) { }
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task HealthyItems_DoNotWaitForWatchdogThreshold()
+    {
+        var item1 = CreateQueueItem("fast1.nzb", "movies", "FastJob1");
+        var item2 = CreateQueueItem("fast2.nzb", "movies", "FastJob2");
+        item1.CreatedAt = DateTime.Now.AddMinutes(-2);
+        item2.CreatedAt = DateTime.Now.AddMinutes(-1);
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.AddRange(item1, item2);
+            await ctx.SaveChangesAsync();
+        }
+
+        var item1CompleteTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var item2ClaimedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DateTime item1CompleteAt = default;
+        DateTime item2ClaimedAt = default;
+        var gate1 = new ManualResetEventSlim(true);
+        var gate2 = new ManualResetEventSlim(true);
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+
+            if (claimed.Id == item1.Id)
+            {
+                return (claimed, new ObservedGateStream(gate1, () =>
+                {
+                    item1CompleteAt = DateTime.UtcNow;
+                    item1CompleteTcs.TrySetResult();
+                }));
+            }
+
+            if (claimed.Id == item2.Id)
+            {
+                item2ClaimedAt = DateTime.UtcNow;
+                item2ClaimedTcs.TrySetResult();
+                return (claimed, new GateStream(gate2));
+            }
+
+            return (claimed, new GateStream(gate2));
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        await item1CompleteTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await item2ClaimedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var gap = item2ClaimedAt - item1CompleteAt;
+        Assert.True(
+            gap < TimeSpan.FromMilliseconds(500),
+            $"Second item claimed {gap.TotalMilliseconds:F0}ms after first completed; expected prompt claim");
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private object? FindInProgressItem(Guid queueItemId)
+    {
+        var field = typeof(QueueManager).GetField(
+            "_inProgress",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var dict = field!.GetValue(_queueManager)!;
+        var args = new object?[] { queueItemId, null };
+        var found = (bool)dict.GetType().GetMethod("TryGetValue")!.Invoke(dict, args)!;
+        return found ? args[1] : null;
+    }
+
+    private static CancellationTokenSource GetWorkerCts(object inProgressItem)
+    {
+        var prop = inProgressItem.GetType().GetProperty(
+            "CancellationTokenSource",
+            BindingFlags.Instance | BindingFlags.Public);
+        return (CancellationTokenSource)prop!.GetValue(inProgressItem)!;
+    }
+
+    private static void SetProgressPercentage(object inProgressItem, int value)
+    {
+        var prop = inProgressItem.GetType().GetProperty(
+            "ProgressPercentage",
+            BindingFlags.Instance | BindingFlags.Public);
+        prop!.SetValue(inProgressItem, value);
+    }
+
+    private static QueueItem CreateQueueItem(string fileName, string category, string jobName)
+    {
+        return new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.Now,
+            FileName = fileName,
+            JobName = jobName,
+            NzbFileSize = 100,
+            TotalSegmentBytes = 200,
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+    }
+
+    /// <summary>
+    /// Blocks reads until the bound worker CTS is cancelled (simulates a cooperative hang).
+    /// </summary>
+    private sealed class StallStream : Stream
+    {
+        private volatile CancellationTokenSource? _workerCts;
+
+        public void BindWorker(CancellationTokenSource workerCts) => _workerCts = workerCts;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var workerCts = _workerCts;
+                if (workerCts is not null && workerCts.IsCancellationRequested)
+                    throw new OperationCanceledException(workerCts.Token);
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// GateStream that invokes a callback after the payload is read once.
+    /// </summary>
+    private sealed class ObservedGateStream(ManualResetEventSlim gate, Action onComplete) : Stream
+    {
+        private readonly GateStream _inner = new(gate);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                onComplete();
+            return read;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -268,8 +268,8 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         var item2ClaimedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         DateTime item1CompleteAt = default;
         DateTime item2ClaimedAt = default;
-        var gate1 = new ManualResetEventSlim(true);
-        var gate2 = new ManualResetEventSlim(true);
+        using var gate1 = new ManualResetEventSlim(true);
+        using var gate2 = new ManualResetEventSlim(true);
 
         _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
         {


### PR DESCRIPTION
## Summary

Ports the progress-based stuck-item watchdog from `elfhosted/nzbdav` `elfhosted/rebased-v3` ([`cd5b536`](https://github.com/elfhosted/nzbdav/commit/cd5b536)) onto current `main`, adapted for the native `QueueManager` / `InProgressQueueItem` shape.

- Each active queue worker runs a progress watchdog that polls `ProgressPercentage` every 30s using monotonic `Environment.TickCount64`. If progress stalls for `QUEUE_ITEM_STUCK_MINUTES` (env-only, default **5**), the watchdog persists `PauseUntil` (15–20 min with jitter) **before** cancelling the worker CTS — so the queue loop does not immediately re-pick the same stuck item.
- The item is **not** failed into history — it retries after the pause expires, matching the existing `PauseUntil` wake-up path.
- Healthy items pay no delay: the watchdog CTS is cancelled immediately via a `ContinueWith` continuation when the processing task completes.
- A fresh `DavDatabaseContext` with a 10s write timeout is used for the `PauseUntil` persist, avoiding contention with the worker's own context.
- `ObjectDisposedException` guards protect all CTS operations against races with concurrent disposal.
- Warning log includes `JobName`, `QueueItemId`, `IdleMinutes`, `ProgressPhase`, `ProgressPercentage`, and `PauseUntil`.

Closes #163

## Test plan

- [x] `StuckProgress_CancelsWorkerAndSetsPauseUntil` — stalling stream triggers watchdog; verifies `PauseUntil` is set (15–20 min range), worker CTS is cancelled, item stays in queue (not moved to history)
- [x] `ProgressingItem_IsNotCancelledByWatchdog` — continuously bumping `ProgressPercentage` prevents cancellation; verifies no `PauseUntil` is set
- [x] `HealthyItems_DoNotWaitForWatchdogThreshold` — fast-completing items are followed by the next item within 500ms, confirming the watchdog does not delay healthy processing
- [ ] Manual: queue an NZB with a known-good provider → completes normally, no watchdog log
- [ ] Manual: simulate a hang (e.g. block provider) → item pauses after ~5 min, warning logged, retries after pause expires