### PR TITLE
fix(webdav): write-stall watchdog timeouts no longer mislabeled as backend read deadlines in logs

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -210,7 +210,9 @@ public class GetWebdavItemController(
                     throw;
                 }
             }
-            catch (OperationCanceledException oce) when (!HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException oce) when (
+                oce is not StreamingWriteTimeoutException
+                && !HttpContext.RequestAborted.IsCancellationRequested)
             {
                 FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Error, "streaming-read-timeout");
                 throw new StreamingReadTimeoutException(

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -56,6 +56,13 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                 context.Response.Clear();
                 context.Response.StatusCode = 499; // Client closed request (stalled read)
             }
+            else
+            {
+                // Headers already sent: abort the truncated body for parity with every other
+                // post-headers failure path, rather than relying on Kestrel to RST the
+                // incomplete Content-Length response.
+                AbortStartedResponse(context);
+            }
 
             var filePath = GetRequestFilePath(context);
             LogWithDedup(RecentStreamingWriteTimeouts, filePath, suppressed =>

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -54,7 +54,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             if (!context.Response.HasStarted)
             {
                 context.Response.Clear();
-                context.Response.StatusCode = 499; // Client closed request (stalled read)
+                context.Response.StatusCode = 499; // Client stopped reading (write-stall watchdog)
             }
             else
             {

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -104,7 +104,9 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                     httpContext, request, response, isHeadRequest, range, copyStart, copyEnd, readCts, ct)
                 .ConfigureAwait(false);
         }
