### PR TITLE
fix(ui): maintenance task status no longer bleeds between Remove Orphaned Files and Prune Completed History

### DIFF
--- a/backend/Tasks/PruneCompletedHistoryTask.cs
+++ b/backend/Tasks/PruneCompletedHistoryTask.cs
@@ -148,7 +148,7 @@ public class PruneCompletedHistoryTask : BaseTask
     private void StartPhase(string message) => _progressHeartbeat?.StartPhase(message);
     private void UpdatePhase(string message) => _progressHeartbeat?.UpdatePhase(message);
     private void Complete(string message) { if (_progressHeartbeat is not null) _progressHeartbeat.Complete(message); else Report(message); }
-    private void Report(string message) { var progress = $"{(_isDryRun ? "Dry Run - " : string.Empty)}{message}"; _progressObserver?.Invoke(progress); _ = _websocketManager.SendMessage(WebsocketTopic.CleanupTaskProgress, progress); }
+    private void Report(string message) { var progress = $"{(_isDryRun ? "Dry Run - " : string.Empty)}{message}"; _progressObserver?.Invoke(progress); _ = _websocketManager.SendMessage(WebsocketTopic.PruneCompletedHistoryTaskProgress, progress); }
 
     internal sealed class ProgressHeartbeat : IAsyncDisposable
     {

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -9,6 +9,7 @@ public class WebsocketTopic
     public static readonly WebsocketTopic ActiveReads = new("ar", TopicType.State);
     public static readonly WebsocketTopic SymlinkTaskProgress = new("stp", TopicType.State);
     public static readonly WebsocketTopic CleanupTaskProgress = new("ctp", TopicType.State);
+    public static readonly WebsocketTopic PruneCompletedHistoryTaskProgress = new("pchp", TopicType.State);
     public static readonly WebsocketTopic RenameWindowsInvalidPathsProgress = new("rwip", TopicType.State);
     public static readonly WebsocketTopic StrmToSymlinksTaskProgress = new("st2sy", TopicType.State);
     public static readonly WebsocketTopic RecreateStrmTaskProgress = new("rstm", TopicType.State);

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -25,6 +25,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | Task | Purpose | Caution |
 |------|---------|---------|
 | Remove Orphaned Files | Drop WebDAV files not linked from library | Permanent; dry run available |
+| Prune Completed History | Remove completed SAB history rows | History-only; mounts stay; unlinked mounts become eligible for orphan cleanup |
 | Rename Windows-Invalid Paths | Sanitize existing names | Needs Windows-safe paths; backup + dry run |
 | Convert STRM → Symlinks | Strategy migration | Needs library dir + rclone mount |
 | Recreate STRM Files | Refresh sidecars | Needs STRM strategy + completed dir + base URL |

--- a/docs/operations/deletion-audit.md
+++ b/docs/operations/deletion-audit.md
@@ -7,8 +7,8 @@ Mounted content under `/content` can vanish for several independent reasons. “
 | History delete with delete-files | Admin UI, or `del_completed_files=1` | Mounted items for that history row are deleted |
 | Cascading child sweep | Deleted directory | Children removed in background |
 | Health repair | Repairs + missing articles | Orphans/blocklisted files are deleted; linked releases are removed and blocklisted through *Arr |
-| Remove Orphaned Files | Manual/scheduled | Deletes files with **no** library symlink/STRM (safety abort if too few links) |
-| History retention | Retention days > 0 | Prunes history with `deleteFiles: false` — mounts stay, lose history link |
+| Remove Orphaned Files | Manual/scheduled | Deletes files with **no** library symlink/STRM and **no** history link (safety abort if too few links) |
+| History retention / Prune Completed History | Retention days > 0, or Maintenance task | Prunes history with `deleteFiles: false` — mounts stay, lose history link; unlinked mounts can then be removed by Remove Orphaned Files |
 | Manual delete | WebDAV DELETE / admin API | Explicit user action |
 | Blocklist filter | Download file blocklist | Matching files never appear in `/content` |
 | Non-persistent `/config` | Volume missing/wiped | Empty DB on restart — entire library looks gone |

--- a/docs/operations/retention-cleanup.md
+++ b/docs/operations/retention-cleanup.md
@@ -27,11 +27,13 @@ Setting `metrics.fetch-retention-hours` to `0` requests rollup-only retention; t
 
 ## NZB blobs
 
-Blobs under `{CONFIG_PATH}/blobs/` remain while referenced by queue, history, or mounted `/content`. When the last reference drops, background cleanup removes them. History retention alone does not make mounts eligible for orphan deletion.
+Blobs under `{CONFIG_PATH}/blobs/` remain while referenced by queue, history, or mounted `/content`. When the last reference drops, background cleanup removes them.
+
+Scheduled history retention and the **Prune Completed History** task delete SAB history rows only (`deleteFiles: false`). They do not delete WebDAV mounts, but they do clear each mount's history link (`HistoryItemId`). **Remove Orphaned Files** then deletes those mounts only if they also have no library symlink or STRM.
 
 ## Orphaned files
 
-**Remove Orphaned Files** (Maintenance) deletes WebDAV files not linked from the library directory. Supports dry run. Schedule optional daily cleanup — set container `TZ`.
+**Remove Orphaned Files** (Maintenance) deletes WebDAV files that are not linked from the library directory and are no longer tied to a SAB history row. Supports dry run. Schedule optional daily cleanup — set container `TZ`. Direct WebDAV or rclone playback is not a library link.
 
 ## NZB file backups
 

--- a/frontend/app/routes/settings/maintenance/prune-completed-history/prune-completed-history.tsx
+++ b/frontend/app/routes/settings/maintenance/prune-completed-history/prune-completed-history.tsx
@@ -43,7 +43,12 @@ export function PruneCompletedHistory({ savedConfig }: PruneCompletedHistoryProp
         <>
             <Alert className="alert-soft mb-4 items-start py-3 text-sm" variant="warning">
                 <Icon name="backup" className="!text-[20px]" />
-                <div><p className="font-semibold">Back up before cleanup</p><p className="mt-0.5 text-xs opacity-80">Pruning SAB history is permanent. WebDAV files are preserved.</p></div>
+                <div>
+                    <p className="font-semibold">Back up before cleanup</p>
+                    <p className="mt-0.5 text-xs opacity-80">
+                        Pruning SAB history is permanent. WebDAV files are preserved, but they lose history protection — files not linked from the organized library will show up in Remove Orphaned Files (including a scheduled run).
+                    </p>
+                </div>
             </Alert>
             <div className="space-y-4">
                 <p className="text-sm text-base-content/70">Remove completed SAB history rows in bulk without deleting mounted WebDAV content.</p>

--- a/frontend/app/routes/settings/maintenance/prune-completed-history/prune-completed-history.tsx
+++ b/frontend/app/routes/settings/maintenance/prune-completed-history/prune-completed-history.tsx
@@ -20,7 +20,7 @@ export function PruneCompletedHistory({ savedConfig }: PruneCompletedHistoryProp
     const progressMessage = progress?.replace("Dry Run - ", "");
     const isFinished = progressMessage?.startsWith("Done") || progressMessage?.startsWith("Failed") || progressMessage?.startsWith("Aborted");
     const isRunning = !isFinished && (isFetching || runStarted);
-    useWebsocketTopic("ctp", "state", setProgress, { onOpen: () => setConnected(true), onClose: () => setProgress(null) });
+    useWebsocketTopic("pchp", "state", setProgress, { onOpen: () => setConnected(true), onClose: () => setProgress(null) });
     useEffect(() => { if (isFinished) setRunStarted(false); }, [isFinished]);
     const buildQueryString = useCallback(() => {
         const params = new URLSearchParams();

--- a/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetPar2FileDescriptorsStepTests.cs
@@ -69,16 +69,14 @@ public class GetPar2FileDescriptorsStepTests
             Par2File("Release [BBBBBBBB].par2", "index-b@example.com", indexB),
         };
 
-        // Progress<int>.Report posts to the captured context asynchronously,
-        // so guard the list and give callbacks a beat to drain.
+        // Progress<int> posts to the captured context asynchronously and can
+        // reorder 50/100 under CI load. Collect synchronously so order is
+        // the step's Report() sequence.
         var reported = new List<int>();
-        var gate = new object();
-        var progress = new Progress<int>(v => { lock (gate) reported.Add(v); });
-        await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client, progress);
-        await Task.Delay(50);
+        await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client, new CollectingProgress(reported));
 
         // Two index files → 50 then 100, not raw counts 1 then 2.
-        lock (gate) Assert.Equal([50, 100], reported);
+        Assert.Equal([50, 100], reported);
     }
 
     [Fact]
@@ -172,6 +170,11 @@ public class GetPar2FileDescriptorsStepTests
         var descriptors = await GetPar2FileDescriptorsStep.GetPar2FileDescriptors(files, client);
 
         Assert.Empty(descriptors);
+    }
+
+    private sealed class CollectingProgress(List<int> reports) : IProgress<int>
+    {
+        public void Report(int value) => reports.Add(value);
     }
 
     private static byte[] FileId(byte fill) => Enumerable.Repeat(fill, 16).ToArray();

