### PR TITLE
fix(db): corrupt database now gets clear recovery guidance instead of endless stack traces

### DIFF
--- a/backend/Database/DatabaseIntegrityCheck.cs
+++ b/backend/Database/DatabaseIntegrityCheck.cs
@@ -51,6 +51,11 @@ internal static class DatabaseIntegrityCheck
             LogCorruption([ex.Message]);
             return false;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Startup is shutting down; a cancelled check is not a corruption finding.
+            return false;
+        }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             // A diagnostic must never break startup.

--- a/backend/Database/DatabaseIntegrityCheck.cs
+++ b/backend/Database/DatabaseIntegrityCheck.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Extensions;
+using Serilog;
+
+namespace NzbWebDAV.Database;
+
+/// <summary>
+/// Verifies the main database file with PRAGMA quick_check after startup migrations,
+/// so corruption surfaces as one clear log event with recovery guidance instead of
+/// scattered "database disk image is malformed" failures across background services.
+/// quick_check (not integrity_check) keeps startup fast on large databases while
+/// still detecting the malformed-image class of corruption. The metrics database is
+/// deliberately not checked: it is rebuildable and disposable.
+/// </summary>
+internal static class DatabaseIntegrityCheck
+{
+    private const int MaxLoggedFindings = 10;
+
+    /// <summary>
+    /// Returns false when corruption was detected. Never throws and never blocks
+    /// startup: the guided restore flow (Settings → Backup &amp; Restore) requires a
+    /// running backend, so crash-looping here would remove the operator's only
+    /// in-app recovery path.
+    /// </summary>
+    public static async Task<bool> VerifyMainDatabaseAsync(
+        DavDatabaseContext databaseContext,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Table-valued pragma form so EF can materialize the scalar result.
+            var findings = await databaseContext.Database
+                .SqlQueryRaw<string>("SELECT quick_check AS Value FROM pragma_quick_check")
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            // quick_check returns a single "ok" row when the database is healthy.
+            var problems = findings
+                .Where(x => !string.Equals(x, "ok", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (problems.Count == 0)
+                return true;
+
+            LogCorruption(problems);
+            return false;
+        }
+        catch (Exception ex) when (ex.IsDatabaseCorruptionException())
+        {
+            // The file is so damaged that quick_check itself could not run.
+            LogCorruption([ex.Message]);
+            return false;
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // A diagnostic must never break startup.
+            Log.Warning(ex, "Database integrity check could not run; continuing startup.");
+            return true;
+        }
+    }
+
+    private static void LogCorruption(List<string> findings)
+    {
+        Log.Error("{Reason}", ExceptionExtensions.DatabaseCorruptionReason);
+        foreach (var finding in findings.Take(MaxLoggedFindings))
+            Log.Error("Database integrity check finding: {Finding}", finding);
+        if (findings.Count > MaxLoggedFindings)
+        {
+            Log.Error(
+                "Database integrity check reported {Count} findings (showing first {Shown})",
+                findings.Count,
+                MaxLoggedFindings);
+        }
+    }
+}

--- a/backend/Database/DatabaseIntegrityCheck.cs
+++ b/backend/Database/DatabaseIntegrityCheck.cs
@@ -61,7 +61,7 @@ internal static class DatabaseIntegrityCheck
 
     private static void LogCorruption(List<string> findings)
     {
-        Log.Error("{Reason}", ExceptionExtensions.DatabaseCorruptionReason);
+        Log.Error("Database integrity check failed. {Reason}", ExceptionExtensions.DatabaseCorruptionReason);
         foreach (var finding in findings.Take(MaxLoggedFindings))
             Log.Error("Database integrity check finding: {Finding}", finding);
         if (findings.Count > MaxLoggedFindings)

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -31,7 +31,12 @@ public static class ExceptionExtensions
     {
         for (var current = exception; current != null; current = current.InnerException)
         {
-            if (current is SqliteException { SqliteErrorCode: 11 }) // SQLITE_CORRUPT
+            // SqliteErrorCode is the primary result code today (extended result codes
+            // are never enabled in this stack). The mask keeps the check correct if
+            // extended codes are ever turned on: SQLITE_CORRUPT_VTAB (267) and
+            // SQLITE_CORRUPT_SEQUENCE (523) share primary code 11 in their low byte.
+            if (current is SqliteException sqlite
+                && (sqlite.SqliteErrorCode == 11 || (sqlite.SqliteExtendedErrorCode & 0xFF) == 11))
                 return true;
         }
 

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Sockets;
+using Microsoft.Data.Sqlite;
 using NzbWebDAV.Exceptions;
 using Serilog;
 
@@ -6,9 +7,35 @@ namespace NzbWebDAV.Extensions;
 
 public static class ExceptionExtensions
 {
+    /// <summary>
+    /// Operator-facing guidance logged when the database file itself is corrupt.
+    /// Points at the guided restore flow and the recovery documentation.
+    /// </summary>
+    internal const string DatabaseCorruptionReason =
+        "Database file is corrupt (SQLite error 11: database disk image is malformed). " +
+        "Restore a backup from Settings → Backup & Restore, or see " +
+        "https://www.infinidysk.com/operations/database-corruption/ for recovery steps.";
+
     public static bool IsRetryableDownloadException(this Exception exception)
     {
         return exception is RetryableDownloadException;
+    }
+
+    /// <summary>
+    /// True when the exception chain contains SQLITE_CORRUPT (primary result code 11),
+    /// meaning the database file itself is damaged. Transient busy/locked errors
+    /// (codes 5/6/8/13) are deliberately excluded: corruption never heals on retry,
+    /// while busy/locked conditions do.
+    /// </summary>
+    public static bool IsDatabaseCorruptionException(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is SqliteException { SqliteErrorCode: 11 }) // SQLITE_CORRUPT
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -50,14 +77,20 @@ public static class ExceptionExtensions
     }
 
     /// <summary>
-    /// Returns a human-readable message for known/expected transport and download
-    /// failures so callers can log a single line without a stack dump. Walks the
-    /// exception chain and prefers the innermost matching message. Unexpected
-    /// exceptions return false so full stack traces are preserved.
+    /// Returns a human-readable message for known/expected failures (transport,
+    /// download, and database corruption) so callers can log a single line without
+    /// a stack dump. Walks the exception chain and prefers the innermost matching
+    /// message. Unexpected exceptions return false so full stack traces are preserved.
     /// </summary>
     public static bool TryGetKnownErrorMessage(this Exception exception, out string reason)
     {
         ArgumentNullException.ThrowIfNull(exception);
+
+        if (exception.IsDatabaseCorruptionException())
+        {
+            reason = DatabaseCorruptionReason;
+            return true;
+        }
 
         string? found = null;
         for (var current = exception; current != null; current = current.InnerException)

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -132,6 +132,12 @@ public partial class Program
                 .RunAsync(databaseContext, metricsBootstrap, startupCancellationToken)
                 .ConfigureAwait(false);
 
+            // Surface database corruption as one clear event with recovery guidance,
+            // before any background service trips over it. Non-fatal by design.
+            await DatabaseIntegrityCheck
+                .VerifyMainDatabaseAsync(databaseContext, startupCancellationToken)
+                .ConfigureAwait(false);
+
             // initialize the config-manager
             var configManager = new ConfigManager();
             await configManager.LoadConfig().ConfigureAwait(false);

--- a/backend/Services/BackgroundServiceErrorHandler.cs
+++ b/backend/Services/BackgroundServiceErrorHandler.cs
@@ -1,0 +1,57 @@
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Logging;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Shared error handling for background services that poll the main database in a
+/// loop. Database corruption (SQLITE_CORRUPT) never heals between retries, so it is
+/// logged on a long throttle and retried on a long delay instead of repeating a log
+/// line every few seconds for the lifetime of the process. All other exceptions keep
+/// the caller's normal delay.
+/// </summary>
+internal static class BackgroundServiceErrorHandler
+{
+    /// <summary>Retry delay used while the database is corrupt.</summary>
+    public static readonly TimeSpan CorruptionDelay = TimeSpan.FromMinutes(5);
+
+    private static readonly TimeSpan CorruptionLogInterval = TimeSpan.FromMinutes(5);
+
+    // Keyed per message template, so each calling service gets its own throttle window.
+    private static readonly LogThrottle CorruptionLogThrottle = new();
+
+    /// <summary>
+    /// Logs the loop failure and returns how long the loop should wait before its next
+    /// iteration. Corruption is throttled (with a suppressed-repeat count) and backed
+    /// off; everything else goes through <see cref="ExceptionExtensions.LogWarningKnownOrStack"/>
+    /// and keeps <paramref name="normalDelay"/>.
+    /// </summary>
+    public static TimeSpan LogAndGetRetryDelay(Exception exception, string messageTemplate, TimeSpan normalDelay)
+    {
+        if (!exception.IsDatabaseCorruptionException())
+        {
+            exception.LogWarningKnownOrStack(messageTemplate);
+            return normalDelay;
+        }
+
+        if (CorruptionLogThrottle.ShouldLog(messageTemplate, CorruptionLogInterval, out var suppressed))
+        {
+            // Always resolves for corruption (IsDatabaseCorruptionException was true).
+            exception.TryGetKnownErrorMessage(out var reason);
+            if (suppressed > 0)
+            {
+                Log.Warning(
+                    messageTemplate + " Reason: {Reason} (suppressed {Suppressed} repeats)",
+                    reason,
+                    suppressed);
+            }
+            else
+            {
+                Log.Warning(messageTemplate + " Reason: {Reason}", reason);
+            }
+        }
+
+        return CorruptionDelay;
+    }
+}

--- a/backend/Services/BlobCleanupService.cs
+++ b/backend/Services/BlobCleanupService.cs
@@ -2,8 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Utils;
-using NzbWebDAV.Extensions;
-using Serilog;
 
 namespace NzbWebDAV.Services;
 
@@ -49,10 +47,11 @@ public class BlobCleanupService : BackgroundService
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                e.LogWarningKnownOrStack("Error processing blob cleanup queue.");
-
-                // Wait 10 seconds before continuing on exception
-                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                var retryDelay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(
+                    e,
+                    "Error processing blob cleanup queue.",
+                    TimeSpan.FromSeconds(10));
+                await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
     }

--- a/backend/Services/DavCleanupService.cs
+++ b/backend/Services/DavCleanupService.cs
@@ -4,8 +4,6 @@ using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
-using NzbWebDAV.Extensions;
-using Serilog;
 
 namespace NzbWebDAV.Services;
 
@@ -35,10 +33,11 @@ public class DavCleanupService : BackgroundService
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                e.LogWarningKnownOrStack("Error processing dav cleanup queue.");
-
-                // Wait 10 seconds before continuing on exception
-                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                var retryDelay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(
+                    e,
+                    "Error processing dav cleanup queue.",
+                    TimeSpan.FromSeconds(10));
+                await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
     }

--- a/backend/Services/HistoryCleanupService.cs
+++ b/backend/Services/HistoryCleanupService.cs
@@ -2,9 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
-using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
-using Serilog;
 
 namespace NzbWebDAV.Services;
 
@@ -84,10 +82,11 @@ public class HistoryCleanupService : BackgroundService
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                e.LogWarningKnownOrStack("Error processing history cleanup queue");
-
-                // Wait 10 seconds before continuing on exception
-                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                var retryDelay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(
+                    e,
+                    "Error processing history cleanup queue",
+                    TimeSpan.FromSeconds(10));
+                await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
     }

--- a/backend/Services/HistoryRetentionService.cs
+++ b/backend/Services/HistoryRetentionService.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
-using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -95,7 +94,9 @@ public class HistoryRetentionService(ConfigManager configManager) : BackgroundSe
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
-            ex.LogWarningKnownOrStack("History retention sweep failed.");
+            // No delay here: the outer loop already waits the configured sweep
+            // interval. The handler throttles corruption logging regardless.
+            _ = BackgroundServiceErrorHandler.LogAndGetRetryDelay(ex, "History retention sweep failed.", TimeSpan.Zero);
         }
     }
 

