### PR TITLE
fix(queue): mount every episode from season packs of split video files

### DIFF
--- a/backend/Queue/FileProcessors/MultipartMkvProcessor.cs
+++ b/backend/Queue/FileProcessors/MultipartMkvProcessor.cs
@@ -1,9 +1,10 @@
-﻿using System.Text.RegularExpressions;
-using NzbWebDAV.Clients.Usenet;
+﻿using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Utils;
+using Serilog;
 
 namespace NzbWebDAV.Queue.FileProcessors;
 
@@ -27,7 +28,24 @@ public class MultipartMkvProcessor : BaseProcessor
 
     public override async Task<BaseProcessor.Result?> ProcessAsync()
     {
-        var sortedFileInfos = _fileInfos.OrderBy(f => GetPartNumber(f.FileName)).ToList();
+        var sortedFileInfos = _fileInfos
+            .OrderBy(f => FilenameUtil.GetSplitVideoPartNumber(f.FileName) ?? int.MaxValue)
+            .ToList();
+
+        var partNumbers = sortedFileInfos
+            .Select(f => FilenameUtil.GetSplitVideoPartNumber(f.FileName))
+            .ToList();
+        if (partNumbers.Any(n => n is null)
+            || partNumbers[0] != 1
+            || partNumbers.Select((n, i) => n == i + 1).Any(ok => !ok))
+        {
+            Log.Warning(
+                "Split video set `{FileName}` has non-contiguous part numbers ({Parts}); mounting anyway",
+                FilenameUtil.GetSplitVideoBaseName(sortedFileInfos.First().FileName)
+                    ?? sortedFileInfos.First().FileName,
+                string.Join(",", partNumbers.Select(n => n?.ToString() ?? "?")));
+        }
+
         var fileParts = new List<DavMultipartFile.FilePart>();
         foreach (var fileInfo in sortedFileInfos)
         {
@@ -52,22 +70,11 @@ public class MultipartMkvProcessor : BaseProcessor
 
         return new Result
         {
-            Filename = GetBaseName(sortedFileInfos.First().FileName),
+            Filename = FilenameUtil.GetSplitVideoBaseName(sortedFileInfos.First().FileName)
+                       ?? sortedFileInfos.First().FileName,
             Parts = fileParts,
             ReleaseDate = sortedFileInfos.First().ReleaseDate,
         };
-    }
-
-    private static string GetBaseName(string filename)
-    {
-        var extensionIndex = filename.LastIndexOf(".mkv", StringComparison.Ordinal);
-        return filename[..(extensionIndex + 4)];
-    }
-
-    private static int GetPartNumber(string filename)
-    {
-        var match = Regex.Match(filename, @"\.mkv\.(\d+)?$", RegexOptions.IgnoreCase);
-        return string.IsNullOrEmpty(match.Groups[1].Value) ? -1 : int.Parse(match.Groups[1].Value);
     }
 
     public new class Result : BaseProcessor.Result

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -452,8 +452,7 @@ public class QueueItemProcessor(
         bool skipRarGroup = false
     )
     {
-        var groups = fileInfos
-            .GroupBy(GetGroupName);
+        var groups = GroupFilesForProcessing(fileInfos);
 
         foreach (var group in groups)
         {
@@ -467,7 +466,7 @@ public class QueueItemProcessor(
                     yield return new RarProcessor(fileInfo, usenetClient, archivePassword, ct);
             }
 
-            else if (group.Key == "multipart-mkv")
+            else if (group.Key.StartsWith("split-video:", StringComparison.Ordinal))
                 yield return new MultipartMkvProcessor(group.ToList(), usenetClient, ct);
 
             else if (group.Key == "other")
@@ -476,11 +475,82 @@ public class QueueItemProcessor(
         }
     }
 
-    private static string GetGroupName(GetFileInfosStep.FileInfo x) =>
+    internal static string GetGroupName(GetFileInfosStep.FileInfo x) =>
         FilenameUtil.Is7zFile(x.FileName) ? "7z"
         : x.IsRar || FilenameUtil.IsRarFile(x.FileName) ? "rar"
-        : FilenameUtil.IsMultipartMkv(x.FileName) ? "multipart-mkv"
+        : FilenameUtil.GetSplitVideoBaseName(x.FileName) is { } baseName
+            ? $"split-video:{baseName.ToLowerInvariant()}"
         : "other";
+
+    internal static List<IGrouping<string, GetFileInfosStep.FileInfo>> GroupFilesForProcessing(
+        IReadOnlyList<GetFileInfosStep.FileInfo> fileInfos)
+    {
+        return MaybeMergeSplitVideoGroups(fileInfos.GroupBy(GetGroupName).ToList());
+    }
+
+    /// <summary>
+    /// When multiple split-video groups have globally disjoint part numbers that
+    /// form one contiguous sequence starting at 1, treat them as one inconsistently
+    /// named set (PAR2 vs subject vs yEnc header disagreement). Season packs always
+    /// collide on part numbers because each splitter restarts at .001.
+    /// </summary>
+    internal static List<IGrouping<string, GetFileInfosStep.FileInfo>> MaybeMergeSplitVideoGroups(
+        List<IGrouping<string, GetFileInfosStep.FileInfo>> groups)
+    {
+        var splitGroups = groups
+            .Where(g => g.Key.StartsWith("split-video:", StringComparison.Ordinal))
+            .ToList();
+        if (splitGroups.Count < 2)
+            return groups;
+
+        var allParts = splitGroups.SelectMany(g => g).ToList();
+        var partNumbers = new List<int>(allParts.Count);
+        foreach (var part in allParts)
+        {
+            var n = FilenameUtil.GetSplitVideoPartNumber(part.FileName);
+            if (n is null)
+                return groups;
+            partNumbers.Add(n.Value);
+        }
+
+        if (partNumbers.Distinct().Count() != partNumbers.Count)
+            return groups;
+
+        var sorted = partNumbers.OrderBy(n => n).ToList();
+        if (sorted[0] != 1)
+            return groups;
+        for (var i = 0; i < sorted.Count; i++)
+        {
+            if (sorted[i] != i + 1)
+                return groups;
+        }
+
+        Log.Information(
+            "Merging {GroupCount} split-video groups with disjoint contiguous part numbers into one set ({FileCount} parts)",
+            splitGroups.Count,
+            allParts.Count);
+
+        var mergedKey = splitGroups[0].Key;
+        var merged = allParts.GroupBy(_ => mergedKey).Single();
+        var result = new List<IGrouping<string, GetFileInfosStep.FileInfo>>(
+            groups.Count - splitGroups.Count + 1);
+        var mergedInserted = false;
+        foreach (var group in groups)
+        {
+            if (group.Key.StartsWith("split-video:", StringComparison.Ordinal))
+            {
+                if (!mergedInserted)
+                {
+                    result.Add(merged);
+                    mergedInserted = true;
+                }
+                continue;
+            }
+            result.Add(group);
+        }
+
+        return result;
+    }
 
     private async Task<DavItem?> GetMountFolder()
     {

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -504,15 +504,13 @@ public class QueueItemProcessor(
             return groups;
 
         var allParts = splitGroups.SelectMany(g => g).ToList();
-        var partNumbers = new List<int>(allParts.Count);
-        foreach (var part in allParts)
-        {
-            var n = FilenameUtil.GetSplitVideoPartNumber(part.FileName);
-            if (n is null)
-                return groups;
-            partNumbers.Add(n.Value);
-        }
+        var parsedPartNumbers = allParts
+            .Select(part => FilenameUtil.GetSplitVideoPartNumber(part.FileName))
+            .ToList();
+        if (parsedPartNumbers.Any(n => n is null))
+            return groups;
 
+        var partNumbers = parsedPartNumbers.Select(n => n!.Value).ToList();
         if (partNumbers.Distinct().Count() != partNumbers.Count)
             return groups;
 

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -24,7 +24,7 @@ public static partial class FilenameUtil
         return IsVideoFile(filename)
                || IsRarFile(filename)
                || Is7zFile(filename)
-               || IsMultipartMkv(filename);
+               || IsSplitVideoFile(filename);
     }
 
     public static bool IsVideoFile(string filename)
@@ -60,10 +60,30 @@ public static partial class FilenameUtil
         return Regex.IsMatch(filename, @"\.7z(\.(\d+))?$", RegexOptions.IgnoreCase);
     }
 
-    public static bool IsMultipartMkv(string? filename)
+    public static bool IsSplitVideoFile(string? filename) =>
+        GetSplitVideoBaseName(filename) is not null;
+
+    /// <summary>
+    /// Strips a trailing numeric split suffix (e.g. <c>.001</c>) when the remainder
+    /// is a known video filename. Returns null for non-splits.
+    /// </summary>
+    public static string? GetSplitVideoBaseName(string? filename)
     {
-        if (string.IsNullOrEmpty(filename)) return false;
-        return Regex.IsMatch(filename, @"\.mkv\.(\d+)?$", RegexOptions.IgnoreCase);
+        if (string.IsNullOrEmpty(filename)) return null;
+        var partExt = Path.GetExtension(filename);
+        if (!Regex.IsMatch(partExt, @"^\.\d+$")) return null;
+        var baseName = filename[..^partExt.Length];
+        return IsVideoFile(baseName) ? baseName : null;
+    }
+
+    /// <summary>
+    /// Part ordinal from a split-video filename (<c>.001</c> → 1). Null when the
+    /// name is not a split video file.
+    /// </summary>
+    public static int? GetSplitVideoPartNumber(string? filename)
+    {
+        if (GetSplitVideoBaseName(filename) is null) return null;
+        return int.Parse(Path.GetExtension(filename!)[1..]);
     }
 
     public static string GetJobName(string filename)

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -72,6 +72,7 @@ public static partial class FilenameUtil
         if (string.IsNullOrEmpty(filename)) return null;
         var partExt = Path.GetExtension(filename);
         if (!Regex.IsMatch(partExt, @"^\.\d+$")) return null;
+        if (!int.TryParse(partExt[1..], out _)) return null;
         var baseName = filename[..^partExt.Length];
         return IsVideoFile(baseName) ? baseName : null;
     }
@@ -82,8 +83,11 @@ public static partial class FilenameUtil
     /// </summary>
     public static int? GetSplitVideoPartNumber(string? filename)
     {
+        if (string.IsNullOrEmpty(filename)) return null;
         if (GetSplitVideoBaseName(filename) is null) return null;
-        return int.Parse(Path.GetExtension(filename!)[1..]);
+        return int.TryParse(Path.GetExtension(filename)[1..], out var partNumber)
+            ? partNumber
+            : null;
     }
 
     public static string GetJobName(string filename)

--- a/tests/NzbWebDAV.Tests/Queue/MultipartMkvAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/MultipartMkvAggregatorTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Queue.FileAggregators;
+using NzbWebDAV.Queue.FileProcessors;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class MultipartMkvAggregatorTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly DavDatabaseContext _context;
+    private readonly DavDatabaseClient _dbClient;
+
+    public MultipartMkvAggregatorTests()
+    {
+        _dbPath = Path.Join(Path.GetTempPath(), $"multipart-mkv-agg-{Guid.NewGuid():N}.sqlite");
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        _context = new DavDatabaseContext(options);
+        _context.Database.EnsureCreated();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        try { File.Delete(_dbPath); } catch (IOException) { /* ignore */ }
+    }
+
+    [Fact]
+    public void UpdateDatabase_CreatesOneDavItemPerProcessorResult()
+    {
+        var historyItemId = Guid.NewGuid();
+        var mount = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "season-pack",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            historyItemId,
+            null);
+        _context.Items.Add(mount);
+
+        new MultipartMkvAggregator(_dbClient, mount, checkedFullHealth: false).UpdateDatabase(
+        [
+            Result("EP01.mkv", 10),
+            Result("EP02.mkv", 20),
+        ]);
+
+        var items = _context.Items.Local
+            .Where(i => i.ParentId == mount.Id)
+            .OrderBy(i => i.Name)
+            .ToList();
+        Assert.Equal(["EP01.mkv", "EP02.mkv"], items.Select(i => i.Name).ToArray());
+        Assert.All(items, i => Assert.Equal(DavItem.ItemSubType.MultipartFile, i.SubType));
+        Assert.Equal([10L, 20L], items.Select(i => i.FileSize).ToArray());
+        Assert.Equal(2, _context.BlobMultipartFiles.Count);
+    }
+
+    private static MultipartMkvProcessor.Result Result(string filename, long size) => new()
+    {
+        Filename = filename,
+        ReleaseDate = DateTimeOffset.UnixEpoch,
+        Parts =
+        [
+            new DavMultipartFile.FilePart
+            {
+                SegmentIds = [filename],
+                SegmentIdByteRange = LongRange.FromStartAndSize(0, size),
+                FilePartByteRange = LongRange.FromStartAndSize(0, size),
+            },
+        ],
+    };
+}

