### PR TITLE
feat(sab): show remaining time and speed for Sonarr/Radarr downloads

### DIFF
--- a/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
+++ b/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
@@ -12,11 +12,15 @@ public class GetFullStatusController(
     protected override Task<IActionResult> Handle()
     {
         // mimic sabnzbd fullstatus
+        var speedLimitKbps = Config.GetSabSpeedLimitKbps();
         var status = new GetFullStatusResponse()
         {
             Status = new SabStatusObject
             {
                 CompleteDir = SabPathResolver.GetCompletedDir(Config),
+                Paused = Config.IsSabQueuePaused(),
+                SpeedLimit = speedLimitKbps.ToString(),
+                SpeedLimitAbs = speedLimitKbps.ToString(),
             }
         };
 

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -72,6 +72,7 @@ public class GetQueueController(
                     : queueItem.Priority == QueueItem.PriorityOption.Paused
                         ? "Paused"
                         : "Queued";
+                var eta = isInProgress ? active.Eta : null;
                 IReadOnlyDictionary<string, long> providerUsage =
                     GetProviderUsageForSlot(isInProgress, queueItem.Id, providerUsageTracker);
                 if (isInProgress && configuredKeys.Count > 0)
@@ -82,12 +83,18 @@ public class GetQueueController(
                     providerUsage = mergedUsage;
                 }
                 return GetQueueResponse.QueueSlot.FromQueueItem(
-                    queueItem, index, percentage, status, providerUsage, displayByMetricsKey);
+                    queueItem, index, percentage, status, eta, providerUsage, displayByMetricsKey);
             })
             .ToList();
 
         // return response
         var speedLimitKbps = Config.GetSabSpeedLimitKbps();
+        var aggregateBytesPerSecond = inProgress.Sum(x => x.BytesPerSecond);
+        var remainingBytes = inProgress.Sum(x =>
+        {
+            var pct = Math.Clamp(x.ProgressPercentage, 0, 100);
+            return (100 - pct) / 100.0 * x.QueueItem.TotalSegmentBytes;
+        });
         return new GetQueueResponse()
         {
             Queue = new GetQueueResponse.QueueObject()
@@ -97,6 +104,10 @@ public class GetQueueController(
                 TotalCount = totalCount,
                 SpeedLimit = speedLimitKbps.ToString(),
                 SpeedLimitAbs = speedLimitKbps.ToString(),
+                Speed = QueueThroughput.FormatSpeed(aggregateBytesPerSecond),
+                KbPerSec = QueueThroughput.FormatKbPerSec(aggregateBytesPerSecond),
+                TimeLeft = QueueThroughput.FromRemaining(aggregateBytesPerSecond, remainingBytes)
+                           ?? TimeSpan.Zero,
             }
         };
     }

--- a/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueResponse.cs
@@ -34,6 +34,16 @@ public class GetQueueResponse : SabBaseResponse
         // duration, so this is always "0".
         [JsonPropertyName("pause_int")]
         public string PauseInt { get; init; } = "0";
+
+        [JsonPropertyName("speed")]
+        public string Speed { get; init; } = "0 ";
+
+        [JsonPropertyName("kbpersec")]
+        public string KbPerSec { get; init; } = "0.00";
+
+        [JsonPropertyName("timeleft")]
+        [JsonConverter(typeof(SabnzbdQueueTimeConverter))]
+        public TimeSpan TimeLeft { get; init; }
     }
 
     public class QueueSlot
@@ -84,6 +94,7 @@ public class GetQueueResponse : SabBaseResponse
             int index = 0,
             int progressPercentage = 0,
             string status = "Queued",
+            TimeSpan? eta = null,
             IReadOnlyDictionary<string, long>? providerUsage = null,
             IReadOnlyDictionary<string, (string Host, string? Nickname)>? displayByMetricsKey = null
         )
@@ -99,7 +110,7 @@ public class GetQueueResponse : SabBaseResponse
                 Percentage = sabProgressPercentage.ToString(CultureInfo.InvariantCulture),
                 TruePercentage = progressPercentage.ToString(CultureInfo.InvariantCulture),
                 Status = status,
