### PR TITLE
feat(sab): support server_stats and warnings so mobile SAB clients can connect

### DIFF
--- a/backend/Api/SabControllers/GetServerStats/GetServerStatsController.cs
+++ b/backend/Api/SabControllers/GetServerStats/GetServerStatsController.cs
@@ -193,23 +193,22 @@ public class GetServerStatsController(
     private static long LocalBoundaryUnixMs(long nowMs, TimeZoneInfo timeZone, BoundaryKind kind)
     {
         var local = TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeMilliseconds(nowMs), timeZone);
-        return kind switch
+        var boundaryDate = kind switch
         {
-            BoundaryKind.Day => new DateTimeOffset(local.Year, local.Month, local.Day, 0, 0, 0, local.Offset)
-                .ToUnixTimeMilliseconds(),
-            BoundaryKind.Week => WeekBoundaryUnixMs(local),
-            BoundaryKind.Month => new DateTimeOffset(local.Year, local.Month, 1, 0, 0, 0, local.Offset)
-                .ToUnixTimeMilliseconds(),
+            BoundaryKind.Day => new DateTime(local.Year, local.Month, local.Day, 0, 0, 0, DateTimeKind.Unspecified),
+            BoundaryKind.Week => WeekBoundaryDate(local),
+            BoundaryKind.Month => new DateTime(local.Year, local.Month, 1, 0, 0, 0, DateTimeKind.Unspecified),
             _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
         };
+        var boundaryOffset = timeZone.GetUtcOffset(boundaryDate);
+        return new DateTimeOffset(boundaryDate, boundaryOffset).ToUnixTimeMilliseconds();
     }
 
-    private static long WeekBoundaryUnixMs(DateTimeOffset local)
+    private static DateTime WeekBoundaryDate(DateTimeOffset local)
     {
         var daysSinceMonday = ((int)local.DayOfWeek + 6) % 7;
-        return new DateTimeOffset(local.Year, local.Month, local.Day, 0, 0, 0, local.Offset)
-            .AddDays(-daysSinceMonday)
-            .ToUnixTimeMilliseconds();
+        var monday = local.DateTime.Date.AddDays(-daysSinceMonday);
+        return new DateTime(monday.Year, monday.Month, monday.Day, 0, 0, 0, DateTimeKind.Unspecified);
     }
 
     private sealed class ProviderAgg

