### PR TITLE
fix(explore): deleting files from Explore now keeps history, caches, and symlinks consistent

### DIFF
--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -5,13 +5,20 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
+using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Api.Controllers.DeleteWebdavItem;
 
 [ApiController]
 [Route("api/delete-webdav-item")]
-public class DeleteWebdavItemController(DavDatabaseClient dbClient, ConfigManager configManager) : BaseApiController
+public class DeleteWebdavItemController(
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    QueueManager queueManager,
+    WebsocketManager websocketManager
+) : BaseApiController
 {
     protected override async Task<IActionResult> HandleRequest()
     {
@@ -28,12 +35,73 @@ public class DeleteWebdavItemController(DavDatabaseClient dbClient, ConfigManage
 
         var item = await ResolvePathAsync(path, ct).ConfigureAwait(false);
         if (item is null) return NotFound(new BaseApiResponse { Status = false, Error = "Item not found." });
+
+        var rootError = DeleteWebdavItemSupport.ValidateDeletableRoot(item.Path);
+        if (rootError is not null)
+            return BadRequest(new BaseApiResponse { Status = false, Error = rootError });
+
         if (item.IsProtected())
             return StatusCode(403, new BaseApiResponse { Status = false, Error = "Cannot delete protected item." });
 
-        await DeleteRecursiveAsync(item.Id, ct).ConfigureAwait(false);
-        await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-        return Ok(new BaseApiResponse { Status = true });
+        if (DeleteWebdavItemSupport.HasInProgressDownload(
+                item.Path, queueManager.GetInProgressQueueItems()))
+        {
+            return Conflict(new BaseApiResponse
+            {
+                Status = false,
+                Error = "Cannot delete while a matching download is in progress."
+            });
+        }
+
+        var subtree = await dbClient.GetSubtreeForDeleteAsync(item.Id, ct).ConfigureAwait(false);
+        if (subtree.Count == 0)
+            return NotFound(new BaseApiResponse { Status = false, Error = "Item not found." });
+
+        DeletionAuditLog.WarnBulkDelete("api-delete", subtree.Count, $"path={item.Path}");
+        var auditItems = subtree
+            .Select(x => new DavItem { Id = x.Id, Type = x.Type, Path = x.Path })
+            .ToList();
+        DeletionAuditLog.RecordBatch("api-delete", auditItems, "admin delete-webdav-item", item.Id);
+
+        await using var transaction = await dbClient.Ctx.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var subtreeIds = subtree.Select(x => x.Id).ToList();
+            foreach (var batch in subtreeIds.ToBatches(500))
+            {
+                await dbClient.Ctx.Items
+                    .Where(x => batch.Contains(x.Id))
+                    .ExecuteDeleteAsync(ct)
+                    .ConfigureAwait(false);
+            }
+
+            var historyIds = subtree
+                .Where(x => x.HistoryItemId.HasValue)
+                .Select(x => x.HistoryItemId!.Value)
+                .Distinct()
+                .ToList();
+            var prunedHistoryIds = await dbClient
+                .PruneUnreferencedHistoryItemsAsync(historyIds, ct)
+                .ConfigureAwait(false);
+
+            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+
+            if (prunedHistoryIds.Count > 0)
+            {
+                _ = websocketManager.SendMessage(
+                    WebsocketTopic.HistoryItemRemoved,
+                    string.Join(",", prunedHistoryIds));
+            }
+
+            _ = DavDatabaseContext.RcloneVfsForget(auditItems);
+            return Ok(new BaseApiResponse { Status = true });
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct).ConfigureAwait(false);
+            throw;
+        }
     }
 
     private async Task<DavItem?> ResolvePathAsync(string path, CancellationToken ct)
@@ -41,8 +109,6 @@ public class DeleteWebdavItemController(DavDatabaseClient dbClient, ConfigManage
         var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0) return null;
 
-        // Preserve per-segment unescape semantics: a name containing an encoded %2F
-        // must stay inside one segment rather than becoming an extra path separator.
         var absolutePath = "/" + string.Join('/', parts.Select(Uri.UnescapeDataString));
         var byPath = await dbClient.GetItemByPathAsync(absolutePath, ct).ConfigureAwait(false);
         if (byPath is not null) return byPath;
@@ -55,21 +121,5 @@ public class DeleteWebdavItemController(DavDatabaseClient dbClient, ConfigManage
             current = child;
         }
         return current;
-    }
-
-    private async Task DeleteRecursiveAsync(Guid id, CancellationToken ct)
-    {
-        var childIds = await dbClient.Ctx.Items
-            .Where(x => x.ParentId == id)
-            .Select(x => x.Id)
-            .ToListAsync(ct).ConfigureAwait(false);
-        foreach (var childId in childIds)
-            await DeleteRecursiveAsync(childId, ct).ConfigureAwait(false);
-        var item = await dbClient.Ctx.Items.FirstOrDefaultAsync(x => x.Id == id, ct).ConfigureAwait(false);
-        if (item is not null)
-        {
-            DeletionAuditLog.Record("api-delete", item, "admin delete-webdav-item");
-            dbClient.Ctx.Items.Remove(item);
-        }
     }
 }

