### PR TITLE
fix(repair): streaming failure repair now shows when Background Repairs must be enabled

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1533,12 +1533,36 @@ public class ConfigManager
 
     public bool IsRepairJobEnabled()
     {
-        var defaultValue = false;
+        return GetRepairDisabledReason() == null;
+    }
+
+    /// <summary>
+    /// When repairs are not fully enabled, returns a human-readable reason naming the missing prerequisite.
+    /// </summary>
+    public string? GetRepairDisabledReason()
+    {
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
-        var isRepairJobEnabled = (configValue != null ? bool.Parse(configValue) : defaultValue);
-        return isRepairJobEnabled
-               && GetLibraryDir() != null
-               && GetArrConfig().GetInstanceCount() > 0;
+        var isRepairJobEnabled = configValue != null && bool.Parse(configValue);
+        var hasLibraryDir = GetLibraryDir() != null;
+        var arrInstanceCount = GetArrConfig().GetInstanceCount();
+        return GetRepairDisabledReason(isRepairJobEnabled, hasLibraryDir, arrInstanceCount);
+    }
+
+    internal static string? GetRepairDisabledReason(
+        bool isRepairEnabled,
+        bool hasLibraryDir,
+        int arrInstanceCount)
+    {
+        if (!isRepairEnabled)
+            return "Enable Background Repairs is off";
+
+        if (!hasLibraryDir)
+            return "Library Directory is not set";
+
+        if (arrInstanceCount <= 0)
+            return "no Radarr/Sonarr instances are configured";
+
+        return null;
     }
 
     /// <summary>

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -23,6 +23,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentReadErrors = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentStreamingReadTimeouts = new();
     private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentStreamingWriteTimeouts = new();
+    private static readonly ConcurrentDictionary<string, (DateTime LastLogged, int SuppressedCount)> RecentSkippedStreamingRepairs = new();
     private static readonly ConcurrentDictionary<Guid, DateTime> RecentRepairTriggers = new();
     private static readonly TimeSpan DedupeWindow = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan RepairDedupeWindow = TimeSpan.FromMinutes(5);
@@ -449,8 +450,12 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
     private void ScheduleRepair(Guid davItemId)
     {
-        if (!configManager.IsRepairJobEnabled())
+        var repairDisabledReason = configManager.GetRepairDisabledReason();
+        if (repairDisabledReason != null)
+        {
+            LogStreamingRepairSkipped(davItemId, repairDisabledReason);
             return;
+        }
 
         // Count every distinct streaming failure before applying either threshold or deduplication.
         // Repeated failures must still advance the repair threshold while duplicate DB scheduling
@@ -512,6 +517,25 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
     internal static bool ShouldScheduleUrgentRepair(int threshold, int failureCount)
     {
         return threshold <= 0 || failureCount >= threshold;
+    }
+
+    private void LogStreamingRepairSkipped(Guid davItemId, string reason)
+    {
+        var dedupeKey = davItemId.ToString();
+        LogWithDedup(RecentSkippedStreamingRepairs, dedupeKey, suppressed =>
+        {
+            if (suppressed > 0)
+                Log.Warning(
+                    "Streaming failure for DavItem {DavItemId} will not trigger repair: {Reason}. Configure Settings > Health & Repairs. (suppressed {SuppressedCount} duplicates in last 60s)",
+                    davItemId,
+                    reason,
+                    suppressed);
+            else
+                Log.Warning(
+                    "Streaming failure for DavItem {DavItemId} will not trigger repair: {Reason}. Configure Settings > Health & Repairs.",
+                    davItemId,
+                    reason);
+        });
     }
 
     private static void LogWithDedup(

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -110,7 +110,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             if (context.Items["DavItem"] is DavItem davItem)
             {
                 RecordMissingArticleForFailFast(davItem, notFound.SegmentId);
-                ScheduleRepair(davItem.Id);
+                ScheduleRepair(davItem);
             }
 
             AbortStartedResponse(context);
@@ -268,7 +268,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             });
 
             if (context.Items["DavItem"] is DavItem davItem)
-                ScheduleRepair(davItem.Id);
+                ScheduleRepair(davItem);
 
             AbortStartedResponse(context);
         }
@@ -343,7 +343,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             Log.Debug(e, "Incomplete file content stack for {FilePath}", filePath);
 
             if (context.Items["DavItem"] is DavItem davItem)
-                ScheduleRepair(davItem.Id);
+                ScheduleRepair(davItem);
 
             AbortStartedResponse(context);
         }
