### PR TITLE
fix(queue): stalled downloads now fail so Sonarr can re-grab them

### DIFF
--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -14,15 +14,18 @@ public class NzbDocument
 
     public List<NzbFile> Files { get; } = [];
 
-    public static async Task<NzbDocument> LoadAsync(Stream stream)
+    public static async Task<NzbDocument> LoadAsync(Stream stream, CancellationToken ct = default)
     {
         try
         {
             var document = new NzbDocument();
             using var reader = XmlReader.Create(stream, XmlSettings);
 
+            // XmlReader.ReadAsync doesn't take a token; check between reads so a
+            // cancelled queue worker stops promptly once the current read returns.
             while (await reader.ReadAsync().ConfigureAwait(false))
             {
+                ct.ThrowIfCancellationRequested();
                 if (reader.NodeType != XmlNodeType.Element) continue;
                 switch (reader.Name)
                 {

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -141,14 +141,24 @@ public class QueueItemProcessor(
                 dbClient.Ctx.ClearChangeTracker();
                 try
                 {
-                    // `ct` is already cancelled here; finalize with a live token so
-                    // the history write can't throw and leave the item queued.
+                    // `ct` is already cancelled here; finalize with a dedicated
+                    // timeout so a wedged finalize-lock holder cannot pin this
+                    // worker forever (CancellationToken.None would also ignore
+                    // shutdown). On timeout, leave the item queued — the stall
+                    // counter persists, so the next attempt fails it again.
+                    using var failCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
                     await MarkQueueItemCompleted(
                             startTime,
                             error: "Download stalled: no progress across repeated attempts. " +
                                    "Failing so the download client can blocklist and re-grab.",
-                            cancellationToken: CancellationToken.None)
+                            cancellationToken: failCts.Token)
                         .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex.IsCancellationException() && ex is not OutOfMemoryException)
+                {
+                    Log.Error(
+                        "Timed out writing history for repeatedly-stalled queue item {JobName}; leaving it queued",
+                        queueItem.JobName);
                 }
                 catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
                 {
@@ -734,9 +744,10 @@ public class QueueItemProcessor(
         CancellationToken? cancellationToken = null
     )
     {
-        // The finalize token defaults to the worker token, but a stuck-watchdog
-        // failure runs after the worker was cancelled, so it must pass a live
-        // token or the history write throws and the item stays queued.
+        // The finalize token defaults to the worker token. The stuck-watchdog
+        // failure path must pass a timeout-bounded token: the worker CT is
+        // already cancelled, and CancellationToken.None would ignore shutdown
+        // and hang forever on a wedged finalize lock.
         var finalizeCt = cancellationToken ?? ct;
         HistoryItem? historyItem = null;
         GetHistoryResponse.HistorySlot? historySlot = null;

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -74,6 +74,20 @@ public class QueueItemProcessor(
     private const int MaxProviderRetryAttempts = 20;
     private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(15);
 
+    /// <summary>
+    /// Set by the queue's stuck watchdog when this worker's cancellation should
+    /// fail the item into history (repeated stalls) rather than leave it queued
+    /// for another retry. Checked in the cancellation catch in <see cref="ProcessAsync"/>.
+    /// </summary>
+    internal Func<bool>? ShouldFailOnCancel { get; set; }
+
+    /// <summary>
+    /// Called once the item reaches a terminal state (completed or failed into
+    /// history) so the manager can drop its per-item watchdog stall counter. Not
+    /// called for a plain cancellation that leaves the item queued for retry.
+    /// </summary>
+    internal Action? OnTerminal { get; set; }
+
     internal static List<string> SelectArticlesForExistenceCheck(
         IEnumerable<IReadOnlyList<string>> segmentsByFile,
         string mode)
@@ -114,8 +128,40 @@ public class QueueItemProcessor(
         // then we need to clear any db changes and finish early.
         catch (Exception e) when (e.GetBaseException().IsCancellationException() && e is not OutOfMemoryException)
         {
-            Log.Information("Processing of queue item {JobName} was cancelled", queueItem.JobName);
-            dbClient.Ctx.ClearChangeTracker();
+            // The stuck watchdog flags a repeatedly-stalled item so it fails into
+            // history (letting Sonarr/Radarr blocklist and re-grab) instead of
+            // pausing and retrying forever. An ordinary cancel — user pause/remove,
+            // shutdown, or a non-final stall — keeps the item queued.
+            if (ShouldFailOnCancel?.Invoke() == true)
+            {
+                Log.Warning(
+                    "Failing queue item {JobName} ({QueueItemId}) into history after repeated stalls",
+                    queueItem.JobName,
+                    queueItem.Id);
+                dbClient.Ctx.ClearChangeTracker();
+                try
+                {
+                    // `ct` is already cancelled here; finalize with a live token so
+                    // the history write can't throw and leave the item queued.
+                    await MarkQueueItemCompleted(
+                            startTime,
+                            error: "Download stalled: no progress across repeated attempts. " +
+                                   "Failing so the download client can blocklist and re-grab.",
+                            cancellationToken: CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
+                {
+                    Log.Error(ex,
+                        "Failed to mark repeatedly-stalled queue item {JobName} as failed",
+                        queueItem.JobName);
+                }
+            }
+            else
+            {
+                Log.Information("Processing of queue item {JobName} was cancelled", queueItem.JobName);
+                dbClient.Ctx.ClearChangeTracker();
+            }
         }
 
         catch (Exception e) when (e.IsRetryableDownloadException() && e is not OutOfMemoryException)
@@ -266,7 +312,7 @@ public class QueueItemProcessor(
         }
 
         // read the nzb document
-        var nzb = await NzbDocument.LoadAsync(queueNzbStream).ConfigureAwait(false);
+        var nzb = await NzbDocument.LoadAsync(queueNzbStream, ct).ConfigureAwait(false);
         var nzbFiles = nzb.Files.Where(x => x.Segments.Count > 0).ToList();
         if (usenetClient is ArticleCachingNntpClient cachingUsenetClient)
             cachingUsenetClient.TrackNzbFiles(nzbFiles);
@@ -684,9 +730,14 @@ public class QueueItemProcessor(
     (
         DateTime startTime,
         string? error = null,
-        Func<Task<DavItem?>>? databaseOperations = null
+        Func<Task<DavItem?>>? databaseOperations = null,
+        CancellationToken? cancellationToken = null
     )
     {
+        // The finalize token defaults to the worker token, but a stuck-watchdog
+        // failure runs after the worker was cancelled, so it must pass a live
+        // token or the history write throws and the item stays queued.
+        var finalizeCt = cancellationToken ?? ct;
         HistoryItem? historyItem = null;
         GetHistoryResponse.HistorySlot? historySlot = null;
         IReadOnlyDictionary<string, long>? providerUsage = null;
@@ -705,8 +756,8 @@ public class QueueItemProcessor(
                 historyItem, mountFolder, configManager, providerUsage, displayByMetricsKey);
             dbClient.Ctx.QueueItems.Remove(queueItem);
             dbClient.Ctx.HistoryItems.Add(historyItem);
-            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-        }).ConfigureAwait(false);
+            await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
+        }, finalizeCt).ConfigureAwait(false);
 
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
         _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historySlot!.ToJson());
@@ -732,9 +783,10 @@ public class QueueItemProcessor(
 
         RecordWatchdogAttemptIfExternal(startTime, error, providerUsage!);
         retryAttempts.TryRemove(queueItem.Id, out _);
+        OnTerminal?.Invoke();
     }
 
-    private async Task WithFinalizeLockAsync(Func<Task> action)
+    private async Task WithFinalizeLockAsync(Func<Task> action, CancellationToken? cancellationToken = null)
     {
         if (finalizeLock is null)
         {
@@ -742,7 +794,8 @@ public class QueueItemProcessor(
             return;
         }
 
-        await finalizeLock.WaitAsync(ct).ConfigureAwait(false);
+        var waitCt = cancellationToken ?? ct;
+        await finalizeLock.WaitAsync(waitCt).ConfigureAwait(false);
         try
         {
             await action().ConfigureAwait(false);

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -770,31 +770,39 @@ public class QueueItemProcessor(
             await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
         }, finalizeCt).ConfigureAwait(false);
 
-        _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
-        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historySlot!.ToJson());
-        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
-        _ = RefreshMonitoredDownloads();
-        if (error is null)
+        try
         {
-            Log.Information(
-                "Completed queue item {JobName} ({QueueItemId}) in {ElapsedSeconds} seconds",
-                queueItem.JobName,
-                queueItem.Id,
-                historyItem!.DownloadTimeSeconds);
-        }
-        else
-        {
-            Log.Error(
-                "Failed queue item {JobName} ({QueueItemId}) after {ElapsedSeconds} seconds: {Reason}",
-                queueItem.JobName,
-                queueItem.Id,
-                historyItem!.DownloadTimeSeconds,
-                error);
-        }
+            _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
+            _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historySlot!.ToJson());
+            _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+            _ = RefreshMonitoredDownloads();
+            if (error is null)
+            {
+                Log.Information(
+                    "Completed queue item {JobName} ({QueueItemId}) in {ElapsedSeconds} seconds",
+                    queueItem.JobName,
+                    queueItem.Id,
+                    historyItem!.DownloadTimeSeconds);
+            }
+            else
+            {
+                Log.Error(
+                    "Failed queue item {JobName} ({QueueItemId}) after {ElapsedSeconds} seconds: {Reason}",
+                    queueItem.JobName,
+                    queueItem.Id,
+                    historyItem!.DownloadTimeSeconds,
+                    error);
+            }
 
-        RecordWatchdogAttemptIfExternal(startTime, error, providerUsage!);
-        retryAttempts.TryRemove(queueItem.Id, out _);
-        OnTerminal?.Invoke();
+            RecordWatchdogAttemptIfExternal(startTime, error, providerUsage!);
+        }
+        finally
+        {
+            // The item is already in history; drop retry/stall counters even if
+            // post-finalize logging or watchdog recording throws.
+            retryAttempts.TryRemove(queueItem.Id, out _);
+            OnTerminal?.Invoke();
+        }
     }
 
     private async Task WithFinalizeLockAsync(Func<Task> action, CancellationToken? cancellationToken = null)

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -19,6 +19,13 @@ public sealed class QueueManager : IDisposable
     private readonly ConcurrentDictionary<Guid, InProgressQueueItem> _inProgress = new();
     private readonly ConcurrentDictionary<Guid, int> _retryAttempts = new();
 
+    // Per-item watchdog stall count. Separate from _retryAttempts (which tracks
+    // provider-connection retries) because a stall is a different failure mode:
+    // the download made no progress at all. Without a cap the pause-and-retry
+    // loop runs forever and the item never reaches SAB history, so Sonarr/Radarr
+    // wait in Activity indefinitely (issue #987).
+    private readonly ConcurrentDictionary<Guid, int> _stallAttempts = new();
+
     private readonly UsenetStreamingClient _usenetClient;
     private readonly CancellationTokenSource? _cancellationTokenSource;
     private readonly SemaphoreSlim _stateLock = new(1, 1);
@@ -51,6 +58,14 @@ public sealed class QueueManager : IDisposable
     internal TimeSpan StuckItemThreshold { get; set; } = DefaultStuckItemThreshold;
     internal TimeSpan StuckItemCheckInterval { get; set; } = TimeSpan.FromSeconds(30);
     internal TimeSpan StuckItemPauseWriteTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    // How long to wait after cancelling a stuck worker before concluding it
+    // ignored the cancellation and logging an Error. Test-overridable.
+    internal TimeSpan StuckCancelGracePeriod { get; set; } = TimeSpan.FromMinutes(2);
+
+    // Number of watchdog stall retries before the item is failed into history
+    // so *Arr clients can blocklist and re-grab. Test-overridable.
+    internal int MaxStuckAttempts { get; set; } = 3;
     internal Func<IReadOnlyCollection<Guid>, CancellationToken, Task<(QueueItem? queueItem, Stream? queueNzbStream)>>?
         GetTopQueueItemOverride
     { get; set; }
@@ -658,6 +673,10 @@ public sealed class QueueManager : IDisposable
             foreach (var item in completed)
             {
                 _inProgress.TryRemove(item.QueueItem.Id, out _);
+                // Do NOT clear _stallAttempts here: a watchdog-cancelled item that
+                // will be retried must keep its stall count so repeated stalls
+                // eventually fail it. The processor clears the counter only when
+                // the item reaches a terminal state (completed or failed).
                 if (_primaryId == item.QueueItem.Id)
                     _primaryId = null;
             }
@@ -787,13 +806,22 @@ public sealed class QueueManager : IDisposable
             WatchdogCts = null!, // set below, after the worker task is created
         };
 
-        var task = new QueueItemProcessor(
+        var processor = new QueueItemProcessor(
             queueItem, queueNzbStream, dbClient, cachingUsenetClient,
             _configManager, _websocketManager, _providerUsageTracker,
             _watchdogLog, _sourceTracker, progressHook, _retryAttempts,
             _finalizeLock, cts.Token,
             stageReporter: stage => inProgressQueueItem.CurrentStage = stage
-        ).ProcessAsync();
+        )
+        {
+            // The stuck watchdog flips this flag on the final stall attempt; the
+            // processor's cancellation catch then fails the item into history.
+            ShouldFailOnCancel = () => inProgressQueueItem.FailOnStuckCancel,
+            // Terminal states (completed/failed) drop the stall counter; a plain
+            // watchdog cancel leaves it so repeated stalls accumulate to the cap.
+            OnTerminal = () => _stallAttempts.TryRemove(queueItem.Id, out _),
+        };
+        var task = processor.ProcessAsync();
         inProgressQueueItem.ProcessingTask = task;
 
         var watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
@@ -872,6 +900,10 @@ public sealed class QueueManager : IDisposable
 
     private async Task WatchForStuckProgressAsync(InProgressQueueItem item, CancellationToken ct)
     {
+        // Per-attempt watchdog: tied to this worker's lifetime via `ct` (the
+        // watchdog CTS is cancelled when the worker completes). Detects a stall,
+        // pauses/cancels (or, on the final attempt, flags fail-to-history), then
+        // returns. A fresh watchdog with a fresh baseline is created per claim.
         var lastProgress = item.ProgressPercentage;
         var lastFetchCount = GetSuccessfulFetchCount(item.QueueItem.Id);
         var lastChangeTick = Environment.TickCount64;
@@ -910,6 +942,36 @@ public sealed class QueueManager : IDisposable
         }
     }
 
+    // Separate from the per-attempt watchdog: observes whether a stuck-cancelled
+    // worker actually stops. If it ignores cancellation past the grace period,
+    // log loudly (the slot stays occupied — we never abandon a live task holding
+    // connections/DB context/finalize lock — but the operator can now see it).
+    private async Task WatchForIgnoredCancelAsync(InProgressQueueItem item)
+    {
+        try
+        {
+            await Task.Delay(StuckCancelGracePeriod).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (item.ProcessingTask.IsCompleted)
+            return;
+
+        Log.Error(
+            "Queue worker ignored cancellation and is still running after {GraceSeconds:0}s. " +
+            "JobName={JobName} QueueItemId={QueueItemId} CurrentStage={CurrentStage} " +
+            "ProgressPercentage={ProgressPercentage}. The worker slot stays occupied until " +
+            "the task completes; restart the container to reclaim it.",
+            StuckCancelGracePeriod.TotalSeconds,
+            item.QueueItem.JobName,
+            item.QueueItem.Id,
+            item.CurrentStage,
+            item.ProgressPercentage);
+    }
+
     private long GetSuccessfulFetchCount(Guid queueItemId)
     {
         var snapshot = _providerUsageTracker.Snapshot(queueItemId);
@@ -923,49 +985,88 @@ public sealed class QueueManager : IDisposable
         var idleMinutes = idleMs / 60000d;
         var phase = DescribeProgressPhase(progress);
         var stage = item.CurrentStage;
-#pragma warning disable CA5394 // pause jitter is not security-sensitive
-        var jitterSeconds = Random.Shared.Next(0, 301);
-#pragma warning restore CA5394
-        var pauseUntil = DateTime.Now + TimeSpan.FromMinutes(15) + TimeSpan.FromSeconds(jitterSeconds);
 
-        try
+        // Count this stall. Once an item stalls MaxStuckAttempts times we stop
+        // pausing-and-retrying and instead fail it into history so Sonarr/Radarr
+        // see a Failed slot and can blocklist + re-grab. Otherwise a persistently
+        // stalling NZB loops "pause → retry → stall" forever and never leaves the
+        // SAB queue (issue #987).
+        var stallCount = _stallAttempts.AddOrUpdate(queueItem.Id, 1, (_, prev) => prev + 1);
+        var failToHistory = stallCount >= MaxStuckAttempts;
+
+        DateTime? pauseUntil = null;
+        if (!failToHistory)
         {
-            await using var ctx = CreateDbContext();
-            using var writeCts = new CancellationTokenSource(StuckItemPauseWriteTimeout);
-            await ctx.QueueItems
-                .Where(q => q.Id == queueItem.Id)
-                .ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, pauseUntil), writeCts.Token)
-                .ConfigureAwait(false);
+#pragma warning disable CA5394 // pause jitter is not security-sensitive
+            var jitterSeconds = Random.Shared.Next(0, 301);
+#pragma warning restore CA5394
+            pauseUntil = DateTime.Now + TimeSpan.FromMinutes(15) + TimeSpan.FromSeconds(jitterSeconds);
+
+            try
+            {
+                await using var ctx = CreateDbContext();
+                using var writeCts = new CancellationTokenSource(StuckItemPauseWriteTimeout);
+                await ctx.QueueItems
+                    .Where(q => q.Id == queueItem.Id)
+                    .ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, pauseUntil.Value), writeCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Log.Warning(
+                    "Timed out persisting PauseUntil for stuck queue item {QueueItemId} ({JobName}); " +
+                    "proceeding with worker cancellation",
+                    queueItem.Id,
+                    queueItem.JobName);
+            }
+#pragma warning disable CA2016
+            catch (Exception e) when (e is not OutOfMemoryException)
+#pragma warning restore CA2016
+            {
+                Log.Warning(e,
+                    "Failed to persist PauseUntil for stuck queue item {QueueItemId} ({JobName})",
+                    queueItem.Id,
+                    queueItem.JobName);
+            }
         }
-        catch (OperationCanceledException)
+
+        if (failToHistory)
         {
             Log.Warning(
-                "Timed out persisting PauseUntil for stuck queue item {QueueItemId} ({JobName}); " +
-                "proceeding with worker cancellation",
+                "Queue item stuck with no progress on attempt {StallCount}/{MaxAttempts}; " +
+                "failing into history so the client can re-grab. JobName={JobName} QueueItemId={QueueItemId} " +
+                "IdleMinutes={IdleMinutes:F1} ProgressPhase={ProgressPhase} CurrentStage={CurrentStage} " +
+                "ProgressPercentage={ProgressPercentage}",
+                stallCount,
+                MaxStuckAttempts,
+                queueItem.JobName,
                 queueItem.Id,
-                queueItem.JobName);
-        }
-#pragma warning disable CA2016
-        catch (Exception e) when (e is not OutOfMemoryException)
-#pragma warning restore CA2016
-        {
-            Log.Warning(e,
-                "Failed to persist PauseUntil for stuck queue item {QueueItemId} ({JobName})",
-                queueItem.Id,
-                queueItem.JobName);
-        }
+                idleMinutes,
+                phase,
+                stage,
+                progress);
 
-        Log.Warning(
-            "Queue item stuck with no progress; pausing and cancelling. JobName={JobName} QueueItemId={QueueItemId} " +
-            "IdleMinutes={IdleMinutes:F1} ProgressPhase={ProgressPhase} CurrentStage={CurrentStage} " +
-            "ProgressPercentage={ProgressPercentage} PauseUntil={PauseUntil}",
-            queueItem.JobName,
-            queueItem.Id,
-            idleMinutes,
-            phase,
-            stage,
-            progress,
-            pauseUntil);
+            // The processor's cancellation catch checks this flag and fails the
+            // item into history instead of leaving it queued.
+            item.FailOnStuckCancel = true;
+        }
+        else
+        {
+            Log.Warning(
+                "Queue item stuck with no progress; pausing and cancelling (attempt {StallCount}/{MaxAttempts}). " +
+                "JobName={JobName} QueueItemId={QueueItemId} " +
+                "IdleMinutes={IdleMinutes:F1} ProgressPhase={ProgressPhase} CurrentStage={CurrentStage} " +
+                "ProgressPercentage={ProgressPercentage} PauseUntil={PauseUntil}",
+                stallCount,
+                MaxStuckAttempts,
+                queueItem.JobName,
+                queueItem.Id,
+                idleMinutes,
+                phase,
+                stage,
+                progress,
+                pauseUntil);
+        }
 
         try
         {
@@ -975,6 +1076,10 @@ public sealed class QueueManager : IDisposable
         {
             // Worker may have finished and disposed the CTS concurrently.
         }
+
+        // If the worker ignores this cancellation, surface it. Fire-and-forget;
+        // the observer self-terminates once the worker task completes.
+        _ = WatchForIgnoredCancelAsync(item);
     }
 
     private static string DescribeProgressPhase(int progress) =>
