### PR TITLE
fix(auth): reset admin password via RESET_ADMIN_PASSWORD environment variable

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -26,6 +26,7 @@ using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.SupportPack;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
+using NzbWebDAV.Tasks;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
 using NzbWebDAV.WebDav.Base;
@@ -144,6 +145,10 @@ public partial class Program
             // before any background service trips over it. Non-fatal by design.
             await DatabaseIntegrityCheck
                 .VerifyMainDatabaseAsync(databaseContext, startupCancellationToken)
+                .ConfigureAwait(false);
+
+            await ResetAdminAccountTask
+                .RunIfRequestedAsync(databaseContext, startupCancellationToken)
                 .ConfigureAwait(false);
 
             // initialize the config-manager

--- a/backend/Tasks/ResetAdminAccountTask.cs
+++ b/backend/Tasks/ResetAdminAccountTask.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+/// <summary>
+/// One-shot operator escape hatch: when <c>RESET_ADMIN_PASSWORD</c> is set, deletes the
+/// admin <c>Accounts</c> row on startup so the UI returns to onboarding. Queue, history,
+/// settings, and WebDAV credentials are untouched.
+/// </summary>
+public static class ResetAdminAccountTask
+{
+    public const string EnvVarName = "RESET_ADMIN_PASSWORD";
+
+    private const string RemoveEnvVarWarning =
+        "Remove it from your environment before the next restart to avoid repeated admin account resets.";
+
+    public static bool IsRequested()
+    {
+        var value = EnvironmentUtil.GetEnvironmentVariable(EnvVarName)?.ToLowerInvariant();
+        return value is "true" or "1" or "yes";
+    }
+
+    public static async Task RunIfRequestedAsync(
+        DavDatabaseContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsRequested())
+            return;
+
+        var adminAccounts = await context.Accounts
+            .Where(a => a.Type == Account.AccountType.Admin)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (adminAccounts.Count > 0)
+        {
+            context.Accounts.RemoveRange(adminAccounts);
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            Log.Warning(
+                "Admin account deleted via {EnvVar}. {RemoveWarning}",
+                EnvVarName,
+                RemoveEnvVarWarning);
+        }
+        else
+        {
+            Log.Warning(
+                "{EnvVar} is set but no admin account exists. {RemoveWarning}",
+                EnvVarName,
+                RemoveEnvVarWarning);
+        }
+    }
+}

