### PR TITLE
fix(ui): player checks the source before reporting a file as unplayable; missing payloads no longer 500 or trigger repair

### DIFF
--- a/backend/Exceptions/MissingFilePayloadException.cs
+++ b/backend/Exceptions/MissingFilePayloadException.cs
@@ -1,0 +1,26 @@
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// The DavItem exists but its streaming payload (blob-store record or legacy
+/// database row) is gone — typically after a database-only restore. The media
+/// itself is not implicated, so this must never trigger Arr repair.
+/// </summary>
+public class MissingFilePayloadException : Exception
+{
+    public MissingFilePayloadException(DavItem item, DavItem.ItemSubType storeKind)
+        : base($"The streaming payload for file '{item.Path}' is missing " +
+               $"(DavItem id: {item.Id}, payload id: {item.FileBlobId?.ToString() ?? "none"}, store: {storeKind}).")
+    {
+        DavItemId = item.Id;
+        FileBlobId = item.FileBlobId;
+        FilePath = item.Path;
+        StoreKind = storeKind;
+    }
+
+    public Guid DavItemId { get; }
+    public Guid? FileBlobId { get; }
+    public string FilePath { get; }
+    public DavItem.ItemSubType StoreKind { get; }
+}

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -271,6 +271,40 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
+        catch (MissingFilePayloadException e)
+        {
+            // The local streaming payload is gone (commonly a database-only
+            // restore): a client-visible data problem, not a server fault, and
+            // never a reason to blocklist the release. The typed header lets
+            // the in-app player distinguish this from an unsupported stream.
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 404;
+                context.Response.Headers["X-InfiniDysk-Stream-Error"] = "missing-file-payload";
+                context.Response.ContentType = "text/plain; charset=utf-8";
+                await context.Response.WriteAsync(
+                    "This file's streaming data is missing from the server. " +
+                    "Remove and re-download the release, or restore from a backup that includes blobs.",
+                    context.RequestAborted).ConfigureAwait(false);
+            }
+
+            var dedupeKey = $"{e.FilePath}|{e.DavItemId}";
+            LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "File {FilePath} cannot be served: its streaming payload is missing (DavItem {DavItemId}, payload {PayloadId}, store {StoreKind}; suppressed {SuppressedCount} duplicates in last 60s)",
+                        e.FilePath, e.DavItemId, e.FileBlobId?.ToString() ?? "none", e.StoreKind, suppressed);
+                else
+                    Log.Warning(
+                        "File {FilePath} cannot be served: its streaming payload is missing (DavItem {DavItemId}, payload {PayloadId}, store {StoreKind})",
+                        e.FilePath, e.DavItemId, e.FileBlobId?.ToString() ?? "none", e.StoreKind);
+            });
+            Log.Debug(e, "Missing streaming payload stack for {FilePath}", e.FilePath);
+
+            AbortStartedResponse(context);
+        }
         catch (Exception e) when (IsDavItemRequest(context) && e is not OutOfMemoryException)
         {
             // A volume that is short or unresolvable is missing data, not a server

--- a/backend/Services/BlobCleanupService.cs
+++ b/backend/Services/BlobCleanupService.cs
@@ -1,13 +1,15 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
 using NzbWebDAV.Utils;
+using Serilog;
 
 namespace NzbWebDAV.Services;
 
 /// <summary>
 /// Background service that processes the blob cleanup queue.
-/// Continuously monitors BlobCleanupQueueItems table and deletes corresponding blobs.
+/// A payload blob is only deleted once no DavItem still references it.
 /// </summary>
 public class BlobCleanupService : BackgroundService
 {
@@ -19,26 +21,15 @@ public class BlobCleanupService : BackgroundService
             {
                 await using var dbContext = new DavDatabaseContext();
 
-                // Get the first item from the queue
-                var cleanupItem = await dbContext.BlobCleanupItems
-                    .FirstOrDefaultAsync(stoppingToken)
-                    .ConfigureAwait(false);
+                var processed = await ProcessNextCleanupItemAsync(dbContext, stoppingToken).ConfigureAwait(false);
 
                 // If no items in queue, wait 10 seconds before checking again
-                if (cleanupItem == null)
+                if (!processed)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
-                    continue;
                 }
 
-                // Delete the blob
-                BlobStore.Delete(cleanupItem.Id);
-
-                // Remove the queue item from database
-                dbContext.BlobCleanupItems.Remove(cleanupItem);
-                await dbContext.SaveChangesAsync(stoppingToken).ConfigureAwait(false);
-
-                // Continue immediately to next iteration to process more items
+                // Otherwise continue immediately to process more items
             }
             catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
             {
@@ -54,5 +45,62 @@ public class BlobCleanupService : BackgroundService
                 await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    /// Processes the next item from the blob cleanup queue, if any.
+    /// Returns <c>false</c> when the queue is empty (nothing to do).
+    /// Extracted as an internal static method so lifecycle behavior is unit-testable
+    /// against a SQLite-backed <see cref="DavDatabaseContext"/> without running the
+    /// background service loop.
+    /// </summary>
+    internal static async Task<bool> ProcessNextCleanupItemAsync(DavDatabaseContext dbContext, CancellationToken ct)
+    {
+        // Get the first item from the queue
+        var cleanupItem = await dbContext.BlobCleanupItems
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (cleanupItem == null) return false;
+
+        var blobId = cleanupItem.Id;
+
+        // Use a serializable (BEGIN IMMEDIATE) transaction so the reference
+        // check and the cleanup-item removal are atomic: a concurrent insert
+        // of a new DavItem referencing this blob id must block until commit,
+        // after which its own cleanup trigger can requeue if needed.
+        await using var tx = await dbContext.Database
+            .BeginTransactionAsync(IsolationLevel.Serializable, ct)
+            .ConfigureAwait(false);
+
+        // Only delete the blob if no DavItem still references it. The delete
+        // trigger queues the old FileBlobId on every removal/rekey, so a blob
+        // that was later re-attached to a live item must never be dropped.
+        var referencingItemPath = await dbContext.Items
+            .Where(x => x.FileBlobId == blobId)
+            .Select(x => x.Path)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (referencingItemPath == null)
+        {
+            // Delete the blob before SaveChangesAsync so a failure leaves the
+            // cleanup item in the DB for a retry; BlobStore.Delete is
+            // idempotent when the file is already gone.
+            BlobStore.Delete(blobId);
+        }
+        else
+        {
+            Log.Debug(
+                "Skipping blob cleanup for {BlobId}: still referenced by dav item at {Path}",
+                blobId, referencingItemPath);
+        }
+
+        // Remove the cleanup queue item and commit.
+        dbContext.BlobCleanupItems.Remove(cleanupItem);
+        await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        await tx.CommitAsync(ct).ConfigureAwait(false);
+
+        return true;
     }
 }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -214,10 +214,21 @@ public class HealthCheckService : BackgroundService
         CancellationToken ct
     )
     {
-        // Urgent sentinel set by ExceptionMiddleware when streaming confirms a permanent failure.
-        // Skip the STAT-only recheck and repair immediately: STAT can pass while BODY returns 430
-        // (see nzbdav-dev#209), and structurally corrupt archives can have every article present.
-        var isUrgentRepair = davItem.NextHealthCheck == DateTimeOffset.UnixEpoch;
+            // Validate local payload metadata before anything else: a missing
+            // payload means zero segments to STAT, which would otherwise read
+            // as a healthy file, and an urgent sentinel would enter Repair
+            // without it — Repair is for bad releases, not local data loss.
+            if (davItem.SubType is DavItem.ItemSubType.NzbFile
+                or DavItem.ItemSubType.RarFile
+                or DavItem.ItemSubType.MultipartFile)
+            {
+                await EnsurePayloadExistsAsync(davItem, dbClient, ct).ConfigureAwait(false);
+            }
+
+            // Urgent sentinel set by ExceptionMiddleware when streaming confirms a permanent failure.
+            // Skip the STAT-only recheck and repair immediately: STAT can pass while BODY returns 430
+            // (see nzbdav-dev#209), and structurally corrupt archives can have every article present.
+            var isUrgentRepair = davItem.NextHealthCheck == DateTimeOffset.UnixEpoch;
 
         // Attribution for latency histograms — does not change pool admission priority.
         using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
@@ -303,6 +314,29 @@ public class HealthCheckService : BackgroundService
                 HealthCheckResult.RepairAction.ActionNeeded,
                 $"Health check deferred: no STAT progress for {HealthCheckProgressTimeout.TotalMinutes:0} minutes.",
                 ct).ConfigureAwait(false);