--- a/tests/NzbWebDAV.Tests/Queue/MultipartMkvProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/MultipartMkvProcessorTests.cs
@@ -1,0 +1,73 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Queue.FileProcessors;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class MultipartMkvProcessorTests
+{
+    [Fact]
+    public async Task ProcessAsync_AssemblesOnlyTheGivenEpisodePartsInOrder()
+    {
+        var ep01 = new MultipartMkvProcessor(
+            [
+                Part("EP01.mkv.002", "ep01-2", 20),
+                Part("EP01.mkv.001", "ep01-1", 10),
+            ],
+            new UnusedNntpClient(),
+            CancellationToken.None);
+        var ep02 = new MultipartMkvProcessor(
+            [
+                Part("EP02.mkv.001", "ep02-1", 30),
+                Part("EP02.mkv.002", "ep02-2", 40),
+            ],
+            new UnusedNntpClient(),
+            CancellationToken.None);
+
+        var result01 = Assert.IsType<MultipartMkvProcessor.Result>(await ep01.ProcessAsync());
+        var result02 = Assert.IsType<MultipartMkvProcessor.Result>(await ep02.ProcessAsync());
+
+        Assert.Equal("EP01.mkv", result01.Filename);
+        Assert.Equal(["ep01-1", "ep01-2"], result01.Parts.Select(p => p.SegmentIds.Single()));
+        Assert.Equal([10, 20], result01.Parts.Select(p => p.FilePartByteRange.Count));
+
+        Assert.Equal("EP02.mkv", result02.Filename);
+        Assert.Equal(["ep02-1", "ep02-2"], result02.Parts.Select(p => p.SegmentIds.Single()));
+        Assert.Equal([30, 40], result02.Parts.Select(p => p.FilePartByteRange.Count));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesCaseInsensitiveMkvBaseName()
+    {
+        var processor = new MultipartMkvProcessor(
+            [Part("EP01.MKV.001", "seg", 10)],
+            new UnusedNntpClient(),
+            CancellationToken.None);
+
+        var result = Assert.IsType<MultipartMkvProcessor.Result>(await processor.ProcessAsync());
+
+        Assert.Equal("EP01.MKV", result.Filename);
+    }
+
+    private static GetFileInfosStep.FileInfo Part(string fileName, string segmentId, long size)
+    {
+        var nzbFile = new NzbFile { Subject = $"\"{fileName}\"" };
+        nzbFile.Segments.Add(new NzbSegment
+        {
+            MessageId = segmentId,
+            Bytes = size,
+            ByteRange = LongRange.FromStartAndSize(0, size),
+        });
+        return new GetFileInfosStep.FileInfo
+        {
+            NzbFile = nzbFile,
+            FileName = fileName,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+            FileSize = size,
+        };
+    }
+
+    private sealed class UnusedNntpClient() : WrappingNntpClient(null!);
+}

--- a/tests/NzbWebDAV.Tests/Queue/SplitVideoGroupingTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/SplitVideoGroupingTests.cs
@@ -1,0 +1,104 @@
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class SplitVideoGroupingTests
+{
+    [Fact]
+    public void GroupFilesForProcessing_KeepsIndependentSplitSetsSeparate()
+    {
+        var files = new[]
+        {
+            Info("EP01.mkv.001"),
+            Info("EP01.mkv.002"),
+            Info("EP02.mkv.001"),
+            Info("EP02.mkv.002"),
+        };
+
+        var splitGroups = SplitGroups(files);
+
+        Assert.Equal(2, splitGroups.Count);
+        Assert.Contains(splitGroups, g => g.Key == "split-video:ep01.mkv" && g.Count() == 2);
+        Assert.Contains(splitGroups, g => g.Key == "split-video:ep02.mkv" && g.Count() == 2);
+    }
+
+    [Fact]
+    public void GroupFilesForProcessing_SharesKeyAcrossMixedCaseBaseNames()
+    {
+        var files = new[]
+        {
+            Info("EP01.mkv.001"),
+            Info("ep01.MKV.002"),
+        };
+
+        var splitGroups = SplitGroups(files);
+
+        var group = Assert.Single(splitGroups);
+        Assert.Equal("split-video:ep01.mkv", group.Key);
+        Assert.Equal(2, group.Count());
+    }
+
+    [Fact]
+    public void GroupFilesForProcessing_MergesDisjointContiguousMisnamedSet()
+    {
+        var files = new[]
+        {
+            Info("A.mkv.001"),
+            Info("B.mkv.002"),
+            Info("B.mkv.003"),
+            Info("release.nfo"),
+        };
+
+        var groups = QueueItemProcessor.GroupFilesForProcessing(files);
+        var splitGroups = groups
+            .Where(g => g.Key.StartsWith("split-video:", StringComparison.Ordinal))
+            .ToList();
+
+        var merged = Assert.Single(splitGroups);
+        Assert.Equal(
+            ["A.mkv.001", "B.mkv.002", "B.mkv.003"],
+            merged.Select(f => f.FileName).OrderBy(n => n, StringComparer.Ordinal).ToArray());
+        Assert.Contains(groups, g => g.Key == "other" && g.Any(f => f.FileName == "release.nfo"));
+    }
+
+    [Fact]
+    public void GroupFilesForProcessing_DoesNotMergeSeasonPackWithCollidingPartNumbers()
+    {
+        var files = new[]
+        {
+            Info("EP01.mkv.001"),
+            Info("EP01.mkv.002"),
+            Info("EP02.mkv.001"),
+            Info("EP02.mkv.002"),
+        };
+
+        Assert.Equal(2, SplitGroups(files).Count);
+    }
+
+    [Fact]
+    public void GroupFilesForProcessing_DoesNotMergeDisjointGappedSets()
+    {
+        var files = new[]
+        {
+            Info("A.mkv.001"),
+            Info("B.mkv.005"),
+        };
+
+        Assert.Equal(2, SplitGroups(files).Count);
+    }
+
+    private static List<IGrouping<string, GetFileInfosStep.FileInfo>> SplitGroups(
+        IReadOnlyList<GetFileInfosStep.FileInfo> files) =>
+        QueueItemProcessor.GroupFilesForProcessing(files)
+            .Where(g => g.Key.StartsWith("split-video:", StringComparison.Ordinal))
+            .ToList();
+
+    private static GetFileInfosStep.FileInfo Info(string fileName) => new()
+    {
+        NzbFile = new NzbFile { Subject = $"\"{fileName}\"" },
+        FileName = fileName,
+        ReleaseDate = DateTimeOffset.UnixEpoch,
+    };
+}

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -11,13 +11,43 @@ public class UtilityTests
     [InlineData("movie.r12", true, false, false)]
     [InlineData("movie.7z.003", false, true, false)]
     [InlineData("movie.mkv.001", false, false, true)]
+    [InlineData("movie.MP4.002", false, false, true)]
+    [InlineData("movie.avi.010", false, false, true)]
     [InlineData("movie.mkv", false, false, false)]
+    [InlineData("movie.mkv.", false, false, false)]
+    [InlineData("movie.rar.001", false, false, false)]
+    [InlineData("notes.pdf.001", false, false, false)]
     public void FilenameClassifiers_RecognizeArchiveConventions(
-        string filename, bool rar, bool sevenZip, bool multipartMkv)
+        string filename, bool rar, bool sevenZip, bool splitVideo)
     {
         Assert.Equal(rar, FilenameUtil.IsRarFile(filename));
         Assert.Equal(sevenZip, FilenameUtil.Is7zFile(filename));
-        Assert.Equal(multipartMkv, FilenameUtil.IsMultipartMkv(filename));
+        Assert.Equal(splitVideo, FilenameUtil.IsSplitVideoFile(filename));
+    }
+
+    [Theory]
+    [InlineData("movie.mkv.001", "movie.mkv")]
+    [InlineData("EP01.MKV.002", "EP01.MKV")]
+    [InlineData("clip.mp4.010", "clip.mp4")]
+    [InlineData("movie.mkv", null)]
+    [InlineData("movie.mkv.", null)]
+    [InlineData("movie.rar.001", null)]
+    [InlineData("notes.pdf.001", null)]
+    [InlineData(null, null)]
+    public void GetSplitVideoBaseName_StripsNumericSuffixForVideoFiles(string? filename, string? expected)
+    {
+        Assert.Equal(expected, FilenameUtil.GetSplitVideoBaseName(filename));
+    }
+
+    [Theory]
+    [InlineData("movie.mkv.001", 1)]
+    [InlineData("clip.mp4.010", 10)]
+    [InlineData("movie.mkv", null)]
+    [InlineData("notes.pdf.001", null)]
+    [InlineData(null, null)]
+    public void GetSplitVideoPartNumber_ParsesNumericSuffix(string? filename, int? expected)
+    {
+        Assert.Equal(expected, FilenameUtil.GetSplitVideoPartNumber(filename));
     }
 
     [Theory]

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -17,6 +17,7 @@ public class UtilityTests
     [InlineData("movie.mkv.", false, false, false)]
     [InlineData("movie.rar.001", false, false, false)]
     [InlineData("notes.pdf.001", false, false, false)]
