### PR TITLE
fix(queue): queue items no longer stall and cancel at 50% on obfuscated releases

### DIFF
--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -370,7 +370,7 @@ public class GetWebdavItemController(
     {
         Response.Headers.ContentType = "text/plain";
         await using var stream = await item.GetReadableStreamAsync(ct).ConfigureAwait(false);
-        var fileDescriptors = await Par2.ReadFileDescriptions(stream, ct).GetAllAsync(ct: ct)
+        var fileDescriptors = await Par2.ReadFileDescriptions(stream, ct: ct).GetAllAsync(ct: ct)
             .ConfigureAwait(false);
         return new MemoryStream(Encoding.UTF8.GetBytes(fileDescriptors.ToIndentedJson()));
     }

--- a/backend/Extensions/ProgressExtensions.cs
+++ b/backend/Extensions/ProgressExtensions.cs
@@ -44,7 +44,10 @@ public static class ProgressExtensions
                     }
 
                     previous = x;
-                    progress?.Report(current!.Value * 100 / _denominator);
+                    // Integer truncation maps a single completion of >100/percent
+                    // processors to the same displayed value; ceil keeps the
+                    // watchdog/UI moving while staying monotonic.
+                    progress?.Report((current!.Value * 100 + _denominator - 1) / _denominator);
                 });
             }
         }

--- a/backend/Par2Recovery/Packets/Par2Packet.cs
+++ b/backend/Par2Recovery/Packets/Par2Packet.cs
@@ -17,26 +17,60 @@ namespace NzbWebDAV.Par2Recovery.Packets
         public async Task ReadAsync(Stream stream)
         {
             // Determine the length of the body as the given packet length, minus the length of the header.
-            var bodyLength = Header.PacketLength - (ulong)Marshal.SizeOf<Par2PacketHeader>();
+            var headerSize = (ulong)Marshal.SizeOf<Par2PacketHeader>();
+            var packetLength = Header.PacketLength;
+            // Guard malformed/truncated lengths before they can underflow the
+            // subtraction or drive a huge allocation / impossible seek.
+            if (packetLength < headerSize || packetLength > (ulong)int.MaxValue)
+                throw new InvalidDataException($"Invalid PAR2 packet length {packetLength}.");
+            var bodyLength = (int)(packetLength - headerSize);
+
+            if (stream.CanSeek)
+            {
+                var remaining = stream.Length - stream.Position;
+                if (bodyLength > remaining)
+                    throw new EndOfStreamException("Truncated PAR2 packet body.");
+            }
 
             // Skip uninteresting bodies (RecvSlic recovery data can be GBs) via
             // seek when possible — NzbFileStream turns forward seeks > 1 MiB
             // into a cheap reopen instead of downloading the skipped bytes.
-            if (SkipBody && stream.CanSeek)
+            // Non-seekable streams fall back to draining in bounded chunks so a
+            // large body is never buffered whole.
+            if (SkipBody)
             {
-                var remaining = stream.Length - stream.Position;
-                if (bodyLength > (ulong)remaining)
-                    throw new EndOfStreamException("Truncated PAR2 packet body.");
-                stream.Seek((long)bodyLength, SeekOrigin.Current);
+                if (stream.CanSeek)
+                {
+                    stream.Seek(bodyLength, SeekOrigin.Current);
+                }
+                else
+                {
+                    await DrainAsync(stream, bodyLength).ConfigureAwait(false);
+                }
                 return;
             }
 
             // Read the calculated number of bytes from the stream.
             var body = new byte[bodyLength];
-            await stream.ReadExactlyAsync(body.AsMemory(0, (int)bodyLength)).ConfigureAwait(false);
+            await stream.ReadExactlyAsync(body.AsMemory(0, bodyLength)).ConfigureAwait(false);
 
             // Pass the body to the further implementation for parsing.
             ParseBody(body);
+        }
+
+        private static async Task DrainAsync(Stream stream, int bytes)
+        {
+            var scratch = new byte[Math.Min(bytes, 64 * 1024)];
+            var remaining = bytes;
+            while (remaining > 0)
+            {
+                var read = await stream.ReadAsync(
+                        scratch.AsMemory(0, Math.Min(scratch.Length, remaining)))
+                    .ConfigureAwait(false);
+                if (read == 0)
+                    throw new EndOfStreamException("Truncated PAR2 packet body.");
+                remaining -= read;
+            }
         }
 
         protected virtual bool SkipBody => false;

--- a/backend/Par2Recovery/Packets/Par2Packet.cs
+++ b/backend/Par2Recovery/Packets/Par2Packet.cs
@@ -19,6 +19,18 @@ namespace NzbWebDAV.Par2Recovery.Packets
             // Determine the length of the body as the given packet length, minus the length of the header.
             var bodyLength = Header.PacketLength - (ulong)Marshal.SizeOf<Par2PacketHeader>();
 
