### PR TITLE
feat(queue): normalize obfuscated video filenames so Radarr/Sonarr can import them

### DIFF
--- a/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
+++ b/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
@@ -69,13 +69,24 @@ public static class GetFileInfosStep
             (FileName: headerFileName, Priority: GetFilenamePriority(headerFileName, 1)),
         }.Where(x => x.FileName is not null).MaxBy(x => x.Priority).FileName ?? "";
 
+        var isRar = file.HasRar4Magic() || file.HasRar5Magic();
+        string? sniffedVideoExtension = null;
+        if (!file.MissingFirstSegment
+            && file.First16KB is not null
+            && !isRar
+            && !FilenameUtil.Is7zFile(filename))
+        {
+            sniffedVideoExtension = VideoSignatureUtil.GuessVideoExtension(file.First16KB);
+        }
+
         return new FileInfo()
         {
             NzbFile = file.NzbFile,
             FileName = filename,
             ReleaseDate = file.ReleaseDate,
             FileSize = (long?)fileDesc?.FileLength,
-            IsRar = file.HasRar4Magic() || file.HasRar5Magic(),
+            IsRar = isRar,
+            SniffedVideoExtension = sniffedVideoExtension,
         };
     }
 
@@ -156,5 +167,6 @@ public static class GetFileInfosStep
         public required DateTimeOffset ReleaseDate { get; init; }
         public long? FileSize { get; init; }
         public bool IsRar { get; init; }
+        public string? SniffedVideoExtension { get; init; }
     }
 }

--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -2,6 +2,7 @@
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Queue.FileAggregators;
 