@@ -1124,6 +1229,13 @@ public sealed class QueueManager : IDisposable
         public DateTime StartedAt { get; init; }
         public CancellationTokenSource WatchdogCts { get; set; } = null!;
         public Task WatchdogTask { get; set; } = Task.CompletedTask;
+
+        /// <summary>
+        /// Set by the stuck watchdog on the final stall attempt. When the worker's
+        /// cancellation is honored, the processor checks this flag and fails the
+        /// item into SAB history instead of leaving it queued for another retry.
+        /// </summary>
+        public bool FailOnStuckCancel { get; set; }
         public bool IsPrimary => QueueDownloadContext.IsPrimary;
 
         public async ValueTask DisposeAsync()

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -992,42 +992,6 @@ public sealed class QueueManager : IDisposable
         var stallCount = _stallAttempts.AddOrUpdate(queueItem.Id, 1, (_, prev) => prev + 1);
         var failToHistory = stallCount >= MaxStuckAttempts;
 
-        DateTime? pauseUntil = null;
-        if (!failToHistory)
-        {
-#pragma warning disable CA5394 // pause jitter is not security-sensitive
-            var jitterSeconds = Random.Shared.Next(0, 301);
-#pragma warning restore CA5394
-            pauseUntil = DateTime.Now + TimeSpan.FromMinutes(15) + TimeSpan.FromSeconds(jitterSeconds);
-
-            try
-            {
-                await using var ctx = CreateDbContext();
-                using var writeCts = new CancellationTokenSource(StuckItemPauseWriteTimeout);
-                await ctx.QueueItems
-                    .Where(q => q.Id == queueItem.Id)
-                    .ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, pauseUntil.Value), writeCts.Token)
-                    .ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                Log.Warning(
-                    "Timed out persisting PauseUntil for stuck queue item {QueueItemId} ({JobName}); " +
-                    "proceeding with worker cancellation",
-                    queueItem.Id,
-                    queueItem.JobName);
-            }
-#pragma warning disable CA2016
-            catch (Exception e) when (e is not OutOfMemoryException)
-#pragma warning restore CA2016
-            {
-                Log.Warning(e,
-                    "Failed to persist PauseUntil for stuck queue item {QueueItemId} ({JobName})",
-                    queueItem.Id,
-                    queueItem.JobName);
-            }
-        }
-
         if (failToHistory)
         {
             Log.Warning(
@@ -1050,6 +1014,38 @@ public sealed class QueueManager : IDisposable
         }
         else
         {
+#pragma warning disable CA5394 // pause jitter is not security-sensitive
+            var jitterSeconds = Random.Shared.Next(0, 301);
+#pragma warning restore CA5394
+            var pauseUntil = DateTime.Now + TimeSpan.FromMinutes(15) + TimeSpan.FromSeconds(jitterSeconds);
+
+            try
+            {
+                await using var ctx = CreateDbContext();
+                using var writeCts = new CancellationTokenSource(StuckItemPauseWriteTimeout);
+                await ctx.QueueItems
+                    .Where(q => q.Id == queueItem.Id)
+                    .ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, pauseUntil), writeCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Log.Warning(
+                    "Timed out persisting PauseUntil for stuck queue item {QueueItemId} ({JobName}); " +
+                    "proceeding with worker cancellation",
+                    queueItem.Id,
+                    queueItem.JobName);
+            }
+#pragma warning disable CA2016
+            catch (Exception e) when (e is not OutOfMemoryException)
+#pragma warning restore CA2016
+            {
+                Log.Warning(e,
+                    "Failed to persist PauseUntil for stuck queue item {QueueItemId} ({JobName})",
+                    queueItem.Id,
+                    queueItem.JobName);
+            }
+
             Log.Warning(
                 "Queue item stuck with no progress; pausing and cancelling (attempt {StallCount}/{MaxAttempts}). " +
                 "JobName={JobName} QueueItemId={QueueItemId} " +

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -259,7 +259,11 @@ public sealed class QueueManager : IDisposable
         {
             await dbClient.RemoveQueueItemsAsync(queueItemIds, ct).ConfigureAwait(false);
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-            foreach (var id in queueItemIds) _retryAttempts.TryRemove(id, out _);
+            foreach (var id in queueItemIds)
+            {
+                _retryAttempts.TryRemove(id, out _);
+                _stallAttempts.TryRemove(id, out _);
+            }
         }, ct).ConfigureAwait(false);
     }
 