+    [InlineData("movie.mkv.999999999999", false, false, false)]
     public void FilenameClassifiers_RecognizeArchiveConventions(
         string filename, bool rar, bool sevenZip, bool splitVideo)
     {
@@ -32,6 +33,7 @@ public class UtilityTests
     [InlineData("movie.mkv", null)]
     [InlineData("movie.mkv.", null)]
     [InlineData("movie.rar.001", null)]
+    [InlineData("movie.mkv.999999999999", null)]
     [InlineData("notes.pdf.001", null)]
     [InlineData(null, null)]
     public void GetSplitVideoBaseName_StripsNumericSuffixForVideoFiles(string? filename, string? expected)
@@ -43,6 +45,7 @@ public class UtilityTests
     [InlineData("movie.mkv.001", 1)]
     [InlineData("clip.mp4.010", 10)]
     [InlineData("movie.mkv", null)]
+    [InlineData("movie.mkv.999999999999", null)]
     [InlineData("notes.pdf.001", null)]
     [InlineData(null, null)]
     public void GetSplitVideoPartNumber_ParsesNumericSuffix(string? filename, int? expected)


### PR DESCRIPTION
Fixes #976

## Summary

NZBs that contain multiple independent split-video sets (HJSplit-style `EP01.mkv.001` / `.002` / … plus `EP02.mkv.001` / …) previously mounted a **single corrupt episode**. All `.mkv.NNN` parts were dumped into one `"multipart-mkv"` bucket, concatenated in part-number order, and named after the first file. RAR season packs were already fine because they re-group by path-within-archive.

This change groups split-video parts by base filename so each episode becomes its own DavItem under `/content` and `completed-symlinks`.

## Changes

- Recognize split video files of any known video type (`.mkv.001`, `.mp4.002`, `.avi.010`, …), not only MKV.
- Group by lowercased base name (`split-video:ep01.mkv`) and run one `MultipartMkvProcessor` per set.
- Merge fallback: if several split-video groups have **globally disjoint** part numbers that form **one contiguous sequence starting at 1**, treat them as one inconsistently named set (PAR2 vs subject vs yEnc header disagreement). Season packs always collide on `.001`, so they stay separate.
- Warn when a set’s part numbers are not contiguous from 1 (still mounts).
- Fix case-sensitive `.mkv` stripping so `EP01.MKV.001` keeps a usable base name.

## Intended side effect

Non-MKV splits now count as an important file type (article-existence checks, missing-article fail-fast, health checks, deobfuscation name priority), matching how MKV splits already behaved. `DeadNzbFailFast` uses its own extension list and is unchanged.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (2693 passed, 9 skipped)
- [ ] Queue a season-pack split NZB and confirm `/content/tv/<job>/` and `completed-symlinks/tv/<job>/` list every episode
- [ ] Spot-check playback of the first minutes of two episodes