+            // Skip uninteresting bodies (RecvSlic recovery data can be GBs) via
+            // seek when possible — NzbFileStream turns forward seeks > 1 MiB
+            // into a cheap reopen instead of downloading the skipped bytes.
+            if (SkipBody && stream.CanSeek)
+            {
+                var remaining = stream.Length - stream.Position;
+                if (bodyLength > (ulong)remaining)
+                    throw new EndOfStreamException("Truncated PAR2 packet body.");
+                stream.Seek((long)bodyLength, SeekOrigin.Current);
+                return;
+            }
+
             // Read the calculated number of bytes from the stream.
             var body = new byte[bodyLength];
             await stream.ReadExactlyAsync(body.AsMemory(0, (int)bodyLength)).ConfigureAwait(false);
@@ -26,6 +38,8 @@ namespace NzbWebDAV.Par2Recovery.Packets
             // Pass the body to the further implementation for parsing.
             ParseBody(body);
         }
+
+        protected virtual bool SkipBody => false;
 
         protected virtual void ParseBody(byte[] body)
         {

--- a/backend/Par2Recovery/Packets/RecvSlic.cs
+++ b/backend/Par2Recovery/Packets/RecvSlic.cs
@@ -1,0 +1,18 @@
+namespace NzbWebDAV.Par2Recovery.Packets
+{
+    /// <summary>
+    /// PAR 2.0 Recovery Slice packet ("PAR 2.0\0RecvSlic"). Carries the recovery
+    /// data itself, so it dominates file size; we only need to know where it
+    /// starts, never its payload.
+    /// </summary>
+    public class RecvSlic : Par2Packet
+    {
+        public const string PacketType = "PAR 2.0\0RecvSlic";
+
+        public RecvSlic(Par2PacketHeader header) : base(header)
+        {
+        }
+
+        protected override bool SkipBody => true;
+    }
+}

--- a/backend/Par2Recovery/Par2.cs
+++ b/backend/Par2Recovery/Par2.cs
@@ -20,6 +20,7 @@ namespace NzbWebDAV.Par2Recovery
         public static async IAsyncEnumerable<FileDesc> ReadFileDescriptions
         (
             Stream stream,
+            bool stopAtRecoverySlice = false,
             [EnumeratorCancellation] CancellationToken ct = default
         )
         {
@@ -50,6 +51,13 @@ namespace NzbWebDAV.Par2Recovery
                         unicodeNamesByFileId[Convert.ToHexString(uniFileN.FileID)] = uniFileN.FileName;
                         break;
                 }
+
+                // Recovery volumes repeat the index packets before the recovery
+                // data, so by the first RecvSlic we already hold every FileDesc
+                // the file contains. Used to recognize obfuscated recovery
+                // volumes whose NZB subjects do not match the vol regex.
+                if (stopAtRecoverySlice && packet is RecvSlic)
+                    break; // volumes duplicate index descriptors before recovery data
             }
 
             foreach (var fileDesc in fileDescs)
@@ -84,6 +92,9 @@ namespace NzbWebDAV.Par2Recovery
                     break;
                 case UniFileN.PacketType:
                     result = new UniFileN(header);
+                    break;
+                case RecvSlic.PacketType:
+                    result = new RecvSlic(header);
                     break;
                 default:
                     result = new Par2Packet(header);

--- a/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
@@ -43,6 +43,9 @@ public static class GetPar2FileDescriptorsStep
         // return all file descriptors, deduplicated by FileID
         var fileDescriptors = new List<FileDesc>();
         var seenFileIds = new HashSet<string>(StringComparer.Ordinal);
+        // Report a 0-100 percentage of index files processed so callers can
+        // scale it into their band without count/percentage mismatch.
+        var total = Math.Max(1, par2Indexes.Count);
         var completed = 0;
         foreach (var par2Index in par2Indexes)
         {
@@ -59,7 +62,7 @@ public static class GetPar2FileDescriptorsStep
                 if (seenFileIds.Add(Convert.ToHexString(fileDescriptor.FileID)))
                     fileDescriptors.Add(fileDescriptor);
             }
-            progress?.Report(++completed);
+            progress?.Report(++completed * 100 / total);
         }
 
         return fileDescriptors;

