### PR TITLE
fix(webdav): streams that end early no longer trigger unhandled Kestrel errors

### DIFF
--- a/backend/Exceptions/IncompleteFileContentException.cs
+++ b/backend/Exceptions/IncompleteFileContentException.cs
@@ -1,0 +1,21 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Thrown when a file stream ends before the declared file or range length is satisfied.
+/// Continuing would produce a truncated HTTP body and trigger Kestrel's Content-Length mismatch.
+/// </summary>
+public class IncompleteFileContentException(string filePath, long expectedBytes, long deliveredBytes)
+    : NonRetryableDownloadException(BuildMessage(filePath, expectedBytes, deliveredBytes))
+{
+    public string FilePath { get; } = filePath;
+    public long ExpectedBytes { get; } = expectedBytes;
+    public long DeliveredBytes { get; } = deliveredBytes;
+
+    private static string BuildMessage(string filePath, long expectedBytes, long deliveredBytes)
+    {
+        var shortfall = expectedBytes - deliveredBytes;
+        return
+            $"File \"{filePath}\" ended {shortfall} bytes early " +
+            $"(delivered {deliveredBytes} of {expectedBytes} expected bytes).";
+    }
+}

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -305,6 +305,47 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
+        catch (IncompleteFileContentException e)
+        {
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 404;
+            }
+
+            var filePath = GetRequestFilePath(context);
+            var seekPosition = context.Request.GetRange()?.Start?.ToString() ?? "0";
+            var userAgent = context.Request.Headers.UserAgent.ToString();
+            if (string.IsNullOrWhiteSpace(userAgent))
+                userAgent = "unknown";
+            var dedupeKey = $"{filePath}|{seekPosition}|{e.ExpectedBytes}|{e.DeliveredBytes}";
+            LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "File {FilePath} delivered {DeliveredBytes} of {ExpectedBytes} expected bytes from byte position {SeekPosition} (client {UserAgent}, suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        e.DeliveredBytes,
+                        e.ExpectedBytes,
+                        seekPosition,
+                        userAgent,
+                        suppressed);
+                else
+                    Log.Warning(
+                        "File {FilePath} delivered {DeliveredBytes} of {ExpectedBytes} expected bytes from byte position {SeekPosition} (client {UserAgent})",
+                        filePath,
+                        e.DeliveredBytes,
+                        e.ExpectedBytes,
+                        seekPosition,
+                        userAgent);
+            });
+            Log.Debug(e, "Incomplete file content stack for {FilePath}", filePath);
+
+            if (context.Items["DavItem"] is DavItem davItem)
+                ScheduleRepair(davItem.Id);
+
+            AbortStartedResponse(context);
+        }
         catch (Exception e) when (IsDavItemRequest(context) && e is not OutOfMemoryException)
         {
             // A volume that is short or unresolvable is missing data, not a server

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -106,6 +106,12 @@ public class DavMultipartFileStream : FastReadOnlyStream
         }
         _innerStream ??= await GetFileStreamAsync(_position, cancellationToken).ConfigureAwait(false);
         var read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        if (read == 0 && _position < _length)
+        {
+            throw new IncompleteFileContentException(
+                _fileName ?? "unknown", _length, _position);
+        }
+
         _position += read;
         return read;
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -333,8 +333,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     /// <summary>
     /// Stop enqueueing once the bytes already in flight cover the read budget plus one
     /// segment of slack, which absorbs the prefix a seek discards from the first segment.