@@ -422,7 +422,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             if ((IsTruncatedCiphertextException(e) || isIncompleteData) &&
                 context.Items["DavItem"] is DavItem truncatedItem)
             {
-                ScheduleRepair(truncatedItem.Id);
+                ScheduleRepair(truncatedItem);
             }
 
             AbortStartedResponse(context);
@@ -448,12 +448,13 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             context.Abort();
     }
 
-    private void ScheduleRepair(Guid davItemId)
+    private void ScheduleRepair(DavItem davItem)
     {
+        var davItemId = davItem.Id;
         var repairDisabledReason = configManager.GetRepairDisabledReason();
         if (repairDisabledReason != null)
         {
-            LogStreamingRepairSkipped(davItemId, repairDisabledReason);
+            LogStreamingRepairSkipped(davItem, repairDisabledReason);
             return;
         }
 
@@ -519,21 +520,21 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         return threshold <= 0 || failureCount >= threshold;
     }
 
-    private void LogStreamingRepairSkipped(Guid davItemId, string reason)
+    private void LogStreamingRepairSkipped(DavItem davItem, string reason)
     {
-        var dedupeKey = davItemId.ToString();
+        var dedupeKey = davItem.Id.ToString();
         LogWithDedup(RecentSkippedStreamingRepairs, dedupeKey, suppressed =>
         {
             if (suppressed > 0)
                 Log.Warning(
-                    "Streaming failure for DavItem {DavItemId} will not trigger repair: {Reason}. Configure Settings > Health & Repairs. (suppressed {SuppressedCount} duplicates in last 60s)",
-                    davItemId,
+                    "Streaming failure for {FilePath} will not trigger repair: {Reason}. Configure Settings > Health & Repairs. (suppressed {SuppressedCount} duplicates in last 60s)",
+                    davItem.Path,
                     reason,
                     suppressed);
             else
                 Log.Warning(
-                    "Streaming failure for DavItem {DavItemId} will not trigger repair: {Reason}. Configure Settings > Health & Repairs.",
-                    davItemId,
+                    "Streaming failure for {FilePath} will not trigger repair: {Reason}. Configure Settings > Health & Repairs.",
+                    davItem.Path,
                     reason);
         });
     }
@@ -609,6 +610,11 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         {
             if (kvp.Value.LastLogged < cutoff)
                 RecentStreamingWriteTimeouts.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in RecentSkippedStreamingRepairs)