--- a/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
@@ -12,6 +12,7 @@ public static class GetPar2FileDescriptorsStep
     (
         List<FetchFirstSegmentsStep.NzbFileWithFirstSegment> files,
         INntpClient usenetClient,
+        IProgress<int>? progress = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -42,6 +43,7 @@ public static class GetPar2FileDescriptorsStep
         // return all file descriptors, deduplicated by FileID
         var fileDescriptors = new List<FileDesc>();
         var seenFileIds = new HashSet<string>(StringComparer.Ordinal);
+        var completed = 0;
         foreach (var par2Index in par2Indexes)
         {
             var segments = par2Index.NzbFile.GetSegmentIds();
@@ -49,11 +51,15 @@ public static class GetPar2FileDescriptorsStep
                 ? par2Index.Header!.PartOffset + par2Index.Header!.PartSize
                 : await usenetClient.GetFileSizeAsync(par2Index.NzbFile, cancellationToken).ConfigureAwait(false);
             await using var stream = usenetClient.GetFileStream(segments, filesize, articleBufferSize: 0);
-            await foreach (var fileDescriptor in Par2.ReadFileDescriptions(stream, cancellationToken).ConfigureAwait(false))
+            // stopAtRecoverySlice: volumes repeat the index packets before the
+            // recovery data, so the first RecvSlic ends descriptor extraction.
+            await foreach (var fileDescriptor in Par2.ReadFileDescriptions(stream, stopAtRecoverySlice: true, cancellationToken)
+                .ConfigureAwait(false))
             {
                 if (seenFileIds.Add(Convert.ToHexString(fileDescriptor.FileID)))
                     fileDescriptors.Add(fileDescriptor);
             }
+            progress?.Report(++completed);
         }
 
         return fileDescriptors;

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -40,9 +40,11 @@ public class QueueItemProcessor(
     IProgress<int> progress,
     ConcurrentDictionary<Guid, int> retryAttempts,
     SemaphoreSlim? finalizeLock,
-    CancellationToken ct
+    CancellationToken ct,
+    Action<string>? stageReporter = null
 )
 {
+    private readonly Action<string> _stageReporter = stageReporter ?? (_ => { });
     public QueueItemProcessor(
         QueueItem queueItem,
         Stream? queueNzbStream,
@@ -189,6 +191,7 @@ public class QueueItemProcessor(
 
     private async Task<T> RunStageAsync<T>(string stage, Func<Task<T>> action)
     {
+        _stageReporter(stage);
         using var stageCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         var stageTimer = Stopwatch.StartNew();
         var monitorTask = MonitorLongRunningStageAsync(stage, stageTimer, stageCts.Token);
@@ -289,10 +292,16 @@ public class QueueItemProcessor(
                 nzbFiles, usenetClient, configManager, ct, part1Progress)).ConfigureAwait(false);
         var msFirstSeg = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
+        // step 2 progress is split 50-55 (par2) / 55-60 (lazy-rar) / 60-100
+        // (processors) so the watchdog sees movement before the first file
+        // processor completes.
+        IProgress<int> par2Progress = progress
+            .Offset(50)
+            .Scale(5, 100);
         var par2FileDescriptors = await RunStageAsync(
             "par2",
             () => GetPar2FileDescriptorsStep.GetPar2FileDescriptors(
-                segments, usenetClient, ct)).ConfigureAwait(false);
+                segments, usenetClient, par2Progress, ct)).ConfigureAwait(false);
         var msPar2 = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
         var fileInfos = GetFileInfosStep.GetFileInfos(
@@ -337,8 +346,15 @@ public class QueueItemProcessor(
         if (configManager.IsLazyRarParsingEnabled() && rarFiles.Count > 0)
         {
             var lazyProc = new LazyRarProcessor(rarFiles, usenetClient, archivePassword, ct);
-            lazyRarResult = await RunStageAsync("lazy-rar", lazyProc.ProcessAsync)
-                .ConfigureAwait(false) as LazyRarProcessor.Result;
+            IProgress<int> lazyRarProgress = progress
+                .Offset(55)
+                .Scale(5, 100);
+            lazyRarResult = await RunStageAsync("lazy-rar", async () =>
+            {
+                var result = await lazyProc.ProcessAsync().ConfigureAwait(false);
+                lazyRarProgress.Report(100);
+                return result;
+            }).ConfigureAwait(false) as LazyRarProcessor.Result;
             // Nested archives need the full eager pass + NestedRarExpansionStep.
             if (lazyRarResult is not null &&
                 FilenameUtil.IsRarFile(Path.GetFileName(lazyRarResult.PathInArchive)))
@@ -354,8 +370,8 @@ public class QueueItemProcessor(
         var skipRarGroup = lazyRarResult is not null;
         var fileProcessors = GetFileProcessors(fileInfos, archivePassword, skipRarGroup).ToList();
         var part2Progress = progress
-            .Offset(50)
-            .Scale(50, 100)
+            .Offset(60)
+            .Scale(40, 100)
             .ToMultiProgress(fileProcessors.Count);
         var fileProcessingResults = await RunStageAsync("processors", async () =>
         {

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -769,14 +769,33 @@ public sealed class QueueManager : IDisposable
         var progressHook = new Progress<int>();
         var completionSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        var inProgressQueueItem = new InProgressQueueItem
+        {
+            QueueItem = queueItem,
+            ProcessingTask = null!, // set below, after the processor is created
+            CompletionSignal = completionSignal,
+            ProgressPercentage = 0,
+            CancellationTokenSource = cts,
+            QueueDownloadContext = queueDownloadContext,
+            QueueContextRegistration = queueContextRegistration,
+            DbContext = dbContext,
+            QueueNzbStream = queueNzbStream,
+            CachingUsenetClient = cachingUsenetClient,
+            StartedAt = DateTime.UtcNow,
+            WatchdogCts = null!, // set below, after the worker task is created
+        };
+
         var task = new QueueItemProcessor(
             queueItem, queueNzbStream, dbClient, cachingUsenetClient,
             _configManager, _websocketManager, _providerUsageTracker,
             _watchdogLog, _sourceTracker, progressHook, _retryAttempts,
-            _finalizeLock, cts.Token
+            _finalizeLock, cts.Token,
+            stageReporter: stage => inProgressQueueItem.CurrentStage = stage
         ).ProcessAsync();
+        inProgressQueueItem.ProcessingTask = task;
 
         var watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        inProgressQueueItem.WatchdogCts = watchdogCts;
 
         _ = task.ContinueWith(
             t =>
@@ -793,21 +812,6 @@ public sealed class QueueManager : IDisposable
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
 
-        var inProgressQueueItem = new InProgressQueueItem
-        {
-            QueueItem = queueItem,
-            ProcessingTask = task,
-            CompletionSignal = completionSignal,
-            ProgressPercentage = 0,
-            CancellationTokenSource = cts,
-            QueueDownloadContext = queueDownloadContext,
-            QueueContextRegistration = queueContextRegistration,
-            DbContext = dbContext,
-            QueueNzbStream = queueNzbStream,
-            CachingUsenetClient = cachingUsenetClient,
-            StartedAt = DateTime.UtcNow,
-            WatchdogCts = watchdogCts,
-        };
         inProgressQueueItem.WatchdogTask =
             WatchForStuckProgressAsync(inProgressQueueItem, watchdogCts.Token);
 
@@ -856,6 +860,7 @@ public sealed class QueueManager : IDisposable
     private async Task WatchForStuckProgressAsync(InProgressQueueItem item, CancellationToken ct)
     {
         var lastProgress = item.ProgressPercentage;
+        var lastFetchCount = GetSuccessfulFetchCount(item.QueueItem.Id);
         var lastChangeTick = Environment.TickCount64;
 
         while (!ct.IsCancellationRequested)
@@ -869,10 +874,16 @@ public sealed class QueueManager : IDisposable
                 return;
             }
 
+            // "Stuck" means no visible progress AND no segment fetches. Long
+            // silent stages (PAR2 descriptor walks, RAR header parses) keep
+            // fetching articles, so they must not trip the watchdog — only a
+            // worker genuinely waiting on a semaphore/pool fetch stops both.
             var currentProgress = item.ProgressPercentage;
-            if (currentProgress != lastProgress)
+            var currentFetchCount = GetSuccessfulFetchCount(item.QueueItem.Id);
+            if (currentProgress != lastProgress || currentFetchCount != lastFetchCount)
             {
                 lastProgress = currentProgress;
+                lastFetchCount = currentFetchCount;
                 lastChangeTick = Environment.TickCount64;
                 continue;
             }
@@ -886,12 +897,19 @@ public sealed class QueueManager : IDisposable
         }
     }
 
+    private long GetSuccessfulFetchCount(Guid queueItemId)
+    {
+        var snapshot = _providerUsageTracker.Snapshot(queueItemId);
+        return snapshot.Values.Aggregate(0L, (sum, count) => sum + count);
+    }
+
     private async Task HandleStuckItemAsync(InProgressQueueItem item, long idleMs)
     {
         var queueItem = item.QueueItem;
         var progress = item.ProgressPercentage;
         var idleMinutes = idleMs / 60000d;
         var phase = DescribeProgressPhase(progress);
+        var stage = item.CurrentStage;
 #pragma warning disable CA5394 // pause jitter is not security-sensitive
         var jitterSeconds = Random.Shared.Next(0, 301);
 #pragma warning restore CA5394
@@ -926,12 +944,13 @@ public sealed class QueueManager : IDisposable
 
         Log.Warning(
             "Queue item stuck with no progress; pausing and cancelling. JobName={JobName} QueueItemId={QueueItemId} " +
-            "IdleMinutes={IdleMinutes:F1} ProgressPhase={ProgressPhase} ProgressPercentage={ProgressPercentage} " +
-            "PauseUntil={PauseUntil}",
+            "IdleMinutes={IdleMinutes:F1} ProgressPhase={ProgressPhase} CurrentStage={CurrentStage} " +
+            "ProgressPercentage={ProgressPercentage} PauseUntil={PauseUntil}",
             queueItem.JobName,
             queueItem.Id,
             idleMinutes,
             phase,
+            stage,
             progress,
             pauseUntil);
 
@@ -1059,7 +1078,13 @@ public sealed class QueueManager : IDisposable
     {
         public QueueItem QueueItem { get; init; } = null!;
         public int ProgressPercentage { get; set; }
-        public Task ProcessingTask { get; init; } = null!;
+
+        /// <summary>
+        /// Name of the queue stage currently executing (e.g. par2, lazy-rar,
+        /// processors). Set by the processor; read by the stuck watchdog.
+        /// </summary>
+        public string CurrentStage { get; set; } = string.Empty;
+        public Task ProcessingTask { get; set; } = null!;
         public TaskCompletionSource CompletionSignal { get; init; } = null!;
         public CancellationTokenSource CancellationTokenSource { get; init; } = null!;
         public QueueDownloadContext QueueDownloadContext { get; init; } = null!;
@@ -1068,7 +1093,7 @@ public sealed class QueueManager : IDisposable
         public Stream? QueueNzbStream { get; init; }
         public ArticleCachingNntpClient CachingUsenetClient { get; init; } = null!;
         public DateTime StartedAt { get; init; }
-        public CancellationTokenSource WatchdogCts { get; init; } = null!;
+        public CancellationTokenSource WatchdogCts { get; set; } = null!;
         public Task WatchdogTask { get; set; } = Task.CompletedTask;
         public bool IsPrimary => QueueDownloadContext.IsPrimary;
 

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2TestPackets.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2TestPackets.cs
@@ -31,6 +31,17 @@ internal static class Par2TestPackets
         return stream.ToArray();
     }
 
+    internal static byte[] BuildRecoveryVolumeBytes(
+        byte[][] fileDescBodies,
+        int recoverySliceBodyLength)
+    {
+        using var stream = new MemoryStream();
+        foreach (var body in fileDescBodies)
+            WritePacket(stream, FileDesc.PacketType, body);
+        WritePacket(stream, RecvSlic.PacketType, new byte[recoverySliceBodyLength]);
+        return stream.ToArray();
+    }
+
     internal static async Task<List<FileDesc>> ReadFileDescsAsync(byte[] par2Bytes)
     {
         var descriptors = new List<FileDesc>();

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2Tests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2Tests.cs
@@ -94,6 +94,68 @@ public class Par2Tests
         Assert.Equal("keep-me.mkv", Assert.Single(descriptions).FileName);
     }
 
+    [Fact]
+    public async Task ReadFileDescriptions_SkipsRecoverySliceBodiesWithoutReadingThem()
+    {
+        var fileId = Enumerable.Repeat((byte)0x33, 16).ToArray();
+        var hugeRecoveryBody = new byte[5 * 1024 * 1024]; // 5 MiB RecvSlic payload
+        Array.Fill(hugeRecoveryBody, (byte)0xAB);
+
+        await using var stream = new ReadTrackingMemoryStream();
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(fileId, "episode.mkv"));
+        WritePacket(stream, RecvSlic.PacketType, hugeRecoveryBody);
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(
+            Enumerable.Repeat((byte)0x44, 16).ToArray(), "trailing.mkv"));
+        stream.Position = 0;
+
+        var descriptions = new List<FileDesc>();
+        await foreach (var description in Par2.ReadFileDescriptions(stream))
+            descriptions.Add(description);
+
+        Assert.Equal(2, descriptions.Count);
+        // The 5 MiB RecvSlic body must be skipped via Seek, not read into memory.
+        Assert.True(stream.TotalBytesRead < hugeRecoveryBody.Length,
+            $"Expected recovery body to be seeked past, but {stream.TotalBytesRead} bytes were read");
+    }
+
+    [Fact]
+    public async Task ReadFileDescriptions_StopAtRecoverySlice_EndsAtFirstRecoverySlice()
+    {
+        var fileId = Enumerable.Repeat((byte)0x55, 16).ToArray();
+
+        await using var stream = new MemoryStream();
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(fileId, "episode.mkv"));
+        WritePacket(stream, RecvSlic.PacketType, new byte[64]);
+        WritePacket(stream, FileDesc.PacketType, BuildFileDescBody(
+            Enumerable.Repeat((byte)0x66, 16).ToArray(), "should-not-be-read.mkv"));
+        stream.Position = 0;
+
+        var descriptions = new List<FileDesc>();
+        await foreach (var description in Par2.ReadFileDescriptions(stream, stopAtRecoverySlice: true))
+            descriptions.Add(description);
+
+        Assert.Equal("episode.mkv", Assert.Single(descriptions).FileName);
+    }
+
+    private sealed class ReadTrackingMemoryStream : MemoryStream
+    {
+        public long TotalBytesRead { get; private set; }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            TotalBytesRead += read;
+            return read;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = base.Read(buffer, offset, count);
+            TotalBytesRead += read;
+            return read;
+        }
+    }
+
     private static byte[] BuildFileDescBody(byte[] fileId, string fileName)
     {
         var nameBytes = Encoding.UTF8.GetBytes(fileName);

--- a/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
@@ -50,6 +50,38 @@ public class GetPar2FileDescriptorsStepTests
     }
 
     [Fact]
+    public async Task GetPar2FileDescriptors_ReportsProgressAsZeroToHundredPercentage()
+    {
+        var idA = FileId(0x0A);
+        var idB = FileId(0x0B);
+        var indexA = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(idA, "Show.S01E01.mkv"));
+        var indexB = Par2TestPackets.BuildPar2Bytes(Par2TestPackets.BuildFileDescBody(idB, "Show.S01E02.mkv"));
+
+        using var client = new Par2ServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["index-a@example.com"] = indexA,
+            ["index-b@example.com"] = indexB,
+        });
+
+        var files = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            Par2File("Release [AAAAAAAA].par2", "index-a@example.com", indexA),
+            Par2File("Release [BBBBBBBB].par2", "index-b@example.com", indexB),
+        };
+
+        // Progress<int>.Report posts to the captured context asynchronously,
+        // so guard the list and give callbacks a beat to drain.
+        var reported = new List<int>();
+        var gate = new object();
+        var progress = new Progress<int>(v => { lock (gate) reported.Add(v); });
+        await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client, progress);
+        await Task.Delay(50);
+
+        // Two index files → 50 then 100, not raw counts 1 then 2.
+        lock (gate) Assert.Equal([50, 100], reported);
+    }
+
+    [Fact]
     public async Task GetPar2FileDescriptors_FallsBackToVolumeWhenNoIndexIdentifiable()
     {
         var idVol = FileId(0x0C);

--- a/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
@@ -73,6 +73,38 @@ public class GetPar2FileDescriptorsStepTests
     }
 
     [Fact]
