### PR TITLE
fix(health): orphan cleanup no longer treats imported files as missing when Library Directory is the mount

### DIFF
--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -81,7 +81,7 @@ public class DeleteWebdavItemController(
                 .Distinct()
                 .ToList();
             var prunedHistoryIds = await dbClient
-                .PruneUnreferencedHistoryItemsAsync(historyIds, ct)
+                .PruneUnreferencedHistoryItemsAsync(historyIds, source: "explore-delete", ct: ct)
                 .ConfigureAwait(false);
 
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);

--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -33,7 +33,10 @@ public class RemoveFromHistoryController(
         if (ids.Count > 0)
         {
             await dbClient.RemoveHistoryItemsAsync(
-                    ids, request.DeleteCompletedFiles, request.CancellationToken)
+                    ids,
+                    request.DeleteCompletedFiles,
+                    source: "sab-history-delete",
+                    ct: request.CancellationToken)
                 .ConfigureAwait(false);
         }
         try

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
+using Serilog;
 
 namespace NzbWebDAV.Database;
 
@@ -372,7 +373,11 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             .FirstOrDefaultAsync(x => x.Id == Guid.Parse(id)).ConfigureAwait(false);
     }
 
-    public async Task RemoveHistoryItemsAsync(List<Guid> ids, bool deleteFiles, CancellationToken ct = default)
+    public async Task RemoveHistoryItemsAsync(
+        List<Guid> ids,
+        bool deleteFiles,
+        string source = "history-delete",
+        CancellationToken ct = default)
     {
         // Capture group keys before delete so we can cascade-clean orphaned watchdog
         // attempts below. Done up front because the deleteFiles=false path doesn't
@@ -400,7 +405,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
                 DeletionAuditLog.Record(
                     "history-delete",
                     davItem,
-                    "SAB/history delete with deleteFiles=true (download dir)");
+                    $"{source} with deleteFiles=true (download dir)");
             }
 
             Ctx.Items.RemoveRange(davItems);
@@ -419,6 +424,17 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
                 .Where(h => ids.Contains(h.Id))
                 .ToListAsync(ct)
                 .ConfigureAwait(false);
+
+            if (existing.Count > 0)
+            {
+                const int sampleSize = 10;
+                Log.Information(
+                    "history-remove source={Source} count={Count} deleteFiles=false sampleIds={SampleIds} sampleNames={SampleNames}",
+                    source,
+                    existing.Count,
+                    string.Join(",", existing.Take(sampleSize).Select(x => x.Id)),
+                    string.Join(", ", existing.Take(sampleSize).Select(x => x.JobName)));
+            }
 
             Ctx.HistoryItems.RemoveRange(existing);
             Ctx.HistoryCleanupItems.AddRange(existing.Select(x => new HistoryCleanupItem
@@ -491,6 +507,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
 
     public async Task<List<Guid>> PruneUnreferencedHistoryItemsAsync(
         IReadOnlyCollection<Guid> historyItemIds,
+        string source = "webdav-unreferenced-prune",
         CancellationToken ct = default)
     {
         if (historyItemIds.Count == 0) return [];
@@ -516,7 +533,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         if (orphanedIds.Count == 0) return [];
 
         foreach (var chunk in orphanedIds.Chunk(batchSize))
-            await RemoveHistoryItemsAsync(chunk.ToList(), deleteFiles: false, ct).ConfigureAwait(false);
+            await RemoveHistoryItemsAsync(chunk.ToList(), deleteFiles: false, source, ct).ConfigureAwait(false);
 
         return orphanedIds;
     }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1180,7 +1180,19 @@ public class HealthCheckService : BackgroundService
             RepairStatus = repairStatus,
             Message = message
         }));
-        await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException e)
+        {
+            Log.Warning(
+                "Health check result not recorded because the file was deleted while the check was running. Path: {Path}",
+                davItem.Path);
+            Log.Debug(e, "Health check concurrency stack for {Path}", davItem.Path);
+            foreach (var entry in e.Entries)
+                entry.State = EntityState.Detached;
+        }
     }
 
     private HealthCheckResult SendStatus(HealthCheckResult result)

--- a/backend/Services/HistoryRetentionService.cs
+++ b/backend/Services/HistoryRetentionService.cs
@@ -59,7 +59,9 @@ public class HistoryRetentionService(ConfigManager configManager) : BackgroundSe
 
             if (ids.Count == 0) break;
 