-        catch (OperationCanceledException oce) when (!httpContext.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException oce) when (
+            oce is not StreamingWriteTimeoutException
+            && !httpContext.RequestAborted.IsCancellationRequested)
         {
             throw new StreamingReadTimeoutException(
                 "WebDAV read exceeded the " +

--- a/frontend/server/backend-proxy-response.test.ts
+++ b/frontend/server/backend-proxy-response.test.ts
@@ -1,8 +1,10 @@
 import http from "node:http";
+import { EventEmitter } from "node:events";
 import type { AddressInfo } from "node:net";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { handleBackendProxyResponse } from "./backend-proxy-response";
+import { logger } from "./logger";
 
 vi.mock("./logger", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -110,6 +112,10 @@ describe("handleBackendProxyResponse", () => {
 
   afterEach(async () => {
     await Promise.all(servers.splice(0).map((server) => close(server)));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   async function startProxy(backendHandler: http.RequestListener): Promise<number> {
@@ -234,4 +240,128 @@ describe("handleBackendProxyResponse", () => {
     expect(result.endedCleanly).toBe(true);
     expect(result.bytes).toBe(400);
   });
+
+  it("does not warn when the client disconnects mid-stream", async () => {
+    const frontendPort = await startProxy((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "video/x-matroska",
+        "Content-Length": "100000",
+      });
+      // Stream slowly so the client is mid-transfer when it disconnects.
+      const interval = setInterval(() => {
+        res.write(Buffer.alloc(200, 1));
+      }, 5);
+      res.on("close", () => clearInterval(interval));
+    });
+
+    await new Promise<void>((resolve) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: frontendPort,
+          path: "/content/movie.mkv",
+          method: "GET",
+        },
+        (res) => {
+          res.on("data", () => {
+            // Disconnect as soon as the first chunk arrives.
+            req.destroy();
+          });
+          res.on("close", () => resolve());
+          res.on("error", () => resolve());
+        },
+      );
+      req.on("error", () => resolve());
+      req.end();
+    });
+
+    // Give the proxy a moment to process the upstream close after the client
+    // disconnect propagates.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns and destroys when the backend aborts with a live client", () => {
+    const { proxyRes, req, res } = createMockStreams({
+      proxyResComplete: false,
+      reqDestroyed: false,
+      resWritableEnded: false,
+    });
+
+    handleBackendProxyResponse(proxyRes as unknown as import("node:http").IncomingMessage,
+      req as unknown as import("node:http").IncomingMessage,
+      res as unknown as import("node:http").ServerResponse);
+
+    proxyRes.emit("close");
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+    expect(message).toContain("ended before its body was complete");
+    expect(res.destroy).toHaveBeenCalled();
+  });
+
+  it("does not warn when the client already disconnected before the backend abort closed", () => {
+    const { proxyRes, req, res } = createMockStreams({
+      proxyResComplete: false,
+      reqDestroyed: true,
+      resWritableEnded: false,
+    });
+
+    handleBackendProxyResponse(proxyRes as unknown as import("node:http").IncomingMessage,
+      req as unknown as import("node:http").IncomingMessage,
+      res as unknown as import("node:http").ServerResponse);
+
+    proxyRes.emit("close");
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(res.destroy).not.toHaveBeenCalled();
+  });
 });
+
+function createMockStreams(opts: {
+  proxyResComplete: boolean;
+  reqDestroyed: boolean;
+  resWritableEnded: boolean;
+}) {
+  const proxyRes = new EventEmitter() as EventEmitter & {
+    complete: boolean;
+    statusCode: number;
+    headers: Record<string, string>;
+    pipe: () => void;
+    resume: () => void;
+  };
+  proxyRes.complete = opts.proxyResComplete;
+  proxyRes.statusCode = 200;
+  proxyRes.headers = { "content-type": "video/x-matroska" };
+  proxyRes.pipe = () => {};
+  proxyRes.resume = () => {};
+
+  const req = new EventEmitter() as EventEmitter & {
+    method: string;
+    url: string;
+    destroyed: boolean;
+    headers: Record<string, string>;
+  };
+  req.method = "GET";
+  req.url = "/content/movie.mkv";
+  req.destroyed = opts.reqDestroyed;
+  req.headers = {};
+
+  const res = new EventEmitter() as EventEmitter & {
+    writableEnded: boolean;
+    destroyed: boolean;
+    headersSent: boolean;
+    writeHead: () => void;
+    end: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  };
+  res.writableEnded = opts.resWritableEnded;
+  res.destroyed = false;
+  res.headersSent = true;
+  res.writeHead = () => {};
+  res.end = vi.fn();
+  res.destroy = vi.fn();
+
+  return { proxyRes, req, res };
+}

--- a/frontend/server/backend-proxy-response.ts
+++ b/frontend/server/backend-proxy-response.ts
@@ -41,6 +41,14 @@ export function handleBackendProxyResponse(
       return;
     }
 
+    // If the downstream client already disconnected (rclone VFS chunk churn,
+    // a scrub, a tab close), the incomplete upstream body is the client's
+    // doing — not a backend failure. `req.destroyed` is set when the client
+    // closes the connection; a backend abort leaves the client's request
+    // alive, so this check distinguishes the two without racing on `res`
+    // teardown.
+    if (req.destroyed) return;
+
     logger.warn(
       `Backend response for ${req.method ?? "?"} ${req.url ?? "?"} ended before its body was `
       + "complete; aborting the client transfer instead of ending it successfully.",

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -256,6 +256,54 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task StreamingWriteTimeout_AfterResponseStarted_AbortsAndLogsWriteStall()
+    {
+        // SWTE must reach the dedicated StreamingWriteTimeoutException branch and log
+        // "streaming-write-timeout", not be wrapped into SRTE and mislabeled as
+        // "streaming-read-timeout-after-headers" (issue #949).
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: true, lifetimeFeature);
+        context.Request.Path = $"/content/write-stall-after-{Guid.NewGuid():N}.mkv";
+        var middleware = CreateMiddleware(
+            _ => throw new StreamingWriteTimeoutException(
+                "Client stopped reading; streaming write timed out."));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        Assert.True(lifetimeFeature.Aborted);
+        var logged = Assert.Single(
+            events,
+            e => e.RenderMessage().Contains("streaming-write-timeout", StringComparison.Ordinal)
+                 && e.Level == LogEventLevel.Warning
+                 && e.Exception is null);
+        Assert.Contains("write stalled", logged.RenderMessage(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            logged.RenderMessage(),
+            "streaming-read-timeout",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task StreamingWriteTimeout_BeforeResponseStarted_Returns499WithoutAborting()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        context.Request.Path = $"/content/write-stall-before-{Guid.NewGuid():N}.mkv";
+        var middleware = CreateMiddleware(
+            _ => throw new StreamingWriteTimeoutException(
+                "Client stopped reading; streaming write timed out."));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        Assert.Equal(499, context.Response.StatusCode);
+        Assert.False(lifetimeFeature.Aborted);
+        Assert.Single(
+            events,
+            e => e.RenderMessage().Contains("streaming-write-timeout", StringComparison.Ordinal)
+                 && e.Level == LogEventLevel.Warning);
+    }
+
+    [Fact]
     public async Task MissingArticle_CoalescesUnicodePathVariants()
     {
         var segmentId = $"<{Guid.NewGuid():N}@test>";

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -278,8 +278,8 @@ public class ExceptionMiddlewareTests
                  && e.Exception is null);
         Assert.Contains("write stalled", logged.RenderMessage(), StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(
-            logged.RenderMessage(),
             "streaming-read-timeout",
+            logged.RenderMessage(),
             StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary

- The 60s streaming-**write** watchdog (client stopped reading but kept the connection open) was being wrapped into `StreamingReadTimeoutException` and logged as `WebDAV read aborted after headers due to backend deadline ... streaming-read-timeout-after-headers` — blaming the Usenet backend for a client-side write stall. The accurate `WebDAV write stalled ... streaming-write-timeout` message was never emitted because the middleware's dedicated `StreamingWriteTimeoutException` branch was dead code for WebDAV GET.
- The frontend proxy also logged `Backend response for GET <file> ended before its body was complete` for **any** incomplete upstream body, including normal client-initiated disconnects (rclone VFS chunk churn, scrubs), where the warning is meaningless noise — the downstream client is already gone.

Both are now fixed. Operators will see accurate `streaming-write-timeout` warnings for write stalls, and the proxy warning only fires for genuine backend aborts with a live client still connected.

## What changed

**Backend (`fix(webdav)`):**
- `StreamingWriteTimeoutException` is excluded from the OCE→SRTE wrap in `GetAndHeadHandlerPatch` and `GetWebdavItemController`, so it reaches the middleware's dedicated SWTE branch and logs `streaming-write-timeout`.
- The SWTE middleware branch now calls `AbortStartedResponse` for the post-headers case, matching every other post-headers failure path (previously relied on Kestrel to RST the incomplete response).
- Regression test: pre-headers read timeouts still wrap to SRTE and emit 503 + `Retry-After` (existing behavior preserved).

**Frontend (`fix(ui)`):**
- The proxy's incomplete-body warning checks `req.destroyed` (set when the client closes the connection) before warning; a backend abort leaves the client's request alive, so this distinguishes the two without racing on `res` teardown.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2632 passed, 0 failed
- [x] `cd frontend && npm run typecheck && npm run build && npm test` — 580 passed, 0 failed
- [ ] Manual: pause a playback client mid-stream for >60s → backend logs `streaming-write-timeout` (not `streaming-read-timeout-after-headers`)
- [ ] Manual: rclone range cancel → no proxy `ended before its body was complete` warning

Fixes #949.