+    public async Task GetPar2FileDescriptors_ObfuscatedRecoveryVolume_DoesNotDownloadRecoveryData()
+    {
+        // Obfuscated releases use hashed subjects with no ".volNN+MM.par2"
+        // suffix, so recovery volumes are not filtered out by name. The step
+        // must still stop at the first recovery slice instead of streaming
+        // the whole volume through the descriptor walker.
+        var idVol = FileId(0x0C);
+        const int recoveryBodyBytes = 4 * 1024 * 1024; // 4 MiB RecvSlic payload
+        var vol = Par2TestPackets.BuildRecoveryVolumeBytes(
+            [Par2TestPackets.BuildFileDescBody(idVol, "movie.mkv")],
+            recoveryBodyBytes);
+
+        using var client = new Par2ServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["vol@example.com"] = vol,
+        });
+
+        var files = new List<FetchFirstSegmentsStep.NzbFileWithFirstSegment>
+        {
+            VideoFile("Release [AAAAAAAA].mkv", "video-a@example.com"),
+            Par2File("deadbeef0123.par2", "vol@example.com", vol),
+        };
+
+        var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
+
+        var descriptor = Assert.Single(descriptors);
+        Assert.Equal("movie.mkv", descriptor.FileName);
+        Assert.True(client.TotalBytesRead < recoveryBodyBytes,
+            $"Expected recovery body to be skipped, but {client.TotalBytesRead} bytes were read");
+    }
+
+    [Fact]
     public async Task GetPar2FileDescriptors_DedupesDescriptorsByFileId()
     {
         var id = FileId(0x0A);
@@ -161,6 +193,7 @@ public class GetPar2FileDescriptorsStepTests
     private sealed class Par2ServingNntpClient(IReadOnlyDictionary<string, byte[]> segments) : NntpClient
     {
         public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
+        public long TotalBytesRead => ReadCountingStream.TotalBytesRead;
 
         public override Task ConnectAsync(
             string host, int port, bool useSsl, CancellationToken cancellationToken) =>
@@ -209,8 +242,30 @@ public class GetPar2FileDescriptorsStepTests
                 SegmentId = key,
                 ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
                 ResponseMessage = "222 body",
-                Stream = new CachedYencStream(headers, new MemoryStream(bytes, writable: false)),
+                Stream = new CachedYencStream(headers, new ReadCountingStream(bytes)),
             });