@@ -948,16 +952,10 @@ public sealed class QueueManager : IDisposable
     // connections/DB context/finalize lock — but the operator can now see it).
     private async Task WatchForIgnoredCancelAsync(InProgressQueueItem item)
     {
-        try
-        {
-            await Task.Delay(StuckCancelGracePeriod).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
-        }
-
-        if (item.ProcessingTask.IsCompleted)
+        // WhenAny does not observe ProcessingTask exceptions — the reaper does.
+        var completed = await Task.WhenAny(item.ProcessingTask, Task.Delay(StuckCancelGracePeriod))
+            .ConfigureAwait(false);
+        if (completed == item.ProcessingTask || item.ProcessingTask.IsCompleted)
             return;
 
         Log.Error(

--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -97,7 +97,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
             try
             {
                 using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(queued.NzbContents));
-                var doc = await NzbDocument.LoadAsync(stream).ConfigureAwait(false);
+                var doc = await NzbDocument.LoadAsync(stream, ct).ConfigureAwait(false);
                 foreach (var file in doc.Files)
                 {
                     AddIds(pool, seen, file.GetSegmentIds(), maxSegments);

--- a/docs/configuration/queue.md
+++ b/docs/configuration/queue.md
@@ -46,11 +46,16 @@ not increase queue depth.
 
 ## Stuck-item watchdog [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 
-Each active queue worker runs a progress watchdog. If `ProgressPercentage` does not
-increase for `QUEUE_ITEM_STUCK_MINUTES` (default **5**), InfiniDysk pauses the item
-(`PauseUntil` ≈ 15–20 minutes with jitter) and cancels the worker so the queue can
-move on. The item is **not** failed into history — it retries after the pause
-expires.
+Each active queue worker runs a progress watchdog. A worker is treated as stuck
+only when it makes no visible progress **and** fetches no segments for
+`QUEUE_ITEM_STUCK_MINUTES` (default **5**) — long silent phases that keep
+fetching (large PAR2 walks, archive header scans) are not penalized.
+
+When an item stalls, InfiniDysk pauses it (`PauseUntil` ≈ 15–20 minutes with
+jitter) and cancels the worker so the queue can move on; the item retries after
+the pause expires. After **3** consecutive stalls the item is failed into history
+with a clear error, so Sonarr/Radarr can blocklist the release and grab another
+one instead of waiting forever.
 
 Tune the stall budget with `QUEUE_ITEM_STUCK_MINUTES` when long phases legitimately
 hold progress (large archives, full article-existence health checks).

--- a/docs/configuration/queue.md
+++ b/docs/configuration/queue.md
@@ -53,9 +53,11 @@ fetching (large PAR2 walks, archive header scans) are not penalized.
 
 When an item stalls, InfiniDysk pauses it (`PauseUntil` ≈ 15–20 minutes with
 jitter) and cancels the worker so the queue can move on; the item retries after
-the pause expires. After **3** consecutive stalls the item is failed into history
-with a clear error, so Sonarr/Radarr can blocklist the release and grab another
-one instead of waiting forever.
+the pause expires. After a download stalls **3** times in total the item is
+failed into history with a clear error, so Sonarr/Radarr can blocklist the
+release and grab another one instead of waiting forever. The stall count is
+cumulative for that enqueue (not reset by a later successful fetch), so a
+release that wedges after a brief burst of progress still fails over.
 
 Tune the stall budget with `QUEUE_ITEM_STUCK_MINUTES` when long phases legitimately
 hold progress (large archives, full article-existence health checks).

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -96,12 +96,47 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             CreateDbContextOverride = () => new DavDatabaseContext(_options),
             StuckItemCheckInterval = TimeSpan.FromMilliseconds(50),
             StuckItemThreshold = TimeSpan.FromMilliseconds(250),
+            StuckCancelGracePeriod = TimeSpan.FromMilliseconds(400),
+        };
+    }
+
+    private void WireStallingClaimOverride(StallStream stall)
+    {
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, stall);
+        };
+    }
+
+    // Each claim returns a FRESH stall stream (matching production, where every
+    // claim reads a fresh NZB blob stream) and captures it so the test can bind
+    // the current worker's CTS. Reusing one stream across claims breaks because
+    // it stays bound to the previous worker's disposed CTS.
+    private void WireStallingClaimOverridePerClaim(Action<StallStream> onClaimed)
+    {
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            var stall = new StallStream();
+            onClaimed(stall);
+            return (claimed, stall);
         };
     }
 
     public Task DisposeAsync()
     {
-        _queueManager.Dispose();
+        // The hung-worker test detaches its manager (sets this to null) because a
+        // never-completing worker makes the coordinator's shutdown await hang.
+        _queueManager?.Dispose();
         Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
         try
         {
@@ -388,6 +423,254 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task EarlyStalls_PauseAndRetry_ItemStaysQueued()
+    {
+        // Stall attempts 1 and 2 (MaxStuckAttempts = 3) must keep the item queued
+        // with PauseUntil set and must NOT write history.
+        var item = CreateQueueItem("retry.nzb", "movies", "RetryJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Each claim gets a fresh stall stream; bind it to its worker's CTS.
+        var claimed = new TaskCompletionSource<StallStream>(TaskCreationOptions.RunContinuationsAsynchronously);
+        WireStallingClaimOverridePerClaim(s => claimed.TrySetResult(s));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        for (var cycle = 0; cycle < 2; cycle++)
+        {
+            var stall = await claimed.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            claimed = new TaskCompletionSource<StallStream>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(10));
+            Assert.NotNull(inProgress);
+            var workerCts = GetWorkerCts(inProgress!);
+            stall.BindWorker(workerCts);
+
+            // Wait for the watchdog to cancel this worker.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
+                await Task.Delay(20);
+            Assert.True(workerCts.IsCancellationRequested, $"stall cycle {cycle}: worker was not cancelled");
+
+            // Wait for the coordinator to reap the cancelled worker.
+            deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (DateTime.UtcNow < deadline && FindInProgressItem(item.Id) is not null)
+                await Task.Delay(20);
+
+            // Still queued, still no history.
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                Assert.Equal(1, await ctx.QueueItems.CountAsync());
+                Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            }
+
+            // Clear PauseUntil so the next cycle can claim it, and wake the
+            // coordinator (which may be idle-sleeping up to a minute).
+            await using (var ctx = new DavDatabaseContext(_options))
+                await ctx.QueueItems.ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, (DateTime?)null));
+            _queueManager.AwakenQueue();
+        }
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ThirdStall_FailsItemIntoHistory()
+    {
+        var item = CreateQueueItem("stall3.nzb", "movies", "StallThreeJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        var claimed = new TaskCompletionSource<StallStream>(TaskCreationOptions.RunContinuationsAsynchronously);
+        WireStallingClaimOverridePerClaim(s => claimed.TrySetResult(s));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        for (var cycle = 0; cycle < 3; cycle++)
+        {
+            var stall = await claimed.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            claimed = new TaskCompletionSource<StallStream>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(15));
+            Assert.NotNull(inProgress);
+            var workerCts = GetWorkerCts(inProgress!);
+            stall.BindWorker(workerCts);
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+            while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
+                await Task.Delay(20);
+            Assert.True(workerCts.IsCancellationRequested, $"stall cycle {cycle}: worker was not cancelled");
+
+            // Wait for reap.
+            deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+            while (DateTime.UtcNow < deadline && FindInProgressItem(item.Id) is not null)
+                await Task.Delay(20);
+
+            if (cycle < 2)
+            {
+                // Retries 1 and 2: still queued, no history.
+                await using (var ctx = new DavDatabaseContext(_options))
+                {
+                    Assert.Equal(1, await ctx.QueueItems.CountAsync());
+                    Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+                }
+                await using (var ctx = new DavDatabaseContext(_options))
+                    await ctx.QueueItems.ExecuteUpdateAsync(s => s.SetProperty(q => q.PauseUntil, (DateTime?)null));
+                _queueManager.AwakenQueue();
+            }
+        }
+
+        // Final stall: item must have failed into history.
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            Assert.Equal(0, await ctx.QueueItems.CountAsync());
+            var history = await ctx.HistoryItems.SingleAsync();
+            Assert.Equal(HistoryItem.DownloadStatusOption.Failed, history.DownloadStatus);
+            Assert.False(string.IsNullOrWhiteSpace(history.FailMessage));
+        }
+
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task CancelWithoutFailFlag_LeavesItemQueued_NoHistory()
+    {
+        // A user-initiated cancel (no FailOnStuckCancel flag) must keep the item
+        // queued and write no history — only the watchdog's final stall may fail.
+        var item = CreateQueueItem("usercancel.nzb", "movies", "UserCancelJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        var claimed = new TaskCompletionSource<StallStream>(TaskCreationOptions.RunContinuationsAsynchronously);
+        WireStallingClaimOverridePerClaim(s => claimed.TrySetResult(s));
+
+        // Push the watchdog threshold beyond the test window so the watchdog never
+        // fires — this isolates the plain (non-watchdog) cancellation path.
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+
+        var stall = await claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5));
+        Assert.NotNull(inProgress);
+        stall.BindWorker(GetWorkerCts(inProgress!));
+
+        // Simulate a user-initiated cancel directly on the worker CTS (bypasses
+        // the watchdog, so FailOnStuckCancel stays false). Immediately stop the
+        // coordinator so it cannot re-claim the still-queued item with a fresh
+        // worker (which would stall a stream bound to no CTS and hang shutdown).
+        await GetWorkerCts(inProgress!).CancelAsync();
+        await cts.CancelAsync();
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            Assert.Equal(1, await ctx.QueueItems.CountAsync());
+            Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+        }
+    }
+
+    [Fact]
+    public async Task WorkerIgnoringCancellation_LogsError_AndKeepsSlot()
+    {
+        // A worker that never observes cancellation occupies its slot forever.
+        // The watchdog must survive its own cancel (unlinked CTS) and surface an
+        // Error after the grace period instead of silently returning.
+        var hung = new HungStream();
+        var item = CreateQueueItem("hung.nzb", "movies", "HungJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        // The hung worker never completes, so the coordinator's shutdown
+        // Task.WhenAll never finishes. Detach the manager from the fixture so the
+        // test's DisposeAsync skips awaiting it, and don't dispose it ourselves.
+        var manager = _queueManager;
+        _queueManager = null!;
+        manager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, hung);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = manager.ProcessQueueAsync(cts.Token);
+
+        object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5), manager);
+        Assert.NotNull(inProgress);
+
+        // Wait for the watchdog to cancel the (uncancellable) worker.
+        var workerCts = GetWorkerCts(inProgress!);
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
+            await Task.Delay(20);
+        Assert.True(workerCts.IsCancellationRequested);
+
+        // Wait past the cancel grace period; the worker task still hasn't finished
+        // and the item must remain in progress (slot occupied, not abandoned).
+        await Task.Delay(TimeSpan.FromMilliseconds(1500));
+        Assert.NotNull(FindInProgressItem(item.Id, manager));
+        Assert.False(GetProcessingTask(inProgress!).IsCompleted);
+
+        // Item remains queued (not failed) — the worker never honored the cancel.
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            Assert.Equal(1, await ctx.QueueItems.CountAsync());
+            Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+        }
+
+        // Stop the coordinator; we do not await or dispose the manager (detached
+        // above) because the hung worker's task never completes.
+        await cts.CancelAsync();
+    }
+
+    private async Task<object?> WaitForInProgress(Guid queueItemId, TimeSpan timeout, QueueManager? manager = null)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var found = FindInProgressItem(queueItemId, manager);
+            if (found is not null) return found;
+            await Task.Delay(20);
+        }
+        return null;
+    }
+
+
+    private static Task GetProcessingTask(object inProgressItem)
+    {
+        var prop = inProgressItem.GetType().GetProperty(
+            "ProcessingTask",
+            BindingFlags.Instance | BindingFlags.Public);
+        return (Task)prop!.GetValue(inProgressItem)!;
+    }
+
+    [Fact]
     public async Task HealthyItems_DoNotWaitForWatchdogThreshold()
     {
         var item1 = CreateQueueItem("fast1.nzb", "movies", "FastJob1");
@@ -450,12 +733,13 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         await loop.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
-    private object? FindInProgressItem(Guid queueItemId)
+    private object? FindInProgressItem(Guid queueItemId, QueueManager? manager = null)
     {
+        manager ??= _queueManager;
         var field = typeof(QueueManager).GetField(
             "_inProgress",
             BindingFlags.Instance | BindingFlags.NonPublic);
-        var dict = field!.GetValue(_queueManager)!;
+        var dict = field!.GetValue(manager)!;
         var args = new object?[] { queueItemId, null };
         var found = (bool)dict.GetType().GetMethod("TryGetValue")!.Invoke(dict, args)!;
         return found ? args[1] : null;
@@ -529,6 +813,39 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
                     throw new OperationCanceledException(workerCts.Token);
                 await Task.Delay(10, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Blocks reads forever and ignores every cancellation token, simulating a
+    /// worker whose underlying I/O does not observe the cancellation token.
+    /// </summary>
+    private sealed class HungStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // Never observes cancellationToken or any worker token.
+            await Task.Delay(Timeout.Infinite).ConfigureAwait(false);
+            return 0;
         }
 
         public override int Read(byte[] buffer, int offset, int count) =>

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -14,6 +14,9 @@ using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Websocket;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace NzbWebDAV.Tests.Queue;
 
@@ -134,9 +137,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
 
     public Task DisposeAsync()
     {
-        // The hung-worker test detaches its manager (sets this to null) because a
-        // never-completing worker makes the coordinator's shutdown await hang.
-        _queueManager?.Dispose();
+        _queueManager.Dispose();
         Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
         try
         {
@@ -591,9 +592,9 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
     [Fact]
     public async Task WorkerIgnoringCancellation_LogsError_AndKeepsSlot()
     {
-        // A worker that never observes cancellation occupies its slot forever.
-        // The watchdog must survive its own cancel (unlinked CTS) and surface an
-        // Error after the grace period instead of silently returning.
+        // A worker that never observes cancellation occupies its slot until the
+        // underlying I/O is released. The ignored-cancel observer must log an
+        // Error after the grace period without abandoning the slot.
         var hung = new HungStream();
         var item = CreateQueueItem("hung.nzb", "movies", "HungJob");
 
@@ -603,12 +604,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             await ctx.SaveChangesAsync();
         }
 
-        // The hung worker never completes, so the coordinator's shutdown
-        // Task.WhenAll never finishes. Detach the manager from the fixture so the
-        // test's DisposeAsync skips awaiting it, and don't dispose it ourselves.
-        var manager = _queueManager;
-        _queueManager = null!;
-        manager.GetTopQueueItemOverride = async (exclude, ct) =>
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
         {
             await using var ctx = new DavDatabaseContext(_options);
             var client = new DavDatabaseClient(ctx);
@@ -618,35 +614,54 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             return (claimed, hung);
         };
 
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Error()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-        var loop = manager.ProcessQueueAsync(cts.Token);
-
-        object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5), manager);
-        Assert.NotNull(inProgress);
-
-        // Wait for the watchdog to cancel the (uncancellable) worker.
-        var workerCts = GetWorkerCts(inProgress!);
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
-            await Task.Delay(20);
-        Assert.True(workerCts.IsCancellationRequested);
-
-        // Wait past the cancel grace period; the worker task still hasn't finished
-        // and the item must remain in progress (slot occupied, not abandoned).
-        await Task.Delay(TimeSpan.FromMilliseconds(1500));
-        Assert.NotNull(FindInProgressItem(item.Id, manager));
-        Assert.False(GetProcessingTask(inProgress!).IsCompleted);
-
-        // Item remains queued (not failed) — the worker never honored the cancel.
-        await using (var ctx = new DavDatabaseContext(_options))
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
         {
-            Assert.Equal(1, await ctx.QueueItems.CountAsync());
-            Assert.Equal(0, await ctx.HistoryItems.CountAsync());
-        }
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5));
+            Assert.NotNull(inProgress);
 