-                TimeLeft = TimeSpan.Zero,
+                TimeLeft = eta ?? TimeSpan.Zero,
                 SizeInMB = FormatSizeMB(queueItem.TotalSegmentBytes),
                 SizeLeftInMB = FormatSizeMB(
                     (100 - sabProgressPercentage) * queueItem.TotalSegmentBytes / 100),
@@ -141,8 +152,32 @@ public class GetQueueResponse : SabBaseResponse
         public override TimeSpan Read(ref Utf8JsonReader r, Type t, JsonSerializerOptions o) =>
             throw new NotImplementedException();
 
-        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
-            writer.WriteStringValue(value.ToString(@"d\:h\:m\:s"));
+        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(Format(value));
+        }
+
+        /// <summary>
+        /// SABnzbd <c>format_time_left</c>: <c>0:00:00</c>, <c>H:MM:SS</c> under 24h,
+        /// <c>D:HH:MM:SS</c> when days &gt; 0.
+        /// </summary>
+        public static string Format(TimeSpan value)
+        {
+            if (value <= TimeSpan.Zero)
+                return "0:00:00";
+
+            var totalSeconds = (int)Math.Round(value.TotalSeconds, MidpointRounding.AwayFromZero);
+            if (totalSeconds <= 0)
+                return "0:00:00";
+
+            var days = totalSeconds / 86400;
+            var hours = totalSeconds % 86400 / 3600;
+            var minutes = totalSeconds % 3600 / 60;
+            var seconds = totalSeconds % 60;
+            if (days > 0)
+                return $"{days}:{hours:D2}:{minutes:D2}:{seconds:D2}";
+            return $"{hours}:{minutes:D2}:{seconds:D2}";
+        }
     }
 
     public class ProviderUsage