--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemSupport.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemSupport.cs
@@ -1,0 +1,41 @@
+using NzbWebDAV.Queue;
+
+namespace NzbWebDAV.Api.Controllers.DeleteWebdavItem;
+
+internal static class DeleteWebdavItemSupport
+{
+    public static string? ValidateDeletableRoot(string absolutePath)
+    {
+        var parts = absolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return "Cannot delete the root directory.";
+
+        return parts[0] switch
+        {
+            "content" => null,
+            "nzbs" => "Items under /nzbs can be removed from the Queue page",
+            "completed-symlinks" => "Entries are cleared from the History page",
+            ".ids" => "Internal system view",
+            _ => "Items can only be deleted from under /content",
+        };
+    }
+
+    public static (string? category, string? jobName) TryGetContentJob(string absolutePath)
+    {
+        var parts = absolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 3) return (null, null);
+        if (!string.Equals(parts[0], "content", StringComparison.Ordinal)) return (null, null);
+        return (parts[1], parts[2]);
+    }
+
+    public static bool HasInProgressDownload(
+        string absolutePath,
+        IEnumerable<QueueManager.InProgressQueueItemSnapshot> inProgress)
+    {
+        var (category, jobName) = TryGetContentJob(absolutePath);
+        if (category is null || jobName is null) return false;
+        return inProgress.Any(x =>
+            string.Equals(x.QueueItem.Category, category, StringComparison.Ordinal)
+            && string.Equals(x.QueueItem.JobName, jobName, StringComparison.Ordinal));
+    }
+}

--- a/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewController.cs
@@ -26,8 +26,13 @@ public class DeleteWebdavItemPreviewController(
                 Error = "WebDAV is read-only. Disable 'Enforce Read-Only' in Settings → WebDAV."
             });
 
-        var path = HttpContext.Request.Query["path"].FirstOrDefault()
-                   ?? throw new BadHttpRequestException("path is required");
+        var path = HttpContext.Request.Query["path"].FirstOrDefault();
+        if (string.IsNullOrEmpty(path))
+            return BadRequest(new DeleteWebdavItemPreviewResponse
+            {
+                Status = false,
+                Error = "path is required"
+            });
         var ct = HttpContext.RequestAborted;
 
         var item = await ResolvePathAsync(path, ct).ConfigureAwait(false);

--- a/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewController.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Api.Controllers.DeleteWebdavItem;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Queue;
+
+namespace NzbWebDAV.Api.Controllers.DeleteWebdavItemPreview;
+
+[ApiController]
+[Route("api/delete-webdav-item-preview")]
+public class DeleteWebdavItemPreviewController(
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    QueueManager queueManager
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        if (configManager.IsEnforceReadonlyWebdavEnabled())
+            return StatusCode(403, new DeleteWebdavItemPreviewResponse
+            {
+                Status = false,
+                Error = "WebDAV is read-only. Disable 'Enforce Read-Only' in Settings → WebDAV."
+            });
+
+        var path = HttpContext.Request.Query["path"].FirstOrDefault()
+                   ?? throw new BadHttpRequestException("path is required");
+        var ct = HttpContext.RequestAborted;
+
+        var item = await ResolvePathAsync(path, ct).ConfigureAwait(false);
+        if (item is null)
+            return NotFound(new DeleteWebdavItemPreviewResponse { Status = false, Error = "Item not found." });
+
+        var rootError = DeleteWebdavItemSupport.ValidateDeletableRoot(item.Path);
+        if (rootError is not null)
+            return BadRequest(new DeleteWebdavItemPreviewResponse { Status = false, Error = rootError });
+
+        if (item.IsProtected())
+            return StatusCode(403, new DeleteWebdavItemPreviewResponse
+            {
+                Status = false,
+                Error = "Cannot delete protected item."
+            });
+
+        if (DeleteWebdavItemSupport.HasInProgressDownload(
+                item.Path, queueManager.GetInProgressQueueItems()))
+        {
+            return Conflict(new DeleteWebdavItemPreviewResponse
+            {
+                Status = false,
+                Error = "Cannot delete while a matching download is in progress."
+            });
+        }
+
+        var subtree = await dbClient.GetSubtreeForDeleteAsync(item.Id, ct).ConfigureAwait(false);
+        if (subtree.Count == 0)
+            return NotFound(new DeleteWebdavItemPreviewResponse { Status = false, Error = "Item not found." });
+
+        var fileCount = subtree.Count(x => x.Type == DavItem.ItemType.UsenetFile);
+        var dirCount = subtree.Count(x => x.Type == DavItem.ItemType.Directory);
+        var totalBytes = item.Type == DavItem.ItemType.Directory
+            ? await dbClient.GetRecursiveSize(item.Id, ct).ConfigureAwait(false)
+            : item.FileSize ?? 0;
+        var linkedHistoryCount = subtree
+            .Where(x => x.HistoryItemId.HasValue)
+            .Select(x => x.HistoryItemId!.Value)
+            .Distinct()
+            .Count();
+
+        return Ok(new DeleteWebdavItemPreviewResponse
+        {
+            Status = true,
+            FileCount = fileCount,
+            DirCount = dirCount,
+            TotalBytes = totalBytes,
+            LinkedHistoryCount = linkedHistoryCount,
+        });
+    }
+
+    private async Task<DavItem?> ResolvePathAsync(string path, CancellationToken ct)
+    {
+        var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return null;
+
+        var absolutePath = "/" + string.Join('/', parts.Select(Uri.UnescapeDataString));
+        var byPath = await dbClient.GetItemByPathAsync(absolutePath, ct).ConfigureAwait(false);
+        if (byPath is not null) return byPath;
+
+        var current = DavItem.Root;
+        foreach (var name in parts.Select(Uri.UnescapeDataString))
+        {
+            var child = await dbClient.GetDirectoryChildAsync(current.Id, name, ct).ConfigureAwait(false);
+            if (child is null) return null;
+            current = child;
+        }
+        return current;
+    }
+}