@@ -15,9 +16,20 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
         foreach (var processorResult in processorResults)
         {
             if (processorResult is not FileProcessor.Result result) continue;
-            if (string.IsNullOrEmpty(result.FileName)) continue; // skip files whose name we can't determine
-            var parentDirectory = EnsureParentDirectory(result.FileName);
-            var name = SanitizeDavName(Path.GetFileName(result.FileName));
+            if (string.IsNullOrEmpty(result.FileName) && result.SniffedVideoExtension is null)
+                continue;
+            var parentDirectory = EnsureParentDirectory(
+                string.IsNullOrEmpty(result.FileName)
+                    ? MountDirectory.Name + result.SniffedVideoExtension
+                    : result.FileName);
+            var leafName = string.IsNullOrEmpty(result.FileName)
+                ? MountDirectory.Name
+                : Path.GetFileName(result.FileName);
+            var name = ImportableVideoNamer.Normalize(
+                SanitizeDavName(leafName),
+                result.SniffedVideoExtension,
+                MountDirectory.Name,
+                allowBaseRename: true);
 
             var davNzbFile = new DavNzbFile()
             {

--- a/backend/Queue/FileAggregators/ImportableVideoNamer.cs
+++ b/backend/Queue/FileAggregators/ImportableVideoNamer.cs
@@ -1,0 +1,31 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Queue.FileAggregators;
+
+internal static class ImportableVideoNamer
+{
+    public static string Normalize(
+        string leafName,
+        string? sniffedVideoExtension,
+        string mountName,
+        bool allowBaseRename)
+    {
+        if (FilenameUtil.IsVideoFile(leafName))
+            return leafName;
+
+        if (sniffedVideoExtension is null)
+            return leafName;
+
+        var extWithoutDot = Path.GetExtension(leafName).TrimStart('.');
+        if (extWithoutDot.Length > 0 && extWithoutDot.All(char.IsDigit))
+            return leafName;
+
+        var baseName = Path.GetFileNameWithoutExtension(leafName);
+        if (string.IsNullOrEmpty(baseName))
+            baseName = mountName;
+        else if (allowBaseRename && ObfuscationUtil.IsProbablyObfuscated(leafName))
+            baseName = mountName;
+
+        return PathSanitizer.SanitizeComponent(baseName + sniffedVideoExtension);
+    }
+}

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -32,12 +32,11 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
     {
         var pathInArchive = result.PathInArchive;
         var parentDirectory = EnsureParentDirectory(pathInArchive);
-        var name = SanitizeDavName(Path.GetFileName(pathInArchive));
-
-        // Mirror the eager path's obfuscation rename: when the archive
-        // contains a single obfuscated file, name it after the mount folder.
-        if (ObfuscationUtil.IsProbablyObfuscated(name))
-            name = SanitizeDavName(mountDirectory.Name + Path.GetExtension(name));
+        var name = ImportableVideoNamer.Normalize(
+            SanitizeDavName(Path.GetFileName(pathInArchive)),
+            result.SniffedVideoExtension,
+            mountDirectory.Name,
+            allowBaseRename: true);
 
         var davMultipartFile = new DavMultipartFile
         {
@@ -94,12 +93,14 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             var fileParts = SortByPartNumber(archiveFile.Value);
             var (fileSize, aesParams) = ResolvePublishedSizeAndAes(fileParts);
             var parentDirectory = EnsureParentDirectory(pathWithinArchive);
-            var name = SanitizeDavName(Path.GetFileName(pathWithinArchive));
-
-            // If there is only one file in the archive and the file-name is obfuscated,
-            // then rename the file to the same name as the containing mount directory.
-            if (archiveFiles.Count == 1 && ObfuscationUtil.IsProbablyObfuscated(name))
-                name = SanitizeDavName(mountDirectory.Name + Path.GetExtension(name));
+            var sniffedVideoExtension = archiveFile.Value
+                .Select(x => x.SniffedVideoExtension)
+                .FirstOrDefault(x => x is not null);
+            var name = ImportableVideoNamer.Normalize(
+                SanitizeDavName(Path.GetFileName(pathWithinArchive)),
+                sniffedVideoExtension,
+                mountDirectory.Name,
+                allowBaseRename: archiveFiles.Count == 1);
 
             var davMultipartFile = new DavMultipartFile()
             {

--- a/backend/Queue/FileAggregators/SevenZipAggregator.cs
+++ b/backend/Queue/FileAggregators/SevenZipAggregator.cs
@@ -31,12 +31,11 @@ public class SevenZipAggregator(
             var pathWithinArchive = sevenZipFile.PathWithinArchive;
             var davMultipartFileMeta = sevenZipFile.DavMultipartFileMeta;
             var parentDirectory = EnsureParentDirectory(pathWithinArchive);
-            var name = SanitizeDavName(Path.GetFileName(pathWithinArchive));
-
-            // If there is only one file in the archive and the file-name is obfuscated,
-            // then rename the file to the same name as the containing mount directory.
-            if (sevenZipFiles.Count == 1 && ObfuscationUtil.IsProbablyObfuscated(name))
-                name = mountDirectory.Name + Path.GetExtension(name);
+            var name = ImportableVideoNamer.Normalize(
+                SanitizeDavName(Path.GetFileName(pathWithinArchive)),
+                sevenZipFile.SniffedVideoExtension,
+                mountDirectory.Name,
+                allowBaseRename: sevenZipFiles.Count == 1);
 
             var davMultipartFile = new DavMultipartFile()
             {

--- a/backend/Queue/FileProcessors/FileProcessor.cs
+++ b/backend/Queue/FileProcessors/FileProcessor.cs
@@ -32,11 +32,14 @@ public class FileProcessor(
                 FileName = fileInfo.FileName,
                 FileSize = fileSize,
                 ReleaseDate = fileInfo.ReleaseDate,
+                SniffedVideoExtension = fileInfo.SniffedVideoExtension,
             };
         }
 
         // Ignore missing articles if it's not a video file (default).
         // In that case, simply skip the file altogether.
+        // Accepted limitation: this check uses the original filename, not a
+        // sniffed extension applied later at mount time.
         catch (UsenetArticleNotFoundException) when (
             !FilenameUtil.IsVideoFile(fileInfo.FileName)
             && configManager.IsSkipNonVideoOnMissingArticlesEnabled())
@@ -54,5 +57,6 @@ public class FileProcessor(
         public required string FileName { get; init; }
         public required long FileSize { get; init; }
         public required DateTimeOffset ReleaseDate { get; init; }
+        public string? SniffedVideoExtension { get; init; }
     }
 }

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -48,10 +48,12 @@ public class LazyRarProcessor(
             ?? await usenetClient.GetFileSizeAsync(firstInfo.NzbFile, ct).ConfigureAwait(false);
 
         List<IRarHeader> headers;
+        byte[] first16KB;
         try
         {
             await using var firstStream = usenetClient.GetFileStream(
                 firstInfo.NzbFile, firstFileSize, articleBufferSize: 0);
+            first16KB = await VideoSignatureUtil.ReadFirst16KBAsync(firstStream, ct).ConfigureAwait(false);
             // Stop as soon as the first file header lands. NzbDav.SharpCompress
             // deferred data-skip means this does not seek past packed payload.
             headers = await RarUtil.ReadHeadersUntilFirstFileAsync(firstStream, password, ct)
@@ -106,6 +108,11 @@ public class LazyRarProcessor(
                 pathInArchive);
             return null;
         }
+
+        var sniffedVideoExtension = VideoSignatureUtil.SniffMemberFromFirst16KB(
+            first16KB,
+            fileHeader.DataStartPosition,
+            fileHeader.GetAesParams(password) is not null);
 
         if (fileHeader.IsUncompressedSizeUnknown)
         {
@@ -231,6 +238,7 @@ public class LazyRarProcessor(
             PendingParts = pending.ToArray(),
             ReleaseDate = firstInfo.ReleaseDate,
             ArchiveName = GetArchiveName(firstInfo.FileName),
+            SniffedVideoExtension = sniffedVideoExtension,
         };
     }
 
@@ -278,5 +286,6 @@ public class LazyRarProcessor(
         public required DavMultipartFile.PendingPart[] PendingParts { get; init; }
         public required DateTimeOffset ReleaseDate { get; init; }
         public required string ArchiveName { get; init; }
+        public string? SniffedVideoExtension { get; init; }
     }
 }

--- a/backend/Queue/FileProcessors/RarProcessor.cs
+++ b/backend/Queue/FileProcessors/RarProcessor.cs
@@ -20,6 +20,7 @@ public class RarProcessor(
     public override async Task<BaseProcessor.Result?> ProcessAsync()
     {
         await using var stream = await GetNzbFileStream().ConfigureAwait(false);
+        var first16KB = await VideoSignatureUtil.ReadFirst16KBAsync(stream, ct).ConfigureAwait(false);
         var headers = await RarUtil.GetRarHeadersAsync(stream, password, ct).ConfigureAwait(false);
         // Validate the uniform-size inference before StoredFileSegments flow into
         // RarAggregator (or NestedRarExpansionStep), which persists the part's
@@ -51,6 +52,10 @@ public class RarProcessor(
                     FileUncompressedSize = x.UncompressedSize,
                     IsUncompressedSizeUnknown = x.IsUncompressedSizeUnknown,
                     ReleaseDate = fileInfo.ReleaseDate,
+                    SniffedVideoExtension = VideoSignatureUtil.SniffMemberFromFirst16KB(
+                        first16KB,
+                        x.DataStartPosition,
+                        x.GetAesParams(password) is not null),
                 }).ToArray(),
         };
     }
@@ -139,6 +144,8 @@ public class RarProcessor(
         public required long FileUncompressedSize { get; init; }
 
         public bool IsUncompressedSizeUnknown { get; init; }
+
+        public string? SniffedVideoExtension { get; init; }
     }
 
     public record PartNumber

--- a/backend/Queue/FileProcessors/SevenZipProcessor.cs
+++ b/backend/Queue/FileProcessors/SevenZipProcessor.cs
@@ -43,6 +43,7 @@ public class SevenZipProcessor : BaseProcessor
             var progress95 = progress.Scale(95, 100);
             var multipartFile = await GetMultipartFile(progress95).ConfigureAwait(false);
             await using var stream = new MultipartFileStream(multipartFile, _usenetClient);
+            var first16KB = await VideoSignatureUtil.ReadFirst16KBAsync(stream, _ct).ConfigureAwait(false);
             var sevenZipEntries = await SevenZipUtil
                 .GetSevenZipEntriesAsync(stream, _archivePassword, _ct)
                 .ConfigureAwait(false);
@@ -67,6 +68,10 @@ public class SevenZipProcessor : BaseProcessor
                     PathWithinArchive = x.PathWithinArchive,
                     DavMultipartFileMeta = GetDavMultipartFileMeta(x, multipartFile),
                     ReleaseDate = _fileInfos.First().ReleaseDate,
+                    SniffedVideoExtension = VideoSignatureUtil.SniffMemberFromFirst16KB(
+                        first16KB,
+                        x.ByteRangeWithinArchive.StartInclusive,
+                        x.IsEncrypted),
                 }).ToList(),
             };
         }