--- a/backend/Api/SabControllers/GetStatus/GetStatusController.cs
+++ b/backend/Api/SabControllers/GetStatus/GetStatusController.cs
@@ -11,11 +11,15 @@ public class GetStatusController(
 {
     protected override Task<IActionResult> Handle()
     {
+        var speedLimitKbps = Config.GetSabSpeedLimitKbps();
         var response = new GetStatusResponse
         {
             Status = new SabStatusObject
             {
                 CompleteDir = SabPathResolver.GetCompletedDir(Config),
+                Paused = Config.IsSabQueuePaused(),
+                SpeedLimit = speedLimitKbps.ToString(),
+                SpeedLimitAbs = speedLimitKbps.ToString(),
             },
         };
         return Task.FromResult<IActionResult>(Ok(response));

--- a/backend/Api/SabControllers/SabStatusObject.cs
+++ b/backend/Api/SabControllers/SabStatusObject.cs
@@ -6,4 +6,13 @@ public sealed class SabStatusObject
 {
     [JsonPropertyName("completedir")]
     public required string CompleteDir { get; init; }
+
+    [JsonPropertyName("paused")]
+    public bool Paused { get; init; }
+
+    [JsonPropertyName("speedlimit")]
+    public string SpeedLimit { get; init; } = "0";
+
+    [JsonPropertyName("speedlimit_abs")]
+    public string SpeedLimitAbs { get; init; } = "0";
 }

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -169,7 +169,7 @@ public sealed class QueueManager : IDisposable
     public IReadOnlyList<InProgressQueueItemSnapshot> GetInProgressQueueItems()
     {
         var items = _inProgress.Values
-            .Select(x => new InProgressQueueItemSnapshot(x.QueueItem, x.ProgressPercentage, x.IsPrimary))
+            .Select(ToSnapshot)
             .ToList();
 
         items.Sort((a, b) =>
@@ -194,7 +194,7 @@ public sealed class QueueManager : IDisposable
     public InProgressQueueItemSnapshot? FindInProgressQueueItem(Guid queueItemId)
     {
         return _inProgress.TryGetValue(queueItemId, out var item)
-            ? new InProgressQueueItemSnapshot(item.QueueItem, item.ProgressPercentage, item.IsPrimary)
+            ? ToSnapshot(item)
             : null;
     }
 
@@ -782,6 +782,8 @@ public sealed class QueueManager : IDisposable
             QueueNzbStream = queueNzbStream,
             CachingUsenetClient = cachingUsenetClient,
             StartedAt = DateTime.UtcNow,
+            LastThroughputSampleTime = DateTime.UtcNow,
+            LastThroughputSampleProgress = 0,
             WatchdogCts = null!, // set below, after the worker task is created
         };
 
@@ -842,6 +844,17 @@ public sealed class QueueManager : IDisposable
                 {
                     if (progress > latestProgress) latestProgress = progress;
                     inProgressQueueItem.ProgressPercentage = latestProgress;
+                    var sample = QueueThroughput.Update(
+                        new QueueThroughput.SampleState(
+                            inProgressQueueItem.BytesPerSecond,
+                            inProgressQueueItem.LastThroughputSampleTime,
+                            inProgressQueueItem.LastThroughputSampleProgress),
+                        latestProgress,
+                        queueItem.TotalSegmentBytes,
+                        DateTime.UtcNow);
+                    inProgressQueueItem.BytesPerSecond = sample.BytesPerSecond;
+                    inProgressQueueItem.LastThroughputSampleTime = sample.LastSampleTime;
+                    inProgressQueueItem.LastThroughputSampleProgress = sample.LastSampleProgress;
                 }
 
                 if (progress is 100 or 200) SendLatestProgress();
@@ -1072,12 +1085,28 @@ public sealed class QueueManager : IDisposable
     public readonly record struct InProgressQueueItemSnapshot(
         QueueItem QueueItem,
         int ProgressPercentage,
-        bool IsPrimary);
+        bool IsPrimary,
+        TimeSpan? Eta = null,
+        double BytesPerSecond = 0);
+
+    private static InProgressQueueItemSnapshot ToSnapshot(InProgressQueueItem item) =>
+        new(
+            item.QueueItem,
+            item.ProgressPercentage,
+            item.IsPrimary,
+            QueueThroughput.ComputeEta(
+                item.BytesPerSecond,
+                item.ProgressPercentage,
+                item.QueueItem.TotalSegmentBytes),
+            item.BytesPerSecond);
 
     private sealed class InProgressQueueItem
     {
         public QueueItem QueueItem { get; init; } = null!;
         public int ProgressPercentage { get; set; }
+        public double BytesPerSecond { get; set; }
+        public DateTime LastThroughputSampleTime { get; set; }
+        public int LastThroughputSampleProgress { get; set; }
 
         /// <summary>
         /// Name of the queue stage currently executing (e.g. par2, lazy-rar,

--- a/backend/Queue/QueueThroughput.cs
+++ b/backend/Queue/QueueThroughput.cs
@@ -33,8 +33,10 @@ internal static class QueueThroughput
         var clamped = Math.Clamp(progress, 0, 100);
         var prevClamped = Math.Clamp(previous.LastSampleProgress, 0, 100);
         var progressDelta = clamped - prevClamped;
+        // Keep LastSampleTime so stall time is included in the next real delta.
+        // Advancing it here would treat a later jump as instant and inflate rate/ETA.
         if (progressDelta <= 0)
-            return previous with { LastSampleTime = now, LastSampleProgress = clamped };
+            return previous;
 
         var seconds = Math.Max(elapsed.TotalSeconds, MinSampleInterval.TotalSeconds);
         var deltaBytes = progressDelta / 100.0 * totalSegmentBytes;
@@ -84,7 +86,7 @@ internal static class QueueThroughput
 
         var val = bytesPerSecond;
         var n = val < 1024 ? 0 : Math.Min(5, (int)Math.Truncate(Math.Log2(val) / 10));
-        val /= Math.Pow(2, 10 * n);
+        val /= Math.Pow(2.0, 10.0 * n);
         var decimals = n > 1 ? 1 : 0;
         ReadOnlySpan<string> units = ["", "K", "M", "G", "T", "P"];
         var number = val.ToString(decimals == 0 ? "0" : "0.0", CultureInfo.InvariantCulture);

--- a/backend/Queue/QueueThroughput.cs
+++ b/backend/Queue/QueueThroughput.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+
+namespace NzbWebDAV.Queue;
+
+/// <summary>
+/// EMA-smoothed queue throughput and SAB-shaped speed/ETA formatting.
+/// Rate is derived from progress-percentage deltas, not raw NNTP bytes.
+/// </summary>
+internal static class QueueThroughput
+{
+    internal const double EmaAlpha = 0.4;
+    internal static readonly TimeSpan MinSampleInterval = TimeSpan.FromMilliseconds(500);
+    internal static readonly TimeSpan MaxEta = TimeSpan.FromDays(1);
+
+    internal readonly record struct SampleState(
+        double BytesPerSecond,
+        DateTime LastSampleTime,
+        int LastSampleProgress);
+
+    internal static SampleState Update(
+        SampleState previous,
+        int progress,
+        long totalSegmentBytes,
+        DateTime now)
+    {
+        if (progress > 100)
+            return previous with { BytesPerSecond = 0, LastSampleProgress = progress };
+
+        var elapsed = now - previous.LastSampleTime;
+        if (elapsed < MinSampleInterval)
+            return previous;
+
+        var clamped = Math.Clamp(progress, 0, 100);
+        var prevClamped = Math.Clamp(previous.LastSampleProgress, 0, 100);
+        var progressDelta = clamped - prevClamped;
+        if (progressDelta <= 0)
+            return previous with { LastSampleTime = now, LastSampleProgress = clamped };
+
+        var seconds = Math.Max(elapsed.TotalSeconds, MinSampleInterval.TotalSeconds);
+        var deltaBytes = progressDelta / 100.0 * totalSegmentBytes;
+        var instantRate = deltaBytes / seconds;
+        var rate = previous.BytesPerSecond <= 0
+            ? instantRate
+            : EmaAlpha * instantRate + (1 - EmaAlpha) * previous.BytesPerSecond;
+
+        return new SampleState(rate, now, clamped);
+    }
+
+    internal static TimeSpan? ComputeEta(
+        double bytesPerSecond,
+        int progressPercentage,
+        long totalSegmentBytes)
+    {
+        if (bytesPerSecond <= 0 || progressPercentage >= 100)
+            return null;
+
+        var pct = Math.Clamp(progressPercentage, 0, 100);
+        var remainingBytes = (100 - pct) / 100.0 * totalSegmentBytes;
+        return FromRemaining(bytesPerSecond, remainingBytes);
+    }
+
+    internal static TimeSpan? FromRemaining(double bytesPerSecond, double remainingBytes)
+    {
+        if (bytesPerSecond <= 0 || remainingBytes <= 0)
+            return null;
+
+        var seconds = remainingBytes / bytesPerSecond;
+        return seconds > MaxEta.TotalSeconds ? MaxEta : TimeSpan.FromSeconds(seconds);
+    }
+
+    internal static string FormatKbPerSec(double bytesPerSecond)
+    {
+        var kb = Math.Max(0, bytesPerSecond) / 1024.0;
+        return kb.ToString("0.00", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// SABnzbd <c>to_units</c> style without a byte postfix: <c>"1.3 M"</c>, idle <c>"0 "</c>.
+    /// </summary>
+    internal static string FormatSpeed(double bytesPerSecond)
+    {
+        if (bytesPerSecond <= 0)
+            return "0 ";
+
+        var val = bytesPerSecond;
+        var n = val < 1024 ? 0 : Math.Min(5, (int)Math.Truncate(Math.Log2(val) / 10));
+        val /= Math.Pow(2, 10 * n);
+        var decimals = n > 1 ? 1 : 0;
+        ReadOnlySpan<string> units = ["", "K", "M", "G", "T", "P"];
+        var number = val.ToString(decimals == 0 ? "0" : "0.0", CultureInfo.InvariantCulture);
+        return n == 0 ? number : $"{number} {units[n]}";
+    }
+}

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -30,6 +30,8 @@ Per-job pause and resume accept UUID(s) via `value` (comma-separated or repeated
 
 `mode=speedlimit` is **accepted and stored** and reflected in queue JSON (`speedlimit` / `speedlimit_abs`). Byte-accurate download throttling is **not** enforced yet — that work is tracked in [#375](https://github.com/infinidysk/infinidysk/issues/375).
 
+Queue JSON reports live throughput for in-progress jobs [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }: per-slot `timeleft` (`H:MM:SS`, or `D:HH:MM:SS` past 24h), plus queue-level `timeleft`, `kbpersec` (KB/s), and `speed` (human units such as `1.3 M`). Queued and paused slots report `0:00:00`. `status` / `fullstatus` include `paused`, `speedlimit`, and `speedlimit_abs`; live speed stays on `mode=queue`.
+
 ## Intentional differences
 
 - Job identifiers are UUIDs rather than `SABnzbd_nzo_*` strings. Treat them as opaque values.

--- a/tests/NzbWebDAV.Tests/Api/GetQueueResponseTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueResponseTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Database.Models;
 
@@ -30,6 +31,62 @@ public class GetQueueResponseTests
             progressPercentage: 150);
 
         Assert.Equal("0.00", slot.SizeLeftInMB);
+    }
+
+    [Fact]
+    public void FromQueueItem_UsesEtaWhenProvided()
+    {
+        var slot = GetQueueResponse.QueueSlot.FromQueueItem(
+            CreateQueueItem(),
+            progressPercentage: 40,
+            status: "Downloading",
+            eta: TimeSpan.FromMinutes(16) + TimeSpan.FromSeconds(44));
+
+        Assert.Equal(TimeSpan.FromMinutes(16) + TimeSpan.FromSeconds(44), slot.TimeLeft);
+    }
+
+    [Fact]
+    public void FromQueueItem_TimeLeftIsZeroWhenEtaUnknown()
+    {
+        var slot = GetQueueResponse.QueueSlot.FromQueueItem(CreateQueueItem());
+        Assert.Equal(TimeSpan.Zero, slot.TimeLeft);
+    }
+
+    [Theory]
+    [InlineData(0, "0:00:00")]
+    [InlineData(16 * 60 + 44, "0:16:44")]
+    [InlineData(25 * 3600, "1:01:00:00")]
+    public void TimeConverter_WritesSabFormat(int totalSeconds, string expected)
+    {
+        Assert.Equal(expected, GetQueueResponse.SabnzbdQueueTimeConverter.Format(TimeSpan.FromSeconds(totalSeconds)));
+    }
+
+    [Fact]
+    public void QueueObject_SerializesSpeedAndTimeleft()
+    {
+        var response = new GetQueueResponse
+        {
+            Queue = new GetQueueResponse.QueueObject
+            {
+                Speed = "1.3 M",
+                KbPerSec = "1296.02",
+                TimeLeft = TimeSpan.FromMinutes(16) + TimeSpan.FromSeconds(44),
+            },
+        };
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(response));
+        var queue = json.RootElement.GetProperty("queue");
+        Assert.Equal("1.3 M", queue.GetProperty("speed").GetString());
+        Assert.Equal("1296.02", queue.GetProperty("kbpersec").GetString());
+        Assert.Equal("0:16:44", queue.GetProperty("timeleft").GetString());
+    }
+
+    [Fact]
+    public void QueueSlot_SerializesZeroTimeleftAsSabZero()
+    {
+        var slot = GetQueueResponse.QueueSlot.FromQueueItem(CreateQueueItem());
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(slot));
+        Assert.Equal("0:00:00", json.RootElement.GetProperty("timeleft").GetString());
     }
 
     private static QueueItem CreateQueueItem() =>

--- a/tests/NzbWebDAV.Tests/Api/SabStatusTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabStatusTests.cs
@@ -19,9 +19,38 @@ public class SabStatusTests
         using var json = JsonDocument.Parse(JsonSerializer.Serialize(response));
 
         Assert.Equal(JsonValueKind.Object, json.RootElement.GetProperty("status").ValueKind);
+        var status = json.RootElement.GetProperty("status");
         Assert.Equal(
             "/downloads/complete",
-            json.RootElement.GetProperty("status").GetProperty("completedir").GetString());
+            status.GetProperty("completedir").GetString());
+        Assert.False(status.GetProperty("paused").GetBoolean());
+        Assert.Equal("0", status.GetProperty("speedlimit").GetString());
+        Assert.Equal("0", status.GetProperty("speedlimit_abs").GetString());
+        Assert.False(status.TryGetProperty("speed", out _));
+        Assert.False(status.TryGetProperty("kbpersec", out _));
+    }
+
+    [Fact]
+    public void StatusResponse_SerializesPauseAndSpeedLimit()
+    {
+        var response = new GetStatusResponse
+        {
+            Status = new SabStatusObject
+            {
+                CompleteDir = "/downloads/complete",
+                Paused = true,
+                SpeedLimit = "400",
+                SpeedLimitAbs = "400",
+            },
+        };
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(response));
+        var status = json.RootElement.GetProperty("status");
+        Assert.True(status.GetProperty("paused").GetBoolean());
+        Assert.Equal("400", status.GetProperty("speedlimit").GetString());
+        Assert.Equal("400", status.GetProperty("speedlimit_abs").GetString());
+        Assert.False(status.TryGetProperty("speed", out _));
+        Assert.False(status.TryGetProperty("kbpersec", out _));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/QueueThroughputTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueThroughputTests.cs
@@ -14,7 +14,7 @@ public class QueueThroughputTests
         var eta = QueueThroughput.ComputeEta(1024 * 1024, 50, TenMb);
 
         Assert.NotNull(eta);
-        Assert.Equal(5, eta.Value.TotalSeconds, 3);
+        Assert.Equal(5, eta!.Value.TotalSeconds, 3);
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class QueueThroughputTests
     {
         var eta = QueueThroughput.ComputeEta(1, 0, 100L * 1024 * 1024 * 1024);
 
-        Assert.Equal(QueueThroughput.MaxEta, eta);
+        Assert.Equal(QueueThroughput.MaxEta, eta!.Value);
     }
 
     [Fact]
@@ -70,6 +70,26 @@ public class QueueThroughputTests
 
         var expected = QueueThroughput.EmaAlpha * (1024 * 1024) + (1 - QueueThroughput.EmaAlpha) * first.BytesPerSecond;
         Assert.Equal(expected, second.BytesPerSecond, 3);
+    }
+
+    [Fact]
+    public void Update_DoesNotAdvanceSampleTimeWhenProgressUnchanged()
+    {
+        var first = QueueThroughput.Update(
+            new QueueThroughput.SampleState(0, T0, 0),
+            10,
+            TenMb,
+            T0.AddSeconds(1));
+        var stalled = QueueThroughput.Update(first, 10, TenMb, T0.AddSeconds(3));
+
+        Assert.Equal(first, stalled);
+
+        var resumed = QueueThroughput.Update(stalled, 20, TenMb, T0.AddSeconds(4));
+        // 10% of 10 MiB over 3s (stall included), not 1s after an advanced timestamp.
+        var instant = TenMb * 0.10 / 3.0;
+        var expected = QueueThroughput.EmaAlpha * instant + (1 - QueueThroughput.EmaAlpha) * first.BytesPerSecond;
+        Assert.Equal(expected, resumed.BytesPerSecond, 3);
+        Assert.Equal(T0.AddSeconds(4), resumed.LastSampleTime);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/QueueThroughputTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueThroughputTests.cs
@@ -1,0 +1,100 @@
+using NzbWebDAV.Queue;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class QueueThroughputTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc);
+    private const long TenMb = 10L * 1024 * 1024;
+
+    [Fact]
+    public void ComputeEta_ReturnsRemainingOverRate()
+    {
+        // 50% of 10 MiB left at 1 MiB/s → 5s
+        var eta = QueueThroughput.ComputeEta(1024 * 1024, 50, TenMb);
+
+        Assert.NotNull(eta);
+        Assert.Equal(5, eta.Value.TotalSeconds, 3);
+    }
+
+    [Fact]
+    public void ComputeEta_ClearsWhenProgressReachesDownloadComplete()
+    {
+        Assert.Null(QueueThroughput.ComputeEta(1024 * 1024, 100, TenMb));
+        Assert.Null(QueueThroughput.ComputeEta(1024 * 1024, 150, TenMb));
+    }
+
+    [Fact]
+    public void ComputeEta_ClearsWhenRateIsZero()
+    {
+        Assert.Null(QueueThroughput.ComputeEta(0, 40, TenMb));
+    }
+
+    [Fact]
+    public void ComputeEta_CapsAt24Hours()
+    {
+        var eta = QueueThroughput.ComputeEta(1, 0, 100L * 1024 * 1024 * 1024);
+
+        Assert.Equal(QueueThroughput.MaxEta, eta);
+    }
+
+    [Fact]
+    public void Update_IgnoresSamplesShorterThanMinimumInterval()
+    {
+        var previous = new QueueThroughput.SampleState(0, T0, 0);
+        var next = QueueThroughput.Update(previous, 10, TenMb, T0.AddMilliseconds(200));
+
+        Assert.Equal(previous, next);
+    }
+
+    [Fact]
+    public void Update_ComputesInstantRateOnFirstSample()
+    {
+        var previous = new QueueThroughput.SampleState(0, T0, 0);
+        var next = QueueThroughput.Update(previous, 10, TenMb, T0.AddSeconds(1));
+
+        // 10% of 10 MiB in 1s → 1 MiB/s
+        Assert.Equal(1024 * 1024, next.BytesPerSecond, 0);
+        Assert.Equal(10, next.LastSampleProgress);
+    }
+
+    [Fact]
+    public void Update_AppliesEmaSmoothing()
+    {
+        var first = QueueThroughput.Update(
+            new QueueThroughput.SampleState(0, T0, 0),
+            10,
+            TenMb,
+            T0.AddSeconds(1));
+        var second = QueueThroughput.Update(first, 20, TenMb, T0.AddSeconds(2));
+
+        var expected = QueueThroughput.EmaAlpha * (1024 * 1024) + (1 - QueueThroughput.EmaAlpha) * first.BytesPerSecond;
+        Assert.Equal(expected, second.BytesPerSecond, 3);
+    }
+
+    [Fact]
+    public void Update_ClearsRateDuringHealthCheckPhase()
+    {
+        var previous = new QueueThroughput.SampleState(1024 * 1024, T0, 90);
+        var next = QueueThroughput.Update(previous, 150, TenMb, T0.AddSeconds(1));
+
+        Assert.Equal(0, next.BytesPerSecond);
+        Assert.Equal(150, next.LastSampleProgress);
+    }
+
+    [Fact]
+    public void FormatKbPerSec_UsesTwoDecimals()
+    {
+        Assert.Equal("0.00", QueueThroughput.FormatKbPerSec(0));
+        Assert.Equal("1296.02", QueueThroughput.FormatKbPerSec(1296.02 * 1024));
+    }
+
+    [Fact]
+    public void FormatSpeed_UsesSabHumanUnits()
+    {
+        Assert.Equal("0 ", QueueThroughput.FormatSpeed(0));
+        Assert.Equal("1.3 M", QueueThroughput.FormatSpeed(1296.02 * 1024));
+        Assert.Equal("500", QueueThroughput.FormatSpeed(500));
+        Assert.Equal("2 K", QueueThroughput.FormatSpeed(2 * 1024));
+    }
+}