--- a/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
@@ -37,6 +37,26 @@ public class PruneCompletedHistoryTaskTests
     }
 
     [Fact]
+    public async Task DryRun_PublishesProgressOnPruneTopicNotCleanupTopic()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            ctx.HistoryItems.Add(CreateHistory(Guid.NewGuid(), "dry-run.nzb", "movies", DateTime.UtcNow.AddDays(-200)));
+            await ctx.SaveChangesAsync(); ctx.ChangeTracker.Clear();
+            var websocket = new WebsocketManager();
+            Assert.True(await new PruneCompletedHistoryTask(websocket, true, null, 90, () => harness.CreateContext()).Execute());
+            var progress = websocket.PeekLastMessage(WebsocketTopic.PruneCompletedHistoryTaskProgress);
+            Assert.NotNull(progress);
+            Assert.StartsWith("Dry Run - Done.", progress);
+            Assert.Null(websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress));
+        }
+        finally { await BaseTask.ResetRunningTaskForTestsAsync(); }
+    }
+
+    [Fact]
     public async Task DryRun_DoesNotModifyDatabase()
     {
         await BaseTask.ResetRunningTaskForTestsAsync();


### PR DESCRIPTION
Fixes #984

## Summary
- Give Prune Completed History its own websocket progress topic (`pchp`) so its status no longer appears in the Remove Orphaned Files card (including a false **View audit** link).
- Warn on the prune card that dropping SAB history also drops history protection, so unlinked WebDAV files will show up in Remove Orphaned Files.
- Document that retention and manual prune clear `HistoryItemId`; orphan cleanup then deletes those mounts only if they also have no library symlink/STRM.

## Test plan
- [x] `cd frontend && npm run typecheck && npm run build && npm test`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] On Maintenance: run an orphan dry run, then a prune dry run (and the reverse). Each card should show only its own status; **View audit** only after a finished orphan run.
- [ ] Confirm the prune warning mentions losing history protection / orphan eligibility.