--- a/backend/Services/NzbBlobCleanupService.cs
+++ b/backend/Services/NzbBlobCleanupService.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Utils;
-using NzbWebDAV.Extensions;
 using Serilog;
 
 namespace NzbWebDAV.Services;
@@ -40,10 +39,11 @@ public class NzbBlobCleanupService : BackgroundService
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                e.LogWarningKnownOrStack("Error processing NZB blob cleanup queue.");
-
-                // Wait 10 seconds before continuing on exception
-                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                var retryDelay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(
+                    e,
+                    "Error processing NZB blob cleanup queue.",
+                    TimeSpan.FromSeconds(10));
+                await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
     }

--- a/backend/Services/WatchdogPurgeService.cs
+++ b/backend/Services/WatchdogPurgeService.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
-using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -42,8 +41,11 @@ public class WatchdogPurgeService : BackgroundService
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                e.LogWarningKnownOrStack("Error purging watchdog entries.");
-                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken).ConfigureAwait(false);
+                var retryDelay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(
+                    e,
+                    "Error purging watchdog entries.",
+                    TimeSpan.FromMinutes(5));
+                await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
     }

--- a/docs/configuration/backup.md
+++ b/docs/configuration/backup.md
@@ -25,4 +25,6 @@ Actions: Create / Upload / Download / Preserve / Restore / Delete.
 
     Backups deliberately exclude `usenet-migration.db` (experimental Altmount migration wizard state and provenance). Deleting that file only loses migration bookkeeping — never mounted WebDAV content. If you restore a database backup mid-migration and the wizard shows many `evicted` releases, reset or forget migration data and re-scan; already-imported releases are re-detected and not resubmitted. See [Migrate from Altmount](../guides/altmount-migration.md).
 
