### PR TITLE
fix(ui): plain HTTP requests to /ws now get a clean 426 and a proxy hint instead of a stack trace

### DIFF
--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -5,6 +5,7 @@ import { WebSocketServer } from "ws";
 import { shouldCompressResponse } from "./server/compression-filter.js";
 import { logger, requestLogger } from "./server/logger.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
+import { websocketUpgradeGuard } from "./server/websocket-upgrade-guard.js";
 import {
   formatBackendUnavailableReason,
   isExpectedBackendUnavailableError,
@@ -111,6 +112,10 @@ app.use(requestLogger);
 // and therefore still sees the full, basename-prefixed path.
 const router = express.Router();
 router.use(securityHeadersMiddleware);
+// Real upgrade requests bypass Express via the http server's `upgrade` event,
+// so this only ever answers plain-HTTP hits on the socket path (misconfigured
+// reverse proxy, uptime probe) before they reach React Router.
+router.all("/ws", websocketUpgradeGuard);
 
 // Initialize the websocket server as soon as both it and the server-module are ready
 interface ServerBuildModule {

--- a/frontend/server/websocket-upgrade-guard.test.ts
+++ b/frontend/server/websocket-upgrade-guard.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
+import { resetClientErrorLogThrottleForTests } from "./request-log-throttle";
+import { websocketUpgradeGuard } from "./websocket-upgrade-guard";
+
+function mockReq(overrides: Record<string, unknown> = {}) {
+  return {
+    method: "GET",
+    ip: "203.0.113.7",
+    socket: { remoteAddress: "10.0.0.1" },
+    ...overrides,
+  };
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 0,
+    headers: new Map<string, string>(),
+    body: "",
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    setHeader(name: string, value: string) {
+      res.headers.set(name, value);
+      return res;
+    },
+    type(_value: string) {
+      return res;
+    },
+    send(body: string) {
+      res.body = body;
+      return res;
+    },
+  };
+  return res;
+}
+
+describe("websocketUpgradeGuard", () => {
+  beforeEach(() => {
+    resetClientErrorLogThrottleForTests();
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+    return () => vi.restoreAllMocks();
+  });
+
+  it("answers 426 with an Upgrade header and a plain-text body", () => {
+    const res = mockRes();
+    websocketUpgradeGuard(mockReq() as never, res as never, vi.fn());
+
+    expect(res.statusCode).toBe(426);
+    expect(res.headers.get("Upgrade")).toBe("websocket");
+    expect(res.body).toMatch(/WebSocket/);
+  });
+
+  it("warns once per client and throttles repeats within the window", () => {
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
+
+    expect(logger.warn).toHaveBeenCalledOnce();
+    const message = vi.mocked(logger.warn).mock.calls[0]?.[0];
+    expect(message).toContain("203.0.113.7");
+    expect(message).toContain("Upgrade/Connection");
+  });
+
+  it("tracks different clients independently", () => {
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
+    websocketUpgradeGuard(mockReq({ ip: "198.51.100.4" }) as never, mockRes() as never, vi.fn());
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/server/websocket-upgrade-guard.test.ts
+++ b/frontend/server/websocket-upgrade-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { logger } from "./logger";
 import { resetClientErrorLogThrottleForTests } from "./request-log-throttle";
 import { websocketUpgradeGuard } from "./websocket-upgrade-guard";
@@ -40,12 +40,15 @@ describe("websocketUpgradeGuard", () => {
   beforeEach(() => {
     resetClientErrorLogThrottleForTests();
     vi.spyOn(logger, "warn").mockImplementation(() => {});
-    return () => vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("answers 426 with an Upgrade header and a plain-text body", () => {
     const res = mockRes();
-    websocketUpgradeGuard(mockReq() as never, res as never, vi.fn());
+    websocketUpgradeGuard(mockReq() as never, res as never);
 
     expect(res.statusCode).toBe(426);
     expect(res.headers.get("Upgrade")).toBe("websocket");
@@ -53,8 +56,8 @@ describe("websocketUpgradeGuard", () => {
   });
 
   it("warns once per client and throttles repeats within the window", () => {
-    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
-    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never);
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never);
 
     expect(logger.warn).toHaveBeenCalledOnce();
     const message = vi.mocked(logger.warn).mock.calls[0]?.[0];
@@ -63,8 +66,8 @@ describe("websocketUpgradeGuard", () => {
   });
 
   it("tracks different clients independently", () => {
-    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
-    websocketUpgradeGuard(mockReq({ ip: "198.51.100.4" }) as never, mockRes() as never, vi.fn());
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never);
+    websocketUpgradeGuard(mockReq({ ip: "198.51.100.4" }) as never, mockRes() as never);
 
     expect(logger.warn).toHaveBeenCalledTimes(2);
   });

--- a/frontend/server/websocket-upgrade-guard.test.ts
+++ b/frontend/server/websocket-upgrade-guard.test.ts
@@ -48,7 +48,7 @@ describe("websocketUpgradeGuard", () => {
 
   it("answers 426 with an Upgrade header and a plain-text body", () => {
     const res = mockRes();
-    websocketUpgradeGuard(mockReq() as never, res as never);
+    websocketUpgradeGuard(mockReq() as never, res as never, vi.fn());
 
     expect(res.statusCode).toBe(426);
     expect(res.headers.get("Upgrade")).toBe("websocket");
@@ -56,8 +56,8 @@ describe("websocketUpgradeGuard", () => {
   });
 
   it("warns once per client and throttles repeats within the window", () => {
-    websocketUpgradeGuard(mockReq() as never, mockRes() as never);
-    websocketUpgradeGuard(mockReq() as never, mockRes() as never);
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
 
     expect(logger.warn).toHaveBeenCalledOnce();
     const message = vi.mocked(logger.warn).mock.calls[0]?.[0];
@@ -66,8 +66,8 @@ describe("websocketUpgradeGuard", () => {
   });
 
   it("tracks different clients independently", () => {
-    websocketUpgradeGuard(mockReq() as never, mockRes() as never);
-    websocketUpgradeGuard(mockReq({ ip: "198.51.100.4" }) as never, mockRes() as never);
+    websocketUpgradeGuard(mockReq() as never, mockRes() as never, vi.fn());
+    websocketUpgradeGuard(mockReq({ ip: "198.51.100.4" }) as never, mockRes() as never, vi.fn());
 
     expect(logger.warn).toHaveBeenCalledTimes(2);
   });

--- a/frontend/server/websocket-upgrade-guard.ts
+++ b/frontend/server/websocket-upgrade-guard.ts
@@ -8,7 +8,7 @@ import { clientErrorKey, shouldLogClientError } from "./request-log-throttle.js"
 // breaks live UI updates), an uptime probe, or a browser tab opened on /ws.
 // Answer 426 instead of letting React Router dump a "No route matches /ws"
 // stack; throttle the warning so a retrying client cannot flood the log.
-export const websocketUpgradeGuard: RequestHandler = (req, res) => {
+export const websocketUpgradeGuard: RequestHandler = (req, res, _next) => {
   const client = req.ip ?? req.socket.remoteAddress ?? "unknown";
   const { log, suppressed } = shouldLogClientError(
     clientErrorKey(req.method, 426, "/ws", client),

--- a/frontend/server/websocket-upgrade-guard.ts
+++ b/frontend/server/websocket-upgrade-guard.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from "express";
+import { logger } from "./logger.js";
+import { clientErrorKey, shouldLogClientError } from "./request-log-throttle.js";
+
+// The WebSocketServer (see server.ts) only intercepts HTTP Upgrade requests,
+// so this handler only ever sees plain HTTP on the socket path — typically a
+// reverse proxy that is not forwarding Upgrade/Connection headers (which also
+// breaks live UI updates), an uptime probe, or a browser tab opened on /ws.
+// Answer 426 instead of letting React Router dump a "No route matches /ws"
+// stack; throttle the warning so a retrying client cannot flood the log.
+export const websocketUpgradeGuard: RequestHandler = (req, res) => {
+  const client = req.ip ?? req.socket.remoteAddress ?? "unknown";
+  const { log, suppressed } = shouldLogClientError(
+    clientErrorKey(req.method, 426, "/ws", client),
+  );
+  if (log) {
+    logger.warn(
+      `Rejected plain HTTP ${req.method} on the WebSocket endpoint from ${client}; `
+      + "this endpoint only accepts WebSocket upgrade requests. If this came from the web UI, "
+      + "the reverse proxy in front is not forwarding Upgrade/Connection headers "
+      + "(see docs/configuration/url-base.md)."
+      + (suppressed > 0 ? ` (+${suppressed} similar suppressed)` : ""),
+    );
+  }
+  res
+    .status(426)
+    .setHeader("Upgrade", "websocket")
+    .type("text/plain")
+    .send("This endpoint only accepts WebSocket connections.\n");
+};

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/compression-filter.ts", "server/request-log-throttle.ts", "server/startup-grace.ts", "server/security-headers.ts", "app/utils/url-base.ts", "vite.config.ts", "vitest.config.ts"],
+  "include": ["server.ts", "server/logger.ts", "server/proxy-path.ts", "server/compression-filter.ts", "server/request-log-throttle.ts", "server/startup-grace.ts", "server/websocket-upgrade-guard.ts", "server/security-headers.ts", "app/utils/url-base.ts", "vite.config.ts", "vitest.config.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,


### PR DESCRIPTION
## Summary

- Refs #956 — the reporter's `Error: No route matches URL "/ws"` stack dump. The WebSocketServer only intercepts HTTP **Upgrade** requests, so any plain HTTP hit on `/ws` (a reverse proxy not forwarding `Upgrade`/`Connection` headers, an uptime probe, a browser tab) fell through Express into React Router and dumped a full stack at Error level with a 500.
- Adds `websocketUpgradeGuard`, registered on the URL_BASE-mounted router before the app module: non-upgrade requests now get **426 Upgrade Required** + `Upgrade: websocket` header + a short plain-text body, and one **throttled** warning (reuses the 60s client-error throttle) naming the likely reverse-proxy cause. The reporter's underlying connectivity issue is proxy config, covered in the issue comment.
- Real upgrade requests bypass Express via the http server's `upgrade` event, so live UI updates are unaffected (verified below).

## Test plan

- [x] `npm run typecheck`, `npm run build`, `npm run build:server` (new module added to `tsconfig.node.json` include list; confirmed `dist-node/server/websocket-upgrade-guard.js` is emitted)
- [x] `npm test` — 56 files / 583 tests pass, including new `websocket-upgrade-guard.test.ts` (426 response, per-client warning throttle)
- [x] Manual smoke on a dev server: `curl -i /ws` → `426` + single WRN line, no stack; RFC 6455 upgrade curl → `101 Switching Protocols` (then normal unauthenticated rejection)
- [ ] CI