@@ -215,5 +220,6 @@ public class SevenZipProcessor : BaseProcessor
         public required string PathWithinArchive { get; init; }
         public required DavMultipartFile.Meta DavMultipartFileMeta { get; init; }
         public required DateTimeOffset ReleaseDate { get; init; }
+        public string? SniffedVideoExtension { get; init; }
     }
 }

--- a/backend/Utils/VideoSignatureUtil.cs
+++ b/backend/Utils/VideoSignatureUtil.cs
@@ -94,7 +94,7 @@ public static class VideoSignatureUtil
     /// </summary>
     public static string? SniffMemberFromFirst16KB(byte[] first16KB, long dataStart, bool encrypted)
     {
-        if (encrypted || dataStart < 0 || dataStart + 16 > first16KB.Length || dataStart + 16 > First16KBLength)
+        if (encrypted || dataStart < 0 || dataStart >= first16KB.Length || dataStart >= First16KBLength)
             return null;
 
         var slice = first16KB.AsSpan((int)dataStart);

--- a/backend/Utils/VideoSignatureUtil.cs
+++ b/backend/Utils/VideoSignatureUtil.cs
@@ -1,0 +1,114 @@
+namespace NzbWebDAV.Utils;
+
+public static class VideoSignatureUtil
+{
+    public const int First16KBLength = 16 * 1024;
+
+    public static async Task<byte[]> ReadFirst16KBAsync(Stream stream, CancellationToken ct)
+    {
+        var buffer = new byte[First16KBLength];
+        if (!stream.CanSeek)
+            throw new InvalidOperationException("Stream must be seekable to read the first 16 KiB.");
+
+        var originalPosition = stream.Position;
+        try
+        {
+            stream.Position = 0;
+            var read = 0;
+            while (read < buffer.Length)
+            {
+                var count = await stream.ReadAsync(buffer.AsMemory(read), ct).ConfigureAwait(false);
+                if (count == 0)
+                    break;
+                read += count;
+            }
+
+            return read == buffer.Length ? buffer : buffer[..read];
+        }
+        finally
+        {
+            stream.Position = originalPosition;
+        }
+    }
+
+    private static ReadOnlySpan<byte> AsfGuid =>
+        [0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C];
+
+    private static ReadOnlySpan<byte> Rar4Magic =>
+        [0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00];
+
+    private static ReadOnlySpan<byte> Rar5Magic =>
+        [0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x01];
+
+    private static ReadOnlySpan<byte> SevenZipMagic =>
+        [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
+
+    /// <summary>
+    /// Sniffs a video container from the leading bytes. Returns a lowercase
+    /// extension including the dot, or null when no known signature matches.
+    /// </summary>
+    public static string? GuessVideoExtension(ReadOnlySpan<byte> data)
+    {
+        if (data.Length >= 4
+            && data[0] == 0x1A && data[1] == 0x45 && data[2] == 0xDF && data[3] == 0xA3)
+            return ".mkv";
+
+        if (data.Length >= 12
+            && data[4] == (byte)'f' && data[5] == (byte)'t' && data[6] == (byte)'y' && data[7] == (byte)'p')
+            return ".mp4";
+
+        if (data.Length >= 12
+            && data[0] == (byte)'R' && data[1] == (byte)'I' && data[2] == (byte)'F' && data[3] == (byte)'F'
+            && data[8] == (byte)'A' && data[9] == (byte)'V' && data[10] == (byte)'I' && data[11] == (byte)' ')
+            return ".avi";
+
+        if (data.Length >= 16 && data[..16].SequenceEqual(AsfGuid))
+            return ".wmv";
+
+        if (data.Length >= 4
+            && data[0] == 0x46 && data[1] == 0x4C && data[2] == 0x56 && data[3] == 0x01)
+            return ".flv";
+
+        if (data.Length >= 4
+            && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0x01 && data[3] == 0xBA)
+            return ".mpg";
+
+        if (IsMpegTransportStream(data))
+            return ".ts";
+
+        return null;
+    }
+
+    public static bool LooksLikeArchiveMagic(ReadOnlySpan<byte> data)
+    {
+        if (data.Length >= Rar4Magic.Length && data[..Rar4Magic.Length].SequenceEqual(Rar4Magic))
+            return true;
+        if (data.Length >= Rar5Magic.Length && data[..Rar5Magic.Length].SequenceEqual(Rar5Magic))
+            return true;
+        return data.Length >= SevenZipMagic.Length && data[..SevenZipMagic.Length].SequenceEqual(SevenZipMagic);
+    }
+
+    /// <summary>
+    /// Sniffs archive member content that starts within the first 16 KiB of the
+    /// parent file. Returns null when encrypted, out of range, or archive magic.
+    /// </summary>
+    public static string? SniffMemberFromFirst16KB(byte[] first16KB, long dataStart, bool encrypted)
+    {
+        if (encrypted || dataStart < 0 || dataStart + 16 > first16KB.Length || dataStart + 16 > First16KBLength)
+            return null;
+
+        var slice = first16KB.AsSpan((int)dataStart);
+        if (LooksLikeArchiveMagic(slice))
+            return null;
+
+        return GuessVideoExtension(slice);
+    }
+
+    private static bool IsMpegTransportStream(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 377 || data[0] != 0x47 || data[188] != 0x47 || data[376] != 0x47)
+            return false;
+
+        return data.Length < 565 || data[564] == 0x47;
+    }
+}

--- a/docs/features/archives.md
+++ b/docs/features/archives.md
@@ -4,4 +4,6 @@ InfiniDysk can stream from inside **RAR** and **7z** archives, including many pa
 
 Queue processing aggregates multi-volume sets and mounts the inner video (or other) files on the WebDAV tree. Lazy RAR parsing reduces work until content is needed. Nested RAR extraction and more resilient handling of obfuscated multi-volume sets [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since }.
 
+When inner files use obfuscated or non-video extensions (for example `.xyz`), InfiniDysk sniffs the first bytes of the payload during queue import and renames mounted files to a recognized video extension (`.mkv`, `.mp4`, and others) so Sonarr and Radarr can import them. Single-file archives also adopt the release folder name when the inner filename looks obfuscated [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }.
+
 If a release is archive-only and *Arr cannot import, check Automatic Queue Management rules and ignored-file globs under [SABnzbd settings](../configuration/sabnzbd.md).

--- a/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
@@ -8,6 +8,7 @@ namespace NzbWebDAV.Tests.Queue;
 public class GetFileInfosStepTests
 {
     private static readonly byte[] Rar4Magic = [0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00];
+    private static readonly byte[] EbmlMagic = [0x1A, 0x45, 0xDF, 0xA3, 0x00, 0x00, 0x00, 0x00];
 
     [Fact]
     public void GetFileInfos_UsesSubjectNameAndDetectsRarMagic()
@@ -33,6 +34,44 @@ public class GetFileInfosStepTests
         Assert.Equal(releaseDate, result.ReleaseDate);
         Assert.True(result.IsRar);
         Assert.Null(result.FileSize);
+    }
+
+    [Fact]
+    public void GetFileInfos_SniffsObfuscatedVideoExtensionFromFirstSegment()
+    {
+        var file = new NzbFile { Subject = "\"b082fa0beaa644d3aa01045d5b8d0b36.xyz\" yEnc" };
+        var input = new FetchFirstSegmentsStep.NzbFileWithFirstSegment
+        {
+            NzbFile = file,
+            Header = null,
+            First16KB = EbmlMagic,
+            MissingFirstSegment = false,
+            ReleaseDate = DateTimeOffset.UtcNow
+        };
+
+        var result = Assert.Single(GetFileInfosStep.GetFileInfos([input], []));
+
+        Assert.Equal("b082fa0beaa644d3aa01045d5b8d0b36.xyz", result.FileName);
+        Assert.Equal(".mkv", result.SniffedVideoExtension);
+    }
+
+    [Fact]
+    public void GetFileInfos_SkipsVideoSniffingForRarMagic()
+    {
+        var file = new NzbFile { Subject = "\"archive.rar\" yEnc" };
+        var input = new FetchFirstSegmentsStep.NzbFileWithFirstSegment
+        {
+            NzbFile = file,
+            Header = null,
+            First16KB = Rar4Magic,
+            MissingFirstSegment = false,
+            ReleaseDate = DateTimeOffset.UtcNow
+        };
+
+        var result = Assert.Single(GetFileInfosStep.GetFileInfos([input], []));
+
+        Assert.True(result.IsRar);
+        Assert.Null(result.SniffedVideoExtension);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/ImportableVideoNamerTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ImportableVideoNamerTests.cs
@@ -1,0 +1,79 @@
+using NzbWebDAV.Queue.FileAggregators;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class ImportableVideoNamerTests
+{
+    private const string Mount = "Movie.Release.2026";
+
+    [Theory]
+    [InlineData("movie.mkv", ".mkv", true, "movie.mkv")]
+    [InlineData("movie.MKV", ".mkv", true, "movie.MKV")]
+    public void Normalize_LeavesRecognizedVideoExtensionsUntouched(
+        string leafName, string sniffed, bool allowBaseRename, string expected)
+    {
+        Assert.Equal(expected, ImportableVideoNamer.Normalize(leafName, sniffed, Mount, allowBaseRename));
+    }
+
+    [Theory]
+    [InlineData("movie.xyz", null, true)]
+    [InlineData("movie.xyz", null, false)]
+    public void Normalize_LeavesNameUntouchedWhenNoSniffedExtension(
+        string leafName, string? sniffed, bool allowBaseRename)
+    {
+        Assert.Equal(leafName, ImportableVideoNamer.Normalize(leafName, sniffed, Mount, allowBaseRename));
+    }
+
+    [Theory]
+    [InlineData("release.mkv.001")]
+    [InlineData("release.6547")]
+    [InlineData("part.01")]
+    public void Normalize_LeavesNumericOnlyExtensionsUntouched(string leafName)
+    {
+        Assert.Equal(leafName, ImportableVideoNamer.Normalize(leafName, ".mkv", Mount, allowBaseRename: true));
+    }
+
+    [Fact]
+    public void Normalize_RenamesObfuscatedSingleFileArchiveUsingMountName()
+    {
+        var leaf = "b082fa0beaa644d3aa01045d5b8d0b36.xyz";
+
+        Assert.Equal(
+            Mount + ".mkv",
+            ImportableVideoNamer.Normalize(leaf, ".mkv", Mount, allowBaseRename: true));
+    }
+
+    [Fact]
+    public void Normalize_KeepsObfuscatedBaseForMultiFileArchive()
+    {
+        var leaf = "b082fa0beaa644d3aa01045d5b8d0b36.xyz";
+
+        Assert.Equal(
+            "b082fa0beaa644d3aa01045d5b8d0b36.mkv",
+            ImportableVideoNamer.Normalize(leaf, ".mkv", Mount, allowBaseRename: false));
+    }
+
+    [Fact]
+    public void Normalize_ChangesOnlyExtensionForClearBaseName()
+    {
+        Assert.Equal(
+            "Movie.Release.2026.mkv",
+            ImportableVideoNamer.Normalize("Movie.Release.2026.xyz", ".mkv", Mount, allowBaseRename: true));
+    }
+
+    [Fact]
+    public void Normalize_UsesMountNameWhenLeafNameIsEmpty()
+    {
+        Assert.Equal(
+            Mount + ".mkv",
+            ImportableVideoNamer.Normalize("", ".mkv", Mount, allowBaseRename: false));
+    }
+
+    [Fact]
+    public void Normalize_SanitizesInvalidCharacters()
+    {
+        Assert.Equal(
+            "Show_ Title_.mkv",
+            ImportableVideoNamer.Normalize("Show: Title?.xyz", ".mkv", Mount, allowBaseRename: true));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -130,6 +130,50 @@ public class LazyRarProcessorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_SniffsVideoExtensionFromStoredPayload()
+    {
+        var payload = new byte[] { 0x1A, 0x45, 0xDF, 0xA3, 0x00, 0x00, 0x00, 0x00 };
+        const int packed = 1_000;
+        const int uncompressed = 3_000;
+        var volumeBytes = BuildRar4SplitFirstVolume(
+            "b082fa0beaa644d3aa01045d5b8d0b36.xyz", packed, uncompressed, payload);
+        var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
+        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync() as LazyRarProcessor.Result;
+
+        Assert.NotNull(result);
+        Assert.Equal(".mkv", result!.SniffedVideoExtension);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SniffFailureLeavesNullExtension()
+    {
+        const int packed = 1_000;
+        const int uncompressed = 3_000;
+        var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
+        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["first@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor([first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync() as LazyRarProcessor.Result;
+
+        Assert.NotNull(result);
+        Assert.Null(result!.SniffedVideoExtension);
+    }
+
+    [Fact]
     public async Task BuildRar4SplitFirstVolume_IsFirstVolumeStoredSplit()
     {
         var bytes = BuildRar4SplitFirstVolume("movie.mkv", packedSize: 100, uncompressedSize: 500);
@@ -166,7 +210,8 @@ public class LazyRarProcessorTests
 
     // Minimal RAR4 multi-volume first part: mark + archive(VOLUME|FIRSTVOLUME) +
     // stored file header (HAS_DATA|SPLIT_AFTER) with full UNP_SIZE + packed payload.
-    private static byte[] BuildRar4SplitFirstVolume(string fileName, int packedSize, int uncompressedSize)
+    private static byte[] BuildRar4SplitFirstVolume(
+        string fileName, int packedSize, int uncompressedSize, ReadOnlySpan<byte> payloadPrefix = default)
     {
         using var ms = new MemoryStream();
         ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
@@ -213,7 +258,9 @@ public class LazyRarProcessorTests
             WriteHeader(ms, body);
         }
 
-        ms.Write(new byte[packedSize]);
+        var payload = new byte[packedSize];
+        payloadPrefix.CopyTo(payload);
+        ms.Write(payload);
         return ms.ToArray();
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
@@ -167,6 +167,18 @@ public class RarAggregatorTests
             () => RarAggregator.ResolvePublishedFileSize([a, b]));
     }
 
+    [Fact]
+    public void ImportableVideoNamer_NormalizesSingleFileArchiveObfuscatedName()
+    {
+        Assert.Equal(
+            "Movie.Release.2026.mkv",
+            ImportableVideoNamer.Normalize(
+                "b082fa0beaa644d3aa01045d5b8d0b36.xyz",
+                ".mkv",
+                "Movie.Release.2026",
+                allowBaseRename: true));
+    }
+
     private static RarProcessor.StoredFileSegment WithSize(
         RarProcessor.StoredFileSegment segment,
         long fileUncompressedSize,

--- a/tests/NzbWebDAV.Tests/Utils/VideoSignatureUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/VideoSignatureUtilTests.cs
@@ -117,4 +117,14 @@ public class VideoSignatureUtilTests
         Assert.Null(VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, 100, encrypted: true));
         Assert.Null(VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, 16_384, encrypted: false));
     }
+
+    [Fact]
+    public void SniffMemberFromFirst16KB_DetectsSignatureNearEndOfBuffer()
+    {
+        var first16KB = new byte[VideoSignatureUtil.First16KBLength];
+        var offset = VideoSignatureUtil.First16KBLength - 8;
+        EbmlMagic.CopyTo(first16KB, offset);
+
+        Assert.Equal(".mkv", VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, offset, encrypted: false));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Utils/VideoSignatureUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/VideoSignatureUtilTests.cs
@@ -1,0 +1,120 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class VideoSignatureUtilTests
+{
+    private static readonly byte[] EbmlMagic = [0x1A, 0x45, 0xDF, 0xA3, 0x00, 0x00, 0x00, 0x00];
+    private static readonly byte[] Mp4Magic =
+    [
+        0x00, 0x00, 0x00, 0x20, (byte)'f', (byte)'t', (byte)'y', (byte)'p',
+        (byte)'i', (byte)'s', (byte)'o', (byte)'m',
+    ];
+    private static readonly byte[] AviMagic =
+    [
+        (byte)'R', (byte)'I', (byte)'F', (byte)'F', 0x00, 0x00, 0x00, 0x00,
+        (byte)'A', (byte)'V', (byte)'I', (byte)' ',
+    ];
+    private static readonly byte[] WmvMagic =
+    [
+        0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C,
+    ];
+    private static readonly byte[] FlvMagic = [0x46, 0x4C, 0x56, 0x01, 0x00, 0x00, 0x00, 0x00];
+    private static readonly byte[] MpgMagic = [0x00, 0x00, 0x01, 0xBA, 0x44, 0x00, 0x04, 0x00];
+    private static readonly byte[] Rar4Magic = [0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00, 0x00];
+    private static readonly byte[] Par2Magic = [0x50, 0x41, 0x52, 0x32, 0x00, 0x00, 0x00, 0x00];
+
+    [Theory]
+    [InlineData(nameof(EbmlMagic), ".mkv")]
+    [InlineData(nameof(Mp4Magic), ".mp4")]
+    [InlineData(nameof(AviMagic), ".avi")]
+    [InlineData(nameof(WmvMagic), ".wmv")]
+    [InlineData(nameof(FlvMagic), ".flv")]
+    [InlineData(nameof(MpgMagic), ".mpg")]
+    public void GuessVideoExtension_DetectsKnownSignatures(string magicName, string expected)
+    {
+        var magic = magicName switch
+        {
+            nameof(EbmlMagic) => EbmlMagic,
+            nameof(Mp4Magic) => Mp4Magic,
+            nameof(AviMagic) => AviMagic,
+            nameof(WmvMagic) => WmvMagic,
+            nameof(FlvMagic) => FlvMagic,
+            nameof(MpgMagic) => MpgMagic,
+            _ => throw new ArgumentOutOfRangeException(nameof(magicName)),
+        };
+
+        Assert.Equal(expected, VideoSignatureUtil.GuessVideoExtension(magic));
+    }
+
+    [Fact]
+    public void GuessVideoExtension_DetectsMpegTransportStream()
+    {
+        var data = new byte[565];
+        data[0] = 0x47;
+        data[188] = 0x47;
+        data[376] = 0x47;
+        data[564] = 0x47;
+
+        Assert.Equal(".ts", VideoSignatureUtil.GuessVideoExtension(data));
+    }
+
+    [Fact]
+    public void GuessVideoExtension_DetectsMpegTransportStreamWithoutFourthSyncByte()
+    {
+        var data = new byte[400];
+        data[0] = 0x47;
+        data[188] = 0x47;
+        data[376] = 0x47;
+
+        Assert.Equal(".ts", VideoSignatureUtil.GuessVideoExtension(data));
+    }
+
+    [Theory]
+    [InlineData(nameof(Rar4Magic))]
+    [InlineData(nameof(Par2Magic))]
+    public void GuessVideoExtension_ReturnsNullForNonVideoMagic(string magicName)
+    {
+        var magic = magicName switch
+        {
+            nameof(Rar4Magic) => Rar4Magic,
+            nameof(Par2Magic) => Par2Magic,
+            _ => throw new ArgumentOutOfRangeException(nameof(magicName)),
+        };
+
+        Assert.Null(VideoSignatureUtil.GuessVideoExtension(magic));
+    }
+
+    [Fact]
+    public void GuessVideoExtension_ReturnsNullForRandomBytes()
+    {
+        Assert.Null(VideoSignatureUtil.GuessVideoExtension([0xDE, 0xAD, 0xBE, 0xEF]));
+    }
+
+    [Fact]
+    public void GuessVideoExtension_ReturnsNullForTruncatedMp4()
+    {
+        Assert.Null(VideoSignatureUtil.GuessVideoExtension(Mp4Magic.AsSpan(0, 8)));
+    }
+
+    [Fact]
+    public void LooksLikeArchiveMagic_DetectsRarAndSevenZip()
+    {
+        Assert.True(VideoSignatureUtil.LooksLikeArchiveMagic(Rar4Magic));
+        Assert.True(VideoSignatureUtil.LooksLikeArchiveMagic([0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C, 0x00]));
+        Assert.False(VideoSignatureUtil.LooksLikeArchiveMagic(EbmlMagic));
+    }
+
+    [Fact]
+    public void SniffMemberFromFirst16KB_SkipsEncryptedAndArchiveMagic()
+    {
+        var first16KB = new byte[VideoSignatureUtil.First16KBLength];
+        EbmlMagic.CopyTo(first16KB, 100);
+        Rar4Magic.CopyTo(first16KB, 200);
+
+        Assert.Equal(".mkv", VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, 100, encrypted: false));
+        Assert.Null(VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, 200, encrypted: false));
+        Assert.Null(VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, 100, encrypted: true));
+        Assert.Null(VideoSignatureUtil.SniffMemberFromFirst16KB(first16KB, 16_384, encrypted: false));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #93.

- Adds **video container signature sniffing** (`VideoSignatureUtil`) that reads the first bytes of non-archive files and archive members to detect MKV (EBML), MP4 (ftyp), AVI (RIFF/AVI), WMV (ASF GUID), FLV, MPEG-PS, and MPEG-TS containers, returning a lowercase extension (`.mkv`, `.mp4`, etc.) or null.
- Carries the sniffed extension through `GetFileInfosStep → FileInfo`, `FileProcessor.Result`, `RarProcessor.StoredFileSegment`, `LazyRarProcessor.Result`, and `SevenZipProcessor.SevenZipFile` so it is available at mount time.
- Introduces `ImportableVideoNamer.Normalize` with a conservative policy: never touches files that already have a recognized video extension, never touches numeric-only extensions (split-file markers like `.001`), and only renames the base name to the release folder name when `allowBaseRename` is true **and** the filename looks obfuscated.
- All three aggregators (`FileAggregator`, `RarAggregator`, `SevenZipAggregator`) now call `ImportableVideoNamer.Normalize` instead of ad-hoc obfuscation rename logic. Single-file archives allow base rename; multi-file archives only fix the extension.
- `LazyRarProcessor` reads the first 16 KiB of the volume stream (bounded, with try/catch fallback) to sniff member content without a full parse.

### Accepted limitation

`SkipNonVideoOnMissingArticles` still checks the **original** filename, not the sniffed extension. A file with an obfuscated `.xyz` extension that is actually video could be skipped by that filter before normalization runs. This is documented with a comment in `FileProcessor.cs`.

## Test plan

- [ ] `VideoSignatureUtilTests`: covers all 7 container signatures, MPEG-TS sync-byte detection (3 and 4 sync bytes), null for non-video magic (RAR, PAR2), null for random/truncated input, `LooksLikeArchiveMagic` for RAR4/5 and 7z, `SniffMemberFromFirst16KB` skips encrypted/out-of-range/archive magic
- [ ] `ImportableVideoNamerTests`: leaves recognized video extensions untouched, leaves names unchanged when no sniffed extension, preserves numeric-only extensions, renames obfuscated base name with mount name (single-file), keeps obfuscated base for multi-file, changes only extension for clear base names, falls back to mount name when leaf is empty, sanitizes invalid path characters
- [ ] `GetFileInfosStepTests`: sniffs video extension from First16KB on non-archive files, skips sniffing for RAR-magic files
- [ ] `LazyRarProcessorTests`: sniffs `.mkv` from EBML payload embedded in RAR volume, leaves null when no video signature matches
- [ ] `RarAggregatorTests`: integration test for single-file archive obfuscated rename via `ImportableVideoNamer`
- [ ] CI: backend build + tests pass