### PR TITLE
fix(webdav): Sonarr/Radarr imports no longer fail with "Permission denied" on default settings

### DIFF
--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -95,21 +95,37 @@ public class DatabaseStoreSymlinkCollection(
 
     protected override async Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)
     {
+        // Cannot delete from symlink root folder
         var isSymlinkFolder = davDirectory.Id == DavItem.SymlinkFolder.Id;
         if (isSymlinkFolder) return await base.DeleteItemAsync(request).ConfigureAwait(false);
-        if (configManager.IsEnforceReadonlyWebdavEnabled()) return DavStatusCode.Forbidden;
-        var child = await dbClient.GetDirectoryChildAsync(TargetId, request.Name, request.CancellationToken).ConfigureAwait(false);
-        if (child is { Type: DavItem.ItemType.Directory } && !child.IsProtected() && davDirectory.ParentId == DavItem.ContentFolder.Id)
+
+        // Clearing a completed release (pruning its history) requires write access, mirroring
+        // the read-only enforcement on real deletes under /content.
+        if (!configManager.IsEnforceReadonlyWebdavEnabled() && davDirectory.ParentId == DavItem.ContentFolder.Id)
         {
-            var historyIds = await dbClient.Ctx.HistoryItems.AsNoTracking()
-                .Where(h => h.DownloadDirId == child.Id && h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed)
-                .Select(h => h.Id).ToListAsync(request.CancellationToken).ConfigureAwait(false);
-            if (historyIds.Count == 0) return DavStatusCode.NotFound;
-            await dbClient.RemoveHistoryItemsAsync(historyIds, deleteFiles: false, request.CancellationToken).ConfigureAwait(false);
-            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
-            _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", historyIds));
-            return DavStatusCode.NoContent;
+            var child = await dbClient.GetDirectoryChildAsync(TargetId, request.Name, request.CancellationToken).ConfigureAwait(false);
+            if (child is { Type: DavItem.ItemType.Directory } && !child.IsProtected())
+            {
+                var historyIds = await dbClient.Ctx.HistoryItems.AsNoTracking()
+                    .Where(h => h.DownloadDirId == child.Id && h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed)
+                    .Select(h => h.Id).ToListAsync(request.CancellationToken).ConfigureAwait(false);
+                if (historyIds.Count > 0)
+                {
+                    await dbClient.RemoveHistoryItemsAsync(historyIds, deleteFiles: false, request.CancellationToken).ConfigureAwait(false);
+                    await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+                    _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", historyIds));
+                    return DavStatusCode.NoContent;
+                }
+            }
         }
+
+        // Every other delete under '/completed-symlinks' must succeed, even when read-only
+        // enforcement is on. Radarr/Sonarr import the symlink by moving it to the media library;
+        // since the symlink lives on a separate file-system (rclone-mounted webdav), the OS
+        // performs a copy-and-delete, and a refused delete fails the whole import. Nothing here
+        // actually exists on disk — the symlink is created in memory per request and the
+        // underlying data under '/content' is untouched — so we cache the name for 30 seconds
+        // to mimic a deletion and return 204 No Content.
         DeletedFiles.AddDeletedFile(request.Name, TimeSpan.FromSeconds(30));
         return DavStatusCode.NoContent;
     }

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -74,7 +74,7 @@ export function WebdavSettings({ config, setNewConfig }: WebdavSettingsProps) {
                     description="Choose how content appears to WebDAV clients and the Dav Explorer."
                 >
                     <ManagedSetting configKey="webdav.enforce-readonly">
-                        <Tooltip placement="bottom" content="Make the WebDAV /content folder read-only so clients cannot delete files there.">
+                        <Tooltip placement="bottom" content="Make the WebDAV /content folder read-only so clients cannot delete files there, and prevent clearing completed history by deleting release folders under /completed-symlinks. Symlink deletes needed for Radarr/Sonarr imports are always allowed.">
                             <Toggle
                                 id="readonly-checkbox"
                                 className="cursor-pointer gap-2 p-0"

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
@@ -50,7 +50,7 @@ public sealed class DatabaseStoreSymlinkCollectionTests : IAsyncLifetime
         _context.HistoryItems.Add(CreateHistory(historyId, "episode.nzb", category.Name, release.Id));
         await _context.SaveChangesAsync();
         var status = await new DatabaseStoreSymlinkCollection(release, _client, _config, _websocket)
-            .DeleteItemAsync("episode.mkv", CancellationToken.None);
+            .DeleteItemAsync("episode.mkv.rclonelink", CancellationToken.None);
         Assert.Equal(DavStatusCode.NoContent, status);
         Assert.NotNull(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == historyId));
     }
