### PR TITLE
feat(queue): audio-only NZBs now import instead of being rejected

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -616,7 +616,7 @@ public class ConfigManager
     /// When true (default), NZBs must contain at least one video or audio file
     /// to be accepted; otherwise the download fails so an alternate can be grabbed.
     /// </summary>
-    public bool IsEnsureImportableVideoEnabled()
+    public bool IsEnsureImportableMediaEnabled()
     {
         var defaultValue = true;
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiEnsureImportableVideo));
@@ -627,7 +627,7 @@ public class ConfigManager
     /// When true (default), non-media files with missing articles are skipped
     /// instead of failing the job. Media files (video and audio) always fail.
     /// </summary>
-    public bool IsSkipNonVideoOnMissingArticlesEnabled()
+    public bool IsSkipNonMediaOnMissingArticlesEnabled()
     {
         var defaultValue = true;
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiSkipNonVideoOnMissingArticles));

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -612,6 +612,10 @@ public class ConfigManager
         return null;
     }
 
+    /// <summary>
+    /// When true (default), NZBs must contain at least one video or audio file
+    /// to be accepted; otherwise the download fails so an alternate can be grabbed.
+    /// </summary>
     public bool IsEnsureImportableVideoEnabled()
     {
         var defaultValue = true;
@@ -620,8 +624,8 @@ public class ConfigManager
     }
 
     /// <summary>
-    /// When true (default), non-video files with missing articles are skipped
-    /// instead of failing the job.
+    /// When true (default), non-media files with missing articles are skipped
+    /// instead of failing the job. Media files (video and audio) always fail.
     /// </summary>
     public bool IsSkipNonVideoOnMissingArticlesEnabled()
     {

--- a/backend/Exceptions/NoMediaFilesFoundException.cs
+++ b/backend/Exceptions/NoMediaFilesFoundException.cs
@@ -1,0 +1,5 @@
+﻿namespace NzbWebDAV.Exceptions;
+
+public class NoMediaFilesFoundException(string message) : NonRetryableDownloadException(message)
+{
+}

--- a/backend/Exceptions/NoVideoFilesFoundException.cs
+++ b/backend/Exceptions/NoVideoFilesFoundException.cs
@@ -1,5 +1,0 @@
-﻿namespace NzbWebDAV.Exceptions;
-
-public class NoVideoFilesFoundException(string message) : NonRetryableDownloadException(message)
-{
-}

--- a/backend/Queue/FileProcessors/FileProcessor.cs
+++ b/backend/Queue/FileProcessors/FileProcessor.cs
@@ -36,16 +36,16 @@ public class FileProcessor(
             };
         }
 
-        // Ignore missing articles if it's not a video file (default).
+        // Ignore missing articles if it's not a media file (default).
         // In that case, simply skip the file altogether.
         // Accepted limitation: this check uses the original filename, not a
         // sniffed extension applied later at mount time.
         catch (UsenetArticleNotFoundException) when (
-            !FilenameUtil.IsVideoFile(fileInfo.FileName)
+            !FilenameUtil.IsMediaFile(fileInfo.FileName)
             && configManager.IsSkipNonVideoOnMissingArticlesEnabled())
         {
             Log.Warning(
-                "File {FileName} has missing articles; skipping it because it is not a video",
+                "File {FileName} has missing articles; skipping it because it is not a media file",
                 fileInfo.FileName);
             return null;
         }

