### PR TITLE
fix(db): log a clear ownership error instead of crash-looping with exit 134 when config files are unreadable

### DIFF
--- a/backend/Database/ConfigPathPreflight.cs
+++ b/backend/Database/ConfigPathPreflight.cs
@@ -52,9 +52,8 @@ internal static class ConfigPathPreflight
 
         if (Directory.Exists(configPath))
         {
-            foreach (var fileName in KnownDatabaseFiles)
+            foreach (var path in KnownDatabaseFiles.Select(fileName => Path.Join(configPath, fileName)))
             {
-                var path = Path.Join(configPath, fileName);
                 ProbeFile(path, failures);
                 ProbeFile(path + "-wal", failures);
                 ProbeFile(path + "-shm", failures);
@@ -62,9 +61,8 @@ internal static class ConfigPathPreflight
 
             ProbeFile(DavDatabaseContext.DatabaseFilePath + ".maintenance.lock", failures);
 
-            foreach (var directory in KnownDirectories)
+            foreach (var path in KnownDirectories.Select(directory => Path.Join(configPath, directory)))
             {
-                var path = Path.Join(configPath, directory);
                 if (Directory.Exists(path) && !CanWriteToDirectory(path))
                     failures.Add($"{path} (directory is not writable)");
             }

--- a/backend/Database/ConfigPathPreflight.cs
+++ b/backend/Database/ConfigPathPreflight.cs
@@ -1,0 +1,119 @@
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Database;
+
+/// <summary>
+/// Fails fast with one actionable error when CONFIG_PATH or a known state file under
+/// it is not readable/writable by the process user, instead of aborting later with an
+/// unhandled UnauthorizedAccessException (which core-dumps and hides the cause).
+/// Best-effort early report: a file can become unreadable between this probe and the
+/// real open, so the open sites (e.g. DatabaseMigrationLease) remain the backstop.
+/// </summary>
+internal static class ConfigPathPreflight
+{
+    // SQLite state files the backend reads and writes under CONFIG_PATH.
+    private static readonly string[] KnownDatabaseFiles =
+    [
+        "db.sqlite",
+        "metrics.sqlite",
+        "warden.db",
+        "usenet-migration.db",
+    ];
+
+    // Directories created lazily by the backend; only probed when they already exist.
+    private static readonly string[] KnownDirectories =
+    [
+        "blobs",
+        "data-protection",
+        "migration-backups",
+    ];
+
+    public static void VerifyAccess()
+    {
+        var configPath = DavDatabaseContext.ConfigPath;
+        var failures = new List<string>();
+
+        if (Directory.Exists(configPath))
+        {
+            if (!CanWriteToDirectory(configPath))
+                failures.Add($"{configPath} (directory is not writable)");
+        }
+        else
+        {
+            try
+            {
+                Directory.CreateDirectory(configPath);
+            }
+            catch (Exception e) when (e is UnauthorizedAccessException or IOException)
+            {
+                failures.Add($"{configPath} (directory cannot be created)");
+            }
+        }
+
+        if (Directory.Exists(configPath))
+        {
+            foreach (var fileName in KnownDatabaseFiles)
+            {
+                var path = Path.Join(configPath, fileName);
+                ProbeFile(path, failures);
+                ProbeFile(path + "-wal", failures);
+                ProbeFile(path + "-shm", failures);
+            }
+
+            ProbeFile(DavDatabaseContext.DatabaseFilePath + ".maintenance.lock", failures);
+
+            foreach (var directory in KnownDirectories)
+            {
+                var path = Path.Join(configPath, directory);
+                if (Directory.Exists(path) && !CanWriteToDirectory(path))
+                    failures.Add($"{path} (directory is not writable)");
+            }
+        }
+
+        if (failures.Count > 0)
+            throw ConfigPathAccessException.ForPaths(configPath, failures);
+    }
+
+    private static void ProbeFile(string path, List<string> failures)
+    {
+        if (!File.Exists(path)) return;
+
+        // Plain FileStream only: never open SQLite databases through EF here, so the
+        // probe cannot create WAL/SHM sidecars, hold locks, or touch the schema.
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            failures.Add(path);
+        }
+        catch (IOException)
+        {
+            // Locked or busy is not a permission problem; the real open sites
+            // already handle those with retries.
+        }
+    }
+
+    private static bool CanWriteToDirectory(string directory)
+    {
+        var probe = Path.Join(directory, $".config-path-probe-{Guid.NewGuid():N}");
+        try
+        {
+            using (var stream = new FileStream(probe, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+            {
+            }
+
+            File.Delete(probe);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+}

--- a/backend/Database/DatabaseMigrationLease.cs
+++ b/backend/Database/DatabaseMigrationLease.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using NzbWebDAV.Exceptions;
 using Serilog;
 
 namespace NzbWebDAV.Database;
@@ -57,6 +58,16 @@ internal sealed class DatabaseMigrationLease : IAsyncDisposable
                             Options = FileOptions.Asynchronous,
                         });
                     return new DatabaseMigrationLease(stream, inProcessLock);
+                }
+                catch (UnauthorizedAccessException unauthorized)
+                {
+                    // Not an IOException, so it never reaches the retry loop below.
+                    // Surface it as an actionable config-path error instead of an
+                    // unhandled core-dump crash.
+                    throw ConfigPathAccessException.ForPath(
+                        leasePath,
+                        Path.GetDirectoryName(leasePath) ?? leasePath,
+                        unauthorized);
                 }
                 catch (IOException)
                 {

--- a/backend/Exceptions/ConfigPathAccessException.cs
+++ b/backend/Exceptions/ConfigPathAccessException.cs
@@ -1,0 +1,58 @@
+using System.Runtime.InteropServices;
+
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Fatal startup error when CONFIG_PATH or a state file beneath it cannot be read
+/// or written by the process user. Carries one operator-actionable message (offending
+/// paths plus the ownership fix) instead of an unhandled UnauthorizedAccessException
+/// that core-dumps before anyone sees it.
+/// </summary>
+public sealed class ConfigPathAccessException(string message, Exception? innerException = null)
+    : Exception(message, innerException)
+{
+    public static ConfigPathAccessException ForPath(
+        string path,
+        string configPath,
+        Exception? innerException = null) =>
+        ForPaths(configPath, [path], innerException);
+
+    public static ConfigPathAccessException ForPaths(
+        string configPath,
+        IReadOnlyCollection<string> offendingPaths,
+        Exception? innerException = null)
+    {
+        var paths = string.Join('\n', offendingPaths.Select(p => $"  - {p}"));
+        var symlinkNote = OperatingSystem.IsWindows()
+            ? ""
+            : " If the config path is a symlink, apply the fix to its real target" +
+              " (chown -R does not traverse symlinks; use a trailing slash).";
+        return new ConfigPathAccessException(
+            $"Cannot read or write configuration path(s) under '{configPath}':\n{paths}\n" +
+            $"Fix ownership/permissions so {CurrentIdentity()} can read and write them " +
+            $"(for example: chown -R <puid>:<pgid> '{configPath}').{symlinkNote}",
+            innerException);
+    }
+
+    private static string CurrentIdentity()
+    {
+        if (OperatingSystem.IsWindows())
+            return $"the account running NzbDAV ({Environment.UserName})";
+        try
+        {
+            return $"the configured PUID/PGID (currently uid={geteuid()}, gid={getegid()})";
+        }
+        catch (Exception)
+        {
+            return $"the configured PUID/PGID (currently {Environment.UserName})";
+        }
+    }
+
+    [DllImport("libc")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    private static extern uint geteuid();
+
+    [DllImport("libc")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    private static extern uint getegid();
+}

--- a/backend/Exceptions/ConfigPathAccessException.cs
+++ b/backend/Exceptions/ConfigPathAccessException.cs
@@ -23,28 +23,31 @@ public sealed class ConfigPathAccessException(string message, Exception? innerEx
         Exception? innerException = null)
     {
         var paths = string.Join('\n', offendingPaths.Select(p => $"  - {p}"));
-        var symlinkNote = OperatingSystem.IsWindows()
-            ? ""
-            : " If the config path is a symlink, apply the fix to its real target" +
+        var remediation = OperatingSystem.IsWindows()
+            ? $"Fix the file permissions so the account running NzbDAV ({Environment.UserName}) " +
+              "can read and write them."
+            : $"Fix ownership/permissions so the configured PUID/PGID (currently {CurrentIdentity()}) " +
+              $"can read and write them (for example: chown -R <puid>:<pgid> '{configPath}')." +
+              " If the config path is a symlink, apply the fix to its real target" +
               " (chown -R does not traverse symlinks; use a trailing slash).";
         return new ConfigPathAccessException(
             $"Cannot read or write configuration path(s) under '{configPath}':\n{paths}\n" +
-            $"Fix ownership/permissions so {CurrentIdentity()} can read and write them " +
-            $"(for example: chown -R <puid>:<pgid> '{configPath}').{symlinkNote}",
+            remediation,
             innerException);
     }
 
     private static string CurrentIdentity()
     {
-        if (OperatingSystem.IsWindows())
-            return $"the account running NzbDAV ({Environment.UserName})";
         try
         {
-            return $"the configured PUID/PGID (currently uid={geteuid()}, gid={getegid()})";
+            return $"uid={geteuid()}, gid={getegid()}";
         }
-        catch (Exception)
+        catch (Exception e) when (e is DllNotFoundException
+            or EntryPointNotFoundException
+            or TypeLoadException)
         {
-            return $"the configured PUID/PGID (currently {Environment.UserName})";
+            // Identity is a best-effort hint for the remediation message only.
+            return $"user '{Environment.UserName}'";
         }
     }
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -15,6 +15,7 @@ using NzbWebDAV.Clients.Rclone;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Middlewares;
@@ -106,6 +107,13 @@ public partial class Program
                 Log.Information(
                     "Stream tracing enabled with a capacity of {Capacity} events (STREAM_TRACE_EVENTS)",
                     streamTraceBuffer.Capacity);
+
+            // Fail fast with one actionable line when CONFIG_PATH or a state file
+            // under it is not accessible, instead of aborting later on an unhandled
+            // UnauthorizedAccessException (which core-dumps and hides the cause).
+            // The yEnc self-test does not touch the config path and skips this.
+            if (!args.Contains("--yenc-self-test"))
+                ConfigPathPreflight.VerifyAccess();
 
             // run database migration / restore, if necessary.
             // Restore must run before opening the live DavDatabaseContext so pending
@@ -372,6 +380,14 @@ public partial class Program
                 app.Services.GetRequiredService<QueueManager>().StartProcessing());
             await app.RunAsync().ConfigureAwait(false);
         }
+        catch (ConfigPathAccessException exception)
+        {
+            // Operator-facing configuration failure — one actionable line, a clean
+            // non-zero exit, and no stack dump / core dump.
+            Log.Fatal("{Message}", exception.Message);
+            Environment.ExitCode = 1;
+            return;
+        }
         catch (Exception exception)
         {
             Log.Fatal(exception, "NzbDav terminated unexpectedly");
@@ -637,7 +653,10 @@ public partial class Program
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             progressFull.Fail(ex.Message);
-            Log.Error(ex, "Database migration failed");
+            // ConfigPathAccessException is already operator-actionable; Main logs the
+            // single fatal line, so skip the stack dump here.
+            if (ex is not ConfigPathAccessException)
+                Log.Error(ex, "Database migration failed");
 
             // Keep the failure visible on the status page briefly before exiting.
             if (statusServerFull is not null)

--- a/tests/NzbWebDAV.Tests/Database/ConfigPathPreflightTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/ConfigPathPreflightTests.cs
@@ -1,0 +1,156 @@
+using NzbWebDAV.Database;
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Tests.Database;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class ConfigPathPreflightTests : IDisposable
+{
+    private readonly string _configRoot;
+    private readonly string? _previousConfigPath;
+
+    public ConfigPathPreflightTests()
+    {
+        _configRoot = Path.Join(Path.GetTempPath(), $"nzbdav-config-preflight-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_configRoot);
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+    }
+
+    [Fact]
+    public void VerifyAccess_PassesOnWritableConfigDirectory()
+    {
+        ConfigPathPreflight.VerifyAccess();
+    }
+
+    [Fact]
+    public void VerifyAccess_PassesWithReadableStateFiles()
+    {
+        File.WriteAllText(Path.Join(_configRoot, "db.sqlite"), "open-only probe target");
+        File.WriteAllText(Path.Join(_configRoot, "db.sqlite.maintenance.lock"), "");
+        Directory.CreateDirectory(Path.Join(_configRoot, "blobs"));
+
+        ConfigPathPreflight.VerifyAccess();
+    }
+
+    [Fact]
+    public void VerifyAccess_CreatesMissingConfigDirectory()
+    {
+        var missing = Path.Join(_configRoot, "nested", "config");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", missing);
+
+        ConfigPathPreflight.VerifyAccess();
+
+        Assert.True(Directory.Exists(missing));
+    }
+
+    [SkippableFact]
+    public void VerifyAccess_ThrowsForUnreadableLeaseFile()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        var lockPath = Path.Join(_configRoot, "db.sqlite.maintenance.lock");
+        File.WriteAllText(lockPath, "left by root-owned install");
+        SetMode(lockPath, UnixFileMode.None);
+        Skip.IfNot(PermissionsEnforced(lockPath), "Test is running as root; file modes are not enforced.");
+
+        var exception = Assert.Throws<ConfigPathAccessException>(() => ConfigPathPreflight.VerifyAccess());
+
+        Assert.Contains(lockPath, exception.Message);
+        Assert.Contains("chown", exception.Message);
+    }
+
+    [SkippableFact]
+    public void VerifyAccess_ListsAllUnreadableStateFiles()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        var lockPath = Path.Join(_configRoot, "db.sqlite.maintenance.lock");
+        var walPath = Path.Join(_configRoot, "db.sqlite-wal");
+        File.WriteAllText(lockPath, "x");
+        File.WriteAllText(walPath, "x");
+        SetMode(lockPath, UnixFileMode.None);
+        SetMode(walPath, UnixFileMode.None);
+        Skip.IfNot(PermissionsEnforced(lockPath), "Test is running as root; file modes are not enforced.");
+
+        var exception = Assert.Throws<ConfigPathAccessException>(() => ConfigPathPreflight.VerifyAccess());
+
+        Assert.Contains(lockPath, exception.Message);
+        Assert.Contains(walPath, exception.Message);
+    }
+
+    [SkippableFact]
+    public void VerifyAccess_ThrowsForUnwritableConfigDirectory()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        SetMode(
+            _configRoot,
+            UnixFileMode.UserRead | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        Skip.IfNot(DirectoryWriteEnforced(_configRoot), "Test is running as root; file modes are not enforced.");
+
+        var exception = Assert.Throws<ConfigPathAccessException>(() => ConfigPathPreflight.VerifyAccess());
+
+        Assert.Contains(_configRoot, exception.Message);
+    }
+
+    // The guard keeps the platform analyzer satisfied; callers skip on Windows anyway.
+    private static void SetMode(string path, UnixFileMode mode)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(path, mode);
+    }
+
+    private static bool PermissionsEnforced(string path)
+    {
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            return false; // root bypasses mode bits
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    private static bool DirectoryWriteEnforced(string directory)
+    {
+        var probe = Path.Join(directory, $".probe-{Guid.NewGuid():N}");
+        try
+        {
+            File.WriteAllBytes(probe, []);
+            File.Delete(probe);
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try
+        {
+            if (Directory.Exists(_configRoot))
+            {
+                foreach (var file in Directory.EnumerateFiles(_configRoot))
+                    SetMode(file, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                SetMode(
+                    _configRoot,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+
+            Directory.Delete(_configRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // best effort cleanup
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // best effort cleanup
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DatabaseMigrationLeaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseMigrationLeaseTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Exceptions;
 
 namespace NzbWebDAV.Tests.Database;
 
@@ -91,6 +92,52 @@ public sealed class DatabaseMigrationLeaseTests
         finally
         {
             DeleteDatabaseFiles(path);
+        }
+    }
+
+    [SkippableFact]
+    public async Task AcquireAsync_ThrowsConfigPathAccessForUnreadableLeaseFile()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        var path = TempDatabasePath();
+        var leasePath = path + ".maintenance.lock";
+        try
+        {
+            await File.WriteAllTextAsync(leasePath, "left by root-owned install");
+            SetMode(leasePath, UnixFileMode.None);
+            Skip.IfNot(PermissionsEnforced(leasePath), "Test is running as root; file modes are not enforced.");
+
+            var exception = await Assert.ThrowsAsync<ConfigPathAccessException>(
+                () => DatabaseMigrationLease.AcquireAsync(path));
+
+            Assert.Contains(leasePath, exception.Message);
+            Assert.IsType<UnauthorizedAccessException>(exception.InnerException);
+        }
+        finally
+        {
+            if (File.Exists(leasePath))
+                SetMode(leasePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    // The guard keeps the platform analyzer satisfied; callers skip on Windows anyway.
+    private static void SetMode(string path, UnixFileMode mode)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(path, mode);
+    }
+
+    private static bool PermissionsEnforced(string path)
+    {
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            return false; // root bypasses mode bits
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes the opaque crash-loop seen when a file under `CONFIG_PATH` (e.g. a root-owned `db.sqlite.maintenance.lock`) is unreadable by the process user — common on PUID/PGID-managed installs like DUMB. Previously this escaped as an unhandled `UnauthorizedAccessException`, producing a core dump and a bare `exit 134` with no actionable message.
- Adds a `ConfigPathPreflight` startup check that probes `CONFIG_PATH` and every known state file (`db.sqlite`, `metrics.sqlite`, `warden.db`, `usenet-migration.db`, WAL/SHM sidecars, the migration lease file, `blobs/`, `data-protection/`, `migration-backups/`) and fails fast with one fatal line listing all offending paths, the effective uid/gid, and the ownership fix — including the symlink gotcha (`chown -R` doesn't traverse symlinked service roots).
- Converts `UnauthorizedAccessException` at the lease open site in `DatabaseMigrationLease` into the same actionable `ConfigPathAccessException` as a backstop for races after the preflight. The `IOException` retry loop (another process holding the lease) is unchanged.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2641 passed, 9 skipped (platform), 0 failed
- [x] New `ConfigPathPreflightTests` cover writable dir, readable state files, missing-dir creation, unreadable lease file, aggregated multi-file failures, and unwritable config dir (self-skip on Windows/root)
- [x] New lease test verifies unreadable lock file throws `ConfigPathAccessException` (with the `UnauthorizedAccessException` as inner) instead of escaping
- [x] Manual reproduction of the original failure: `chmod 000` on `db.sqlite.maintenance.lock`, then `--db-migration` now prints one fatal line and exits 1 — no stack, no core dump