### PR TITLE
feat(queue): bulk pause, retry, category, and clear actions on queue and history

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -71,7 +71,7 @@ public class AddFileRequest()
         return NzbStreamUtil.NormalizeFileName(fileName);
     }
 
-    protected static QueueItem.PriorityOption MapPriorityOption(string? priority)
+    internal static QueueItem.PriorityOption MapPriorityOption(string? priority)
     {
         return priority switch
         {

--- a/backend/Api/SabControllers/Pause/PauseController.cs
+++ b/backend/Api/SabControllers/Pause/PauseController.cs
@@ -2,22 +2,32 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Api.SabControllers.Pause;
 
-/// <summary>
-/// SAB-compatible <c>mode=pause</c> (and <c>mode=queue&amp;name=pause</c>).
-/// Stops the queue coordinator from starting new downloads; items already in
-/// progress finish naturally and WebDAV keeps serving mounted content.
-/// </summary>
 public class PauseController(
     HttpContext httpContext,
     DavDatabaseClient dbClient,
-    ConfigManager configManager
+    ConfigManager configManager,
+    QueueManager queueManager,
+    WebsocketManager websocketManager
 ) : SabApiController.BaseController(httpContext, configManager)
 {
-    public async Task<PauseResponse> Pause(CancellationToken ct)
+    public Task<PauseResponse> Pause(CancellationToken ct) =>
+        Pause(new PauseRequest { NzoIds = [], CancellationToken = ct }, ct);
+
+    public async Task<PauseResponse> Pause(PauseRequest request, CancellationToken ct)
     {
+        if (request.NzoIds.Count > 0)
+        {
+            await queueManager.PauseQueueItemsAsync(request.NzoIds, dbClient, ct).ConfigureAwait(false);
+            foreach (var id in request.NzoIds)
+                _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{id}|Paused");
+            return new PauseResponse { Status = true };
+        }
+
         await ConfigPersistenceUtil.SetValueAsync(
             dbClient, Config, ConfigKeys.QueuePaused, "true", ct).ConfigureAwait(false);
         return new PauseResponse { Status = true };
@@ -25,6 +35,7 @@ public class PauseController(
 
     protected override async Task<IActionResult> Handle()
     {
-        return Ok(await Pause(Context.RequestAborted).ConfigureAwait(false));
+        var request = await PauseRequest.New(Context).ConfigureAwait(false);
+        return Ok(await Pause(request, Context.RequestAborted).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/Pause/PauseRequest.cs
+++ b/backend/Api/SabControllers/Pause/PauseRequest.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.SabControllers.Pause;
+
+public class PauseRequest
+{
+    public List<Guid> NzoIds { get; init; } = [];
+    public CancellationToken CancellationToken { get; init; }
+
+    public static async Task<PauseRequest> New(HttpContext httpContext)
+    {
+        var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
+            .ConfigureAwait(false);
+        return new PauseRequest
+        {
+            NzoIds = parsed.NzoIds,
+            CancellationToken = SigtermUtil.GetCancellationToken(),
+        };
+    }
+}

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
@@ -20,6 +20,7 @@ public class RemoveFromQueueController(
     {
         var ids = request.DeleteAll
             ? await dbClient.Ctx.QueueItems.AsNoTracking()
+                .Where(item => request.Category == null || item.Category == request.Category)
                 .Select(item => item.Id)
                 .ToListAsync(request.CancellationToken)
                 .ConfigureAwait(false)

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -20,7 +20,8 @@ public class RemoveFromQueueController(
     {
         var ids = request.DeleteAll
             ? await dbClient.Ctx.QueueItems.AsNoTracking()
-                .Where(item => request.Category == null || item.Category == request.Category)
+                .Where(item => request.Category == null ||
+                              EF.Functions.Collate(item.Category, "NOCASE") == request.Category)
                 .Select(item => item.Id)
                 .ToListAsync(request.CancellationToken)
                 .ConfigureAwait(false)

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueRequest.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueRequest.cs
@@ -1,6 +1,6 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.SabControllers.RemoveFromQueue;
@@ -9,6 +9,7 @@ public class RemoveFromQueueRequest()
 {
     public List<Guid> NzoIds { get; init; } = [];
     public bool DeleteAll { get; init; }
+    public string? Category { get; init; }
     public bool DeleteFilesRequested { get; init; }
     public CancellationToken CancellationToken { get; init; }
 
@@ -16,33 +17,21 @@ public class RemoveFromQueueRequest()
     {
         var cancellationToken = SigtermUtil.GetCancellationToken();
         var query = SabDeleteValueParser.Parse(httpContext, allowFailed: false);
-        var bodyIds = await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false);
+        var parsed = await SabNzoIdsParser.ParseAsync(httpContext, cancellationToken).ConfigureAwait(false);
+        var category = httpContext.GetRequestParam("cat")
+                       ?? httpContext.GetRequestParam("category");
+        if (category == "*")
+            category = null;
+
         return new RemoveFromQueueRequest()
         {
-            NzoIds = query.NzoIds.Concat(bodyIds).Distinct().ToList(),
+            NzoIds = query.DeleteAll
+                ? []
+                : query.NzoIds.Concat(parsed.NzoIds).Distinct().ToList(),
             DeleteAll = query.DeleteAll,
+            Category = category,
             DeleteFilesRequested = httpContext.Request.Query["del_files"] == "1",
             CancellationToken = cancellationToken
         };
-    }
-
-    private static async Task<List<Guid>> NzoIdsFromRequestBody(HttpContext httpContext, CancellationToken ct)
-    {
-        try
-        {
-            await using var stream = httpContext.Request.Body;
-            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(stream, cancellationToken: ct).ConfigureAwait(false);
-            return deserialized?.NzoIds ?? [];
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    private class RequestBody
-    {
-        [JsonPropertyName("nzo_ids")]
-        public List<Guid> NzoIds { get; set; } = [];
     }
 }

--- a/backend/Api/SabControllers/Resume/ResumeController.cs
+++ b/backend/Api/SabControllers/Resume/ResumeController.cs
@@ -3,23 +3,31 @@ using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Queue;
+using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Api.SabControllers.Resume;
 
-/// <summary>
-/// SAB-compatible <c>mode=resume</c> (and <c>mode=queue&amp;name=resume</c>).
-/// Clears the queue pause flag and wakes the queue coordinator so it starts
-/// claiming work again without waiting for its idle-poll interval.
-/// </summary>
 public class ResumeController(
     HttpContext httpContext,
     DavDatabaseClient dbClient,
     ConfigManager configManager,
-    QueueManager queueManager
+    QueueManager queueManager,
+    WebsocketManager websocketManager
 ) : SabApiController.BaseController(httpContext, configManager)
 {
-    public async Task<ResumeResponse> Resume(CancellationToken ct)
+    public async Task<ResumeResponse> Resume(CancellationToken ct) =>
+        await Resume(new ResumeRequest { NzoIds = [], CancellationToken = ct }, ct).ConfigureAwait(false);
+
+    public async Task<ResumeResponse> Resume(ResumeRequest request, CancellationToken ct)
     {
+        if (request.NzoIds.Count > 0)
+        {
+            await queueManager.ResumeQueueItemsAsync(request.NzoIds, dbClient, ct).ConfigureAwait(false);
+            foreach (var id in request.NzoIds)
+                _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{id}|Queued");
+            return new ResumeResponse { Status = true };
+        }
+
         await ConfigPersistenceUtil.SetValueAsync(
             dbClient, Config, ConfigKeys.QueuePaused, "false", ct).ConfigureAwait(false);
         queueManager.AwakenQueue();
@@ -28,6 +36,7 @@ public class ResumeController(
 
     protected override async Task<IActionResult> Handle()
     {
-        return Ok(await Resume(Context.RequestAborted).ConfigureAwait(false));
+        var request = await ResumeRequest.New(Context).ConfigureAwait(false);
+        return Ok(await Resume(request, Context.RequestAborted).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/Resume/ResumeRequest.cs
+++ b/backend/Api/SabControllers/Resume/ResumeRequest.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.SabControllers.Resume;
+
+public class ResumeRequest
+{
+    public List<Guid> NzoIds { get; init; } = [];
+    public CancellationToken CancellationToken { get; init; }
+
+    public static async Task<ResumeRequest> New(HttpContext httpContext)
+    {
+        var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
+            .ConfigureAwait(false);
+        return new ResumeRequest
+        {
+            NzoIds = parsed.NzoIds,
+            CancellationToken = SigtermUtil.GetCancellationToken(),
+        };
+    }
+}

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
@@ -20,8 +20,46 @@ public class RetryHistoryController(
 {
     public async Task<RetryHistoryResponse> RetryHistoryAsync(RetryHistoryRequest request)
     {
+        var succeeded = new List<string>();
+        var failed = new List<RetryHistoryFailedItem>();
+
+        foreach (var nzoId in request.NzoIds)
+        {
+            try
+            {
+                var newId = await RetrySingleHistoryItemAsync(nzoId, request.CancellationToken)
+                    .ConfigureAwait(false);
+                succeeded.Add(newId.ToString());
+            }
+            catch (BadHttpRequestException e)
+            {
+                failed.Add(new RetryHistoryFailedItem
+                {
+                    NzoId = nzoId.ToString(),
+                    Error = e.Message,
+                });
+            }
+        }
+
+        if (succeeded.Count == 0 && failed.Count > 0)
+            throw new BadHttpRequestException(failed[0].Error);
+
+        var response = new RetryHistoryResponse
+        {
+            Status = succeeded.Count > 0,
+            NzoIds = succeeded.Count > 0 ? succeeded : null,
+            Failed = failed.Count > 0 ? failed : null,
+        };
+        if (succeeded.Count == 1)
+            response.NzoId = succeeded[0];
+
+        return response;
+    }
+
+    private async Task<Guid> RetrySingleHistoryItemAsync(Guid nzoId, CancellationToken ct)
+    {
         var historyItem = await dbClient.Ctx.HistoryItems.AsNoTracking()
-            .FirstOrDefaultAsync(item => item.Id == request.NzoId, request.CancellationToken)
+            .FirstOrDefaultAsync(item => item.Id == nzoId, ct)
             .ConfigureAwait(false);
 
         if (historyItem is null)
@@ -47,7 +85,7 @@ public class RetryHistoryController(
             PostProcessing = QueueItem.PostProcessingOption.None,
             IndexerName = historyItem.IndexerName,
             ContentGroupKey = historyItem.ContentGroupKey,
-            CancellationToken = request.CancellationToken,
+            CancellationToken = ct,
         };
 
         var addFileController = new AddFileController(
@@ -56,16 +94,12 @@ public class RetryHistoryController(
         if (addResponse.NzoIds.Count == 0)
             throw new BadHttpRequestException("Failed to re-queue NZB.");
 
-        return new RetryHistoryResponse
-        {
-            Status = true,
-            NzoId = addResponse.NzoIds[0],
-        };
+        return Guid.Parse(addResponse.NzoIds[0]);
     }
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = RetryHistoryRequest.New(Context);
+        var request = await RetryHistoryRequest.New(Context).ConfigureAwait(false);
         return Ok(await RetryHistoryAsync(request).ConfigureAwait(false));
     }
 }

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryRequest.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
@@ -6,18 +7,19 @@ namespace NzbWebDAV.Api.SabControllers.RetryHistory;
 
 public class RetryHistoryRequest
 {
-    public Guid NzoId { get; private init; }
-    public CancellationToken CancellationToken { get; private init; }
+    public List<Guid> NzoIds { get; init; } = [];
+    public CancellationToken CancellationToken { get; init; }
 
-    public static RetryHistoryRequest New(HttpContext httpContext)
+    public static async Task<RetryHistoryRequest> New(HttpContext httpContext)
     {
-        var value = httpContext.GetRequestParam("value");
-        if (string.IsNullOrWhiteSpace(value) || !Guid.TryParse(value, out var nzoId))
+        var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
+            .ConfigureAwait(false);
+        if (parsed.NzoIds.Count == 0)
             throw new BadHttpRequestException("Missing or invalid value (nzo_id).");
 
         return new RetryHistoryRequest
         {
-            NzoId = nzoId,
+            NzoIds = parsed.NzoIds,
             CancellationToken = SigtermUtil.GetCancellationToken(),
         };
     }

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryResponse.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryResponse.cs
@@ -5,5 +5,20 @@ namespace NzbWebDAV.Api.SabControllers.RetryHistory;
 public class RetryHistoryResponse : SabBaseResponse
 {
     [JsonPropertyName("nzo_id")]
+    public string? NzoId { get; set; }
+
+    [JsonPropertyName("nzo_ids")]
+    public List<string>? NzoIds { get; set; }
+
+    [JsonPropertyName("failed")]
+    public List<RetryHistoryFailedItem>? Failed { get; set; }
+}
+
+public class RetryHistoryFailedItem
+{
+    [JsonPropertyName("nzo_id")]
     public string NzoId { get; set; } = null!;
+
+    [JsonPropertyName("error")]
+    public string Error { get; set; } = null!;
 }

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -14,6 +14,8 @@ using NzbWebDAV.Api.SabControllers.Pause;
 using NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
 using NzbWebDAV.Api.SabControllers.Resume;
+using NzbWebDAV.Api.SabControllers.SetQueueCategory;
+using NzbWebDAV.Api.SabControllers.SetQueuePriority;
 using NzbWebDAV.Api.SabControllers.RetryHistory;
 using NzbWebDAV.Api.SabControllers.SpeedLimit;
 using NzbWebDAV.Auth;
@@ -100,9 +102,9 @@ public class SabApiController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager, hitTracker);
 
             case "pause":
-                return new PauseController(HttpContext, dbClient, configManager);
+                return new PauseController(HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "resume":
-                return new ResumeController(HttpContext, dbClient, configManager, queueManager);
+                return new ResumeController(HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "speedlimit":
                 return new SpeedLimitController(HttpContext, dbClient, configManager);
 
@@ -112,10 +114,13 @@ public class SabApiController(
             case "queue" when HttpContext.GetRequestParam("name") == "move":
                 return new MoveInQueueController(
                     HttpContext, dbClient, configManager, websocketManager);
+            case "queue" when HttpContext.GetRequestParam("name") == "priority":
+                return new SetQueuePriorityController(
+                    HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "queue" when HttpContext.GetRequestParam("name") == "pause":
-                return new PauseController(HttpContext, dbClient, configManager);
+                return new PauseController(HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "queue" when HttpContext.GetRequestParam("name") == "resume":
-                return new ResumeController(HttpContext, dbClient, configManager, queueManager);
+                return new ResumeController(HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "queue":
                 return new GetQueueController(
                     HttpContext, dbClient, queueManager, configManager, providerUsageTracker);
@@ -127,6 +132,9 @@ public class SabApiController(
                 return new GetHistoryController(
                     HttpContext, dbClient, configManager, providerUsageTracker);
 
+            case "change_cat":
+                return new SetQueueCategoryController(
+                    HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "retry":
                 return new RetryHistoryController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager);

--- a/backend/Api/SabControllers/SabNzoIdsParser.cs
+++ b/backend/Api/SabControllers/SabNzoIdsParser.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+internal static class SabNzoIdsParser
+{
+    internal sealed record Result(List<Guid> NzoIds);
+
+    internal static List<Guid> ParseQuery(HttpContext context)
+    {
+        var ids = new List<Guid>();
+        var seen = new HashSet<Guid>();
+        foreach (var token in context.GetQueryParamValues("value")
+                     .SelectMany(value => value.Split(',', StringSplitOptions.TrimEntries |
+                                                          StringSplitOptions.RemoveEmptyEntries)))
+        {
+            if (Guid.TryParse(token, out var id) && seen.Add(id))
+                ids.Add(id);
+        }
+
+        return ids;
+    }
+
+    internal static async Task<Result> ParseAsync(HttpContext context, CancellationToken ct)
+    {
+        var queryIds = ParseQuery(context);
+        var bodyIds = await ParseBodyAsync(context, ct).ConfigureAwait(false);
+        return new Result(queryIds.Concat(bodyIds).Distinct().ToList());
+    }
+
+    private static async Task<List<Guid>> ParseBodyAsync(HttpContext context, CancellationToken ct)
+    {
+        try
+        {
+            await using var stream = context.Request.Body;
+            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(stream, cancellationToken: ct)
+                .ConfigureAwait(false);
+            return deserialized?.NzoIds ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private class RequestBody
+    {
+        [JsonPropertyName("nzo_ids")]
+        public List<Guid> NzoIds { get; set; } = [];
+    }
+}

--- a/backend/Api/SabControllers/SabNzoIdsParser.cs
+++ b/backend/Api/SabControllers/SabNzoIdsParser.cs
@@ -35,12 +35,12 @@ internal static class SabNzoIdsParser
     {
         try
         {
-            await using var stream = context.Request.Body;
-            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(stream, cancellationToken: ct)
+            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(
+                    context.Request.Body, cancellationToken: ct)
                 .ConfigureAwait(false);
             return deserialized?.NzoIds ?? [];
         }
-        catch
+        catch (JsonException)
         {
             return [];
         }

--- a/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryController.cs
+++ b/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryController.cs
@@ -20,10 +20,10 @@ public class SetQueueCategoryController(
         if (request.NzoIds.Count == 0)
             return new SetQueueCategoryResponse { Status = true };
 
-        await queueManager.SetQueueItemsCategoryAsync(
+        var updatedIds = await queueManager.SetQueueItemsCategoryAsync(
             request.NzoIds, request.Category, dbClient, request.CancellationToken).ConfigureAwait(false);
 
-        foreach (var id in request.NzoIds)
+        foreach (var id in updatedIds)
             _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{id}|Queued");
 
         return new SetQueueCategoryResponse { Status = true };

--- a/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryController.cs
+++ b/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.SabControllers.SetQueueCategory;
+
+public class SetQueueCategoryController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    QueueManager queueManager,
+    WebsocketManager websocketManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<SetQueueCategoryResponse> SetCategory(SetQueueCategoryRequest request)
+    {
+        if (request.NzoIds.Count == 0)
+            return new SetQueueCategoryResponse { Status = true };
+
+        await queueManager.SetQueueItemsCategoryAsync(
+            request.NzoIds, request.Category, dbClient, request.CancellationToken).ConfigureAwait(false);
+
+        foreach (var id in request.NzoIds)
+            _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{id}|Queued");
+
+        return new SetQueueCategoryResponse { Status = true };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        var request = await SetQueueCategoryRequest.New(Context, Config).ConfigureAwait(false);
+        return Ok(await SetCategory(request).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryRequest.cs
+++ b/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryRequest.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.SabControllers.SetQueueCategory;
+
+public class SetQueueCategoryRequest
+{
+    public List<Guid> NzoIds { get; init; } = [];
+    public string Category { get; init; } = null!;
+    public CancellationToken CancellationToken { get; init; }
+
+    public static async Task<SetQueueCategoryRequest> New(HttpContext httpContext, ConfigManager configManager)
+    {
+        var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
+            .ConfigureAwait(false);
+        var category = httpContext.GetRequestParam("cat")
+                       ?? httpContext.GetRequestParam("category");
+        if (string.IsNullOrWhiteSpace(category))
+            throw new BadHttpRequestException("Missing cat/category param.");
+
+        var allowed = configManager.GetApiCategories();
+        if (!allowed.Contains(category, StringComparer.OrdinalIgnoreCase))
+            throw new BadHttpRequestException("Invalid category.");
+
+        return new SetQueueCategoryRequest
+        {
+            NzoIds = parsed.NzoIds,
+            Category = category,
+            CancellationToken = SigtermUtil.GetCancellationToken(),
+        };
+    }
+}

--- a/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryResponse.cs
+++ b/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryResponse.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Api.SabControllers.SetQueueCategory;
+
+public class SetQueueCategoryResponse : SabBaseResponse
+{
+}

--- a/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityController.cs
+++ b/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.SabControllers.SetQueuePriority;
+
+public class SetQueuePriorityController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    QueueManager queueManager,
+    WebsocketManager websocketManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<SetQueuePriorityResponse> SetPriority(SetQueuePriorityRequest request)
+    {
+        if (request.NzoIds.Count == 0)
+            return new SetQueuePriorityResponse { Status = true };
+
+        await queueManager.SetQueueItemsPriorityAsync(
+            request.NzoIds, request.Priority, dbClient, request.CancellationToken).ConfigureAwait(false);
+
+        var status = request.Priority == QueueItem.PriorityOption.Paused ? "Paused" : "Queued";
+        foreach (var id in request.NzoIds)
+            _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{id}|{status}");
+
+        return new SetQueuePriorityResponse { Status = true };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        var request = await SetQueuePriorityRequest.New(Context).ConfigureAwait(false);
+        return Ok(await SetPriority(request).ConfigureAwait(false));
+    }
+}

--- a/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityRequest.cs
+++ b/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityRequest.cs
@@ -17,7 +17,8 @@ public class SetQueuePriorityRequest
     {
         var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
             .ConfigureAwait(false);
-        var priority = AddFileRequest.MapPriorityOption(httpContext.GetRequestParam("value2"));
+        var priority = AddFileRequest.MapPriorityOption(
+            httpContext.GetRequestParam("value2") ?? httpContext.GetRequestParam("priority"));
         return new SetQueuePriorityRequest
         {
             NzoIds = parsed.NzoIds,

--- a/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityRequest.cs
+++ b/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityRequest.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.SabControllers.SetQueuePriority;
+
+public class SetQueuePriorityRequest
+{
+    public List<Guid> NzoIds { get; init; } = [];
+    public QueueItem.PriorityOption Priority { get; init; }
+    public CancellationToken CancellationToken { get; init; }
+
+    public static async Task<SetQueuePriorityRequest> New(HttpContext httpContext)
+    {
+        var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
+            .ConfigureAwait(false);
+        var priority = AddFileRequest.MapPriorityOption(httpContext.GetRequestParam("value2"));
+        return new SetQueuePriorityRequest
+        {
+            NzoIds = parsed.NzoIds,
+            Priority = priority,
+            CancellationToken = SigtermUtil.GetCancellationToken(),
+        };
+    }
+}

--- a/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityResponse.cs
+++ b/backend/Api/SabControllers/SetQueuePriority/SetQueuePriorityResponse.cs
@@ -1,0 +1,5 @@
+namespace NzbWebDAV.Api.SabControllers.SetQueuePriority;
+
+public class SetQueuePriorityResponse : SabBaseResponse
+{
+}

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -294,12 +294,22 @@ public sealed class QueueManager : IDisposable
 
         await LockAsync(async () =>
         {
-            await dbClient.Ctx.QueueItems
-                .Where(item => queueItemIds.Contains(item.Id))
-                .ExecuteUpdateAsync(
+            var update = dbClient.Ctx.QueueItems
+                .Where(item => queueItemIds.Contains(item.Id));
+            if (priority != QueueItem.PriorityOption.Paused)
+            {
+                await update.ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(q => q.Priority, priority)
+                        .SetProperty(q => q.PauseUntil, (DateTime?)null),
+                    ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await update.ExecuteUpdateAsync(
                     s => s.SetProperty(q => q.Priority, priority),
-                    ct)
-                .ConfigureAwait(false);
+                    ct).ConfigureAwait(false);
+            }
         }, ct).ConfigureAwait(false);
 
         if (priority == QueueItem.PriorityOption.Paused)
@@ -308,17 +318,17 @@ public sealed class QueueManager : IDisposable
         AwakenQueue();
     }
 
-    public async Task SetQueueItemsCategoryAsync(
+    public async Task<List<Guid>> SetQueueItemsCategoryAsync(
         List<Guid> queueItemIds,
         string category,
         DavDatabaseClient dbClient,
         CancellationToken ct = default)
     {
-        if (queueItemIds.Count == 0) return;
+        if (queueItemIds.Count == 0) return [];
 
         var inProgressIds = _inProgress.Keys.ToHashSet();
         var eligibleIds = queueItemIds.Where(id => !inProgressIds.Contains(id)).ToList();
-        if (eligibleIds.Count == 0) return;
+        if (eligibleIds.Count == 0) return [];
 
         await LockAsync(async () =>
         {
@@ -329,6 +339,8 @@ public sealed class QueueManager : IDisposable
                     ct)
                 .ConfigureAwait(false);
         }, ct).ConfigureAwait(false);
+
+        return eligibleIds;
     }
 
     private async Task CancelInProgressQueueItemsAsync(List<Guid> queueItemIds, CancellationToken ct)

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Config;
@@ -238,6 +239,126 @@ public sealed class QueueManager : IDisposable
             foreach (var id in queueItemIds) _retryAttempts.TryRemove(id, out _);
         }, ct).ConfigureAwait(false);
     }
+
+
+    public async Task PauseQueueItemsAsync(
+        List<Guid> queueItemIds,
+        DavDatabaseClient dbClient,
+        CancellationToken ct = default)
+    {
+        if (queueItemIds.Count == 0) return;
+
+        await LockAsync(async () =>
+        {
+            await dbClient.Ctx.QueueItems
+                .Where(item => queueItemIds.Contains(item.Id))
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(q => q.Priority, QueueItem.PriorityOption.Paused),
+                    ct)
+                .ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+
+        await CancelInProgressQueueItemsAsync(queueItemIds, ct).ConfigureAwait(false);
+        AwakenQueue();
+    }
+
+    public async Task ResumeQueueItemsAsync(
+        List<Guid> queueItemIds,
+        DavDatabaseClient dbClient,
+        CancellationToken ct = default)
+    {
+        if (queueItemIds.Count == 0) return;
+
+        await LockAsync(async () =>
+        {
+            await dbClient.Ctx.QueueItems
+                .Where(item => queueItemIds.Contains(item.Id))
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(q => q.Priority, QueueItem.PriorityOption.Normal)
+                        .SetProperty(q => q.PauseUntil, (DateTime?)null),
+                    ct)
+                .ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+
+        AwakenQueue();
+    }
+
+    public async Task SetQueueItemsPriorityAsync(
+        List<Guid> queueItemIds,
+        QueueItem.PriorityOption priority,
+        DavDatabaseClient dbClient,
+        CancellationToken ct = default)
+    {
+        if (queueItemIds.Count == 0) return;
+
+        await LockAsync(async () =>
+        {
+            await dbClient.Ctx.QueueItems
+                .Where(item => queueItemIds.Contains(item.Id))
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(q => q.Priority, priority),
+                    ct)
+                .ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+
+        if (priority == QueueItem.PriorityOption.Paused)
+            await CancelInProgressQueueItemsAsync(queueItemIds, ct).ConfigureAwait(false);
+
+        AwakenQueue();
+    }
+
+    public async Task SetQueueItemsCategoryAsync(
+        List<Guid> queueItemIds,
+        string category,
+        DavDatabaseClient dbClient,
+        CancellationToken ct = default)
+    {
+        if (queueItemIds.Count == 0) return;
+
+        var inProgressIds = _inProgress.Keys.ToHashSet();
+        var eligibleIds = queueItemIds.Where(id => !inProgressIds.Contains(id)).ToList();
+        if (eligibleIds.Count == 0) return;
+
+        await LockAsync(async () =>
+        {
+            await dbClient.Ctx.QueueItems
+                .Where(item => eligibleIds.Contains(item.Id))
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(q => q.Category, category),
+                    ct)
+                .ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+    }
+
+    private async Task CancelInProgressQueueItemsAsync(List<Guid> queueItemIds, CancellationToken ct)
+    {
+        if (queueItemIds.Count == 0) return;
+
+        List<InProgressQueueItem> toCancel = [];
+        await LockAsync(() =>
+        {
+            toCancel = _inProgress.Values
+                .Where(x => queueItemIds.Contains(x.QueueItem.Id))
+                .ToList();
+        }, ct).ConfigureAwait(false);
+
+        foreach (var item in toCancel)
+        {
+            try
+            {
+                await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+                await item.ProcessingTask.ConfigureAwait(false);
+            }
+#pragma warning disable CA2016
+            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+            {
+                Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
+            }
+        }
+    }
+
 
     internal async Task ProcessQueueAsync(CancellationToken ct)
     {

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -6,15 +6,26 @@ InfiniDysk implements the SABnzbd-compatible operations used by Sonarr, Radarr, 
 
 - `version`, `status`, `fullstatus`, `get_config`, and `get_cats`
 - `addfile` and `addurl`
-- `queue` listing and `queue&name=delete`
+- `queue` listing and `queue&name=delete`, `queue&name=pause`, `queue&name=resume`, `queue&name=priority`, and `queue&name=move`
 - `pause` / `resume` (also `queue&name=pause` / `queue&name=resume`) and `speedlimit` [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
+- `change_cat` for per-job category changes on queued items
+- `retry` for failed history re-queue (single or bulk) [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
 - `history` listing and `history&name=delete`
 
 Queue and history filters accept both `cat` and `category`. The default category sentinel returned by `get_cats` is `*`.
 
 ## Pause, resume, and speed limit [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
 
-`mode=pause` / `mode=resume` stop and restart **new** queue dequeues. Workers already downloading finish naturally. WebDAV mounts keep serving — pause does not interrupt playback. Queue JSON reports `paused` accurately. Items added with SAB priority `-2` (Paused) are skipped until their priority changes; queue slots report `status: Paused` for those jobs.
+`mode=pause` / `mode=resume` stop and restart **new** queue dequeues. Workers already downloading finish naturally unless a per-job pause cancels them. WebDAV mounts keep serving — pause does not interrupt playback. Queue JSON reports `paused` accurately. Items added with SAB priority `-2` (Paused) are skipped until their priority changes; queue slots report `status: Paused` for those jobs.
+
+
+Per-job pause and resume accept UUID(s) via `value` (comma-separated or repeated) or a JSON body `{"nzo_ids":["…"]}` on `mode=pause`, `mode=resume`, and the `queue&name=pause` / `queue&name=resume` aliases. Without ids, pause/resume applies to the whole queue coordinator (legacy global behavior).
+
+`mode=queue&name=priority` sets priority for one or more jobs. Pass the SAB priority code as `value2` (or `priority`): `-2` Paused, `-1` Low, `0` Normal, `1` High, `2` Force. Paused uses the same per-job pause path as `queue&name=pause`.
+
+`mode=change_cat` sets category for queued jobs (not actively downloading). Pass `cat` / `category` plus job id(s) in `value` or `nzo_ids`. Categories must match configured API categories.
+
+`mode=retry` re-queues failed history items. Accepts a single `value` id or multiple ids (comma-separated / repeated `value`, or `nzo_ids` JSON). Bulk retry returns `nzo_ids` for successes and a `failed` array with per-item errors when some items cannot be retried. History bulk actions in the admin UI do not change category on retry (category is copied from the history row).
 
 `mode=speedlimit` is **accepted and stored** and reflected in queue JSON (`speedlimit` / `speedlimit_abs`). Byte-accurate download throttling is **not** enforced yet — that work is tracked in [#375](https://github.com/infinidysk/infinidysk/issues/375).
 
@@ -46,8 +57,8 @@ The same allowlist can be set with `TRUSTED_INTERNAL_HOSTS` when the UI setting 
 
 ## Delete behavior
 
-Queue delete accepts UUID(s), repeated `value` parameters, or `value=all`. SAB `del_files=1` has no extra effect (no incomplete-download directory).
+Queue delete accepts UUID(s), repeated `value` parameters, `value=all`, or `value=all` with `cat` / `category` to clear only that category. SAB `del_files=1` has no extra effect (no incomplete-download directory).
 
-History delete accepts UUIDs, `value=all`, or `value=failed`. The admin UI can delete mounted content for completed jobs with InfiniDysk-specific `del_completed_files=1` — download clients should **not** send this after importing a symlink/STRM, or playback sources disappear.
+History delete accepts UUIDs, `value=all`, or `value=failed`. The admin UI can delete mounted content for completed jobs with InfiniDysk-specific `del_completed_files=1` — download clients should **not** send this after importing a symlink/STRM, or playback sources disappear. The history UI also offers **Clear failed** and **Clear all** actions that call `history&name=delete` with `value=failed` or `value=all`.
 
 [SABnzbd settings](../configuration/sabnzbd.md)

--- a/frontend/app/routes/queue/components/action-button/action-button.tsx
+++ b/frontend/app/routes/queue/components/action-button/action-button.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Button, Icon } from "~/components/ui";
 
 export type ActionButtonProps = {
-    type: "delete" | "explore" | "menu" | "move-top" | "retry",
+    type: "delete" | "explore" | "menu" | "move-top" | "retry" | "pause" | "resume",
     text?: string,
     disabled?: boolean,
     selected?: boolean,
@@ -15,6 +15,8 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
         : type === "explore" ? "folder"
         : type === "move-top" ? "vertical_align_top"
         : type === "retry" ? "refresh"
+        : type === "pause" ? "pause"
+        : type === "resume" ? "play_arrow"
         : "more_horiz";
 
     return (
@@ -23,7 +25,7 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
             size="xsmall"
             disabled={disabled}
             aria-pressed={type === "menu" ? selected : undefined}
-            aria-label={!text ? (type === "move-top" ? "Move to top" : type === "retry" ? "Retry" : type) : undefined}
+            aria-label={!text ? (type === "move-top" ? "Move to top" : type === "retry" ? "Retry" : type === "pause" ? "Pause" : type === "resume" ? "Resume" : type) : undefined}
             className={`${type === "menu" ? "w-[30px] px-1" : ""} ${selected ? "bg-base-content/20 text-base-content" : ""}`}
             onClick={onClick}
         >

--- a/frontend/app/routes/queue/components/history-table/history-retry.ts
+++ b/frontend/app/routes/queue/components/history-table/history-retry.ts
@@ -44,3 +44,62 @@ export async function retryHistoryItem(
         return { ok: false, error: "Failed to retry history item." };
     }
 }
+
+
+export type BulkHistoryRetryResult = {
+    ok: boolean;
+    succeeded: string[];
+    failed: Array<{ nzoId: string; error: string }>;
+};
+
+export async function retryHistoryItems(
+    nzoIds: string[],
+    fetchImpl: typeof fetch = fetch,
+): Promise<BulkHistoryRetryResult> {
+    if (nzoIds.length === 0) {
+        return { ok: false, succeeded: [], failed: [] };
+    }
+
+    try {
+        const response = await fetchImpl("/api?mode=retry", {
+            method: "POST",
+            headers: { "Content-Type": "application/json;charset=UTF-8" },
+            body: JSON.stringify({ nzo_ids: nzoIds }),
+        });
+        let data: {
+            status?: boolean;
+            error?: string;
+            nzo_ids?: string[];
+            failed?: Array<{ nzo_id: string; error: string }>;
+        } | null = null;
+        try {
+            data = await response.json();
+        } catch {
+            data = null;
+        }
+
+        const succeeded = data?.nzo_ids ?? [];
+        const failed = (data?.failed ?? []).map((item) => ({
+            nzoId: item.nzo_id,
+            error: item.error,
+        }));
+
+        if (response.ok && data?.status === true) {
+            return { ok: true, succeeded, failed };
+        }
+
+        return {
+            ok: false,
+            succeeded,
+            failed: failed.length > 0
+                ? failed
+                : [{ nzoId: nzoIds[0]!, error: data?.error || "Failed to retry history items." }],
+        };
+    } catch {
+        return {
+            ok: false,
+            succeeded: [],
+            failed: [{ nzoId: nzoIds[0]!, error: "Failed to retry history items." }],
+        };
+    }
+}

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -215,9 +215,6 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
     const isReadOnly = useIsReadOnly();
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
-    const [isConfirmingClearFailed, setIsConfirmingClearFailed] = useState(false);
-    const [isConfirmingClearAll, setIsConfirmingClearAll] = useState(false);
-    const [bulkRetryError, setBulkRetryError] = useState<string | null>(null);
     const [isRetrying, setIsRetrying] = useState(false);
     const [retryError, setRetryError] = useState<string | null>(null);
 

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -10,8 +10,9 @@ import { PageSection } from "../page-section/page-section"
 import { Pagination } from "../pagination/pagination"
 import { DropdownOptions } from "~/routes/explore/dropdown-options/dropdown-options"
 import { ExportNzb, Remove } from "~/routes/explore/item-menu/item-menu"
-import { canRetryHistorySlot, retryHistoryItem, shouldAcceptRetryClick } from "./history-retry"
+import { canRetryHistorySlot, retryHistoryItem, retryHistoryItems, shouldAcceptRetryClick } from "./history-retry"
 import { useIsReadOnly } from "~/auth/authorization"
+import { Button, Tooltip } from "~/components/ui"
 
 export type HistoryTableProps = {
     historySlots: PresentationHistorySlot[],
@@ -44,8 +45,41 @@ export function HistoryTable({
 }: HistoryTableProps) {
     const isReadOnly = useIsReadOnly();
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
+    const [isConfirmingClearFailed, setIsConfirmingClearFailed] = useState(false);
+    const [isConfirmingClearAll, setIsConfirmingClearAll] = useState(false);
+    const [bulkRetryError, setBulkRetryError] = useState<string | null>(null);
     const selectedCount = historySlots.filter(x => !!x.isSelected).length;
     const headerCheckboxState: TriCheckboxState = selectedCount === 0 ? 'none' : selectedCount === historySlots.length ? 'all' : 'some';
+
+
+    const selectedRetryableIds = historySlots
+        .filter(x => !!x.isSelected && canRetryHistorySlot(x))
+        .map(x => x.nzo_id);
+
+    const onBulkRetry = useCallback(async () => {
+        if (selectedRetryableIds.length === 0) return;
+        setBulkRetryError(null);
+        const result = await retryHistoryItems(selectedRetryableIds);
+        if (!result.ok) {
+            setBulkRetryError(result.failed[0]?.error ?? "Failed to retry history items.");
+        }
+    }, [selectedRetryableIds]);
+
+    const onConfirmClearFailed = useCallback(async (deleteCompletedFiles?: boolean) => {
+        setIsConfirmingClearFailed(false);
+        try {
+            const url = `/api?mode=history&name=delete&value=failed&del_completed_files=${deleteCompletedFiles ? 1 : 0}`;
+            await fetch(url, { method: "POST" });
+        } catch { /* best effort */ }
+    }, []);
+
+    const onConfirmClearAllHistory = useCallback(async (deleteCompletedFiles?: boolean) => {
+        setIsConfirmingClearAll(false);
+        try {
+            const url = `/api?mode=history&name=delete&value=all&del_completed_files=${deleteCompletedFiles ? 1 : 0}`;
+            await fetch(url, { method: "POST" });
+        } catch { /* best effort */ }
+    }, []);
 
     const onSelectAll = useCallback((isSelected: boolean) => {
         onIsSelectedChanged(new Set<string>(historySlots.map(x => x.nzo_id)), isSelected);
@@ -84,11 +118,25 @@ export function HistoryTable({
     }, [historySlots, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
     const sectionTitle = (
-        <div className="flex items-center gap-2.5">
+        <div className="flex flex-wrap items-center gap-2.5">
             <h2 className="text-xl font-semibold text-base-content">History</h2>
-            {!isReadOnly && headerCheckboxState !== 'none' &&
-                <ActionButton type="delete" onClick={onRemove} />
+            {!isReadOnly && totalHistoryCount > 0 &&
+                <>
+                    <Button variant="secondary" size="xsmall" onClick={() => setIsConfirmingClearFailed(true)}>Clear failed</Button>
+                    <Button variant="secondary" size="xsmall" onClick={() => setIsConfirmingClearAll(true)}>Clear all</Button>
+                </>
             }
+            {!isReadOnly && headerCheckboxState !== 'none' &&
+                <>
+                    {selectedRetryableIds.length > 0 &&
+                        <Tooltip content="Retry selected failed items">
+                            <ActionButton type="retry" onClick={onBulkRetry} />
+                        </Tooltip>
+                    }
+                    <ActionButton type="delete" onClick={onRemove} />
+                </>
+            }
+            {bulkRetryError && <span className="text-xs text-error">{bulkRetryError}</span>}
         </div>
     );
 
@@ -137,6 +185,20 @@ export function HistoryTable({
                 checkboxMessage="Delete mounted files"
                 onConfirm={onConfirmRemoval}
                 onCancel={onCancelRemoval} />
+            <ConfirmModal
+                show={isConfirmingClearFailed}
+                title="Clear failed history?"
+                message="All failed history items will be removed."
+                checkboxMessage="Delete mounted files"
+                onConfirm={onConfirmClearFailed}
+                onCancel={() => setIsConfirmingClearFailed(false)} />
+            <ConfirmModal
+                show={isConfirmingClearAll}
+                title="Clear all history?"
+                message="All history items will be removed."
+                checkboxMessage="Delete mounted files"
+                onConfirm={onConfirmClearAllHistory}
+                onCancel={() => setIsConfirmingClearAll(false)} />
         </PageSection>
     );
 }
@@ -153,6 +215,9 @@ export function HistoryRow({ slot, onIsSelectedChanged, onIsRemovingChanged, onR
     const isReadOnly = useIsReadOnly();
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
+    const [isConfirmingClearFailed, setIsConfirmingClearFailed] = useState(false);
+    const [isConfirmingClearAll, setIsConfirmingClearAll] = useState(false);
+    const [bulkRetryError, setBulkRetryError] = useState<string | null>(null);
     const [isRetrying, setIsRetrying] = useState(false);
     const [retryError, setRetryError] = useState<string | null>(null);
 

--- a/frontend/app/routes/queue/components/queue-table/queue-bulk-actions.test.ts
+++ b/frontend/app/routes/queue/components/queue-table/queue-bulk-actions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildClearQueueUrl,
+    buildQueuePauseResumeUrl,
+    canPauseQueueSlot,
+    canResumeQueueSlot,
+} from "./queue-bulk-actions";
+
+describe("queue-bulk-actions", () => {
+    it("canPauseQueueSlot excludes paused and uploading rows", () => {
+        expect(canPauseQueueSlot({ status: "Queued" })).toBe(true);
+        expect(canPauseQueueSlot({ status: "Paused" })).toBe(false);
+        expect(canPauseQueueSlot({ status: "Queued", isUploading: true })).toBe(false);
+    });
+
+    it("canResumeQueueSlot only allows paused rows", () => {
+        expect(canResumeQueueSlot({ status: "Paused" })).toBe(true);
+        expect(canResumeQueueSlot({ status: "Queued" })).toBe(false);
+    });
+
+    it("buildClearQueueUrl adds category when provided", () => {
+        expect(buildClearQueueUrl()).toBe("/api?mode=queue&name=delete&value=all");
+        expect(buildClearQueueUrl("tv")).toBe("/api?mode=queue&name=delete&value=all&cat=tv");
+    });
+
+    it("buildQueuePauseResumeUrl uses queue name aliases", () => {
+        expect(buildQueuePauseResumeUrl("pause")).toBe("/api?mode=queue&name=pause");
+    });
+});

--- a/frontend/app/routes/queue/components/queue-table/queue-bulk-actions.ts
+++ b/frontend/app/routes/queue/components/queue-table/queue-bulk-actions.ts
@@ -1,0 +1,74 @@
+export type QueueBulkSlot = {
+    status: string;
+    isUploading?: boolean;
+    isRemoving?: boolean;
+};
+
+export function canPauseQueueSlot(slot: QueueBulkSlot): boolean {
+    return !slot.isUploading && slot.status !== "Paused" && !slot.isRemoving;
+}
+
+export function canResumeQueueSlot(slot: QueueBulkSlot): boolean {
+    return !slot.isUploading && slot.status === "Paused" && !slot.isRemoving;
+}
+
+export function buildClearQueueUrl(category?: string): string {
+    const base = "/api?mode=queue&name=delete&value=all";
+    if (!category) return base;
+    return `${base}&cat=${encodeURIComponent(category)}`;
+}
+
+export function buildQueuePauseResumeUrl(action: "pause" | "resume"): string {
+    return `/api?mode=queue&name=${action}`;
+}
+
+export function buildSetQueuePriorityUrl(priority: string): string {
+    return `/api?mode=queue&name=priority&value2=${encodeURIComponent(priority)}`;
+}
+
+export function buildSetQueueCategoryUrl(category: string): string {
+    return `/api?mode=change_cat&cat=${encodeURIComponent(category)}`;
+}
+
+async function postQueueIds(url: string, nzoIds: string[]): Promise<boolean> {
+    if (nzoIds.length === 0) return false;
+    try {
+        const response = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json;charset=UTF-8" },
+            body: JSON.stringify({ nzo_ids: nzoIds }),
+        });
+        if (!response.ok) return false;
+        const data = await response.json();
+        return data.status === true;
+    } catch {
+        return false;
+    }
+}
+
+export function postQueuePause(nzoIds: string[]): Promise<boolean> {
+    return postQueueIds(buildQueuePauseResumeUrl("pause"), nzoIds);
+}
+
+export function postQueueResume(nzoIds: string[]): Promise<boolean> {
+    return postQueueIds(buildQueuePauseResumeUrl("resume"), nzoIds);
+}
+
+export function postQueuePriority(nzoIds: string[], priority: string): Promise<boolean> {
+    return postQueueIds(buildSetQueuePriorityUrl(priority), nzoIds);
+}
+
+export function postQueueCategory(nzoIds: string[], category: string): Promise<boolean> {
+    return postQueueIds(buildSetQueueCategoryUrl(category), nzoIds);
+}
+
+export async function postClearQueue(category?: string): Promise<boolean> {
+    try {
+        const response = await fetch(buildClearQueueUrl(category), { method: "POST" });
+        if (!response.ok) return false;
+        const data = await response.json();
+        return data.status === true;
+    } catch {
+        return false;
+    }
+}

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -8,8 +8,17 @@ import { PageSection } from "../page-section/page-section"
 import { Pagination } from "../pagination/pagination"
 import { EmptyQueue } from "../empty-queue/empty-queue"
 import { SimpleDropdown } from "../simple-dropdown/simple-dropdown"
-import { Tooltip } from "~/components/ui"
+import { Button, Tooltip } from "~/components/ui"
 import { useIsReadOnly } from "~/auth/authorization"
+import {
+    canPauseQueueSlot,
+    canResumeQueueSlot,
+    postClearQueue,
+    postQueueCategory,
+    postQueuePause,
+    postQueuePriority,
+    postQueueResume,
+} from "./queue-bulk-actions"
 
 export type QueueTableProps = {
     queueSlots: PresentationQueueSlot[],
@@ -69,10 +78,23 @@ export function QueueTable({
 }: QueueTableProps) {
     const isReadOnly = useIsReadOnly();
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
+    const [isConfirmingClearAll, setIsConfirmingClearAll] = useState(false);
+    const [isConfirmingClearCategory, setIsConfirmingClearCategory] = useState(false);
+    const [clearCategory, setClearCategory] = useState(categories[0] ?? "");
+    const [bulkSetCategory, setBulkSetCategory] = useState(categories[0] ?? "");
+    const [bulkPriority, setBulkPriority] = useState("0");
     const selectedCount = queueSlots.filter(x => !!x.isSelected).length;
     const headerCheckboxState: TriCheckboxState = selectedCount === 0 ? 'none' : selectedCount === queueSlots.length ? 'all' : 'some';
     const selectedMovableIds = useMemo(
         () => queueSlots.filter(x => !!x.isSelected && !x.isUploading).map(x => x.nzo_id),
+        [queueSlots],
+    );
+    const selectedPausableIds = useMemo(
+        () => queueSlots.filter(x => !!x.isSelected && canPauseQueueSlot(x)).map(x => x.nzo_id),
+        [queueSlots],
+    );
+    const selectedResumableIds = useMemo(
+        () => queueSlots.filter(x => !!x.isSelected && canResumeQueueSlot(x)).map(x => x.nzo_id),
         [queueSlots],
     );
 
@@ -136,6 +158,38 @@ export function QueueTable({
         onIsRemovingChanged(queued_nzo_ids, false);
     }, [queueSlots, setIsConfirmingRemoval, onIsRemovingChanged, onRemoved]);
 
+
+    const onPauseSelected = useCallback(async () => {
+        if (selectedPausableIds.length === 0) return;
+        await postQueuePause(selectedPausableIds);
+    }, [selectedPausableIds]);
+
+    const onResumeSelected = useCallback(async () => {
+        if (selectedResumableIds.length === 0) return;
+        await postQueueResume(selectedResumableIds);
+    }, [selectedResumableIds]);
+
+    const onSetPrioritySelected = useCallback(async (priority: string) => {
+        if (selectedMovableIds.length === 0) return;
+        await postQueuePriority(selectedMovableIds, priority);
+    }, [selectedMovableIds]);
+
+    const onSetCategorySelected = useCallback(async () => {
+        if (selectedMovableIds.length === 0 || !bulkSetCategory) return;
+        await postQueueCategory(selectedMovableIds, bulkSetCategory);
+    }, [selectedMovableIds, bulkSetCategory]);
+
+    const onConfirmClearAll = useCallback(async () => {
+        setIsConfirmingClearAll(false);
+        await postClearQueue();
+    }, []);
+
+    const onConfirmClearCategory = useCallback(async () => {
+        setIsConfirmingClearCategory(false);
+        if (!clearCategory) return;
+        await postClearQueue(clearCategory);
+    }, [clearCategory]);
+
     const onMoveSelectedToTop = useCallback(async () => {
         if (selectedMovableIds.length === 0) return;
         const ok = await moveQueueItemsToTop(selectedMovableIds);
@@ -153,19 +207,52 @@ export function QueueTable({
     ), [categories, isReadOnly, manualCategoryRef]);
 
     const sectionTitle = (
-        <div className="flex items-center gap-2.5">
+        <div className="flex flex-wrap items-center gap-2.5">
             <h2
                 className={`${isReadOnly ? "" : "cursor-pointer"} text-xl font-semibold text-base-content`}
                 onClick={isReadOnly ? undefined : onUploadClicked}
             >
                 Queue
             </h2>
+            {!isReadOnly && totalQueueCount > 0 &&
+                <>
+                    <Button variant="secondary" size="xsmall" onClick={() => setIsConfirmingClearAll(true)}>Clear all</Button>
+                    {categories.length > 0 &&
+                        <>
+                            <SimpleDropdown options={categories} value={clearCategory} onChange={setClearCategory} />
+                            <Button variant="secondary" size="xsmall" onClick={() => setIsConfirmingClearCategory(true)}>Clear category</Button>
+                        </>
+                    }
+                </>
+            }
             {!isReadOnly && headerCheckboxState !== 'none' &&
                 <>
+                    {selectedPausableIds.length > 0 &&
+                        <Tooltip content="Pause selected">
+                            <ActionButton type="pause" onClick={onPauseSelected} />
+                        </Tooltip>
+                    }
+                    {selectedResumableIds.length > 0 &&
+                        <Tooltip content="Resume selected">
+                            <ActionButton type="resume" onClick={onResumeSelected} />
+                        </Tooltip>
+                    }
                     {selectedMovableIds.length > 0 &&
                         <Tooltip content="Move selected to top of queue">
                             <ActionButton type="move-top" onClick={onMoveSelectedToTop} />
                         </Tooltip>
+                    }
+                    {selectedMovableIds.length > 0 && categories.length > 0 &&
+                        <>
+                            <SimpleDropdown options={categories} value={bulkSetCategory} onChange={setBulkSetCategory} />
+                            <Button variant="secondary" size="xsmall" onClick={onSetCategorySelected}>Set category</Button>
+                        </>
+                    }
+                    {selectedMovableIds.length > 0 &&
+                        <>
+                            <SimpleDropdown options={["-1", "0", "1", "2"]} value={bulkPriority} onChange={setBulkPriority} />
+                            <Button variant="secondary" size="xsmall" onClick={() => onSetPrioritySelected(bulkPriority)}>Set priority</Button>
+                        </>
                     }
                     <ActionButton type="delete" onClick={onRemove} />
                 </>
@@ -231,6 +318,18 @@ export function QueueTable({
                 message={`${selectedCount} item(s) will be removed`}
                 onConfirm={onConfirmRemoval}
                 onCancel={onCancelRemoval} />
+            <ConfirmModal
+                show={isConfirmingClearAll}
+                title="Clear entire queue?"
+                message="All queued items will be removed. In-progress downloads will be cancelled."
+                onConfirm={onConfirmClearAll}
+                onCancel={() => setIsConfirmingClearAll(false)} />
+            <ConfirmModal
+                show={isConfirmingClearCategory}
+                title="Clear category?"
+                message={`All items in category "${clearCategory}" will be removed.`}
+                onConfirm={onConfirmClearCategory}
+                onCancel={() => setIsConfirmingClearCategory(false)} />
         </PageSection>
     );
 }

--- a/tests/NzbWebDAV.Tests/Api/CategoryScopedQueueDeleteTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/CategoryScopedQueueDeleteTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.RemoveFromQueue;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class CategoryScopedQueueDeleteTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-cat-del-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+
+        _context.QueueItems.AddRange(
+            CreateItem("tv", "a.nzb"),
+            CreateItem("movies", "b.nzb"),
+            CreateItem("tv", "three.nzb"));
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { }
+    }
+
+    [Fact]
+    public async Task RemoveFromQueueRequest_AllWithCategory_FiltersCategory()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?value=all&cat=tv");
+        context.Request.Body = Stream.Null;
+
+        var request = await RemoveFromQueueRequest.New(context);
+
+        Assert.True(request.DeleteAll);
+        Assert.Equal("tv", request.Category);
+    }
+
+    private static QueueItem CreateItem(string category, string fileName) => new()
+    {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        FileName = fileName,
+        JobName = category,
+        NzbFileSize = 1,
+        TotalSegmentBytes = 1,
+        Category = category,
+        Priority = QueueItem.PriorityOption.Normal,
+        PostProcessing = QueueItem.PostProcessingOption.None,
+    };
+}

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -95,10 +95,10 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         var historyId = Guid.NewGuid();
         await SeedFailedHistoryAsync(historyId, fileName, category, writeBlob: true);
 
-        var response = await CreateController().RetryHistoryAsync(CreateRequest(historyId));
+        var response = await CreateController().RetryHistoryAsync(await CreateRequest(historyId));
 
         Assert.True(response.Status);
-        var newId = Guid.Parse(response.NzoId);
+        var newId = Guid.Parse(response.NzoId!);
         Assert.NotEqual(historyId, newId);
 
         Assert.NotNull(await _context.HistoryItems.AsNoTracking()
@@ -118,8 +118,9 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         var historyId = Guid.NewGuid();
         await SeedFailedHistoryAsync(historyId, "Missing.Blob.nzb", "tv", writeBlob: false);
 
+        var request = await CreateRequest(historyId);
         var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
-            () => CreateController().RetryHistoryAsync(CreateRequest(historyId)));
+            () => CreateController().RetryHistoryAsync(request));
         Assert.Equal("The NZB file could not be found.", ex.Message);
         Assert.Empty(await _context.QueueItems.AsNoTracking().ToListAsync());
     }
@@ -135,8 +136,9 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
             HistoryItem.DownloadStatusOption.Completed,
             writeBlob: true);
 
+        var request = await CreateRequest(historyId);
         var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
-            () => CreateController().RetryHistoryAsync(CreateRequest(historyId)));
+            () => CreateController().RetryHistoryAsync(request));
         Assert.Equal("Only failed history items can be retried.", ex.Message);
         Assert.Empty(await _context.QueueItems.AsNoTracking().ToListAsync());
     }
@@ -144,27 +146,30 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
     [Fact]
     public async Task RetryHistoryAsync_UnknownId_ThrowsBadRequest()
     {
+        var request = await CreateRequest(Guid.NewGuid());
         var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
-            () => CreateController().RetryHistoryAsync(CreateRequest(Guid.NewGuid())));
+            () => CreateController().RetryHistoryAsync(request));
         Assert.Equal("History item not found.", ex.Message);
     }
 
     [Fact]
-    public void RetryHistoryRequest_MalformedValue_ThrowsBadRequest()
+    public async Task RetryHistoryRequest_MalformedValue_ThrowsBadRequest()
     {
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?value=not-a-guid");
+        context.Request.Body = Stream.Null;
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
+        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
         Assert.Equal("Missing or invalid value (nzo_id).", ex.Message);
     }
 
     [Fact]
-    public void RetryHistoryRequest_MissingValue_ThrowsBadRequest()
+    public async Task RetryHistoryRequest_MissingValue_ThrowsBadRequest()
     {
         var context = new DefaultHttpContext();
+        context.Request.Body = Stream.Null;
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
+        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
         Assert.Equal("Missing or invalid value (nzo_id).", ex.Message);
     }
 
@@ -193,10 +198,10 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
-        var response = await CreateController().RetryHistoryAsync(CreateRequest(historyId));
+        var response = await CreateController().RetryHistoryAsync(await CreateRequest(historyId));
 
         Assert.True(response.Status);
-        var newId = Guid.Parse(response.NzoId);
+        var newId = Guid.Parse(response.NzoId!);
         Assert.NotEqual(existingQueueId, newId);
         Assert.Null(await _context.QueueItems.AsNoTracking()
             .SingleOrDefaultAsync(q => q.Id == existingQueueId));
@@ -204,6 +209,27 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
             .SingleAsync(q => q.Category == category && q.FileName == fileName)).Id);
         Assert.NotNull(await _context.HistoryItems.AsNoTracking()
             .SingleOrDefaultAsync(h => h.Id == historyId));
+    }
+
+
+    [Fact]
+    public async Task RetryHistoryAsync_PartialFailure_ReturnsSucceededAndFailed()
+    {
+        var okId = Guid.NewGuid();
+        var badId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(okId, "Ok.nzb", "tv", writeBlob: true);
+
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?value={okId}&value={badId}");
+        context.Request.Body = Stream.Null;
+        var request = await RetryHistoryRequest.New(context);
+        var response = await CreateController().RetryHistoryAsync(request);
+
+        Assert.True(response.Status);
+        Assert.NotNull(response.NzoIds);
+        Assert.Single(response.NzoIds!);
+        Assert.NotNull(response.Failed);
+        Assert.Single(response.Failed!);
     }
 
     private RetryHistoryController CreateController() =>
@@ -214,11 +240,12 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
             _configManager,
             _websocketManager);
 
-    private static RetryHistoryRequest CreateRequest(Guid nzoId)
+    private static async Task<RetryHistoryRequest> CreateRequest(Guid nzoId)
     {
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString($"?value={nzoId}");
-        return RetryHistoryRequest.New(context);
+        context.Request.Body = Stream.Null;
+        return await RetryHistoryRequest.New(context);
     }
 
     private Task SeedFailedHistoryAsync(Guid id, string fileName, string category, bool writeBlob) =>

--- a/tests/NzbWebDAV.Tests/Api/SabNzoIdsParsingTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabNzoIdsParsingTests.cs
@@ -1,0 +1,45 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class SabNzoIdsParsingTests
+{
+    [Fact]
+    public void ParseQuery_SplitsCommaSeparatedAndRepeatedValues()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var third = Guid.NewGuid();
+        var context = CreateContext($"?value={first},{second}&value={third}");
+
+        var ids = SabNzoIdsParser.ParseQuery(context);
+
+        Assert.Equal([first, second, third], ids);
+    }
+
+    [Fact]
+    public async Task ParseAsync_MergesQueryAndJsonBody()
+    {
+        var fromQuery = Guid.NewGuid();
+        var fromBody = Guid.NewGuid();
+        var context = CreateContext($"?value={fromQuery}");
+        var json = JsonSerializer.Serialize(new { nzo_ids = new[] { fromBody } });
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        context.Request.ContentType = "application/json";
+
+        var result = await SabNzoIdsParser.ParseAsync(context, CancellationToken.None);
+
+        Assert.Equal([fromQuery, fromBody], result.NzoIds);
+    }
+
+    private static DefaultHttpContext CreateContext(string queryString)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(queryString);
+        context.Request.Body = Stream.Null;
+        return context;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/SabNzoIdsParsingTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabNzoIdsParsingTests.cs
@@ -27,7 +27,8 @@ public class SabNzoIdsParsingTests
         var fromBody = Guid.NewGuid();
         var context = CreateContext($"?value={fromQuery}");
         var json = JsonSerializer.Serialize(new { nzo_ids = new[] { fromBody } });
-        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        await using var body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        context.Request.Body = body;
         context.Request.ContentType = "application/json";
 
         var result = await SabNzoIdsParser.ParseAsync(context, CancellationToken.None);

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -288,6 +288,26 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
         Assert.Equal("Invalid mode", ex.Message);
     }
 
+
+    [Fact]
+    public async Task PerJobPause_SetsPriorityPaused()
+    {
+        var item = CreateQueueItem("job.nzb", QueueItem.PriorityOption.Normal, DateTime.UtcNow);
+        _context.QueueItems.Add(item);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?value={item.Id}");
+        context.Request.Body = Stream.Null;
+        var response = await new PauseController(context, _dbClient, _configManager, _queueManager, _websocketManager)
+            .Pause(await PauseRequest.New(context), CancellationToken.None);
+
+        Assert.True(response.Status);
+        var updated = await _context.QueueItems.AsNoTracking().SingleAsync(q => q.Id == item.Id);
+        Assert.Equal(QueueItem.PriorityOption.Paused, updated.Priority);
+    }
+
     private SabApiController CreateSabApiController(HttpContext httpContext)
     {
         var controller = new SabApiController(
@@ -305,10 +325,10 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
     }
 
     private PauseController CreatePauseController() =>
-        new(new DefaultHttpContext(), _dbClient, _configManager);
+        new(new DefaultHttpContext(), _dbClient, _configManager, _queueManager, _websocketManager);
 
     private ResumeController CreateResumeController() =>
-        new(new DefaultHttpContext(), _dbClient, _configManager, _queueManager);
+        new(new DefaultHttpContext(), _dbClient, _configManager, _queueManager, _websocketManager);
 
     private SpeedLimitController CreateSpeedLimitController() =>
         new(new DefaultHttpContext(), _dbClient, _configManager);

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerPauseResumeTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Queue;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class QueueManagerPauseResumeTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-qm-pr-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        var configManager = new ConfigManager();
+        var websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { }
+    }
+
+    [Fact]
+    public async Task PauseQueueItemsAsync_SetsPausedPriority()
+    {
+        var item = CreateItem();
+        _context.QueueItems.Add(item);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await _queueManager.PauseQueueItemsAsync([item.Id], _dbClient);
+
+        var updated = await _context.QueueItems.AsNoTracking().SingleAsync(q => q.Id == item.Id);
+        Assert.Equal(QueueItem.PriorityOption.Paused, updated.Priority);
+    }
+
+    [Fact]
+    public async Task ResumeQueueItemsAsync_ClearsPauseUntilAndSetsNormal()
+    {
+        var item = CreateItem();
+        item.Priority = QueueItem.PriorityOption.Paused;
+        item.PauseUntil = DateTime.UtcNow.AddHours(1);
+        _context.QueueItems.Add(item);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await _queueManager.ResumeQueueItemsAsync([item.Id], _dbClient);
+
+        var updated = await _context.QueueItems.AsNoTracking().SingleAsync(q => q.Id == item.Id);
+        Assert.Equal(QueueItem.PriorityOption.Normal, updated.Priority);
+        Assert.Null(updated.PauseUntil);
+    }
+
+    private static QueueItem CreateItem() => new()
+    {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        FileName = "test.nzb",
+        JobName = "test",
+        NzbFileSize = 1,
+        TotalSegmentBytes = 1,
+        Category = "tv",
+        Priority = QueueItem.PriorityOption.Normal,
+        PostProcessing = QueueItem.PostProcessingOption.None,
+    };
+}


### PR DESCRIPTION
## Summary

Closes #69

Adds comprehensive bulk operations to the queue and history pages, extending the SABnzbd-compatible API and admin UI well beyond the existing multi-select delete:

- **Per-job pause/resume** via `mode=pause` / `mode=resume` (and `queue&name=pause` / `queue&name=resume`) with UUID(s) in `value` or JSON body `nzo_ids`. Without ids, falls back to legacy global queue pause/resume.
- **Set priority** via `mode=queue&name=priority` with SAB priority codes (`-2` Paused, `-1` Low, `0` Normal, `1` High, `2` Force) in `value2`.
- **Set category** via `mode=change_cat` with `cat`/`category` param, validated against configured API categories. Excludes actively downloading items.
- **Category-scoped queue delete** — `mode=queue&name=delete&value=all&cat=<category>` clears only items matching the specified category.
- **Bulk history retry** — `mode=retry` now accepts multiple ids (comma-separated, repeated `value`, or `nzo_ids` JSON). Returns `nzo_ids` for successes and a `failed` array with per-item errors for partial failures.
- **Shared `SabNzoIdsParser`** extracts and deduplicates NZO ids from query + JSON body, replacing duplicated parsing logic across controllers.

### Frontend

- **Queue page**: Pause/Resume selected, Set category dropdown, Set priority dropdown, Clear all, Clear category — all with confirmation modals and gated by `!isReadOnly`.
- **History page**: Bulk retry (selected failed items), Clear failed, Clear all — with confirmation modals and gated by `!isReadOnly`.

### Backend safety

- Per-item pause sets DB `Priority=Paused` **before** cancelling in-progress workers, ensuring the queue loop cannot re-pick items during the cancel window.
- Category change skips actively downloading items to avoid mid-stream disruption.
- Resume clears `PauseUntil` alongside setting `Priority=Normal`, sends `Queued` websocket update, and calls `AwakenQueue`.

### Docs

- `docs/features/sab-api.md` updated with all new endpoints and behaviors.

## Test plan

- [x] Backend tests pass: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (2473 passed, 9 skipped)
  - `SabNzoIdsParsingTests` — comma-separated, repeated, and JSON body id parsing
  - `SabPauseResumeTests.PerJobPause_SetsPriorityPaused` — per-job pause sets DB priority
  - `QueueManagerPauseResumeTests` — pause sets Paused priority, resume clears PauseUntil and sets Normal
  - `CategoryScopedQueueDeleteTests` — delete-all with category filter
  - `RetryHistoryControllerTests.RetryHistoryAsync_PartialFailure_ReturnsSucceededAndFailed` — bulk retry partial failure
- [x] Frontend tests pass: `cd frontend && npm run typecheck && npm test` (523 passed)
  - `queue-bulk-actions.test.ts` — URL builders, canPause/canResume slot helpers
- [ ] Manual: queue page bulk pause/resume/priority/category/clear-all/clear-category with confirmation modals
- [ ] Manual: history page bulk retry, clear failed, clear all with confirmation modals
- [ ] Manual: all bulk action buttons hidden for read-only sessions
- [ ] Manual: per-job pause cancels active download; resume re-queues it
- [ ] Manual: category change does not affect actively downloading items