### PR TITLE
fix(ui): Explore can delete files whose names contain %

### DIFF
--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -33,7 +33,8 @@ public class DeleteWebdavItemController(
                    ?? throw new BadHttpRequestException("path is required");
         var ct = HttpContext.RequestAborted;
 
-        var item = await ResolvePathAsync(path, ct).ConfigureAwait(false);
+        var item = await DeleteWebdavItemSupport.ResolvePathAsync(dbClient, path, ct)
+            .ConfigureAwait(false);
         if (item is null) return NotFound(new BaseApiResponse { Status = false, Error = "Item not found." });
 
         var rootError = DeleteWebdavItemSupport.ValidateDeletableRoot(item.Path);
@@ -102,24 +103,5 @@ public class DeleteWebdavItemController(
             await transaction.RollbackAsync(ct).ConfigureAwait(false);
             throw;
         }
-    }
-
-    private async Task<DavItem?> ResolvePathAsync(string path, CancellationToken ct)
-    {
-        var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0) return null;
-
-        var absolutePath = "/" + string.Join('/', parts.Select(Uri.UnescapeDataString));
-        var byPath = await dbClient.GetItemByPathAsync(absolutePath, ct).ConfigureAwait(false);
-        if (byPath is not null) return byPath;
-
-        var current = DavItem.Root;
-        foreach (var name in parts.Select(Uri.UnescapeDataString))
-        {
-            var child = await dbClient.GetDirectoryChildAsync(current.Id, name, ct).ConfigureAwait(false);
-            if (child is null) return null;
-            current = child;
-        }
-        return current;
     }
 }

--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemSupport.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemSupport.cs
@@ -1,9 +1,61 @@
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 
 namespace NzbWebDAV.Api.Controllers.DeleteWebdavItem;
 
 internal static class DeleteWebdavItemSupport
 {
+    /// <summary>
+    /// Resolves a WebDAV item from an Explore/API path. Literal names are tried first so
+    /// files that actually contain <c>%2C</c> (or other percent sequences) are found;
+    /// percent-decoded lookup is only a fallback for callers that still send encoded paths.
+    /// </summary>
+    public static async Task<DavItem?> ResolvePathAsync(
+        DavDatabaseClient dbClient,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return null;
+
+        var item = await LookupAsync(dbClient, parts, cancellationToken).ConfigureAwait(false);
+        if (item is not null) return item;
+
+        var unescaped = new string[parts.Length];
+        var changed = false;
+        for (var i = 0; i < parts.Length; i++)
+        {
+            unescaped[i] = Uri.UnescapeDataString(parts[i]);
+            changed |= !string.Equals(unescaped[i], parts[i], StringComparison.Ordinal);
+        }
+
+        if (!changed) return null;
+        return await LookupAsync(dbClient, unescaped, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<DavItem?> LookupAsync(
+        DavDatabaseClient dbClient,
+        string[] parts,
+        CancellationToken cancellationToken)
+    {
+        var absolutePath = "/" + string.Join('/', parts);
+        var byPath = await dbClient.GetItemByPathAsync(absolutePath, cancellationToken)
+            .ConfigureAwait(false);
+        if (byPath is not null) return byPath;
+
+        var current = DavItem.Root;
+        foreach (var name in parts)
+        {
+            var child = await dbClient.GetDirectoryChildAsync(current.Id, name, cancellationToken)
+                .ConfigureAwait(false);
+            if (child is null) return null;
+            current = child;
+        }
+
+        return current;
+    }
+
     public static string? ValidateDeletableRoot(string absolutePath)
     {
         var parts = absolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);

--- a/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItemPreview/DeleteWebdavItemPreviewController.cs
@@ -35,7 +35,8 @@ public class DeleteWebdavItemPreviewController(
             });
         var ct = HttpContext.RequestAborted;
 
-        var item = await ResolvePathAsync(path, ct).ConfigureAwait(false);
+        var item = await DeleteWebdavItemSupport.ResolvePathAsync(dbClient, path, ct)
+            .ConfigureAwait(false);
         if (item is null)
             return NotFound(new DeleteWebdavItemPreviewResponse { Status = false, Error = "Item not found." });
 
@@ -83,24 +84,5 @@ public class DeleteWebdavItemPreviewController(
             TotalBytes = totalBytes,
             LinkedHistoryCount = linkedHistoryCount,
         });
-    }
-
-    private async Task<DavItem?> ResolvePathAsync(string path, CancellationToken ct)
-    {
-        var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0) return null;
-
-        var absolutePath = "/" + string.Join('/', parts.Select(Uri.UnescapeDataString));
-        var byPath = await dbClient.GetItemByPathAsync(absolutePath, ct).ConfigureAwait(false);
-        if (byPath is not null) return byPath;
-
-        var current = DavItem.Root;
-        foreach (var name in parts.Select(Uri.UnescapeDataString))
-        {
-            var child = await dbClient.GetDirectoryChildAsync(current.Id, name, ct).ConfigureAwait(false);
-            if (child is null) return null;
-            current = child;
-        }
-        return current;
     }
 }

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -44,7 +44,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
     // Single-fetch navigation requests use an internal `.data` URL, so derive
     // the WebDAV path from the matched wildcard rather than request.url.