--- a/backend/Queue/FileProcessors/FileProcessor.cs
+++ b/backend/Queue/FileProcessors/FileProcessor.cs
@@ -42,7 +42,7 @@ public class FileProcessor(
         // sniffed extension applied later at mount time.
         catch (UsenetArticleNotFoundException) when (
             !FilenameUtil.IsMediaFile(fileInfo.FileName)
-            && configManager.IsSkipNonVideoOnMissingArticlesEnabled())
+            && configManager.IsSkipNonMediaOnMissingArticlesEnabled())
         {
             Log.Warning(
                 "File {FileName} has missing articles; skipping it because it is not a media file",

--- a/backend/Queue/PostProcessors/EnsureImportableMediaValidator.cs
+++ b/backend/Queue/PostProcessors/EnsureImportableMediaValidator.cs
@@ -6,13 +6,13 @@ using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Queue.PostProcessors;
 
-public class EnsureImportableVideoValidator(DavDatabaseClient dbClient)
+public class EnsureImportableMediaValidator(DavDatabaseClient dbClient)
 {
     public void ThrowIfValidationFails()
     {
         if (!IsValid())
         {
-            throw new NoVideoFilesFoundException("No importable videos found.");
+            throw new NoMediaFilesFoundException("No importable media files found.");
         }
     }
 
@@ -22,6 +22,6 @@ public class EnsureImportableVideoValidator(DavDatabaseClient dbClient)
             .Where(x => x.State == EntityState.Added)
             .Select(x => x.Entity)
             .Where(x => x.Type != DavItem.ItemType.Directory)
-            .Any(x => FilenameUtil.IsVideoFile(x.Name));
+            .Any(x => FilenameUtil.IsMediaFile(x.Name));
     }
 }

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -503,9 +503,9 @@ public class QueueItemProcessor(
             new RenameDuplicatesPostProcessor(dbClient).RenameDuplicates();
             new BlocklistedFilePostProcessor(configManager, dbClient).RemoveFilteredFiles();
 
-            // validate video files found
+            // validate media files found
             if (configManager.IsEnsureImportableVideoEnabled())
-                new EnsureImportableVideoValidator(dbClient).ThrowIfValidationFails();
+                new EnsureImportableMediaValidator(dbClient).ThrowIfValidationFails();
 
             // create strm files, if necessary
             if (configManager.GetImportStrategy() == "strm")

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -504,7 +504,7 @@ public class QueueItemProcessor(
             new BlocklistedFilePostProcessor(configManager, dbClient).RemoveFilteredFiles();
 
             // validate media files found
-            if (configManager.IsEnsureImportableVideoEnabled())
+            if (configManager.IsEnsureImportableMediaEnabled())
                 new EnsureImportableMediaValidator(dbClient).ThrowIfValidationFails();
 
             // create strm files, if necessary

--- a/backend/Utils/ContentTypeUtil.cs
+++ b/backend/Utils/ContentTypeUtil.cs
@@ -10,7 +10,18 @@ public static class ContentTypeUtil
     {
         // ReSharper disable once UseObjectOrCollectionInitializer
         var provider = new FileExtensionContentTypeProvider();
+        // audio
         provider.Mappings[".flac"] = "audio/flac";
+        provider.Mappings[".opus"] = "audio/opus";
+        provider.Mappings[".ape"] = "audio/x-ape";
+        provider.Mappings[".wv"] = "audio/x-wavpack";
+        provider.Mappings[".dsf"] = "audio/x-dsf";
+        provider.Mappings[".dff"] = "audio/x-dff";
+        provider.Mappings[".m4b"] = "audio/mp4";
+        provider.Mappings[".mka"] = "audio/x-matroska";
+        provider.Mappings[".aiff"] = "audio/aiff";
+        provider.Mappings[".aif"] = "audio/aiff";
+        // video
         provider.Mappings[".mkv"] = "video/x-matroska";
         provider.Mappings[".mk3d"] = "video/x-matroska";
         provider.Mappings[".m4v"] = "video/x-m4v";

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -19,9 +19,15 @@ public static partial class FilenameUtil
         ".img", ".iso", ".vob", ".mkv", ".mk3d", ".ts", ".wtv", ".m2ts"
     ];
 
+    private static readonly HashSet<string> AudioExtensions =
+    [
+        ".flac", ".mp3", ".m4a", ".ogg", ".opus", ".ape", ".wv", ".wav", ".aac", ".alac",
+        ".dsf", ".dff", ".wma", ".aiff", ".aif", ".m4b", ".mka"
+    ];
+
     public static bool IsImportantFileType(string filename)
     {
-        return IsVideoFile(filename)
+        return IsMediaFile(filename)
                || IsRarFile(filename)
                || Is7zFile(filename)
                || IsSplitVideoFile(filename);
@@ -30,6 +36,16 @@ public static partial class FilenameUtil
     public static bool IsVideoFile(string filename)
     {
         return VideoExtensions.Contains(Path.GetExtension(filename).ToLowerInvariant());
+    }
+
+    public static bool IsAudioFile(string filename)
+    {
+        return AudioExtensions.Contains(Path.GetExtension(filename).ToLowerInvariant());
+    }
+
+    public static bool IsMediaFile(string filename)
+    {
+        return IsVideoFile(filename) || IsAudioFile(filename);
     }
 
     public static bool IsRarFile(string? filename)

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -21,8 +21,8 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Filter sample videos [since 0.10.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.10.0){ .nzbdav-since } | `api.sample-filter-enabled` | on | Discard videos with whole-word `sample`/`samples` under 20% of the largest video in the NZB |
 | Behavior for Duplicate NZBs | `api.duplicate-nzb-behavior` | `increment` | increment / mark-failed |
 | Trusted local hosts [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | `api.addurl-trusted-hosts` | env `TRUSTED_INTERNAL_HOSTS` | SSRF allowlist for private addurl |
-| Fail downloads without video | `api.ensure-importable-video` | on | Reject non-video NZBs |
-| Fail when non-video missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-video by default | |
+| Fail downloads without video or audio | `api.ensure-importable-video` | on | Reject NZBs with no media files |
+| Fail when non-media missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-media by default | |
 | Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category; may be slow |
 | Article health check mode | `api.article-existence-check-mode` | `full` | Full or per-file sampled verification |
 | Always send full History | `api.ignore-history-limit` | on | Ignore client history limit |

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -22,7 +22,7 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Behavior for Duplicate NZBs | `api.duplicate-nzb-behavior` | `increment` | increment / mark-failed |
 | Trusted local hosts [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | `api.addurl-trusted-hosts` | env `TRUSTED_INTERNAL_HOSTS` | SSRF allowlist for private addurl |
 | Fail downloads without video or audio | `api.ensure-importable-video` | on | Reject NZBs with no media files |
-| Fail when non-media missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-media by default | |
+| Fail when non-media missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-media by default | Media files (video/audio) always fail on missing articles; companion files are skipped unless this is enabled |
 | Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category; may be slow |
 | Article health check mode | `api.article-existence-check-mode` | `full` | Full or per-file sampled verification |
 | Always send full History | `api.ignore-history-limit` | on | Ignore client history limit |

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -275,7 +275,7 @@ export function SabnzbdSettings({ config, setNewConfig }: SabnzbdSettingsProps) 
                 description="Decide which import problems fail a download and trigger an alternate grab."
             >
                 <ManagedSetting configKey="api.ensure-importable-video">
-                    <Tooltip content="Mark downloads as failed when no video or audio file is found, so Radarr or Sonarr can grab another NZB.">
+                    <Tooltip content="Mark downloads as failed when no video or audio file is found, so your *Arr app can grab another NZB.">
                         <Toggle
                             id="ensure-importable-video-checkbox"
                             className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -275,7 +275,7 @@ export function SabnzbdSettings({ config, setNewConfig }: SabnzbdSettingsProps) 
                 description="Decide which import problems fail a download and trigger an alternate grab."
             >
                 <ManagedSetting configKey="api.ensure-importable-video">
-                    <Tooltip content="Mark downloads as failed when no video file is found, so Radarr or Sonarr can grab another NZB.">
+                    <Tooltip content="Mark downloads as failed when no video or audio file is found, so Radarr or Sonarr can grab another NZB.">
                         <Toggle
                             id="ensure-importable-video-checkbox"
                             className="cursor-pointer gap-2 p-0"
@@ -284,13 +284,13 @@ export function SabnzbdSettings({ config, setNewConfig }: SabnzbdSettingsProps) 
                                 ...config,
                                 "api.ensure-importable-video": String(e.target.checked),
                             })}
-                            label={<span className="text-sm text-base-content">Fail downloads for NZBs without video content</span>}
+                            label={<span className="text-sm text-base-content">Fail downloads for NZBs without video or audio content</span>}
                         />
                     </Tooltip>
                 </ManagedSetting>
 
                 <ManagedSetting configKey="api.skip-non-video-on-missing-articles">
-                    <Tooltip content="By default, missing articles in PAR2, NFO, or subtitle files are skipped. Enable this to fail the download so an alternate can be grabbed.">
+                    <Tooltip content="By default, missing articles in PAR2, NFO, or subtitle files are skipped. Audio and video files always fail. Enable this to also fail the download for other missing files.">
                         <Toggle
                             id="fail-missing-non-video-checkbox"
                             className="cursor-pointer gap-2 p-0"
@@ -299,7 +299,7 @@ export function SabnzbdSettings({ config, setNewConfig }: SabnzbdSettingsProps) 
                                 ...config,
                                 "api.skip-non-video-on-missing-articles": String(!e.target.checked),
                             })}
