### PR TITLE
feat(ui): play media in-app from Files with auto-resume and playback diagnostics

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -160,7 +160,7 @@ public class GetWebdavItemController(
                 request.Item,
                 request.SuffixLength.HasValue ? null : request.RangeStart ?? 0,
                 ResolveReadRegion(request));
-            var sessionId = TrackReadSession(request.Item);
+            var sessionId = TrackReadSession(request);
             HttpContext.Items["readSessionId"] = sessionId;
             using var scope = providerUsageTracker.BeginScope(sessionId);
             using var metricsScope = MultiProviderNntpClient.BeginReadSessionScope(sessionId);
@@ -313,15 +313,16 @@ public class GetWebdavItemController(
         });
     }
 
-    private Guid TrackReadSession(string itemPath)
+    private Guid TrackReadSession(GetWebdavItemRequest request)
     {
         // Provisional name from the URL path. GetWebdavItem replaces it with
         // item.Name (the real human-readable filename) once the store lookup runs.
-        var fileName = Path.GetFileName(itemPath);
+        var fileName = Path.GetFileName(request.Item);
         var userAgent = Request.Headers.UserAgent.ToString();
         var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
         var clientKey = $"{clientIp}|{userAgent}";
-        return activeReadRegistry.GetOrCreate(itemPath, clientKey, fileName, fileSize: null, userAgent, clientIp);
+        return activeReadRegistry.GetOrCreate(
+            request.Item, clientKey, fileName, fileSize: null, userAgent, clientIp, request.PlayerSession);
     }
 
     [HttpHead]

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -16,6 +16,9 @@ public class GetWebdavItemRequest
     // The controller resolves this to a concrete start/end once fileSize is known.
     public long? SuffixLength { get; init; }
     public bool ShouldDownload { get; init; }
+    // Optional non-secret id that lets an in-app player instance correlate its
+    // requests with the active-read broadcast. Carries no authority.
+    public string? PlayerSession { get; init; }
 
     public GetWebdavItemRequest(HttpContext context)
     {
@@ -28,6 +31,9 @@ public class GetWebdavItemRequest
 
         // determine whether to download
         ShouldDownload = context.GetQueryParam("download")?.ToLowerInvariant() == "true";
+
+        // short opaque client-supplied correlation token; ignore invalid values
+        PlayerSession = NormalizePlayerSession(context.GetQueryParam("playerSession"));
 
         // authenticate the downloadKey
         var downloadKey = context.Request.Query["downloadKey"];
@@ -97,6 +103,20 @@ public class GetWebdavItemRequest
         rangeStart = start;
         rangeEnd = parsedEnd;
         return true;
+    }
+
+    /// <summary>
+    /// Keep only short, URL-safe opaque tokens. The value flows into the
+    /// active-read dedupe key, so reject anything long or exotic rather than
+    /// letting a client mint unbounded key cardinality.
+    /// </summary>
+    internal static string? NormalizePlayerSession(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw) || raw.Length > 64) return null;
+        foreach (var c in raw)
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('-' or '_'))
+                return null;
+        return raw;
     }
 
     private static bool VerifyDownloadKey(string? downloadKey, string path, ConfigManager configManager)

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemRequest.cs
@@ -113,10 +113,10 @@ public class GetWebdavItemRequest
     internal static string? NormalizePlayerSession(string? raw)
     {
         if (string.IsNullOrEmpty(raw) || raw.Length > 64) return null;
-        foreach (var c in raw)
-            if (!char.IsAsciiLetterOrDigit(c) && c is not ('-' or '_'))
-                return null;
-        return raw;
+        return raw.All(IsValidPlayerSessionChar) ? raw : null;
+
+        static bool IsValidPlayerSessionChar(char c)
+            => char.IsAsciiLetterOrDigit(c) || c is '-' or '_';
     }
 
     private static bool VerifyDownloadKey(string? downloadKey, string path, ConfigManager configManager)

--- a/backend/Services/ActiveReadRegistry.cs
+++ b/backend/Services/ActiveReadRegistry.cs
@@ -34,9 +34,10 @@ public class ActiveReadRegistry
         string fileName,
         long? fileSize,
         string? clientUserAgent = null,
-        string? clientIp = null)
+        string? clientIp = null,
+        string? playerSession = null)
     {
-        var key = BuildKey(path, clientKey);
+        var key = BuildKey(path, clientKey, playerSession);
         var now = DateTimeOffset.UtcNow;
 
         while (true)
@@ -61,6 +62,7 @@ public class ActiveReadRegistry
                 ClientKey = clientKey,
                 ClientUserAgent = clientUserAgent,
                 ClientIp = clientIp,
+                PlayerSession = playerSession,
                 StartedAt = now,
                 LastActivityAt = now,
             };
@@ -132,9 +134,13 @@ public class ActiveReadRegistry
     /// Returns the pruned entries so callers can clear external bookkeeping
     /// and persist a terminal record of the session.
     /// </summary>