+        }
+        catch (MissingFilePayloadException e)
+        {
+            // Local payload metadata is gone (commonly a database-only restore).
+            // This says nothing about the release's health, so surface it for
+            // operator action instead of deleting or blocklisting through Arr.
+            CompleteHealthProgress(davItem.Id);
+            var utcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+            Log.Warning(
+                "Health check cannot run for {Path}: {Reason}",
+                davItem.Path, e.Message);
+            Log.Debug(e, "Missing streaming payload stack for {Path}", davItem.Path);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                string.Join(" ", [
+                    "The file's streaming data is missing from the server",
+                    "(often a database restore without the blobs/ folder).",
+                    "Remove and re-download the release, or restore from a backup that includes blobs."
+                ]), ct).ConfigureAwait(false);
         }
         catch (UsenetArticleNotFoundException e)
         {
@@ -553,24 +587,45 @@ public class HealthCheckService : BackgroundService
         davItem.ReleaseDate = articleHeaders.Date;
     }
 
+    private static async Task EnsurePayloadExistsAsync(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        CancellationToken ct)
+    {
+        var exists = davItem.SubType switch
+        {
+            DavItem.ItemSubType.NzbFile =>
+                await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false) is not null,
+            DavItem.ItemSubType.RarFile =>
+                await dbClient.GetDavRarFileAsync(davItem, ct).ConfigureAwait(false) is not null,
+            DavItem.ItemSubType.MultipartFile =>
+                await dbClient.GetDavMultipartFileAsync(davItem, ct).ConfigureAwait(false) is not null,
+            _ => true,
+        };
+        if (!exists) throw new MissingFilePayloadException(davItem, davItem.SubType);
+    }
+
     private async Task<List<string>> GetAllSegments(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
     {
         if (davItem.SubType == DavItem.ItemSubType.NzbFile)
         {
             var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
-            return nzbFile?.SegmentIds?.ToList() ?? [];
+            return nzbFile?.SegmentIds?.ToList()
+                ?? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.NzbFile);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.RarFile)
         {
             var rarFile = await dbClient.GetDavRarFileAsync(davItem, ct).ConfigureAwait(false);
-            return rarFile?.RarParts?.SelectMany(x => x.SegmentIds)?.ToList() ?? [];
+            return rarFile?.RarParts?.SelectMany(x => x.SegmentIds)?.ToList()
+                ?? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.RarFile);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.MultipartFile)
         {
             var multipartFile = await dbClient.GetDavMultipartFileAsync(davItem, ct).ConfigureAwait(false);
-            return multipartFile?.Metadata?.FileParts?.SelectMany(x => x.SegmentIds)?.ToList() ?? [];
+            return multipartFile?.Metadata?.FileParts?.SelectMany(x => x.SegmentIds)?.ToList()
+                ?? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.MultipartFile);
         }
 
         return [];

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -214,21 +214,10 @@ public class HealthCheckService : BackgroundService
         CancellationToken ct
     )
     {
-            // Validate local payload metadata before anything else: a missing
-            // payload means zero segments to STAT, which would otherwise read
-            // as a healthy file, and an urgent sentinel would enter Repair
-            // without it — Repair is for bad releases, not local data loss.
-            if (davItem.SubType is DavItem.ItemSubType.NzbFile
-                or DavItem.ItemSubType.RarFile
-                or DavItem.ItemSubType.MultipartFile)
-            {
-                await EnsurePayloadExistsAsync(davItem, dbClient, ct).ConfigureAwait(false);
-            }
-
-            // Urgent sentinel set by ExceptionMiddleware when streaming confirms a permanent failure.
-            // Skip the STAT-only recheck and repair immediately: STAT can pass while BODY returns 430
-            // (see nzbdav-dev#209), and structurally corrupt archives can have every article present.
-            var isUrgentRepair = davItem.NextHealthCheck == DateTimeOffset.UnixEpoch;
+        // Urgent sentinel set by ExceptionMiddleware when streaming confirms a permanent failure.
+        // Skip the STAT-only recheck and repair immediately: STAT can pass while BODY returns 430
+        // (see nzbdav-dev#209), and structurally corrupt archives can have every article present.
+        var isUrgentRepair = davItem.NextHealthCheck == DateTimeOffset.UnixEpoch;
 
         // Attribution for latency histograms — does not change pool admission priority.
         using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
@@ -238,6 +227,11 @@ public class HealthCheckService : BackgroundService
         {
             if (isUrgentRepair)
             {
+                // Validate the local payload before Repair: missing metadata is
+                // local data loss, not a bad release, and must not reach the
+                // Arr remove-and-blocklist path. Routine checks get the same
+                // guarantee from GetAllSegments below.
+                await EnsurePayloadExistsAsync(davItem, dbClient, ct).ConfigureAwait(false);
                 Log.Information("Performing urgent dynamic repair for {FilePath}", davItem.Path);
                 await HandleUrgentRepair(davItem, dbClient, ct).ConfigureAwait(false);
                 return;

--- a/backend/WebDav/DatabaseStoreMultipartFile.cs
+++ b/backend/WebDav/DatabaseStoreMultipartFile.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Streams;
 using NzbWebDAV.WebDav.Base;
@@ -32,9 +33,9 @@ public class DatabaseStoreMultipartFile(
         // store the DavItem being accessed in the http context
         Context.Items["DavItem"] = davMultipartFile;
 
-        var id = davMultipartFile.Id;
         var multipartFile = await dbClient.GetDavMultipartFileAsync(davMultipartFile, ct).ConfigureAwait(false);
-        if (multipartFile is null) throw new FileNotFoundException($"Could not find nzb file with id: {id}");
+        if (multipartFile is null)
+            throw new MissingFilePayloadException(davMultipartFile, DavItem.ItemSubType.MultipartFile);
 
         if (multipartFile.Metadata.AesParams != null
             && multipartFile.Metadata.IsLazy

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Streams;
 using NzbWebDAV.WebDav.Base;
 
@@ -29,9 +30,9 @@ public class DatabaseStoreNzbFile(
         // store the DavItem being accessed in the http context
         Context.Items["DavItem"] = davNzbFile;
 
-        var id = davNzbFile.Id;
         var file = await dbClient.GetDavNzbFileAsync(davNzbFile, cancellationToken).ConfigureAwait(false);
-        if (file is null) throw new FileNotFoundException($"Could not find nzb file with id: {id}");
+        if (file is null)
+            throw new MissingFilePayloadException(davNzbFile, DavItem.ItemSubType.NzbFile);
         return GetStream(file);
     }
 

--- a/backend/WebDav/DatabaseStoreRarFile.cs
+++ b/backend/WebDav/DatabaseStoreRarFile.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Streams;
 using NzbWebDAV.WebDav.Base;
 
@@ -30,9 +31,9 @@ public class DatabaseStoreRarFile(
         // store the DavItem being accessed in the http context
         Context.Items["DavItem"] = davRarFile;
 
-        var id = davRarFile.Id;
         var rarFile = await dbClient.GetDavRarFileAsync(davRarFile, ct).ConfigureAwait(false);
-        if (rarFile is null) throw new FileNotFoundException($"Could not find nzb file with id: {id}");
+        if (rarFile is null)
+            throw new MissingFilePayloadException(davRarFile, DavItem.ItemSubType.RarFile);
         return GetStream(rarFile);
     }
 

--- a/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
+++ b/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
@@ -411,7 +411,6 @@ export function buildDiagnosticsSnapshot(
             maxAttempts: player.maxAttempts,
             startupMs: player.startupMs,
             error: player.error,
-            unsupportedCodecs: player.unsupportedCodecs,
             events: player.events,
         },
         mediaElement: el ? {

--- a/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
+++ b/frontend/app/routes/explore/media-preview/media-diagnostics.tsx
@@ -411,6 +411,7 @@ export function buildDiagnosticsSnapshot(
             maxAttempts: player.maxAttempts,
             startupMs: player.startupMs,
             error: player.error,
+            unavailableStatus: player.unavailableStatus,
             events: player.events,
         },
         mediaElement: el ? {

--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -13,15 +13,12 @@ type MediaElementProto = {
 let playMock: ReturnType<typeof vi.fn>;
 let loadMock: ReturnType<typeof vi.fn>;
 const savedDialog: Partial<Record<"showModal" | "close", PropertyDescriptor | undefined>> = {};
-let savedCanPlayType: PropertyDescriptor | undefined;
 
 beforeEach(() => {
     playMock = vi.fn<MediaElementProto["play"]>().mockResolvedValue(undefined);
     loadMock = vi.fn<MediaElementProto["load"]>().mockImplementation(() => {});
     Object.defineProperty(HTMLMediaElement.prototype, "play", { configurable: true, value: playMock });
     Object.defineProperty(HTMLMediaElement.prototype, "load", { configurable: true, value: loadMock });
-
-    savedCanPlayType = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, "canPlayType");
 
     // jsdom may not implement modal dialog show/close.
     savedDialog.showModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, "showModal");
@@ -40,11 +37,6 @@ afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
-    if (savedCanPlayType) {
-        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", savedCanPlayType);
-    } else {
-        Reflect.deleteProperty(HTMLMediaElement.prototype, "canPlayType");
-    }
     for (const key of ["showModal", "close"] as const) {
         const descriptor = savedDialog[key];
         if (descriptor) {
@@ -162,55 +154,42 @@ describe("MediaPreview", () => {
         }
     });
 
-    it("shows an unsupported-format state instead of looping on decode errors", () => {
-        const { container } = renderPreview();
-        const video = container.querySelector("video")!;
-        fireMediaError(video, 4, "no decoder");
-
-        expect(screen.getByRole("alert").textContent).toContain("cannot decode");
-        expect(screen.getByRole("alert").textContent).toContain("video/x-matroska");
-        expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
-    });
-
-    it("names the codecs the browser has no decoder for", () => {
-        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
-            configurable: true,
-            value: (type: string) => (/hvc1|hev1/.test(type) ? "" : "probably"),
-        });
-        const { container } = renderPreview();
-        fireMediaError(container.querySelector("video")!, 4, "no decoder");
-
-        expect(screen.getByRole("alert").textContent).toContain("No decoder available for HEVC / H.265");
-    });
-
-    it("recovers when code 4 hides an HTTP failure and all decoders are present", async () => {
-        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
-            configurable: true,
-            value: () => "probably",
-        });
+    it("recovers when code 4 hides a server-side failure", async () => {
         vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 
         const { container } = renderPreview();
         fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_COULD_NOT_OPEN");
 
-        // The reachability probe fails → normal bounded recovery, not a dead end.
+        // The source probe fails → normal bounded recovery, not a dead end.
         expect(await screen.findByText(/Stream interrupted/)).toBeTruthy();
         expect(screen.queryByRole("alert")).toBeNull();
     });
 
-    it("stays unsupported when code 4 occurs but the source serves bytes", async () => {
-        Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
-            configurable: true,
-            value: () => "probably",
-        });
+    it("shows an unsupported state only when the source served bytes", async () => {
         vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, status: 206 }));
 
         const { container } = renderPreview();
         fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_NO_SUPPORTED_STREAMS");
 
         const alert = await screen.findByRole("alert");
-        expect(alert.textContent).toContain("cannot decode");
+        expect(alert.textContent).toContain("could not play");
         expect(alert.textContent).toContain("DEMUXER_ERROR_NO_SUPPORTED_STREAMS");
+    });
+
+    it("names the missing-payload failure when the backend reports it", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            headers: new Headers({ "x-infinidysk-stream-error": "missing-file-payload" }),
+        }));
+
+        const { container } = renderPreview();
+        fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_COULD_NOT_OPEN");
+
+        const alert = await screen.findByRole("alert");
+        expect(alert.textContent).toContain("streaming data is missing");
+        expect(alert.textContent).toContain("blobs/ folder");
+        expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
     });
 
     it("recovers from a decode error once playback has progressed", () => {

--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -155,7 +155,8 @@ describe("MediaPreview", () => {
     });
 
     it("recovers when code 4 hides a server-side failure", async () => {
-        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+            { ok: false, status: 500, headers: new Headers() }));
 
         const { container } = renderPreview();
         fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_COULD_NOT_OPEN");
@@ -174,6 +175,21 @@ describe("MediaPreview", () => {
         const alert = await screen.findByRole("alert");
         expect(alert.textContent).toContain("could not play");
         expect(alert.textContent).toContain("DEMUXER_ERROR_NO_SUPPORTED_STREAMS");
+    });
+
+    it("fails terminally with the HTTP status when the server refuses the file", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+            { ok: false, status: 403, headers: new Headers() }));
+
+        const { container } = renderPreview();
+        fireMediaError(container.querySelector("video")!, 4, "DEMUXER_ERROR_COULD_NOT_OPEN");
+
+        const alert = await screen.findByRole("alert");
+        expect(alert.textContent).toContain("refused to serve this file");
+        expect(alert.textContent).toContain("HTTP 403");
+        // Terminal state, not a recovery loop.
+        expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
+        expect(screen.queryByText(/Stream interrupted/)).toBeNull();
     });
 
     it("names the missing-payload failure when the backend reports it", async () => {

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -152,12 +152,21 @@ function StatusBanner({ player, mimeType }: { player: ReturnType<typeof useMedia
                 <Alert variant="warning" className="alert-soft py-2 text-sm" role="alert">
                     <Icon name="videocam_off" className="!text-[18px]" />
                     <span>
-                        This browser cannot decode {mimeType || "this format"}
+                        This browser could not play {mimeType || "this file"}
                         {player.error?.message ? ` (${player.error.message})` : ""}.
-                        {player.unsupportedCodecs.length > 0
-                            ? ` No decoder available for ${player.unsupportedCodecs.join(", ")}.`
-                            : ""}
-                        {" "}Use Open direct or Download and play it in an external player.
+                        {" "}The container or one of its streams may be unsupported here —
+                        use Open direct or Download and play it in an external player.
+                    </span>
+                </Alert>
+            );
+        case "missing-payload":
+            return (
+                <Alert variant="danger" className="alert-soft py-2 text-sm" role="alert">
+                    <Icon name="error" className="!text-[18px]" />
+                    <span>
+                        This file cannot be served: its streaming data is missing from the server
+                        (often a database restore without the blobs/ folder).
+                        {" "}Remove and re-download the release, or restore from a backup that includes blobs.
                     </span>
                 </Alert>
             );

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -159,6 +159,17 @@ function StatusBanner({ player, mimeType }: { player: ReturnType<typeof useMedia
                     </span>
                 </Alert>
             );
+        case "unavailable":
+            return (
+                <Alert variant="danger" className="alert-soft py-2 text-sm" role="alert">
+                    <Icon name="error" className="!text-[18px]" />
+                    <span>
+                        The server refused to serve this file
+                        {player.unavailableStatus !== null ? ` (HTTP ${player.unavailableStatus})` : ""}.
+                        {" "}Close the preview and try again, or use Download.
+                    </span>
+                </Alert>
+            );
         case "missing-payload":
             return (
                 <Alert variant="danger" className="alert-soft py-2 text-sm" role="alert">

--- a/frontend/app/routes/explore/media-preview/media-utils.test.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.test.ts
@@ -4,13 +4,11 @@ import {
     backoffMs,
     bufferedAhead,
     buildMediaSrc,
-    canProbeCodecs,
     classifyMediaError,
     formatClock,
     formatTimeRanges,
     networkStateLabel,
-    probeSourceReachable,
-    probeUnsupportedCodecs,
+    probeSource,
     readyStateLabel,
     type TimeRangesLike,
 } from "./media-utils";
@@ -46,47 +44,57 @@ describe("classifyMediaError", () => {
     });
 });
 
-describe("probeUnsupportedCodecs", () => {
-    const supportAll = () => "probably";
+describe("probeSource", () => {
+    const headerMap = (entries: Record<string, string>) =>
+        ({ get: (name: string) => entries[name.toLowerCase()] ?? null }) as Headers;
 
-    it("reports nothing when the browser supports everything probed", () => {
-        expect(probeUnsupportedCodecs(supportAll)).toEqual([]);
-    });
-
-    it("names codecs the browser rejects", () => {
-        const missing = probeUnsupportedCodecs(type => (type.includes("hvc1") || type.includes("hev1") ? "" : "probably"));
-        expect(missing).toEqual(["HEVC / H.265", "HEVC 10-bit"]);
-    });
-
-    it("probes the Dolby Digital variants independently", () => {
-        const missing = probeUnsupportedCodecs(type => (type.includes('"ac-3"') ? "" : "probably"));
-        expect(missing).toEqual(["Dolby Digital (AC-3)"]);
-    });
-
-    it("stays silent when canPlayType rejects even the baseline", () => {
-        expect(probeUnsupportedCodecs(() => "")).toEqual([]);
-        expect(canProbeCodecs(() => "")).toBe(false);
-        expect(canProbeCodecs(supportAll)).toBe(true);
-    });
-});
-
-describe("probeSourceReachable", () => {
-    it("asks for a single byte and reports an OK response as reachable", async () => {
+    it("asks for a single byte and reports an OK response as served", async () => {
         const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({ ok: true } as Response);
-        await expect(probeSourceReachable("/view/a.mp4?downloadKey=k", fetchFn)).resolves.toBe(true);
+        await expect(probeSource("/view/a.mp4?downloadKey=k", fetchFn)).resolves.toEqual({ kind: "served" });
         const [url, init] = fetchFn.mock.calls[0]!;
         expect(url).toBe("/view/a.mp4?downloadKey=k");
         expect(init?.headers).toEqual({ Range: "bytes=0-0" });
     });
 
-    it("reports HTTP errors as unreachable", async () => {
-        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({ ok: false, status: 500 } as Response);
-        await expect(probeSourceReachable("/view/a.mp4", fetchFn)).resolves.toBe(false);
+    it("recognizes the backend's typed missing-payload 404", async () => {
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({
+            ok: false,
+            status: 404,
+            headers: headerMap({ "x-infinidysk-stream-error": "missing-file-payload" }),
+        } as Response);
+        await expect(probeSource("/view/a.mp4", fetchFn)).resolves.toEqual({ kind: "missing-payload" });
     });
 
-    it("reports thrown fetches (network down, timeout) as unreachable", async () => {
+    it("treats other 4xx as refused, preserving the status", async () => {
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({
+            ok: false,
+            status: 403,
+            headers: headerMap({}),
+        } as Response);
+        await expect(probeSource("/view/a.mp4", fetchFn)).resolves.toEqual({ kind: "denied", status: 403 });
+    });
+
+    it("treats a plain 404 without the marker header as refused", async () => {
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({
+            ok: false,
+            status: 404,
+            headers: headerMap({}),
+        } as Response);
+        await expect(probeSource("/view/a.mp4", fetchFn)).resolves.toEqual({ kind: "denied", status: 404 });
+    });
+
+    it("treats 5xx as a server error worth retrying", async () => {
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({
+            ok: false,
+            status: 500,
+            headers: headerMap({}),
+        } as Response);
+        await expect(probeSource("/view/a.mp4", fetchFn)).resolves.toEqual({ kind: "server-error", status: 500 });
+    });
+
+    it("treats thrown fetches (network down, timeout) as server errors", async () => {
         const fetchFn = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("network down"));
-        await expect(probeSourceReachable("/view/a.mp4", fetchFn)).resolves.toBe(false);
+        await expect(probeSource("/view/a.mp4", fetchFn)).resolves.toEqual({ kind: "server-error", status: null });
     });
 });
 

--- a/frontend/app/routes/explore/media-preview/media-utils.ts
+++ b/frontend/app/routes/explore/media-preview/media-utils.ts
@@ -17,10 +17,10 @@ export type MediaErrorKind = "aborted" | "retry" | "unsupported";
 /**
  * MEDIA_ERR_* codes: 1 aborted, 2 network, 3 decode, 4 src-not-supported.
  *
- * A decode error after frames have already played means the decoder works and
- * the bytes went bad (missing or zero-filled segments), so it is worth a
- * reload; a decode error before any progress means the browser never had a
- * working pipeline for this file.
+ * A decode error after frames have already played means the decoder pipeline
+ * worked, so the failure came from the bytes — worth a reload-and-resume; a
+ * decode error before any decoded frame means the browser never had a working
+ * pipeline for this file.
  */
 export function classifyMediaError(code: number | null, hadPlaybackProgress = false): MediaErrorKind {
     switch (code) {
@@ -31,64 +31,41 @@ export function classifyMediaError(code: number | null, hadPlaybackProgress = fa
     }
 }
 
-export type CanPlayType = (type: string) => string;
+export type SourceProbeOutcome =
+    | { kind: "served" }
+    | { kind: "missing-payload" }
+    | { kind: "denied"; status: number }
+    | { kind: "server-error"; status: number | null };
 
-/** Baseline every browser with a working media stack decodes. */
-const BASELINE_TYPE = 'video/mp4; codecs="avc1.42E01E"';
-
-/**
- * Codecs common in Usenet releases that browsers frequently cannot decode.
- * A label counts as unsupported only when every equivalent type string is
- * rejected (HEVC is spelled both hvc1 and hev1 depending on the platform).
- */
-const CODEC_PROBES: { label: string; types: string[] }[] = [
-    { label: "HEVC / H.265", types: ['video/mp4; codecs="hvc1.1.6.L93.B0"', 'video/mp4; codecs="hev1.1.6.L93.B0"'] },
-    { label: "HEVC 10-bit", types: ['video/mp4; codecs="hvc1.2.4.L120.B0"', 'video/mp4; codecs="hev1.2.4.L120.B0"'] },
-    { label: "AV1", types: ['video/mp4; codecs="av01.0.05M.08"'] },
-    { label: "Dolby Digital (AC-3)", types: ['audio/mp4; codecs="ac-3"'] },
-    { label: "Dolby Digital Plus (E-AC-3)", types: ['audio/mp4; codecs="ec-3"'] },
-];
-
-/**
- * True when canPlayType gives informative answers: a browser with a working
- * media stack always accepts baseline H.264, so a rejection there means the
- * probe environment cannot tell us anything (e.g. jsdom).
- */
-export function canProbeCodecs(canPlayType: CanPlayType): boolean {
-    return canPlayType(BASELINE_TYPE) !== "";
-}
-
-/**
- * Labels of the probed codecs this browser reports no support for. Returns
- * nothing when even the baseline is rejected — that means canPlayType is
- * uninformative (non-browser environment), not that every codec is missing.
- */
-export function probeUnsupportedCodecs(canPlayType: CanPlayType): string[] {
-    if (!canProbeCodecs(canPlayType)) return [];
-    return CODEC_PROBES
-        .filter(probe => probe.types.every(type => canPlayType(type) === ""))
-        .map(probe => probe.label);
-}
+export const MISSING_PAYLOAD_HEADER = "x-infinidysk-stream-error";
+export const MISSING_PAYLOAD_VALUE = "missing-file-payload";
 
 /**
  * Chromium reports a media fetch that failed at the HTTP layer with the same
- * MEDIA_ERR_SRC_NOT_SUPPORTED code as a missing decoder. A one-byte ranged
- * GET reproduces the media request cheaply and tells the two apart: an OK
- * response means the server served bytes and the browser rejected them.
+ * MEDIA_ERR_SRC_NOT_SUPPORTED code as an unsupported stream. A one-byte ranged
+ * GET reproduces the media request cheaply and preserves the failure's status
+ * so the player can tell a dead source apart from bytes the browser rejected.
  */
-export async function probeSourceReachable(
+export async function probeSource(
     src: string,
     fetchFn: typeof fetch = fetch,
-): Promise<boolean> {
+): Promise<SourceProbeOutcome> {
     try {
         const response = await fetchFn(src, {
             headers: { Range: "bytes=0-0" },
             cache: "no-store",
             signal: AbortSignal.timeout(10_000),
         });
-        return response.ok;
+        if (response.ok) return { kind: "served" };
+        const status = response.status;
+        if (status === 404 && response.headers.get(MISSING_PAYLOAD_HEADER) === MISSING_PAYLOAD_VALUE) {
+            return { kind: "missing-payload" };
+        }
+        return status < 500
+            ? { kind: "denied", status }
+            : { kind: "server-error", status };
     } catch {
-        return false;
+        return { kind: "server-error", status: null };
     }
 }
 

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -14,6 +14,7 @@ export type PlayerStatus =
     | "recovering"
     | "failed"
     | "unsupported"
+    | "unavailable"
     | "missing-payload";
 
 export type PlayerEvent = {
@@ -47,6 +48,7 @@ export function useMediaPlayer({ src }: { src: string }) {
     const [error, setError] = useState<PlayerError | null>(null);
     const [startupMs, setStartupMs] = useState<number | null>(null);
     const [events, setEvents] = useState<PlayerEvent[]>([]);
+    const [unavailableStatus, setUnavailableStatus] = useState<number | null>(null);
 
     const attemptsRef = useRef(0);
     const framesBaselineRef = useRef(0);
@@ -152,6 +154,7 @@ export function useMediaPlayer({ src }: { src: string }) {
         setError(null);
         setStartupMs(null);
         setEvents([]);
+        setUnavailableStatus(null);
     }, [src, clearRecoveryTimer]);
 
     // The source is applied imperatively, not via the JSX src attribute:
@@ -180,7 +183,9 @@ export function useMediaPlayer({ src }: { src: string }) {
         const interval = setInterval(() => {
             const el = mediaRef.current;
             if (!el || el.paused || el.ended || el.seeking) return;
-            if (status === "recovering" || status === "failed" || status === "unsupported") return;
+            if (status === "recovering" || status === "failed"
+                || status === "unsupported" || status === "unavailable"
+                || status === "missing-payload") return;
             const last = lastProgressAtRef.current;
             if (last !== null && Date.now() - last > STALL_THRESHOLD_MS) {
                 beginRecovery(`no playback progress for ${Math.round(STALL_THRESHOLD_MS / 1000)}s`);
@@ -229,7 +234,8 @@ export function useMediaPlayer({ src }: { src: string }) {
                     break;
                 case "denied":
                     log("source-check", `media request refused with HTTP ${outcome.status}`);
-                    setStatus("failed");
+                    setUnavailableStatus(outcome.status);
+                    setStatus("unavailable");
                     break;
                 case "server-error":
                     log("source-check", outcome.status !== null
@@ -337,6 +343,7 @@ export function useMediaPlayer({ src }: { src: string }) {
         error,
         startupMs,
         events,
+        unavailableStatus,
         retry,
         lastGoodTimeRef,
         lastProgressAtRef,

--- a/frontend/app/routes/explore/media-preview/use-media-player.ts
+++ b/frontend/app/routes/explore/media-preview/use-media-player.ts
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
     backoffMs,
-    canProbeCodecs,
     classifyMediaError,
     MAX_AUTO_ATTEMPTS,
-    probeSourceReachable,
-    probeUnsupportedCodecs,
+    probeSource,
     STALL_THRESHOLD_MS,
 } from "./media-utils";
 
@@ -15,7 +13,8 @@ export type PlayerStatus =
     | "playing"
     | "recovering"
     | "failed"
-    | "unsupported";
+    | "unsupported"
+    | "missing-payload";
 
 export type PlayerEvent = {
     at: number;
@@ -48,7 +47,6 @@ export function useMediaPlayer({ src }: { src: string }) {
     const [error, setError] = useState<PlayerError | null>(null);
     const [startupMs, setStartupMs] = useState<number | null>(null);
     const [events, setEvents] = useState<PlayerEvent[]>([]);
-    const [unsupportedCodecs, setUnsupportedCodecs] = useState<string[]>([]);
 
     const attemptsRef = useRef(0);
     const framesBaselineRef = useRef(0);
@@ -154,7 +152,6 @@ export function useMediaPlayer({ src }: { src: string }) {
         setError(null);
         setStartupMs(null);
         setEvents([]);
-        setUnsupportedCodecs([]);
     }, [src, clearRecoveryTimer]);
 
     // The source is applied imperatively, not via the JSX src attribute:
@@ -208,30 +205,40 @@ export function useMediaPlayer({ src }: { src: string }) {
         return lastProgressAtRef.current !== null;
     };
 
-    const handleUnsupported = (el: HTMLMediaElement | null, code: number | null) => {
-        const canPlay = el ? (type: string) => el.canPlayType(type) : null;
-        const missing = canPlay ? probeUnsupportedCodecs(canPlay) : [];
-        setUnsupportedCodecs(missing);
-        if (missing.length > 0) log("unsupported", `no decoder for ${missing.join(", ")}`);
-
-        // Chromium reports a media fetch that failed at the HTTP layer with
-        // the same code 4 as a missing decoder. When every probed decoder is
-        // present, verify the source before blaming the browser: a failing
-        // request goes through normal bounded recovery instead.
-        if (code === 4 && canPlay && canProbeCodecs(canPlay) && missing.length === 0) {
-            const generation = generationRef.current;
-            void probeSourceReachable(src).then(reachable => {
-                if (generationRef.current !== generation) return;
-                if (reachable) {
-                    setStatus("unsupported");
-                } else {
-                    log("source-check", "media request failed at the HTTP layer");
-                    beginRecovery("media request failed");
-                }
-            });
+    // Chromium reports a media fetch that failed at the HTTP layer with the
+    // same code 4 as an unsupported stream, so verify the source before
+    // deciding which failure this is.
+    const handleUnsupported = (code: number | null) => {
+        if (code !== 4) {
+            setStatus("unsupported");
             return;
         }
-        setStatus("unsupported");
+        const generation = generationRef.current;
+        void probeSource(src).then(outcome => {
+            if (generationRef.current !== generation) return;
+            switch (outcome.kind) {
+                case "served":
+                    // Bytes were served; the browser rejected them.
+                    setStatus("unsupported");
+                    break;
+                case "missing-payload":
+                    // Local file metadata is gone — re-downloading won't help
+                    // it, so surface a terminal state instead of retry loops.
+                    log("source-check", "backend reports the file data is missing");
+                    setStatus("missing-payload");
+                    break;
+                case "denied":
+                    log("source-check", `media request refused with HTTP ${outcome.status}`);
+                    setStatus("failed");
+                    break;
+                case "server-error":
+                    log("source-check", outcome.status !== null
+                        ? `media request failed with HTTP ${outcome.status}`
+                        : "media request failed (network or timeout)");
+                    beginRecovery("media request failed");
+                    break;
+            }
+        });
     };
 
     const handlers = {
@@ -308,7 +315,7 @@ export function useMediaPlayer({ src }: { src: string }) {
             setError({ code, message });
             log("error", `code ${code ?? "?"}${message ? `: ${message}` : ""}`);
             if (kind === "unsupported") {
-                handleUnsupported(el, code);
+                handleUnsupported(code);
                 return;
             }
             // Code 3 lands here only when frames already decoded — name the
@@ -330,7 +337,6 @@ export function useMediaPlayer({ src }: { src: string }) {
         error,
         startupMs,
         events,
-        unsupportedCodecs,
         retry,
         lastGoodTimeRef,
         lastProgressAtRef,

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -207,6 +207,72 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task MissingFilePayloadBeforeResponseStarted_ReturnsTyped404WithoutAborting()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw CreateMissingPayloadException());
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.Equal("missing-file-payload", context.Response.Headers["X-InfiniDysk-Stream-Error"].ToString());
+        Assert.False(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task MissingFilePayload_LogsOneWarningLineWithoutAStackDump()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        var payloadId = Guid.NewGuid();
+        var middleware = CreateMiddleware(_ => throw CreateMissingPayloadException(payloadId));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        var logged = Assert.Single(events,
+            e => e.Level == LogEventLevel.Warning
+                 && e.RenderMessage().Contains("streaming payload is missing", StringComparison.Ordinal));
+        Assert.Contains(payloadId.ToString(), logged.RenderMessage(), StringComparison.Ordinal);
+        Assert.Null(logged.Exception);
+        Assert.DoesNotContain(events, e => e.Level >= LogEventLevel.Error);
+    }
+
+    [Fact]
+    public async Task MissingFilePayloadWithDavItem_DoesNotRecordStreamingFailure()
+    {
+        // Missing local metadata is not evidence of a bad release; feeding it to
+        // the failure tracker would eventually trigger Arr remove-and-blocklist.
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw CreateMissingPayloadException(),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    private static MissingFilePayloadException CreateMissingPayloadException(Guid? payloadId = null)
+    {
+        var id = Guid.NewGuid();
+        return new MissingFilePayloadException(
+            new DavItem
+            {
+                Id = id,
+                IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+                Path = $"/content/movies/missing-payload-{id:N}.mkv",
+                FileBlobId = payloadId,
+            },
+            DavItem.ItemSubType.MultipartFile);
+    }
+
+    [Fact]
     public async Task StreamingReadTimeout_BeforeResponseStarted_Returns503WithRetryAfter()
     {
         var lifetimeFeature = new TestHttpRequestLifetimeFeature();

--- a/tests/NzbWebDAV.Tests/Services/BlobCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/BlobCleanupServiceTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class BlobCleanupServiceTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-blob-cleanup-cfg-{Guid.NewGuid():N}");
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-blob-cleanup-{Guid.NewGuid():N}.sqlite");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task UnreferencedBlob_IsDeletedAndDequeued()
+    {
+        var blobId = Guid.NewGuid();
+        await using (Stream stream = new MemoryStream("payload"u8.ToArray()))
+            await BlobStore.WriteBlob(blobId, stream);
+        _context.BlobCleanupItems.Add(new BlobCleanupItem { Id = blobId });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var processed = await BlobCleanupService.ProcessNextCleanupItemAsync(_context, CancellationToken.None);
+
+        Assert.True(processed);
+        Assert.Null(BlobStore.ReadBlob(blobId));
+        Assert.Empty(await _context.BlobCleanupItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task ReferencedBlob_IsKeptAndDequeued()
+    {
+        // A queued cleanup id whose blob was re-attached to a live DavItem
+        // (e.g. a restore/reimport) must not lose the live payload.
+        var blobId = Guid.NewGuid();
+        await using (Stream stream = new MemoryStream("payload"u8.ToArray()))
+            await BlobStore.WriteBlob(blobId, stream);
+        var davItem = DavItem.New(
+            Guid.NewGuid(), DavItem.ContentFolder, $"live-{blobId:N}.mkv", 100,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            releaseDate: null, lastHealthCheck: null, historyItemId: null,
+            fileBlobId: blobId);
+        _context.Items.Add(davItem);
+        _context.BlobCleanupItems.Add(new BlobCleanupItem { Id = blobId });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var processed = await BlobCleanupService.ProcessNextCleanupItemAsync(_context, CancellationToken.None);
+
+        Assert.True(processed);
+        Assert.NotNull(BlobStore.ReadBlob(blobId));
+        Assert.Empty(await _context.BlobCleanupItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task EmptyQueue_ReportsNothingToDo()
+    {
+        var processed = await BlobCleanupService.ProcessNextCleanupItemAsync(_context, CancellationToken.None);
+
+        Assert.False(processed);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckMissingPayloadTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckMissingPayloadTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Tests.Services;
+
+/// <summary>
+/// A DavItem whose streaming payload is gone (database-only restore, blob
+/// loss) must surface as a missing-payload failure rather than being treated
+/// as a zero-segment healthy file.
+/// </summary>
+public sealed class HealthCheckMissingPayloadTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-health-payload-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task NzbFile_WithoutPayloadOrLegacyRow_LooksUpNull()
+    {
+        var item = NewUsenetFile(DavItem.ItemSubType.NzbFile, fileBlobId: null);
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync();
+
+        Assert.Null(await _dbClient.GetDavNzbFileAsync(item));
+    }
+
+    [Fact]
+    public async Task MultipartFile_WithDanglingFileBlobId_LooksUpNull()
+    {
+        var item = NewUsenetFile(DavItem.ItemSubType.MultipartFile, fileBlobId: Guid.NewGuid());
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync();
+
+        // Dangling blob reference: no blob file and no legacy row.
+        Assert.Null(await _dbClient.GetDavMultipartFileAsync(item));
+    }
+
+    [Fact]
+    public async Task NzbFile_WithLegacyRow_ResolvesItsPayload()
+    {
+        var item = NewUsenetFile(DavItem.ItemSubType.NzbFile, fileBlobId: null);
+        _context.Items.Add(item);
+        _context.NzbFiles.Add(new DavNzbFile { Id = item.Id, SegmentIds = [$"<{Guid.NewGuid():N}@test>"] });
+        await _context.SaveChangesAsync();
+
+        var file = await _dbClient.GetDavNzbFileAsync(item);
+        Assert.NotNull(file);
+        Assert.Single(file.SegmentIds);
+    }
+
+    [Fact]
+    public void MissingFilePayloadException_CarriesIdentityContext()
+    {
+        var payloadId = Guid.NewGuid();
+        var item = NewUsenetFile(DavItem.ItemSubType.MultipartFile, fileBlobId: payloadId);
+
+        var ex = new MissingFilePayloadException(item, DavItem.ItemSubType.MultipartFile);
+
+        Assert.Equal(item.Id, ex.DavItemId);
+        Assert.Equal(payloadId, ex.FileBlobId);
+        Assert.Equal(item.Path, ex.FilePath);
+        Assert.Equal(DavItem.ItemSubType.MultipartFile, ex.StoreKind);
+        Assert.Contains(payloadId.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
+    private static DavItem NewUsenetFile(DavItem.ItemSubType subType, Guid? fileBlobId)
+    {
+        return DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            $"payload-{Guid.NewGuid():N}.mkv",
+            fileSize: 100,
+            DavItem.ItemType.UsenetFile,
+            subType,
+            releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: fileBlobId);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged #955, which still misdiagnosed the reported failures. The user's stack trace showed the real cause: `/view` returned **500** because the DavItem's streaming payload was gone (blob-store record and legacy DB row both absent) — not a codec problem. Chromium maps that HTTP failure to code 4, and #955's codec probe then blamed AC-3/E-AC-3 on an H.264/AAC MP4 (per screenshot). `canPlayType` reports codecs the *browser* lacks, not what the *file* contains, so the codec list was misleading by construction.

- **Player:** removes the codec-probe list. On code 4 it now re-requests one byte of the source and preserves the outcome: bytes served → generic unsupported banner (no invented codec names); the backend's typed `missing-file-payload` 404 → terminal "streaming data is missing (restore included no blobs/)" guidance; other 4xx → terminal failure; 5xx/timeout/network → bounded recovery. Mid-playback decode errors (code 3 after decoded frames) keep reload-and-resume recovery.
- **Backend:** the three file stores now throw `MissingFilePayloadException` (carrying DavItem id, payload id, path, store kind) instead of a bare `FileNotFoundException`; the middleware answers a typed 404 with a deduped one-line warning and no stack dump, and deliberately keeps the failure out of the streaming-failure tracker so local metadata loss can never blocklist a good release in Arr.
- **Health checks:** payload existence is validated before STAT sampling or urgent repair. Missing payload → `Unhealthy / ActionNeeded` with guidance; previously it could be marked healthy (zero segments) or enter Arr remove-and-blocklist repair.
- **Blob cleanup (defensive):** `BlobCleanupService` now rechecks the DavItem reference inside a serializable transaction before deleting, mirroring `NzbBlobCleanupService`; a blob re-attached to a live item (restore/reimport) can no longer be dropped from the cleanup queue.

## Test plan

- [x] `npm run typecheck && npm run lint && npm test` (593 frontend tests; new probe-outcome coverage for served / missing-payload / 4xx / 5xx / network)
- [x] `dotnet test tests/NzbWebDAV.Tests` (2662 pass; new middleware tests for the typed 404 and no-repair invariant, new blob-cleanup reference-check tests)
- [ ] Manual: preview a missing-payload file in the dev build and confirm the terminal "streaming data is missing" banner; confirm Open direct on it shows the friendly File unavailable page
- [ ] Manual: confirm a genuinely unsupported file still reaches the generic unsupported banner when bytes are served

Note: whether the user's missing blobs came from a DB-only restore, legacy migration state, or volume loss is an instance-level question (check `backups/last-restore-report.json`); the cleanup hardening here is defensive and not asserted as the cause.