### PR TITLE
fix(ui): queue page no longer fails to load when the manual upload category is empty

### DIFF
--- a/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.tsx
+++ b/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.tsx
@@ -11,7 +11,7 @@ export type SimpleDropdownProps = {
 }
 
 export const SimpleDropdown = memo(({ type, options, value, onChange, valueRef, ariaLabel }: SimpleDropdownProps) => {
-    if (!valueRef && (!value || !onChange)) {
+    if (!valueRef && (value == null || !onChange)) {
         throw new Error("SimpleDropdown requires either the valueRef prop or both the value and onChange props.")
     }
 

--- a/frontend/app/routes/queue/route.test.ts
+++ b/frontend/app/routes/queue/route.test.ts
@@ -116,6 +116,35 @@ describe("queue route loader", () => {
     });
   });
 
+  it("falls back to a non-empty manual category and filters empty category segments", async () => {
+    getQueueMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getHistoryMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getConfigMock.mockResolvedValueOnce([
+      { configName: "api.categories", configValue: ",tv,, movies," },
+      { configName: "api.manual-category", configValue: "" },
+    ]);
+
+    const result = await loader(loaderRequest());
+
+    expect(result.manualCategory).toBe("uncategorized");
+    expect(result.categories).toEqual(["uncategorized", "tv", "movies"]);
+    expect(result.categories).not.toContain("");
+  });
+
+  it("falls back to a non-empty manual category when it is whitespace-only", async () => {
+    getQueueMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getHistoryMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getConfigMock.mockResolvedValueOnce([
+      { configName: "api.categories", configValue: "tv" },
+      { configName: "api.manual-category", configValue: "   " },
+    ]);
+
+    const result = await loader(loaderRequest());
+
+    expect(result.manualCategory).toBe("uncategorized");
+    expect(result.categories).toEqual(["uncategorized", "tv"]);
+  });
+
   it("surfaces backend failures instead of returning partial queue data", async () => {
     getQueueMock.mockRejectedValueOnce(new Error("queue unavailable"));
     getHistoryMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -40,8 +40,8 @@ export async function loader({ request }: Route.LoaderArgs) {
         ?.configValue ?? "uncategorized,audio,software,tv,movies";
     const manualCategory = config
         .find(x => x.configName === "api.manual-category")
-        ?.configValue ?? "uncategorized";
-    let categories = categoriesValue.split(',').map(x => x.trim());
+        ?.configValue?.trim() || "uncategorized";
+    let categories = categoriesValue.split(',').map(x => x.trim()).filter(Boolean);
     if (!categories.includes(manualCategory)) {
         categories = [manualCategory, ...categories];
     }


### PR DESCRIPTION
## Summary

- Fixes a reproducible SSR crash on `/queue` (500 on every load, UI stuck on the "Connecting to InfiniDysk" screen in a reload loop) that starts as soon as items are added to the queue — matching the user report in #970.
- Root cause: `SimpleDropdown` treated an empty-string `value` as missing (`!value`) and threw during SSR; the queue loader can produce exactly that when `api.manual-category` is saved as an empty string (the settings page allows it, and the `Fix-Empty-Categories` migration repairs DB rows but not the config value).
- Fix: the guard now only rejects `null`/`undefined`, and the queue loader normalizes the manual category (`trim() || "uncategorized"`) and filters empty category segments — the same normalization the SABnzbd settings page already applies.

Fixes #970

Note: the reload loop that masks the real error (#971) is intentionally out of scope here and filed separately.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 596 tests pass, including 2 new loader regression tests covering empty and whitespace-only `api.manual-category` and empty segments in `api.categories`
- [ ] Manual: clear Settings > SABnzbd > Manual Upload Category, save, add an item to the queue, confirm `/queue` loads