### PR TITLE
chore(docs): mark 1.1.0 docs with since pills for metrics retention and SAB bulk ops

### DIFF
--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -7,9 +7,9 @@ InfiniDysk implements the SABnzbd-compatible operations used by Sonarr, Radarr, 
 - `version`, `status`, `fullstatus`, `get_config`, and `get_cats`
 - `server_stats` and `warnings` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 - `addfile` and `addurl`
-- `queue` listing and `queue&name=delete`, `queue&name=pause`, `queue&name=resume`, `queue&name=priority`, and `queue&name=move`
+- `queue` listing and `queue&name=delete`, `queue&name=pause`, `queue&name=resume`, `queue&name=priority`, `queue&name=move`, and `queue&name=change_cat` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 - `pause` / `resume` (also `queue&name=pause` / `queue&name=resume`) and `speedlimit` [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
-- `change_cat` for per-job category changes on queued items
+- `change_cat` for per-job category changes on queued items [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 - `retry` for failed history re-queue (single or bulk) [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
 - `history` listing and `history&name=delete`
 

--- a/docs/operations/retention-cleanup.md
+++ b/docs/operations/retention-cleanup.md
@@ -10,7 +10,7 @@
 
 Configure in **Settings → Maintenance**.
 
-## Metrics database
+## Metrics database [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 
 InfiniDysk stores streaming and provider metrics in a separate SQLite file (`metrics.sqlite` under `CONFIG_PATH`). Size grows with throughput because each article fetch writes a raw row to `SegmentFetches`.
 


### PR DESCRIPTION
## Summary
- Add `since 1.1.0` pill to the Metrics database section in retention/cleanup docs
- Mark new SAB queue operations (`priority`, `move`, `change_cat`) and the `change_cat` bullet with `since 1.1.0` pills

## Test plan
- [ ] Confirm pills render correctly in Zensical (`zensical serve` or docs CI)
- [ ] Spot-check links point to `https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0`