### PR TITLE
fix(sharpcompress): 7z archives containing empty files no longer fail the download

### DIFF
--- a/libs/SharpCompress/Common/SevenZip/SevenZipFilePart.cs
+++ b/libs/SharpCompress/Common/SevenZip/SevenZipFilePart.cs
@@ -104,6 +104,12 @@ internal class SevenZipFilePart : FilePart
             return CompressionType.None;
         }
 
+        // Entries without a stream (e.g. zero-byte files) have no folder or coders.
+        if (!Header.HasStream || Folder is null)
+        {
+            return CompressionType.None;
+        }
+
         // Report the primary non-crypto coder. AES-first chains (encrypted stored/compressed
         // entries) must not throw: AES + Copy resolves to None, AES + LZMA to LZMA, etc.
         var coder = GetPrimaryCoder();
@@ -223,7 +229,8 @@ internal class SevenZipFilePart : FilePart
         {
             _isEncrypted ??=
                 !Header.IsDir
-                && Folder?._coders.FindIndex(c => c._methodId._id == CMethodId.K_AES_ID) != -1;
+                && Folder is not null
+                && Folder._coders.FindIndex(c => c._methodId._id == CMethodId.K_AES_ID) != -1;
             return _isEncrypted.Value;
         }
     }

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipWriterTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipWriterTests.cs
@@ -271,6 +271,45 @@ public class SevenZipWriterTests : TestBase
     }
 
     [Fact]
+    public void SevenZipArchive_EmptyFileEntry_MetadataDoesNotThrow()
+    {
+        // Streamless entries (zero-byte files) have no folder, hence no coders.
+        // Reading their metadata must not throw, and they are not encrypted.
+        // https://github.com/infinidysk/infinidysk/issues/948
+        using var archiveStream = new MemoryStream();
+        using (var writer = new SevenZipWriter(archiveStream, new SevenZipWriterOptions()))
+        {
+            using (var empty = new MemoryStream())
+            {
+                writer.Write("empty.txt", empty, DateTime.UtcNow);
+            }
+
+            using (var content = new MemoryStream("real content"u8.ToArray()))
+            {
+                writer.Write("real.txt", content, DateTime.UtcNow);
+            }
+        }
+
+        archiveStream.Position = 0;
+        using var archive = (SevenZipArchive)SevenZipArchive.OpenArchive(archiveStream);
+        var emptyEntry = archive.Entries.First(e => e.Key == "empty.txt");
+
+        Assert.Equal(CompressionType.None, emptyEntry.CompressionType);
+        Assert.False(emptyEntry.IsEncrypted);
+
+        using var emptyOutput = new MemoryStream();
+        using (var emptyStream = emptyEntry.OpenEntryStream())
+        {
+            emptyStream.CopyTo(emptyOutput);
+        }
+        Assert.Equal(0, (int)emptyOutput.Length);
+
+        var realEntry = archive.Entries.First(e => e.Key == "real.txt");
+        Assert.NotEqual(CompressionType.None, realEntry.CompressionType);
+        Assert.False(realEntry.IsEncrypted);
+    }
+
+    [Fact]
     public void SevenZipWriter_LZMA2_SingleFile_RoundTrip()
     {
         var content =


### PR DESCRIPTION
## Summary

- Fixes [#948](https://github.com/infinidysk/infinidysk/issues/948): a 7z archive containing a zero-byte file crashed queue processing with `ArgumentNullException ("Parameter 'Folder')`. Streamless entries have no folder in the 7z format, so `SevenZipFilePart.Folder` is null and `GetPrimaryCoder()` threw via `Folder.NotNull()`; the backend reads `CompressionType` eagerly for every 7z entry (`SevenZipUtil`), so one empty file failed the whole job.
- `CompressionType` now returns `None` for streamless entries (no stream = no compression coder), matching how directories are already handled.
- Also fixes adjacent latent bug: `IsEncrypted` misreported `true` for streamless entries (`Folder?._coders.FindIndex(...) != -1` is null-lifted to true).
- Adds a writer round-trip regression test covering `CompressionType`, `IsEncrypted`, and zero-byte extraction of the empty entry.

## Test plan

- [x] New regression test `SevenZipArchive_EmptyFileEntry_MetadataDoesNotThrow` fails before the fix with the exact `ArgumentNullException` from the user's support pack, passes after
- [x] `dotnet test tests/SharpCompress.Tests/SharpCompress.Tests.csproj -c Release --filter "format!=stress"` — 2125 passed, 0 failed
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2632 passed, 0 failed