### PR TITLE
fix(ui): show the real error instead of looping "Connecting to InfiniDysk" when a page fails to load

### DIFF
--- a/frontend/app/components/migration-progress.test.ts
+++ b/frontend/app/components/migration-progress.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  clearMigrationObserved,
   clearReloadAttempts,
   decideMigrationStatusPoll,
   MAX_RELOAD_ATTEMPTS,
+  readMigrationObserved,
   readReloadAttempts,
+  writeMigrationObserved,
   writeReloadAttempts,
 } from "./migration-progress";
 
@@ -86,6 +89,13 @@ describe("decideMigrationStatusPoll", () => {
     });
   });
 
+  it("keeps reloading on 404 after migration has been observed", () => {
+    expect(decideMigrationStatusPoll(404, null, MAX_RELOAD_ATTEMPTS, true)).toEqual({
+      action: "connecting",
+      reloadMs: 1500,
+    });
+  });
+
   it("treats 502/503 as connecting with a longer reload", () => {
     expect(decideMigrationStatusPoll(502, null)).toEqual({
       action: "connecting",
@@ -145,5 +155,15 @@ describe("reload attempt storage", () => {
     writeReloadAttempts(storage, 2, now);
     clearReloadAttempts(storage);
     expect(readReloadAttempts(storage, now)).toBe(0);
+  });
+
+  it("persists migration observed across reloads", () => {
+    const storage = createMemoryStorage();
+
+    expect(readMigrationObserved(storage)).toBe(false);
+    writeMigrationObserved(storage);
+    expect(readMigrationObserved(storage)).toBe(true);
+    clearMigrationObserved(storage);
+    expect(readMigrationObserved(storage)).toBe(false);
   });
 });

--- a/frontend/app/components/migration-progress.test.ts
+++ b/frontend/app/components/migration-progress.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { decideMigrationStatusPoll } from "./migration-progress";
+import {
+  clearReloadAttempts,
+  decideMigrationStatusPoll,
+  MAX_RELOAD_ATTEMPTS,
+  readReloadAttempts,
+  writeReloadAttempts,
+} from "./migration-progress";
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
 
 describe("decideMigrationStatusPoll", () => {
   it("keeps polling while migration JSON is running", () => {
@@ -45,6 +75,17 @@ describe("decideMigrationStatusPoll", () => {
     });
   });
 
+  it("keeps reloading on 404 until the attempt cap is reached", () => {
+    expect(decideMigrationStatusPoll(404, null, MAX_RELOAD_ATTEMPTS - 1)).toEqual({
+      action: "connecting",
+      reloadMs: 1500,
+    });
+    expect(decideMigrationStatusPoll(404, null, MAX_RELOAD_ATTEMPTS)).toEqual({
+      action: "fallback",
+      stopPolling: true,
+    });
+  });
+
   it("treats 502/503 as connecting with a longer reload", () => {
     expect(decideMigrationStatusPoll(502, null)).toEqual({
       action: "connecting",
@@ -65,5 +106,44 @@ describe("decideMigrationStatusPoll", () => {
       action: "fallback",
       stopPolling: true,
     });
+  });
+});
+
+describe("reload attempt storage", () => {
+  it("returns 0 when storage is empty or corrupt", () => {
+    const storage = createMemoryStorage();
+    expect(readReloadAttempts(storage, 1_000)).toBe(0);
+
+    storage.setItem("infinidysk.migration-reload-attempts", "{not-json");
+    expect(readReloadAttempts(storage, 1_000)).toBe(0);
+
+    storage.setItem("infinidysk.migration-reload-attempts", JSON.stringify({ count: "bad", lastAt: 1 }));
+    expect(readReloadAttempts(storage, 1_000)).toBe(0);
+  });
+
+  it("reads and writes reload attempts", () => {
+    const storage = createMemoryStorage();
+    const now = 10_000;
+
+    writeReloadAttempts(storage, 2, now);
+    expect(readReloadAttempts(storage, now)).toBe(2);
+    expect(readReloadAttempts(storage, now + 30_000)).toBe(2);
+  });
+
+  it("expires stale reload attempts after the reset window", () => {
+    const storage = createMemoryStorage();
+    const now = 10_000;
+
+    writeReloadAttempts(storage, 2, now);
+    expect(readReloadAttempts(storage, now + 2 * 60 * 1000 + 1)).toBe(0);
+  });
+
+  it("clears stored reload attempts", () => {
+    const storage = createMemoryStorage();
+    const now = 10_000;
+
+    writeReloadAttempts(storage, 2, now);
+    clearReloadAttempts(storage);
+    expect(readReloadAttempts(storage, now)).toBe(0);
   });
 });

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -36,6 +36,7 @@ export type MigrationPollDecision =
 export const MAX_RELOAD_ATTEMPTS = 3;
 
 const RELOAD_KEY = "infinidysk.migration-reload-attempts";
+const MIGRATION_OBSERVED_KEY = "infinidysk.migration-observed";
 const RESET_AFTER_MS = 2 * 60 * 1000;
 
 type ReloadAttemptState = {
@@ -72,11 +73,24 @@ export function clearReloadAttempts(storage: Storage): void {
   storage.removeItem(RELOAD_KEY);
 }
 
+export function readMigrationObserved(storage: Storage): boolean {
+  return storage.getItem(MIGRATION_OBSERVED_KEY) === "1";
+}
+
+export function writeMigrationObserved(storage: Storage): void {
+  storage.setItem(MIGRATION_OBSERVED_KEY, "1");
+}
+
+export function clearMigrationObserved(storage: Storage): void {
+  storage.removeItem(MIGRATION_OBSERVED_KEY);
+}
+
 /** Pure decision helper for MigrationBoundary polling (testable without React). */
 export function decideMigrationStatusPoll(
   httpStatus: number,
   body: unknown,
   reloadAttempts = 0,
+  seenMigration = false,
 ): MigrationPollDecision {
   if (httpStatus >= 200 && httpStatus < 300) {
     if (isMigrationStatus(body)) {
@@ -88,6 +102,9 @@ export function decideMigrationStatusPoll(
   }
 
   if (httpStatus === 404) {
+    if (seenMigration) {
+      return { action: "connecting", reloadMs: 1500 };
+    }
     return reloadAttempts >= MAX_RELOAD_ATTEMPTS
       ? { action: "fallback", stopPolling: true }
       : { action: "connecting", reloadMs: 1500 };
@@ -164,16 +181,21 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
         if (cancelled) return;
 
         let reloadAttempts = 0;
+        let migrationObserved = false;
         try {
           reloadAttempts = readReloadAttempts(window.sessionStorage, Date.now());
+          migrationObserved = readMigrationObserved(window.sessionStorage);
         } catch {
           reloadAttempts = 0;
+          migrationObserved = false;
         }
 
-        const decision = decideMigrationStatusPoll(res.status, body, reloadAttempts);
+        const hasSeenMigration = seenMigration.current || migrationObserved;
+        const decision = decideMigrationStatusPoll(res.status, body, reloadAttempts, hasSeenMigration);
         if (decision.action === "migrating") {
           try {
             clearReloadAttempts(window.sessionStorage);
+            writeMigrationObserved(window.sessionStorage);
           } catch {
             // Ignore storage failures in private browsing modes.
           }
@@ -186,7 +208,7 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
 
         if (decision.action === "connecting") {
           setPhase("connecting");
-          if (res.status === 404) {
+          if (res.status === 404 && !hasSeenMigration) {
             try {
               writeReloadAttempts(window.sessionStorage, reloadAttempts + 1, Date.now());
             } catch {
@@ -199,6 +221,7 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
 
         try {
           clearReloadAttempts(window.sessionStorage);
+          clearMigrationObserved(window.sessionStorage);
         } catch {
           // Ignore storage failures in private browsing modes.
         }

--- a/frontend/app/components/migration-progress.tsx
+++ b/frontend/app/components/migration-progress.tsx
@@ -33,10 +33,50 @@ export type MigrationPollDecision =
   | { action: "connecting"; reloadMs: number }
   | { action: "fallback"; stopPolling: true };
 
+export const MAX_RELOAD_ATTEMPTS = 3;
+
+const RELOAD_KEY = "infinidysk.migration-reload-attempts";
+const RESET_AFTER_MS = 2 * 60 * 1000;
+
+type ReloadAttemptState = {
+  count: number;
+  lastAt: number;
+};
+
+function isReloadAttemptState(value: unknown): value is ReloadAttemptState {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v["count"] === "number" && typeof v["lastAt"] === "number";
+}
+
+export function readReloadAttempts(storage: Storage, now: number): number {
+  const raw = storage.getItem(RELOAD_KEY);
+  if (!raw) return 0;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isReloadAttemptState(parsed)) return 0;
+    if (now - parsed.lastAt > RESET_AFTER_MS) return 0;
+    return parsed.count;
+  } catch {
+    return 0;
+  }
+}
+
+export function writeReloadAttempts(storage: Storage, count: number, now: number): void {
+  const state: ReloadAttemptState = { count, lastAt: now };
+  storage.setItem(RELOAD_KEY, JSON.stringify(state));
+}
+
+export function clearReloadAttempts(storage: Storage): void {
+  storage.removeItem(RELOAD_KEY);
+}
+
 /** Pure decision helper for MigrationBoundary polling (testable without React). */
 export function decideMigrationStatusPoll(
   httpStatus: number,
   body: unknown,
+  reloadAttempts = 0,
 ): MigrationPollDecision {
   if (httpStatus >= 200 && httpStatus < 300) {
     if (isMigrationStatus(body)) {
@@ -48,7 +88,9 @@ export function decideMigrationStatusPoll(
   }
 
   if (httpStatus === 404) {
-    return { action: "connecting", reloadMs: 1500 };
+    return reloadAttempts >= MAX_RELOAD_ATTEMPTS
+      ? { action: "fallback", stopPolling: true }
+      : { action: "connecting", reloadMs: 1500 };
   }
 
   if (httpStatus === 502 || httpStatus === 503) {
@@ -121,8 +163,20 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
         const body: unknown = res.ok ? await res.json().catch(() => null) : null;
         if (cancelled) return;
 
-        const decision = decideMigrationStatusPoll(res.status, body);
+        let reloadAttempts = 0;
+        try {
+          reloadAttempts = readReloadAttempts(window.sessionStorage, Date.now());
+        } catch {
+          reloadAttempts = 0;
+        }
+
+        const decision = decideMigrationStatusPoll(res.status, body, reloadAttempts);
         if (decision.action === "migrating") {
+          try {
+            clearReloadAttempts(window.sessionStorage);
+          } catch {
+            // Ignore storage failures in private browsing modes.
+          }
           seenMigration.current = true;
           setStatus(decision.status);
           setPhase("migrating");
@@ -132,10 +186,22 @@ export function MigrationBoundary({ fallback }: { fallback: FallbackProps }) {
 
         if (decision.action === "connecting") {
           setPhase("connecting");
+          if (res.status === 404) {
+            try {
+              writeReloadAttempts(window.sessionStorage, reloadAttempts + 1, Date.now());
+            } catch {
+              // Ignore storage failures in private browsing modes.
+            }
+          }
           scheduleReloadAndStop(decision.reloadMs);
           return;
         }
 
+        try {
+          clearReloadAttempts(window.sessionStorage);
+        } catch {
+          // Ignore storage failures in private browsing modes.
+        }
         setPhase("fallback");
         stopPolling();
       } catch {


### PR DESCRIPTION
## Summary

- Cap consecutive `/api/migration-status` 404-triggered reloads in `MigrationBoundary` so persistent SSR errors stop looping on the startup screen and render the real error card instead.
- Persist the attempt counter in `sessionStorage` (with a 2-minute expiry) so it survives page reloads but resets after a successful load or observed migration.
- Preserve the migration handoff happy path: counters are cleared when migration JSON is observed, so post-migration 404s still reload normally.

Fixes #971.

The underlying `/queue` 500 from an empty manual category is tracked separately in #970.

## Test plan

- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test -- migration-progress.test.ts`
- [ ] Manual: trigger a persistent SSR error (e.g. #970 repro) and confirm the fallback error card appears after ~3 reload cycles instead of looping forever
- [ ] Manual: confirm database migration startup still reloads through the 404 handoff after an upgrade