### PR TITLE
fix(webdav): /ready no longer returns 4XX instead of the readiness status

### DIFF
--- a/backend/Extensions/NWebDavOptionsExtensions.cs
+++ b/backend/Extensions/NWebDavOptionsExtensions.cs
@@ -10,6 +10,7 @@ public static class NWebDavOptionsExtensions
         return context => !context.Request.Path.StartsWithSegments("/api", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/view", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/health", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/ready", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/ws", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/p", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/adapters", StringComparison.Ordinal);

--- a/frontend/server/proxy-path.test.ts
+++ b/frontend/server/proxy-path.test.ts
@@ -24,6 +24,7 @@ describe("matchesBackendPathPrefix", () => {
   it.each([
     "/api",
     "/api/get-config",
+    "/ready",
     "/view",
     "/view/movies",
     "/adapters",
@@ -32,7 +33,13 @@ describe("matchesBackendPathPrefix", () => {
     expect(matchesBackendPathPrefix(path)).toBe(true);
   });
 
-  it.each(["/apifoo", "/viewport.css", "/contents-page", "/adaptersfoo"])(
+  it.each([
+    "/apifoo",
+    "/readyfoo",
+    "/viewport.css",
+    "/contents-page",
+    "/adaptersfoo",
+  ])(
     "rejects bare-prefix false positive %s",
     (path) => {
       expect(matchesBackendPathPrefix(path)).toBe(false);
@@ -65,6 +72,7 @@ describe("shouldProxyToBackend", () => {
   it.each([
     "/api",
     "/api/get-config",
+    "/ready",
     "/view",
     "/view/movies",
     "/.ids/item",

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -1,5 +1,6 @@
 const BACKEND_PATH_PREFIXES = [
   "/api",
+  "/ready",
   "/view",
   "/.ids",
   "/nzbs",

--- a/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
@@ -59,6 +59,17 @@ public sealed class HttpPipelineIntegrationTests(NzbDavWebApplicationFactory fac
     }
 
     [Fact]
+    public async Task ReadyEndpoint_IsAvailableWithoutAuthentication()
+    {
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/ready");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Healthy", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task SabVersionEndpoint_MatchesUnauthenticatedCompatibilityRoute()
     {
         using var client = factory.CreateClient();

--- a/tests/NzbWebDAV.Tests/Extensions/NWebDavOptionsFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/NWebDavOptionsFilterTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Http;
+using NWebDav.Server;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Tests.Extensions;
+
+public class NWebDavOptionsFilterTests
+{
+    private static bool ClaimedByWebDav(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        return new NWebDavOptions().GetFilter()(context);
+    }
+
+    [Theory]
+    [InlineData("/api")]
+    [InlineData("/api/get-config")]
+    [InlineData("/view")]
+    [InlineData("/health")]
+    [InlineData("/ready")]
+    [InlineData("/ws")]
+    [InlineData("/p")]
+    [InlineData("/adapters")]
+    [InlineData("/adapters/addon/token/manifest.json")]
+    public void LeavesApplicationRoutesAlone(string path)
+    {
+        Assert.False(ClaimedByWebDav(path));
+    }
+
+    [Theory]
+    [InlineData("/content/movie.mkv")]
+    [InlineData("/completed-symlinks/movie")]
+    [InlineData("/.ids/abc")]
+    [InlineData("/nzbs/file.nzb")]
+    [InlineData("/")]
+    public void ClaimsWebDavRoutes(string path)
+    {
+        Assert.True(ClaimedByWebDav(path));
+    }
+
+    [Theory]
+    [InlineData("/readyfoo")]
+    [InlineData("/healthfoo")]
+    public void MatchesOnSegmentBoundariesOnly(string path)
+    {
+        Assert.True(ClaimedByWebDav(path));
+    }
+}


### PR DESCRIPTION
Adds /ready to the WebDAV path filter and the frontend's backend proxy prefixes so the endpoint reaches StreamingReadinessCheck instead of returning 401 on the backend port and 404 on the frontend one.