### PR TITLE
fix(queue): season packs with per-episode par2 files now get correct episode filenames

### DIFF
--- a/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
@@ -15,22 +15,41 @@ public static class GetPar2FileDescriptorsStep
         CancellationToken cancellationToken = default
     )
     {
-        // find the par2 index file
-        var par2Index = files
+        // Find the par2 index files. Most NZBs carry a single par2 set, but
+        // some (e.g. per-episode season packs) carry one par2 set per content
+        // file, each with its own index holding FileDesc packets we need.
+        // Recovery volumes duplicate the index descriptors, so they are only
+        // used as a fallback when no index file can be identified.
+        var par2Candidates = files
             .Where(x => !x.MissingFirstSegment)
             .Where(x => Par2.HasPar2MagicBytes(x.First16KB!))
-            .MinBy(x => x.NzbFile.Segments.Count);
-        if (par2Index is null) return [];
+            .ToList();
+        var par2Indexes = par2Candidates
+            .Where(x => !Par2.ParVolume.IsMatch(x.NzbFile.GetSubjectFileName()))
+            .ToList();
+        if (par2Indexes.Count == 0
+            && par2Candidates.MinBy(x => x.NzbFile.Segments.Count) is { } fallback)
+        {
+            par2Indexes.Add(fallback);
+        }
 
-        // return all file descriptors
+        // return all file descriptors, deduplicated by FileID
         var fileDescriptors = new List<FileDesc>();
-        var segments = par2Index.NzbFile.GetSegmentIds();
-        var filesize = par2Index.NzbFile.Segments.Count == 1
-            ? par2Index.Header!.PartOffset + par2Index.Header!.PartSize
-            : await usenetClient.GetFileSizeAsync(par2Index.NzbFile, cancellationToken).ConfigureAwait(false);
-        await using var stream = usenetClient.GetFileStream(segments, filesize, articleBufferSize: 0);
-        await foreach (var fileDescriptor in Par2.ReadFileDescriptions(stream, cancellationToken).ConfigureAwait(false))
-            fileDescriptors.Add(fileDescriptor);
+        var seenFileIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var par2Index in par2Indexes)
+        {
+            var segments = par2Index.NzbFile.GetSegmentIds();
+            var filesize = par2Index.NzbFile.Segments.Count == 1
+                ? par2Index.Header!.PartOffset + par2Index.Header!.PartSize
+                : await usenetClient.GetFileSizeAsync(par2Index.NzbFile, cancellationToken).ConfigureAwait(false);
+            await using var stream = usenetClient.GetFileStream(segments, filesize, articleBufferSize: 0);
+            await foreach (var fileDescriptor in Par2.ReadFileDescriptions(stream, cancellationToken).ConfigureAwait(false))
+            {
+                if (seenFileIds.Add(Convert.ToHexString(fileDescriptor.FileID)))
+                    fileDescriptors.Add(fileDescriptor);
+            }
+        }
+
         return fileDescriptors;
     }
 }

--- a/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
@@ -20,17 +20,23 @@ public static class GetPar2FileDescriptorsStep
         // file, each with its own index holding FileDesc packets we need.
         // Recovery volumes duplicate the index descriptors, so they are only
         // used as a fallback when no index file can be identified.
+        // Sort by segment count then first message-id so dedup/fallback
+        // selection is deterministic regardless of network completion
+        // order. Smallest files first preserves the original preference
+        // for index files over larger recovery volumes in the fallback.
         var par2Candidates = files
             .Where(x => !x.MissingFirstSegment)
             .Where(x => Par2.HasPar2MagicBytes(x.First16KB!))