+Restoring after `SQLite Error 11` ("database disk image is malformed")? See [Database corruption](../operations/database-corruption.md).
+
 [Backups and upgrades](../guides/backups-upgrades.md)

--- a/docs/operations/database-corruption.md
+++ b/docs/operations/database-corruption.md
@@ -1,0 +1,47 @@
+# Database corruption
+
+SQLite reports corruption as `SQLite Error 11: 'database disk image is malformed'`. It means the database file itself (`/config/db.sqlite`) is damaged — it is **not** a bug in a specific query, and retrying never heals it.
+
+## Symptoms
+
+- Repeating log lines such as `Error processing blob cleanup queue. Reason: Database file is corrupt ...` from background services.
+- A startup integrity check failure [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }: after migrations, the backend runs `PRAGMA quick_check` on the main database and logs an Error with recovery guidance when the file is damaged. Startup deliberately continues so you can still reach the restore UI.
+- WebDAV listings, queue, or history views failing or returning stale data.
+
+## Causes
+
+Corruption is almost always environmental:
+
+- `/config` on a **network filesystem** (SMB/NFS) that does not honor SQLite's locking and `fsync` requirements — the most common cause.
+- **Unclean shutdowns**: container killed mid-write (`docker kill`, OOM killer, power loss).
+- **Failing or full storage** underneath `/config`.
+
+InfiniDysk runs SQLite in WAL mode with `synchronous=NORMAL`, which mitigates but cannot prevent corruption on filesystems that lie about durability.
+
+## Recovery
+
+### Restore from a backup (recommended)
+
+Use the guided restore under **Settings → Backup & Restore** — see [Backup and restore](../configuration/backup.md). Restore replaces settings, queue, history, and WebDAV tree metadata, creates a pre-restore safety backup, and restarts into maintenance. Blobs under `/config/blobs/` are not part of SQL dumps; missing blobs are reported in the UI after the restore.
+
+If you do not have a backup, enable **daily backups** after recovering so the next incident is a one-click restore.
+
+### Advanced: salvage with the SQLite CLI
+
+On a copy of the file, with the container stopped:
+
+```bash
+sqlite3 /config/db.sqlite ".recover" | sqlite3 /config/db-recovered.sqlite
+```
+
+`.recover` extracts whatever rows are still readable into a fresh database. Expect partial data loss: rows on damaged pages are skipped. Point `/config` at the recovered file only after verifying it opens cleanly (`PRAGMA integrity_check` should print `ok`).
+
+### Last resort: fresh start
+
+Stop the container, move `db.sqlite*` aside, and start again. A fresh database loses settings, queue, history, and the WebDAV tree metadata (the content itself lives on Usenet and can be re-added).
+
+## Prevention
+
+- Keep `/config` on **local disk**, not a network share.
+- Enable **daily backups** with a retention count under **Settings → Backup & Restore**.
+- Stop the container gracefully (`docker stop`, not `docker kill`) so SQLite can checkpoint the WAL.