@@ -100,7 +100,7 @@ public sealed class DatabaseStoreSymlinkCollectionTests : IAsyncLifetime
         _context.HistoryItems.Add(CreateHistory(historyId, "episode.nzb", category.Name, release.Id));
         await _context.SaveChangesAsync();
         var status = await new DatabaseStoreSymlinkCollection(release, _client, _config, _websocket)
-            .DeleteItemAsync("episode.mkv", CancellationToken.None);
+            .DeleteItemAsync("episode.mkv.rclonelink", CancellationToken.None);
         Assert.Equal(DavStatusCode.NoContent, status);
         Assert.NotNull(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == historyId));
     }

--- a/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DatabaseStoreSymlinkCollectionTests.cs
@@ -72,8 +72,10 @@ public sealed class DatabaseStoreSymlinkCollectionTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task DeleteItemAsync_WhenReadonlyWebdavEnabled_ReturnsForbiddenForReleaseDirectory()
+    public async Task DeleteItemAsync_WhenReadonlyWebdavEnabled_ReleaseDirectoryDeleteSucceedsAndPreservesHistory()
     {
+        // *Arr imports move the symlink via copy-and-delete, so deletes under
+        // /completed-symlinks must succeed even when read-only enforcement is on.
         _config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.WebdavEnforceReadonly, ConfigValue = "true" }]);
         var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "tv");
         var release = NewDir(Guid.NewGuid(), category, "Show.S01E01");
@@ -83,7 +85,37 @@ public sealed class DatabaseStoreSymlinkCollectionTests : IAsyncLifetime
         await _context.SaveChangesAsync();
         var status = await new DatabaseStoreSymlinkCollection(category, _client, _config, _websocket)
             .DeleteItemAsync(release.Name, CancellationToken.None);
-        Assert.Equal(DavStatusCode.Forbidden, status);
+        Assert.Equal(DavStatusCode.NoContent, status);
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == historyId));
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_WhenReadonlyWebdavEnabled_FileDeleteReturnsNoContent()
+    {
+        _config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.WebdavEnforceReadonly, ConfigValue = "true" }]);
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "tv");
+        var release = NewDir(Guid.NewGuid(), category, "Show.S01E01");
+        var historyId = Guid.NewGuid();
+        _context.Items.AddRange(category, release);
+        _context.HistoryItems.Add(CreateHistory(historyId, "episode.nzb", category.Name, release.Id));
+        await _context.SaveChangesAsync();
+        var status = await new DatabaseStoreSymlinkCollection(release, _client, _config, _websocket)
+            .DeleteItemAsync("episode.mkv", CancellationToken.None);
+        Assert.Equal(DavStatusCode.NoContent, status);
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == historyId));
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_ReleaseDirectoryWithoutHistory_ReturnsNoContentAndRemovesNothing()
+    {
+        var category = NewDir(Guid.NewGuid(), DavItem.ContentFolder, "movies");
+        var release = NewDir(Guid.NewGuid(), category, "Show.S01E01");
+        _context.Items.AddRange(category, release);
+        await _context.SaveChangesAsync();
+        var status = await new DatabaseStoreSymlinkCollection(category, _client, _config, _websocket)
+            .DeleteItemAsync(release.Name, CancellationToken.None);
+        Assert.Equal(DavStatusCode.NoContent, status);
+        Assert.NotNull(await _context.Items.AsNoTracking().FirstOrDefaultAsync(x => x.Id == release.Id));
     }
 
     private static DavItem NewDir(Guid id, DavItem parent, string name) =>


### PR DESCRIPTION
## Summary

- Fixes a 1.1.0-rc.1 regression where Sonarr/Radarr imports using the completed-symlinks strategy fail with `UnauthorizedAccessException` / `[Errno 13] Permission denied` on default installs.
- Root cause: #930 gated every WebDAV DELETE under `/completed-symlinks` on `webdav.enforce-readonly` (default **on**), returning 403 where 1.0.1 always fake-succeeded with 204. *Arr imports move the symlink to the library via copy+delete, so the refused delete fails the whole import.
- Only the history-pruning branch now requires write access (mirroring `/content` deletes); all other deletes under `/completed-symlinks` fall through to the 1.0.1 fake-delete 204 — including release directories with no matching completed history, which had also regressed from 204 to a new 404.

Reporter workaround until this ships: Settings → WebDAV → turn off "Enforce Read-Only" and re-import (no downgrade needed).

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2643 passed, 9 skipped (Linux-only cases on macOS)
- [x] New regression tests: file delete and release-dir delete under `/completed-symlinks` with read-only enforcement ON return 204 and preserve history; release-dir delete with no matching history returns 204 instead of 404
- [x] Existing #930 pruning tests (read-only OFF) unchanged and passing
- [x] `npm run typecheck` (frontend tooltip string change only)
- [ ] Manual: symlink-strategy import in Sonarr with default settings on the RC image