-    public IReadOnlyList<Entry> PruneExpired()
+    public IReadOnlyList<Entry> PruneExpired() => PruneExpired(DateTimeOffset.UtcNow);
+
+    // Test-visible overload: lets tests expire entries without waiting out the
+    // activity window in real time.
+    internal IReadOnlyList<Entry> PruneExpired(DateTimeOffset now)
     {
-        var cutoff = DateTimeOffset.UtcNow - ActivityWindow;
+        var cutoff = now - ActivityWindow;
         var expired = _entries
             .Where(kv => kv.Value.LastActivityAt < cutoff)
             .Select(kv => kv.Value)
@@ -145,7 +151,7 @@ public class ActiveReadRegistry
             // this expired entry — a fresh session for the same player and
             // file may have already claimed the key, in which case we leave
             // the new mapping intact.
-            var key = BuildKey(entry.Path, entry.ClientKey);
+            var key = BuildKey(entry.Path, entry.ClientKey, entry.PlayerSession);
             ((ICollection<KeyValuePair<string, Guid>>)_keyToId)
                 .Remove(new KeyValuePair<string, Guid>(key, entry.Id));
             _entries.TryRemove(entry.Id, out _);
@@ -155,7 +161,13 @@ public class ActiveReadRegistry
 
     public int Count => _entries.Count;
 
-    private static string BuildKey(string path, string clientKey) => path + "\n" + clientKey;
+    // The player-session token joins the dedupe key so two in-app players
+    // streaming the same file from the same browser/IP still get distinct
+    // sessions; requests without one (external players) dedupe as before.
+    private static string BuildKey(string path, string clientKey, string? playerSession)
+        => playerSession is null
+            ? path + "\n" + clientKey
+            : path + "\n" + clientKey + "\nps:" + playerSession;
 
     public sealed class Entry
     {
@@ -166,6 +178,7 @@ public class ActiveReadRegistry
         public string ClientKey { get; init; } = "";
         public string? ClientUserAgent { get; set; }
         public string? ClientIp { get; set; }
+        public string? PlayerSession { get; init; }
         public DateTimeOffset StartedAt { get; init; }
         public DateTimeOffset LastActivityAt { get; set; }
         public long BytesRead;

--- a/backend/Services/ActiveReadsBroadcaster.cs
+++ b/backend/Services/ActiveReadsBroadcaster.cs
@@ -97,10 +97,12 @@ public class ActiveReadsBroadcaster(
                 startedAt = e.StartedAt.ToUnixTimeMilliseconds(),
                 lastActivityAt = e.LastActivityAt.ToUnixTimeMilliseconds(),
                 bytesRead = Interlocked.Read(ref e.BytesRead),
+                bytesFetched = Interlocked.Read(ref e.BytesFetched),
                 currentOffset = Interlocked.Read(ref e.CurrentOffset),
                 fileSize = e.FileSize,
                 clientIp = e.ClientIp,
                 clientUserAgent = e.ClientUserAgent,
+                playerSession = e.PlayerSession,
                 providers = (usage.GetValueOrDefault(e.Id) ?? new Dictionary<string, long>())
                     .Select(kv =>
                     {

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -822,10 +822,12 @@ export type ActiveRead = {
     startedAt: number,
     lastActivityAt: number,
     bytesRead: number,
+    bytesFetched?: number,
     currentOffset: number,
     fileSize: number | null,
     clientIp?: string | null | undefined,
     clientUserAgent?: string | null | undefined,
+    playerSession?: string | null | undefined,
     providers: { host: string, nickname?: string | null | undefined, segments: number }[],
 }
 

--- a/frontend/app/components/ui/modal.tsx
+++ b/frontend/app/components/ui/modal.tsx
@@ -10,11 +10,14 @@ export type ModalProps = {
   footer?: ReactNode;
   onClose: () => void;
   className?: string;
+  /** Box width preset; "default" matches the historical max-w-xl. */
+  size?: "default" | "wide";
   /** When true, backdrop / Escape / X cannot dismiss the dialog. */
   preventClose?: boolean;
 };
 
-export function Modal({ open, title, children, footer, onClose, className = "", preventClose = false }: ModalProps) {
+export function Modal({ open, title, children, footer, onClose, className = "", size = "default", preventClose = false }: ModalProps) {
+  const sizeClass = size === "wide" ? "max-w-5xl" : "max-w-xl";
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
@@ -45,7 +48,7 @@ export function Modal({ open, title, children, footer, onClose, className = "", 
         if (open) onClose();
       }}
     >
-      <div className={`modal-box max-h-[90dvh] w-full max-w-xl overflow-y-auto ${className}`}>
+      <div className={`modal-box max-h-[90dvh] w-full ${sizeClass} overflow-y-auto ${className}`}>
         <form method="dialog">
           <Button
             type="submit"

--- a/frontend/app/routes/explore/file-kind/file-kind.test.ts
+++ b/frontend/app/routes/explore/file-kind/file-kind.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+    fileKindRank,
+    getExtension,
+    getIcon,
+    getMime,
+    isAudioFile,
+    isPlayableMedia,
+    isVideoFile,
+} from "./file-kind";
+
+describe("getExtension", () => {
+    it("returns the lowercase-preserving extension for normal names", () => {
+        expect(getExtension("Movie.MKV")).toBe(".MKV");
+        expect(getExtension("a.b.c")).toBe(".c");
+    });
+
+    it("returns undefined for dotfiles and extensionless names", () => {
+        expect(getExtension(".par2")).toBeUndefined();
+        expect(getExtension("README")).toBeUndefined();
+    });
+});
+
+describe("getMime", () => {
+    it("coerces false/null/undefined to empty string", () => {
+        expect(getMime({ name: "x.bin", mimeType: false })).toBe("");
+        expect(getMime({ name: "x.bin", mimeType: null })).toBe("");
+        expect(getMime({ name: "x.bin" })).toBe("");
+        expect(getMime({ name: "x.bin", mimeType: "video/mp4" })).toBe("video/mp4");
+    });
+});
+
+describe("isVideoFile", () => {
+    it("detects video by mime, .mkv extension, and application/mp4", () => {
+        expect(isVideoFile({ name: "a.mp4", mimeType: "video/mp4" })).toBe(true);
+        expect(isVideoFile({ name: "a.mkv", mimeType: false })).toBe(true);
+        expect(isVideoFile({ name: "a.mp4", mimeType: "application/mp4" })).toBe(true);
+        expect(isVideoFile({ name: "a.txt", mimeType: "text/plain" })).toBe(false);
+    });
+});
+
+describe("isAudioFile / isPlayableMedia", () => {
+    it("detects audio by mime only", () => {
+        expect(isAudioFile({ name: "a.flac", mimeType: "audio/flac" })).toBe(true);
+        expect(isAudioFile({ name: "a.flac", mimeType: false })).toBe(false);
+    });
+
+    it("treats video and audio as playable, everything else as not", () => {
+        expect(isPlayableMedia({ name: "a.mkv", mimeType: "video/x-matroska" })).toBe(true);
+        expect(isPlayableMedia({ name: "a.mp3", mimeType: "audio/mpeg" })).toBe(true);
+        expect(isPlayableMedia({ name: "a.nzb", mimeType: false })).toBe(false);
+        expect(isPlayableMedia({ name: "a.png", mimeType: "image/png" })).toBe(false);
+    });
+});
+
+describe("fileKindRank", () => {
+    it("does not throw when mimeType is false (mime-types miss)", () => {
+        expect(() => fileKindRank({ name: "a.unknownext", mimeType: false })).not.toThrow();
+        expect(fileKindRank({ name: "a.unknownext", mimeType: false })).toBe(3);
+    });
+
+    it("orders video before image before audio before other", () => {
+        expect(fileKindRank({ name: "v.mkv", mimeType: false })).toBe(0);
+        expect(fileKindRank({ name: "i.png", mimeType: "image/png" })).toBe(1);
+        expect(fileKindRank({ name: "s.flac", mimeType: "audio/flac" })).toBe(2);
+        expect(fileKindRank({ name: "r.nfo", mimeType: "text/plain" })).toBe(3);
+    });
+});
+
+describe("getIcon", () => {
+    it("maps kinds to material symbols and handles false mimeType", () => {
+        expect(getIcon({ name: "a.mkv", mimeType: false })).toBe("movie");
+        expect(getIcon({ name: "a.mp4", mimeType: "video/mp4" })).toBe("movie");
+        expect(getIcon({ name: "a.png", mimeType: "image/png" })).toBe("image");
+        expect(getIcon({ name: "a.flac", mimeType: "audio/flac" })).toBe("audio_file");
+        expect(getIcon({ name: "a.nfo", mimeType: "text/plain" })).toBe("draft");
+        expect(getIcon({ name: "a.xyz", mimeType: false })).toBe("draft");
+    });
+});

--- a/frontend/app/routes/explore/file-kind/file-kind.ts
+++ b/frontend/app/routes/explore/file-kind/file-kind.ts
@@ -1,0 +1,49 @@
+import type { DirectoryItem } from "~/clients/backend-client.server";
+
+export type NamedFile = Pick<DirectoryItem, "name"> & {
+    // mime-types lookup() returns false for unknown extensions; tolerate it here
+    // so classification never throws on files the MIME database doesn't know.
+    mimeType?: string | false | null;
+};
+
+export function getExtension(filename: string): string | undefined {
+    const lastDotIndex = filename.lastIndexOf('.');
+    if (lastDotIndex === -1 || lastDotIndex === 0) return undefined;
+    return filename.slice(lastDotIndex);
+}
+
+export function getMime(file: NamedFile): string {
+    return typeof file.mimeType === "string" ? file.mimeType : "";
+}
+
+export function isVideoFile(file: NamedFile): boolean {
+    const mime = getMime(file);
+    return mime.startsWith("video")
+        || getExtension(file.name)?.toLowerCase() === ".mkv"
+        || mime === "application/mp4";
+}
+
+export function isAudioFile(file: NamedFile): boolean {
+    return getMime(file).startsWith("audio");
+}
+
+/** Media the in-app preview can attempt with a native element. */
+export function isPlayableMedia(file: NamedFile): boolean {
+    return isVideoFile(file) || isAudioFile(file);
+}
+
+export function fileKindRank(item: NamedFile): number {
+    if (isVideoFile(item)) return 0;
+    const mime = getMime(item);
+    if (mime.startsWith("image")) return 1;
+    if (mime.startsWith("audio")) return 2;
+    return 3;
+}
+
+export function getIcon(file: NamedFile): string {
+    if (isVideoFile(file)) return "movie";
+    const mime = getMime(file);
+    if (mime.startsWith("image")) return "image";
+    if (mime.startsWith("audio")) return "audio_file";
+    return "draft";
+}

--- a/frontend/app/routes/explore/item-menu/item-menu.tsx
+++ b/frontend/app/routes/explore/item-menu/item-menu.tsx
@@ -8,10 +8,12 @@ export type ItemMenuProps = {
     openClassName?: string
     exploreFile?: ExploreFile,
     previewPath?: string,
+    /** When set, Preview opens the in-app player instead of navigating. */
+    onPreview?: () => void,
     onRemove?: () => void,
 }
 
-export function ItemMenu({ className, openClassName, exploreFile, previewPath, onRemove }: ItemMenuProps): ReactNode {
+export function ItemMenu({ className, openClassName, exploreFile, previewPath, onPreview, onRemove }: ItemMenuProps): ReactNode {
     const [isOpen, setIsOpen] = useState(false);
     const exportNzbUrl = exploreFile ? `/api/download-nzb?nzbBlobId=${exploreFile.nzbBlobId}` : undefined;
     const downloadUrl = previewPath ? `${previewPath}&download=true` : undefined;
@@ -23,7 +25,9 @@ export function ItemMenu({ className, openClassName, exploreFile, previewPath, o
     }, []);
 
     const options = [
-        previewPath ? { option: <Preview />, linkTo: previewPath } : undefined,
+        onPreview
+            ? { option: <Preview />, onSelect: onPreview }
+            : previewPath ? { option: <Preview />, linkTo: previewPath } : undefined,
         downloadUrl ? { option: <Download />, linkTo: downloadUrl } : undefined,
         exploreFile?.nzbBlobId && exportNzbUrl ? { option: <ExportNzb />, linkTo: exportNzbUrl } : undefined,
         onRemove ? { option: <Remove />, variant: "danger" as const, onSelect: onRemove } : undefined,

--- a/frontend/app/routes/explore/media-preview/media-diagnostics.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-diagnostics.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { buildDiagnosticsSnapshot, type MediaDiagnosticsProps } from "./media-diagnostics";
+import type { ActiveRead } from "~/clients/backend-client.server";
+import type { MediaPlayer } from "./use-media-player";
+
+function fakePlayer(): MediaPlayer {
+    return {
+        status: "playing",
+        buffering: false,
+        attempts: 1,
+        maxAttempts: 3,
+        error: null,
+        startupMs: 420,
+        events: [{ at: 1_000, kind: "play" }],
+        lastGoodTimeRef: { current: 12.5 },
+        lastProgressAtRef: { current: 2_000 },
+    } as unknown as MediaPlayer;
+}
+
+function fakeProps(): MediaDiagnosticsProps {
+    return {
+        player: fakePlayer(),
+        getMedia: () => null,
+        playerSession: "player-session-1",
+        fileName: "movie.mkv",
+        filePath: "content/movies/movie.mkv",
+        mimeType: "video/x-matroska",
+        sizeBytes: 1_000_000,
+    };
+}
+
+const fakeRead: ActiveRead = {
+    id: "read-session-id",
+    fileName: "movie.mkv",
+    path: "content/movies/movie.mkv",
+    startedAt: 1_000,
+    lastActivityAt: 2_000,
+    bytesRead: 100,
+    bytesFetched: 200,
+    currentOffset: 100,
+    fileSize: 1_000_000,
+    clientIp: "203.0.113.10",
+    clientUserAgent: "Mozilla/5.0",
+    playerSession: "player-session-1",
+    providers: [{ host: "news.example.com", nickname: "Main", segments: 12 }],
+};
+
+describe("buildDiagnosticsSnapshot", () => {
+    it("never includes the download key, client IP, or raw segment ids", () => {
+        const snapshot = buildDiagnosticsSnapshot(
+            fakeProps(),
+            fakeRead,
+            null,
+            null,
+            null,
+            [{
+                seq: 7,
+                at: 1_000,
+                kind: "Segment",
+                provider: "abc",
+                status: "Ok",
+                segmentId: "full-message-id@usenet.example",
+            }],
+        );
+        const json = JSON.stringify(snapshot);
+
+        expect(json).not.toContain("downloadKey");
+        expect(json).not.toContain("203.0.113.10");
+        expect(json).not.toContain("full-message-id@usenet.example");
+        expect(json).toContain("full-message"); // truncated prefix retained
+        expect(snapshot.backendRead?.sessionId).toBe("read-session-id");
+        expect(snapshot.backendRead?.bytesFetched).toBe(200);
+        expect(snapshot.playerSession).toBe("player-session-1");
+    });
+
+    it("handles missing backend read and trace data", () => {
+        const snapshot = buildDiagnosticsSnapshot(fakeProps(), null, null, null, null, null);
+        expect(snapshot.backendRead).toBeNull();
+        expect(snapshot.traceSummary).toBeNull();
+        expect(snapshot.recentTraceEvents).toBeNull();
+    });
+});

--- a/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
+++ b/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
@@ -1,0 +1,494 @@
+import { useEffect, useRef, useState } from "react";
+import type {
+    ActiveRead,
+    ActiveReadsMessage,
+    LiveStatsMessage,
+} from "~/clients/backend-client.server";
+import { Button, Icon } from "~/components/ui";
+import { formatFileSize } from "~/utils/file-size";
+import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { toStreamTracingStatus, type StreamTracingStatus } from "~/utils/stream-tracing-status";
+import { withUrlBase } from "~/utils/url-base";
+import {
+    bufferedAhead,
+    formatClock,
+    formatTimeRanges,
+    networkStateLabel,
+    readyStateLabel,
+} from "./media-utils";
+import {
+    describeTraceEvent,
+    redactTraceEvents,
+    summarizeTrace,
+    type StreamTraceEvent,
+} from "./media-trace";
+import type { MediaPlayer } from "./use-media-player";
+
+const TOPIC_ACTIVE_READS = "ar";
+const TOPIC_LIVE_STATS = "ls";
+const STATUS_POLL_MS = 5_000;
+const EVENTS_POLL_MS = 3_000;
+const RECENT_EVENTS_SHOWN = 50;
+
+export type MediaDiagnosticsProps = {
+    player: MediaPlayer;
+    getMedia: () => HTMLMediaElement | null;
+    playerSession: string;
+    fileName: string;
+    filePath: string;
+    mimeType: string;
+    sizeBytes: number | null;
+};
+
+export function MediaDiagnostics(props: MediaDiagnosticsProps) {
+    const { player, getMedia, playerSession } = props;
+
+    // Low-frequency tick drives all derived readouts; the media element
+    // itself is outside this subtree, so ticking never re-renders it.
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        const interval = setInterval(() => setNow(Date.now()), 500);
+        return () => clearInterval(interval);
+    }, []);
+
+    const [reads, setReads] = useState<ActiveRead[]>([]);
+    const [liveStats, setLiveStats] = useState<LiveStatsMessage | null>(null);
+    const prevBytesRef = useRef<{ id: string, bytes: number, at: number, rate: number } | null>(null);
+
+    useWebsocketTopic(TOPIC_ACTIVE_READS, "state", message => {
+        try {
+            const payload = JSON.parse(message) as ActiveReadsMessage;
+            setReads(payload.reads ?? []);
+        } catch { /* ignore malformed payloads */ }
+    });
+    useWebsocketTopic(TOPIC_LIVE_STATS, "state", message => {
+        try {
+            setLiveStats(JSON.parse(message) as LiveStatsMessage);
+        } catch { /* ignore malformed payloads */ }
+    });
+
+    const matchedRead = reads.find(r => r.playerSession === playerSession) ?? null;
+    const readRate = matchedRead ? smoothRate(prevBytesRef, matchedRead, now) : 0;
+
+    const [traceStatus, setTraceStatus] = useState<StreamTracingStatus | null>(null);
+    const [traceEvents, setTraceEvents] = useState<StreamTraceEvent[] | null>(null);
+    const [traceBusy, setTraceBusy] = useState(false);
+    const [traceError, setTraceError] = useState<string | null>(null);
+    const [copyNote, setCopyNote] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const load = () => {
+            void fetch(withUrlBase("/settings/stream-tracing"))
+                .then(async response => {
+                    if (!response.ok || cancelled) return;
+                    const data = await response.json() as Record<string, unknown>;
+                    if (!cancelled) setTraceStatus(toStreamTracingStatus(data));
+                })
+                .catch(() => { /* status stays null; row shows unavailable */ });
+        };
+        load();
+        const interval = setInterval(load, STATUS_POLL_MS);
+        return () => { cancelled = true; clearInterval(interval); };
+    }, []);
+
+    const sessionId = matchedRead?.id ?? null;
+    const tracingActive = Boolean(traceStatus && (traceStatus.enabled || traceStatus.retained));
+
+    useEffect(() => {
+        if (!sessionId || !tracingActive) return;
+        let cancelled = false;
+        const load = () => {
+            void fetch(withUrlBase(`/api/get-stream-trace?sessionId=${encodeURIComponent(sessionId)}`))
+                .then(async response => {
+                    if (!response.ok || cancelled) return;
+                    const data = await response.json() as { events?: StreamTraceEvent[] };
+                    if (!cancelled) setTraceEvents(data.events ?? []);
+                })
+                .catch(() => { /* keep last events on transient failure */ });
+        };
+        load();
+        const interval = setInterval(load, EVENTS_POLL_MS);
+        return () => { cancelled = true; clearInterval(interval); };
+    }, [sessionId, tracingActive]);
+
+    const startTrace = async () => {
+        setTraceBusy(true);
+        setTraceError(null);
+        try {
+            const form = new FormData();
+            form.append("enabled", "true");
+            form.append("minutes", "15");
+            form.append("capacity", "100000");
+            const response = await fetch(withUrlBase("/settings/stream-tracing"), { method: "POST", body: form });
+            if (!response.ok) {
+                const body = await response.json().catch(() => null) as { error?: string } | null;
+                throw new Error(body?.error || `Could not start tracing (${response.status})`);
+            }
+            const data = await response.json() as Record<string, unknown>;
+            setTraceStatus(toStreamTracingStatus(data));
+        } catch (e) {
+            setTraceError(e instanceof Error ? e.message : "Could not start tracing");
+        } finally {
+            setTraceBusy(false);
+        }
+    };
+
+    const el = getMedia();
+    const summary = traceEvents ? summarizeTrace(traceEvents) : null;
+    const recentEvents = traceEvents ? traceEvents.slice(-RECENT_EVENTS_SHOWN).reverse() : [];
+
+    const copyText = (text: string, note: string) => {
+        void navigator.clipboard.writeText(text)
+            .then(() => {
+                setCopyNote(note);
+                setTimeout(() => setCopyNote(null), 2000);
+            })
+            .catch(() => setCopyNote("Copy failed"));
+    };
+
+    const copySnapshot = () => {
+        const snapshot = buildDiagnosticsSnapshot(props, matchedRead, liveStats, el, summary, traceEvents);
+        copyText(JSON.stringify(snapshot, null, 2), "Diagnostics copied");
+    };
+
+    return (
+        <div className="flex flex-col gap-4 rounded-lg border border-base-content/10 bg-base-200 p-3 text-xs">
+            <Section title="Player">
+                <Grid>
+                    <Field label="Status" value={player.status + (player.buffering ? " · buffering" : "")} />
+                    <Field label="Startup" value={player.startupMs != null ? `${player.startupMs} ms` : "—"} />
+                    <Field
+                        label="Position"
+                        value={el ? `${formatClock(el.currentTime)} / ${formatClock(el.duration)}` : "—"}
+                        mono
+                    />
+                    <Field label="Buffer ahead" value={el ? `${bufferedAhead(el.buffered, el.currentTime).toFixed(1)} s` : "—"} mono />
+                    <Field label="Buffered" value={el ? formatTimeRanges(el.buffered) : "—"} mono />
+                    <Field label="Ready state" value={el ? readyStateLabel(el.readyState) : "—"} mono />
+                    <Field label="Network state" value={el ? networkStateLabel(el.networkState) : "—"} mono />
+                    <Field label="Resolution" value={videoDimensions(el)} mono />
+                    <Field label="Playback rate" value={el ? `${el.playbackRate}×` : "—"} mono />
+                    <Field label="Paused" value={el ? (el.paused ? "yes" : "no") : "—"} />
+                    <Field label="Seeking" value={el ? (el.seeking ? "yes" : "no") : "—"} />
+                    <Field label="Dropped frames" value={droppedFrames(el)} mono />
+                    <Field
+                        label="Last progress"
+                        value={player.lastProgressAtRef.current != null
+                            ? `${((now - player.lastProgressAtRef.current) / 1000).toFixed(1)} s ago`
+                            : "—"}
+                        mono
+                    />
+                    <Field label="Recovery attempts" value={`${player.attempts}/${player.maxAttempts}`} mono />
+                    <Field label="Online" value={navigator.onLine ? "yes" : "no"} />
+                    <Field label="Page visible" value={document.visibilityState === "visible" ? "yes" : "no"} />
+                </Grid>
+            </Section>
+
+            <Section title="Backend read">
+                {matchedRead ? (
+                    <>
+                        <Grid>
+                            <Field
+                                label="Session"
+                                value={matchedRead.id.slice(0, 8)}
+                                mono
+                                action={
+                                    <CopyButton
+                                        label="Copy read session ID"
+                                        onCopy={() => copyText(matchedRead.id, "Session ID copied")}
+                                    />
+                                }
+                            />
+                            <Field
+                                label="Offset"
+                                value={matchedRead.fileSize
+                                    ? `${formatFileSize(matchedRead.currentOffset)} / ${formatFileSize(matchedRead.fileSize)}`
+                                    : formatFileSize(matchedRead.currentOffset)}
+                                mono
+                            />
+                            <Field label="Served" value={formatFileSize(matchedRead.bytesRead)} mono />
+                            <Field
+                                label="Fetched"
+                                value={matchedRead.bytesFetched != null ? formatFileSize(matchedRead.bytesFetched) : "—"}
+                                mono
+                            />
+                            <Field label="Rate" value={`${formatFileSize(Math.round(readRate))}/s`} mono />
+                            <Field
+                                label="Last activity"
+                                value={`${Math.max(0, Math.round((now - matchedRead.lastActivityAt) / 1000))} s ago`}
+                                mono
+                            />
+                        </Grid>
+                        {matchedRead.providers.length > 0 && (
+                            <div className="mt-1 flex flex-wrap gap-1.5">
+                                {matchedRead.providers.map(p => (
+                                    <span key={p.host} className="badge badge-ghost badge-sm font-mono">
+                                        {p.nickname ?? p.host} · {p.segments}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                    </>
+                ) : (
+                    <p className="text-base-content/50">
+                        No matching active read. The backend session appears once bytes start flowing.
+                    </p>
+                )}
+                {liveStats && (
+                    <p className="mt-1 text-base-content/45">
+                        Server-wide: {liveStats.activeReads} active read{liveStats.activeReads === 1 ? "" : "s"}
+                        {liveStats.inFlightArticleBytes != null
+                            ? ` · ${formatFileSize(liveStats.inFlightArticleBytes)} article RAM in flight`
+                            : ""}
+                        {` · ${formatFileSize(Math.round(liveStats.bytesServedPerMinute / 60))}/s served`}
+                    </p>
+                )}
+            </Section>
+
+            <Section title="Stream trace">
+                {traceError && (
+                    <p role="alert" className="alert alert-error alert-soft mb-2 py-2">{traceError}</p>
+                )}
+                {!traceStatus && (
+                    <p className="text-base-content/50">Trace status unavailable.</p>
+                )}
+                {traceStatus && !tracingActive && (
+                    <div className="flex flex-wrap items-center gap-2">
+                        <p className="flex-1 text-base-content/50">
+                            Developer stream tracing is off. Segment-level events are only captured while tracing is on.
+                        </p>
+                        <Button size="xsmall" variant="outline" onClick={() => void startTrace()} disabled={traceBusy}>
+                            {traceBusy ? <span className="loading loading-spinner loading-xs" /> : <Icon name="fiber_manual_record" className="!text-[14px]" />}
+                            Record 15 min
+                        </Button>
+                    </div>
+                )}
+                {traceStatus?.enabled && (
+                    <p className="text-base-content/50">
+                        Recording until {new Date(traceStatus.expiresAtUnixMs).toLocaleTimeString()}
+                        {" · "}{traceStatus.eventCount.toLocaleString()} events
+                    </p>
+                )}
+                {traceStatus?.overflowed && (
+                    <p className="alert alert-warning alert-soft py-2">
+                        Trace buffer wrapped — events shown are a partial window
+                        ({traceStatus.retainedEventCount.toLocaleString()} of {traceStatus.eventCount.toLocaleString()} retained).
+                    </p>
+                )}
+                {tracingActive && !sessionId && (
+                    <p className="text-base-content/50">Waiting for this playback session to appear in the trace…</p>
+                )}
+                {summary && (
+                    <>
+                        <Grid>
+                            <Field label="Ranges" value={`${summary.rangeOpens} opened · ${summary.rangeEnds} ended`} mono />
+                            <Field label="Seeks" value={String(summary.seeks)} mono />
+                            <Field label="Segments" value={String(summary.segments)} mono />
+                            <Field label="Retries" value={String(summary.retries)} mono />
+                            <Field label="Failovers" value={String(summary.failovers)} mono />
+                            <Field label="Zero fills" value={String(summary.zeroFills)} mono />
+                            <Field label="Prefetch changes" value={String(summary.prefetchChanges)} mono />
+                            <Field label="Bytes served" value={formatFileSize(summary.bytesServed)} mono />
+                            {summary.lastEndReason && (
+                                <Field
+                                    label="Last range end"
+                                    value={summary.lastEndReason + (summary.lastEndMessage ? ` · ${summary.lastEndMessage}` : "")}
+                                />
+                            )}
+                        </Grid>
+                        {Object.keys(summary.segmentsByStatus).length > 0 && (
+                            <div className="mt-1 flex flex-wrap gap-1.5">
+                                {Object.entries(summary.segmentsByStatus).map(([statusName, count]) => (
+                                    <span key={statusName} className="badge badge-ghost badge-sm font-mono">
+                                        {statusName} · {count}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                        {summary.stallTotalsMs && (
+                            <p className="mt-1 font-mono text-base-content/50">
+                                last range waits — conn {summary.stallTotalsMs["connWait"]} ms
+                                · provider {summary.stallTotalsMs["providerWait"]} ms
+                                · body {summary.stallTotalsMs["bodyDrain"]} ms
+                                · consumer {summary.stallTotalsMs["consumerWait"]} ms
+                                · client {summary.stallTotalsMs["clientWrite"]} ms
+                            </p>
+                        )}
+                        <div className="mt-2 max-h-48 overflow-y-auto rounded border border-base-content/10 bg-base-300 p-2 font-mono text-[11px] leading-relaxed">
+                            {recentEvents.length === 0 && (
+                                <p className="text-base-content/45">No events recorded for this session yet.</p>
+                            )}
+                            {recentEvents.map(e => (
+                                <div key={e.seq} className="flex gap-2">
+                                    <span className="shrink-0 text-base-content/40">
+                                        {new Date(e.at).toLocaleTimeString(undefined, { hour12: false })}.
+                                        {String(e.at % 1000).padStart(3, "0")}
+                                    </span>
+                                    <span className="shrink-0 font-semibold text-base-content/70">{e.kind}</span>
+                                    <span className="min-w-0 break-all text-base-content/55">{describeTraceEvent(e)}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </Section>
+
+            <div className="flex flex-wrap items-center gap-2 border-t border-base-content/10 pt-2">
+                <Button size="xsmall" variant="ghost" onClick={copySnapshot}>
+                    <Icon name="content_copy" className="!text-[16px]" />
+                    Copy diagnostics JSON
+                </Button>
+                {copyNote && <span className="text-success">{copyNote}</span>}
+                <span className="ml-auto text-base-content/40">player session {playerSession.slice(0, 8)}</span>
+            </div>
+
+            <details className="text-base-content/50">
+                <summary className="cursor-pointer select-none">Player event log ({player.events.length})</summary>
+                <div className="mt-1 max-h-40 overflow-y-auto rounded border border-base-content/10 bg-base-300 p-2 font-mono text-[11px] leading-relaxed">
+                    {player.events.length === 0 && <p className="text-base-content/45">No events yet.</p>}
+                    {[...player.events].reverse().map((e, i) => (
+                        <div key={`${e.at}-${i}`} className="flex gap-2">
+                            <span className="shrink-0 text-base-content/40">
+                                {new Date(e.at).toLocaleTimeString(undefined, { hour12: false })}
+                            </span>
+                            <span className="shrink-0 font-semibold text-base-content/70">{e.kind}</span>
+                            {e.detail && <span className="min-w-0 break-all text-base-content/55">{e.detail}</span>}
+                        </div>
+                    ))}
+                </div>
+            </details>
+        </div>
+    );
+}
+
+function smoothRate(
+    prevRef: { current: { id: string, bytes: number, at: number, rate: number } | null },
+    read: ActiveRead,
+    now: number,
+): number {
+    const prev = prevRef.current;
+    let rate = prev?.id === read.id ? prev.rate : 0;
+    if (prev && prev.id === read.id && now > prev.at) {
+        const dt = (now - prev.at) / 1000;
+        const db = read.bytesRead - prev.bytes;
+        if (dt > 0 && db >= 0) {
+            rate = prev.rate * 0.4 + (db / dt) * 0.6;
+        }
+    }
+    prevRef.current = { id: read.id, bytes: read.bytesRead, at: now, rate };
+    return rate;
+}
+
+function droppedFrames(el: HTMLMediaElement | null): string {
+    if (!(el instanceof HTMLVideoElement) || typeof el.getVideoPlaybackQuality !== "function") return "—";
+    const quality = el.getVideoPlaybackQuality();
+    return `${quality.droppedVideoFrames} / ${quality.totalVideoFrames}`;
+}
+
+function videoDimensions(el: HTMLMediaElement | null): string {
+    if (!(el instanceof HTMLVideoElement) || el.videoWidth === 0) return "—";
+    return `${el.videoWidth}×${el.videoHeight}`;
+}
+
+function buildDiagnosticsSnapshot(
+    props: MediaDiagnosticsProps,
+    read: ActiveRead | null,
+    liveStats: LiveStatsMessage | null,
+    el: HTMLMediaElement | null,
+    summary: ReturnType<typeof summarizeTrace> | null,
+    traceEvents: StreamTraceEvent[] | null,
+) {
+    const { player, playerSession, fileName, filePath, mimeType, sizeBytes } = props;
+    return {
+        capturedAt: new Date().toISOString(),
+        file: { name: fileName, path: filePath, mimeType, sizeBytes },
+        playerSession,
+        player: {
+            status: player.status,
+            buffering: player.buffering,
+            attempts: player.attempts,
+            maxAttempts: player.maxAttempts,
+            startupMs: player.startupMs,
+            error: player.error,
+            events: player.events,
+        },
+        mediaElement: el ? {
+            currentTime: el.currentTime,
+            duration: Number.isFinite(el.duration) ? el.duration : null,
+            paused: el.paused,
+            seeking: el.seeking,
+            ended: el.ended,
+            playbackRate: el.playbackRate,
+            readyState: readyStateLabel(el.readyState),
+            networkState: networkStateLabel(el.networkState),
+            buffered: formatTimeRanges(el.buffered),
+            bufferAheadSeconds: bufferedAhead(el.buffered, el.currentTime),
+            lastGoodTime: player.lastGoodTimeRef.current,
+        } : null,
+        backendRead: read ? {
+            sessionId: read.id,
+            bytesRead: read.bytesRead,
+            bytesFetched: read.bytesFetched ?? null,
+            currentOffset: read.currentOffset,
+            fileSize: read.fileSize,
+            startedAt: new Date(read.startedAt).toISOString(),
+            lastActivityAt: new Date(read.lastActivityAt).toISOString(),
+            clientUserAgent: read.clientUserAgent ?? null,
+            providers: read.providers,
+        } : null,
+        liveStats: liveStats ? {
+            activeReads: liveStats.activeReads,
+            bytesServedPerMinute: liveStats.bytesServedPerMinute,
+            inFlightArticleBytes: liveStats.inFlightArticleBytes ?? null,
+        } : null,
+        // The signed URL, downloadKey, client IP, and full segment ids are
+        // deliberately excluded from copied diagnostics.
+        traceSummary: summary,
+        recentTraceEvents: traceEvents ? redactTraceEvents(traceEvents.slice(-RECENT_EVENTS_SHOWN)) : null,
+    };
+}
+
+function Section({ title, children }: { title: string, children: React.ReactNode }) {
+    return (
+        <section>
+            <h4 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-base-content/50">
+                {title}
+            </h4>
+            {children}
+        </section>
+    );
+}
+
+function Grid({ children }: { children: React.ReactNode }) {
+    return <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 md:grid-cols-3">{children}</div>;
+}
+
+function Field({ label, value, mono = false, action }: {
+    label: string,
+    value: string,
+    mono?: boolean,
+    action?: React.ReactNode,
+}) {
+    return (
+        <div className="flex min-w-0 items-baseline gap-1">
+            <span className="shrink-0 text-base-content/45">{label}</span>
+            <span className={`min-w-0 break-all text-base-content ${mono ? "font-mono" : ""}`}>{value}</span>
+            {action}
+        </div>
+    );
+}
+
+function CopyButton({ label, onCopy }: { label: string, onCopy: () => void }) {
+    return (
+        <button
+            type="button"
+            className="btn btn-ghost btn-xs btn-circle -my-1"
+            title={label}
+            aria-label={label}
+            onClick={onCopy}
+        >
+            <Icon name="content_copy" className="!text-[13px]" />
+        </button>
+    );
+}

--- a/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
+++ b/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
@@ -391,7 +391,7 @@ function videoDimensions(el: HTMLMediaElement | null): string {
     return `${el.videoWidth}×${el.videoHeight}`;
 }
 
-function buildDiagnosticsSnapshot(
+export function buildDiagnosticsSnapshot(
     props: MediaDiagnosticsProps,
     read: ActiveRead | null,
     liveStats: LiveStatsMessage | null,

--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -163,6 +163,55 @@ describe("MediaPreview", () => {
         expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
     });
 
+    it("clears the recovering banner when the stream reloads while paused", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = renderPreview();
+            const video = container.querySelector("video")!;
+            // User never started playback (autoplay blocked path).
+            fireEvent(video, new Event("pause"));
+
+            fireMediaError(video, 2, "network down");
+            expect(screen.getByRole("status").textContent).toContain("Stream interrupted");
+
+            act(() => { vi.advanceTimersByTime(1000); });
+            fireEvent(video, new Event("loadedmetadata"));
+            fireEvent(video, new Event("canplay"));
+
+            // No play event follows while paused — the banner must still clear.
+            expect(screen.queryByRole("status")).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("re-arms the attempt budget after recovered playback stays stable", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = renderPreview();
+            const video = container.querySelector("video")!;
+
+            fireMediaError(video, 2, "first blip");
+            expect(screen.getByRole("status").textContent).toContain("attempt 1/3");
+            act(() => { vi.advanceTimersByTime(1000); });
+            fireEvent(video, new Event("loadedmetadata"));
+            fireEvent(video, new Event("canplay"));
+            fireEvent(video, new Event("play"));
+
+            // 15s of forward progress: lastGoodTime advances each timeupdate.
+            for (let t = 1; t <= 15; t++) {
+                Object.defineProperty(video, "currentTime", { configurable: true, value: t });
+                act(() => { vi.advanceTimersByTime(1000); });
+                fireEvent(video, new Event("timeupdate"));
+            }
+
+            fireMediaError(video, 2, "second blip");
+            expect(screen.getByRole("status").textContent).toContain("attempt 1/3");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("ignores self-inflicted abort errors from reload/close", () => {
         const { container } = renderPreview();
         const video = container.querySelector("video")!;

--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaPreview } from "./media-preview";
+
+const PREVIEW_URL = "/view/content/movie.mkv?downloadKey=deadbeef&extension=.mkv";
+
+type MediaElementProto = {
+    play: () => Promise<void>;
+    load: () => void;
+};
+
+let playMock: ReturnType<typeof vi.fn>;
+let loadMock: ReturnType<typeof vi.fn>;
+const savedDialog: Partial<Record<"showModal" | "close", PropertyDescriptor | undefined>> = {};
+
+beforeEach(() => {
+    playMock = vi.fn<MediaElementProto["play"]>().mockResolvedValue(undefined);
+    loadMock = vi.fn<MediaElementProto["load"]>().mockImplementation(() => {});
+    Object.defineProperty(HTMLMediaElement.prototype, "play", { configurable: true, value: playMock });
+    Object.defineProperty(HTMLMediaElement.prototype, "load", { configurable: true, value: loadMock });
+
+    // jsdom may not implement modal dialog show/close.
+    savedDialog.showModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, "showModal");
+    savedDialog.close = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, "close");
+    Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
+        configurable: true,
+        value(this: HTMLDialogElement) { this.setAttribute("open", ""); },
+    });
+    Object.defineProperty(HTMLDialogElement.prototype, "close", {
+        configurable: true,
+        value(this: HTMLDialogElement) { this.removeAttribute("open"); },
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    for (const key of ["showModal", "close"] as const) {
+        const descriptor = savedDialog[key];
+        if (descriptor) {
+            Object.defineProperty(HTMLDialogElement.prototype, key, descriptor);
+        } else {
+            Reflect.deleteProperty(HTMLDialogElement.prototype, key);
+        }
+    }
+});
+
+function renderPreview(overrides: Partial<Parameters<typeof MediaPreview>[0]> = {}) {
+    return render(
+        <MediaPreview
+            fileName="movie.mkv"
+            filePath="content/movie.mkv"
+            mimeType="video/x-matroska"
+            sizeBytes={1_500_000_000}
+            previewUrl={PREVIEW_URL}
+            onClose={vi.fn()}
+            {...overrides}
+        />,
+    );
+}
+
+function fireMediaError(el: HTMLMediaElement, code: number, message = "boom") {
+    Object.defineProperty(el, "error", {
+        configurable: true,
+        get: () => ({ code, message }),
+    });
+    fireEvent(el, new Event("error"));
+}
+
+describe("MediaPreview", () => {
+    it("renders a video element for video files with a playerSession on the source", () => {
+        const { container } = renderPreview();
+        const video = container.querySelector("video");
+        expect(video).not.toBeNull();
+        expect(video!.getAttribute("src")).toMatch(
+            /^\/view\/content\/movie\.mkv\?downloadKey=deadbeef&extension=\.mkv&playerSession=[A-Za-z0-9_-]+$/,
+        );
+        expect(video!.hasAttribute("controls")).toBe(true);
+        expect(video!.getAttribute("preload")).toBe("metadata");
+        expect(video!.hasAttribute("playsinline")).toBe(true);
+    });
+
+    it("renders an audio element for audio files", () => {
+        const { container } = renderPreview({
+            fileName: "song.flac",
+            filePath: "content/song.flac",
+            mimeType: "audio/flac",
+        });
+        expect(container.querySelector("audio")).not.toBeNull();
+        expect(container.querySelector("video")).toBeNull();
+    });
+
+    it("attempts autoplay when the media can play", () => {
+        const { container } = renderPreview();
+        fireEvent(container.querySelector("video")!, new Event("canplay"));
+        expect(playMock).toHaveBeenCalled();
+    });
+
+    it("keeps escape hatches pointing at the direct and download URLs", () => {
+        renderPreview();
+        const openDirect = screen.getByRole("link", { name: /open direct/i });
+        expect(openDirect.getAttribute("href")).toBe(PREVIEW_URL);
+        expect(openDirect.getAttribute("target")).toBe("_blank");
+        expect(screen.getByRole("link", { name: /download/i }).getAttribute("href"))
+            .toBe(`${PREVIEW_URL}&download=true`);
+    });
+
+    it("recovers from network errors with the same URL and resumes playback", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = renderPreview();
+            const video = container.querySelector("video")!;
+            fireEvent(video, new Event("canplay"));
+            fireEvent(video, new Event("play"));
+
+            fireMediaError(video, 2, "network down");
+            expect(screen.getByRole("status").textContent).toContain("Stream interrupted");
+            expect(screen.getByRole("status").textContent).toContain("attempt 1/3");
+
+            const srcBefore = video.getAttribute("src");
+            act(() => { vi.advanceTimersByTime(1000); });
+            // Same URL reloaded — playerSession continuity preserved.
+            expect(video.getAttribute("src")).toBe(srcBefore);
+            expect(loadMock).toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("gives up after the retry budget and offers a manual retry", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = renderPreview();
+            const video = container.querySelector("video")!;
+            fireEvent(video, new Event("play"));
+
+            fireMediaError(video, 2);
+            act(() => { vi.advanceTimersByTime(1000); });
+            fireMediaError(video, 2);
+            act(() => { vi.advanceTimersByTime(2000); });
+            fireMediaError(video, 2);
+            act(() => { vi.advanceTimersByTime(4000); });
+            fireMediaError(video, 2);
+
+            expect(screen.getByRole("alert").textContent).toContain("Playback failed after 3 attempts");
+            const retry = screen.getByRole("button", { name: /retry/i });
+            fireEvent.click(retry);
+            expect(loadMock).toHaveBeenCalled();
+            expect(screen.queryByRole("alert")?.textContent ?? "").not.toContain("Playback failed");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("shows an unsupported-format state instead of looping on decode errors", () => {
+        const { container } = renderPreview();
+        const video = container.querySelector("video")!;
+        fireMediaError(video, 4, "no decoder");
+
+        expect(screen.getByRole("alert").textContent).toContain("cannot decode");
+        expect(screen.getByRole("alert").textContent).toContain("video/x-matroska");
+        expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
+    });
+
+    it("ignores self-inflicted abort errors from reload/close", () => {
+        const { container } = renderPreview();
+        const video = container.querySelector("video")!;
+        fireMediaError(video, 1, "aborted by us");
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(screen.getByRole("status").textContent).toContain("Loading");
+    });
+
+    it("releases the source on unmount so the stream is aborted", () => {
+        const { container, unmount } = renderPreview();
+        const video = container.querySelector("video")!;
+        unmount();
+        expect(video.getAttribute("src")).toBeNull();
+        expect(loadMock).toHaveBeenCalled();
+    });
+
+    it("toggles the diagnostics drawer", () => {
+        renderPreview();
+        const toggle = screen.getByRole("button", { name: /diagnostics/i });
+        expect(toggle.getAttribute("aria-expanded")).toBe("false");
+        fireEvent.click(toggle);
+        expect(toggle.getAttribute("aria-expanded")).toBe("true");
+        expect(screen.getByText("Backend read")).toBeTruthy();
+        expect(screen.getByText("Stream trace")).toBeTruthy();
+    });
+});

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -35,9 +35,10 @@ export function MediaPreview(props: MediaPreviewProps) {
     const kind = isVideoFile({ name: fileName, mimeType }) ? "video" : "audio";
     const downloadUrl = `${previewUrl}&download=true`;
 
+    // src is applied by the player hook's effect (see useMediaPlayer); a JSX
+    // src attribute would be wiped by StrictMode's simulated unmount cycle.
     const mediaElementProps = {
         ref: player.setMediaEl,
-        src,
         controls: true,
         playsInline: true,
         preload: "metadata" as const,
@@ -114,6 +115,8 @@ function StatusBanner({ player, mimeType }: { player: ReturnType<typeof useMedia
                     Loading…
                 </div>
             );
+        case "ready":
+            return null;
         case "playing":
             return player.buffering ? (
                 <div className="flex items-center gap-2 text-sm text-base-content/60" role="status">

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, Icon, Modal } from "~/components/ui";
 import { formatFileSize } from "~/utils/file-size";
 import { isVideoFile } from "../file-kind/file-kind";
 import { MediaDiagnostics } from "./media-diagnostics";
-import { buildMediaSrc, formatClock } from "./media-utils";
+import { appendQueryParam, buildMediaSrc, formatClock } from "./media-utils";
 import { useMediaPlayer } from "./use-media-player";
 
 export type MediaPreviewProps = {
@@ -33,7 +33,7 @@ export function MediaPreview(props: MediaPreviewProps) {
     const [showDiagnostics, setShowDiagnostics] = useState(false);
 
     const kind = isVideoFile({ name: fileName, mimeType }) ? "video" : "audio";
-    const downloadUrl = `${previewUrl}&download=true`;
+    const downloadUrl = appendQueryParam(previewUrl, "download", "true");
 
     // src is applied by the player hook's effect (see useMediaPlayer); a JSX
     // src attribute would be wiped by StrictMode's simulated unmount cycle.

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -1,0 +1,155 @@
+import { useMemo, useState } from "react";
+import { Alert, Button, Icon, Modal } from "~/components/ui";
+import { formatFileSize } from "~/utils/file-size";
+import { isVideoFile } from "../file-kind/file-kind";
+import { MediaDiagnostics } from "./media-diagnostics";
+import { buildMediaSrc, formatClock } from "./media-utils";
+import { useMediaPlayer } from "./use-media-player";
+
+export type MediaPreviewProps = {
+    fileName: string;
+    filePath: string;
+    mimeType: string;
+    sizeBytes: number | null;
+    /** Signed /view URL (already includes downloadKey). */
+    previewUrl: string;
+    onClose: () => void;
+};
+
+/**
+ * In-app native player for Explore. Mounted iff the preview is open — unmount
+ * releases the media source, aborting the in-flight range request so the
+ * backend stops pulling Usenet segments for a player nobody is watching.
+ */
+export function MediaPreview(props: MediaPreviewProps) {
+    const { fileName, filePath, mimeType, sizeBytes, previewUrl, onClose } = props;
+
+    // One non-secret correlation id per mounted player; stable across retries
+    // so all range requests map to one backend read session.
+    const playerSession = useMemo(() => crypto.randomUUID(), []);
+    const src = useMemo(() => buildMediaSrc(previewUrl, playerSession), [previewUrl, playerSession]);
+
+    const player = useMediaPlayer({ src });
+    const [showDiagnostics, setShowDiagnostics] = useState(false);
+
+    const kind = isVideoFile({ name: fileName, mimeType }) ? "video" : "audio";
+    const downloadUrl = `${previewUrl}&download=true`;
+
+    const mediaElementProps = {
+        ref: player.setMediaEl,
+        src,
+        controls: true,
+        playsInline: true,
+        preload: "metadata" as const,
+        ...player.handlers,
+    };
+
+    return (
+        <Modal open title={fileName} onClose={onClose} size="wide">
+            <div className="flex flex-col gap-3">
+                <StatusBanner player={player} mimeType={mimeType} />
+
+                {kind === "video" ? (
+                    <video
+                        {...mediaElementProps}
+                        className="max-h-[65dvh] w-full rounded-lg bg-black"
+                        aria-label={fileName}
+                    />
+                ) : (
+                    <audio {...mediaElementProps} className="w-full" aria-label={fileName} />
+                )}
+
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                        variant={showDiagnostics ? "secondary" : "ghost"}
+                        size="small"
+                        onClick={() => setShowDiagnostics(x => !x)}
+                        aria-expanded={showDiagnostics}
+                    >
+                        <Icon name="troubleshoot" className="!text-[18px]" />
+                        Diagnostics
+                    </Button>
+                    <a
+                        href={previewUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-ghost btn-sm gap-2"
+                    >
+                        <Icon name="open_in_new" className="!text-[18px]" />
+                        Open direct
+                    </a>
+                    <a href={downloadUrl} className="btn btn-ghost btn-sm gap-2">
+                        <Icon name="download" className="!text-[18px]" />
+                        Download
+                    </a>
+                    {sizeBytes != null && (
+                        <span className="ml-auto font-mono text-xs text-base-content/50">
+                            {formatFileSize(sizeBytes)}
+                        </span>
+                    )}
+                </div>
+
+                {showDiagnostics && (
+                    <MediaDiagnostics
+                        player={player}
+                        getMedia={() => player.mediaRef.current}
+                        playerSession={playerSession}
+                        fileName={fileName}
+                        filePath={filePath}
+                        mimeType={mimeType}
+                        sizeBytes={sizeBytes}
+                    />
+                )}
+            </div>
+        </Modal>
+    );
+}
+
+function StatusBanner({ player, mimeType }: { player: ReturnType<typeof useMediaPlayer>, mimeType: string }) {
+    switch (player.status) {
+        case "loading":
+            return (
+                <div className="flex items-center gap-2 text-sm text-base-content/60" role="status">
+                    <span className="loading loading-spinner loading-xs" />
+                    Loading…
+                </div>
+            );
+        case "playing":
+            return player.buffering ? (
+                <div className="flex items-center gap-2 text-sm text-base-content/60" role="status">
+                    <span className="loading loading-spinner loading-xs" />
+                    Buffering…
+                </div>
+            ) : null;
+        case "recovering":
+            return (
+                <Alert variant="warning" className="alert-soft py-2 text-sm" role="status">
+                    <span className="loading loading-spinner loading-xs" />
+                    Stream interrupted — resuming
+                    {player.lastGoodTimeRef.current > 0 ? ` from ${formatClock(player.lastGoodTimeRef.current)}` : ""}
+                    {" "}(attempt {player.attempts}/{player.maxAttempts})
+                </Alert>
+            );
+        case "failed":
+            return (
+                <Alert variant="danger" className="alert-soft py-2 text-sm" role="alert">
+                    <Icon name="error" className="!text-[18px]" />
+                    <span>
+                        Playback failed after {player.maxAttempts} attempts
+                        {player.error?.message ? ` — ${player.error.message}` : ""}.
+                    </span>
+                    <Button variant="danger" size="xsmall" onClick={player.retry}>
+                        <Icon name="refresh" className="!text-[16px]" />
+                        Retry
+                    </Button>
+                </Alert>
+            );
+        case "unsupported":
+            return (
+                <Alert variant="warning" className="alert-soft py-2 text-sm" role="alert">
+                    <Icon name="videocam_off" className="!text-[18px]" />
+                    This browser cannot decode {mimeType || "this format"}. Use Open direct or Download and play it in an external player.
+                </Alert>
+            );
+    }
+}

--- a/frontend/app/routes/explore/media-preview/media-trace.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-trace.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+    describeTraceEvent,
+    redactTraceEvents,
+    summarizeTrace,
+    type StreamTraceEvent,
+} from "./media-trace";
+
+function event(partial: Partial<StreamTraceEvent> & { kind: string }): StreamTraceEvent {
+    return { seq: 1, at: 1_000, ...partial };
+}
+
+describe("summarizeTrace", () => {
+    it("counts each event kind and tracks the last range end", () => {
+        const events = [
+            event({ kind: "RangeOpen", rangeStart: 0, rangeEnd: 999 }),
+            event({ kind: "Segment", provider: "a", status: "Ok" }),
+            event({ kind: "Segment", provider: "b", status: "Ok" }),
+            event({ kind: "Segment", provider: "a", status: "NotFound" }),
+            event({ kind: "Seek", offset: 500 }),
+            event({ kind: "Retry", attempt: 2 }),
+            event({ kind: "Failover", fromProvider: "a", toProvider: "b" }),
+            event({ kind: "ZeroFill", bytes: 64 }),
+            event({ kind: "PrefetchWidth", previousBatchSize: 4, batchSize: 2 }),
+            event({
+                kind: "RangeEnd",
+                endReason: "Completed",
+                bytesServed: 1000,
+                connWaitMs: 5,
+                providerWaitMs: 50,
+                bodyDrainMs: 10,
+                consumerWaitMs: 20,
+                clientWriteMs: 1,
+            }),
+        ];
+
+        const summary = summarizeTrace(events);
+        expect(summary.rangeOpens).toBe(1);
+        expect(summary.rangeEnds).toBe(1);
+        expect(summary.seeks).toBe(1);
+        expect(summary.segments).toBe(3);
+        expect(summary.segmentsByStatus).toEqual({ Ok: 2, NotFound: 1 });
+        expect(summary.retries).toBe(1);
+        expect(summary.failovers).toBe(1);
+        expect(summary.zeroFills).toBe(1);
+        expect(summary.prefetchChanges).toBe(1);
+        expect(summary.bytesServed).toBe(1000);
+        expect(summary.lastEndReason).toBe("Completed");
+        expect(summary.stallTotalsMs).toEqual({
+            connWait: 5, providerWait: 50, bodyDrain: 10, consumerWait: 20, clientWrite: 1,
+        });
+    });
+
+    it("returns zeros for an empty trace", () => {
+        const summary = summarizeTrace([]);
+        expect(summary.segments).toBe(0);
+        expect(summary.lastEndReason).toBeNull();
+        expect(summary.stallTotalsMs).toBeNull();
+    });
+});
+
+describe("redactTraceEvents", () => {
+    it("truncates segment ids and leaves other events untouched", () => {
+        const longId = "abcdefghijklmnopqrstuvwxyz@provider";
+        const [redacted] = redactTraceEvents([event({ kind: "Segment", segmentId: longId })]);
+        expect(redacted!.segmentId).toBe("abcdefghijkl…");
+        expect(redacted!.segmentId).not.toContain("provider");
+
+        const [untouched] = redactTraceEvents([event({ kind: "Seek", offset: 5 })]);
+        expect(untouched!.segmentId).toBeUndefined();
+    });
+});
+
+describe("describeTraceEvent", () => {
+    it("renders human-readable lines per kind", () => {
+        expect(describeTraceEvent(event({ kind: "RangeOpen", rangeStart: 0, rangeEnd: 99 }))).toBe("range 0–99");
+        expect(describeTraceEvent(event({ kind: "Failover", fromProvider: "a", toProvider: "b" }))).toBe("a → b");
+        expect(describeTraceEvent(event({ kind: "PrefetchWidth", previousBatchSize: 4, batchSize: 2 }))).toBe("4 → 2");
+        expect(describeTraceEvent(event({ kind: "RangeEnd", endReason: "Aborted", bytesServed: 512 })))
+            .toBe("Aborted · 512 B");
+    });
+});

--- a/frontend/app/routes/explore/media-preview/media-trace.ts
+++ b/frontend/app/routes/explore/media-preview/media-trace.ts
@@ -1,0 +1,137 @@
+/** Subset of the backend StreamTraceEvent payload used by the diagnostics drawer. */
+export type StreamTraceEvent = {
+    seq: number;
+    at: number;
+    kind: string;
+    rangeStart?: number | null;
+    rangeEnd?: number | null;
+    offset?: number | null;
+    provider?: string | null;
+    status?: string | null;
+    durationMs?: number | null;
+    retries?: number | null;
+    segmentId?: string | null;
+    bytes?: number | null;
+    endReason?: string | null;
+    bytesServed?: number | null;
+    fromProvider?: string | null;
+    toProvider?: string | null;
+    attempt?: number | null;
+    message?: string | null;
+    batchSize?: number | null;
+    previousBatchSize?: number | null;
+    connWaitMs?: number | null;
+    providerWaitMs?: number | null;
+    bodyDrainMs?: number | null;
+    consumerWaitMs?: number | null;
+    clientWriteMs?: number | null;
+    connOpened?: number | null;
+    connReused?: number | null;
+    fetches?: number | null;
+};
+
+export type TraceSummary = {
+    rangeOpens: number;
+    rangeEnds: number;
+    seeks: number;
+    segments: number;
+    segmentsByStatus: Record<string, number>;
+    zeroFills: number;
+    failovers: number;
+    retries: number;
+    prefetchChanges: number;
+    bytesServed: number;
+    lastEndReason: string | null;
+    lastEndMessage: string | null;
+    stallTotalsMs: Record<string, number> | null;
+};
+
+export function summarizeTrace(events: StreamTraceEvent[]): TraceSummary {
+    const summary: TraceSummary = {
+        rangeOpens: 0,
+        rangeEnds: 0,
+        seeks: 0,
+        segments: 0,
+        segmentsByStatus: {},
+        zeroFills: 0,
+        failovers: 0,
+        retries: 0,
+        prefetchChanges: 0,
+        bytesServed: 0,
+        lastEndReason: null,
+        lastEndMessage: null,
+        stallTotalsMs: null,
+    };
+    for (const e of events) {
+        switch (e.kind) {
+            case "RangeOpen":
+                summary.rangeOpens++;
+                break;
+            case "RangeEnd":
+                summary.rangeEnds++;
+                summary.bytesServed += e.bytesServed ?? 0;
+                if (e.endReason) summary.lastEndReason = e.endReason;
+                if (e.message) summary.lastEndMessage = e.message;
+                summary.stallTotalsMs = {
+                    connWait: e.connWaitMs ?? 0,
+                    providerWait: e.providerWaitMs ?? 0,
+                    bodyDrain: e.bodyDrainMs ?? 0,
+                    consumerWait: e.consumerWaitMs ?? 0,
+                    clientWrite: e.clientWriteMs ?? 0,
+                };
+                break;
+            case "Seek":
+                summary.seeks++;
+                break;
+            case "Segment":
+                summary.segments++;
+                if (e.status) {
+                    summary.segmentsByStatus[e.status] = (summary.segmentsByStatus[e.status] ?? 0) + 1;
+                }
+                break;
+            case "ZeroFill":
+                summary.zeroFills++;
+                break;
+            case "Failover":
+                summary.failovers++;
+                break;
+            case "Retry":
+                summary.retries++;
+                break;
+            case "PrefetchWidth":
+                summary.prefetchChanges++;
+                break;
+        }
+    }
+    return summary;
+}
+
+/** Drop raw message-ids from copied output; keep enough to correlate counts. */
+export function redactTraceEvents(events: StreamTraceEvent[]): StreamTraceEvent[] {
+    return events.map(e => e.segmentId
+        ? { ...e, segmentId: `${e.segmentId.slice(0, 12)}…` }
+        : e);
+}
+
+export function describeTraceEvent(e: StreamTraceEvent): string {
+    switch (e.kind) {
+        case "RangeOpen":
+            return `range ${e.rangeStart ?? 0}–${e.rangeEnd ?? "end"}`;
+        case "RangeEnd":
+            return `${e.endReason ?? "?"}${e.bytesServed != null ? ` · ${e.bytesServed} B` : ""}${e.message ? ` · ${e.message}` : ""}`;
+        case "Seek":
+            return `offset ${e.offset ?? "?"}`;
+        case "Segment":
+            return `${e.provider ?? "?"} ${e.status ?? "?"}${e.durationMs != null ? ` · ${e.durationMs} ms` : ""}${e.retries ? ` · ${e.retries} retries` : ""}`;
+        case "ZeroFill":
+            return `${e.bytes ?? "?"} B zero-filled${e.message ? ` · ${e.message}` : ""}`;
+        case "Failover":
+            return `${e.fromProvider ?? "?"} → ${e.toProvider ?? "?"}${e.message ? ` · ${e.message}` : ""}`;
+        case "Retry":
+            return `attempt ${e.attempt ?? "?"}${e.message ? ` · ${e.message}` : ""}`;
+        case "PrefetchWidth":
+            return `${e.previousBatchSize ?? "?"} → ${e.batchSize ?? "?"}`;
+        default:
+            return e.message ?? e.kind;
+    }
+}

--- a/frontend/app/routes/explore/media-preview/media-utils.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+    appendQueryParam,
     backoffMs,
     bufferedAhead,
     buildMediaSrc,
@@ -44,6 +45,17 @@ describe("buildMediaSrc", () => {
 
     it("encodes the session value", () => {
         expect(buildMediaSrc("/view/a.mkv?downloadKey=abc", "a b")).toContain("playerSession=a%20b");
+    });
+});
+
+describe("appendQueryParam", () => {
+    it("uses ? when the url has no query string", () => {
+        expect(appendQueryParam("/view/a.mkv", "download", "true")).toBe("/view/a.mkv?download=true");
+    });
+
+    it("uses & when the url already has a query string", () => {
+        expect(appendQueryParam("/view/a.mkv?downloadKey=k", "download", "true"))
+            .toBe("/view/a.mkv?downloadKey=k&download=true");
     });
 });
 

--- a/frontend/app/routes/explore/media-preview/media-utils.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+    backoffMs,
+    bufferedAhead,
+    buildMediaSrc,
+    classifyMediaError,
+    formatClock,
+    formatTimeRanges,
+    networkStateLabel,
+    readyStateLabel,
+    type TimeRangesLike,
+} from "./media-utils";
+
+describe("backoffMs", () => {
+    it("doubles per attempt and stays bounded", () => {
+        expect(backoffMs(0)).toBe(1000);
+        expect(backoffMs(1)).toBe(2000);
+        expect(backoffMs(2)).toBe(4000);
+        expect(backoffMs(10)).toBe(16_000);
+    });
+});
+
+describe("classifyMediaError", () => {
+    it("ignores self-inflicted aborts", () => {
+        expect(classifyMediaError(1)).toBe("aborted");
+    });
+
+    it("retries network and unknown failures", () => {
+        expect(classifyMediaError(2)).toBe("retry");
+        expect(classifyMediaError(null)).toBe("retry");
+    });
+
+    it("does not retry decode or unsupported-source failures", () => {
+        expect(classifyMediaError(3)).toBe("unsupported");
+        expect(classifyMediaError(4)).toBe("unsupported");
+    });
+});
+
+describe("buildMediaSrc", () => {
+    it("appends playerSession to an already-signed url", () => {
+        expect(buildMediaSrc("/view/a.mkv?downloadKey=abc", "session-1"))
+            .toBe("/view/a.mkv?downloadKey=abc&playerSession=session-1");
+    });
+
+    it("encodes the session value", () => {
+        expect(buildMediaSrc("/view/a.mkv?downloadKey=abc", "a b")).toContain("playerSession=a%20b");
+    });
+});
+
+describe("formatClock", () => {
+    it("formats h:mm:ss / m:ss", () => {
+        expect(formatClock(0)).toBe("0:00");
+        expect(formatClock(65)).toBe("1:05");
+        expect(formatClock(3661)).toBe("1:01:01");
+        expect(formatClock(Number.NaN)).toBe("—");
+        expect(formatClock(-5)).toBe("—");
+    });
+});
+
+function ranges(pairs: [number, number][]): TimeRangesLike {
+    return {
+        length: pairs.length,
+        start: i => pairs[i]![0],
+        end: i => pairs[i]![1],
+    };
+}
+
+describe("formatTimeRanges", () => {
+    it("formats each range and handles empty", () => {
+        expect(formatTimeRanges(ranges([[0, 30], [60, 90]]))).toBe("0:00–0:30, 1:00–1:30");
+        expect(formatTimeRanges(ranges([]))).toBe("—");
+    });
+});
+
+describe("bufferedAhead", () => {
+    it("returns seconds to the end of the containing range", () => {
+        expect(bufferedAhead(ranges([[0, 100]]), 40)).toBe(60);
+        expect(bufferedAhead(ranges([[0, 10], [20, 100]]), 50)).toBe(50);
+    });
+
+    it("returns 0 when the playhead is outside all ranges", () => {
+        expect(bufferedAhead(ranges([[50, 100]]), 10)).toBe(0);
+        expect(bufferedAhead(ranges([]), 10)).toBe(0);
+    });
+});
+
+describe("state labels", () => {
+    it("labels known states and falls back for unknown", () => {
+        expect(readyStateLabel(4)).toBe("HAVE_ENOUGH_DATA");
+        expect(networkStateLabel(2)).toBe("NETWORK_LOADING");
+        expect(readyStateLabel(99)).toBe("unknown (99)");
+    });
+});

--- a/frontend/app/routes/explore/media-preview/media-utils.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.ts
@@ -1,0 +1,86 @@
+/** Delay before auto-recovery attempt n (0-based): 1s, 2s, 4s. */
+export function backoffMs(attempt: number): number {
+    return 1000 * 2 ** Math.min(attempt, 4);
+}
+
+export const MAX_AUTO_ATTEMPTS = 3;
+
+/**
+ * Well above the default per-segment timeout/retry budget (~8s x 3) so the
+ * watchdog only fires when the backend's own recovery has failed and the
+ * response is not coming back — short `waiting` events never trigger it.
+ */
+export const STALL_THRESHOLD_MS = 30_000;
+
+export type MediaErrorKind = "aborted" | "retry" | "unsupported";
+
+/** MEDIA_ERR_* codes: 1 aborted, 2 network, 3 decode, 4 src-not-supported. */
+export function classifyMediaError(code: number | null): MediaErrorKind {
+    switch (code) {
+        case 1: return "aborted";
+        case 3:
+        case 4: return "unsupported";
+        default: return "retry";
+    }
+}
+
+export function buildMediaSrc(previewUrl: string, playerSession: string): string {
+    return `${previewUrl}&playerSession=${encodeURIComponent(playerSession)}`;
+}
+
+export function formatClock(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds < 0) return "—";
+    const total = Math.floor(seconds);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    const mm = h > 0 ? String(m).padStart(2, "0") : String(m);
+    return `${h > 0 ? `${h}:` : ""}${mm}:${String(s).padStart(2, "0")}`;
+}
+
+export type TimeRangesLike = {
+    length: number;
+    start(index: number): number;
+    end(index: number): number;
+};
+
+export function formatTimeRanges(ranges: TimeRangesLike): string {
+    const parts: string[] = [];
+    for (let i = 0; i < ranges.length; i++) {
+        parts.push(`${formatClock(ranges.start(i))}–${formatClock(ranges.end(i))}`);
+    }
+    return parts.join(", ") || "—";
+}
+
+/** Seconds buffered ahead of the playhead (0 when the playhead is unbuffered). */
+export function bufferedAhead(ranges: TimeRangesLike, currentTime: number): number {
+    for (let i = 0; i < ranges.length; i++) {
+        if (ranges.start(i) <= currentTime && currentTime <= ranges.end(i)) {
+            return Math.max(0, ranges.end(i) - currentTime);
+        }
+    }
+    return 0;
+}
+
+const READY_STATE_LABELS: Record<number, string> = {
+    0: "HAVE_NOTHING",
+    1: "HAVE_METADATA",
+    2: "HAVE_CURRENT_DATA",
+    3: "HAVE_FUTURE_DATA",
+    4: "HAVE_ENOUGH_DATA",
+};
+
+const NETWORK_STATE_LABELS: Record<number, string> = {
+    0: "NETWORK_EMPTY",
+    1: "NETWORK_IDLE",
+    2: "NETWORK_LOADING",
+    3: "NETWORK_NO_SOURCE",
+};
+
+export function readyStateLabel(value: number): string {
+    return READY_STATE_LABELS[value] ?? `unknown (${value})`;
+}
+
+export function networkStateLabel(value: number): string {
+    return NETWORK_STATE_LABELS[value] ?? `unknown (${value})`;
+}

--- a/frontend/app/routes/explore/media-preview/media-utils.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.ts
@@ -24,8 +24,14 @@ export function classifyMediaError(code: number | null): MediaErrorKind {
     }
 }
 
+/** Append a query parameter, choosing `?` vs `&` from the existing URL. */
+export function appendQueryParam(url: string, key: string, value: string): string {
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}${key}=${encodeURIComponent(value)}`;
+}
+
 export function buildMediaSrc(previewUrl: string, playerSession: string): string {
-    return `${previewUrl}&playerSession=${encodeURIComponent(playerSession)}`;
+    return appendQueryParam(previewUrl, "playerSession", playerSession);
 }
 
 export function formatClock(seconds: number): string {

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+    backoffMs,
+    classifyMediaError,
+    MAX_AUTO_ATTEMPTS,
+    STALL_THRESHOLD_MS,
+} from "./media-utils";
+
+export type PlayerStatus =
+    | "loading"
+    | "playing"
+    | "recovering"
+    | "failed"
+    | "unsupported";
+
+export type PlayerEvent = {
+    at: number;
+    kind: string;
+    detail?: string;
+};
+
+export type PlayerError = {
+    code: number | null;
+    message: string | null;
+};
+
+const MAX_EVENTS = 200;
+
+/**
+ * Drives a native media element pointed at a signed /view URL: autoplay on
+ * open, progress tracking, and bounded recovery that reopens the same URL
+ * (fresh range request) and resumes from the last good position when the
+ * backend aborts a stream after exhausted transient retries.
+ */
+export function useMediaPlayer({ src }: { src: string }) {
+    const mediaRef = useRef<HTMLMediaElement | null>(null);
+    const [status, setStatus] = useState<PlayerStatus>("loading");
+    const [buffering, setBuffering] = useState(false);
+    const [attempts, setAttempts] = useState(0);
+    const [error, setError] = useState<PlayerError | null>(null);
+    const [startupMs, setStartupMs] = useState<number | null>(null);
+    const [events, setEvents] = useState<PlayerEvent[]>([]);
+
+    const attemptsRef = useRef(0);
+    const lastGoodTimeRef = useRef(0);
+    const lastProgressAtRef = useRef<number | null>(null);
+    const loadStartedAtRef = useRef<number>(Date.now());
+    const startupRecordedRef = useRef(false);
+    const pendingSeekRef = useRef<number | null>(null);
+    const wasPlayingRef = useRef(true); // opening click implies intent to play
+    const generationRef = useRef(0);
+    const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const log = useCallback((kind: string, detail?: string) => {
+        setEvents(prev => {
+            const next = [...prev, { at: Date.now(), kind, ...(detail ? { detail } : {}) }];
+            return next.length > MAX_EVENTS ? next.slice(next.length - MAX_EVENTS) : next;
+        });
+    }, []);
+
+    const clearRecoveryTimer = useCallback(() => {
+        if (recoveryTimerRef.current !== null) {
+            clearTimeout(recoveryTimerRef.current);
+            recoveryTimerRef.current = null;
+        }
+    }, []);
+
+    const reload = useCallback(() => {
+        const el = mediaRef.current;
+        if (!el) return;
+        generationRef.current += 1;
+        // Same URL on purpose: playerSession continuity keeps the read session
+        // correlated, and load() already forces a fresh request.
+        el.src = src;
+        loadStartedAtRef.current = Date.now();
+        el.load();
+    }, [src]);
+
+    const beginRecovery = useCallback((reason: string) => {
+        if (attemptsRef.current >= MAX_AUTO_ATTEMPTS) {
+            setStatus("failed");
+            log("failed", reason);
+            return;
+        }
+        const attempt = attemptsRef.current;
+        attemptsRef.current = attempt + 1;
+        setAttempts(attempt + 1);
+        setStatus("recovering");
+        setError(null);
+        log("recovering", `attempt ${attempt + 1}/${MAX_AUTO_ATTEMPTS}: ${reason}`);
+
+        const el = mediaRef.current;
+        wasPlayingRef.current = el ? !el.paused && !el.ended : true;
+        pendingSeekRef.current = lastGoodTimeRef.current;
+
+        clearRecoveryTimer();
+        recoveryTimerRef.current = setTimeout(reload, backoffMs(attempt));
+    }, [clearRecoveryTimer, log, reload]);
+
+    /** Manual retry from the failed state — resets the automatic attempt budget. */
+    const retry = useCallback(() => {
+        clearRecoveryTimer();
+        attemptsRef.current = 0;
+        setAttempts(0);
+        setError(null);
+        setStatus("loading");
+        log("retry", "manual");
+        reload();
+    }, [clearRecoveryTimer, log, reload]);
+
+    // React 19 ref cleanup: runs when the element detaches (unmount/close),
+    // which passive-effect cleanups cannot guarantee — refs are nulled before
+    // they run. Removing src + load() aborts the in-flight range request.
+    const setMediaEl = useCallback((el: HTMLMediaElement | null) => {
+        mediaRef.current = el;
+        if (!el) return undefined;
+        return () => {
+            el.removeAttribute("src");
+            el.load();
+        };
+    }, []);
+
+    // Reset all per-source state when a different file is previewed.
+    useEffect(() => {
+        clearRecoveryTimer();
+        attemptsRef.current = 0;
+        lastGoodTimeRef.current = 0;
+        lastProgressAtRef.current = null;
+        pendingSeekRef.current = null;
+        wasPlayingRef.current = true;
+        loadStartedAtRef.current = Date.now();
+        startupRecordedRef.current = false;
+        setStatus("loading");
+        setBuffering(false);
+        setAttempts(0);
+        setError(null);
+        setStartupMs(null);
+        setEvents([]);
+    }, [src, clearRecoveryTimer]);
+
+    // On unmount/close: stop pending recovery. The source release itself is
+    // handled by the callback-ref cleanup in setMediaEl (refs are already
+    // detached by the time effect cleanups run).
+    useEffect(() => {
+        return () => clearRecoveryTimer();
+    }, [clearRecoveryTimer]);
+
+    // Progress watchdog: the primary stall signal (browsers fire stalled /
+    // waiting inconsistently). Only fires when playback should be advancing
+    // but hasn't for the whole backend retry budget.
+    useEffect(() => {
+        const interval = setInterval(() => {
+            const el = mediaRef.current;
+            if (!el || el.paused || el.ended || el.seeking) return;
+            if (status === "recovering" || status === "failed" || status === "unsupported") return;
+            const last = lastProgressAtRef.current;
+            if (last !== null && Date.now() - last > STALL_THRESHOLD_MS) {
+                beginRecovery(`no playback progress for ${Math.round(STALL_THRESHOLD_MS / 1000)}s`);
+            }
+        }, 1000);
+        return () => clearInterval(interval);
+    }, [status, beginRecovery]);
+
+    const recordStartup = useCallback(() => {
+        if (startupRecordedRef.current) return;
+        startupRecordedRef.current = true;
+        setStartupMs(Date.now() - loadStartedAtRef.current);
+    }, []);
+
+    const handlers = {
+        onLoadStart: () => log("loadstart"),
+        onLoadedMetadata: () => {
+            const el = mediaRef.current;
+            log("loadedmetadata");
+            if (el && pendingSeekRef.current !== null && Number.isFinite(el.duration)) {
+                el.currentTime = Math.min(pendingSeekRef.current, Math.max(0, el.duration - 0.25));
+                pendingSeekRef.current = null;
+            }
+        },
+        onCanPlay: () => {
+            const el = mediaRef.current;
+            recordStartup();
+            setBuffering(false);
+            if (el && wasPlayingRef.current) {
+                // play() may return undefined in non-standard environments.
+                void Promise.resolve(el.play()).catch(() => { /* autoplay blocked — controls remain */ });
+            }
+        },
+        onPlay: () => {
+            setStatus("playing");
+            log("play");
+        },
+        onPlaying: () => {
+            setStatus("playing");
+            setBuffering(false);
+        },
+        onPause: () => log("pause"),
+        onTimeUpdate: () => {
+            const el = mediaRef.current;
+            if (!el) return;
+            lastGoodTimeRef.current = el.currentTime;
+            lastProgressAtRef.current = Date.now();
+            setBuffering(false);
+        },
+        onSeeked: () => {
+            const el = mediaRef.current;
+            if (!el) return;
+            lastGoodTimeRef.current = el.currentTime;
+            lastProgressAtRef.current = Date.now();
+            log("seeked", formatSeekDetail(el.currentTime));
+        },
+        onSeeking: () => log("seeking"),
+        onWaiting: () => {
+            setBuffering(true);
+            log("waiting");
+        },
+        onStalled: () => log("stalled"),
+        onEmptied: () => log("emptied"),
+        onError: () => {
+            const el = mediaRef.current;
+            const mediaError = el?.error ?? null;
+            const code = mediaError?.code ?? null;
+            const kind = classifyMediaError(code);
+            // ABORTED fires for our own close/reload — never a real failure.
+            if (kind === "aborted") return;
+            const message = mediaError?.message ?? null;
+            setError({ code, message });
+            log("error", `code ${code ?? "?"}${message ? `: ${message}` : ""}`);
+            if (kind === "unsupported") {
+                setStatus("unsupported");
+                return;
+            }
+            beginRecovery("network error");
+        },
+    };
+
+    return {
+        mediaRef,
+        setMediaEl,
+        handlers,
+        status,
+        buffering,
+        attempts,
+        maxAttempts: MAX_AUTO_ATTEMPTS,
+        error,
+        startupMs,
+        events,
+        retry,
+        lastGoodTimeRef,
+        lastProgressAtRef,
+    };
+}
+
+function formatSeekDetail(time: number): string {
+    return `to ${time.toFixed(1)}s`;
+}
+
+export type MediaPlayer = ReturnType<typeof useMediaPlayer>;

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -8,6 +8,7 @@ import {
 
 export type PlayerStatus =
     | "loading"
+    | "ready"
     | "playing"
     | "recovering"
     | "failed"
@@ -25,6 +26,10 @@ export type PlayerError = {
 };
 
 const MAX_EVENTS = 200;
+
+/** A recovery that holds playback for this long counts as stable and
+ *  re-arms the automatic attempt budget. */
+const RECOVERY_STABLE_MS = 10_000;
 
 /**
  * Drives a native media element pointed at a signed /view URL: autoplay on
@@ -50,6 +55,7 @@ export function useMediaPlayer({ src }: { src: string }) {
     const wasPlayingRef = useRef(true); // opening click implies intent to play
     const generationRef = useRef(0);
     const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const lastRecoveryAtRef = useRef<number | null>(null);
 
     const log = useCallback((kind: string, detail?: string) => {
         setEvents(prev => {
@@ -84,6 +90,7 @@ export function useMediaPlayer({ src }: { src: string }) {
         }
         const attempt = attemptsRef.current;
         attemptsRef.current = attempt + 1;
+        lastRecoveryAtRef.current = Date.now();
         setAttempts(attempt + 1);
         setStatus("recovering");
         setError(null);
@@ -138,6 +145,18 @@ export function useMediaPlayer({ src }: { src: string }) {
         setEvents([]);
     }, [src, clearRecoveryTimer]);
 
+    // The source is applied imperatively, not via the JSX src attribute:
+    // React 19 StrictMode's simulated unmount runs callback-ref cleanups
+    // (which strip src) without re-applying props, permanently wiping a
+    // JSX-set attribute. An effect re-establishes the source on every cycle.
+    useEffect(() => {
+        const el = mediaRef.current;
+        if (!el) return;
+        el.src = src;
+        loadStartedAtRef.current = Date.now();
+        el.load();
+    }, [src]);
+
     // On unmount/close: stop pending recovery. The source release itself is
     // handled by the callback-ref cleanup in setMediaEl (refs are already
     // detached by the time effect cleanups run).
@@ -181,6 +200,9 @@ export function useMediaPlayer({ src }: { src: string }) {
             const el = mediaRef.current;
             recordStartup();
             setBuffering(false);
+            // Recovered/loaded while paused: leave the recover/loading banner
+            // even though no play event will follow.
+            setStatus(prev => (prev === "recovering" || prev === "loading" ? "ready" : prev));
             if (el && wasPlayingRef.current) {
                 // play() may return undefined in non-standard environments.
                 void Promise.resolve(el.play()).catch(() => { /* autoplay blocked — controls remain */ });
@@ -194,13 +216,24 @@ export function useMediaPlayer({ src }: { src: string }) {
             setStatus("playing");
             setBuffering(false);
         },
-        onPause: () => log("pause"),
+        onPause: () => {
+            setStatus(prev => (prev === "playing" ? "ready" : prev));
+            log("pause");
+        },
         onTimeUpdate: () => {
             const el = mediaRef.current;
             if (!el) return;
             lastGoodTimeRef.current = el.currentTime;
             lastProgressAtRef.current = Date.now();
             setBuffering(false);
+            // A recovery that sustains playback re-arms the attempt budget.
+            if (attemptsRef.current > 0
+                && lastRecoveryAtRef.current !== null
+                && Date.now() - lastRecoveryAtRef.current > RECOVERY_STABLE_MS) {
+                attemptsRef.current = 0;
+                setAttempts(0);
+                log("recovered", "playback stable");
+            }
         },
         onSeeked: () => {
             const el = mediaRef.current;

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -435,6 +435,9 @@ function Body(props: ExplorePageData) {
                                     href={getFilePath(x as ExploreFile)}
                                     className={getItemContentClassName(canDelete, true)}
                                     onClick={e => {
+                                        // Only intercept plain left-clicks — keep
+                                        // Cmd/Ctrl/middle-click opening the raw link.
+                                        if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
                                         if (openPreview(x as ExploreFile)) e.preventDefault();
                                     }}
                                 >

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -12,8 +12,9 @@ import { getDownloadKey } from "~/auth/downloads.server";
 import { Loading } from "../_index/components/loading/loading";
 import { formatFileSize } from "~/utils/file-size";
 import { parseExploreWebdavPath } from "~/utils/path";
-import { fileKindRank, getExtension, getIcon } from "./file-kind/file-kind";
+import { fileKindRank, getExtension, getIcon, isPlayableMedia } from "./file-kind/file-kind";
 import { ItemMenu } from "./item-menu/item-menu";
+import { MediaPreview } from "./media-preview/media-preview";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { classNames } from "~/utils/styling";
 import { Icon, Checkbox, Button } from "~/components/ui";
@@ -102,12 +103,15 @@ function Body(props: ExplorePageData) {
     const [deletePreview, setDeletePreview] = useState<DeletePreviewAggregate | null>(null);
     const [deleteError, setDeleteError] = useState<string | null>(null);
     const [isDeleting, setIsDeleting] = useState(false);
+    const [preview, setPreview] = useState<{ file: ExploreFile, url: string } | null>(null);
     const lastClickedRef = useRef<string | null>(null);
 
-    // Reset selection and query when navigating between folders.
+    // Reset selection and query when navigating between folders; closing the
+    // preview here also releases its stream instead of leaving it orphaned.
     useEffect(() => {
         setSelected(new Set());
         setQuery("");
+        setPreview(null);
         lastClickedRef.current = null;
     }, [location.pathname]);
 
@@ -168,6 +172,14 @@ function Body(props: ExplorePageData) {
         const extensionQueryParam = extension ? `&extension=${extension}` : '';
         return `/view/${relativePath}?downloadKey=${file.downloadKey}${extensionQueryParam}`;
     }, [location.pathname]);
+
+    // Playable media opens in the in-app preview; everything else keeps the
+    // direct-link behavior. Returns true when the preview took over.
+    const openPreview = useCallback((file: ExploreFile) => {
+        if (!isPlayableMedia(file)) return false;
+        setPreview({ file, url: getFilePath(file) });
+        return true;
+    }, [getFilePath]);
 
     const requestDelete = useCallback((names: string[]) => {
         if (names.length === 0) return;
@@ -422,8 +434,11 @@ function Body(props: ExplorePageData) {
                                 <a
                                     href={getFilePath(x as ExploreFile)}
                                     className={getItemContentClassName(canDelete, true)}
+                                    onClick={e => {
+                                        if (openPreview(x as ExploreFile)) e.preventDefault();
+                                    }}
                                 >
-                                    <Icon name={getIcon(x as ExploreFile)} className="text-base-content/50 shrink-0 !text-[34px]" />
+                                    <Icon name={getIcon(x)} className="text-base-content/50 shrink-0 !text-[34px]" />
                                     <div className="flex flex-col gap-1 leading-snug text-base-content">
                                         <div className="break-all font-medium">{x.name}</div>
                                         <div className="text-xs text-base-content/50">{formatFileSize(x.size)}</div>
@@ -434,6 +449,9 @@ function Body(props: ExplorePageData) {
                                     openClassName={ITEM_MENU_OPEN_CLASS}
                                     exploreFile={x as ExploreFile}
                                     previewPath={getFilePath(x as ExploreFile)}
+                                    {...(isPlayableMedia(x)
+                                        ? { onPreview: () => { openPreview(x as ExploreFile); } }
+                                        : {})}
                                     {...(canDelete ? { onRemove: () => requestDelete([x.name]) } : {})} />
                             </div>
                         );
@@ -442,6 +460,16 @@ function Body(props: ExplorePageData) {
             }
             </>}
             {showSkeleton && <Loading className="w-[calc(100%-75px)] min-h-0 flex-1 grow" />}
+            {preview && (
+                <MediaPreview
+                    fileName={preview.file.name}
+                    filePath={getRelativePath(getWebdavPathDecoded(location.pathname), preview.file.name)}
+                    mimeType={preview.file.mimeType}
+                    sizeBytes={preview.file.size ?? null}
+                    previewUrl={preview.url}
+                    onClose={() => setPreview(null)}
+                />
+            )}
             <ConfirmModal
                 show={pendingDelete !== null}
                 title={pendingDelete && pendingDelete.length > 1 ? "Delete items" : "Delete item"}

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -12,6 +12,7 @@ import { getDownloadKey } from "~/auth/downloads.server";
 import { Loading } from "../_index/components/loading/loading";
 import { formatFileSize } from "~/utils/file-size";
 import { parseExploreWebdavPath } from "~/utils/path";
+import { fileKindRank, getExtension, getIcon } from "./file-kind/file-kind";
 import { ItemMenu } from "./item-menu/item-menu";
 import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { classNames } from "~/utils/styling";
@@ -59,7 +60,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                 if (x.isDirectory) return x;
                 return {
                     ...x,
-                    mimeType: getMimeType(x.name),
+                    mimeType: getMimeType(x.name) || "",
                     downloadKey: getDownloadKey(getRelativePath(path, x.name))
                 };
             })
@@ -677,31 +678,8 @@ function compareItems(a: DirectoryItem, b: DirectoryItem, key: SortKey, dir: Sor
     return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" });
 }
 
-function fileKindRank(item: DirectoryItem): number {
-    const ext = getExtension(item.name)?.toLowerCase() ?? "";
-    const mime = (item as ExploreFile).mimeType ?? "";
-    if (mime.startsWith("video") || ext === ".mkv" || mime === "application/mp4") return 0;
-    if (mime.startsWith("image")) return 1;
-    if (mime.startsWith("audio")) return 2;
-    return 3;
-}
-
 function formatCount(n: number, label: string) {
     return `${n} ${label}${n === 1 ? "" : "s"}`;
-}
-
-function getExtension(filename: string): string | undefined {
-    const lastDotIndex = filename.lastIndexOf('.');
-    if (lastDotIndex === -1 || lastDotIndex === 0) return undefined;
-    return filename.slice(lastDotIndex);
-}
-
-function getIcon(file: ExploreFile) {
-    if (file.name.toLowerCase().endsWith(".mkv")) return "movie";
-    if (file.mimeType === "application/mp4") return "movie";
-    if (file.mimeType && file.mimeType.startsWith("video")) return "movie";
-    if (file.mimeType && file.mimeType.startsWith("image")) return "image";
-    return "draft";
 }
 
 function getWebdavPath(pathname: string): string {

--- a/tests/NzbWebDAV.Tests/Api/GetWebdavItemRequestRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetWebdavItemRequestRangeTests.cs
@@ -44,4 +44,31 @@ public class GetWebdavItemRequestRangeTests
     {
         Assert.Equal(expected, GetWebdavItemController.ResolveRangeEnd(rangeEnd, fileSize));
     }
+
+    [Theory]
+    [InlineData("550e8400-e29b-41d4-a716-446655440000")]
+    [InlineData("abc123")]
+    [InlineData("player_session-1")]
+    public void NormalizePlayerSession_AcceptsShortOpaqueTokens(string raw)
+    {
+        Assert.Equal(raw, GetWebdavItemRequest.NormalizePlayerSession(raw));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("has spaces")]
+    [InlineData("has?query&chars")]
+    [InlineData("newline\ninjection")]
+    public void NormalizePlayerSession_RejectsMissingOrUnsafeValues(string? raw)
+    {
+        Assert.Null(GetWebdavItemRequest.NormalizePlayerSession(raw));
+    }
+
+    [Fact]
+    public void NormalizePlayerSession_RejectsOverlongValues()
+    {
+        Assert.Null(GetWebdavItemRequest.NormalizePlayerSession(new string('a', 65)));
+        Assert.NotNull(GetWebdavItemRequest.NormalizePlayerSession(new string('a', 64)));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Services/ActiveReadRegistryEnrichmentTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ActiveReadRegistryEnrichmentTests.cs
@@ -39,4 +39,59 @@ public class ActiveReadRegistryEnrichmentTests
         Assert.Equal(ReadSession.EndReasonCode.Aborted, entry.EndReason);
         Assert.Equal(25, registry.GetBytesRead(id));
     }
+
+    [Fact]
+    public void GetOrCreate_SamePlayerSession_DedupesOntoOneSession()
+    {
+        var registry = new ActiveReadRegistry();
+        var first = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "abc123");
+        var second = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "abc123");
+
+        Assert.Equal(first, second);
+        Assert.Single(registry.Snapshot());
+        Assert.Equal("abc123", registry.Snapshot().Single().PlayerSession);
+    }
+
+    [Fact]
+    public void GetOrCreate_DifferentPlayerSessions_StayDistinct()
+    {
+        var registry = new ActiveReadRegistry();
+        var first = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "player-a");
+        var second = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "player-b");
+
+        Assert.NotEqual(first, second);
+        Assert.Equal(2, registry.Snapshot().Count);
+    }
+
+    [Fact]
+    public void GetOrCreate_MissingPlayerSession_KeepsLegacyDedupe()
+    {
+        var registry = new ActiveReadRegistry();
+        var first = registry.GetOrCreate("/p", "k", "f", 100);
+        var second = registry.GetOrCreate("/p", "k", "f", 100);
+
+        Assert.Equal(first, second);
+        Assert.Null(registry.Snapshot().Single().PlayerSession);
+
+        // A keyed player does not merge into an existing keyless session.
+        var keyed = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "player-a");
+        Assert.NotEqual(first, keyed);
+    }
+
+    [Fact]
+    public void PruneExpired_RemovesPlayerSessionDedupeMapping()
+    {
+        var registry = new ActiveReadRegistry();
+        var first = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "player-a");
+
+        // Force expiry by pruning with the entry untouched beyond the window:
+        // there is no clock injection, so verify via a fresh registry instance
+        // that a second GetOrCreate after PruneExpired re-creates rather than
+        // resurrecting the expired mapping.
+        var expired = registry.PruneExpired(DateTimeOffset.UtcNow.AddSeconds(31));
+        Assert.Single(expired);
+
+        var recreated = registry.GetOrCreate("/p", "k", "f", 100, playerSession: "player-a");
+        Assert.NotEqual(first, recreated);
+    }
 }


### PR DESCRIPTION
## Summary

Implements [#848](https://github.com/infinidysk/infinidysk/issues/848). Video and audio files in **Files** now open in an in-app native player instead of navigating away to the browser's bare viewer page:

- **Bounded auto-recovery.** On a network error or a 30s no-progress watchdog stall, the player reopens the same signed `/view` URL (a fresh range request), restores the last good position, and resumes — the manual pause/resume ritual from the desync investigations, automated. Decode/unsupported errors show a clear "browser cannot decode this" state with **Open direct** / **Download** escape hatches instead of looping. The budget (3 attempts, 1s/2s/4s backoff) re-arms after 10s of stable playback.
- **No orphaned streams.** Closing the preview releases the media source, aborting the in-flight range request; the backend read session expires inside its normal 15s window. Folder navigation closes the preview for the same reason.
- **Diagnostics drawer (opt-in).** Client telemetry (startup ms, buffer ranges/ahead, ready/network state, resolution, dropped frames, retry history), the correlated backend read (offset, bytes served/fetched, rate, per-provider segments), server-wide live totals, and — only when developer stream tracing is explicitly enabled — per-session trace summaries and a raw event list with overflow warnings. **Copy diagnostics JSON** redacts the download key, client IP, and full segment IDs.
- **Player correlation.** A non-secret `playerSession` query token joins the active-read dedupe key, so concurrent in-app players of the same file no longer collapse into one read session; external clients (no token) behave exactly as before. The broadcast now also carries `bytesFetched`.
- Drive-by fixes: Explore no longer crashes when type-sorting files whose extension `mime-types` doesn't know (`false.startsWith` throw), and audio files get an `audio_file` icon.

No transcoding, MSE, blob URLs, or speculative prefetching — the byte path is unchanged.

## Performance gate (measured on a live dev instance, 648 MB MKV over real providers)

| Gate | Result |
|------|--------|
| No material increase in initial ranges/bytes vs. direct playback | Pass — same signed `/view` URL, native element, `preload="metadata"`; no extra requests added |
| Startup latency | ~560 ms warm / ~1.4 s cold to first playable frame |
| Abandoned reads close promptly | Pass — read session dropped from active reads within the 15s window after close |
| Aborted stream auto-resumes faster than manual pause/resume | Pass — injected mid-stream error at 4.7s → reload → position restored → playing again with zero user action; previously a manual ritual |
| Correlation | Distinct `playerSession`s on one file → 2 active reads; same session → 1 (verified via overview stats) |
| Seek | New range opened, playback resumed, trace captured 65 segment fetches with per-stage waits |

One caveat: the recovery test used an injected media error; a genuine transient-abort reproduction (exhausted provider timeouts per PR #802) is in the manual checklist below.

## Test plan

- [x] Backend tests: 2,630 passed, 9 skipped (platform-specific)
- [x] Frontend: 575 tests passed, typecheck clean, lint clean (0 errors), production build passes
- [x] Live: playback autoplay, seek to mid-file, close cleanup, diagnostics drawer, trace recording + event list, correlation counts
- [x] Live: full backend loss correctly surfaces the app-level migration/startup splash (not a per-player error loop)
- [ ] Manual: reproduce a real transient provider timeout and confirm auto-resume without A/V drift
- [ ] Manual: Safari with MKV shows the unsupported-format state (expected) and Open direct/Download work