-                            label={<span className="text-sm text-base-content">Fail downloads when non-video files have missing articles</span>}
+                            label={<span className="text-sm text-base-content">Fail downloads when non-media files have missing articles</span>}
                         />
                     </Tooltip>
                 </ManagedSetting>

--- a/tests/NzbWebDAV.Tests/Queue/EnsureImportableMediaValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/EnsureImportableMediaValidatorTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Queue.PostProcessors;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class EnsureImportableMediaValidatorTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly DavDatabaseContext _context;
+    private readonly DavDatabaseClient _dbClient;
+
+    public EnsureImportableMediaValidatorTests()
+    {
+        _dbPath = Path.Join(Path.GetTempPath(), $"media-validator-test-{Guid.NewGuid():N}.sqlite");
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        _context = new DavDatabaseContext(options);
+        _context.Database.EnsureCreated();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        try { File.Delete(_dbPath); } catch (IOException) { /* ignore */ }
+    }
+
+    [Fact]
+    public void ThrowIfValidationFails_WithVideoFile_DoesNotThrow()
+    {
+        SeedFile("Show.S01E01.mkv");
+
+        var validator = new EnsureImportableMediaValidator(_dbClient);
+        var exception = Record.Exception(validator.ThrowIfValidationFails);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ThrowIfValidationFails_WithAudioFile_DoesNotThrow()
+    {
+        SeedFile("Artist.Track.flac");
+
+        var validator = new EnsureImportableMediaValidator(_dbClient);
+        var exception = Record.Exception(validator.ThrowIfValidationFails);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ThrowIfValidationFails_WithAudioFileMp3_DoesNotThrow()
+    {
+        SeedFile("Artist.Track.mp3");
+
+        var validator = new EnsureImportableMediaValidator(_dbClient);
+        var exception = Record.Exception(validator.ThrowIfValidationFails);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ThrowIfValidationFails_WithMixedVideoAndAudio_DoesNotThrow()
+    {
+        SeedFile("Show.S01E01.mkv");
+        SeedFile("Artist.Track.flac");
+
+        var validator = new EnsureImportableMediaValidator(_dbClient);
+        var exception = Record.Exception(validator.ThrowIfValidationFails);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ThrowIfValidationFails_WithoutMedia_ThrowsNoMediaFilesFoundException()
+    {
+        SeedFile("release.nfo");
+        SeedFile("checksums.par2");
+
+        var validator = new EnsureImportableMediaValidator(_dbClient);
+        var exception = Record.Exception(validator.ThrowIfValidationFails);
+
+        Assert.IsType<NoMediaFilesFoundException>(exception);
+        Assert.Equal("No importable media files found.", exception?.Message);
+    }
+
+    private void SeedFile(string name)
+    {
+        var parent = DavItem.New(
+            Guid.NewGuid(), DavItem.ContentFolder, "TestRelease", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        _context.Items.Add(parent);
+
+        var blob = new DavNzbFile
+        {
+            Id = Guid.NewGuid(),
+            SegmentIds = ["<seg@example.com>"],
+        };
+        var item = DavItem.New(
+            Guid.NewGuid(), parent, name, 100,
+            DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+            null, null, null, blob.Id);
+        _context.Items.Add(item);
+        _context.AddBlob(blob);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/FileProcessorMissingArticlesTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FileProcessorMissingArticlesTests.cs
@@ -12,10 +12,10 @@ namespace NzbWebDAV.Tests.Queue;
 public class FileProcessorMissingArticlesTests
 {
     [Fact]
-    public void IsSkipNonVideoOnMissingArticlesEnabled_DefaultsTrue()
+    public void IsSkipNonMediaOnMissingArticlesEnabled_DefaultsTrue()
     {
         var config = new ConfigManager();
-        Assert.True(config.IsSkipNonVideoOnMissingArticlesEnabled());
+        Assert.True(config.IsSkipNonMediaOnMissingArticlesEnabled());
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Utils/FileFilterUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/FileFilterUtilTests.cs
@@ -71,6 +71,13 @@ public class FileFilterUtilTests
     }
 
     [Fact]
+    public void IsSampleFile_AudioFile_IsNotFiltered()
+    {
+        Assert.False(FileFilterUtil.IsSampleFile("sample.flac", SampleSize, FeatureSize));
+        Assert.False(FileFilterUtil.IsSampleFile("sample.mp3", SampleSize, FeatureSize));
+    }
+
+    [Fact]
     public void IsSampleFile_WithoutAKnownSize_IsNotFiltered()
     {
         Assert.False(FileFilterUtil.IsSampleFile("sample.mkv", null, FeatureSize));

--- a/tests/NzbWebDAV.Tests/Utils/FilenameUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/FilenameUtilTests.cs
@@ -1,0 +1,95 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class FilenameUtilTests
+{
+    [Theory]
+    [InlineData("song.flac")]
+    [InlineData("song.mp3")]
+    [InlineData("song.m4a")]
+    [InlineData("song.ogg")]
+    [InlineData("song.opus")]
+    [InlineData("song.ape")]
+    [InlineData("song.wv")]
+    [InlineData("song.wav")]
+    [InlineData("song.aac")]
+    [InlineData("song.alac")]
+    [InlineData("song.dsf")]
+    [InlineData("song.dff")]
+    [InlineData("song.wma")]
+    [InlineData("song.aiff")]
+    [InlineData("song.aif")]
+    [InlineData("song.m4b")]
+    [InlineData("song.mka")]
+    [InlineData("Song.FLAC")]
+    [InlineData("Song.Mp3")]
+    public void IsAudioFile_WithAudioExtension_ReturnsTrue(string filename)
+    {
+        Assert.True(FilenameUtil.IsAudioFile(filename));
+    }
+
+    [Theory]
+    [InlineData("video.mkv")]
+    [InlineData("video.mp4")]
+    [InlineData("video.avi")]
+    [InlineData("file.nfo")]
+    [InlineData("file.par2")]
+    [InlineData("file.srt")]
+    [InlineData("file.jpg")]
+    [InlineData("file.rar")]
+    [InlineData("file.txt")]
+    [InlineData("file")]
+    public void IsAudioFile_WithoutAudioExtension_ReturnsFalse(string filename)
+    {
+        Assert.False(FilenameUtil.IsAudioFile(filename));
+    }
+
+    [Theory]
+    [InlineData("video.mkv")]
+    [InlineData("video.mp4")]
+    [InlineData("song.flac")]
+    [InlineData("song.mp3")]
+    [InlineData("song.ogg")]
+    public void IsMediaFile_WithVideoOrAudio_ReturnsTrue(string filename)
+    {
+        Assert.True(FilenameUtil.IsMediaFile(filename));
+    }
+
+    [Theory]
+    [InlineData("file.nfo")]
+    [InlineData("file.par2")]
+    [InlineData("file.srt")]
+    [InlineData("file.jpg")]
+    [InlineData("file.rar")]
+    [InlineData("file.txt")]
+    [InlineData("file")]
+    public void IsMediaFile_WithoutMediaExtension_ReturnsFalse(string filename)
+    {
+        Assert.False(FilenameUtil.IsMediaFile(filename));
+    }
+
+    [Theory]
+    [InlineData("video.mkv")]
+    [InlineData("song.flac")]
+    [InlineData("song.mp3")]
+    [InlineData("archive.rar")]
+    [InlineData("archive.7z")]
+    [InlineData("video.mkv.001")]
+    public void IsImportantFileType_WithMediaOrArchive_ReturnsTrue(string filename)
+    {
+        Assert.True(FilenameUtil.IsImportantFileType(filename));
+    }
+
+    [Theory]
+    [InlineData("file.nfo")]
+    [InlineData("file.par2")]
+    [InlineData("file.srt")]
+    [InlineData("file.jpg")]
+    [InlineData("file.txt")]
+    [InlineData("file")]
+    public void IsImportantFileType_WithoutImportantType_ReturnsFalse(string filename)
+    {
+        Assert.False(FilenameUtil.IsImportantFileType(filename));
+    }
+}


### PR DESCRIPTION
## Summary

Implements #756 — audio files are now classified alongside video as importable media, so audio-only NZBs (music releases) pass import validation instead of failing with "No importable videos found." This is a prerequisite for full Lidarr support (#110) and enables music libraries to use the same stream-first workflow as video libraries.

- `FilenameUtil.IsAudioFile` / `IsMediaFile` recognize 17 common audio extensions (`.flac`, `.mp3`, `.m4a`, `.ogg`, `.opus`, `.ape`, `.wv`, `.wav`, `.aac`, `.alac`, `.dsf`, `.dff`, `.wma`, `.aiff`, `.aif`, `.m4b`, `.mka`)
- `IsImportantFileType` now includes audio, so health-check missing-segment tracking, streaming fail-fast, and article-existence pre-checks cover audio the same as video
- `EnsureImportableVideoValidator` renamed to `EnsureImportableMediaValidator`; audio-only NZBs now pass the "must contain media" check
- Audio tracks with missing articles now fail the job (same protection as video) instead of being silently dropped by the skip-non-video path
- Audio MIME mappings added for WebDAV serving (`.opus`, `.ape`, `.wv`, `.dsf`, `.dff`, `.m4b`, `.mka`, `.aiff`)
- Config keys unchanged (`api.ensure-importable-video`, `api.skip-non-video-on-missing-articles`) — no migration needed; labels, tooltips, and docs updated to say "video or audio" / "non-media"
- Sample filter intentionally stays video-only; STRM sidecars and audio signature sniffing are deferred to Lidarr work (#110)

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests` — 2,835 passed, 0 failed (includes 43 new tests: `FilenameUtilTests`, `EnsureImportableMediaValidatorTests`, audio cases in `FileFilterUtilTests`)
- [x] Backend builds clean with 0 warnings
- [ ] Manual: submit an audio-only NZB (e.g. FLAC album) in the `audio` category and confirm it mounts and streams via WebDAV