--- a/backend/Api/SabControllers/GetServerStats/GetServerStatsController.cs
+++ b/backend/Api/SabControllers/GetServerStats/GetServerStatsController.cs
@@ -1,0 +1,240 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services.Metrics;
+
+namespace NzbWebDAV.Api.SabControllers.GetServerStats;
+
+public class GetServerStatsController(
+    HttpContext httpContext,
+    ConfigManager configManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    protected override async Task<IActionResult> Handle()
+    {
+        await using var metrics = new MetricsDbContext();
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var response = await BuildAsync(metrics, Config, nowMs, TimeZoneInfo.Local).ConfigureAwait(false);
+        return Ok(response);
+    }
+
+    internal static async Task<GetServerStatsResponse> BuildAsync(
+        MetricsDbContext metrics,
+        ConfigManager configManager,
+        long nowMs,
+        TimeZoneInfo timeZone)
+    {
+        var dayBoundary = LocalBoundaryUnixMs(nowMs, timeZone, BoundaryKind.Day);
+        var weekBoundary = LocalBoundaryUnixMs(nowMs, timeZone, BoundaryKind.Week);
+        var monthBoundary = LocalBoundaryUnixMs(nowMs, timeZone, BoundaryKind.Month);
+
+        var hourlyRows = await metrics.ProviderHourly
+            .Where(h => h.Hour <= nowMs)
+            .Select(h => new HourlyRow(
+                h.Hour,
+                h.Provider,
+                h.Articles,
+                h.BytesFetched,
+                h.Misses,
+                h.Errors))
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var lifetimeRows = await metrics.ProviderLifetimeTotals
+            .Select(l => new LifetimeRow(
+                l.Provider,
+                l.Articles,
+                l.BytesFetched,
+                l.Misses,
+                l.Errors))
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var byMetricsKey = new Dictionary<string, ProviderAgg>(StringComparer.Ordinal);
+        foreach (var row in hourlyRows)
+        {
+            if (!byMetricsKey.TryGetValue(row.Provider, out var agg))
+            {
+                agg = new ProviderAgg();
+                byMetricsKey[row.Provider] = agg;
+            }
+
+            AddHourlyRow(
+                agg,
+                row,
+                dayBoundary,
+                weekBoundary,
+                monthBoundary,
+                FormatDayLabel(row.Hour, timeZone));
+        }
+
+        foreach (var row in lifetimeRows)
+        {
+            if (!byMetricsKey.TryGetValue(row.Provider, out var agg))
+            {
+                agg = new ProviderAgg();
+                byMetricsKey[row.Provider] = agg;
+            }
+
+            agg.TotalBytes += row.BytesFetched;
+        }
+
+        var labelsByMetricsKey = ProviderUsageHelper
+            .BuildLabelsByMetricsKey(configManager.GetUsenetProviderConfig().Providers);
+        var usedServerKeys = new Dictionary<string, string>(StringComparer.Ordinal);
+        var servers = new Dictionary<string, GetServerStatsResponse.ServerStats>(StringComparer.Ordinal);
+
+        foreach (var provider in configManager.GetUsenetProviderConfig().Providers
+                     .Where(p => p.ProviderId != Guid.Empty))
+        {
+            var metricsKey = UsenetProviderIdentity.MetricsKey(provider);
+            var label = labelsByMetricsKey.GetValueOrDefault(metricsKey);
+            var serverKey = ResolveServerKey(metricsKey, label, usedServerKeys);
+            byMetricsKey.TryGetValue(metricsKey, out var agg);
+            servers[serverKey] = ToServerStats(agg);
+        }
+
+        long total = 0, month = 0, week = 0, day = 0;
+        foreach (var agg in byMetricsKey.Values)
+        {
+            total += agg.TotalBytes;
+            month += agg.MonthBytes;
+            week += agg.WeekBytes;
+            day += agg.DayBytes;
+        }
+
+        return new GetServerStatsResponse
+        {
+            Total = total,
+            Month = month,
+            Week = week,
+            Day = day,
+            Servers = servers,
+        };
+    }
+
+    private static void AddHourlyRow(
+        ProviderAgg agg,
+        HourlyRow row,
+        long dayBoundary,
+        long weekBoundary,
+        long monthBoundary,
+        string dayLabel)
+    {
+        if (row.Hour >= dayBoundary)
+            agg.DayBytes += row.BytesFetched;
+        if (row.Hour >= weekBoundary)
+            agg.WeekBytes += row.BytesFetched;
+        if (row.Hour >= monthBoundary)
+            agg.MonthBytes += row.BytesFetched;
+        agg.TotalBytes += row.BytesFetched;
+
+        AddToMap(agg.Daily, dayLabel, row.BytesFetched);
+        AddToMap(agg.ArticlesTried, dayLabel, row.Articles);
+        AddToMap(agg.ArticlesSuccess, dayLabel, Math.Max(0, row.Articles - row.Misses - row.Errors));
+    }
+
+    private static GetServerStatsResponse.ServerStats ToServerStats(ProviderAgg? agg) =>
+        agg is null
+            ? new GetServerStatsResponse.ServerStats()
+            : new GetServerStatsResponse.ServerStats
+            {
+                Total = agg.TotalBytes,
+                Month = agg.MonthBytes,
+                Week = agg.WeekBytes,
+                Day = agg.DayBytes,
+                Daily = new Dictionary<string, long>(agg.Daily),
+                ArticlesTried = new Dictionary<string, long>(agg.ArticlesTried),
+                ArticlesSuccess = new Dictionary<string, long>(agg.ArticlesSuccess),
+            };
+
+    internal static string ResolveServerKey(
+        string metricsKey,
+        string? label,
+        IDictionary<string, string> usedServerKeys)
+    {
+        var candidate = string.IsNullOrEmpty(label) ? metricsKey : label;
+        if (!usedServerKeys.TryGetValue(candidate, out var existing))
+        {
+            usedServerKeys[candidate] = metricsKey;
+            return candidate;
+        }
+
+        if (string.Equals(existing, metricsKey, StringComparison.Ordinal))
+            return candidate;
+
+        usedServerKeys[metricsKey] = metricsKey;
+        return metricsKey;
+    }
+
+    private static void AddToMap(Dictionary<string, long> map, string key, long amount)
+    {
+        map.TryGetValue(key, out var current);
+        map[key] = current + amount;
+    }
+
+    private static string FormatDayLabel(long hourMs, TimeZoneInfo timeZone)
+    {
+        var local = TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeMilliseconds(hourMs), timeZone);
+        return local.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private enum BoundaryKind
+    {
+        Day,
+        Week,
+        Month,
+    }
+
+    private static long LocalBoundaryUnixMs(long nowMs, TimeZoneInfo timeZone, BoundaryKind kind)
+    {
+        var local = TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeMilliseconds(nowMs), timeZone);
+        return kind switch
+        {
+            BoundaryKind.Day => new DateTimeOffset(local.Year, local.Month, local.Day, 0, 0, 0, local.Offset)
+                .ToUnixTimeMilliseconds(),
+            BoundaryKind.Week => WeekBoundaryUnixMs(local),
+            BoundaryKind.Month => new DateTimeOffset(local.Year, local.Month, 1, 0, 0, 0, local.Offset)
+                .ToUnixTimeMilliseconds(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+    }
+
+    private static long WeekBoundaryUnixMs(DateTimeOffset local)
+    {
+        var daysSinceMonday = ((int)local.DayOfWeek + 6) % 7;
+        return new DateTimeOffset(local.Year, local.Month, local.Day, 0, 0, 0, local.Offset)
+            .AddDays(-daysSinceMonday)
+            .ToUnixTimeMilliseconds();
+    }
+
+    private sealed class ProviderAgg
+    {
+        public long TotalBytes;
+        public long MonthBytes;
+        public long WeekBytes;
+        public long DayBytes;
+        public Dictionary<string, long> Daily { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, long> ArticlesTried { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, long> ArticlesSuccess { get; } = new(StringComparer.Ordinal);
+    }
+
+    private readonly record struct HourlyRow(
+        long Hour,
+        string Provider,
+        long Articles,
+        long BytesFetched,
+        long Misses,
+        long Errors);
+
+    private readonly record struct LifetimeRow(
+        string Provider,
+        long Articles,
+        long BytesFetched,
+        long Misses,
+        long Errors);
+}

--- a/backend/Api/SabControllers/GetServerStats/GetServerStatsResponse.cs
+++ b/backend/Api/SabControllers/GetServerStats/GetServerStatsResponse.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.SabControllers.GetServerStats;
+
+public class GetServerStatsResponse
+{
+    [JsonPropertyName("total")]
+    public long Total { get; set; }
+
+    [JsonPropertyName("month")]
+    public long Month { get; set; }
+
+    [JsonPropertyName("week")]
+    public long Week { get; set; }
+
+    [JsonPropertyName("day")]
+    public long Day { get; set; }
+
+    [JsonPropertyName("servers")]
+    public Dictionary<string, ServerStats> Servers { get; set; } = new();
+
+    public class ServerStats
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; set; }
+
+        [JsonPropertyName("month")]
+        public long Month { get; set; }
+
+        [JsonPropertyName("week")]
+        public long Week { get; set; }
+
+        [JsonPropertyName("day")]
+        public long Day { get; set; }
+
+        [JsonPropertyName("daily")]
+        public Dictionary<string, long> Daily { get; set; } = new();
+
+        [JsonPropertyName("articles_tried")]
+        public Dictionary<string, long> ArticlesTried { get; set; } = new();
+
+        [JsonPropertyName("articles_success")]
+        public Dictionary<string, long> ArticlesSuccess { get; set; } = new();
+    }
+}

--- a/backend/Api/SabControllers/GetWarnings/GetWarningsController.cs
+++ b/backend/Api/SabControllers/GetWarnings/GetWarningsController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Logging;
+
+namespace NzbWebDAV.Api.SabControllers.GetWarnings;
+
+public class GetWarningsController(
+    HttpContext httpContext,
+    ConfigManager configManager,
+    WarningLogBuffer warningLogBuffer
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    protected override Task<IActionResult> Handle()
+    {
+        var response = BuildResponse(Context.GetRequestParam("name"));
+        return Task.FromResult<IActionResult>(Ok(response));
+    }
+
+    internal GetWarningsResponse BuildResponse(string? name)
+    {
+        if (name is not null and not ("show" or "clear"))
+            throw new BadHttpRequestException("Invalid name");
+
+        var snapshot = warningLogBuffer.Sink.Snapshot(
+            50,
+            levels: null,
+            source: null,
+            search: null,
+            beforeSequence: null);
+
+        return new GetWarningsResponse
+        {
+            Warnings = snapshot.Entries.Select(MapWarning).ToList(),
+        };
+    }
+
+    internal static GetWarningsResponse.WarningItem MapWarning(LogEntry entry) =>
+        new()
+        {
+            Type = entry.Level.ToUpperInvariant(),
+            Text = entry.Exception is not null
+                ? entry.Message + "\n" + entry.Exception
+                : entry.Message,
+            Time = entry.TimestampUnixMs / 1000,
+        };
+}

--- a/backend/Api/SabControllers/GetWarnings/GetWarningsController.cs
+++ b/backend/Api/SabControllers/GetWarnings/GetWarningsController.cs
@@ -21,7 +21,7 @@ public class GetWarningsController(
     internal GetWarningsResponse BuildResponse(string? name)
     {
         if (name is not null and not ("show" or "clear"))
-            throw new BadHttpRequestException("Invalid name");
+            throw new BadHttpRequestException($"Invalid name parameter '{name}'; expected 'show' or 'clear'");
 
         var snapshot = warningLogBuffer.Sink.Snapshot(
             50,

--- a/backend/Api/SabControllers/GetWarnings/GetWarningsResponse.cs
+++ b/backend/Api/SabControllers/GetWarnings/GetWarningsResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.SabControllers.GetWarnings;
+
+public class GetWarningsResponse
+{
+    [JsonPropertyName("warnings")]
+    public List<WarningItem> Warnings { get; set; } = new();
+
+    public class WarningItem
+    {
+        [JsonPropertyName("type")]
+        public required string Type { get; init; }
+
+        [JsonPropertyName("text")]
+        public required string Text { get; init; }
+
+        [JsonPropertyName("time")]
+        public required long Time { get; init; }
+    }
+}

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -10,6 +10,7 @@ using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Api.SabControllers.GetServerStats;
 using NzbWebDAV.Api.SabControllers.GetStatus;
 using NzbWebDAV.Api.SabControllers.GetVersion;
+using NzbWebDAV.Api.SabControllers.GetWarnings;
 using NzbWebDAV.Api.SabControllers.MoveInQueue;
 using NzbWebDAV.Api.SabControllers.Pause;
 using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
@@ -21,6 +22,7 @@ using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -35,7 +37,8 @@ public class SabApiController(
     QueueManager queueManager,
     WebsocketManager websocketManager,
     NzbWebDAV.Services.ProviderUsageTracker providerUsageTracker,
-    NzbWebDAV.Services.IndexerHitTracker hitTracker
+    NzbWebDAV.Services.IndexerHitTracker hitTracker,
+    WarningLogBuffer warningLogBuffer
 ) : ControllerBase
 {
     [HttpGet]
@@ -95,6 +98,8 @@ public class SabApiController(
                     HttpContext, configManager);
             case "server_stats":
                 return new GetServerStatsController(HttpContext, configManager);
+            case "warnings":
+                return new GetWarningsController(HttpContext, configManager, warningLogBuffer);
             case "addfile":
                 return new AddFileController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager);

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Api.SabControllers.GetConfig;
 using NzbWebDAV.Api.SabControllers.GetFullStatus;
 using NzbWebDAV.Api.SabControllers.GetHistory;
 using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Api.SabControllers.GetServerStats;
 using NzbWebDAV.Api.SabControllers.GetStatus;
 using NzbWebDAV.Api.SabControllers.GetVersion;
 using NzbWebDAV.Api.SabControllers.MoveInQueue;
@@ -92,6 +93,8 @@ public class SabApiController(
             case "fullstatus":
                 return new GetFullStatusController(
                     HttpContext, configManager);
+            case "server_stats":
+                return new GetServerStatsController(HttpContext, configManager);
             case "addfile":
                 return new AddFileController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager);

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -5,6 +5,7 @@ InfiniDysk implements the SABnzbd-compatible operations used by Sonarr, Radarr, 
 ## Supported operations
 
 - `version`, `status`, `fullstatus`, `get_config`, and `get_cats`
+- `server_stats` and `warnings` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 - `addfile` and `addurl`
 - `queue` listing and `queue&name=delete`
 - `pause` / `resume` (also `queue&name=pause` / `queue&name=resume`) and `speedlimit` [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
@@ -26,6 +27,8 @@ Queue and history filters accept both `cat` and `category`. The default category
 - History has no separate archive tier. `history&name=delete` permanently removes matching history rows.
 - **Ignore SAB history limit** can ignore a client's `limit`; InfiniDysk still enforces a server-side maximum page size.
 - Authentication failures use HTTP error status codes instead of always returning HTTP 200 with an error body.
+- `server_stats` aggregates provider bandwidth from retained `ProviderHourly` rollups (plus folded lifetime totals for all-time bytes). The per-server `daily` map and article counters are bounded by the hourly retention window — pruned buckets are not reconstructed.
+- `warnings` returns recent Warning-and-above log entries from the in-memory buffer. `name=clear` is accepted for SAB client compatibility but does not clear the buffer (support packs rely on it). Use Settings → Support to collect the full warning log.
 
 ## `addurl` and private / LAN hosts [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since }
 

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -13,6 +13,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
@@ -296,7 +297,8 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
             _queueManager,
             _websocketManager,
             new ProviderUsageTracker(),
-            new IndexerHitTracker());
+            new IndexerHitTracker(),
+            new WarningLogBuffer(new LogBufferSink(50)));
         controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
         {
             HttpContext = httpContext,

--- a/tests/NzbWebDAV.Tests/Api/SabServerStatsTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabServerStatsTests.cs
@@ -1,0 +1,326 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.GetServerStats;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+public sealed class SabServerStatsTests
+{
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+    private static readonly long NowMs = new DateTimeOffset(2026, 8, 12, 15, 0, 0, TimeSpan.Zero)
+        .ToUnixTimeMilliseconds();
+    private static readonly long DayBoundary = new DateTimeOffset(2026, 8, 12, 0, 0, 0, TimeSpan.Zero)
+        .ToUnixTimeMilliseconds();
+    private static readonly long WeekBoundary = new DateTimeOffset(2026, 8, 10, 0, 0, 0, TimeSpan.Zero)
+        .ToUnixTimeMilliseconds();
+    private static readonly long MonthBoundary = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero)
+        .ToUnixTimeMilliseconds();
+
+    [Fact]
+    public async Task BuildAsync_ComputesDayWeekMonthTotals()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "alice");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var config = ConfigWithProviders(provider);
+
+        harness.Context.ProviderHourly.AddRange(
+            Hour(key, MonthBoundary - 3_600_000, bytes: 100),
+            Hour(key, WeekBoundary - 3_600_000, bytes: 200),
+            Hour(key, DayBoundary - 3_600_000, bytes: 300),
+            Hour(key, DayBoundary + 3_600_000, bytes: 400));
+        await harness.Context.SaveChangesAsync();
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.Equal(1000, stats.Total);
+        Assert.Equal(900, stats.Month);
+        Assert.Equal(700, stats.Week);
+        Assert.Equal(400, stats.Day);
+        Assert.Equal(1000, stats.Servers["news.example.com"].Total);
+        Assert.Equal(400, stats.Servers["news.example.com"].Day);
+    }
+
+    [Fact]
+    public async Task BuildAsync_FoldsLifetimeTotalsIntoServerAndRootTotals()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "alice");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var config = ConfigWithProviders(provider);
+
+        harness.Context.ProviderHourly.Add(Hour(key, DayBoundary, bytes: 250));
+        harness.Context.ProviderLifetimeTotals.Add(new ProviderLifetimeTotal
+        {
+            Provider = key,
+            BytesFetched = 750,
+            Articles = 5,
+        });
+        await harness.Context.SaveChangesAsync();
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.Equal(1000, stats.Total);
+        Assert.Equal(1000, stats.Servers["news.example.com"].Total);
+    }
+
+    [Fact]
+    public async Task BuildAsync_GroupsDailyBytesAndArticlesByLocalDayLabel()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "alice");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var config = ConfigWithProviders(provider);
+        var aug9 = new DateTimeOffset(2026, 8, 9, 22, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var aug10 = new DateTimeOffset(2026, 8, 10, 10, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        harness.Context.ProviderHourly.AddRange(
+            Hour(key, aug9, bytes: 111, articles: 10, misses: 1, errors: 1),
+            Hour(key, aug10, bytes: 222, articles: 4, misses: 10, errors: 10));
+        await harness.Context.SaveChangesAsync();
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+        var server = stats.Servers["news.example.com"];
+
+        Assert.Equal(111, server.Daily["2026-08-09"]);
+        Assert.Equal(222, server.Daily["2026-08-10"]);
+        Assert.Equal(10, server.ArticlesTried["2026-08-09"]);
+        Assert.Equal(8, server.ArticlesSuccess["2026-08-09"]);
+        Assert.Equal(4, server.ArticlesTried["2026-08-10"]);
+        Assert.Equal(0, server.ArticlesSuccess["2026-08-10"]);
+    }
+
+    [Fact]
+    public async Task BuildAsync_UsesMetricsKeyWhenDisplayLabelsCollide()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var first = MakeProvider("news.example.com", "alice");
+        var second = MakeProvider("news.example.com", "bob");
+        var firstKey = UsenetProviderIdentity.MetricsKey(first);
+        var secondKey = UsenetProviderIdentity.MetricsKey(second);
+        var config = ConfigWithProviders(first, second);
+
+        harness.Context.ProviderHourly.AddRange(
+            Hour(firstKey, DayBoundary, bytes: 100),
+            Hour(secondKey, DayBoundary, bytes: 200));
+        await harness.Context.SaveChangesAsync();
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.True(stats.Servers.ContainsKey("news.example.com"));
+        Assert.True(stats.Servers.ContainsKey(secondKey));
+        Assert.Equal(100, stats.Servers["news.example.com"].Total);
+        Assert.Equal(200, stats.Servers[secondKey].Total);
+    }
+
+    [Fact]
+    public async Task BuildAsync_IncludesUnconfiguredProvidersInRootTotalsOnly()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "alice");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var config = ConfigWithProviders(provider);
+
+        harness.Context.ProviderHourly.AddRange(
+            Hour(key, DayBoundary, bytes: 100),
+            Hour("deleted-provider", DayBoundary, bytes: 50));
+        await harness.Context.SaveChangesAsync();
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.Equal(150, stats.Total);
+        Assert.Equal(150, stats.Day);
+        Assert.Single(stats.Servers);
+        Assert.Equal(100, stats.Servers["news.example.com"].Total);
+    }
+
+    [Fact]
+    public async Task BuildAsync_IncludesConfiguredProvidersWithZeroTraffic()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "alice", nickname: "Primary");
+        var config = ConfigWithProviders(provider);
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.Single(stats.Servers);
+        Assert.True(stats.Servers.ContainsKey("Primary"));
+        Assert.Equal(0, stats.Servers["Primary"].Total);
+        Assert.Equal(0, stats.Total);
+    }
+
+    [Fact]
+    public async Task BuildAsync_IgnoresHourlyRowsAfterNow()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var provider = MakeProvider("news.example.com", "alice");
+        var key = UsenetProviderIdentity.MetricsKey(provider);
+        var config = ConfigWithProviders(provider);
+
+        harness.Context.ProviderHourly.AddRange(
+            Hour(key, DayBoundary, bytes: 100),
+            Hour(key, NowMs + 3_600_000, bytes: 999));
+        await harness.Context.SaveChangesAsync();
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.Equal(100, stats.Total);
+    }
+
+    [Fact]
+    public async Task BuildAsync_EmptyDatabaseReturnsZeros()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var config = ConfigWithProviders(MakeProvider("news.example.com", "alice"));
+
+        var stats = await GetServerStatsController.BuildAsync(harness.Context, config, NowMs, Utc);
+
+        Assert.Equal(0, stats.Total);
+        Assert.Equal(0, stats.Month);
+        Assert.Equal(0, stats.Week);
+        Assert.Equal(0, stats.Day);
+        Assert.Single(stats.Servers);
+        Assert.Equal(0, stats.Servers["news.example.com"].Total);
+    }
+
+    [Fact]
+    public void Response_SerializesExactSnakeCaseKeys()
+    {
+        var response = new GetServerStatsResponse
+        {
+            Total = 1,
+            Month = 2,
+            Week = 3,
+            Day = 4,
+            Servers =
+            {
+                ["server-a"] = new GetServerStatsResponse.ServerStats
+                {
+                    Total = 5,
+                    Month = 6,
+                    Week = 7,
+                    Day = 8,
+                    Daily = { ["2026-08-10"] = 9 },
+                    ArticlesTried = { ["2026-08-10"] = 10 },
+                    ArticlesSuccess = { ["2026-08-10"] = 11 },
+                },
+            },
+        };
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(response));
+        var root = json.RootElement;
+
+        Assert.True(root.TryGetProperty("total", out _));
+        Assert.True(root.TryGetProperty("month", out _));
+        Assert.True(root.TryGetProperty("week", out _));
+        Assert.True(root.TryGetProperty("day", out _));
+        Assert.True(root.TryGetProperty("servers", out var servers));
+        var server = servers.GetProperty("server-a");
+        Assert.True(server.TryGetProperty("daily", out _));
+        Assert.True(server.TryGetProperty("articles_tried", out _));
+        Assert.True(server.TryGetProperty("articles_success", out _));
+    }
+
+    private static ProviderHourly Hour(
+        string provider,
+        long hour,
+        long bytes,
+        long articles = 0,
+        long misses = 0,
+        long errors = 0) =>
+        new()
+        {
+            Hour = hour,
+            Provider = provider,
+            BytesFetched = bytes,
+            Articles = articles,
+            Misses = misses,
+            Errors = errors,
+        };
+
+    private static ConfigManager ConfigWithProviders(params UsenetProviderConfig.ConnectionDetails[] providers)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers = providers.ToList(),
+                }),
+            },
+        ]);
+        return config;
+    }
+
+    private static UsenetProviderConfig.ConnectionDetails MakeProvider(
+        string host,
+        string user,
+        string? nickname = null,
+        Guid? providerId = null) =>
+        new()
+        {
+            ProviderId = providerId ?? Guid.NewGuid(),
+            Type = ProviderType.Pooled,
+            Host = host,
+            Port = 563,
+            UseSsl = true,
+            User = user,
+            Pass = "pass",
+            MaxConnections = 10,
+            Nickname = nickname,
+        };
+
+    private sealed class MetricsHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+
+        private MetricsHarness(string dir, MetricsDbContext context)
+        {
+            _dir = dir;
+            Context = context;
+        }
+
+        public MetricsDbContext Context { get; }
+
+        public static async Task<MetricsHarness> CreateAsync()
+        {
+            var dir = Path.Join(Path.GetTempPath(), $"nzbdav-sab-server-stats-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = Path.Join(dir, "metrics.sqlite");
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            return new MetricsHarness(dir, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/SabWarningsTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabWarningsTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.GetWarnings;
+using NzbWebDAV.Config;
+using NzbWebDAV.Logging;
+using Serilog;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Api;
+
+public sealed class SabWarningsTests
+{
+    [Fact]
+    public void Response_SerializesWarningsArray()
+    {
+        var response = new GetWarningsResponse
+        {
+            Warnings =
+            [
+                new GetWarningsResponse.WarningItem
+                {
+                    Type = "WARNING",
+                    Text = "Provider timeout",
+                    Time = 1_700_000_000,
+                },
+            ],
+        };
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(response));
+        var warnings = json.RootElement.GetProperty("warnings");
+        Assert.Equal(JsonValueKind.Array, warnings.ValueKind);
+        Assert.Equal("WARNING", warnings[0].GetProperty("type").GetString());
+        Assert.Equal("Provider timeout", warnings[0].GetProperty("text").GetString());
+        Assert.Equal(1_700_000_000, warnings[0].GetProperty("time").GetInt64());
+    }
+
+    [Fact]
+    public void MapWarning_UppercasesLevelAndConvertsTimestampToSeconds()
+    {
+        var item = GetWarningsController.MapWarning(new LogEntry
+        {
+            Sequence = 1,
+            TimestampUnixMs = 1_700_000_123_000,
+            Level = "Warning",
+            Message = "Streaming stalled",
+        });
+
+        Assert.Equal("WARNING", item.Type);
+        Assert.Equal("Streaming stalled", item.Text);
+        Assert.Equal(1_700_000_123, item.Time);
+    }
+
+    [Fact]
+    public void MapWarning_AppendsExceptionText()
+    {
+        var item = GetWarningsController.MapWarning(new LogEntry
+        {
+            Sequence = 1,
+            TimestampUnixMs = 1_000,
+            Level = "Error",
+            Message = "Download failed",
+            Exception = "System.IO.IOException: broken pipe",
+        });
+
+        Assert.Equal("ERROR", item.Type);
+        Assert.Equal("Download failed\nSystem.IO.IOException: broken pipe", item.Text);
+    }
+
+    [Fact]
+    public void BuildResponse_ReturnsWarningsFromBuffer()
+    {
+        var buffer = CreateBufferWithWarning("Queue paused by operator");
+        var controller = CreateController(buffer);
+
+        var response = controller.BuildResponse(name: null);
+
+        Assert.Single(response.Warnings);
+        Assert.Equal("Queue paused by operator", response.Warnings[0].Text);
+    }
+
+    [Fact]
+    public void BuildResponse_NameClear_ReturnsWarningsWithoutClearingBuffer()
+    {
+        var buffer = CreateBufferWithWarning("Keep this warning");
+        var controller = CreateController(buffer);
+
+        var first = controller.BuildResponse("clear");
+        var second = controller.BuildResponse("clear");
+
+        Assert.Single(first.Warnings);
+        Assert.Single(second.Warnings);
+        Assert.Equal("Keep this warning", second.Warnings[0].Text);
+    }
+
+    [Fact]
+    public void BuildResponse_InvalidName_ThrowsBadHttpRequest()
+    {
+        var buffer = new WarningLogBuffer(new LogBufferSink(10));
+        var controller = CreateController(buffer);
+
+        Assert.Throws<BadHttpRequestException>(() => controller.BuildResponse("purge"));
+    }
+
+    private static WarningLogBuffer CreateBufferWithWarning(string message)
+    {
+        var sink = new LogBufferSink(10);
+        var buffer = new WarningLogBuffer(sink);
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink, restrictedToMinimumLevel: LogEventLevel.Verbose)
+            .CreateLogger();
+        logger.Warning(message);
+        return buffer;
+    }
+
+    private static GetWarningsController CreateController(WarningLogBuffer buffer) =>
+        new(new DefaultHttpContext(), new ConfigManager(), buffer);
+}


### PR DESCRIPTION
## Summary

- Adds `mode=server_stats` — aggregates `ProviderHourly` rollups and folded `ProviderLifetimeTotal` rows into the SAB JSON shape (`total`/`month`/`week`/`day` at root and per-server, plus per-server `daily`, `articles_tried`, `articles_success` maps). Configured providers with zero traffic appear; unconfigured provider bytes fold into root totals only. Label collisions (two providers with the same display name) fall back to the metrics key.
- Adds `mode=warnings` — returns recent Warning-and-above entries from the in-memory `WarningLogBuffer`. `name=clear` is accepted for client compat but intentionally does not clear the buffer (support packs rely on it). `Type` is uppercased, `Time` is unix seconds, invalid `name` values return 400.
- Wires both modes in `SabApiController.GetController()` with `WarningLogBuffer` DI.

Closes #86

## Intentional differences from SABnzbd

- `name=clear` returns the warnings list rather than `{ "status": true }` — the buffer backs support-pack collection and should not be cleared by SAB clients.
- Per-server `daily`/article counters are bounded by the hourly retention window; pruned buckets are not reconstructed.

## Test plan

- [x] `SabServerStatsTests`: boundary math (day/week/month), lifetime total fold-in, daily grouping with article success/tried, label collision fallback, unconfigured providers in root totals only, configured providers with zero traffic, future-hour exclusion, empty DB, exact snake_case serialization
- [x] `SabWarningsTests`: serialization shape, `MapWarning` uppercases level and converts ms → seconds, exception text appended, buffer integration, `name=clear` returns warnings without clearing, invalid name throws `BadHttpRequestException`
- [x] `SabPauseResumeTests` updated to pass the new `WarningLogBuffer` constructor parameter
- [x] Docs: since pill for 1.1.0, intentional-differences section updated