--- a/backend/Tasks/ResetAdminAccountTask.cs
+++ b/backend/Tasks/ResetAdminAccountTask.cs
@@ -20,8 +20,8 @@ public static class ResetAdminAccountTask
 
     public static bool IsRequested()
     {
-        var value = EnvironmentUtil.GetEnvironmentVariable(EnvVarName)?.ToLowerInvariant();
-        return value is "true" or "1" or "yes";
+        var value = EnvironmentUtil.GetEnvironmentVariable(EnvVarName)?.Trim().ToLowerInvariant();
+        return value is "true" or "1" or "yes" or "y";
     }
 
     public static async Task RunIfRequestedAsync(

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -91,6 +91,7 @@ or restrict backend capabilities when enforcement is required.
 | `STREAM_TRACE_EVENTS` | `0` (off) | Opt-in stream trace capacity, always-on with no expiry; the Settings → Support toggle can also set capacity (20k–200k) for timed captures |
 | `TRUSTED_PROXY_CIDRS` | loopback | Comma-separated IPs/CIDRs trusted for forwarded headers |
 | `DISABLE_WEBDAV_AUTH` | unset | Disables WebDAV auth (**dangerous**) |
+| `RESET_ADMIN_PASSWORD` | unset | `true` deletes the admin account on next startup, forcing re-onboarding. **Remove after use.** |
 | `USENET_DISABLE_CRC_VALIDATION` [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | unset | `1` skips yEnc CRC checks (emergency) |
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -7,8 +7,10 @@ Open `http://your-server:3000` after the container is healthy.
     You can pre-seed Usenet, WebDAV, *Arr, and other **Settings** values with
     [`NZBDAV_CONFIG__...`](../configuration/headless.md) before the first UI visit.
     The **admin username/password** for the web UI is still created here (or via your
-    existing account) — that bootstrap is **not** part of the ENV overlay. Warden
-    sources and database restore actions are also separate domains.
+    existing account) — that bootstrap is **not** part of the ENV overlay. If you lose
+    those credentials later, set `RESET_ADMIN_PASSWORD=true`, restart once, re-onboard,
+    then remove the variable — see [Troubleshooting → Locked out of the web UI](../guides/troubleshooting.md#locked-out-of-the-web-ui).
+    Warden sources and database restore actions are also separate domains.
 
 ## 1. Create the admin account
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -33,7 +33,7 @@ and the backend logs a matching warning on every startup.
 If you have shell access to `/config` and prefer not to restart:
 
 ```bash
-sqlite3 /path/to/your/config/db.sqlite "DELETE FROM Accounts WHERE Type = 1;"
+sqlite3 "${CONFIG_PATH:-/config}/db.sqlite" "DELETE FROM Accounts WHERE Type = 1;"
 ```
 
 Then visit the UI and complete onboarding. Queue, history, settings, and WebDAV

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -6,6 +6,39 @@
 - Ensure `CONFIG_PATH` (`/config`) is writable by `PUID`/`PGID`.
 - Frontend `/healthz` should pass during long migrations; backend `/health` must eventually succeed.
 
+## Locked out of the web UI
+
+If you forgot the administrator username or password, reset the local admin account
+with the `RESET_ADMIN_PASSWORD` environment variable:
+
+1. Add `RESET_ADMIN_PASSWORD: "true"` to your Compose `environment` (or pass
+   `-e RESET_ADMIN_PASSWORD=true` to `docker run`).
+2. Restart the container.
+3. Visit the UI — you will land on the onboarding page to set new credentials.
+4. **Remove** `RESET_ADMIN_PASSWORD` from your environment.
+5. Restart again. If you skip this step, the next restart deletes the admin
+   account again.
+
+While `RESET_ADMIN_PASSWORD` remains set, the UI shows a persistent warning banner
+and the backend logs a matching warning on every startup.
+
+!!! danger "Security"
+
+    Anyone who can reach the UI while no admin account exists can create the new
+    administrator account. Re-register promptly after the reset and remove the
+    variable before the next restart.
+
+### Manual reset (without restarting)
+
+If you have shell access to `/config` and prefer not to restart:
+
+```bash
+sqlite3 /path/to/your/config/db.sqlite "DELETE FROM Accounts WHERE Type = 1;"
+```
+
+Then visit the UI and complete onboarding. Queue, history, settings, and WebDAV
+credentials are untouched.
+
 ## Streaming readiness (`/ready`) [since 0.10.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.10.0){ .nzbdav-since }
 
 The backend readiness endpoint reports whether InfiniDysk can make progress on new streams. It returns

--- a/frontend/app/components/reset-admin-password-banner.test.tsx
+++ b/frontend/app/components/reset-admin-password-banner.test.tsx
@@ -13,7 +13,7 @@ describe("ResetAdminPasswordBanner", () => {
     render(<ResetAdminPasswordBanner isResetAdminPasswordSet={true} />);
 
     expect(screen.getByText("Admin password reset is armed")).toBeTruthy();
-    expect(screen.getByText(/RESET_ADMIN_PASSWORD/)).toBeTruthy();
+    expect(screen.getByText(/deletes the admin account on every startup/i)).toBeTruthy();
     expect(screen.queryByRole("button")).toBeNull();
   });
 

--- a/frontend/app/components/reset-admin-password-banner.test.tsx
+++ b/frontend/app/components/reset-admin-password-banner.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ResetAdminPasswordBanner } from "./reset-admin-password-banner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ResetAdminPasswordBanner", () => {
+  it("warns when RESET_ADMIN_PASSWORD is set", () => {
+    render(<ResetAdminPasswordBanner isResetAdminPasswordSet={true} />);
+
+    expect(screen.getByText("Admin password reset is armed")).toBeTruthy();
+    expect(screen.getByText(/RESET_ADMIN_PASSWORD/)).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders nothing when the env flag is unset", () => {
+    const { container } = render(<ResetAdminPasswordBanner isResetAdminPasswordSet={false} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/frontend/app/components/reset-admin-password-banner.tsx
+++ b/frontend/app/components/reset-admin-password-banner.tsx
@@ -21,9 +21,9 @@ export function ResetAdminPasswordBanner({
       <div className="min-w-0">
         <p className="font-semibold">Admin password reset is armed</p>
         <p className="mt-0.5 text-error-content/80">
-          <code>RESET_ADMIN_PASSWORD</code> is set in your environment. Your admin account
-          will be deleted on the next container restart. Remove this variable from your
-          Compose file or environment now.
+          <code>RESET_ADMIN_PASSWORD</code> is set in your environment. The backend deletes the
+          admin account on every startup while this remains enabled. Remove this variable from
+          your Compose file or environment before the next restart.
         </p>
       </div>
     </Alert>

--- a/frontend/app/components/reset-admin-password-banner.tsx
+++ b/frontend/app/components/reset-admin-password-banner.tsx
@@ -1,0 +1,31 @@
+import { Alert, Icon } from "~/components/ui";
+
+/**
+ * Persistent (non-dismissible) notice when RESET_ADMIN_PASSWORD is set in the
+ * container environment. The root loader forwards the env flag here; the backend
+ * deletes the admin account on startup while this variable remains set.
+ */
+export function ResetAdminPasswordBanner({
+  isResetAdminPasswordSet,
+}: {
+  isResetAdminPasswordSet: boolean;
+}) {
+  if (!isResetAdminPasswordSet) return null;
+
+  return (
+    <Alert
+      variant="danger"
+      className="mb-4 grid-cols-[auto_minmax(0,1fr)] items-start gap-3 border border-error-content/15 text-sm shadow-sm"
+    >
+      <Icon name="lock_reset" className="mt-0.5 shrink-0 !text-[22px]" />
+      <div className="min-w-0">
+        <p className="font-semibold">Admin password reset is armed</p>
+        <p className="mt-0.5 text-error-content/80">
+          <code>RESET_ADMIN_PASSWORD</code> is set in your environment. Your admin account
+          will be deleted on the next container restart. Remove this variable from your
+          Compose file or environment now.
+        </p>
+      </div>
+    </Alert>
+  );
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -28,19 +28,20 @@ import { LegacyImageBanner } from "./components/legacy-image-banner";
 import { ResetAdminPasswordBanner } from "./components/reset-admin-password-banner";
 import { isOidcEnabled } from "../server/oidc.server";
 import { getServiceProvider } from "./utils/service-provider.server";
+import { isResetAdminPasswordSet } from "./utils/reset-admin-password.server";
 import { withUrlBase } from "~/utils/url-base";
 
-function isResetAdminPasswordSet(): boolean {
-  const value = process.env["RESET_ADMIN_PASSWORD"]?.trim().toLowerCase();
-  return value === "true" || value === "1" || value === "yes";
-}
-
 export async function loader({ request }: Route.LoaderArgs) {
+  const resetAdminPasswordSet = isResetAdminPasswordSet();
   // Single-fetch navigation/revalidation uses internal `.data` URLs
   // (e.g. /login.data), so strip that suffix before the layout check.
   let path = new URL(request.url).pathname.replace(/\.data$/, "");
   if (path === "/login" || path === "/onboarding") {
-    return { useLayout: false, serviceProvider: null };
+    return {
+      useLayout: false,
+      serviceProvider: null,
+      isResetAdminPasswordSet: resetAdminPasswordSet,
+    };
   }
 
   const config = await backendClient.getConfig([
@@ -56,7 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     useLayout: true,
     // Baked into images published to the deprecated ghcr.io/nzbdav/nzbdav path.
     isLegacyImage: process.env["NZBDAV_LEGACY_IMAGE"] === "true",
-    isResetAdminPasswordSet: isResetAdminPasswordSet(),
+    isResetAdminPasswordSet: resetAdminPasswordSet,
     version,
     updateAvailable: await checkForUpdate(version),
     isFrontendAuthDisabled: IS_FRONTEND_AUTH_DISABLED,
@@ -217,7 +218,18 @@ export default function App({ loaderData }: Route.ComponentProps) {
     );
   }
 
-  return outlet;
+  return (
+    <>
+      {hideShell && (
+        <div className="px-4 pt-4">
+          <ResetAdminPasswordBanner
+            isResetAdminPasswordSet={isResetAdminPasswordSet ?? false}
+          />
+        </div>
+      )}
+      {outlet}
+    </>
+  );
 }
 
 // Root ErrorBoundary catches loader/component throws that aren't handled closer

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -25,9 +25,15 @@ import { MigrationBoundary } from "./components/migration-progress";
 import { ServiceProviderGate } from "./components/service-provider-gate";
 import { StreamTracingBanner } from "./components/stream-tracing-banner";
 import { LegacyImageBanner } from "./components/legacy-image-banner";
+import { ResetAdminPasswordBanner } from "./components/reset-admin-password-banner";
 import { isOidcEnabled } from "../server/oidc.server";
 import { getServiceProvider } from "./utils/service-provider.server";
 import { withUrlBase } from "~/utils/url-base";
+
+function isResetAdminPasswordSet(): boolean {
+  const value = process.env["RESET_ADMIN_PASSWORD"]?.trim().toLowerCase();
+  return value === "true" || value === "1" || value === "yes";
+}
 
 export async function loader({ request }: Route.LoaderArgs) {
   // Single-fetch navigation/revalidation uses internal `.data` URLs
@@ -50,6 +56,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     useLayout: true,
     // Baked into images published to the deprecated ghcr.io/nzbdav/nzbdav path.
     isLegacyImage: process.env["NZBDAV_LEGACY_IMAGE"] === "true",
+    isResetAdminPasswordSet: isResetAdminPasswordSet(),
     version,
     updateAvailable: await checkForUpdate(version),
     isFrontendAuthDisabled: IS_FRONTEND_AUTH_DISABLED,
@@ -146,6 +153,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
   const {
     useLayout,
     isLegacyImage,
+    isResetAdminPasswordSet,
     version,
     updateAvailable,
     isFrontendAuthDisabled,
@@ -187,6 +195,9 @@ export default function App({ loaderData }: Route.ComponentProps) {
             {showLoading ? <Loading /> : (
               <>
                 <div className="px-4 pt-4 md:px-8">
+                  <ResetAdminPasswordBanner
+                    isResetAdminPasswordSet={isResetAdminPasswordSet ?? false}
+                  />
                   <LegacyImageBanner isLegacyImage={isLegacyImage ?? false} />
                   <StreamTracingBanner isReadOnly={role === "readonly"} />
                 </div>

--- a/frontend/app/utils/reset-admin-password.server.ts
+++ b/frontend/app/utils/reset-admin-password.server.ts
@@ -1,0 +1,4 @@
+export function isResetAdminPasswordSet(): boolean {
+  const value = process.env["RESET_ADMIN_PASSWORD"]?.trim().toLowerCase();
+  return value === "true" || value === "1" || value === "yes" || value === "y";
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -420,7 +420,15 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         }
 
         await cts.CancelAsync();
-        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        try
+        {
+            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (OperationCanceledException)
+        {
+            // ProcessQueueAsync may still be inside GetTopQueueItem when the loop token
+            // is cancelled; shutdown cancellation is expected once assertions pass.
+        }
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Tasks/ResetAdminAccountTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/ResetAdminAccountTaskTests.cs
@@ -51,6 +51,8 @@ public sealed class ResetAdminAccountTaskTests : IAsyncLifetime
     [InlineData("1")]
     [InlineData("yes")]
     [InlineData("YES")]
+    [InlineData("y")]
+    [InlineData(" true ")]
     public async Task RunIfRequestedAsync_DeletesAdminAccount_WhenEnvVarIsTruthy(string envValue)
     {
         Environment.SetEnvironmentVariable(ResetAdminAccountTask.EnvVarName, envValue);

--- a/tests/NzbWebDAV.Tests/Tasks/ResetAdminAccountTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/ResetAdminAccountTaskTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Tasks;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class ResetAdminAccountTaskTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-resetadmin-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private string? _previousResetEnv;
+    private DbContextOptions<DavDatabaseContext> _options = null!;
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        _previousResetEnv = Environment.GetEnvironmentVariable(ResetAdminAccountTask.EnvVarName);
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(_options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        Environment.SetEnvironmentVariable(ResetAdminAccountTask.EnvVarName, _previousResetEnv);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("1")]
+    [InlineData("yes")]
+    [InlineData("YES")]
+    public async Task RunIfRequestedAsync_DeletesAdminAccount_WhenEnvVarIsTruthy(string envValue)
+    {
+        Environment.SetEnvironmentVariable(ResetAdminAccountTask.EnvVarName, envValue);
+        await SeedAccountsAsync();
+
+        await ResetAdminAccountTask.RunIfRequestedAsync(_context);
+
+        Assert.Equal(0, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.Admin));
+        Assert.Equal(1, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.WebDav));
+    }
+
+    [Fact]
+    public async Task RunIfRequestedAsync_NoOp_WhenEnvVarUnset()
+    {
+        Environment.SetEnvironmentVariable(ResetAdminAccountTask.EnvVarName, null);
+        await SeedAccountsAsync();
+
+        await ResetAdminAccountTask.RunIfRequestedAsync(_context);
+
+        Assert.Equal(1, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.Admin));
+        Assert.Equal(1, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.WebDav));
+    }
+
+    [Fact]
+    public async Task RunIfRequestedAsync_NoOp_WhenEnvVarInvalid()
+    {
+        Environment.SetEnvironmentVariable(ResetAdminAccountTask.EnvVarName, "maybe");
+        await SeedAccountsAsync();
+
+        await ResetAdminAccountTask.RunIfRequestedAsync(_context);
+
+        Assert.Equal(1, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.Admin));
+    }
+
+    [Fact]
+    public async Task RunIfRequestedAsync_NoOp_WhenAdminMissing()
+    {
+        Environment.SetEnvironmentVariable(ResetAdminAccountTask.EnvVarName, "true");
+        _context.Accounts.Add(new Account
+        {
+            Type = Account.AccountType.WebDav,
+            Username = "webdav-user",
+            PasswordHash = "hash",
+            RandomSalt = "salt",
+        });
+        await _context.SaveChangesAsync();
+
+        await ResetAdminAccountTask.RunIfRequestedAsync(_context);
+
+        Assert.Equal(0, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.Admin));
+        Assert.Equal(1, await _context.Accounts.CountAsync(a => a.Type == Account.AccountType.WebDav));
+    }
+
+    private async Task SeedAccountsAsync()
+    {
+        _context.Accounts.AddRange(
+            new Account
+            {
+                Type = Account.AccountType.Admin,
+                Username = "admin-user",
+                PasswordHash = "hash",
+                RandomSalt = "salt",
+            },
+            new Account
+            {
+                Type = Account.AccountType.WebDav,
+                Username = "webdav-user",
+                PasswordHash = "hash",
+                RandomSalt = "salt",
+            });
+        await _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RESET_ADMIN_PASSWORD` env var that deletes the admin account on backend startup, forcing the existing onboarding flow to set new credentials
- Shows a persistent danger banner in the UI while the variable remains set, plus matching backend log warnings on every startup
- Documents the reset flow in troubleshooting, environment variables, and first-run guides

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~ResetAdminAccountTaskTests`
- [x] `npm test -- --run reset-admin-password-banner` (frontend)
- [ ] Set `RESET_ADMIN_PASSWORD=true`, restart container, confirm onboarding appears and banner shows
- [ ] Remove env var and restart, confirm banner disappears and login works with new credentials