-    /// Exact segment sizes are used when the import recorded them; otherwise the estimate
-    /// stands in, since over- or under-fetching only costs bandwidth.
+    /// Requires recorded per-segment sizes; without them the estimate can undershoot actual
+    /// segment lengths and truncate a range response, so prefetch is capped only by
+    /// <see cref="WaitForPrefetchCeilingAsync"/>.
     /// </summary>
     private bool ShouldStopPrefetch(int segmentsEnqueued, long enqueuedBytes)
     {
@@ -343,8 +344,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             if (_segmentSizes.TryGetExactSize(0, out var slack))
                 return enqueuedBytes >= _readBudget.Value + slack;
-            if (_estimatedSegmentSize <= 0) return false;
-            return segmentsEnqueued * _estimatedSegmentSize >= _readBudget.Value + _estimatedSegmentSize;
+            return false;
         }
 
         // Full-file / non-range: never permanently stop (consumer needs the whole file).

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -292,7 +292,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                            traceRange, readCts, fileName, ct).ConfigureAwait(false);
+                            traceRange, readCts, path, ct).ConfigureAwait(false);
                         FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Completed);
                         ClearStreamingFailureAfterCompletedRead(
                             _failureTracker,

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -10,8 +10,8 @@ using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
-using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
@@ -292,7 +292,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                         readCts.CancelAfter(Timeout.InfiniteTimeSpan);
                         await CopyToAsync(stream, response.Body, copyStart, copyEnd,
                             (n, pos) => _activeReadRegistry.Touch(sessionId, n, pos),
-                            traceRange, readCts, ct).ConfigureAwait(false);
+                            traceRange, readCts, fileName, ct).ConfigureAwait(false);
                         FinishRange(sessionId, traceRange, ReadSession.EndReasonCode.Completed);
                         ClearStreamingFailureAfterCompletedRead(
                             _failureTracker,
@@ -405,6 +405,7 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         Action<long, long>? onBytesServed,
         StreamTraceRangeContext? traceRange,
         CancellationTokenSource readCts,
+        string filePath,
         CancellationToken cancellationToken)
     {
         // Skip to the first offset
@@ -435,7 +436,16 @@ public class GetAndHeadHandlerPatch : IRequestHandler
 
                 // We're done, if we cannot read any data anymore
                 if (bytesRead == 0)
+                {
+                    ThrowIfCopyEndedEarly(
+                        bytesRemaining: bytesToRead,
+                        rangeEnd: end,
+                        rangeStart: start,
+                        bytesDeliveredInRange: position - start,
+                        filePath,
+                        src);
                     return;
+                }
 
                 // Write the data to the destination stream. Bound the write so a client
                 // that stopped reading but kept the connection open (HTTP/2 flow control,
@@ -458,6 +468,42 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Range GETs promise a finite Content-Length; a clean EOF before that many bytes
+    /// are copied must fail explicitly so ExceptionMiddleware can abort instead of letting
+    /// Kestrel log an unhandled Content-Length mismatch. Full GETs with a known stream
+    /// length use the same rule; natural EOF at the declared length is allowed.
+    /// </summary>
+    internal static void ThrowIfCopyEndedEarly(
+        long bytesRemaining,
+        long? rangeEnd,
+        long rangeStart,
+        long bytesDeliveredInRange,
+        string filePath,
+        Stream src)
+    {
+        if (rangeEnd.HasValue)
+        {
+            if (bytesRemaining > 0)
+            {
+                throw new IncompleteFileContentException(
+                    filePath,
+                    rangeEnd.Value - rangeStart + 1,
+                    bytesDeliveredInRange);
+            }
+
+            return;
+        }
+
+        if (src.CanSeek && bytesDeliveredInRange < src.Length - rangeStart)
+        {
+            throw new IncompleteFileContentException(
+                filePath,
+                src.Length - rangeStart,
+                bytesDeliveredInRange);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -190,6 +190,69 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task IncompleteFileContentBeforeResponseStarted_ReturnsNotFoundWithoutAborting()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new IncompleteFileContentException("/content/tv/show.mkv", 16_777_216, 14_000_000));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task IncompleteFileContentAfterResponseStarted_AbortsConnection()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new IncompleteFileContentException("/content/tv/show.mkv", 16_777_216, 14_000_000));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task IncompleteFileContentWithDavItem_RecordsStreamingFailure()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new IncompleteFileContentException("/content/tv/show.mkv", 16_777_216, 14_000_000),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    [Fact]
+    public async Task IncompleteFileContent_LogsOneWarningLineWithoutAStackDump()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new IncompleteFileContentException(
+                "/content/tv/show.mkv", 33_554_432, 32_000_000));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        var logged = Assert.Single(
+            events,
+            e => e.Level == LogEventLevel.Warning
+                 && e.RenderMessage().Contains("delivered 32000000", StringComparison.Ordinal)
+                 && e.RenderMessage().Contains("33554432 expected bytes", StringComparison.Ordinal));
+        Assert.Null(logged.Exception);
+    }
+
+    [Fact]
     public async Task IncompleteMultipartPart_LogsOneWarningLineWithoutAStackDump()
     {
         var reason = $"volume ended 3071980 bytes early ({Guid.NewGuid()})";

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -147,6 +147,46 @@ public class DavMultipartFileStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_PendingPartsWithoutResolver_EndsBeforeDeclaredLength_ThrowsIncompleteFileContent()
+    {
+        using var client = new FakeNntpClient(new Dictionary<string, byte[]>
+        {
+            ["segment"] = Enumerable.Range(0, 8).Select(x => (byte)x).ToArray(),
+        }, useCachedYencStreams: true);
+        var multipart = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(0, 8),
+            fileRange: LongRange.FromStartAndSize(0, 8));
+        multipart.Metadata.PendingParts =
+        [
+            new DavMultipartFile.PendingPart
+            {
+                SegmentIds = ["vol2-seg"],
+                SegmentIdByteRange = LongRange.FromStartAndSize(0, 8),
+                EstimatedDataSize = 8,
+            }
+        ];
+        await using var stream = new DavMultipartFileStream(
+            multipart,
+            client,
+            articleBufferSize: 0,
+            resolver: null,
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv");
+
+        var buffer = new byte[16];
+        Assert.Equal(8, await stream.ReadAsync(buffer.AsMemory(0, 8)));
+
+        var failure = await Assert.ThrowsAsync<IncompleteFileContentException>(async () =>
+        {
+            _ = await stream.ReadAsync(buffer.AsMemory(8));
+        });
+
+        Assert.Equal(16, failure.ExpectedBytes);
+        Assert.Equal(8, failure.DeliveredBytes);
+        Assert.Contains("movie.mkv", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ReadAsync_UnresolvableTrailingVolume_DoesNotLookLikeEndOfFile()
     {
         using var client = new FakeNntpClient(new Dictionary<string, byte[]>

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -12,12 +12,11 @@ namespace NzbWebDAV.Tests.Streams;
 public class MultiSegmentStreamPrefetchBudgetTests
 {
     [Fact]
-    public async Task ReadBudget_CapsPrefetchBelowArticleBufferSize()
+    public async Task ReadBudget_WithoutExactSizes_DeliversFullConsumerRange()
     {
         const int segmentCount = 20;
         const int segmentSize = 1000;
         const int articleBufferSize = 10;
-        // 2.5 segments of budget → stop once enqueued*size >= budget + size → 4 segments max
         const long readBudget = 2500;
 
         var segments = Enumerable.Range(0, segmentCount)
@@ -37,6 +36,47 @@ public class MultiSegmentStreamPrefetchBudgetTests
             CancellationToken.None,
             fileName: "budget.bin",
             readBudget: readBudget);
+
+        var buffer = new byte[readBudget];
+        var totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            var n = await stream.ReadAsync(buffer.AsMemory(totalRead));
+            if (n == 0) break;
+            totalRead += n;
+        }
+
+        Assert.Equal(readBudget, totalRead);
+    }
+
+    [Fact]
+    public async Task ReadBudget_WithExactSizes_CapsPrefetchBelowArticleBufferSize()
+    {
+        const int segmentCount = 20;
+        const int segmentSize = 1000;
+        const int articleBufferSize = 10;
+        // 2.5 segments of budget → stop once enqueued*size >= budget + size → 4 segments max
+        const long readBudget = 2500;
+
+        var segments = Enumerable.Range(0, segmentCount)
+            .ToDictionary(
+                i => $"seg-{i}",
+                i => Enumerable.Repeat((byte)(i % 256), segmentSize).ToArray());
+        var client = new FakeNntpClient(segments, useCachedYencStreams: true);
+        var segmentIds = segments.Keys.ToArray().AsMemory();
+        var exactSizes = Enumerable.Repeat((long)segmentSize, segmentCount).ToArray();
+
+        await using var stream = MultiSegmentStream.Create(
+            segmentIds,
+            client,
+            articleBufferSize,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "budget.bin",
+            readBudget: readBudget,
+            exactSegmentSizes: exactSizes.AsMemory());
 
         var buffer = new byte[readBudget];
         var totalRead = 0;

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -388,6 +388,30 @@ public class NzbFileStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_EndsBeforeDeclaredFileSize_ThrowsIncompleteFileContent()
+    {
+        using var client = new FakeNntpClient(new Dictionary<string, byte[]>
+        {
+            ["seg"] = Enumerable.Repeat((byte)1, 10).ToArray(),
+        }, useCachedYencStreams: true);
+        await using var stream = new NzbFileStream(
+            ["seg"],
+            fileSize: 100,
+            client,
+            articleBufferSize: 0,
+            segmentByteRanges: null,
+            usePipelinedBodyRequests: false,
+            fileName: "short.bin");
+
+        var buffer = new byte[100];
+        var firstRead = await stream.ReadAsync(buffer);
+        Assert.Equal(10, firstRead);
+
+        var secondRead = await stream.ReadAsync(buffer.AsMemory(10));
+        Assert.Equal(0, secondRead);
+    }
+
+    [Fact]
     public async Task Seek_WhenIndexedSegmentEndsBeforeOffset_ThrowsAndDisposesBodies()
     {
         string[] segmentIds = ["short"];

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -388,7 +388,7 @@ public class NzbFileStreamTests
     }
 
     [Fact]
-    public async Task ReadAsync_EndsBeforeDeclaredFileSize_ThrowsIncompleteFileContent()
+    public async Task ReadAsync_EndsBeforeDeclaredFileSize_ReturnsZeroWithoutThrowing()
     {
         using var client = new FakeNntpClient(new Dictionary<string, byte[]>
         {

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
 using NzbWebDAV.WebDav.Base;
 
@@ -99,6 +100,73 @@ public class GetAndHeadHandlerRangeTests
     private static DavItem NewDavItem()
     {
         return new DavItem { Id = Guid.NewGuid() };
+    }
+
+    [Fact]
+    public void ThrowIfCopyEndedEarly_ThrowsWhenRangeEndsBeforePromisedLength()
+    {
+        using var src = new MemoryStream(new byte[1000]);
+        var failure = Assert.Throws<IncompleteFileContentException>(() =>
+            GetAndHeadHandlerPatch.ThrowIfCopyEndedEarly(
+                bytesRemaining: 1024,
+                rangeEnd: 499,
+                rangeStart: 0,
+                bytesDeliveredInRange: 256,
+                filePath: "/content/movies/short.mkv",
+                src));
+
+        Assert.Equal(500, failure.ExpectedBytes);
+        Assert.Equal(256, failure.DeliveredBytes);
+        Assert.Contains("short.mkv", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ThrowIfCopyEndedEarly_ThrowsWhenFullFileEndsBeforeDeclaredLength()
+    {
+        using var src = new MemoryStream(new byte[100]);
+        var failure = Assert.Throws<IncompleteFileContentException>(() =>
+            GetAndHeadHandlerPatch.ThrowIfCopyEndedEarly(
+                bytesRemaining: long.MaxValue,
+                rangeEnd: null,
+                rangeStart: 0,
+                bytesDeliveredInRange: 10,
+                filePath: "/content/movies/short.mkv",
+                src));
+
+        Assert.Equal(100, failure.ExpectedBytes);
+        Assert.Equal(10, failure.DeliveredBytes);
+    }
+
+    [Fact]
+    public void ThrowIfCopyEndedEarly_AllowsNaturalEofOnFullFileGet()
+    {
+        using var src = new MemoryStream(new byte[100]);
+        var ex = Record.Exception(() =>
+            GetAndHeadHandlerPatch.ThrowIfCopyEndedEarly(
+                bytesRemaining: long.MaxValue,
+                rangeEnd: null,
+                rangeStart: 0,
+                bytesDeliveredInRange: 100,
+                filePath: "/content/movies/full.mkv",
+                src));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ThrowIfCopyEndedEarly_AllowsCompletedRange()
+    {
+        using var src = new MemoryStream(new byte[1000]);
+        var ex = Record.Exception(() =>
+            GetAndHeadHandlerPatch.ThrowIfCopyEndedEarly(
+                bytesRemaining: 0,
+                rangeEnd: 499,
+                rangeStart: 0,
+                bytesDeliveredInRange: 500,
+                filePath: "/content/movies/ok.mkv",
+                src));
+
+        Assert.Null(ex);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #966. When a WebDAV range or full-file response ended before the promised `Content-Length`, `CopyToAsync` treated clean EOF as success and Kestrel logged unhandled `Response Content-Length mismatch` errors (seen during Jellyfin library scans over rclone).

- Add `IncompleteFileContentException` and throw from `CopyToAsync` when a bounded range or seekable full-file copy ends short
- Handle it in `ExceptionMiddleware`: 404 pre-headers, abort post-headers, deduped warning with expected/delivered bytes, schedule repair when `DavItem` is known
- Guard `DavMultipartFileStream` when enumeration ends before declared length
- Only apply read-budget prefetch stop in `MultiSegmentStream` when exact per-segment sizes are recorded (avoids estimate-based truncation)

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (2664 passed)
- [ ] Reproduce Jellyfin/rclone scan against a library with retention gaps; confirm warnings replace Kestrel stack traces