### PR TITLE
chore(docs): document release channel and tag definitions

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -1,5 +1,9 @@
 # Contributing
 
+!!! note "Source builds are a development workflow, not a deployment method"
+
+    Running InfiniDysk from a cloned repository is how the project is developed, but it is **not a supported deployment method** — releases are tested as the published [Docker image](../getting-started/docker.md) and [prebuilt Linux archives](../getting-started/prebuilt-archives.md). You are still welcome to run from source; it is simply not a path releases are tested against. See [Release channels and tags](../getting-started/index.md#release-channels-and-tags) for the supported channels.
+
 ## Shared environment
 
 Frontend and backend must share:

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -2,6 +2,8 @@
 
 InfiniDysk ships as a single multi-arch image: `ghcr.io/infinidysk/infinidysk`. The container runs the frontend (public port `3000`) and backend (internal `8080`).
 
+The examples use `:latest` (current stable). See [Release channels and tags](index.md#release-channels-and-tags) for the `lts`, `rc`, and `dev` channels — and pin an exact version tag (`v1.2.3`) when you want reproducible deploys.
+
 !!! tip "Hosted with DUMB"
 
     Prefer a batteries-included Arr stack? InfiniDysk is a **fully supported core module** in [Debrid Unlimited Media Bridge (DUMB)](https://dumbarr.com/) — see the [InfiniDysk service guide](https://dumbarr.com/services/core/nzbdav/) and [setup options](index.md#setup-and-hosting-options).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -65,6 +65,23 @@ Choose a path based on where you are:
 
 DUMB treats InfiniDysk as a first-class Usenet WebDAV / SABnzbd-compatible workflow service (`core_service: nzbdav`), including automatic Arr download-client and symlink-path integration when you select it during onboarding. Prefer DUMB’s own docs for stack-specific paths and ports; use this site for InfiniDysk Settings, features, and troubleshooting.
 
+## Release channels and tags
+
+Docker images and [prebuilt Linux archives](prebuilt-archives.md) follow the same release train. Choose a tag based on how much change you want to absorb:
+
+| Tag | Definition |
+|-----|------------|
+| `latest` | The current stable release — the same definition as any project. Recommended for most deployments. |
+| `lts` | A curated stable pointer that generally trails `latest` by a few minor/patch releases, for operators who prefer the front lines to do the testing. Docker image tag only; promoted manually, not on every release. |
+| `rc` | Release candidate for the upcoming version, promoted from `dev` builds after basic regression testing. Preferred for all but the most daring testers. |
+| `dev` | Work-in-progress snapshots deployed to the maintainer’s non-production instance to validate basic functionality. Expect a noisy tag: frequent, sometimes non-functional builds, with no per-build version numbers. Testing only. |
+
+For reproducible deployments, pin an exact version tag (`v1.2.3`) or a rolling minor/major alias (`v1.2`, `v1`). Versioned `v*-rc.*` pre-releases and image tags are removed when the stable release ships; the rolling `rc` and `dev` tags persist.
+
+!!! note "Building from source"
+
+    Cloning the repository and running from source remains possible — see [Contributing](../community/contributing.md) — but it is a development workflow, not a supported deployment method. Releases are tested as the published Docker image and prebuilt Linux archives; source builds are not part of release testing.
+
 ## After install
 
 | Goal | Next |

--- a/docs/getting-started/prebuilt-archives.md
+++ b/docs/getting-started/prebuilt-archives.md
@@ -4,6 +4,10 @@ Prebuilt release archives run InfiniDysk directly on Linux without Docker or a
 source build. They include the compiled backend, frontend, production Node.js
 dependencies, and rapidyenc native library.
 
+Archives follow the same [release channels and tags](index.md#release-channels-and-tags)
+as the Docker image: stable builds below, `rc` and `dev` builds under
+[Pre-release testing](#pre-release-testing).
+
 ## Requirements
 
 - Linux x64 or ARM64
@@ -57,6 +61,16 @@ For automation, the rolling `rc` pre-release always exposes stable asset URLs:
 The archive's `version.txt` identifies the exact release candidate. The rolling
 `rc` release remains after a stable release ships (it is not deleted), so check
 its version before assuming it is newer than `latest`.
+
+Work-in-progress `dev` snapshots follow the same pattern on the rolling `dev`
+pre-release:
+
+- [linux-x64](https://github.com/infinidysk/infinidysk/releases/download/dev/infinidysk-dev-linux-x64.tar.gz)
+- [linux-arm64](https://github.com/infinidysk/infinidysk/releases/download/dev/infinidysk-dev-linux-arm64.tar.gz)
+
+`dev` builds are unversioned, refresh whenever the maintainer validates a
+snapshot on non-production, and may be non-functional — see
+[Release channels and tags](index.md#release-channels-and-tags).
 
 ## Upgrade
 

--- a/docs/guides/backups-upgrades.md
+++ b/docs/guides/backups-upgrades.md
@@ -33,7 +33,7 @@ Database migrations apply automatically on startup. **Back up `/config` before u
 
 Coming from nzbdav-dev `v0.6.4` or a community fork? See [Migration paths](../getting-started/migration.md).
 
-Tags: `latest`, version tags, `dev` (unversioned tip snapshot), and `rc` (latest release candidate) — see [GitHub Releases](https://github.com/infinidysk/infinidysk/releases) and [Changelog](../community/changelog.md).
+Tags: `latest` (current stable), `lts` (trails `latest` by a few releases), `rc` (release candidate), and `dev` (unversioned tip snapshot), plus pinned version tags — see [Release channels and tags](../getting-started/index.md#release-channels-and-tags), [GitHub Releases](https://github.com/infinidysk/infinidysk/releases), and [Changelog](../community/changelog.md).
 
 ## Watchtower / Arr updates
 


### PR DESCRIPTION
## Summary
- Adds a canonical **Release channels and tags** section to Getting Started defining `latest`, `lts`, `rc`, and `dev`, and notes Docker images and prebuilt Linux archives follow the same release train.
- Links the tag guidance from the Docker, prebuilt-archives, and backups/upgrades pages; documents the rolling `dev` archive download URLs alongside `rc`.
- Clarifies in Contributing that running from a cloned repo is a development workflow, not a supported/tested deployment method.

## Test plan
- [x] `zensical build --clean --strict` passes with no issues
- [ ] Review rendered Getting Started → Release channels and tags section on the docs site