--- a/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewResponse.cs
+++ b/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewResponse.cs
@@ -1,0 +1,11 @@
+using NzbWebDAV.Api.Controllers;
+
+namespace NzbWebDAV.Api.Controllers.DeleteWebdavItemPreview;
+
+public class DeleteWebdavItemPreviewResponse : BaseApiResponse
+{
+    public int FileCount { get; init; }
+    public int DirCount { get; init; }
+    public long TotalBytes { get; init; }
+    public int LinkedHistoryCount { get; init; }
+}

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -495,19 +495,29 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     {
         if (historyItemIds.Count == 0) return [];
 
+        const int batchSize = 500;
         var distinctIds = historyItemIds.Distinct().ToList();
-        var stillReferenced = await Ctx.Items
-            .AsNoTracking()
-            .Where(x => x.HistoryItemId != null && distinctIds.Contains(x.HistoryItemId.Value))
-            .Select(x => x.HistoryItemId!.Value)
-            .Distinct()
-            .ToListAsync(ct)
-            .ConfigureAwait(false);
 
-        var orphanedIds = distinctIds.Except(stillReferenced).ToList();
+        var stillReferenced = new HashSet<Guid>();
+        foreach (var chunk in distinctIds.Chunk(batchSize))
+        {
+            var batch = chunk.ToList();
+            var refs = await Ctx.Items
+                .AsNoTracking()
+                .Where(x => x.HistoryItemId != null && batch.Contains(x.HistoryItemId.Value))
+                .Select(x => x.HistoryItemId!.Value)
+                .Distinct()
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            stillReferenced.UnionWith(refs);
+        }
+
+        var orphanedIds = distinctIds.Where(id => !stillReferenced.Contains(id)).ToList();
         if (orphanedIds.Count == 0) return [];
 
-        await RemoveHistoryItemsAsync(orphanedIds, deleteFiles: false, ct).ConfigureAwait(false);
+        foreach (var chunk in orphanedIds.Chunk(batchSize))
+            await RemoveHistoryItemsAsync(chunk.ToList(), deleteFiles: false, ct).ConfigureAwait(false);
+
         return orphanedIds;
     }
 

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -435,6 +435,82 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             excludeHistoryIds: ids).ConfigureAwait(false);
     }
 
+    public sealed record DavSubtreeDeleteEntry(
+        Guid Id,
+        string Path,
+        Guid? HistoryItemId,
+        DavItem.ItemType Type);
+
+    public async Task<List<DavSubtreeDeleteEntry>> GetSubtreeForDeleteAsync(
+        Guid rootId,
+        CancellationToken ct = default)
+    {
+        const string sql = """
+            WITH RECURSIVE Subtree AS (
+                SELECT Id, Path, HistoryItemId, Type
+                FROM DavItems
+                WHERE Id = @rootId
+
+                UNION ALL
+
+                SELECT d.Id, d.Path, d.HistoryItemId, d.Type
+                FROM DavItems d
+                INNER JOIN Subtree s ON d.ParentId = s.Id
+            )
+            SELECT Id, Path, HistoryItemId, Type FROM Subtree;
+            """;
+
+        var connection = Ctx.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@rootId";
+        parameter.Value = rootId;
+        command.Parameters.Add(parameter);
+
+        var entries = new List<DavSubtreeDeleteEntry>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            Guid? historyItemId = null;
+            if (!await reader.IsDBNullAsync(2, ct).ConfigureAwait(false))
+                historyItemId = reader.GetGuid(2);
+
+            entries.Add(new DavSubtreeDeleteEntry(
+                reader.GetGuid(0),
+                reader.GetString(1),
+                historyItemId,
+                (DavItem.ItemType)reader.GetInt32(3)));
+        }
+
+        return entries;
+    }
+
+    public async Task<List<Guid>> PruneUnreferencedHistoryItemsAsync(
+        IReadOnlyCollection<Guid> historyItemIds,
+        CancellationToken ct = default)
+    {
+        if (historyItemIds.Count == 0) return [];
+
+        var distinctIds = historyItemIds.Distinct().ToList();
+        var stillReferenced = await Ctx.Items
+            .AsNoTracking()
+            .Where(x => x.HistoryItemId != null && distinctIds.Contains(x.HistoryItemId.Value))
+            .Select(x => x.HistoryItemId!.Value)
+            .Distinct()
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var orphanedIds = distinctIds.Except(stillReferenced).ToList();
+        if (orphanedIds.Count == 0) return [];
+
+        await RemoveHistoryItemsAsync(orphanedIds, deleteFiles: false, ct).ConfigureAwait(false);
+        return orphanedIds;
+    }
+
     private class FileSizeResult
     {
         public long TotalSize { get; init; }

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -147,20 +147,11 @@ public class DatabaseStoreCollection(
     private async Task PruneEmptyHistoryAsync(Guid? historyItemId, CancellationToken ct)
     {
         if (historyItemId is null) return;
-        var historyId = historyItemId.Value;
-        var stillReferenced = await dbClient.Ctx.Items
-            .AsNoTracking()
-            .AnyAsync(x => x.HistoryItemId == historyId, ct)
+        var pruned = await dbClient.PruneUnreferencedHistoryItemsAsync([historyItemId.Value], ct)
             .ConfigureAwait(false);
-        if (stillReferenced) return;
+        if (pruned.Count == 0) return;
 
-        var history = await dbClient.Ctx.HistoryItems
-            .FirstOrDefaultAsync(h => h.Id == historyId, ct)
-            .ConfigureAwait(false);
-        if (history is null) return;
-
-        dbClient.Ctx.HistoryItems.Remove(history);
         await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, historyId.ToString());
+        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, pruned[0].ToString());
     }
 }