-        // Stop the coordinator; we do not await or dispose the manager (detached
-        // above) because the hung worker's task never completes.
-        await cts.CancelAsync();
+            var workerCts = GetWorkerCts(inProgress!);
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
+                await Task.Delay(20);
+            Assert.True(workerCts.IsCancellationRequested);
+
+            deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (DateTime.UtcNow < deadline &&
+                   !sink.Events.Any(e => e.Level == LogEventLevel.Error
+                       && e.RenderMessage().Contains("ignored cancellation", StringComparison.OrdinalIgnoreCase)))
+            {
+                await Task.Delay(20);
+            }
+
+            Assert.Contains(sink.Events, e =>
+                e.Level == LogEventLevel.Error
+                && e.RenderMessage().Contains("ignored cancellation", StringComparison.OrdinalIgnoreCase)
+                && e.RenderMessage().Contains("HungJob", StringComparison.Ordinal));
+            Assert.NotNull(FindInProgressItem(item.Id));
+            Assert.False(GetProcessingTask(inProgress!).IsCompleted);
+
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                Assert.Equal(1, await ctx.QueueItems.CountAsync());
+                Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            }
+        }
+        finally
+        {
+            hung.Release();
+            await cts.CancelAsync();
+            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            Log.Logger = previous;
+        }
     }
 
     private async Task<object?> WaitForInProgress(Guid queueItemId, TimeSpan timeout, QueueManager? manager = null)