### PR DESCRIPTION
Fixes #979

## Summary

Sonarr and Radarr Activity never showed remaining time because SAB queue slots always reported `timeleft` as zero. This fills the SAB `mode=queue` fields those clients actually bind, using SABnzbd 5.1 formats.

- Per-item throughput and ETA in the queue coordinator (progress-delta, EMA-smoothed, download phase only; cleared during health-check).
- Slot `timeleft` for in-progress jobs (`H:MM:SS`, or `D:HH:MM:SS` past 24h). Queued and paused slots stay `0:00:00`.
- Queue-level `timeleft`, `kbpersec` (KB/s, two decimals), and `speed` (human units such as `1.3 M`).
- `status` / `fullstatus` now include the SAB header fields `paused`, `speedlimit`, and `speedlimit_abs`. Live speed stays on `mode=queue` — it is not a status field.

This also closes the leftover ETA item called out on #129. Prefix `sonarr*` category filters, treating `cat=*` as all jobs, byte-accurate NNTP counters, and speed-limit enforcement (#375) remain out of scope.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2720 passed, 9 skipped
- [x] Queue JSON: `kbpersec` two decimals, `speed` human units, slot/queue `timeleft` non-zero and `0:00:00` when unknown
- [x] Time converter: 16m44s → `0:16:44`; 25h → 4-part; zero → `0:00:00`
- [x] Status JSON: `paused` / `speedlimit` present; no `speed` / `kbpersec` on `SabStatusObject`
- [x] ETA helper: known inputs, clears at progress ≥ 100, 24h cap
- [ ] Manual: start a download from Sonarr/Radarr and confirm Activity shows remaining time (not blank / 0:00:00)