+        }
+
+        private sealed class ReadCountingStream : MemoryStream
+        {
+            public static long TotalBytesRead => _totalBytesRead;
+            private static long _totalBytesRead;
+
+            public ReadCountingStream(byte[] bytes) : base(bytes, writable: false) { }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                var read = await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                Interlocked.Add(ref _totalBytesRead, read);
+                return read;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var read = base.Read(buffer, offset, count);
+                Interlocked.Add(ref _totalBytesRead, read);
+                return read;
+            }
         }
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(

--- a/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
@@ -192,8 +192,11 @@ public class GetPar2FileDescriptorsStepTests
     /// </summary>
     private sealed class Par2ServingNntpClient(IReadOnlyDictionary<string, byte[]> segments) : NntpClient
     {
+        private long _totalBytesRead;
         public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
-        public long TotalBytesRead => ReadCountingStream.TotalBytesRead;
+        public long TotalBytesRead => Interlocked.Read(ref _totalBytesRead);
+
+        private long AddBytesRead(int read) => Interlocked.Add(ref _totalBytesRead, read);
 
         public override Task ConnectAsync(
             string host, int port, bool useSsl, CancellationToken cancellationToken) =>
@@ -242,28 +245,23 @@ public class GetPar2FileDescriptorsStepTests
                 SegmentId = key,
                 ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
                 ResponseMessage = "222 body",
-                Stream = new CachedYencStream(headers, new ReadCountingStream(bytes)),
+                Stream = new CachedYencStream(headers, new ReadCountingStream(bytes, AddBytesRead)),
             });
         }
 