--- a/tests/NzbWebDAV.Tests/Database/DatabaseIntegrityCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseIntegrityCheckTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+
+namespace NzbWebDAV.Tests.Database;
+
+public class DatabaseIntegrityCheckTests : IAsyncLifetime
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(),
+        "nzbdav-db-integrity-" + Guid.NewGuid().ToString("N"));
+
+    private string DatabasePath => Path.Combine(_tempDir, "db.sqlite");
+
+    public Task InitializeAsync()
+    {
+        Directory.CreateDirectory(_tempDir);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        SqliteConnection.ClearAllPools();
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task VerifyMainDatabaseAsync_HealthyDatabase_Passes()
+    {
+        await CreateMultiPageDatabaseAsync();
+        await using var context = CreateContext();
+
+        var ok = await DatabaseIntegrityCheck.VerifyMainDatabaseAsync(context);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public async Task VerifyMainDatabaseAsync_CorruptDatabase_IsDetected()
+    {
+        await CreateMultiPageDatabaseAsync();
+
+        // Invalidate the b-tree page-type byte of page 2 (offset = page size).
+        // Page 1 holds the 100-byte database header, so corruption is applied
+        // past it to stay in the SQLITE_CORRUPT class rather than SQLITE_NOTADB.
+        SqliteConnection.ClearAllPools();
+        await using (var stream = new FileStream(DatabasePath, FileMode.Open, FileAccess.ReadWrite))
+        {
+            stream.Seek(4096, SeekOrigin.Begin);
+            stream.WriteByte(0xFF);
+        }
+
+        await using var context = CreateContext();
+        var ok = await DatabaseIntegrityCheck.VerifyMainDatabaseAsync(context);
+
+        Assert.False(ok);
+    }
+
+    private DavDatabaseContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DatabasePath}")
+            .Options;
+        return new DavDatabaseContext(options);
+    }
+
+    private async Task CreateMultiPageDatabaseAsync()
+    {
+        await using var connection = new SqliteConnection($"Data Source={DatabasePath}");
+        await connection.OpenAsync();
+
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE payload (data TEXT NOT NULL);";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        // ~100 KB across many rows so the table spans well beyond page 2.
+        var filler = new string('x', 500);
+        for (var i = 0; i < 200; i++)
+        {
+            await using var insert = connection.CreateCommand();
+            insert.CommandText = "INSERT INTO payload (data) VALUES ($data);";
+            insert.Parameters.AddWithValue("$data", filler);
+            await insert.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DatabaseIntegrityCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseIntegrityCheckTests.cs
@@ -6,11 +6,11 @@ namespace NzbWebDAV.Tests.Database;
 
 public class DatabaseIntegrityCheckTests : IAsyncLifetime
 {
-    private readonly string _tempDir = Path.Combine(
+    private readonly string _tempDir = Path.Join(
         Path.GetTempPath(),
-        "nzbdav-db-integrity-" + Guid.NewGuid().ToString("N"));
+        $"nzbdav-db-integrity-{Guid.NewGuid():N}");
 
-    private string DatabasePath => Path.Combine(_tempDir, "db.sqlite");
+    private string DatabasePath => Path.Join(_tempDir, "db.sqlite");
 
     public Task InitializeAsync()
     {
@@ -21,7 +21,11 @@ public class DatabaseIntegrityCheckTests : IAsyncLifetime
     public Task DisposeAsync()
     {
         SqliteConnection.ClearAllPools();
-        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
         return Task.CompletedTask;
     }
 

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Sockets;
+using Microsoft.Data.Sqlite;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 
@@ -114,6 +115,56 @@ public class ExceptionExtensionsTests
 
         Assert.True(aggregate.TryGetCausingException<TimeoutException>(out var found));
         Assert.Same(inner, found);
+    }
+
+    [Fact]
+    public void IsDatabaseCorruptionException_RecognizesSqliteCorrupt()
+    {
+        var ex = new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);
+
+        Assert.True(ex.IsDatabaseCorruptionException());
+    }
+
+    [Fact]
+    public void IsDatabaseCorruptionException_RecognizesNestedCorrupt()
+    {
+        var inner = new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);
+        var outer = new InvalidOperationException("An error occurred while saving changes.", inner);
+
+        Assert.True(outer.IsDatabaseCorruptionException());
+    }
+
+    [Theory]
+    [InlineData(5)] // SQLITE_BUSY
+    [InlineData(6)] // SQLITE_LOCKED
+    [InlineData(8)] // SQLITE_READONLY
+    [InlineData(13)] // SQLITE_FULL
+    [InlineData(26)] // SQLITE_NOTADB
+    public void IsDatabaseCorruptionException_RejectsTransientAndOtherSqliteErrors(int errorCode)
+    {
+        var ex = new SqliteException("some other sqlite error", errorCode);
+
+        Assert.False(ex.IsDatabaseCorruptionException());
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_Corruption_ReturnsRecoveryGuidance()
+    {
+        var ex = new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Contains("corrupt", reason);
+        Assert.Contains("Backup & Restore", reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_OtherSqliteErrors_StayUnknown()
+    {
+        // Busy/locked and friends stay unclassified: they are transient and
+        // handled by their own retry paths, not by corruption guidance.
+        var ex = new SqliteException("SQLite Error 5: 'database is locked'.", 5);
+
+        Assert.False(ex.TryGetKnownErrorMessage(out _));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/BackgroundServiceErrorHandlerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/BackgroundServiceErrorHandlerTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Data.Sqlite;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class BackgroundServiceErrorHandlerTests
+{
+    private static readonly TimeSpan NormalDelay = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public void LogAndGetRetryDelay_Corruption_UsesLongBackoff()
+    {
+        var ex = new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);
+
+        var delay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(ex, "test loop failed.", NormalDelay);
+
+        Assert.Equal(BackgroundServiceErrorHandler.CorruptionDelay, delay);
+    }
+
+    [Fact]
+    public void LogAndGetRetryDelay_NestedCorruption_UsesLongBackoff()
+    {
+        var inner = new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);
+        var ex = new InvalidOperationException("wrapper", inner);
+
+        var delay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(ex, "test loop failed.", NormalDelay);
+
+        Assert.Equal(BackgroundServiceErrorHandler.CorruptionDelay, delay);
+    }
+
+    [Fact]
+    public void LogAndGetRetryDelay_TransientSqliteError_KeepsNormalDelay()
+    {
+        var ex = new SqliteException("SQLite Error 5: 'database is locked'.", 5);
+
+        var delay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(ex, "test loop failed.", NormalDelay);
+
+        Assert.Equal(NormalDelay, delay);
+    }
+
+    [Fact]
+    public void LogAndGetRetryDelay_UnexpectedException_KeepsNormalDelay()
+    {
+        var delay = BackgroundServiceErrorHandler.LogAndGetRetryDelay(
+            new NullReferenceException("unexpected bug"),
+            "test loop failed.",
+            NormalDelay);
+
+        Assert.Equal(NormalDelay, delay);
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -78,6 +78,7 @@ nav = [
     { "Retention and cleanup" = "operations/retention-cleanup.md" },
     { "Logs and crash dumps" = "operations/logs-crash-dumps.md" },
     { "Deletion audit" = "operations/deletion-audit.md" },
+    { "Database corruption" = "operations/database-corruption.md" },
   ]},
   { "Community" = [
     { "Rename FAQ" = "community/renaming-to-infinidysk.md" },


### PR DESCRIPTION
Fixes #942

## Summary

- A corrupt `db.sqlite` (`SQLite Error 11: 'database disk image is malformed'`) previously made every background cleanup loop log a full stack trace every 10 seconds, forever, with no recovery guidance. `SQLITE_CORRUPT` is now classified as a known operational failure, so logs show a single actionable line: restore a backup from **Settings → Backup & Restore**, with a docs link.
- The six main-database background pollers (blob/dav/history/NZB-blob cleanup, watchdog purge, history retention) now throttle that warning to once per 5 minutes and retry on a 5-minute backoff, since corruption never heals between 10-second retries. All other exceptions keep their existing logging and delays.
- Startup now runs `PRAGMA quick_check` on the main database after migrations and logs a loud, self-identifying Error with recovery steps when the file is damaged. Startup deliberately continues so the guided restore UI stays reachable.
- New docs page: **Operations → Database corruption** (symptoms, causes, restore, `sqlite3 .recover` salvage, prevention), cross-linked from the backup page.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2582 passed, 0 failed
- [x] New tests: corruption classification (direct/nested/rejects busy-locked-readonly-full-notadb), retry-delay decision, startup integrity check (healthy DB passes; byte-flipped page-2 DB is detected)
- [x] `zensical build --clean --strict` passes with the new docs page
- [x] Reviewed by a second model (glm-5.2-max): SHIP WITH NITS, no blockers; both actionable nits addressed in the final commit
- [ ] CI green