-    const parsed = parseExploreWebdavPath(params["*"] ?? "");
+    // The splat is already percent-decoded; decoding again would turn a
+    // literal "%2C" in a release name into a comma.
+    const parsed = parseExploreWebdavPath(params["*"] ?? "", { decode: false });
     if (!parsed.ok) {
         return {
             parentDirectories: [],
@@ -721,7 +723,8 @@ function getWebdavPath(pathname: string): string {
 }
 
 function getWebdavPathDecoded(pathname: string): string {
-    const parsed = parseExploreWebdavPath(getWebdavPath(pathname));
+    // location.pathname is already percent-decoded by the browser / router.
+    const parsed = parseExploreWebdavPath(getWebdavPath(pathname), { decode: false });
     return parsed.ok ? parsed.path : "";
 }
 

--- a/frontend/app/utils/path.ts
+++ b/frontend/app/utils/path.ts
@@ -38,16 +38,34 @@ export type ParsedExploreWebdavPath =
     | { ok: true; path: string }
     | { ok: false };
 
+export type ParseExploreWebdavPathOptions = {
+    /**
+     * When true (default), percent-decode `raw`. Use for encoded hrefs.
+     * React Router splat params and `location.pathname` are already decoded —
+     * pass false so names that literally contain `%2C` (or a trailing `%`) stay intact.
+     */
+    decode?: boolean;
+};
+
 /**
- * Decodes and validates an explore wildcard / WebDAV path.
- * Rejects malformed percent-encoding and empty path segments (e.g. content//release).
+ * Validates an explore wildcard / WebDAV path.
+ * Rejects empty path segments (e.g. content//release). When `decode` is true,
+ * also rejects malformed percent-encoding.
  */
-export function parseExploreWebdavPath(raw: string): ParsedExploreWebdavPath {
+export function parseExploreWebdavPath(
+    raw: string,
+    options?: ParseExploreWebdavPathOptions,
+): ParsedExploreWebdavPath {
+    const shouldDecode = options?.decode !== false;
     let decoded: string;
-    try {
-        decoded = decodeURIComponent(raw);
-    } catch {
-        return { ok: false };
+    if (shouldDecode) {
+        try {
+            decoded = decodeURIComponent(raw);
+        } catch {
+            return { ok: false };
+        }
+    } else {
+        decoded = raw;
     }
 
     // Drop only a leading empty segment (from a leading /) and a trailing empty

--- a/frontend/app/utils/utils.test.ts
+++ b/frontend/app/utils/utils.test.ts
@@ -130,9 +130,30 @@ describe("parseExploreWebdavPath", () => {
     expect(parseExploreWebdavPath("content//")).toEqual({ ok: false });
   });
 
-  it("rejects malformed percent-encoding", () => {
-    expect(parseExploreWebdavPath("content/%E0%A4%A")).toEqual({ ok: false });
-  });
+    it("rejects malformed percent-encoding", () => {
+        expect(parseExploreWebdavPath("content/%E0%A4%A")).toEqual({ ok: false });
+    });
+
+    it("keeps literal percent sequences when the path is already decoded", () => {
+        expect(parseExploreWebdavPath(
+            "content/tv/S02E14.Such.Sweet.Sorrow%2C.Part.2.1080",
+            { decode: false },
+        )).toEqual({
+            ok: true,
+            path: "content/tv/S02E14.Such.Sweet.Sorrow%2C.Part.2.1080",
+        });
+        expect(parseExploreWebdavPath("content/100%", { decode: false })).toEqual({
+            ok: true,
+            path: "content/100%",
+        });
+    });
+
+    it("decodes percent sequences when the input is still encoded", () => {
+        expect(parseExploreWebdavPath("content/Sorrow%2C.Part.2")).toEqual({
+            ok: true,
+            path: "content/Sorrow,.Part.2",
+        });
+    });
 });
 
 describe("secret masking", () => {

--- a/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
@@ -178,6 +178,44 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DeleteAsync_FileNameWithPercentSequence_RemovesRow()
+    {
+        var (_, file, historyId) = await SeedContentReleaseAsync(
+            fileName: "S02E14.Such.Sweet.Sorrow%2C.Part.2.1080.mkv");
+
+        var result = await InvokeDeleteAsync(file.Path);
+        Assert.Equal(200, GetStatusCode(result));
+        Assert.True(ReadResponse<BaseApiResponse>(result).Status);
+
+        Assert.Null(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == file.Id));
+        Assert.Null(await _context.HistoryItems.AsNoTracking().SingleOrDefaultAsync(x => x.Id == historyId));
+    }
+
+    [Fact]
+    public async Task PreviewAsync_FileNameWithPercentSequence_FindsItem()
+    {
+        var (_, file, _) = await SeedContentReleaseAsync(
+            fileName: "S02E14.Such.Sweet.Sorrow%2C.Part.2.1080.mkv");
+
+        var result = await InvokePreviewAsync(file.Path);
+        Assert.Equal(200, GetStatusCode(result));
+        var response = ReadResponse<DeleteWebdavItemPreviewResponse>(result);
+        Assert.True(response.Status);
+        Assert.Equal(1, response.FileCount);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_PercentEncodedSpaceFallback_RemovesRow()
+    {
+        var (_, file, _) = await SeedContentReleaseAsync(fileName: "file name.mkv");
+        var encodedPath = file.Path.Replace("file name.mkv", "file%20name.mkv", StringComparison.Ordinal);
+
+        var result = await InvokeDeleteAsync(encodedPath);
+        Assert.Equal(200, GetStatusCode(result));
+        Assert.Null(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == file.Id));
+    }
+
+    [Fact]
     public async Task DeleteAsync_File_KeepsHistoryWhenSiblingRemains()
     {
         var (jobDir, file, historyId) = await SeedContentReleaseAsync();


### PR DESCRIPTION
## Summary
Usenet releases sometimes keep URL-encoding in the filename (`Such.Sweet.Sorrow%2C.Part.2` = comma). Explore treated that `%2C` as encoding and looked up a comma instead, so delete/preview returned **Item not found**.

- Resolve Explore delete paths **literally first**, and only percent-decode as a fallback for callers that still send encoded paths.
- Stop running `decodeURIComponent` on React Router splat params and `location.pathname`, which are already decoded (a second decode also breaks folders named `100%`).

Fixes the leftover-file delete case from #990.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~DeleteWebdavItemControllerTests`
- [x] `cd frontend && npm test -- app/utils/utils.test.ts && npm run typecheck`
- [ ] In Explore, delete a file whose name contains `%2C` (or `100%`) with WebDAV read-only **off**
- [ ] Confirm a normal file (spaces, no `%`) still deletes from Explore