-        private sealed class ReadCountingStream : MemoryStream
+        private sealed class ReadCountingStream(byte[] bytes, Func<int, long> onRead) : MemoryStream(bytes, writable: false)
         {
-            public static long TotalBytesRead => _totalBytesRead;
-            private static long _totalBytesRead;
-
-            public ReadCountingStream(byte[] bytes) : base(bytes, writable: false) { }
-
             public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
             {
                 var read = await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-                Interlocked.Add(ref _totalBytesRead, read);
+                onRead(read);
                 return read;
             }
 
             public override int Read(byte[] buffer, int offset, int count)
             {
                 var read = base.Read(buffer, offset, count);
-                Interlocked.Add(ref _totalBytesRead, read);
+                onRead(read);
                 return read;
             }
         }

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -26,6 +26,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
     private DbContextOptions<DavDatabaseContext> _options = null!;
     private ConfigManager _configManager = null!;
     private QueueManager _queueManager = null!;
+    private ProviderUsageTracker _queueManagerUsageTracker = null!;
 
     public async Task InitializeAsync()
     {
@@ -81,11 +82,12 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             new StreamTraceBuffer(100),
             new ActiveReadRegistry());
 
+        _queueManagerUsageTracker = new ProviderUsageTracker();
         _queueManager = new QueueManager(
             usenet,
             _configManager,
             new WebsocketManager(),
-            new ProviderUsageTracker(),
+            _queueManagerUsageTracker,
             new WatchdogLog(),
             new QueueItemSourceTracker(),
             new BenchmarkGate(),
@@ -251,6 +253,141 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task FetchingButSilentItem_IsNotCancelledByWatchdog()
+    {
+        // A long stage (e.g. a large PAR2 descriptor walk) reports no progress
+        // but keeps fetching articles. The watchdog must treat segment fetches
+        // as liveness and leave the worker alone.
+        var stall = new StallStream();
+        var item = CreateQueueItem("fetching.nzb", "movies", "FetchingJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, stall);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        object? inProgress = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            inProgress = FindInProgressItem(item.Id);
+            if (inProgress is not null) break;
+            await Task.Delay(20);
+        }
+
+        Assert.NotNull(inProgress);
+        stall.BindWorker(GetWorkerCts(inProgress!));
+
+        // Freeze the percentage but keep recording segment fetches for this
+        // queue item, mimicking a silent-but-working stage.
+        using var fetchCts = new CancellationTokenSource();
+        var fetchTask = Task.Run(async () =>
+        {
+            while (!fetchCts.Token.IsCancellationRequested)
+            {
+                RecordSegmentFetch(item.Id);
+                await Task.Delay(60, fetchCts.Token);
+            }
+        }, fetchCts.Token);
+
+        // Well past the 250ms threshold with zero percentage movement.
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        Assert.False(GetWorkerCts(inProgress!).IsCancellationRequested);
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            var pauseUntil = await ctx.QueueItems.AsNoTracking()
+                .Where(q => q.Id == item.Id)
+                .Select(q => q.PauseUntil)
+                .FirstAsync();
+            Assert.Null(pauseUntil);
+        }
+
+        await fetchCts.CancelAsync();
+        try { await fetchTask; }
+        catch (OperationCanceledException) { }
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task SilentAndIdleItem_IsCancelledByWatchdog()
+    {
+        // Neither progress nor segment fetches: a genuinely wedged worker.
+        var stall = new StallStream();
+        var item = CreateQueueItem("idle.nzb", "movies", "IdleJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, stall);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        object? inProgress = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            inProgress = FindInProgressItem(item.Id);
+            if (inProgress is not null) break;
+            await Task.Delay(20);
+        }
+
+        Assert.NotNull(inProgress);
+        stall.BindWorker(GetWorkerCts(inProgress!));
+
+        // No progress, no fetches — the watchdog should still pause+cancel.
+        // PauseUntil is written before CancelAsync, so poll for cancellation
+        // (the terminal action) rather than asserting both after one observation.
+        deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        var workerCts = GetWorkerCts(inProgress!);
+        while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
+            await Task.Delay(20);
+
+        Assert.True(workerCts.IsCancellationRequested);
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            var pauseUntil = await ctx.QueueItems.AsNoTracking()
+                .Where(q => q.Id == item.Id)
+                .Select(q => q.PauseUntil)
+                .FirstOrDefaultAsync();
+            Assert.NotNull(pauseUntil);
+        }
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task HealthyItems_DoNotWaitForWatchdogThreshold()
     {
         var item1 = CreateQueueItem("fast1.nzb", "movies", "FastJob1");
@@ -338,6 +475,12 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             "ProgressPercentage",
             BindingFlags.Instance | BindingFlags.Public);
         prop!.SetValue(inProgressItem, value);
+    }
+
+    private void RecordSegmentFetch(Guid queueItemId)
+    {
+        using var scope = _queueManagerUsageTracker.BeginScope(queueItemId);
+        _queueManagerUsageTracker.RecordSuccess("nntp.example");
     }
 
     private static QueueItem CreateQueueItem(string fileName, string category, string jobName)

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -320,7 +320,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
 
         await fetchCts.CancelAsync();
         try { await fetchTask; }