--- a/docs/features/webdav-filesystem.md
+++ b/docs/features/webdav-filesystem.md
@@ -17,3 +17,11 @@ Content streams from Usenet on read — files are not fully downloaded to disk f
 Configure credentials and filesystem behavior under [WebDAV settings](../configuration/webdav.md),
 and playback behavior under [Streaming settings](../configuration/streaming.md).
 Mount with [rclone](../guides/mounting-webdav.md) for filesystem clients.
+
+## Deleting from Explore [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
+
+From **Explore**, you can delete individual files or entire release folders under `/content/{category}/{release}/…`. The confirmation dialog shows how many files, folders, bytes, and linked history entries will be affected.
+
+Deletion is limited to mounted content under `/content`. Use the **Queue** page to remove NZBs from `/nzbs`, and the **History** page to clear `completed-symlinks` entries. Internal paths such as `/.ids` cannot be deleted from Explore.
+
+When the last file referencing a history entry is removed, the history row is pruned automatically so external SAB clients do not keep pointing at deleted mounts.

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -98,6 +98,7 @@ function Body(props: ExplorePageData) {
     const [sortDir, setSortDir] = useState<SortDir>("asc");
     const [selected, setSelected] = useState<Set<string>>(() => new Set());
     const [pendingDelete, setPendingDelete] = useState<string[] | null>(null);
+    const [deletePreview, setDeletePreview] = useState<DeletePreviewAggregate | null>(null);
     const [deleteError, setDeleteError] = useState<string | null>(null);
     const [isDeleting, setIsDeleting] = useState(false);
     const lastClickedRef = useRef<string | null>(null);
@@ -176,8 +177,42 @@ function Body(props: ExplorePageData) {
     const cancelDelete = useCallback(() => {
         if (isDeleting) return;
         setPendingDelete(null);
+        setDeletePreview(null);
         setDeleteError(null);
     }, [isDeleting]);
+
+    useEffect(() => {
+        if (!pendingDelete || pendingDelete.length === 0) {
+            setDeletePreview(null);
+            return;
+        }
+        const pathname = getWebdavPathDecoded(location.pathname);
+        let cancelled = false;
+        (async () => {
+            try {
+                const previews = await Promise.all(
+                    pendingDelete.map(async (name) => {
+                        const fullPath = pathname ? `${pathname}/${name}` : name;
+                        const resp = await fetch(
+                            withUrlBase(`/api/delete-webdav-item-preview?path=${encodeURIComponent(fullPath)}`),
+                        );
+                        if (!resp.ok) throw new Error("preview failed");
+                        return await resp.json() as DeletePreviewResponse;
+                    }),
+                );
+                if (cancelled) return;
+                setDeletePreview({
+                    fileCount: previews.reduce((acc, p) => acc + p.fileCount, 0),
+                    dirCount: previews.reduce((acc, p) => acc + p.dirCount, 0),
+                    totalBytes: previews.reduce((acc, p) => acc + p.totalBytes, 0),
+                    linkedHistoryCount: previews.reduce((acc, p) => acc + p.linkedHistoryCount, 0),
+                });
+            } catch {
+                if (!cancelled) setDeletePreview(null);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [pendingDelete, location.pathname]);
 
     const performDelete = useCallback(async () => {
         if (!pendingDelete || pendingDelete.length === 0) return;
@@ -408,7 +443,7 @@ function Body(props: ExplorePageData) {
             <ConfirmModal
                 show={pendingDelete !== null}
                 title={pendingDelete && pendingDelete.length > 1 ? "Delete items" : "Delete item"}
-                message={renderDeleteMessage(pendingDelete)}
+                message={renderDeleteMessage(pendingDelete, deletePreview)}
                 confirmText={isDeleting ? "Deleting..." : "Delete"}
                 cancelText="Cancel"
                 {...(deleteError != null ? { errorMessage: deleteError } : {})}
@@ -584,12 +619,26 @@ function CheckCell(props: { name: string, checked: boolean, onToggle: (name: str
     );
 }
 
-function renderDeleteMessage(pending: string[] | null) {
+function renderDeleteMessage(
+    pending: string[] | null,
+    preview: DeletePreviewAggregate | null,
+) {
     if (!pending || pending.length === 0) return null;
+    const impact = preview
+        ? (
+            <div className="mt-2 text-base-content/70">
+                Deletes {preview.fileCount} file{preview.fileCount === 1 ? "" : "s"} / {preview.dirCount} folder{preview.dirCount === 1 ? "" : "s"} ({formatFileSize(preview.totalBytes)}).
+                {preview.linkedHistoryCount > 0 && (
+                    <> Removes {preview.linkedHistoryCount} history entr{preview.linkedHistoryCount === 1 ? "y" : "ies"}.</>
+                )}
+            </div>
+        )
+        : null;
     if (pending.length === 1) {
         return (
             <div>
                 Delete <strong>{pending[0]}</strong>?
+                {impact}
                 <div className="mt-2 text-base-content/50">This cannot be undone.</div>
             </div>
         );
@@ -601,6 +650,7 @@ function renderDeleteMessage(pending: string[] | null) {
                 {pending.slice(0, 30).map(n => <li key={n}>{n}</li>)}
                 {pending.length > 30 && <li>…and {pending.length - 30} more</li>}
             </ul>
+            {impact}
             <div className="mt-2 text-base-content/50">This cannot be undone.</div>
         </div>
     );
@@ -675,8 +725,17 @@ function getParentDirectories(webdavPath: string): string[] {
 }
 
 function isDeletable(parentDirectories: string[]): boolean {
-    return parentDirectories.length >= 2;
+    return parentDirectories[0] === "content" && parentDirectories.length >= 2;
 }
+
+type DeletePreviewResponse = {
+    fileCount: number,
+    dirCount: number,
+    totalBytes: number,
+    linkedHistoryCount: number,
+};
+
+type DeletePreviewAggregate = DeletePreviewResponse;
 
 function getClassName(item: DirectoryItem | ExploreFile, isSelected: boolean) {
     return classNames([

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -190,16 +190,16 @@ function Body(props: ExplorePageData) {
         let cancelled = false;
         (async () => {
             try {
-                const previews = await Promise.all(
-                    pendingDelete.map(async (name) => {
-                        const fullPath = pathname ? `${pathname}/${name}` : name;
-                        const resp = await fetch(
-                            withUrlBase(`/api/delete-webdav-item-preview?path=${encodeURIComponent(fullPath)}`),
-                        );
-                        if (!resp.ok) throw new Error("preview failed");
-                        return await resp.json() as DeletePreviewResponse;
-                    }),
-                );
+                const previews: DeletePreviewResponse[] = [];
+                for (const name of pendingDelete) {
+                    if (cancelled) return;
+                    const fullPath = pathname ? `${pathname}/${name}` : name;
+                    const resp = await fetch(
+                        withUrlBase(`/api/delete-webdav-item-preview?path=${encodeURIComponent(fullPath)}`),
+                    );
+                    if (!resp.ok) throw new Error("preview failed");
+                    previews.push(await resp.json() as DeletePreviewResponse);
+                }
                 if (cancelled) return;
                 setDeletePreview({
                     fileCount: previews.reduce((acc, p) => acc + p.fileCount, 0),

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -8,6 +8,7 @@ import { websocketServer } from "./websocket.server";
 import { safeDecodePath, shouldProxyToBackend } from "./proxy-path";
 import { logger } from "./logger";
 import { authMiddleware } from "~/auth/auth-middleware.server";
+import { getSessionUser } from "~/auth/authentication.server";
 import { setApiKeyForAuthenticatedRequests } from "./inject-api-key.server";
 import {
   BACKEND_FAILURE_LOG_THROTTLE_MS,
@@ -130,6 +131,24 @@ const credentialRateLimiter = rateLimit({
 app.use(async (req, res, next) => {
   if (shouldProxyToBackend(req.method, req.path)) {
     await setApiKeyForAuthenticatedRequests(req);
+
+    const decodedPath = safeDecodePath(req.path);
+    if (
+      decodedPath !== null
+      && req.method.toUpperCase() === "POST"
+      && (decodedPath === "/api/delete-webdav-item"
+        || decodedPath.startsWith("/api/delete-webdav-item/"))
+    ) {
+      const user = await getSessionUser(req);
+      if (user?.role === "readonly") {
+        res.status(403).json({
+          status: false,
+          error: "Read-only users cannot delete files.",
+        });
+        return;
+      }
+    }
+
     return forwardToBackend(req, res, next);
   }
   next();

--- a/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
@@ -1,0 +1,550 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using NzbWebDAV.Api.Controllers;
+using NzbWebDAV.Api.Controllers.DeleteWebdavItem;
+using NzbWebDAV.Api.Controllers.DeleteWebdavItemPreview;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
+{
+    private const string ApiKey = "delete-webdav-item-test-key";
+
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-del-webdav-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private string? _previousApiKey;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+    private WebsocketManager _websocketManager = null!;
+    private ServiceProvider? _serviceProvider;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        _previousApiKey = Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", ApiKey);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WebdavEnforceReadonly,
+                ConfigValue = "false",
+            },
+        ]);
+
+        _websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        _serviceProvider?.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", _previousApiKey);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Theory]
+    [InlineData("/content/tv/Show.S01E01/episode.mkv", "tv", "Show.S01E01", true)]
+    [InlineData("/content/tv/Show.S01E01/episode.mkv", "tv", "Other.Show", false)]
+    [InlineData("/content/tv/Show.S01E01/episode.mkv", "movies", "Show.S01E01", false)]
+    [InlineData("/nzbs/tv/Show.S01E01.nzb", "tv", "Show.S01E01", false)]
+    [InlineData("/content/tv", "tv", "Show.S01E01", false)]
+    public void HasInProgressDownload_MatchesCategoryAndJobName(
+        string path,
+        string category,
+        string jobName,
+        bool expected)
+    {
+        var inProgress = new[]
+        {
+            new QueueManager.InProgressQueueItemSnapshot(
+                new QueueItem
+                {
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.UtcNow,
+                    FileName = $"{jobName}.nzb",
+                    JobName = jobName,
+                    NzbFileSize = 1,
+                    TotalSegmentBytes = 1,
+                    Category = category,
+                    Priority = QueueItem.PriorityOption.Normal,
+                    PostProcessing = QueueItem.PostProcessingOption.None,
+                },
+                42,
+                true),
+        };
+
+        Assert.Equal(expected, DeleteWebdavItemSupport.HasInProgressDownload(path, inProgress));
+    }
+
+    [Theory]
+    [InlineData("/nzbs")]
+    [InlineData("/completed-symlinks")]
+    [InlineData("/.ids")]
+    public async Task DeleteAsync_RootScopedPaths_Returns400(string path)
+    {
+        var result = await InvokeDeleteAsync(path);
+        Assert.Equal(400, GetStatusCode(result));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ProtectedContentCategory_Returns403()
+    {
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "tv");
+        _context.Items.Add(category);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var result = await InvokeDeleteAsync(category.Path);
+        Assert.Equal(403, GetStatusCode(result));
+        var response = ReadResponse<BaseApiResponse>(result);
+        Assert.Equal("Cannot delete protected item.", response.Error);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_File_RemovesRowAndPrunesUnreferencedHistory()
+    {
+        var (_, file, historyId) = await SeedContentReleaseAsync();
+
+        var result = await InvokeDeleteAsync(file.Path);
+        Assert.Equal(200, GetStatusCode(result));
+        Assert.True(ReadResponse<BaseApiResponse>(result).Status);
+
+        Assert.Null(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == file.Id));
+        Assert.Null(await _context.HistoryItems.AsNoTracking().SingleOrDefaultAsync(x => x.Id == historyId));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_File_KeepsHistoryWhenSiblingRemains()
+    {
+        var (jobDir, file, historyId) = await SeedContentReleaseAsync();
+        var sibling = DavItem.New(
+            Guid.NewGuid(),
+            jobDir,
+            "sibling.mkv",
+            200,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            historyId,
+            Guid.NewGuid());
+        _context.Items.Add(sibling);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var result = await InvokeDeleteAsync(file.Path);
+        Assert.Equal(200, GetStatusCode(result));
+
+        Assert.Null(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == file.Id));
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking().SingleOrDefaultAsync(x => x.Id == historyId));
+        Assert.NotNull(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == sibling.Id));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RecursiveTree_DeletesAllLevelsInOneCall()
+    {
+        var (jobDir, _, _) = await SeedContentReleaseAsync();
+        var seasonDir = NewDir(Guid.NewGuid(), jobDir, "Season 01");
+        var nestedFile = DavItem.New(
+            Guid.NewGuid(),
+            seasonDir,
+            "nested.mkv",
+            50,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            Guid.NewGuid());
+        _context.Items.AddRange(seasonDir, nestedFile);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var ids = new[] { jobDir.Id, seasonDir.Id, nestedFile.Id };
+        var result = await InvokeDeleteAsync(jobDir.Path);
+        Assert.Equal(200, GetStatusCode(result));
+
+        foreach (var id in ids)
+            Assert.Null(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == id));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_InProgressQueueItem_Returns409()
+    {
+        var (jobDir, _, _) = await SeedContentReleaseAsync(category: "tv", jobName: "Show.S01E01");
+        AddInProgressForTest(
+            _queueManager,
+            new QueueItem
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                FileName = "Show.S01E01.nzb",
+                JobName = "Show.S01E01",
+                NzbFileSize = 1,
+                TotalSegmentBytes = 1,
+                Category = "tv",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            });
+
+        var result = await InvokeDeleteAsync(jobDir.Path);
+        Assert.Equal(409, GetStatusCode(result));
+        var response = ReadResponse<BaseApiResponse>(result);
+        Assert.Equal("Cannot delete while a matching download is in progress.", response.Error);
+    }
+
+    [Fact]
+    public async Task ExecuteDeleteAsync_FiresBlobCleanupTrigger()
+    {
+        var blobId = Guid.NewGuid();
+        await using (var stream = new MemoryStream("blob-payload"u8.ToArray()))
+            await BlobStore.WriteBlob(blobId, stream);
+
+        var category = await EnsureCategoryAsync("movies");
+        var jobDir = NewDir(Guid.NewGuid(), category, "Blob.Job");
+        var file = DavItem.New(
+            Guid.NewGuid(),
+            jobDir,
+            "blob.mkv",
+            10,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            null,
+            blobId);
+        _context.Items.AddRange(jobDir, file);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await _context.Items
+            .Where(x => x.Id == file.Id)
+            .ExecuteDeleteAsync();
+
+        Assert.NotNull(await _context.BlobCleanupItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == blobId));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StalePath_Returns404()
+    {
+        var result = await InvokeDeleteAsync("/content/tv/missing-release/episode.mkv");
+        Assert.Equal(404, GetStatusCode(result));
+        var response = ReadResponse<BaseApiResponse>(result);
+        Assert.Equal("Item not found.", response.Error);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ReadonlySetting_Returns403()
+    {
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WebdavEnforceReadonly,
+                ConfigValue = "true",
+            },
+        ]);
+
+        var (_, file, _) = await SeedContentReleaseAsync();
+        var result = await InvokeDeleteAsync(file.Path);
+        Assert.Equal(403, GetStatusCode(result));
+        var response = ReadResponse<BaseApiResponse>(result);
+        Assert.Contains("read-only", response.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PreviewAsync_ReturnsCountsBytesAndHistory()
+    {
+        var historyId = Guid.NewGuid();
+        var nzbBlobId = Guid.NewGuid();
+        var category = await EnsureCategoryAsync("tv");
+        var jobDir = NewDir(Guid.NewGuid(), category, "Show.S01E01");
+        var seasonDir = NewDir(Guid.NewGuid(), jobDir, "Season 01");
+        var fileOne = DavItem.New(
+            Guid.NewGuid(),
+            seasonDir,
+            "S01E01.mkv",
+            100,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            historyId,
+            Guid.NewGuid(),
+            nzbBlobId);
+        var fileTwo = DavItem.New(
+            Guid.NewGuid(),
+            seasonDir,
+            "S01E02.mkv",
+            250,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            historyId,
+            Guid.NewGuid(),
+            nzbBlobId);
+        _context.HistoryItems.Add(CreateHistory(historyId, "Show.S01E01.nzb", "tv", nzbBlobId));
+        _context.NzbNames.Add(new NzbName { Id = nzbBlobId, FileName = "Show.S01E01.nzb" });
+        _context.Items.AddRange(jobDir, seasonDir, fileOne, fileTwo);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var result = await InvokePreviewAsync(jobDir.Path);
+        Assert.Equal(200, GetStatusCode(result));
+        var response = ReadResponse<DeleteWebdavItemPreviewResponse>(result);
+
+        Assert.True(response.Status);
+        Assert.Equal(2, response.FileCount);
+        Assert.Equal(2, response.DirCount);
+        Assert.Equal(350, response.TotalBytes);
+        Assert.Equal(1, response.LinkedHistoryCount);
+    }
+
+    [Fact]
+    public async Task PruneUnreferencedHistoryItemsAsync_EnqueuesHistoryCleanupAndNzbBlobCleanup()
+    {
+        var historyId = Guid.NewGuid();
+        var nzbBlobId = Guid.NewGuid();
+        _context.HistoryItems.Add(CreateHistory(historyId, "orphan.nzb", "tv", nzbBlobId));
+        _context.NzbNames.Add(new NzbName { Id = nzbBlobId, FileName = "orphan.nzb" });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var pruned = await _dbClient.PruneUnreferencedHistoryItemsAsync([historyId]);
+        await _context.SaveChangesAsync();
+
+        Assert.Equal([historyId], pruned);
+        Assert.Null(await _context.HistoryItems.AsNoTracking().SingleOrDefaultAsync(x => x.Id == historyId));
+        Assert.NotNull(await _context.HistoryCleanupItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == historyId));
+        Assert.NotNull(await _context.NzbBlobCleanupItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == nzbBlobId));
+    }
+
+    private DeleteWebdavItemController CreateDeleteController()
+    {
+        var controller = new DeleteWebdavItemController(
+            _dbClient,
+            _configManager,
+            _queueManager,
+            _websocketManager);
+        controller.ControllerContext = new ControllerContext { HttpContext = CreateHttpContext() };
+        return controller;
+    }
+
+    private DeleteWebdavItemPreviewController CreatePreviewController()
+    {
+        var controller = new DeleteWebdavItemPreviewController(
+            _dbClient,
+            _configManager,
+            _queueManager);
+        controller.ControllerContext = new ControllerContext { HttpContext = CreateHttpContext() };
+        return controller;
+    }
+
+    private HttpContext CreateHttpContext()
+    {
+        _serviceProvider?.Dispose();
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_configManager)
+            .BuildServiceProvider();
+        var httpContext = new DefaultHttpContext { RequestServices = _serviceProvider };
+        httpContext.Request.Headers["x-api-key"] = ApiKey;
+        return httpContext;
+    }
+
+    private async Task<IActionResult> InvokeDeleteAsync(string path)
+    {
+        var controller = CreateDeleteController();
+        controller.HttpContext.Request.Method = HttpMethods.Post;
+        controller.HttpContext.Request.ContentType = "application/x-www-form-urlencoded";
+        controller.HttpContext.Request.Form = new FormCollection(
+            new Dictionary<string, StringValues> { ["path"] = path });
+        return await controller.HandleApiRequest();
+    }
+
+    private async Task<IActionResult> InvokePreviewAsync(string path)
+    {
+        var controller = CreatePreviewController();
+        controller.HttpContext.Request.Method = HttpMethods.Get;
+        controller.HttpContext.Request.QueryString = new QueryString($"?path={Uri.EscapeDataString(path)}");
+        return await controller.HandleApiRequest();
+    }
+
+    private async Task<(DavItem JobDir, DavItem File, Guid HistoryId)> SeedContentReleaseAsync(
+        string category = "tv",
+        string jobName = "Show.S01E01",
+        string fileName = "episode.mkv",
+        long fileSize = 100)
+    {
+        var historyId = Guid.NewGuid();
+        var nzbBlobId = Guid.NewGuid();
+        var categoryDir = await EnsureCategoryAsync(category);
+        var jobDir = NewDir(Guid.NewGuid(), categoryDir, jobName);
+        var file = DavItem.New(
+            Guid.NewGuid(),
+            jobDir,
+            fileName,
+            fileSize,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            historyId,
+            Guid.NewGuid(),
+            nzbBlobId);
+        _context.HistoryItems.Add(CreateHistory(historyId, $"{jobName}.nzb", category, nzbBlobId));
+        _context.NzbNames.Add(new NzbName { Id = nzbBlobId, FileName = $"{jobName}.nzb" });
+        _context.Items.AddRange(jobDir, file);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return (jobDir, file, historyId);
+    }
+
+    private async Task<DavItem> EnsureCategoryAsync(string category)
+    {
+        var existing = await _context.Items.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.ParentId == DavItem.ContentFolder.Id && x.Name == category);
+        if (existing is not null)
+            return existing;
+
+        var categoryDir = NewDir(Guid.NewGuid(), DavItem.ContentFolder, category);
+        _context.Items.Add(categoryDir);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return categoryDir;
+    }
+
+    private static DavItem NewDir(Guid id, DavItem parent, string name) =>
+        DavItem.New(
+            id,
+            parent,
+            name,
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+
+    private static HistoryItem CreateHistory(Guid id, string fileName, string category, Guid nzbBlobId) => new()
+    {
+        Id = id,
+        CreatedAt = DateTime.UtcNow,
+        FileName = fileName,
+        JobName = Path.GetFileNameWithoutExtension(fileName),
+        Category = category,
+        DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+        TotalSegmentBytes = 100,
+        DownloadTimeSeconds = 1,
+        NzbBlobId = nzbBlobId,
+    };
+
+    private static int GetStatusCode(IActionResult result)
+    {
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result);
+        return objectResult.StatusCode ?? 0;
+    }
+
+    private static T ReadResponse<T>(IActionResult result) where T : class
+    {
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result);
+        return Assert.IsType<T>(objectResult.Value);
+    }
+
+    private static void AddInProgressForTest(QueueManager queueManager, QueueItem queueItem)
+    {
+        var managerType = typeof(QueueManager);
+        var inProgressField = managerType.GetField("_inProgress", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("QueueManager._inProgress not found");
+        var inProgressDict = inProgressField.GetValue(queueManager)
+            ?? throw new InvalidOperationException("QueueManager._inProgress was null");
+        var itemType = managerType.GetNestedType("InProgressQueueItem", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("InProgressQueueItem type not found");
+        var inProgressItem = Activator.CreateInstance(itemType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create InProgressQueueItem");
+
+        itemType.GetProperty("QueueItem")!.SetValue(inProgressItem, queueItem);
+        itemType.GetProperty("ProgressPercentage")!.SetValue(inProgressItem, 10);
+        itemType.GetProperty("ProcessingTask")!.SetValue(inProgressItem, Task.CompletedTask);
+        itemType.GetProperty("CompletionSignal")!.SetValue(inProgressItem, new TaskCompletionSource());
+        itemType.GetProperty("CancellationTokenSource")!.SetValue(inProgressItem, new CancellationTokenSource());
+        itemType.GetProperty("QueueDownloadContext")!.SetValue(inProgressItem, new QueueDownloadContext
+        {
+            IsPrimary = true,
+            GetFanOutConcurrency = () => 1,
+        });
+
+        var tryAdd = inProgressDict.GetType().GetMethod("TryAdd")
+            ?? throw new InvalidOperationException("TryAdd not found on _inProgress dictionary");
+        if (!(bool)tryAdd.Invoke(inProgressDict, [queueItem.Id, inProgressItem])!)
+            throw new InvalidOperationException("Failed to add in-progress queue item for test");
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #767 — adds safe, consistent deletion actions to the Explore UI so operators can remove individual virtual files or recursively remove directories under `/content`.

Improvements over the first-cut implementation:

- **Root scoping**: only items under `/content` can be deleted; `/nzbs`, `/completed-symlinks`, and `/.ids` return clear 400 messages directing users to Queue or History pages
- **In-progress guard**: if a matching download is active (matched by `Category` + `JobName`), the endpoint returns 409 instead of silently deleting underneath the queue
- **Set-based recursive CTE delete**: replaces the old N+1 `DeleteRecursiveAsync` loop with a single `WITH RECURSIVE` CTE that collects the full subtree, then batch-deletes via `ExecuteDeleteAsync` in chunks of 500 — fires the `TR_DavItems_Delete_AddBlobCleanup` SQLite trigger for blob cleanup
- **History pruning via `RemoveHistoryItemsAsync`**: when the last DavItem referencing a history entry is deleted, orphaned history rows are pruned through the existing `RemoveHistoryItemsAsync` path, which enqueues both `HistoryCleanupItems` and `NzbBlobCleanupItems` for background cleanup
- **Batched `HistoryItemRemoved` websocket**: pruned history IDs are sent as a single comma-joined message so the frontend can update in one pass
- **Explicit `RcloneVfsForget`**: called after the transaction commits so rclone caches don't serve stale entries
- **Preview endpoint** (`/api/delete-webdav-item-preview`): returns `fileCount`, `dirCount`, `totalBytes`, and `linkedHistoryCount` so the UI can show impact details before confirming
- **Frontend confirmation enrichment**: `isDeletable` now checks for `/content` root; the `ConfirmModal` shows file/folder counts, total size, and affected history entries from the preview
- **Readonly proxy enforcement**: `frontend/server/app.ts` blocks POST to `/api/delete-webdav-item*` for readonly sessions with 403
- **Shared `DatabaseStoreCollection` path**: the existing WebDAV DELETE handler now also uses `PruneUnreferencedHistoryItemsAsync` for consistent history cleanup
- **Documentation**: `docs/features/webdav-filesystem.md` updated with deletion behavior and a `since 1.1.0` pill
- **Playback safety**: deletion operates on database rows only; open streams to Usenet providers are unaffected

## Test plan

- [x] `DeleteAsync_RootScopedPaths_Returns400` — `/nzbs`, `/completed-symlinks`, `/.ids` all return 400
- [x] `DeleteAsync_ProtectedContentCategory_Returns403` — protected category directories return 403
- [x] `DeleteAsync_File_RemovesRowAndPrunesUnreferencedHistory` — single file deletion prunes orphaned history
- [x] `DeleteAsync_File_KeepsHistoryWhenSiblingRemains` — history preserved when sibling file still references it
- [x] `DeleteAsync_RecursiveTree_DeletesAllLevelsInOneCall` — recursive directory delete removes all descendants
- [x] `DeleteAsync_InProgressQueueItem_Returns409` — in-progress download blocks deletion with 409
- [x] `ExecuteDeleteAsync_FiresBlobCleanupTrigger` — `ExecuteDeleteAsync` fires `TR_DavItems_Delete_AddBlobCleanup` SQLite trigger
- [x] `DeleteAsync_StalePath_Returns404` — missing path returns 404
- [x] `DeleteAsync_ReadonlySetting_Returns403` — read-only WebDAV setting blocks deletion
- [x] `PreviewAsync_ReturnsCountsBytesAndHistory` — preview returns correct counts and linked history
- [x] `PruneUnreferencedHistoryItemsAsync_EnqueuesHistoryCleanupAndNzbBlobCleanup` — pruning enqueues both history and NZB blob cleanup items
- [x] `HasInProgressDownload_MatchesCategoryAndJobName` — in-progress matching logic covers positive and negative cases
- [ ] Manual: delete a file from Explore UI, verify history row disappears from History page
- [ ] Manual: attempt delete on `/nzbs` path, verify 400 error shown
- [ ] Manual: verify rclone mount does not serve deleted entries after VFS forget