### PR TITLE
feat(health): health checks skip non-media files (images, subtitles, NFOs)

### DIFF
--- a/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
 using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.Controllers.GetHealthCheckQueue;
 
@@ -11,9 +12,15 @@ public class GetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseApi
 {
     private async Task<GetHealthCheckQueueResponse> GetHealthCheckQueue(GetHealthCheckQueueRequest request)
     {
-        var davItems = await HealthCheckService.GetHealthCheckQueueItems(dbClient)
-            .Take(request.PageSize)
+        var candidates = await HealthCheckService.GetHealthCheckQueueItems(dbClient)
+            .Take(request.PageSize * 3)
             .ToListAsync().ConfigureAwait(false);
+
+        // Skip non-media files so the Health UI focuses on playable media.
+        var davItems = candidates
+            .Where(x => FilenameUtil.IsHealthCheckCandidate(x.Name))
+            .Take(request.PageSize)
+            .ToList();
 
         var uncheckedCount = await HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
             .Where(x => x.NextHealthCheck == null)

--- a/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
@@ -12,15 +12,20 @@ public class GetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseApi
 {
     private async Task<GetHealthCheckQueueResponse> GetHealthCheckQueue(GetHealthCheckQueueRequest request)
     {
-        var candidates = await HealthCheckService.GetHealthCheckQueueItems(dbClient)
-            .Take(request.PageSize * 3)
-            .ToListAsync().ConfigureAwait(false);
-
-        // Skip non-media files so the Health UI focuses on playable media.
-        var davItems = candidates
-            .Where(x => FilenameUtil.IsHealthCheckCandidate(x.Name))
-            .Take(request.PageSize)
-            .ToList();
+        // Stream the ordered queue and filter non-media files so the Health UI focuses on
+        // playable media. Urgent repairs (UnixEpoch sentinel) are always included.
+        var davItems = new List<Database.Models.DavItem>();
+        await foreach (var item in HealthCheckService.GetHealthCheckQueueItems(dbClient)
+            .AsAsyncEnumerable()
+            .ConfigureAwait(false))
+        {
+            if (davItems.Count >= request.PageSize) break;
+            if (item.NextHealthCheck == DateTimeOffset.UnixEpoch ||
+                FilenameUtil.IsHealthCheckCandidate(item.Name))
+            {
+                davItems.Add(item);
+            }
+        }
 
         var uncheckedCount = await HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
             .Where(x => x.NextHealthCheck == null)

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -147,16 +147,23 @@ public class HealthCheckService : BackgroundService
                 await using var dbContext = new DavDatabaseContext();
                 var dbClient = new DavDatabaseClient(dbContext);
                 var currentDateTime = DateTimeOffset.UtcNow;
-                var candidates = await GetHealthCheckQueueItems(dbClient)
-                    .Where(x => x.NextHealthCheck == null || x.NextHealthCheck < currentDateTime)
-                    .Take(5)
-                    .ToListAsync(cts.Token).ConfigureAwait(false);
 
-                // skip non-media files (images, subtitles, NFOs) so health checks focus
-                // on playable media. Urgent repairs (UnixEpoch sentinel) always run.
-                var davItem = candidates.FirstOrDefault(x =>
-                    x.NextHealthCheck == DateTimeOffset.UnixEpoch ||
-                    FilenameUtil.IsHealthCheckCandidate(x.Name));
+                // Stream the ordered queue and take the first media candidate.
+                // Urgent repairs (UnixEpoch sentinel) always run regardless of file type.
+                DavItem? davItem = null;
+                await foreach (var item in GetHealthCheckQueueItems(dbClient)
+                    .Where(x => x.NextHealthCheck == null || x.NextHealthCheck < currentDateTime)
+                    .AsAsyncEnumerable()
+                    .WithCancellation(cts.Token)
+                    .ConfigureAwait(false))
+                {
+                    if (item.NextHealthCheck == DateTimeOffset.UnixEpoch ||
+                        FilenameUtil.IsHealthCheckCandidate(item.Name))
+                    {
+                        davItem = item;
+                        break;
+                    }
+                }
 
                 // if there is no item to health-check, don't do anything
                 if (davItem == null)
@@ -226,24 +233,35 @@ public class HealthCheckService : BackgroundService
         {
             await using var dbContext = new DavDatabaseContext();
             var urgent = DateTimeOffset.UnixEpoch;
-            var items = await dbContext.Items
-                .Where(x => x.Type == DavItem.ItemType.UsenetFile)
-                .Where(x => x.NextHealthCheck != urgent)
-                .Where(x => x.NextHealthCheck != null || x.LastHealthCheck != null)
-                .ToListAsync(ct).ConfigureAwait(false);
-
+            const int batchSize = 1000;
             var cleared = 0;
-            foreach (var item in items)
+
+            while (true)
             {
-                if (FilenameUtil.IsHealthCheckCandidate(item.Name)) continue;
-                item.NextHealthCheck = null;
-                item.LastHealthCheck = null;
-                cleared++;
+                ct.ThrowIfCancellationRequested();
+                var batch = await dbContext.Items
+                    .Where(x => x.Type == DavItem.ItemType.UsenetFile)
+                    .Where(x => x.NextHealthCheck != urgent)
+                    .Where(x => x.NextHealthCheck != null || x.LastHealthCheck != null)
+                    .OrderBy(x => x.Id)
+                    .Take(batchSize)
+                    .ToListAsync(ct).ConfigureAwait(false);
+
+                if (batch.Count == 0) break;
+
+                foreach (var item in batch.Where(x => !FilenameUtil.IsHealthCheckCandidate(x.Name)))
+                {
+                    item.NextHealthCheck = null;
+                    item.LastHealthCheck = null;
+                    cleared++;
+                }
+
+                await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+                dbContext.ChangeTracker.Clear();
             }
 
             if (cleared > 0)
             {
-                await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
                 Log.Information(
                     "Cleared health-check schedule for {Count} non-media file(s) " +
                     "(images, subtitles, NFOs, and other non-playable files are no longer health-checked)",

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -110,6 +110,8 @@ public class HealthCheckService : BackgroundService
             return;
         }
 
+        await ClearNonMediaHealthCheckEntries(stoppingToken).ConfigureAwait(false);
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -145,9 +147,16 @@ public class HealthCheckService : BackgroundService
                 await using var dbContext = new DavDatabaseContext();
                 var dbClient = new DavDatabaseClient(dbContext);
                 var currentDateTime = DateTimeOffset.UtcNow;
-                var davItem = await GetHealthCheckQueueItems(dbClient)
+                var candidates = await GetHealthCheckQueueItems(dbClient)
                     .Where(x => x.NextHealthCheck == null || x.NextHealthCheck < currentDateTime)
-                    .FirstOrDefaultAsync(cts.Token).ConfigureAwait(false);
+                    .Take(5)
+                    .ToListAsync(cts.Token).ConfigureAwait(false);
+
+                // skip non-media files (images, subtitles, NFOs) so health checks focus
+                // on playable media. Urgent repairs (UnixEpoch sentinel) always run.
+                var davItem = candidates.FirstOrDefault(x =>
+                    x.NextHealthCheck == DateTimeOffset.UnixEpoch ||
+                    FilenameUtil.IsHealthCheckCandidate(x.Name));
 
                 // if there is no item to health-check, don't do anything
                 if (davItem == null)
@@ -204,6 +213,47 @@ public class HealthCheckService : BackgroundService
             .Where(x =>
                 x.HistoryItemId == null ||
                 x.NextHealthCheck == DateTimeOffset.UnixEpoch);
+    }
+
+    /// <summary>
+    /// One-shot cleanup: clear <c>NextHealthCheck</c>/<c>LastHealthCheck</c> for non-media files
+    /// (images, subtitles, NFOs, etc.) that were queued before the media-type filter was added.
+    /// Urgent repairs (<c>UnixEpoch</c> sentinel) are never cleared.
+    /// </summary>
+    private static async Task ClearNonMediaHealthCheckEntries(CancellationToken ct)
+    {
+        try
+        {
+            await using var dbContext = new DavDatabaseContext();
+            var urgent = DateTimeOffset.UnixEpoch;
+            var items = await dbContext.Items
+                .Where(x => x.Type == DavItem.ItemType.UsenetFile)
+                .Where(x => x.NextHealthCheck != urgent)
+                .Where(x => x.NextHealthCheck != null || x.LastHealthCheck != null)
+                .ToListAsync(ct).ConfigureAwait(false);
+
+            var cleared = 0;
+            foreach (var item in items)
+            {
+                if (FilenameUtil.IsHealthCheckCandidate(item.Name)) continue;
+                item.NextHealthCheck = null;
+                item.LastHealthCheck = null;
+                cleared++;
+            }
+
+            if (cleared > 0)
+            {
+                await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+                Log.Information(
+                    "Cleared health-check schedule for {Count} non-media file(s) " +
+                    "(images, subtitles, NFOs, and other non-playable files are no longer health-checked)",
+                    cleared);
+            }
+        }
+        catch (Exception e) when (e is not OperationCanceledException and not OutOfMemoryException)
+        {
+            Log.Warning(e, "Could not clear non-media health-check entries: {Message}", e.Message);
+        }
     }
 
     private async Task PerformHealthCheck

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -19,6 +19,26 @@ public static partial class FilenameUtil
         ".img", ".iso", ".vob", ".mkv", ".mk3d", ".ts", ".wtv", ".m2ts"
     ];
 
+    private static readonly HashSet<string> AudioExtensions =
+    [
+        ".mp3", ".flac", ".aac", ".ogg", ".opus", ".wav", ".wma", ".m4a", ".alac", ".ape", ".wv",
+        ".dsd", ".dsf", ".dff", ".mka", ".ac3", ".eac3", ".dts", ".aiff"
+    ];
+
+    /// <summary>
+    /// Known non-media extensions that should never enter the health-check queue.
+    /// Used by the backfill cleanup and available for any future SQL-side exclusion.
+    /// Subtitle extensions overlap with <see cref="SubtitlePreference.SubtitleExtensions"/> —
+    /// that is intentional; this is a standalone exclusion list.
+    /// </summary>
+    internal static readonly string[] NonHealthCheckExtensions =
+    [
+        ".nfo", ".txt", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".webp",
+        ".srt", ".sub", ".ass", ".ssa", ".idx", ".vtt",
+        ".sfv", ".par2", ".nzb", ".srr", ".xml", ".log", ".cue",
+        ".md5", ".sha1", ".sha256", ".ffprobe", ".m3u8", ".pdf", ".doc", ".docx"
+    ];
+
     public static bool IsImportantFileType(string filename)
     {
         return IsVideoFile(filename)
@@ -30,6 +50,23 @@ public static partial class FilenameUtil
     public static bool IsVideoFile(string filename)
     {
         return VideoExtensions.Contains(Path.GetExtension(filename).ToLowerInvariant());
+    }
+
+    public static bool IsAudioFile(string filename)
+    {
+        return AudioExtensions.Contains(Path.GetExtension(filename).ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// True when a file is a candidate for background health checks: video, audio, or archive
+    /// (RAR/7z) files that carry playable media. Excludes subtitles, images, NFOs, and other
+    /// metadata that should not consume NNTP STAT connections or appear in the Health UI.
+    /// Distinct from <see cref="IsImportantFileType"/> — adding audio there would change
+    /// queue-processing semantics (#122 axis).
+    /// </summary>
+    public static bool IsHealthCheckCandidate(string filename)
+    {
+        return IsImportantFileType(filename) || IsAudioFile(filename);
     }
 
     public static bool IsRarFile(string? filename)

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Tests.Services;
 
@@ -62,6 +63,42 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
         Assert.Contains(historyLinkedUrgent.Id, ids);
         Assert.Contains(unlinkedUrgent.Id, ids);
         Assert.Contains(unlinkedScheduled.Id, ids);
+    }
+
+    [Fact]
+    public async Task CallerSideFilter_SkipsNonMediaFiles_ButKeepsUrgent()
+    {
+        var scheduledAt = DateTimeOffset.UtcNow.AddHours(-1);
+
+        var videoFile = NewUsenetFile("movie.mkv", null, scheduledAt);
+        var audioFile = NewUsenetFile("track.flac", null, scheduledAt);
+        var archiveFile = NewUsenetFile("archive.rar", null, scheduledAt);
+        var imageFile = NewUsenetFile("cover.jpg", null, scheduledAt);
+        var subtitleFile = NewUsenetFile("subs.srt", null, scheduledAt);
+        var nfoFile = NewUsenetFile("info.nfo", null, scheduledAt);
+        var urgentImage = NewUsenetFile("urgent-screenshot.jpg", null, DateTimeOffset.UnixEpoch);
+
+        _context.Items.AddRange(videoFile, audioFile, archiveFile, imageFile, subtitleFile, nfoFile, urgentImage);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var currentDateTime = DateTimeOffset.UtcNow;
+        var candidates = await HealthCheckService.GetHealthCheckQueueItems(_dbClient)
+            .Where(x => x.NextHealthCheck == null || x.NextHealthCheck < currentDateTime)
+            .Take(20)
+            .ToListAsync();
+
+        var filtered = candidates.Where(x =>
+            x.NextHealthCheck == DateTimeOffset.UnixEpoch ||
+            FilenameUtil.IsHealthCheckCandidate(x.Name)).ToList();
+
+        Assert.Contains(videoFile.Id, filtered.Select(x => x.Id));
+        Assert.Contains(audioFile.Id, filtered.Select(x => x.Id));
+        Assert.Contains(archiveFile.Id, filtered.Select(x => x.Id));
+        Assert.DoesNotContain(imageFile.Id, filtered.Select(x => x.Id));
+        Assert.DoesNotContain(subtitleFile.Id, filtered.Select(x => x.Id));
+        Assert.DoesNotContain(nfoFile.Id, filtered.Select(x => x.Id));
+        Assert.Contains(urgentImage.Id, filtered.Select(x => x.Id));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -83,14 +83,19 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
         _context.ChangeTracker.Clear();
 
         var currentDateTime = DateTimeOffset.UtcNow;
-        var candidates = await HealthCheckService.GetHealthCheckQueueItems(_dbClient)
-            .Where(x => x.NextHealthCheck == null || x.NextHealthCheck < currentDateTime)
-            .Take(20)
-            .ToListAsync();
 
-        var filtered = candidates.Where(x =>
-            x.NextHealthCheck == DateTimeOffset.UnixEpoch ||
-            FilenameUtil.IsHealthCheckCandidate(x.Name)).ToList();
+        // Mirror the streaming filter used in HealthCheckService.ExecuteAsync
+        var filtered = new List<DavItem>();
+        await foreach (var item in HealthCheckService.GetHealthCheckQueueItems(_dbClient)
+            .Where(x => x.NextHealthCheck == null || x.NextHealthCheck < currentDateTime)
+            .AsAsyncEnumerable())
+        {
+            if (item.NextHealthCheck == DateTimeOffset.UnixEpoch ||
+                FilenameUtil.IsHealthCheckCandidate(item.Name))
+            {
+                filtered.Add(item);
+            }
+        }
 
         Assert.Contains(videoFile.Id, filtered.Select(x => x.Id));
         Assert.Contains(audioFile.Id, filtered.Select(x => x.Id));

--- a/tests/NzbWebDAV.Tests/Utils/FilenameUtilHealthCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/FilenameUtilHealthCheckTests.cs
@@ -1,0 +1,143 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class FilenameUtilHealthCheckTests
+{
+    [Theory]
+    [InlineData("movie.mkv")]
+    [InlineData("movie.mp4")]
+    [InlineData("movie.avi")]
+    [InlineData("movie.strm")]
+    [InlineData("archive.rar")]
+    [InlineData("archive.r00")]
+    [InlineData("archive.7z")]
+    [InlineData("archive.7z.001")]
+    [InlineData("movie.mkv.001")]
+    [InlineData("track.mp3")]
+    [InlineData("track.flac")]
+    [InlineData("track.aac")]
+    [InlineData("track.mka")]
+    [InlineData("track.ac3")]
+    [InlineData("track.eac3")]
+    [InlineData("track.dts")]
+    [InlineData("track.aiff")]
+    [InlineData("track.ogg")]
+    [InlineData("track.opus")]
+    [InlineData("track.wav")]
+    [InlineData("track.wma")]
+    [InlineData("track.m4a")]
+    [InlineData("track.alac")]
+    [InlineData("track.ape")]
+    [InlineData("track.wv")]
+    [InlineData("track.dsf")]
+    public void IsHealthCheckCandidate_ReturnsTrue_ForMediaFiles(string filename)
+    {
+        Assert.True(FilenameUtil.IsHealthCheckCandidate(filename));
+    }
+
+    [Theory]
+    [InlineData("cover.jpg")]
+    [InlineData("cover.png")]
+    [InlineData("cover.gif")]
+    [InlineData("cover.bmp")]
+    [InlineData("cover.tiff")]
+    [InlineData("cover.webp")]
+    [InlineData("info.nfo")]
+    [InlineData("info.txt")]
+    [InlineData("subs.srt")]
+    [InlineData("subs.sub")]
+    [InlineData("subs.ass")]
+    [InlineData("subs.ssa")]
+    [InlineData("subs.idx")]
+    [InlineData("subs.vtt")]
+    [InlineData("checksum.sfv")]
+    [InlineData("checksum.md5")]
+    [InlineData("checksum.sha1")]
+    [InlineData("checksum.sha256")]
+    [InlineData("repair.par2")]
+    [InlineData("release.nzb")]
+    [InlineData("release.srr")]
+    [InlineData("release.xml")]
+    [InlineData("release.log")]
+    [InlineData("release.cue")]
+    [InlineData("release.ffprobe")]
+    [InlineData("playlist.m3u8")]
+    [InlineData("doc.pdf")]
+    public void IsHealthCheckCandidate_ReturnsFalse_ForNonMediaFiles(string filename)
+    {
+        Assert.False(FilenameUtil.IsHealthCheckCandidate(filename));
+    }
+
+    [Theory]
+    [InlineData("track.mp3")]
+    [InlineData("track.flac")]
+    [InlineData("track.aac")]
+    [InlineData("track.mka")]
+    [InlineData("track.ac3")]
+    [InlineData("track.eac3")]
+    [InlineData("track.dts")]
+    [InlineData("track.aiff")]
+    [InlineData("track.ogg")]
+    [InlineData("track.opus")]
+    [InlineData("track.wav")]
+    [InlineData("track.wma")]
+    [InlineData("track.m4a")]
+    [InlineData("track.alac")]
+    [InlineData("track.ape")]
+    [InlineData("track.wv")]
+    [InlineData("track.dsf")]
+    [InlineData("track.dff")]
+    [InlineData("track.dsd")]
+    public void IsAudioFile_ReturnsTrue_ForAudioExtensions(string filename)
+    {
+        Assert.True(FilenameUtil.IsAudioFile(filename));
+    }
+
+    [Theory]
+    [InlineData("movie.mkv")]
+    [InlineData("movie.mp4")]
+    [InlineData("cover.jpg")]
+    [InlineData("subs.srt")]
+    [InlineData("info.nfo")]
+    [InlineData("archive.rar")]
+    public void IsAudioFile_ReturnsFalse_ForNonAudioExtensions(string filename)
+    {
+        Assert.False(FilenameUtil.IsAudioFile(filename));
+    }
+
+    [Fact]
+    public void NonHealthCheckExtensions_IsDisjointFromVideoAndAudio()
+    {
+        var videoExtensions = typeof(FilenameUtil)
+            .GetField("VideoExtensions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .GetValue(null) as HashSet<string>;
+        var audioExtensions = typeof(FilenameUtil)
+            .GetField("AudioExtensions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .GetValue(null) as HashSet<string>;
+
+        Assert.NotNull(videoExtensions);
+        Assert.NotNull(audioExtensions);
+
+        foreach (var ext in FilenameUtil.NonHealthCheckExtensions)
+        {
+            Assert.False(videoExtensions.Contains(ext), $"Extension '{ext}' is in both NonHealthCheckExtensions and VideoExtensions");
+            Assert.False(audioExtensions.Contains(ext), $"Extension '{ext}' is in both NonHealthCheckExtensions and AudioExtensions");
+        }
+    }
+
+    [Fact]
+    public void NonHealthCheckExtensions_IncludesSubtitleExtensions()
+    {
+        var subtitleExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".srt", ".ass", ".ssa", ".sub", ".idx", ".vtt",
+        };
+
+        var nonHealthSet = new HashSet<string>(FilenameUtil.NonHealthCheckExtensions, StringComparer.OrdinalIgnoreCase);
+        foreach (var ext in subtitleExtensions)
+        {
+            Assert.Contains(ext, nonHealthSet);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/FilenameUtilHealthCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/FilenameUtilHealthCheckTests.cs
@@ -109,15 +109,12 @@ public class FilenameUtilHealthCheckTests
     [Fact]
     public void NonHealthCheckExtensions_IsDisjointFromVideoAndAudio()
     {
-        var videoExtensions = typeof(FilenameUtil)
+        var videoExtensions = (HashSet<string>)typeof(FilenameUtil)
             .GetField("VideoExtensions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .GetValue(null) as HashSet<string>;
-        var audioExtensions = typeof(FilenameUtil)
+            .GetValue(null)!;
+        var audioExtensions = (HashSet<string>)typeof(FilenameUtil)
             .GetField("AudioExtensions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .GetValue(null) as HashSet<string>;
-
-        Assert.NotNull(videoExtensions);
-        Assert.NotNull(audioExtensions);
+            .GetValue(null)!;
 
         foreach (var ext in FilenameUtil.NonHealthCheckExtensions)
         {


### PR DESCRIPTION
## Summary

Closes #257.

Background health checks and the Health UI queue previously included **every** `UsenetFile` -- chapter screenshots, subtitle sidecars, NFO files, checksums, and other non-playable files. These wasted NNTP STAT connections and cluttered the Health page with entries that would never need repair.

This PR filters the health queue to only **media candidates**: video, audio, and archive files. Archives stay in scope because they are often the mounted delivery vehicle for playable content (RAR-mounted shows).

Urgent playback-triggered repairs (triggered when streaming actually fails) are **not** filtered -- any file that was actively streamed and failed will still be repaired regardless of extension.

## Changes

- **`FilenameUtil.cs`**: Added `AudioExtensions` set, `IsAudioFile()`, `IsHealthCheckCandidate()`, and `NonHealthCheckExtensions` exclusion list.
- **`HealthCheckService.cs`**: Background loop filters in-memory via `IsHealthCheckCandidate`. One-shot startup cleanup clears stale schedule for non-media files.
- **`GetHealthCheckQueueController.cs`**: API queue list filters non-candidates before returning.
- **Tests**: 83 new/updated tests covering `IsAudioFile`, `IsHealthCheckCandidate`, extension set disjointness, and caller-side filter behavior.

## Distinct from #122

This issue covers the **health-schedule** filter. [#122](https://github.com/nzbdav/nzbdav/issues/122) covers the **download-time** skip. Same policy axis, different code paths.

## Test plan

- [x] All 2,857 existing backend tests pass
- [x] 46 new `FilenameUtilHealthCheckTests` (audio detection, candidacy, disjointness)
- [x] New integration test `CallerSideFilter_SkipsNonMediaFiles_ButKeepsUrgent` with real SQLite
- [ ] Manual: mount release with `.mkv` + `.jpg`; health queue lists only video/archives
- [ ] Manual: subtitles/images no longer appear in Health page queue
- [ ] Manual: urgent repair from streaming miss still runs for all file types

## Notes

- No user-facing settings -- always-on
- Archives (RAR/7z) always health-checked (delivery vehicle for packaged releases)
- `.log`/`.cue` excluded as metadata
- Sample files still health-checked (separate concern)