-            await dbClient.RemoveHistoryItemsAsync(ids, deleteFiles: false, ct).ConfigureAwait(false);
+            await dbClient.RemoveHistoryItemsAsync(
+                    ids, deleteFiles: false, source: "history-retention", ct: ct)
+                .ConfigureAwait(false);
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
             dbClient.Ctx.ChangeTracker.Clear();
             totalRemoved += ids.Count;

--- a/backend/Services/VariantResolver.cs
+++ b/backend/Services/VariantResolver.cs
@@ -116,7 +116,9 @@ public class VariantResolver(ConfigManager configManager)
 
         try
         {
-            await dbClient.RemoveHistoryItemsAsync(toRemove, deleteFiles: true, ct).ConfigureAwait(false);
+            await dbClient.RemoveHistoryItemsAsync(
+                    toRemove, deleteFiles: true, source: "variants-eviction", ct: ct)
+                .ConfigureAwait(false);
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
             if (websocketManager is not null)
                 _ = websocketManager.SendMessage(

--- a/backend/Tasks/PruneCompletedHistoryTask.cs
+++ b/backend/Tasks/PruneCompletedHistoryTask.cs
@@ -118,7 +118,9 @@ public class PruneCompletedHistoryTask : BaseTask
             var ids = await BuildFilterQuery(dbClient.Ctx, _category, _olderThanDays).OrderBy(h => h.CreatedAt).Select(h => h.Id).Take(BatchSize).ToListAsync(CancellationToken).ConfigureAwait(false);
             if (ids.Count == 0) break;
             var existingCount = await dbClient.Ctx.HistoryItems.CountAsync(h => ids.Contains(h.Id), CancellationToken).ConfigureAwait(false);
-            await dbClient.RemoveHistoryItemsAsync(ids, deleteFiles: false, CancellationToken).ConfigureAwait(false);
+            await dbClient.RemoveHistoryItemsAsync(
+                    ids, deleteFiles: false, source: "prune-completed-history", ct: CancellationToken)
+                .ConfigureAwait(false);
             await dbClient.Ctx.SaveChangesAsync(CancellationToken).ConfigureAwait(false);
             dbClient.Ctx.ChangeTracker.Clear();
             var remainingCount = await dbClient.Ctx.HistoryItems.CountAsync(h => ids.Contains(h.Id), CancellationToken).ConfigureAwait(false);

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -744,11 +744,15 @@ public class RemoveUnlinkedFilesTask : BaseTask
         if (normalizedLibraryDir.Length == 0 || normalizedMountDir.Length == 0)
             return false;
 
-        if (string.Equals(normalizedLibraryDir, normalizedMountDir, StringComparison.Ordinal))
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (string.Equals(normalizedLibraryDir, normalizedMountDir, comparison))
             return true;
 
         var prefix = normalizedMountDir + Path.DirectorySeparatorChar;
-        return normalizedLibraryDir.StartsWith(prefix, StringComparison.Ordinal);
+        return normalizedLibraryDir.StartsWith(prefix, comparison);
     }
 
     private static string NormalizeConfiguredPath(string? path)

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -108,6 +108,23 @@ public class RemoveUnlinkedFilesTask : BaseTask
 
     private async Task RemoveUnlinkedFiles()
     {
+        if (IsLibraryDirInsideRcloneMount(
+                _configManager.GetLibraryDir(),
+                _configManager.GetRcloneMountDir(),
+                out var libraryDir,
+                out var mountDir))
+        {
+            _allRemovedPaths.Clear();
+            var detail =
+                $"Library Directory '{libraryDir}' is inside the rclone mount '{mountDir}'. " +
+                "That path is InfiniDysk's virtual filesystem (completed-symlinks, content, .ids), " +
+                "not your organized library. Point Library Directory at the folder that contains " +
+                "your Arr root folders — outside the rclone mount — then retry.";
+            Log.Warning("Remove Orphaned Files aborted. Reason: {Reason}", detail);
+            Complete($"Aborted: {detail} Cancelling to prevent a misleading orphan report.");
+            return;
+        }
+
         // get linked file paths
         StartPhase("Scanning all linked files...");
         var startTime = DateTime.Now;
@@ -709,6 +726,49 @@ public class RemoveUnlinkedFilesTask : BaseTask
         return _allRemovedPaths.Count > 0
             ? string.Join("\n", _allRemovedPaths)
             : "This list is Empty.\nYou must first run the task.";
+    }
+
+    /// <summary>
+    /// Virtual mount paths (completed-symlinks, content, .ids) are generated from current
+    /// history rows, so they cannot protect files after history is cleared. Scanning them as
+    /// the organized library produces a circular, misleading orphan report.
+    /// </summary>
+    internal static bool IsLibraryDirInsideRcloneMount(
+        string? libraryDir,
+        string? mountDir,
+        out string normalizedLibraryDir,
+        out string normalizedMountDir)
+    {
+        normalizedLibraryDir = NormalizeConfiguredPath(libraryDir);
+        normalizedMountDir = NormalizeConfiguredPath(mountDir);
+        if (normalizedLibraryDir.Length == 0 || normalizedMountDir.Length == 0)
+            return false;
+
+        if (string.Equals(normalizedLibraryDir, normalizedMountDir, StringComparison.Ordinal))
+            return true;
+
+        var prefix = normalizedMountDir + Path.DirectorySeparatorChar;
+        return normalizedLibraryDir.StartsWith(prefix, StringComparison.Ordinal);
+    }
+
+    private static string NormalizeConfiguredPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        var trimmed = path.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        try
+        {
+            return Path.GetFullPath(trimmed)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+        catch (Exception e) when (e is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return trimmed;
+        }
     }
 
     internal static void ClearAuditPathsForTests() => _allRemovedPaths = [];

--- a/backend/UsenetMigration/Runner/MigrationHistoryCleaner.cs
+++ b/backend/UsenetMigration/Runner/MigrationHistoryCleaner.cs
@@ -62,7 +62,8 @@ public sealed class MigrationHistoryCleaner(UsenetMigrationStore store)
             if (existingIds.Count == 0)
                 continue;
 
-            await davClient.RemoveHistoryItemsAsync(existingIds, deleteFiles: false, ct)
+            await davClient.RemoveHistoryItemsAsync(
+                    existingIds, deleteFiles: false, source: "usenet-migration-cleanup", ct: ct)
                 .ConfigureAwait(false);
             await davContext.SaveChangesAsync(ct).ConfigureAwait(false);
             davContext.ChangeTracker.Clear();

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -147,7 +147,8 @@ public class DatabaseStoreCollection(
     private async Task PruneEmptyHistoryAsync(Guid? historyItemId, CancellationToken ct)
     {
         if (historyItemId is null) return;
-        var pruned = await dbClient.PruneUnreferencedHistoryItemsAsync([historyItemId.Value], ct)
+        var pruned = await dbClient.PruneUnreferencedHistoryItemsAsync(
+                [historyItemId.Value], source: "webdav-unreferenced-prune", ct: ct)
             .ConfigureAwait(false);
         if (pruned.Count == 0) return;
 

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -111,7 +111,12 @@ public class DatabaseStoreSymlinkCollection(
                     .Select(h => h.Id).ToListAsync(request.CancellationToken).ConfigureAwait(false);
                 if (historyIds.Count > 0)
                 {
-                    await dbClient.RemoveHistoryItemsAsync(historyIds, deleteFiles: false, request.CancellationToken).ConfigureAwait(false);
+                    await dbClient.RemoveHistoryItemsAsync(
+                            historyIds,
+                            deleteFiles: false,
+                            source: "completed-symlinks-folder-delete",
+                            ct: request.CancellationToken)
+                        .ConfigureAwait(false);
                     await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
                     _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", historyIds));
                     return DavStatusCode.NoContent;

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -22,4 +22,6 @@ Only **Usenet** queue items are acted upon. Typical mappings:
 - **Remove** — already imported
 - **Do Nothing** — ID mismatches and similar manual-import cases
 
+Any action other than **Do Nothing** tells the Arr to delete the queue record with `removeFromClient=true`. The Arr then removes the download from InfiniDysk History even when its own **Remove Completed** checkbox is off. That is independent of mounted files, which stay.
+
 [Connect *Arr](../getting-started/connect-arr.md)

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -24,7 +24,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 
 | Task | Purpose | Caution |
 |------|---------|---------|
-| Remove Orphaned Files | Drop WebDAV files not linked from library | Permanent; dry run available |
+| Remove Orphaned Files | Drop WebDAV files not linked from library | Permanent; dry run available. Library Directory must be the organized library, not the rclone mount |
 | Prune Completed History | Remove completed SAB history rows | History-only; mounts stay; unlinked mounts become eligible for orphan cleanup |
 | Rename Windows-Invalid Paths | Sanitize existing names | Needs Windows-safe paths; backup + dry run |
 | Convert STRM → Symlinks | Strategy migration | Needs library dir + rclone mount |

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -17,7 +17,7 @@ Background health monitoring and replacement of unhealthy library items.
 | Check older releases less thoroughly [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | `repair.healthcheck-aging` | off | Aging taper |
 | Repair After Streaming Failures | `repair.auto-remove-after-failures` | `0` | Consecutive streaming failures before urgent repair; `0` = immediate repair |
 | Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items are removed and blocklisted through *Arr instead of force-deleted |
-| Library Directory | `media.library-dir` | empty | Organized media path in container |
+| Library Directory | `media.library-dir` | empty | Organized library root in the container — parent of your Arr root folders. Never the rclone mount or `/completed-symlinks` |
 
 `repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
 articles and corrupt archives. With a value greater than `0`, InfiniDysk waits for that many

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -66,4 +66,6 @@ Queue delete accepts UUID(s), repeated `value` parameters, `value=all`, or `valu
 
 History delete accepts UUIDs, `value=all`, or `value=failed`. The admin UI can delete mounted content for completed jobs with InfiniDysk-specific `del_completed_files=1` — download clients should **not** send this after importing a symlink/STRM, or playback sources disappear. The history UI also offers **Clear failed** and **Clear all** actions that call `history&name=delete` with `value=failed` or `value=all`.
 
+A History row vanishing after a successful Arr import is expected SAB-client cleanup, not a missing mount. Typical triggers: the Arr's **Remove Completed** download-client option, InfiniDysk **Automatic Queue Management** rules (those send `removeFromClient=true`, independent of Remove Completed), or a WebDAV DELETE of a `/completed-symlinks/<category>/<release>` folder. Those paths remove the history row and clear `HistoryItemId`; the WebDAV files stay.
+
 [SABnzbd settings](../configuration/sabnzbd.md)

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -79,7 +79,7 @@ Allow Docker DNS or LAN hosts under **Trusted local hosts** — [SABnzbd API](..
 
 ## Why did files disappear?
 
-See [Deletion audit](../operations/deletion-audit.md) — history retention ≠ deleting mounts; orphan cleanup and *Arr actions can remove content.
+See [Deletion audit](../operations/deletion-audit.md) — history retention ≠ deleting mounts; orphan cleanup and *Arr actions can remove content. History rows disappearing after import are usually the Arr or a `/completed-symlinks` folder delete, not InfiniDysk deleting the file. If Remove Orphaned Files lists imported files, check that **Library Directory** is your organized library root, not the rclone mount.
 
 ## Provider / missing articles
 

--- a/docs/operations/deletion-audit.md
+++ b/docs/operations/deletion-audit.md
@@ -9,6 +9,7 @@ Mounted content under `/content` can vanish for several independent reasons. “
 | Health repair | Repairs + missing articles | Orphans/blocklisted files are deleted; linked releases are removed and blocklisted through *Arr |
 | Remove Orphaned Files | Manual/scheduled | Deletes files with **no** library symlink/STRM and **no** history link (safety abort if too few links) |
 | History retention / Prune Completed History | Retention days > 0, or Maintenance task | Prunes history with `deleteFiles: false` — mounts stay, lose history link; unlinked mounts can then be removed by Remove Orphaned Files |
+| SAB/Arr history delete without delete-files | Arr Remove Completed, queue rules with `removeFromClient=true`, or `/completed-symlinks` folder DELETE | History row gone; mounts stay. Logged as `history-remove source=… deleteFiles=false` |
 | Manual delete | WebDAV DELETE / admin API | Explicit user action |
 | Blocklist filter | Download file blocklist | Matching files never appear in `/content` |
 | Non-persistent `/config` | Volume missing/wiped | Empty DB on restart — entire library looks gone |
@@ -30,6 +31,7 @@ dav-delete source=health-repair ... reason=missing articles; orphaned ...
 dav-delete source=remove-orphaned ... reason=no library symlink/strm link
 dav-delete source=webdav-delete ... reason=client DELETE on UsenetFile
 dav-delete source=blocklist-filter ... reason=filename matches blocklist pattern ...
+history-remove source=sab-history-delete count=1 deleteFiles=false ...
 ```
 
 Large history deletes may also emit `dav-delete-bulk`.

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -6,7 +6,7 @@
 
 Requires:
 
-- **Library Directory** visible inside the container
+- **Library Directory** visible inside the container — the organized library root (parent of Arr root folders), never the rclone mount or `/completed-symlinks`
 - At least one configured [Radarr/Sonarr instance](../configuration/arrs.md)
 - **Enable Background Repairs**
 

--- a/docs/operations/retention-cleanup.md
+++ b/docs/operations/retention-cleanup.md
@@ -35,6 +35,10 @@ Scheduled history retention and the **Prune Completed History** task delete SAB 
 
 **Remove Orphaned Files** (Maintenance) deletes WebDAV files that are not linked from the library directory and are no longer tied to a SAB history row. Supports dry run. Schedule optional daily cleanup — set container `TZ`. Direct WebDAV or rclone playback is not a library link.
 
+**Library Directory** must be the organized library root that contains your Arr-imported symlinks or STRMs (the parent of your Radarr/Sonarr root folders). It must be visible inside the InfiniDysk container. Do not point it at the rclone mount (`rclone.mount-dir`) or at `/completed-symlinks` — that folder is InfiniDysk's virtual view of current History rows, so scanning it cannot protect files after history is cleared. Remove Orphaned Files aborts (dry run included) when Library Directory is the mount or a path inside it.
+
+History entries disappearing after an Arr import are client-initiated cleanup, not InfiniDysk deleting the mount: the Arr's **Remove Completed** setting, InfiniDysk **Automatic Queue Management** rules that call the Arr with `removeFromClient=true`, or a WebDAV DELETE of a release folder under `/completed-symlinks`. Mounted files stay streamable; only the History row is removed.
+
 ## NZB file backups
 
 Optional copies of incoming NZBs (SABnzbd settings) prune by `api.nzb-backup-retention-days`.

--- a/frontend/app/routes/settings/library/library.tsx
+++ b/frontend/app/routes/settings/library/library.tsx
@@ -20,8 +20,11 @@ export function LibrarySettings({ config, setNewConfig }: LibrarySettingsProps) 
                     value={config["media.library-dir"]}
                     onChange={e => setNewConfig({ ...config, "media.library-dir": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="library-dir-help">
-                    The path to your organized media library that contains all your imported symlinks.
-                    Make sure this path is visible to your InfiniDysk container.
+                    The organized library root that contains your imported Arr symlinks or STRMs
+                    (the parent of your Radarr/Sonarr root folders). Must be visible inside the
+                    InfiniDysk container. Do not point this at the rclone mount or at
+                    <code className="text-base-content/70">/completed-symlinks</code> — those are
+                    InfiniDysk&apos;s virtual filesystem, not your library.
                 </p>
             </div>
         </div>

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -471,6 +471,134 @@ public class RemoveUnlinkedFilesTaskTests
         }
     }
 
+    [Theory]
+    [InlineData("/mnt/debrid/nzbdav/completed-symlinks", "/mnt/debrid/nzbdav", true)]
+    [InlineData("/mnt/debrid/nzbdav", "/mnt/debrid/nzbdav", true)]
+    [InlineData("/mnt/debrid/nzbdav/", "/mnt/debrid/nzbdav", true)]
+    [InlineData("/mnt/debrid/nzbdav/content", "/mnt/debrid/nzbdav", true)]
+    [InlineData("/mnt/debrid/nzbdav-symlinks", "/mnt/debrid/nzbdav", false)]
+    [InlineData("/mnt/debrid/combined_symlinks", "/mnt/debrid/nzbdav", false)]
+    [InlineData("/mnt/media", "/mnt/debrid/nzbdav", false)]
+    [InlineData("", "/mnt/debrid/nzbdav", false)]
+    [InlineData(null, "/mnt/debrid/nzbdav", false)]
+    public void IsLibraryDirInsideRcloneMount_DetectsVirtualMountPaths(
+        string? libraryDir,
+        string mountDir,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            RemoveUnlinkedFilesTask.IsLibraryDirInsideRcloneMount(
+                libraryDir, mountDir, out _, out _));
+    }
+
+    [Fact]
+    public async Task DryRun_Aborts_WhenLibraryDirIsInsideRcloneMount()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var mountDir = Path.Join(Path.GetTempPath(), $"nzbdav-mount-{Guid.NewGuid():N}");
+        var libraryDir = Path.Join(mountDir, "completed-symlinks");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+                new ConfigItem { ConfigName = ConfigKeys.RcloneMountDir, ConfigValue = mountDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var task = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.Contains("Aborted:", progress, StringComparison.Ordinal);
+            Assert.Contains("inside the rclone mount", progress, StringComparison.Ordinal);
+            Assert.Contains(libraryDir, progress, StringComparison.Ordinal);
+            Assert.Contains(mountDir, progress, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(mountDir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DryRun_DoesNotAbort_WhenLibraryDirIsOutsideRcloneMount()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var mountDir = Path.Join(Path.GetTempPath(), $"nzbdav-mount-{Guid.NewGuid():N}");
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(mountDir);
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+
+            var linkedIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToList();
+            foreach (var id in linkedIds)
+            {
+                ctx.Items.Add(DavItem.New(
+                    id,
+                    DavItem.ContentFolder,
+                    $"{id:N}.mkv",
+                    10,
+                    DavItem.ItemType.UsenetFile,
+                    DavItem.ItemSubType.NzbFile,
+                    null,
+                    null,
+                    null,
+                    null));
+                await File.WriteAllTextAsync(
+                    Path.Join(libraryDir, $"{id:N}.strm"),
+                    $"http://localhost/view/.ids/{id}.mkv");
+            }
+
+            await ctx.SaveChangesAsync();
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+                new ConfigItem { ConfigName = ConfigKeys.RcloneMountDir, ConfigValue = mountDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var task = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await task.Execute());
+
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.DoesNotContain("inside the rclone mount", progress, StringComparison.Ordinal);
+            Assert.StartsWith("Dry Run - Done.", progress);
+            Assert.Contains("Identified 0 unlinked files", progress);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch (IOException) { /* best effort */ }
+            try { Directory.Delete(mountDir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
     [Fact]
     public async Task InsertLinkedIdBatchAsync_InsertsAllIds()
     {

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -493,6 +493,18 @@ public class RemoveUnlinkedFilesTaskTests
     }
 
     [Fact]
+    public void IsLibraryDirInsideRcloneMount_UsesOsAwareCasing()
+    {
+        var inside = RemoveUnlinkedFilesTask.IsLibraryDirInsideRcloneMount(
+            "/mnt/debrid/NZBDAV/completed-symlinks",
+            "/mnt/debrid/nzbdav",
+            out _,
+            out _);
+
+        Assert.Equal(OperatingSystem.IsWindows(), inside);
+    }
+
+    [Fact]
     public async Task DryRun_Aborts_WhenLibraryDirIsInsideRcloneMount()
     {
         await BaseTask.ResetRunningTaskForTestsAsync();


### PR DESCRIPTION
## Summary

Fixes the misleading **Remove Orphaned Files** dry-run from [#990](https://github.com/infinidysk/infinidysk/issues/990): when Library Directory is set to the rclone mount (or `/completed-symlinks` inside it), imported files look orphaned after Arr cleanup even though they still stream.

- Abort dry-run and real orphan cleanup when Library Directory is the rclone mount or a path inside it, with both paths in the message.
- Log history-only removals (`deleteFiles=false`) with a source so SAB API, `/completed-symlinks` folder deletes, retention, and prune are greppable.
- Log a one-line Warning instead of an Error stack when a health-checked file is deleted mid-check.
- Clarify Library Directory in Settings help and docs. History vanishing after import is client-initiated cleanup; mounts stay.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (2757 passed)
- [x] Guard unit tests: library dir inside mount aborts; sibling path such as `nzbdav-symlinks` vs `nzbdav` does not; dry-run abort surfaces both paths
- [ ] Manual: set Library Directory to `{mount}/completed-symlinks`, run dry-run, confirm abort message names both paths
- [ ] Manual: set Library Directory to the organized library root, dry-run, confirm imported files with `/.ids` symlinks are not listed
- [ ] After Arr import, grep logs for `history-remove source=` and confirm the trigger (sab-history-delete / completed-symlinks-folder-delete / queue rules via SAB)