-        catch (OperationCanceledException) { }
+        catch (OperationCanceledException) { /* expected: fetch loop cancelled */ }
 
         await cts.CancelAsync();
         await loop.WaitAsync(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
## Summary

Queue items on 1.1.0-rc builds stall at exactly **50%** in `file processing`, get paused and cancelled by the stuck watchdog after 5 idle minutes, then re-stall on every retry. This PR fixes the root cause and hardens the watchdog.

**Root cause (two rc.1 changes interacting):**

1. **#941 (multi-PAR2-index merge)** walks every PAR2-magic file whose NZB *subject* doesn't literally match `.volNN+MM.par2`. Obfuscated releases use hashed subjects, so recovery volumes are misclassified as index files and walked end-to-end.
2. **`Par2Packet.ReadAsync`** downloaded the full body of every packet — including multi-hundred-MB RecvSlic recovery payloads — through an unbuffered stream. Walking a 500 MB volume meant downloading 500 MB at the 50% mark with zero progress, tripping the new stuck watchdog (#934).

**Changes:**

- **PAR2 reader:** seek past non-descriptor packet bodies instead of reading them; stop the descriptor walk at the first recovery slice (volumes duplicate the index's descriptors).
- **Stuck watchdog:** treat live segment fetches (via `ProviderUsageTracker`) as liveness, not just integer percentage movement — a worker that's still downloading isn't stuck. Include the current stage name in the stuck warning.
- **Progress UX:** report PAR2/lazy-RAR progress in the 50–60 band; fix `MultiProgress` truncation so the first completion of >50 processors still bumps the displayed percentage.

Fixes #969

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2672 passed, 0 failed
- [x] `dotnet test tests/SharpCompress.Tests/SharpCompress.Tests.csproj -c Release --filter "format!=stress"` — 2125 passed
- [x] New: RecvSlic bodies are seeked past (bytes-read assertion), descriptor walk stops at first recovery slice, obfuscated volume no longer fully downloaded
- [x] New watchdog tests: fetching-but-silent item is **not** cancelled; truly idle item **is** (ran 3× for stability)
- [ ] Manual: import an obfuscated multi-volume release and confirm it passes 50% promptly