### PR TITLE
fix(ui): player now says which codec your browser is missing instead of blaming the file type

### DIFF
--- a/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
+++ b/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
@@ -411,6 +411,7 @@ export function buildDiagnosticsSnapshot(
             maxAttempts: player.maxAttempts,
             startupMs: player.startupMs,
             error: player.error,
+            unsupportedCodecs: player.unsupportedCodecs,
             events: player.events,
         },
         mediaElement: el ? {

--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -39,6 +39,7 @@ beforeEach(() => {
 afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     if (savedCanPlayType) {
         Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", savedCanPlayType);
     } else {
@@ -180,6 +181,36 @@ describe("MediaPreview", () => {
         fireMediaError(container.querySelector("video")!, 4, "no decoder");
 
         expect(screen.getByRole("alert").textContent).toContain("No decoder available for HEVC / H.265");
+    });
+
+    it("recovers when code 4 hides an HTTP failure and all decoders are present", async () => {
+        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
+            configurable: true,
+            value: () => "probably",
+        });
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+        const { container } = renderPreview();
+        fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_COULD_NOT_OPEN");
+
+        // The reachability probe fails → normal bounded recovery, not a dead end.
+        expect(await screen.findByText(/Stream interrupted/)).toBeTruthy();
+        expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("stays unsupported when code 4 occurs but the source serves bytes", async () => {
+        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
+            configurable: true,
+            value: () => "probably",
+        });
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, status: 206 }));
+
+        const { container } = renderPreview();
+        fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_NO_SUPPORTED_STREAMS");
+
+        const alert = await screen.findByRole("alert");
+        expect(alert.textContent).toContain("cannot decode");
+        expect(alert.textContent).toContain("DEMUXER_ERROR_NO_SUPPORTED_STREAMS");
     });
 
     it("recovers from a decode error once playback has progressed", () => {

--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -13,12 +13,15 @@ type MediaElementProto = {
 let playMock: ReturnType<typeof vi.fn>;
 let loadMock: ReturnType<typeof vi.fn>;
 const savedDialog: Partial<Record<"showModal" | "close", PropertyDescriptor | undefined>> = {};
+let savedCanPlayType: PropertyDescriptor | undefined;
 
 beforeEach(() => {
     playMock = vi.fn<MediaElementProto["play"]>().mockResolvedValue(undefined);
     loadMock = vi.fn<MediaElementProto["load"]>().mockImplementation(() => {});
     Object.defineProperty(HTMLMediaElement.prototype, "play", { configurable: true, value: playMock });
     Object.defineProperty(HTMLMediaElement.prototype, "load", { configurable: true, value: loadMock });
+
+    savedCanPlayType = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, "canPlayType");
 
     // jsdom may not implement modal dialog show/close.
     savedDialog.showModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, "showModal");
@@ -36,6 +39,11 @@ beforeEach(() => {
 afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    if (savedCanPlayType) {
+        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", savedCanPlayType);
+    } else {
+        Reflect.deleteProperty(HTMLMediaElement.prototype, "canPlayType");
+    }
     for (const key of ["showModal", "close"] as const) {
         const descriptor = savedDialog[key];
         if (descriptor) {
@@ -161,6 +169,37 @@ describe("MediaPreview", () => {
         expect(screen.getByRole("alert").textContent).toContain("cannot decode");
         expect(screen.getByRole("alert").textContent).toContain("video/x-matroska");
         expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
+    });
+
+    it("names the codecs the browser has no decoder for", () => {
+        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
+            configurable: true,
+            value: (type: string) => (/hvc1|hev1/.test(type) ? "" : "probably"),
+        });
+        const { container } = renderPreview();
+        fireMediaError(container.querySelector("video")!, 4, "no decoder");
+
+        expect(screen.getByRole("alert").textContent).toContain("No decoder available for HEVC / H.265");
+    });
+
+    it("recovers from a decode error once playback has progressed", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = renderPreview();
+            const video = container.querySelector("video")!;
+            fireEvent(video, new Event("canplay"));
+            fireEvent(video, new Event("play"));
+            Object.defineProperty(video, "currentTime", { configurable: true, value: 12 });
+            fireEvent(video, new Event("timeupdate"));
+
+            // A mid-stream decode failure is corrupt bytes, not a missing decoder.
+            fireMediaError(video, 3, "PIPELINE_ERROR_DECODE");
+            expect(screen.getByRole("status").textContent).toContain("Stream interrupted");
+            act(() => { vi.advanceTimersByTime(1000); });
+            expect(loadMock).toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it("clears the recovering banner when the stream reloads while paused", () => {

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -151,7 +151,14 @@ function StatusBanner({ player, mimeType }: { player: ReturnType<typeof useMedia
             return (
                 <Alert variant="warning" className="alert-soft py-2 text-sm" role="alert">
                     <Icon name="videocam_off" className="!text-[18px]" />
-                    This browser cannot decode {mimeType || "this format"}. Use Open direct or Download and play it in an external player.
+                    <span>
+                        This browser cannot decode {mimeType || "this format"}
+                        {player.error?.message ? ` (${player.error.message})` : ""}.
+                        {player.unsupportedCodecs.length > 0
+                            ? ` No decoder available for ${player.unsupportedCodecs.join(", ")}.`
+                            : ""}
+                        {" "}Use Open direct or Download and play it in an external player.
+                    </span>
                 </Alert>
             );
     }

--- a/frontend/app/routes/explore/media-preview/media-utils.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.test.ts
@@ -72,20 +72,20 @@ describe("probeUnsupportedCodecs", () => {
 
 describe("probeSourceReachable", () => {
     it("asks for a single byte and reports an OK response as reachable", async () => {
-        const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({ ok: true } as Response);
         await expect(probeSourceReachable("/view/a.mp4?downloadKey=k", fetchFn)).resolves.toBe(true);
         const [url, init] = fetchFn.mock.calls[0]!;
         expect(url).toBe("/view/a.mp4?downloadKey=k");
-        expect(init.headers).toEqual({ Range: "bytes=0-0" });
+        expect(init?.headers).toEqual({ Range: "bytes=0-0" });
     });
 
     it("reports HTTP errors as unreachable", async () => {
-        const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({ ok: false, status: 500 } as Response);
         await expect(probeSourceReachable("/view/a.mp4", fetchFn)).resolves.toBe(false);
     });
 
     it("reports thrown fetches (network down, timeout) as unreachable", async () => {
-        const fetchFn = vi.fn().mockRejectedValue(new TypeError("network down"));
+        const fetchFn = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("network down"));
         await expect(probeSourceReachable("/view/a.mp4", fetchFn)).resolves.toBe(false);
     });
 });

--- a/frontend/app/routes/explore/media-preview/media-utils.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
     appendQueryParam,
     backoffMs,
     bufferedAhead,
     buildMediaSrc,
+    canProbeCodecs,
     classifyMediaError,
     formatClock,
     formatTimeRanges,
     networkStateLabel,
+    probeSourceReachable,
     probeUnsupportedCodecs,
     readyStateLabel,
     type TimeRangesLike,
@@ -56,8 +58,35 @@ describe("probeUnsupportedCodecs", () => {
         expect(missing).toEqual(["HEVC / H.265", "HEVC 10-bit"]);
     });
 
+    it("probes the Dolby Digital variants independently", () => {
+        const missing = probeUnsupportedCodecs(type => (type.includes('"ac-3"') ? "" : "probably"));
+        expect(missing).toEqual(["Dolby Digital (AC-3)"]);
+    });
+
     it("stays silent when canPlayType rejects even the baseline", () => {
         expect(probeUnsupportedCodecs(() => "")).toEqual([]);
+        expect(canProbeCodecs(() => "")).toBe(false);
+        expect(canProbeCodecs(supportAll)).toBe(true);
+    });
+});
+
+describe("probeSourceReachable", () => {
+    it("asks for a single byte and reports an OK response as reachable", async () => {
+        const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+        await expect(probeSourceReachable("/view/a.mp4?downloadKey=k", fetchFn)).resolves.toBe(true);
+        const [url, init] = fetchFn.mock.calls[0]!;
+        expect(url).toBe("/view/a.mp4?downloadKey=k");
+        expect(init.headers).toEqual({ Range: "bytes=0-0" });
+    });
+
+    it("reports HTTP errors as unreachable", async () => {
+        const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+        await expect(probeSourceReachable("/view/a.mp4", fetchFn)).resolves.toBe(false);
+    });
+
+    it("reports thrown fetches (network down, timeout) as unreachable", async () => {
+        const fetchFn = vi.fn().mockRejectedValue(new TypeError("network down"));
+        await expect(probeSourceReachable("/view/a.mp4", fetchFn)).resolves.toBe(false);
     });
 });
 

--- a/frontend/app/routes/explore/media-preview/media-utils.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.test.ts
@@ -8,6 +8,7 @@ import {
     formatClock,
     formatTimeRanges,
     networkStateLabel,
+    probeUnsupportedCodecs,
     readyStateLabel,
     type TimeRangesLike,
 } from "./media-utils";
@@ -34,6 +35,29 @@ describe("classifyMediaError", () => {
     it("does not retry decode or unsupported-source failures", () => {
         expect(classifyMediaError(3)).toBe("unsupported");
         expect(classifyMediaError(4)).toBe("unsupported");
+    });
+
+    it("retries a decode failure that arrives after playback progressed", () => {
+        expect(classifyMediaError(3, true)).toBe("retry");
+        // The demuxer never accepted the source, so progress cannot rescue it.
+        expect(classifyMediaError(4, true)).toBe("unsupported");
+    });
+});
+
+describe("probeUnsupportedCodecs", () => {
+    const supportAll = () => "probably";
+
+    it("reports nothing when the browser supports everything probed", () => {
+        expect(probeUnsupportedCodecs(supportAll)).toEqual([]);
+    });
+
+    it("names codecs the browser rejects", () => {
+        const missing = probeUnsupportedCodecs(type => (type.includes("hvc1") || type.includes("hev1") ? "" : "probably"));
+        expect(missing).toEqual(["HEVC / H.265", "HEVC 10-bit"]);
+    });
+
+    it("stays silent when canPlayType rejects even the baseline", () => {
+        expect(probeUnsupportedCodecs(() => "")).toEqual([]);
     });
 });
 

--- a/frontend/app/routes/explore/media-preview/media-utils.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.ts
@@ -14,14 +14,50 @@ export const STALL_THRESHOLD_MS = 30_000;
 
 export type MediaErrorKind = "aborted" | "retry" | "unsupported";
 
-/** MEDIA_ERR_* codes: 1 aborted, 2 network, 3 decode, 4 src-not-supported. */
-export function classifyMediaError(code: number | null): MediaErrorKind {
+/**
+ * MEDIA_ERR_* codes: 1 aborted, 2 network, 3 decode, 4 src-not-supported.
+ *
+ * A decode error after frames have already played means the decoder works and
+ * the bytes went bad (missing or zero-filled segments), so it is worth a
+ * reload; a decode error before any progress means the browser never had a
+ * working pipeline for this file.
+ */
+export function classifyMediaError(code: number | null, hadPlaybackProgress = false): MediaErrorKind {
     switch (code) {
         case 1: return "aborted";
-        case 3:
+        case 3: return hadPlaybackProgress ? "retry" : "unsupported";
         case 4: return "unsupported";
         default: return "retry";
     }
+}
+
+export type CanPlayType = (type: string) => string;
+
+/** Baseline every browser with a working media stack decodes. */
+const BASELINE_TYPE = 'video/mp4; codecs="avc1.42E01E"';
+
+/**
+ * Codecs common in Usenet releases that browsers frequently cannot decode.
+ * A label counts as unsupported only when every equivalent type string is
+ * rejected (HEVC is spelled both hvc1 and hev1 depending on the platform).
+ */
+const CODEC_PROBES: { label: string, types: string[] }[] = [
+    { label: "HEVC / H.265", types: ['video/mp4; codecs="hvc1.1.6.L93.B0"', 'video/mp4; codecs="hev1.1.6.L93.B0"'] },
+    { label: "HEVC 10-bit", types: ['video/mp4; codecs="hvc1.2.4.L120.B0"', 'video/mp4; codecs="hev1.2.4.L120.B0"'] },
+    { label: "AV1", types: ['video/mp4; codecs="av01.0.05M.08"'] },
+    { label: "Dolby Digital Plus (E-AC-3)", types: ['audio/mp4; codecs="ec-3"'] },
+];
+
+/**
+ * Labels of the probed codecs this browser reports no support for. Returns
+ * nothing when even the baseline is rejected — that means canPlayType is
+ * uninformative (non-browser environment), not that every codec is missing.
+ */
+export function probeUnsupportedCodecs(canPlayType: CanPlayType): string[] {
+    if (canPlayType(BASELINE_TYPE) === "") return [];
+    return CODEC_PROBES
+        .filter(probe => probe.types.every(type => canPlayType(type) === ""))
+        .map(probe => probe.label);
 }
 
 /** Append a query parameter, choosing `?` vs `&` from the existing URL. */

--- a/frontend/app/routes/explore/media-preview/media-utils.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.ts
@@ -45,8 +45,18 @@ const CODEC_PROBES: { label: string, types: string[] }[] = [
     { label: "HEVC / H.265", types: ['video/mp4; codecs="hvc1.1.6.L93.B0"', 'video/mp4; codecs="hev1.1.6.L93.B0"'] },
     { label: "HEVC 10-bit", types: ['video/mp4; codecs="hvc1.2.4.L120.B0"', 'video/mp4; codecs="hev1.2.4.L120.B0"'] },
     { label: "AV1", types: ['video/mp4; codecs="av01.0.05M.08"'] },
+    { label: "Dolby Digital (AC-3)", types: ['audio/mp4; codecs="ac-3"'] },
     { label: "Dolby Digital Plus (E-AC-3)", types: ['audio/mp4; codecs="ec-3"'] },
 ];
+
+/**
+ * True when canPlayType gives informative answers: a browser with a working
+ * media stack always accepts baseline H.264, so a rejection there means the
+ * probe environment cannot tell us anything (e.g. jsdom).
+ */
+export function canProbeCodecs(canPlayType: CanPlayType): boolean {
+    return canPlayType(BASELINE_TYPE) !== "";
+}
 
 /**
  * Labels of the probed codecs this browser reports no support for. Returns
@@ -54,10 +64,32 @@ const CODEC_PROBES: { label: string, types: string[] }[] = [
  * uninformative (non-browser environment), not that every codec is missing.
  */
 export function probeUnsupportedCodecs(canPlayType: CanPlayType): string[] {
-    if (canPlayType(BASELINE_TYPE) === "") return [];
+    if (!canProbeCodecs(canPlayType)) return [];
     return CODEC_PROBES
         .filter(probe => probe.types.every(type => canPlayType(type) === ""))
         .map(probe => probe.label);
+}
+
+/**
+ * Chromium reports a media fetch that failed at the HTTP layer with the same
+ * MEDIA_ERR_SRC_NOT_SUPPORTED code as a missing decoder. A one-byte ranged
+ * GET reproduces the media request cheaply and tells the two apart: an OK
+ * response means the server served bytes and the browser rejected them.
+ */
+export async function probeSourceReachable(
+    src: string,
+    fetchFn: typeof fetch = fetch,
+): Promise<boolean> {
+    try {
+        const response = await fetchFn(src, {
+            headers: { Range: "bytes=0-0" },
+            cache: "no-store",
+            signal: AbortSignal.timeout(10_000),
+        });
+        return response.ok;
+    } catch {
+        return false;
+    }
 }
 
 /** Append a query parameter, choosing `?` vs `&` from the existing URL. */

--- a/frontend/app/routes/explore/media-preview/media-utils.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.ts
@@ -41,7 +41,7 @@ const BASELINE_TYPE = 'video/mp4; codecs="avc1.42E01E"';
  * A label counts as unsupported only when every equivalent type string is
  * rejected (HEVC is spelled both hvc1 and hev1 depending on the platform).
  */
-const CODEC_PROBES: { label: string, types: string[] }[] = [
+const CODEC_PROBES: { label: string; types: string[] }[] = [
     { label: "HEVC / H.265", types: ['video/mp4; codecs="hvc1.1.6.L93.B0"', 'video/mp4; codecs="hev1.1.6.L93.B0"'] },
     { label: "HEVC 10-bit", types: ['video/mp4; codecs="hvc1.2.4.L120.B0"', 'video/mp4; codecs="hev1.2.4.L120.B0"'] },
     { label: "AV1", types: ['video/mp4; codecs="av01.0.05M.08"'] },

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -3,6 +3,7 @@ import {
     backoffMs,
     classifyMediaError,
     MAX_AUTO_ATTEMPTS,
+    probeUnsupportedCodecs,
     STALL_THRESHOLD_MS,
 } from "./media-utils";
 
@@ -45,6 +46,7 @@ export function useMediaPlayer({ src }: { src: string }) {
     const [error, setError] = useState<PlayerError | null>(null);
     const [startupMs, setStartupMs] = useState<number | null>(null);
     const [events, setEvents] = useState<PlayerEvent[]>([]);
+    const [unsupportedCodecs, setUnsupportedCodecs] = useState<string[]>([]);
 
     const attemptsRef = useRef(0);
     const lastGoodTimeRef = useRef(0);
@@ -143,6 +145,7 @@ export function useMediaPlayer({ src }: { src: string }) {
         setError(null);
         setStartupMs(null);
         setEvents([]);
+        setUnsupportedCodecs([]);
     }, [src, clearRecoveryTimer]);
 
     // The source is applied imperatively, not via the JSX src attribute:
@@ -253,13 +256,16 @@ export function useMediaPlayer({ src }: { src: string }) {
             const el = mediaRef.current;
             const mediaError = el?.error ?? null;
             const code = mediaError?.code ?? null;
-            const kind = classifyMediaError(code);
+            const kind = classifyMediaError(code, lastProgressAtRef.current !== null);
             // ABORTED fires for our own close/reload — never a real failure.
             if (kind === "aborted") return;
             const message = mediaError?.message ?? null;
             setError({ code, message });
             log("error", `code ${code ?? "?"}${message ? `: ${message}` : ""}`);
             if (kind === "unsupported") {
+                const missing = el ? probeUnsupportedCodecs(type => el.canPlayType(type)) : [];
+                setUnsupportedCodecs(missing);
+                if (missing.length > 0) log("unsupported", `no decoder for ${missing.join(", ")}`);
                 setStatus("unsupported");
                 return;
             }
@@ -278,6 +284,7 @@ export function useMediaPlayer({ src }: { src: string }) {
         error,
         startupMs,
         events,
+        unsupportedCodecs,
         retry,
         lastGoodTimeRef,
         lastProgressAtRef,

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
     backoffMs,
+    canProbeCodecs,
     classifyMediaError,
     MAX_AUTO_ATTEMPTS,
+    probeSourceReachable,
     probeUnsupportedCodecs,
     STALL_THRESHOLD_MS,
 } from "./media-utils";
@@ -49,6 +51,7 @@ export function useMediaPlayer({ src }: { src: string }) {
     const [unsupportedCodecs, setUnsupportedCodecs] = useState<string[]>([]);
 
     const attemptsRef = useRef(0);
+    const framesBaselineRef = useRef(0);
     const lastGoodTimeRef = useRef(0);
     const lastProgressAtRef = useRef<number | null>(null);
     const loadStartedAtRef = useRef<number>(Date.now());
@@ -129,9 +132,15 @@ export function useMediaPlayer({ src }: { src: string }) {
         };
     }, []);
 
-    // Reset all per-source state when a different file is previewed.
+    // Reset all per-source state when a different file is previewed. Bumping
+    // the generation invalidates async work (recovery timers, source checks)
+    // still in flight for the previous source.
     useEffect(() => {
         clearRecoveryTimer();
+        generationRef.current += 1;
+        // VideoPlaybackQuality counters are cumulative for the element's
+        // lifetime; snapshot them so progress checks only count this source.
+        framesBaselineRef.current = totalVideoFrames(mediaRef.current) ?? 0;
         attemptsRef.current = 0;
         lastGoodTimeRef.current = 0;
         lastProgressAtRef.current = null;
@@ -188,6 +197,42 @@ export function useMediaPlayer({ src }: { src: string }) {
         startupRecordedRef.current = true;
         setStartupMs(Date.now() - loadStartedAtRef.current);
     }, []);
+
+    // Frames decoded for the current source are the strongest evidence the
+    // decoder pipeline worked. Audio elements have no frame counter and fall
+    // back to the progress watchdog timestamp (which a recovery seek can also
+    // set — a weaker signal, but the retry budget bounds the damage).
+    const hasDecodedProgress = (el: HTMLMediaElement | null): boolean => {
+        const frames = totalVideoFrames(el);
+        if (frames !== null) return frames > framesBaselineRef.current;
+        return lastProgressAtRef.current !== null;
+    };
+
+    const handleUnsupported = (el: HTMLMediaElement | null, code: number | null) => {
+        const canPlay = el ? (type: string) => el.canPlayType(type) : null;
+        const missing = canPlay ? probeUnsupportedCodecs(canPlay) : [];
+        setUnsupportedCodecs(missing);
+        if (missing.length > 0) log("unsupported", `no decoder for ${missing.join(", ")}`);
+
+        // Chromium reports a media fetch that failed at the HTTP layer with
+        // the same code 4 as a missing decoder. When every probed decoder is
+        // present, verify the source before blaming the browser: a failing
+        // request goes through normal bounded recovery instead.
+        if (code === 4 && canPlay && canProbeCodecs(canPlay) && missing.length === 0) {
+            const generation = generationRef.current;
+            void probeSourceReachable(src).then(reachable => {
+                if (generationRef.current !== generation) return;
+                if (reachable) {
+                    setStatus("unsupported");
+                } else {
+                    log("source-check", "media request failed at the HTTP layer");
+                    beginRecovery("media request failed");
+                }
+            });
+            return;
+        }
+        setStatus("unsupported");
+    };
 
     const handlers = {
         onLoadStart: () => log("loadstart"),
@@ -256,17 +301,14 @@ export function useMediaPlayer({ src }: { src: string }) {
             const el = mediaRef.current;
             const mediaError = el?.error ?? null;
             const code = mediaError?.code ?? null;
-            const kind = classifyMediaError(code, lastProgressAtRef.current !== null);
+            const kind = classifyMediaError(code, hasDecodedProgress(el));
             // ABORTED fires for our own close/reload — never a real failure.
             if (kind === "aborted") return;
             const message = mediaError?.message ?? null;
             setError({ code, message });
             log("error", `code ${code ?? "?"}${message ? `: ${message}` : ""}`);
             if (kind === "unsupported") {
-                const missing = el ? probeUnsupportedCodecs(type => el.canPlayType(type)) : [];
-                setUnsupportedCodecs(missing);
-                if (missing.length > 0) log("unsupported", `no decoder for ${missing.join(", ")}`);
-                setStatus("unsupported");
+                handleUnsupported(el, code);
                 return;
             }
             beginRecovery("network error");
@@ -293,6 +335,12 @@ export function useMediaPlayer({ src }: { src: string }) {
 
 function formatSeekDetail(time: number): string {
     return `to ${time.toFixed(1)}s`;
+}
+
+/** null when the element cannot report frame counts (audio, older engines). */
+function totalVideoFrames(el: HTMLMediaElement | null): number | null {
+    if (!(el instanceof HTMLVideoElement) || typeof el.getVideoPlaybackQuality !== "function") return null;
+    return el.getVideoPlaybackQuality().totalVideoFrames;
 }
 
 export type MediaPlayer = ReturnType<typeof useMediaPlayer>;

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -311,7 +311,11 @@ export function useMediaPlayer({ src }: { src: string }) {
                 handleUnsupported(el, code);
                 return;
             }
-            beginRecovery("network error");
+            // Code 3 lands here only when frames already decoded — name the
+            // real trigger so the event log and diagnostics stay truthful.
+            beginRecovery(code === 3
+                ? `decode error after playback progress${message ? ` (${message})` : ""}`
+                : "network error");
         },
     };
 


### PR DESCRIPTION
## Summary

Reported against the 1.1.0 in-app player: Microsoft Edge shows `This browser cannot decode video/mp4. Use Open direct or Download…` for x265/HEVC releases. `video/mp4` is supported everywhere — the container was never the problem, so the banner sent users looking in the wrong place. Edge decodes HEVC only through the Windows HEVC Video Extension and a working Media Foundation decoder path, which is the most likely failing case here (root cause on the reporting machine is still unconfirmed; see the open investigation into a 500 on the same file's direct link — this PR makes the player tell those cases apart instead of guessing).

- The unsupported banner now probes `canPlayType` for the codecs Usenet releases commonly use (HEVC, HEVC 10-bit, AV1, AC-3, E-AC-3) and names the ones this browser has no decoder for, plus the browser's own `MediaError.message` (for example `DEMUXER_ERROR_NO_SUPPORTED_STREAMS`). The probe stays silent when even baseline H.264 is rejected, so a non-browser environment cannot produce a bogus "everything is missing" list.
- **Code 4 no longer blindly blames the browser.** Chromium reports a media fetch that failed at the HTTP layer (4xx/5xx, connection killed before demux) with the same `MEDIA_ERR_SRC_NOT_SUPPORTED` code as a missing decoder. When every probed decoder is present, the player now re-requests one byte of the source: an HTTP failure routes into the normal bounded recovery path; only a served-but-rejected stream ends in the unsupported banner.
- `MEDIA_ERR_DECODE` that arrives after frames have actually been decoded (per `getVideoPlaybackQuality`, baselined per source; audio falls back to the progress watchdog) is treated as a recoverable stream fault (missing or zero-filled segments) and goes through reload-and-resume instead of dead-ending. A decode error before any decoded frame still means no working pipeline and stays unsupported.
- Missing-codec labels are included in the copied diagnostics JSON so playback reports say why the browser refused the file.

**Known limitation:** the probe reports the *browser's* missing decoders, not the *file's* codecs — we don't demux client-side, so a Chrome user failing on HEVC may also see AC-3/E-AC-3 listed if their browser lacks those. The wording ("No decoder available for …") is scoped accordingly. Mapping to the file's actual streams would need codec extraction at import time; out of scope here.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (592 tests; covers the codec probe, AC-3/E-AC-3 independence, decode-recovery after decoded frames, the code-4 reachability check in both outcomes, and the codec-naming banner)
- [ ] Manual: open an HEVC mp4 in Edge without the HEVC Video Extension and confirm the banner names HEVC / H.265; confirm Open direct and Download still work
- [ ] Manual: interrupt a playing stream so a decode error fires mid-playback and confirm it recovers rather than showing the unsupported banner
- [ ] Manual: force the backend to 500 a /view request and confirm the player enters recovery instead of the unsupported banner