### PR TITLE
fix: retrieve NZBs from indexers that require a SABnzbd User-Agent

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1689,7 +1689,7 @@ public class ConfigManager
 
     public string GetUserAgent()
     {
-        var defaultValue = $"nzbdav/{AppVersion}";
+        var defaultValue = "SABnzbd/5.1.0";
         return StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiUserAgent))
                ?? EnvironmentUtil.GetEnvironmentVariable("NZB_GRAB_USER_AGENT")
                ?? defaultValue;

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -114,7 +114,7 @@ These apply only when the matching Settings value is empty **and** no
 |----------|-----------------|------------------------|
 | `FRONTEND_BACKEND_API_KEY` | API Key | required |
 | `CATEGORIES` | Categories | `audio,software,tv,movies` |
-| `NZB_GRAB_USER_AGENT` | User Agent / retrieve UA | `nzbdav/{version}` |
+| `NZB_GRAB_USER_AGENT` | User Agent / retrieve UA | `SABnzbd/5.1.0` |
 | `NZB_SEARCH_USER_AGENT` | Search User-Agent | `nzbdav/{version}` |
 | `TRUSTED_INTERNAL_HOSTS` [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | Trusted local hosts | none |
 | `MOUNT_DIR` | Rclone Mount Directory | `/mnt/nzbdav` |

--- a/docs/configuration/indexers.md
+++ b/docs/configuration/indexers.md
@@ -14,7 +14,7 @@ Newznab indexers/aggregators, global request defaults, and title exclude pattern
 |---------|------------|---------|--------|
 | HTTP(S) Proxy URL | in `indexers.instances` | empty | Used when indexer has no override |
 | Default Search User-Agent | `api.search-user-agent` | empty → `nzbdav/{ver}` or `NZB_SEARCH_USER_AGENT` | Search/caps queries |
-| Default Retrieve User-Agent | `api.user-agent` | empty → `nzbdav/{ver}` or `NZB_GRAB_USER_AGENT` | Fetching `.nzb` |
+| Default Retrieve User-Agent | `api.user-agent` | empty → `SABnzbd/5.1.0` or `NZB_GRAB_USER_AGENT` | Fetching `.nzb` |
 | Request timeout (seconds) | in instances | `30` | Per-request timeout |
 | Search results per indexer | in instances | `100` | Page size |
 | Exclude result patterns | `search.exclude-patterns` | empty | JS regex per line (case-insensitive) |

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -558,14 +558,15 @@ export function IndexersSettings({ config, setNewConfig, savedConfig, onSyncedCo
                             type="text"
                             id="indexers-default-retrieve-user-agent"
                             className="w-full"
-                            placeholder="nzbdav/<version>"
+                            placeholder="SABnzbd/5.1.0"
                             value={defaultRetrieveUserAgent}
                             onChange={e => handleRetrieveUserAgentChange(e.target.value)}
                         />
                         <HelpText>
                             Sent when retrieving .nzb files, including SAB <code>addurl</code> requests
                             matched to an indexer. Per-indexer overrides take precedence. Leave blank to
-                            use the application default.
+                            use <code>SABnzbd/5.1.0</code> so indexers that require a SABnzbd client
+                            accept grabs.
                         </HelpText>
                     </div>
                     </ManagedSetting>

--- a/tests/NzbWebDAV.Tests/Config/RetrieveUserAgentConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/RetrieveUserAgentConfigTests.cs
@@ -1,0 +1,59 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class RetrieveUserAgentConfigTests
+{
+    [Fact]
+    public void GetUserAgent_DefaultsToSabnzbdWhenUnset()
+    {
+        var previous = Environment.GetEnvironmentVariable("NZB_GRAB_USER_AGENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("NZB_GRAB_USER_AGENT", null);
+            var config = new ConfigManager();
+            Assert.Equal("SABnzbd/5.1.0", config.GetUserAgent());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NZB_GRAB_USER_AGENT", previous);
+        }
+    }
+
+    [Fact]
+    public void GetUserAgent_UsesSavedConfigValue()
+    {
+        var previous = Environment.GetEnvironmentVariable("NZB_GRAB_USER_AGENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("NZB_GRAB_USER_AGENT", "env-agent");
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.ApiUserAgent, ConfigValue = "custom-agent" },
+            ]);
+            Assert.Equal("custom-agent", config.GetUserAgent());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NZB_GRAB_USER_AGENT", previous);
+        }
+    }
+
+    [Fact]
+    public void GetUserAgent_UsesEnvWhenConfigEmpty()
+    {
+        var previous = Environment.GetEnvironmentVariable("NZB_GRAB_USER_AGENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("NZB_GRAB_USER_AGENT", "env-agent");
+            var config = new ConfigManager();
+            Assert.Equal("env-agent", config.GetUserAgent());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NZB_GRAB_USER_AGENT", previous);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Blank **Default Retrieve User-Agent** now sends `SABnzbd/5.1.0` instead of `nzbdav/{version}`, so indexers that only allow SABnzbd grabs (e.g. Treasure Maps / SceneNZBs) work without a manual setting.
- Search User-Agent is unchanged. Saved `api.user-agent`, `NZB_GRAB_USER_AGENT`, and per-indexer overrides still win.
- Settings placeholder/help text and indexer docs match the new default.

## Test plan
- [ ] Leave Default Retrieve User-Agent blank; confirm NZB grabs (SAB `addurl` / profile play) send `SABnzbd/5.1.0`.
- [ ] Set a custom retrieve UA (or `NZB_GRAB_USER_AGENT`) and confirm it still overrides the default.
- [ ] Confirm search queries still use `nzbdav/{version}` when Default Search User-Agent is blank.
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~RetrieveUserAgentConfigTests"`