+            .OrderBy(x => x.NzbFile.Segments.Count)
+            .ThenBy(x => x.NzbFile.Segments[0].MessageId, StringComparer.Ordinal)
             .ToList();
         var par2Indexes = par2Candidates
             .Where(x => !Par2.ParVolume.IsMatch(x.NzbFile.GetSubjectFileName()))
             .ToList();
         if (par2Indexes.Count == 0
-            && par2Candidates.MinBy(x => x.NzbFile.Segments.Count) is { } fallback)
+            && par2Candidates.Count > 0)
         {
-            par2Indexes.Add(fallback);
+            par2Indexes.Add(par2Candidates[0]);
         }
 
         // return all file descriptors, deduplicated by FileID

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -188,7 +188,7 @@ function Body(props: ExplorePageData) {
         }
         const pathname = getWebdavPathDecoded(location.pathname);
         let cancelled = false;
-        (async () => {
+        void (async () => {
             try {
                 const previews: DeletePreviewResponse[] = [];
                 for (const name of pendingDelete) {

--- a/frontend/app/routes/queue/components/history-table/history-retry.ts
+++ b/frontend/app/routes/queue/components/history-table/history-retry.ts
@@ -59,6 +59,14 @@ export type BulkHistoryRetryResult = {
     failed: Array<{ nzoId: string; error: string }>;
 };
 
+// SABnzbd API (`/api?mode=retry` bulk) response shape
+type BulkRetryResponse = {
+    status?: boolean;
+    error?: string;
+    nzo_ids?: string[];
+    failed?: Array<{ nzo_id: string; error: string }>;
+};
+
 export async function retryHistoryItems(
     nzoIds: string[],
     fetchImpl: typeof fetch = fetch,
@@ -73,14 +81,9 @@ export async function retryHistoryItems(
             headers: { "Content-Type": "application/json;charset=UTF-8" },
             body: JSON.stringify({ nzo_ids: nzoIds }),
         });
-        let data: {
-            status?: boolean;
-            error?: string;
-            nzo_ids?: string[];
-            failed?: Array<{ nzo_id: string; error: string }>;
-        } | null = null;
+        let data: BulkRetryResponse | null = null;
         try {
-            data = await response.json();
+            data = (await response.json()) as BulkRetryResponse;
         } catch {
             data = null;
         }

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -131,7 +131,7 @@ export function HistoryTable({
                 <>
                     {selectedRetryableIds.length > 0 &&
                         <Tooltip content="Retry selected failed items">
-                            <ActionButton type="retry" onClick={onBulkRetry} />
+                            <ActionButton type="retry" onClick={() => void onBulkRetry()} />
                         </Tooltip>
                     }
                     <ActionButton type="delete" onClick={onRemove} />
@@ -191,14 +191,14 @@ export function HistoryTable({
                 title="Clear failed history?"
                 message="All failed history items will be removed."
                 checkboxMessage="Delete mounted files"
-                onConfirm={onConfirmClearFailed}
+                onConfirm={(isChecked) => void onConfirmClearFailed(isChecked)}
                 onCancel={() => setIsConfirmingClearFailed(false)} />
             <ConfirmModal
                 show={isConfirmingClearAll}
                 title="Clear all history?"
                 message="All history items will be removed."
                 checkboxMessage="Delete mounted files"
-                onConfirm={onConfirmClearAllHistory}
+                onConfirm={(isChecked) => void onConfirmClearAllHistory(isChecked)}
                 onCancel={() => setIsConfirmingClearAll(false)} />
         </PageSection>
     );

--- a/frontend/app/routes/queue/components/queue-table/queue-bulk-actions.ts
+++ b/frontend/app/routes/queue/components/queue-table/queue-bulk-actions.ts
@@ -39,7 +39,7 @@ async function postQueueIds(url: string, nzoIds: string[]): Promise<boolean> {
             body: JSON.stringify({ nzo_ids: nzoIds }),
         });
         if (!response.ok) return false;
-        const data = await response.json();
+        const data = await response.json() as { status?: boolean };
         return data.status === true;
     } catch {
         return false;
@@ -66,7 +66,7 @@ export async function postClearQueue(category?: string): Promise<boolean> {
     try {
         const response = await fetch(buildClearQueueUrl(category), { method: "POST" });
         if (!response.ok) return false;
-        const data = await response.json();
+        const data = await response.json() as { status?: boolean };
         return data.status === true;
     } catch {
         return false;

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -231,12 +231,12 @@ export function QueueTable({
                 <>
                     {selectedPausableIds.length > 0 &&
                         <Tooltip content="Pause selected">
-                            <ActionButton type="pause" onClick={onPauseSelected} />
+                            <ActionButton type="pause" onClick={() => void onPauseSelected()} />
                         </Tooltip>
                     }
                     {selectedResumableIds.length > 0 &&
                         <Tooltip content="Resume selected">
-                            <ActionButton type="resume" onClick={onResumeSelected} />
+                            <ActionButton type="resume" onClick={() => void onResumeSelected()} />
                         </Tooltip>
                     }
                     {selectedMovableIds.length > 0 &&
@@ -247,13 +247,13 @@ export function QueueTable({
                     {selectedMovableIds.length > 0 && categories.length > 0 &&
                         <>
                             <SimpleDropdown options={categories} value={bulkSetCategory} onChange={setBulkSetCategory} />
-                            <Button variant="secondary" size="xsmall" onClick={onSetCategorySelected}>Set category</Button>
+                            <Button variant="secondary" size="xsmall" onClick={() => void onSetCategorySelected()}>Set category</Button>
                         </>
                     }
                     {selectedMovableIds.length > 0 &&
                         <>
                             <SimpleDropdown options={["-1", "0", "1", "2"]} value={bulkPriority} onChange={setBulkPriority} />
-                            <Button variant="secondary" size="xsmall" onClick={() => onSetPrioritySelected(bulkPriority)}>Set priority</Button>
+                            <Button variant="secondary" size="xsmall" onClick={() => void onSetPrioritySelected(bulkPriority)}>Set priority</Button>
                         </>
                     }
                     <ActionButton type="delete" onClick={onRemove} />
@@ -324,13 +324,13 @@ export function QueueTable({
                 show={isConfirmingClearAll}
                 title="Clear entire queue?"
                 message="All queued items will be removed. In-progress downloads will be cancelled."
-                onConfirm={onConfirmClearAll}
+                onConfirm={() => void onConfirmClearAll()}
                 onCancel={() => setIsConfirmingClearAll(false)} />
             <ConfirmModal
                 show={isConfirmingClearCategory}
                 title="Clear category?"
                 message={`All items in category "${clearCategory}" will be removed.`}
-                onConfirm={onConfirmClearCategory}
+                onConfirm={() => void onConfirmClearCategory()}
                 onCancel={() => setIsConfirmingClearCategory(false)} />
         </PageSection>
     );

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2TestPackets.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2TestPackets.cs
@@ -1,0 +1,69 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Par2Recovery.Packets;
+
+namespace NzbWebDAV.Tests.Par2Recovery;
+
+internal static class Par2TestPackets
+{
+    internal static byte[] BuildFileDescBody(
+        byte[] fileId,
+        string fileName,
+        byte[]? file16kHash = null,
+        ulong fileLength = 0)
+    {
+        var nameBytes = Encoding.UTF8.GetBytes(fileName);
+        var paddedLen = (nameBytes.Length + 3) / 4 * 4;
+        var body = new byte[56 + paddedLen];
+        fileId.CopyTo(body, 0);
+        (file16kHash ?? new byte[16]).CopyTo(body, 32);
+        BitConverter.TryWriteBytes(body.AsSpan(48, 8), fileLength);
+        nameBytes.CopyTo(body, 56);
+        return body;
+    }
+
+    internal static byte[] BuildPar2Bytes(params byte[][] fileDescBodies)
+    {
+        using var stream = new MemoryStream();
+        foreach (var body in fileDescBodies)
+            WritePacket(stream, FileDesc.PacketType, body);
+        return stream.ToArray();
+    }
+
+    internal static async Task<List<FileDesc>> ReadFileDescsAsync(byte[] par2Bytes)
+    {
+        var descriptors = new List<FileDesc>();
+        await using var stream = new MemoryStream(par2Bytes);
+        await foreach (var descriptor in Par2.ReadFileDescriptions(stream))
+            descriptors.Add(descriptor);
+        return descriptors;
+    }
+
+    private static void WritePacket(Stream stream, string packetType, byte[] body)
+    {
+        var headerSize = Marshal.SizeOf<Par2PacketHeader>();
+        var header = new Par2PacketHeader
+        {
+            Magic = "PAR2\0PKT"u8.ToArray(),
+            PacketLength = (ulong)(headerSize + body.Length),
+            PacketHash = new byte[16],
+            RecoverySetID = new byte[16],
+            PacketType = Encoding.ASCII.GetBytes(packetType.PadRight(16, '\0')[..16]),
+        };
+
+        var headerBytes = new byte[headerSize];
+        var handle = GCHandle.Alloc(headerBytes, GCHandleType.Pinned);
+        try
+        {
+            Marshal.StructureToPtr(header, handle.AddrOfPinnedObject(), false);
+        }
+        finally
+        {
+            handle.Free();
+        }
+
+        stream.Write(headerBytes);
+        stream.Write(body);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
@@ -58,6 +58,7 @@ public class GetFileInfosStepTests
             ReleaseDate = DateTimeOffset.UnixEpoch,
         };
     }
+
     private static readonly byte[] EbmlMagic = [0x1A, 0x45, 0xDF, 0xA3, 0x00, 0x00, 0x00, 0x00];
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
@@ -1,6 +1,8 @@
+using System.Security.Cryptography;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Tests.Par2Recovery;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Queue;
@@ -8,6 +10,54 @@ namespace NzbWebDAV.Tests.Queue;
 public class GetFileInfosStepTests
 {
     private static readonly byte[] Rar4Magic = [0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00];
+
+    [Fact]
+    public async Task GetFileInfos_AssignsPar2NamesFromMultiplePar2Sets()
+    {
+        // Season packs with one par2 set per episode yield one descriptor per
+        // set; every file whose 16k hash matches must get its own par2 name.
+        var first16kA = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+        var first16kB = Enumerable.Range(100, 64).Select(i => (byte)i).ToArray();
+#pragma warning disable CA5351 // MD5 here is content hashing for the NZB/PAR2 ecosystem, not security
+        var descriptors = await Par2TestPackets.ReadFileDescsAsync(Par2TestPackets.BuildPar2Bytes(
+            Par2TestPackets.BuildFileDescBody(
+                FileId(0x0A), "Show.S01E01.mkv", MD5.HashData(first16kA), fileLength: 970),
+            Par2TestPackets.BuildFileDescBody(
+                FileId(0x0B), "Show.S01E02.mkv", MD5.HashData(first16kB), fileLength: 1950)));
+#pragma warning restore CA5351
+
+        var inputs = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            VideoFile("obfuscated [AAAAAAAA].mkv", yencodedSize: 1000, first16kA),
+            VideoFile("obfuscated [BBBBBBBB].mkv", yencodedSize: 2000, first16kB),
+            VideoFile("obfuscated [CCCCCCCC].mkv", yencodedSize: 3000, new byte[64]),
+        };
+
+        var results = GetFileInfosStep.GetFileInfos(inputs, descriptors);
+
+        Assert.Equal("Show.S01E01.mkv", results[0].FileName);
+        Assert.Equal("Show.S01E02.mkv", results[1].FileName);
+        Assert.Equal("obfuscated [CCCCCCCC].mkv", results[2].FileName);
+    }
+
+    private static byte[] FileId(byte fill) => Enumerable.Repeat(fill, 16).ToArray();
+
+    private static FetchFirstSegmentsStep.NzbFileWithFirstSegment VideoFile(
+        string subject, long yencodedSize, byte[] first16Kb)
+    {
+        return new()
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = $"\"{subject}\" yEnc (1/1)",
+                Segments = { new NzbSegment { MessageId = "video@example.com", Bytes = yencodedSize } },
+            },
+            Header = null,
+            First16KB = first16Kb,
+            MissingFirstSegment = false,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+        };
+    }
     private static readonly byte[] EbmlMagic = [0x1A, 0x45, 0xDF, 0xA3, 0x00, 0x00, 0x00, 0x00];
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
@@ -1,0 +1,244 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
+using NzbWebDAV.Queue.DeobfuscationSteps._2.GetPar2FileDescriptors;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Par2Recovery;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class GetPar2FileDescriptorsStepTests
+{
+    [Fact]
+    public async Task GetPar2FileDescriptors_MergesDescriptorsFromAllIndexFiles()
+    {
+        // Per-episode season-pack layout: one single-segment par2 index per
+        // content file. Every index must be read, not just the first/smallest.
+        var idA = FileId(0x0A);
+        var idB = FileId(0x0B);
+        var indexA = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(idA, "Show.S01E01.mkv"));
+        var indexB = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(idB, "Show.S01E02.mkv"));
+        var vol = Par2TestPackets.BuildPar2Bytes(
+            Par2TestPackets.BuildFileDescBody(FileId(0x0C), "volume-descriptor.mkv"));
+
+        using var client = new Par2ServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["index-a@example.com"] = indexA,
+            ["index-b@example.com"] = indexB,
+            ["vol@example.com"] = vol,
+        });
+
+        var files = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            VideoFile("Release [AAAAAAAA].mkv", "video-a@example.com"),
+            Par2File("Release [BBBBBBBB].par2", "index-b@example.com", indexB),
+            Par2File("Release [AAAAAAAA].par2", "index-a@example.com", indexA),
+            Par2File("Release [AAAAAAAA].vol00+01.par2", "vol@example.com", vol),
+        };
+
+        var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
+
+        Assert.Equal(
+            [Convert.ToHexString(idB), Convert.ToHexString(idA)],
+            descriptors.Select(x => Convert.ToHexString(x.FileID)).ToArray());
+        // Recovery volumes duplicate index descriptors; they must not be read.
+        Assert.DoesNotContain("vol@example.com", client.RequestedSegmentIds);
+    }
+
+    [Fact]
+    public async Task GetPar2FileDescriptors_FallsBackToVolumeWhenNoIndexIdentifiable()
+    {
+        var idVol = FileId(0x0C);
+        var vol = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(idVol, "movie.mkv"));
+
+        using var client = new Par2ServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["vol@example.com"] = vol,
+        });
+
+        var files = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            VideoFile("Release [AAAAAAAA].mkv", "video-a@example.com"),
+            Par2File("Release.vol00+01.par2", "vol@example.com", vol),
+        };
+
+        var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
+
+        var descriptor = Assert.Single(descriptors);
+        Assert.Equal("movie.mkv", descriptor.FileName);
+    }
+
+    [Fact]
+    public async Task GetPar2FileDescriptors_DedupesDescriptorsByFileId()
+    {
+        var id = FileId(0x0A);
+        var indexA = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(id, "Show.S01E01.mkv"));
+        var indexB = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(id, "Show.S01E01.mkv"));
+
+        using var client = new Par2ServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["index-a@example.com"] = indexA,
+            ["index-b@example.com"] = indexB,
+        });
+
+        var files = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            Par2File("Release [AAAAAAAA].par2", "index-a@example.com", indexA),
+            Par2File("Release [BBBBBBBB].par2", "index-b@example.com", indexB),
+        };
+
+        var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
+
+        Assert.Single(descriptors);
+    }
+
+    [Fact]
+    public async Task GetPar2FileDescriptors_ReturnsEmptyWhenNoPar2Present()
+    {
+        using var client = new Par2ServingNntpClient(new Dictionary<string, byte[]>());
+        var files = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            VideoFile("Release [AAAAAAAA].mkv", "video-a@example.com"),
+        };
+
+        var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
+
+        Assert.Empty(descriptors);
+    }
+
+    private static byte[] FileId(byte fill) => Enumerable.Repeat(fill, 16).ToArray();
+
+    private static FetchFirstSegmentsStep.NzbFileWithFirstSegment Par2File(
+        string subjectName, string messageId, byte[] par2Bytes)
+    {
+        return new()
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = $"\"{subjectName}\" yEnc (1/1)",
+                Segments = { new NzbSegment { MessageId = messageId, Bytes = par2Bytes.Length } },
+            },
+            Header = new UsenetYencHeader
+            {
+                FileName = subjectName,
+                FileSize = par2Bytes.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = par2Bytes.Length,
+            },
+            First16KB = par2Bytes,
+            MissingFirstSegment = false,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+        };
+    }
+
+    private static FetchFirstSegmentsStep.NzbFileWithFirstSegment VideoFile(string subjectName, string messageId)
+    {
+        return new()
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = $"\"{subjectName}\" yEnc (1/1)",
+                Segments = { new NzbSegment { MessageId = messageId, Bytes = 1000 } },
+            },
+            Header = null,
+            First16KB = new byte[64], // no par2 magic
+            MissingFirstSegment = false,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+        };
+    }
+
+    /// <summary>
+    /// Serves raw decoded bytes via CachedYencStream so tests do not depend on
+    /// rapidyenc native (same approach as LazyRarProcessorTests).
+    /// </summary>
+    private sealed class Par2ServingNntpClient(IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var key = segmentId.ToString();
+            RequestedSegmentIds.Add(key);
+            if (!segments.TryGetValue(key, out var bytes))
+                throw new UsenetArticleNotFoundException(key);
+
+            var headers = new UsenetYencHeader
+            {
+                FileName = "file.par2",
+                FileSize = bytes.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = bytes.Length,
+            };
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body",
+                Stream = new CachedYencStream(headers, new MemoryStream(bytes, writable: false)),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(id => DecodedBodyAsync(id, cancellationToken))
+                .ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
@@ -41,8 +41,9 @@ public class GetPar2FileDescriptorsStepTests
 
         var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
 
+        // Sorted by message-id for deterministic ordering: index-a before index-b
         Assert.Equal(
-            [Convert.ToHexString(idB), Convert.ToHexString(idA)],
+            [Convert.ToHexString(idA), Convert.ToHexString(idB)],
             descriptors.Select(x => Convert.ToHexString(x.FileID)).ToArray());
         // Recovery volumes duplicate index descriptors; they must not be read.
         Assert.DoesNotContain("vol@example.com", client.RequestedSegmentIds);


### PR DESCRIPTION
## Summary

- Fixes #936: NZBs that ship one PAR2 set per content file (a common obfuscated anime season-pack layout) previously read FileDesc packets from a single par2 index, so exactly one file — picked effectively at random via first-segment completion order — got its real episode filename while the rest kept hashed `[HASH]` names that Sonarr/Radarr cannot parse.
- `GetPar2FileDescriptorsStep` now merges FileDesc packets from **all** par2 index files, deduplicated by `FileID`; `.volNN+MM.par2` recovery volumes are skipped (they duplicate index descriptors) with a fallback to the smallest par2 file when no index is identifiable.
- Verified live against the reported NZB: before the fix, 24 of 25 episodes kept hashed names and one random file got `S01E01-…`; with this change every episode resolves its par2-provided name.

## Test plan

- [x] New `GetPar2FileDescriptorsStepTests`: multi-index merge, recovery-volume exclusion, volumes-only fallback, FileID dedupe, no-par2 empty case
- [x] New `GetFileInfosStepTests` case: 16k-hash matching across descriptors from multiple par2 sets; unmatched files keep subject names
- [x] Full backend suite: 2567 passed, 0 failed
- [ ] Re-import the reported NZB on a dev instance and confirm all 25 episodes get real filenames