### PR TITLE
fix(webdav): directory timestamps no longer report year 0001, fixing macOS mounts and rclone/Plex mtimes

### DIFF
--- a/backend/Database/Models/DavItem.cs
+++ b/backend/Database/Models/DavItem.cs
@@ -96,6 +96,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.WebdavRoot,
         Path = "/",
+        CreatedAt = DateTime.UnixEpoch,
     };
 
     public static readonly DavItem NzbFolder = new()
@@ -107,6 +108,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.NzbsRoot,
         Path = "/nzbs",
+        CreatedAt = DateTime.UnixEpoch,
     };
 
     public static readonly DavItem ContentFolder = new()
@@ -118,6 +120,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.ContentRoot,
         Path = "/content",
+        CreatedAt = DateTime.UnixEpoch,
     };
 
     public static readonly DavItem SymlinkFolder = new()
@@ -129,6 +132,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.SymlinkRoot,
         Path = "/completed-symlinks",
+        CreatedAt = DateTime.UnixEpoch,
     };
 
     public static readonly DavItem IdsFolder = new()
@@ -140,5 +144,6 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.IdsRoot,
         Path = "/.ids",
+        CreatedAt = DateTime.UnixEpoch,
     };
 }

--- a/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
@@ -38,7 +38,7 @@ public class BaseStoreCollectionPropertyManager() : PropertyManager<BaseStoreCol
         },
         new DavGetLastModified<BaseStoreCollection>
         {
-            Getter = x => x.CreatedAt.ToUniversalTime()
+            Getter = x => WebDavCreatedAtUtil.GetLastModifiedUtc(x.CreatedAt)
         },
         new Win32FileAttributes<BaseStoreCollection>
         {

--- a/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
@@ -23,7 +23,7 @@ public class BaseStoreItemPropertyManager() : PropertyManager<BaseStoreItem>(Dav
         },
         new DavGetLastModified<BaseStoreItem>
         {
-            Getter = x => x.CreatedAt.ToUniversalTime()
+            Getter = x => WebDavCreatedAtUtil.GetLastModifiedUtc(x.CreatedAt)
         },
         new Win32FileAttributes<BaseStoreItem>
         {

--- a/backend/WebDav/Base/WebDavCreatedAtUtil.cs
+++ b/backend/WebDav/Base/WebDavCreatedAtUtil.cs
@@ -1,0 +1,18 @@
+namespace NzbWebDAV.WebDav.Base;
+
+/// <summary>
+/// Normalizes WebDAV resource timestamps so PROPFIND/Last-Modified never emit
+/// <see cref="DateTime.MinValue"/> (year 0001), which breaks macOS mount_webdav
+/// and rclone/Plex mtimes.
+/// </summary>
+internal static class WebDavCreatedAtUtil
+{
+    /// <summary>Deterministic fallback for virtual folders and legacy rows with no real CreatedAt.</summary>
+    public static DateTime Fallback { get; } = DateTime.UnixEpoch;
+
+    public static DateTime Normalize(DateTime createdAt)
+        => createdAt == default ? Fallback : createdAt;
+
+    public static DateTime GetLastModifiedUtc(DateTime createdAt)
+        => Normalize(createdAt).ToUniversalTime();
+}

--- a/backend/WebDav/DatabaseStoreIdsCollection.cs
+++ b/backend/WebDav/DatabaseStoreIdsCollection.cs
@@ -25,7 +25,7 @@ public class DatabaseStoreIdsCollection(
 {
     public override string Name => name;
     public override string UniqueKey => currentPath;
-    public override DateTime CreatedAt => default;
+    public override DateTime CreatedAt => WebDavCreatedAtUtil.Fallback;
 
     private const string Alphabet = "0123456789abcdef";
 

--- a/tests/NzbWebDAV.Tests/WebDav/GetLastModifiedPropertyTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetLastModifiedPropertyTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.WebDav.Base;
 using NzbWebDAV.WebDav.Requests;
 
@@ -40,6 +41,41 @@ public class GetLastModifiedPropertyTests
 
         if (TimeZoneInfo.Local.GetUtcOffset(createdAt) != TimeSpan.Zero)
             Assert.NotEqual(createdAt.ToString("R"), value);
+    }
+
+    [Fact]
+    public async Task Item_GetLastModified_MinValue_UsesUnixEpochFallback()
+    {
+        var item = new StubStoreItem(default);
+
+        var value = (string?)await item.PropertyManager!
+            .GetPropertyAsync(item, DavGetLastModified<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(DateTime.UnixEpoch.ToString("R"), value);
+        Assert.DoesNotContain("0001", value);
+    }
+
+    [Fact]
+    public async Task Collection_GetLastModified_MinValue_UsesUnixEpochFallback()
+    {
+        var collection = new StubStoreCollection(default);
+
+        var value = (string?)await collection.PropertyManager!
+            .GetPropertyAsync(collection, DavGetLastModified<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(DateTime.UnixEpoch.ToString("R"), value);
+        Assert.DoesNotContain("0001", value);
+    }
+
+    [Fact]
+    public void StaticDavItems_HaveNonMinValueCreatedAt()
+    {
+        Assert.NotEqual(default, DavItem.Root.CreatedAt);
+        Assert.NotEqual(default, DavItem.NzbFolder.CreatedAt);
+        Assert.NotEqual(default, DavItem.ContentFolder.CreatedAt);
+        Assert.NotEqual(default, DavItem.SymlinkFolder.CreatedAt);
+        Assert.NotEqual(default, DavItem.IdsFolder.CreatedAt);
+        Assert.Equal(DateTime.UnixEpoch, DavItem.Root.CreatedAt);
     }
 
     private sealed class StubStoreItem(DateTime createdAt) : BaseStoreReadonlyItem


### PR DESCRIPTION
## Summary

- Normalize `DateTime.MinValue` `CreatedAt` values to Unix epoch in WebDAV property managers so `getlastmodified` and `Last-Modified` headers never emit year-0001 HTTP-dates
- Set fallback timestamps on static `DavItem` folders and virtual `.ids` hash-prefix directories (`DatabaseStoreIdsCollection`)
- Add regression tests for MinValue handling and static folder timestamps

Fixes #965

## Problem

`PROPFIND` on virtual `.ids` hash-prefix directories returned `getlastmodified` of `Mon, 01 Jan 0001` (`DateTime.MinValue` rendered as an HTTP-date). This broke macOS `mount_webdav`, and rclone with `--no-modtime` propagated the broken mtime into Plex and other downstream indexers.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~GetLastModifiedPropertyTests"` (7 passed)