+        {
+            if (kvp.Value.LastLogged < cutoff)
+                RecentSkippedStreamingRepairs.TryRemove(kvp.Key, out _);
         }
         foreach (var kvp in RecentRepairTriggers)
         {

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -19,6 +19,14 @@ Background health monitoring and replacement of unhealthy library items.
 | Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items are removed and blocklisted through *Arr instead of force-deleted |
 | Library Directory | `media.library-dir` | empty | Organized library root in the container — parent of your Arr root folders. Never the rclone mount or `/completed-symlinks` |
 
+!!! note "Streaming failure repair requires Background Repairs"
+
+    **Repair After Streaming Failures** (`repair.auto-remove-after-failures`) only takes effect when
+    **Enable Background Repairs** (`repair.enable`) is on, which itself requires **Library Directory**
+    and at least one configured *Arr instance. If a streaming failure is detected but repairs are not
+    fully enabled, InfiniDysk logs a warning naming the missing prerequisite instead of scheduling
+    urgent repair.
+
 `repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
 articles and corrupt archives. With a value greater than `0`, InfiniDysk waits for that many
 consecutive failures before it starts an urgent repair. At the threshold, linked library items are

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -24,6 +24,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
     const helpText = canEnableRepairs
         ? "When enabled, usenet items will be continuously monitored for health. Unhealthy items will be removed. If an unhealthy item is part of your Radarr/Sonarr library, a new search will be triggered to find a replacement."
         : "When enabled, usenet items will be continuously monitored for health. Unhealthy items will be removed and replaced. This setting can only be enabled once your Library-Directory and Radarr/Sonarr instances are configured.";
+    const isRepairEnabled = canEnableRepairs && config["repair.enable"] === "true";
     const autoRemoveAfter = config["repair.auto-remove-after-failures"] ?? "0";
     const autoRemoveEnabled = isNonNegativeInteger(autoRemoveAfter) && Number(autoRemoveAfter) > 0;
 
@@ -141,6 +142,11 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 description="Choose when repeated playback failures should trigger repair or removal."
                 contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
             >
+            {!isRepairEnabled && (
+                <p className="text-[11px] leading-relaxed text-base-content/45 lg:col-span-2">
+                    Enable Background Repairs above to activate streaming failure handling.
+                </p>
+            )}
             <ManagedSetting configKey="repair.auto-remove-after-failures">
             <div className="space-y-2">
                 <label className="block text-sm font-medium text-base-content" htmlFor="auto-remove-after-failures-input">Repair After Streaming Failures</label>
@@ -151,6 +157,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     aria-describedby="auto-remove-after-failures-help"
                     placeholder="0"
                     value={autoRemoveAfter}
+                    disabled={!isRepairEnabled}
                     onChange={e => setNewConfig({ ...config, "repair.auto-remove-after-failures": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45" id="auto-remove-after-failures-help">
                     Wait for this many consecutive streaming playback failures before urgent repair starts. Linked library
@@ -165,7 +172,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     id="auto-remove-unlinked-only-checkbox"
                     className="cursor-pointer gap-2 p-0"
                     checked={(config["repair.auto-remove-unlinked-only"] ?? "true") === "true"}
-                    disabled={!autoRemoveEnabled}
+                    disabled={!isRepairEnabled || !autoRemoveEnabled}
                     onChange={e => setNewConfig({ ...config, "repair.auto-remove-unlinked-only": "" + e.target.checked })}
                     label={<span className="text-sm text-base-content">Auto-remove unlinked files only</span>}
                 />

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -146,6 +146,30 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task StreamingFailureWithRepairsDisabled_WarnsWithReasonInsteadOfSchedulingRepair()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        // Default ConfigManager: repair.enable is off, so repair must be skipped with a reason.
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetArticleNotFoundException("missing-segment"),
+            new ConfigManager(),
+            failureTracker);
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        var logged = Assert.Single(events, e =>
+            e.RenderMessage().Contains("will not trigger repair", StringComparison.Ordinal));
+        Assert.Equal(LogEventLevel.Warning, logged.Level);
+        Assert.Null(logged.Exception);
+        Assert.Contains(davItem.Path, logged.RenderMessage(), StringComparison.Ordinal);
+        Assert.Contains("Enable Background Repairs is off", logged.RenderMessage(), StringComparison.Ordinal);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    [Fact]
     public async Task IncompleteMultipartPartBeforeResponseStarted_ReturnsNotFoundWithoutAborting()
     {
         var lifetimeFeature = new TestHttpRequestLifetimeFeature();

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -507,6 +507,33 @@ public class ExceptionMiddlewareTests
         Assert.Equal(expected, ExceptionMiddleware.ShouldScheduleUrgentRepair(threshold, failureCount));
     }
 
+    [Theory]
+    [InlineData(false, true, 1, "Enable Background Repairs is off")]
+    [InlineData(true, false, 1, "Library Directory is not set")]
+    [InlineData(true, true, 0, "no Radarr/Sonarr instances are configured")]
+    public void GetRepairDisabledReason_NamesMissingPrerequisite(
+        bool isRepairEnabled,
+        bool hasLibraryDir,
+        int arrInstanceCount,
+        string expected)
+    {
+        Assert.Equal(expected, ConfigManager.GetRepairDisabledReason(isRepairEnabled, hasLibraryDir, arrInstanceCount));
+    }
+
+    [Fact]
+    public void GetRepairDisabledReason_ReturnsNullWhenFullyEnabled()
+    {
+        Assert.Null(ConfigManager.GetRepairDisabledReason(true, true, 1));
+    }
+
+    [Fact]
+    public void GetRepairDisabledReason_InstanceReflectsConfiguredPrerequisites()
+    {
+        var configManager = CreateRepairEnabledConfig();
+        Assert.Null(configManager.GetRepairDisabledReason());
+        Assert.True(configManager.IsRepairJobEnabled());
+    }
+
     private static ExceptionMiddleware CreateMiddleware(
         RequestDelegate next,
         ConfigManager? configManager = null,


### PR DESCRIPTION
## Summary

- Disables **Repair After Streaming Failures** controls until **Enable Background Repairs** is on, with an inline note explaining the dependency
- Logs a deduplicated warning when a streaming failure cannot schedule repair, naming the specific missing prerequisite (toggle off, library dir, or Arr instances)
- Documents the prerequisite in `docs/configuration/repairs.md`

## Context

Users can configure streaming failure thresholds without realizing the master **Enable Background Repairs** toggle must also be on. When repairs are disabled, missing-article failures are logged but repair scheduling silently no-ops — making it look like the feature is broken.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ExceptionMiddlewareTests"` (33 passed)
- [ ] Open Settings > Health & Repairs with library dir + Arr configured but repairs disabled — streaming failure card shows note and disabled inputs
- [ ] Enable Background Repairs — streaming failure inputs become editable
- [ ] Trigger a streaming failure with repairs disabled — logs warning naming missing prerequisite