@@ -825,11 +840,17 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Blocks reads forever and ignores every cancellation token, simulating a
-    /// worker whose underlying I/O does not observe the cancellation token.
+    /// Blocks reads until <see cref="Release"/> is called and ignores every
+    /// cancellation token, simulating a worker whose underlying I/O does not
+    /// observe the worker CTS. Releasing lets the test dispose the manager.
     /// </summary>
     private sealed class HungStream : Stream
     {
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Release() => _release.TrySetCanceled();
+
         public override bool CanRead => true;
         public override bool CanSeek => false;
         public override bool CanWrite => false;
@@ -843,8 +864,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         public override async Task<int> ReadAsync(
             byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            // Never observes cancellationToken or any worker token.
-            await Task.Delay(Timeout.Infinite).ConfigureAwait(false);
+            await _release.Task.ConfigureAwait(false);
             return 0;
         }
 
@@ -855,6 +875,24 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Fixes the v1.1.0 watchdog defect reported in [#987](https://github.com/infinidysk/infinidysk/issues/987): a download that stalled (no progress, no segment fetches) was paused ~15–20 min and retried **forever**, never appearing in SAB history — so Sonarr/Radarr sat in Activity for hours and could never blocklist and re-grab.
- After **3** consecutive stalls the item now fails into history with a clear error, letting *Arr clients re-grab automatically. The first two stalls still pause-and-retry as before.
- Also surfaces a worker that **ignores cancellation** (a separate Error log after a grace period) instead of the queue silently wedging a slot until restart; and threads cancellation into NZB parsing.

## Root cause

`QueueManager.HandleStuckItemAsync` set `PauseUntil` + cancelled the worker but always left the item queued; `QueueItemProcessor`'s cancellation catch never wrote history. No stall cap existed (unlike the 20-attempt provider-retry cap). The watchdog CTS was also linked to the worker CTS, so it could never observe a worker that ignored the cancel.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 2746 passed, 0 failed
- [x] New `QueueStuckWatchdogTests`: attempts 1–2 pause-and-retry (queued, no history); attempt 3 fails into history; user-initiated cancel without the fail flag does **not** write history; ignored-cancel worker keeps its slot and is surfaced
- [ ] Manual: stall a download (e.g. throttle provider), confirm it fails into history after 3 watchdog pauses and Sonarr re-grabs

Closes #987