### PR TITLE
feat(health): show deleted and repaired NZBs in the health UI

### DIFF
--- a/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryController.cs
+++ b/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryController.cs
@@ -13,16 +13,29 @@ public class GetHealthCheckHistoryController(DavDatabaseClient dbClient) : BaseA
         var now = DateTime.UtcNow;
         var tomorrow = now.AddDays(1);
         var thirtyDaysAgo = now.AddDays(-30);
-        var statsPromise = dbClient.GetHealthCheckStatsAsync(thirtyDaysAgo, tomorrow);
-        var itemsPromise = dbClient.Ctx.HealthCheckResults
+        var stats = await dbClient.GetHealthCheckStatsAsync(
+            thirtyDaysAgo,
+            tomorrow,
+            request.CancellationToken).ConfigureAwait(false);
+        var itemsQuery = dbClient.Ctx.HealthCheckResults
+            .AsNoTracking();
+        if (request.RepairStatuses is not null)
+            itemsQuery = itemsQuery.Where(x => request.RepairStatuses.Contains(x.RepairStatus));
+
+        var totalCount = await itemsQuery.CountAsync(request.CancellationToken).ConfigureAwait(false);
+        var items = await itemsQuery
             .OrderByDescending(x => x.CreatedAt)
+            .ThenByDescending(x => x.Id)
+            .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
-            .ToListAsync();
+            .ToListAsync(request.CancellationToken)
+            .ConfigureAwait(false);
 
         return new GetHealthCheckHistoryResponse()
         {
-            Stats = await statsPromise.ConfigureAwait(false),
-            Items = await itemsPromise.ConfigureAwait(false)
+            Stats = stats,
+            Items = items,
+            TotalCount = totalCount,
         };
     }
 

--- a/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryRequest.cs
+++ b/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryRequest.cs
@@ -47,7 +47,9 @@ public class GetHealthCheckHistoryRequest
                         "Invalid repairStatus parameter (use none, repaired, deleted, or action-needed)")
                 });
             }
-            RepairStatuses = repairStatuses;
+            // An empty or comma-only repairStatus value (e.g. "?repairStatus=") means "no filter"
+            // rather than filtering out every row.
+            RepairStatuses = repairStatuses.Count > 0 ? repairStatuses : null;
         }
     }
 }

--- a/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryRequest.cs
+++ b/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryRequest.cs
@@ -1,23 +1,53 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.Controllers.GetHealthCheckHistory;
 
 public class GetHealthCheckHistoryRequest
 {
+    public int Page { get; init; } = 1;
     public int PageSize { get; init; } = 20;
+    public IReadOnlySet<HealthCheckResult.RepairAction>? RepairStatuses { get; init; }
     public CancellationToken CancellationToken { get; init; }
 
     public GetHealthCheckHistoryRequest(HttpContext context)
     {
+        var pageParam = context.GetQueryParam("page");
         var pageSizeParam = context.GetQueryParam("pageSize");
+        var repairStatusParam = context.GetQueryParam("repairStatus");
         CancellationToken = context.RequestAborted;
+
+        if (pageParam is not null)
+        {
+            if (!int.TryParse(pageParam, out var page) || page < 1)
+                throw new BadHttpRequestException("Invalid page parameter");
+            Page = page;
+        }
 
         if (pageSizeParam is not null)
         {
-            var isValidStartParam = int.TryParse(pageSizeParam, out int pageSize);
-            if (!isValidStartParam) throw new BadHttpRequestException("Invalid pageSize parameter");
+            if (!int.TryParse(pageSizeParam, out var pageSize) || pageSize is < 1 or > 250)
+                throw new BadHttpRequestException("Invalid pageSize parameter");
             PageSize = pageSize;
+        }
+
+        if (repairStatusParam is not null)
+        {
+            var repairStatuses = new HashSet<HealthCheckResult.RepairAction>();
+            foreach (var status in repairStatusParam.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                repairStatuses.Add(status.ToLowerInvariant() switch
+                {
+                    "none" => HealthCheckResult.RepairAction.None,
+                    "repaired" => HealthCheckResult.RepairAction.Repaired,
+                    "deleted" => HealthCheckResult.RepairAction.Deleted,
+                    "action-needed" => HealthCheckResult.RepairAction.ActionNeeded,
+                    _ => throw new BadHttpRequestException(
+                        "Invalid repairStatus parameter (use none, repaired, deleted, or action-needed)")
+                });
+            }
+            RepairStatuses = repairStatuses;
         }
     }
 }

--- a/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryResponse.cs
+++ b/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryResponse.cs
@@ -6,4 +6,5 @@ public class GetHealthCheckHistoryResponse : BaseApiResponse
 {
     public required List<HealthCheckStat> Stats { get; init; }
     public required List<HealthCheckResult> Items { get; init; }
+    public required int TotalCount { get; init; }
 }

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -479,6 +479,12 @@ public sealed class DavDatabaseContext : DbContext
             e.Property(i => i.Path)
                 .IsRequired();
 
+            e.Property(i => i.NzbFileName)
+                .IsRequired(false);
+
+            e.Property(i => i.JobName)
+                .IsRequired(false);
+
             e.Property(i => i.Result)
                 .HasConversion<int>()
                 .IsRequired();
@@ -498,6 +504,10 @@ public sealed class DavDatabaseContext : DbContext
 
             e.HasIndex(h => h.DavItemId)
                 .HasFilter("\"RepairStatus\" = 3")
+                .IsUnique(false);
+
+            e.HasIndex(i => new { i.RepairStatus, i.CreatedAt })
+                .HasFilter("\"RepairStatus\" IN (1, 2)")
                 .IsUnique(false);
         });
 

--- a/backend/Database/Migrations/20260817185420_Add-NzbIdentity-To-HealthCheckResults.Designer.cs
+++ b/backend/Database/Migrations/20260817185420_Add-NzbIdentity-To-HealthCheckResults.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NzbWebDAV.Database;
 
@@ -10,9 +11,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.Migrations
 {
     [DbContext(typeof(DavDatabaseContext))]
-    partial class DavDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260817185420_Add-NzbIdentity-To-HealthCheckResults")]
+    partial class AddNzbIdentityToHealthCheckResults
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/backend/Database/Migrations/20260817185420_Add-NzbIdentity-To-HealthCheckResults.cs
+++ b/backend/Database/Migrations/20260817185420_Add-NzbIdentity-To-HealthCheckResults.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNzbIdentityToHealthCheckResults : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "JobName",
+                table: "HealthCheckResults",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NzbFileName",
+                table: "HealthCheckResults",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthCheckResults_RepairStatus_CreatedAt",
+                table: "HealthCheckResults",
+                columns: new[] { "RepairStatus", "CreatedAt" },
+                filter: "\"RepairStatus\" IN (1, 2)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_HealthCheckResults_RepairStatus_CreatedAt",
+                table: "HealthCheckResults");
+
+            migrationBuilder.DropColumn(
+                name: "JobName",
+                table: "HealthCheckResults");
+
+            migrationBuilder.DropColumn(
+                name: "NzbFileName",
+                table: "HealthCheckResults");
+        }
+    }
+}

--- a/backend/Database/Models/HealthCheckResult.cs
+++ b/backend/Database/Models/HealthCheckResult.cs
@@ -6,6 +6,8 @@ public class HealthCheckResult
     public DateTimeOffset CreatedAt { get; init; }
     public Guid DavItemId { get; init; }
     public string Path { get; init; } = null!;
+    public string? NzbFileName { get; init; }
+    public string? JobName { get; init; }
     public HealthResult Result { get; init; }
     public RepairAction RepairStatus { get; set; }
     public string? Message { get; set; }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1170,11 +1170,16 @@ public class HealthCheckService : BackgroundService
         CancellationToken ct
     )
     {
+        var identity = repairStatus is HealthCheckResult.RepairAction.Deleted or HealthCheckResult.RepairAction.Repaired
+            ? await GetRepairHistoryIdentityAsync(dbClient.Ctx, davItem, ct).ConfigureAwait(false)
+            : null;
         dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()
         {
             Id = Guid.NewGuid(),
             DavItemId = davItem.Id,
             Path = davItem.Path,
+            NzbFileName = identity?.NzbFileName,
+            JobName = identity?.JobName,
             CreatedAt = DateTimeOffset.UtcNow,
             Result = result,
             RepairStatus = repairStatus,
@@ -1194,6 +1199,28 @@ public class HealthCheckService : BackgroundService
                 entry.State = EntityState.Detached;
         }
     }
+
+    internal static async Task<RepairHistoryIdentity?> GetRepairHistoryIdentityAsync
+    (
+        DavDatabaseContext context,
+        DavItem davItem,
+        CancellationToken ct
+    )
+    {
+        if (davItem.NzbBlobId is not Guid nzbBlobId) return null;
+
+        var nzbFileName = await context.NzbNames
+            .AsNoTracking()
+            .Where(x => x.Id == nzbBlobId)
+            .Select(x => x.FileName)
+            .SingleOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        if (nzbFileName is null) return null;
+
+        return new RepairHistoryIdentity(nzbFileName, FilenameUtil.GetJobName(nzbFileName));
+    }
+
+    internal sealed record RepairHistoryIdentity(string NzbFileName, string JobName);
 
     private HealthCheckResult SendStatus(HealthCheckResult result)
     {

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -21,6 +21,16 @@ when InfiniDysk restarts.
 
 Health result rows prune by age (**Maintenance** retention or `DATABASE_HEALTHCHECK_RETENTION_DAYS`). Reset counters from Maintenance when needed.
 
+## Repair history [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+The **Health** page lists items that Background Repairs automatically deleted or repaired, with the
+time and reason for the action. New rows retain the original NZB filename and release name so you
+can locate a replacement; rows created before this feature show the affected WebDAV path instead.
+
+The list follows Health-check retention and is cleared with the Health-check statistics reset in
+**Settings → Maintenance**. It records automatic health actions only — deleting items manually or
+through the API does not add a repair-history row.
+
 ## Manual checks
 
 Use the Health UI / repairs flows in the app to inspect failures. Known transport issues should appear as clear warnings in logs rather than opaque crashes — see [Logs](logs-crash-dumps.md).

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -124,7 +124,7 @@ describe("BackendClient", () => {
     expect((init?.body as FormData).get("nzbFile")).toBeInstanceOf(File);
   });
 
-  it("gets health queue and history with optional page sizes", async () => {
+  it("gets health queue and filtered paginated history", async () => {
     const queue = { uncheckedCount: 0, items: [] };
     const history = { stats: [], items: [] };
     fetchMock
@@ -132,10 +132,14 @@ describe("BackendClient", () => {
       .mockResolvedValueOnce(jsonResponse(history));
 
     await expect(backendClient.getHealthCheckQueue(30)).resolves.toEqual(queue);
-    await expect(backendClient.getHealthCheckHistory()).resolves.toEqual(history);
+    await expect(backendClient.getHealthCheckHistory({
+      page: 2,
+      pageSize: 25,
+      repairStatus: "deleted,repaired",
+    })).resolves.toEqual(history);
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       "http://backend/api/get-health-check-queue?pageSize=30",
-      "http://backend/api/get-health-check-history",
+      "http://backend/api/get-health-check-history?page=2&pageSize=25&repairStatus=deleted%2Crepaired",
     ]);
   });
 

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -126,7 +126,7 @@ describe("BackendClient", () => {
 
   it("gets health queue and filtered paginated history", async () => {
     const queue = { uncheckedCount: 0, items: [] };
-    const history = { stats: [], items: [] };
+    const history = { stats: [], items: [], totalCount: 0 };
     fetchMock
       .mockResolvedValueOnce(jsonResponse(queue))
       .mockResolvedValueOnce(jsonResponse(history));

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -270,9 +270,13 @@ class BackendClient {
         return data.deletedRows ?? 0;
     }
 
-    public async getHealthCheckHistory(pageSize?: number): Promise<HealthCheckHistoryResponse> {
-        const query = pageSize !== undefined ? `?pageSize=${pageSize}` : "";
-        return await call<HealthCheckHistoryResponse>(`/api/get-health-check-history${query}`, "Failed to get health check history", {
+    public async getHealthCheckHistory(params: GetHealthCheckHistoryParams = {}): Promise<HealthCheckHistoryResponse> {
+        const qs = new URLSearchParams();
+        if (params.page !== undefined) qs.set("page", String(params.page));
+        if (params.pageSize !== undefined) qs.set("pageSize", String(params.pageSize));
+        if (params.repairStatus) qs.set("repairStatus", params.repairStatus);
+        const query = qs.toString();
+        return await call<HealthCheckHistoryResponse>(`/api/get-health-check-history${query ? `?${query}` : ""}`, "Failed to get health check history", {
             method: "GET",
         });
     }
@@ -585,7 +589,14 @@ export type HealthCheckQueueItem = {
 
 export type HealthCheckHistoryResponse = {
     stats: HealthCheckStats[],
-    items: HealthCheckResult[]
+    items: HealthCheckResult[],
+    totalCount: number,
+}
+
+export type GetHealthCheckHistoryParams = {
+    page?: number,
+    pageSize?: number,
+    repairStatus?: string,
 }
 
 export type HealthCheckStats = {
@@ -599,6 +610,8 @@ export type HealthCheckResult = {
     createdAt: string,
     davItemId: string,
     path: string,
+    nzbFileName: string | null,
+    jobName: string | null,
     result: HealthResult,
     repairStatus: RepairAction,
     message: string | null

--- a/frontend/app/routes/health/components/health-history-table/health-history-table.test.tsx
+++ b/frontend/app/routes/health/components/health-history-table/health-history-table.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { HealthCheckResult } from "~/clients/backend-client.server";
+import { HealthHistoryTable } from "./health-history-table";
+
+function render(items: HealthCheckResult[] = []) {
+    return renderToStaticMarkup(
+        <HealthHistoryTable
+            items={items}
+            totalCount={items.length}
+            page={1}
+            pageSize={25}
+            pageSizeOptions={[25, 50]}
+            filter="all"
+            refreshing={false}
+            onFilterSelected={vi.fn()}
+            onPageSelected={vi.fn()}
+            onPageSizeSelected={vi.fn()}
+            onRefresh={vi.fn()}
+        />,
+    );
+}
+
+describe("HealthHistoryTable", () => {
+    it("shows the snapped NZB identity and deleted disposition", () => {
+        const markup = render([{
+            id: "1",
+            createdAt: "2026-08-17T12:00:00Z",
+            davItemId: "dav-1",
+            path: "/content/movies/Example/Example.mkv",
+            nzbFileName: "Example.Release.nzb",
+            jobName: "Example.Release",
+            result: 1,
+            repairStatus: 2,
+            message: "Deleted file.",
+        }]);
+
+        expect(markup).toContain("Example.Release.nzb");
+        expect(markup).toContain("Example.Release");
+        expect(markup).toContain("Deleted");
+        expect(markup).toContain("Deleted file.");
+    });
+
+    it("falls back to the WebDAV path for legacy rows", () => {
+        const markup = render([{
+            id: "1",
+            createdAt: "2026-08-17T12:00:00Z",
+            davItemId: "dav-1",
+            path: "/content/tv/Example/episode.mkv",
+            nzbFileName: null,
+            jobName: null,
+            result: 1,
+            repairStatus: 1,
+            message: null,
+        }]);
+
+        expect(markup).toContain("episode.mkv");
+        expect(markup).toContain("/content/tv/Example/episode.mkv");
+        expect(markup).toContain("Repaired");
+    });
+
+    it("explains empty repair history", () => {
+        const markup = render();
+
+        expect(markup).toContain("No deleted or repaired items");
+        expect(markup).toContain("health-check retention");
+    });
+});

--- a/frontend/app/routes/health/components/health-history-table/health-history-table.tsx
+++ b/frontend/app/routes/health/components/health-history-table/health-history-table.tsx
@@ -1,0 +1,234 @@
+import type { HealthCheckResult } from "~/clients/backend-client.server";
+import { Badge, Icon } from "~/components/ui";
+import { Pagination } from "~/routes/queue/components/pagination/pagination";
+import { Truncate } from "~/routes/queue/components/truncate/truncate";
+
+export type HealthHistoryFilter = "all" | "deleted" | "repaired";
+
+export type HealthHistoryTableProps = {
+    items: HealthCheckResult[],
+    totalCount: number,
+    page: number,
+    pageSize: number,
+    pageSizeOptions: readonly number[],
+    filter: HealthHistoryFilter,
+    refreshing: boolean,
+    onFilterSelected: (filter: HealthHistoryFilter) => void,
+    onPageSelected: (page: number) => void,
+    onPageSizeSelected: (pageSize: number) => void,
+    onRefresh: () => void,
+}
+
+const desktopHeaderClass =
+    "hidden min-[900px]:table-cell px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide";
+const desktopCellClass =
+    "hidden min-[900px]:table-cell max-w-[240px] px-3 py-3 align-top text-xs text-base-content/70";
+const RepairActionDeleted: HealthCheckResult["repairStatus"] = 2;
+
+export function HealthHistoryTable({
+    items,
+    totalCount,
+    page,
+    pageSize,
+    pageSizeOptions,
+    filter,
+    refreshing,
+    onFilterSelected,
+    onPageSelected,
+    onPageSizeSelected,
+    onRefresh,
+}: HealthHistoryTableProps) {
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+    return (
+        <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
+            <div className="card-body gap-0 p-0">
+                <div className="flex flex-wrap items-center justify-between gap-3 border-b border-base-content/10 px-4 py-4 md:px-6">
+                    <div>
+                        <h2 className="card-title text-xl">Repair history</h2>
+                        <p className="mt-1 text-xs text-base-content/60">
+                            Deleted and repaired items are retained according to your health-check retention setting.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        className="btn btn-primary btn-sm gap-2"
+                        onClick={onRefresh}
+                        disabled={refreshing}
+                    >
+                        <Icon name="refresh" className={`!text-[16px] ${refreshing ? "animate-spin" : ""}`} />
+                        Refresh
+                    </button>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-b border-base-content/10 px-4 py-3 md:px-6">
+                    <div className="join flex-wrap">
+                        <FilterButton active={filter === "all"} onClick={() => onFilterSelected("all")}>
+                            Deleted &amp; repaired
+                        </FilterButton>
+                        <FilterButton active={filter === "deleted"} onClick={() => onFilterSelected("deleted")}>
+                            Deleted
+                        </FilterButton>
+                        <FilterButton active={filter === "repaired"} onClick={() => onFilterSelected("repaired")}>
+                            Repaired
+                        </FilterButton>
+                    </div>
+                    {totalCount > 0 && (
+                        <Badge className="badge-ghost badge-sm font-mono tabular-nums">
+                            {totalCount}
+                        </Badge>
+                    )}
+                </div>
+
+                {items.length === 0 ? (
+                    <EmptyState filter={filter} />
+                ) : (
+                    <>
+                        <div className="overflow-x-auto">
+                            <table className="table table-zebra table-sm mb-0 w-full min-w-0 text-base-content min-[900px]:min-w-[900px]">
+                                <thead>
+                                    <tr className="border-base-content/10 [&_th]:bg-base-200 [&_th]:text-base-content/70">
+                                        <th className="py-3 pl-4 text-left text-xs font-semibold uppercase tracking-wide md:pl-6">
+                                            NZB
+                                        </th>
+                                        <th className={desktopHeaderClass}>Status</th>
+                                        <th className={desktopHeaderClass}>Reason</th>
+                                        <th className={`${desktopHeaderClass} pr-4 md:pr-6`}>When</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {items.map(item => <HistoryRow key={item.id} item={item} />)}
+                                </tbody>
+                            </table>
+                        </div>
+                        <div className="border-t border-base-content/10 px-4 py-3 md:px-6">
+                            <Pagination
+                                pageNumber={page}
+                                totalPages={totalPages}
+                                totalCount={totalCount}
+                                pageSize={pageSize}
+                                pageSizeOptions={pageSizeOptions}
+                                onPageSelected={onPageSelected}
+                                onPageSizeSelected={onPageSizeSelected}
+                            />
+                        </div>
+                    </>
+                )}
+            </div>
+        </section>
+    );
+}
+
+function FilterButton({
+    active,
+    onClick,
+    children,
+}: {
+    active: boolean;
+    onClick: () => void;
+    children: React.ReactNode;
+}) {
+    return (
+        <button
+            type="button"
+            className={`btn btn-sm join-item ${active ? "btn-primary" : "btn-ghost"}`}
+            onClick={onClick}
+        >
+            {children}
+        </button>
+    );
+}
+
+function HistoryRow({ item }: { item: HealthCheckResult }) {
+    const title = item.nzbFileName ?? basename(item.path);
+    const timestamp = formatTimestamp(item.createdAt);
+
+    return (
+        <tr className="border-base-content/10">
+            <td className="max-w-[320px] py-3 pl-4 align-top md:pl-6 max-[899px]:max-w-none">
+                <div className="flex min-w-0 flex-col gap-1">
+                    <div className="break-all text-sm font-medium leading-snug text-base-content">
+                        <Truncate>{title}</Truncate>
+                    </div>
+                    {item.jobName && item.jobName !== title && (
+                        <div className="break-all text-xs text-base-content/60">
+                            <Truncate>{item.jobName}</Truncate>
+                        </div>
+                    )}
+                    <div className="break-all text-xs leading-snug text-base-content/45">
+                        <Truncate>{item.path}</Truncate>
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 min-[900px]:hidden">
+                        <StatusBadge item={item} />
+                        <MetaChip label="When" value={timestamp.relative} title={timestamp.absolute} />
+                        {item.message && <MetaChip label="Reason" value={item.message} title={item.message} />}
+                    </div>
+                </div>
+            </td>
+            <td className={desktopCellClass}>
+                <StatusBadge item={item} />
+            </td>
+            <td className={desktopCellClass}>
+                <div className="line-clamp-3 leading-snug" title={item.message ?? undefined}>
+                    {item.message ?? "—"}
+                </div>
+            </td>
+            <td className={`${desktopCellClass} pr-4 font-mono tabular-nums md:pr-6`} title={timestamp.absolute}>
+                <time dateTime={item.createdAt}>{timestamp.relative}</time>
+            </td>
+        </tr>
+    );
+}
+
+function StatusBadge({ item }: { item: HealthCheckResult }) {
+    const deleted = item.repairStatus === RepairActionDeleted;
+    return (
+        <Badge className={`badge-sm ${deleted ? "badge-error" : "badge-info"}`}>
+            {deleted ? "Deleted" : "Repaired"}
+        </Badge>
+    );
+}
+
+function MetaChip({ label, value, title }: { label: string; value: string; title?: string }) {
+    return (
+        <span className="inline-flex max-w-full items-center gap-1.5 text-[11px] text-base-content/55">
+            <span className="shrink-0 uppercase tracking-wide text-base-content/40">{label}</span>
+            <span className="truncate font-mono tabular-nums text-base-content/70" title={title}>{value}</span>
+        </span>
+    );
+}
+
+function EmptyState({ filter }: { filter: HealthHistoryFilter }) {
+    const label = filter === "all" ? "deleted or repaired" : filter;
+    return (
+        <div className="hero min-h-[220px] py-8">
+            <div className="hero-content">
+                <div className="flex max-w-md flex-col items-center text-center">
+                    <Icon name="history" className="mb-3 !text-[48px] text-base-content/40" />
+                    <h3 className="text-base font-semibold text-base-content">No {label} items</h3>
+                    <p className="mt-1 text-xs leading-relaxed text-base-content/60">
+                        New automatic health repairs and deletions will appear here until health-check retention removes them.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function basename(path: string) {
+    const segments = path.split('/').filter(Boolean);
+    return segments.at(-1) ?? path;
+}
+
+function formatTimestamp(value: string) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return { relative: "Unknown", absolute: "Unknown" };
+
+    const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+    const relative = seconds < 5 ? "just now"
+        : seconds < 60 ? `${seconds}s ago`
+            : seconds < 3600 ? `${Math.floor(seconds / 60)}m ago`
+                : seconds < 86400 ? `${Math.floor(seconds / 3600)}h ago`
+                    : `${Math.floor(seconds / 86400)}d ago`;
+    return { relative, absolute: date.toLocaleString() };
+}

--- a/frontend/app/routes/health/components/health-history-table/health-history-table.tsx
+++ b/frontend/app/routes/health/components/health-history-table/health-history-table.tsx
@@ -23,6 +23,8 @@ const desktopHeaderClass =
     "hidden min-[900px]:table-cell px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide";
 const desktopCellClass =
     "hidden min-[900px]:table-cell max-w-[240px] px-3 py-3 align-top text-xs text-base-content/70";
+// Numeric value mirrors the backend RepairAction enum declared in
+// ~/clients/backend-client.server (a .server module, so its enums cannot be value-imported here).
 const RepairActionDeleted: HealthCheckResult["repairStatus"] = 2;
 
 export function HealthHistoryTable({

--- a/frontend/app/routes/health/route.test.ts
+++ b/frontend/app/routes/health/route.test.ts
@@ -40,6 +40,12 @@ vi.mock("./health-queue-state", () => ({
   completeHealthCheck: vi.fn(),
 }));
 
+function loaderArgs(path = "/health") {
+  return {
+    request: new Request(`http://localhost${path}`),
+  } as Parameters<typeof loader>[0];
+}
+
 describe("health route loader", () => {
   beforeEach(() => {
     getConfigMock.mockReset();
@@ -58,20 +64,29 @@ describe("health route loader", () => {
     getHealthCheckHistoryMock.mockResolvedValueOnce({
       stats: historyStats,
       items: historyItems,
+      totalCount: 1,
     });
     getConfigMock.mockResolvedValueOnce([
       { configName: "repair.enable", configValue: "TRUE" },
     ]);
 
-    await expect(loader()).resolves.toEqual({
+    await expect(loader(loaderArgs())).resolves.toEqual({
       uncheckedCount: 12,
       queueItems,
       historyStats,
       historyItems,
+      historyTotalCount: 1,
+      historyPage: 1,
+      historyPageSize: 25,
+      historyFilter: "all",
       isEnabled: true,
     });
     expect(getHealthCheckQueueMock).toHaveBeenCalledWith(30);
-    expect(getHealthCheckHistoryMock).toHaveBeenCalledOnce();
+    expect(getHealthCheckHistoryMock).toHaveBeenCalledWith({
+      page: 1,
+      pageSize: 25,
+      repairStatus: "deleted,repaired",
+    });
     expect(getConfigMock).toHaveBeenCalledWith(["repair.enable"]);
   });
 
@@ -83,6 +98,7 @@ describe("health route loader", () => {
     getHealthCheckHistoryMock.mockResolvedValue({
       stats: [],
       items: [],
+      totalCount: 0,
     });
     getConfigMock
       .mockResolvedValueOnce([])
@@ -90,15 +106,32 @@ describe("health route loader", () => {
         { configName: "repair.enable", configValue: "false" },
       ]);
 
-    await expect(loader()).resolves.toMatchObject({ isEnabled: false });
-    await expect(loader()).resolves.toMatchObject({ isEnabled: false });
+    await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: false });
+    await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: false });
+  });
+
+  it("uses URL-backed paging and repair-status filters", async () => {
+    getHealthCheckQueueMock.mockResolvedValue({ uncheckedCount: 0, items: [] });
+    getHealthCheckHistoryMock.mockResolvedValue({ stats: [], items: [], totalCount: 0 });
+    getConfigMock.mockResolvedValue([]);
+
+    await expect(loader(loaderArgs("/health?page=3&pageSize=50&status=deleted"))).resolves.toMatchObject({
+      historyPage: 3,
+      historyPageSize: 50,
+      historyFilter: "deleted",
+    });
+    expect(getHealthCheckHistoryMock).toHaveBeenCalledWith({
+      page: 3,
+      pageSize: 50,
+      repairStatus: "deleted",
+    });
   });
 
   it("surfaces backend failures instead of returning partial health data", async () => {
     getHealthCheckQueueMock.mockRejectedValueOnce(new Error("queue unavailable"));
-    getHealthCheckHistoryMock.mockResolvedValueOnce({ stats: [], items: [] });
+    getHealthCheckHistoryMock.mockResolvedValueOnce({ stats: [], items: [], totalCount: 0 });
     getConfigMock.mockResolvedValueOnce([]);
 
-    await expect(loader()).rejects.toThrow("queue unavailable");
+    await expect(loader(loaderArgs())).rejects.toThrow("queue unavailable");
   });
 });

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -2,7 +2,9 @@ import type { Route } from "./+types/route";
 import { backendClient } from "~/clients/backend-client.server";
 import { HealthTable } from "./components/health-table/health-table";
 import { HealthStats } from "./components/health-stats/health-stats";
+import { HealthHistoryTable, type HealthHistoryFilter } from "./components/health-history-table/health-history-table";
 import { useCallback, useEffect, useState } from "react";
+import { useRevalidator, useSearchParams } from "react-router";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
 import { Alert, Icon } from "~/components/ui";
 import type { HealthCheckQueueResponse, HealthResult, RepairAction } from "~/clients/backend-client.server";
@@ -18,11 +20,37 @@ const topicSubscriptions = {
     [topicNames.healthItemProgress]: 'event',
 } as const;
 
-export async function loader() {
+const PAGE_SIZE_OPTIONS = [25, 50, 100, 250] as const;
+const DEFAULT_PAGE_SIZE = 25;
+
+function parsePage(value: string | null): number {
+    const page = parseInt(value ?? "1", 10);
+    return Number.isFinite(page) && page > 0 ? page : 1;
+}
+
+function parsePageSize(value: string | null): number {
+    const size = parseInt(value ?? String(DEFAULT_PAGE_SIZE), 10);
+    return (PAGE_SIZE_OPTIONS as readonly number[]).includes(size) ? size : DEFAULT_PAGE_SIZE;
+}
+
+function parseHistoryFilter(value: string | null): HealthHistoryFilter {
+    return value === "deleted" || value === "repaired" ? value : "all";
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
     const enabledKey = 'repair.enable';
+    const url = new URL(request.url);
+    const historyPage = parsePage(url.searchParams.get("page"));
+    const historyPageSize = parsePageSize(url.searchParams.get("pageSize"));
+    const historyFilter = parseHistoryFilter(url.searchParams.get("status"));
+    const repairStatus = historyFilter === "all" ? "deleted,repaired" : historyFilter;
     const [queueData, historyData, config] = await Promise.all([
         backendClient.getHealthCheckQueue(30),
-        backendClient.getHealthCheckHistory(),
+        backendClient.getHealthCheckHistory({
+            page: historyPage,
+            pageSize: historyPageSize,
+            repairStatus,
+        }),
         backendClient.getConfig([enabledKey])
     ]);
 
@@ -31,6 +59,10 @@ export async function loader() {
         queueItems: queueData.items,
         historyStats: historyData.stats,
         historyItems: historyData.items,
+        historyTotalCount: historyData.totalCount,
+        historyPage,
+        historyPageSize,
+        historyFilter,
         isEnabled: config
             .filter(x => x.configName === enabledKey)
             .filter(x => x.configValue.toLowerCase() === "true")
@@ -41,11 +73,46 @@ export async function loader() {
 export default function Health({ loaderData }: Route.ComponentProps) {
     const { isEnabled } = loaderData;
     const [historyStats, setHistoryStats] = useState(loaderData.historyStats);
+    const [historyItems, setHistoryItems] = useState(loaderData.historyItems);
+    const [historyTotalCount, setHistoryTotalCount] = useState(loaderData.historyTotalCount);
     const [queueState, setQueueState] = useState<HealthQueueState>({
         items: loaderData.queueItems,
         uncheckedCount: loaderData.uncheckedCount,
     });
     const { items: queueItems, uncheckedCount } = queueState;
+    const [, setSearchParams] = useSearchParams();
+    const revalidator = useRevalidator();
+
+    useEffect(() => { setHistoryStats(loaderData.historyStats); }, [loaderData.historyStats]);
+    useEffect(() => { setHistoryItems(loaderData.historyItems); }, [loaderData.historyItems]);
+    useEffect(() => { setHistoryTotalCount(loaderData.historyTotalCount); }, [loaderData.historyTotalCount]);
+    useEffect(() => {
+        setQueueState({
+            items: loaderData.queueItems,
+            uncheckedCount: loaderData.uncheckedCount,
+        });
+    }, [loaderData.queueItems, loaderData.uncheckedCount]);
+
+    const setHistoryParams = useCallback((params: { page?: number; pageSize?: number; status?: HealthHistoryFilter }) => {
+        setSearchParams(previous => {
+            const next = new URLSearchParams(previous);
+            if (params.page !== undefined) next.set("page", String(params.page));
+            if (params.pageSize !== undefined) next.set("pageSize", String(params.pageSize));
+            if (params.status !== undefined) {
+                if (params.status === "all") next.delete("status");
+                else next.set("status", params.status);
+            }
+            return next;
+        }, { preventScrollReset: true });
+    }, [setSearchParams]);
+
+    const onHistoryFilterSelected = useCallback((filter: HealthHistoryFilter) => {
+        setHistoryParams({ status: filter, page: 1 });
+    }, [setHistoryParams]);
+
+    const onHistoryPageSizeSelected = useCallback((pageSize: number) => {
+        setHistoryParams({ pageSize, page: 1 });
+    }, [setHistoryParams]);
 
     // effects
     useEffect(() => {
@@ -146,6 +213,19 @@ export default function Health({ loaderData }: Route.ComponentProps) {
                     </div>
                 </Alert>
             }
+            <HealthHistoryTable
+                items={historyItems}
+                totalCount={historyTotalCount}
+                page={loaderData.historyPage}
+                pageSize={loaderData.historyPageSize}
+                pageSizeOptions={PAGE_SIZE_OPTIONS}
+                filter={loaderData.historyFilter}
+                refreshing={revalidator.state !== "idle"}
+                onFilterSelected={onHistoryFilterSelected}
+                onPageSelected={page => setHistoryParams({ page })}
+                onPageSizeSelected={onHistoryPageSizeSelected}
+                onRefresh={() => void revalidator.revalidate()}
+            />
             <HealthTable isEnabled={isEnabled} healthCheckItems={queueItems.filter((_, index) => index < 10)} />
         </div>
     );

--- a/tests/NzbWebDAV.Tests/Api/GetHealthCheckHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHealthCheckHistoryControllerTests.cs
@@ -59,6 +59,23 @@ public sealed class GetHealthCheckHistoryControllerTests : IAsyncLifetime
     }
 
     [Theory]
+    [InlineData("?repairStatus=")]
+    [InlineData("?repairStatus=,")]
+    public async Task GetAsync_EmptyRepairStatusTreatedAsNoFilter(string query)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var deleted = NewResult(now.AddSeconds(-1), HealthCheckResult.RepairAction.Deleted);
+        var healthy = NewResult(now.AddSeconds(-2), HealthCheckResult.RepairAction.None);
+        _context.HealthCheckResults.AddRange(deleted, healthy);
+        await _context.SaveChangesAsync();
+
+        var response = await InvokeAsync(query);
+
+        Assert.Equal(2, response.TotalCount);
+        Assert.Equal(2, response.Items.Count);
+    }
+
+    [Theory]
     [InlineData("?repairStatus=unknown")]
     [InlineData("?page=0")]
     [InlineData("?pageSize=0")]

--- a/tests/NzbWebDAV.Tests/Api/GetHealthCheckHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHealthCheckHistoryControllerTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Controllers.GetHealthCheckHistory;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Api;
+
+public sealed class GetHealthCheckHistoryControllerTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-health-history-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersPagedItemsWithoutFilteringStats()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var deletedNewest = NewResult(now.AddSeconds(-1), HealthCheckResult.RepairAction.Deleted);
+        var repaired = NewResult(now.AddSeconds(-2), HealthCheckResult.RepairAction.Repaired);
+        var deletedOldest = NewResult(now.AddSeconds(-3), HealthCheckResult.RepairAction.Deleted);
+        var healthy = NewResult(now.AddSeconds(-4), HealthCheckResult.RepairAction.None);
+        _context.HealthCheckResults.AddRange(deletedNewest, repaired, deletedOldest, healthy);
+        await _context.SaveChangesAsync();
+
+        var response = await InvokeAsync("?repairStatus=deleted,repaired&page=2&pageSize=2");
+
+        Assert.Equal(3, response.TotalCount);
+        Assert.Equal([deletedOldest.Id], response.Items.Select(x => x.Id));
+        Assert.Contains(response.Stats, x => x.RepairStatus == HealthCheckResult.RepairAction.None && x.Count == 1);
+        Assert.Contains(response.Stats, x => x.RepairStatus == HealthCheckResult.RepairAction.Deleted && x.Count == 2);
+        Assert.Contains(response.Stats, x => x.RepairStatus == HealthCheckResult.RepairAction.Repaired && x.Count == 1);
+    }
+
+    [Theory]
+    [InlineData("?repairStatus=unknown")]
+    [InlineData("?page=0")]
+    [InlineData("?pageSize=0")]
+    [InlineData("?pageSize=251")]
+    public async Task HandleApiRequest_InvalidQueryReturns400(string query)
+    {
+        var result = await InvokeActionAsync(query);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetRepairHistoryIdentityAsync_SnapshotsOriginalNzbIdentity()
+    {
+        var nzbBlobId = Guid.NewGuid();
+        _context.NzbNames.Add(new NzbName { Id = nzbBlobId, FileName = "Example.Release.2026.nzb" });
+        await _context.SaveChangesAsync();
+
+        var identity = await HealthCheckService.GetRepairHistoryIdentityAsync(
+            _context,
+            new DavItem { NzbBlobId = nzbBlobId },
+            CancellationToken.None);
+
+        Assert.NotNull(identity);
+        Assert.Equal("Example.Release.2026.nzb", identity.NzbFileName);
+        Assert.Equal("Example.Release.2026", identity.JobName);
+    }
+
+    [Fact]
+    public async Task GetRepairHistoryIdentityAsync_ReturnsNullWithoutRetainedProvenance()
+    {
+        var identity = await HealthCheckService.GetRepairHistoryIdentityAsync(
+            _context,
+            new DavItem { NzbBlobId = Guid.NewGuid() },
+            CancellationToken.None);
+
+        Assert.Null(identity);
+    }
+
+    private async Task<GetHealthCheckHistoryResponse> InvokeAsync(string query)
+    {
+        var result = await InvokeActionAsync(query);
+        return Assert.IsType<OkObjectResult>(result).Value as GetHealthCheckHistoryResponse
+            ?? throw new Xunit.Sdk.XunitException("Expected health history response.");
+    }
+
+    private Task<IActionResult> InvokeActionAsync(string query)
+    {
+        var controller = new TestController(_dbClient);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        controller.HttpContext.Request.QueryString = new QueryString(query);
+        return controller.InvokeAsync();
+    }
+
+    private static HealthCheckResult NewResult(DateTimeOffset createdAt, HealthCheckResult.RepairAction repairStatus) => new()
+    {
+        Id = Guid.NewGuid(),
+        CreatedAt = createdAt,
+        DavItemId = Guid.NewGuid(),
+        Path = "/content/example.mkv",
+        Result = repairStatus == HealthCheckResult.RepairAction.None
+            ? HealthCheckResult.HealthResult.Healthy
+            : HealthCheckResult.HealthResult.Unhealthy,
+        RepairStatus = repairStatus,
+        Message = null,
+    };
+
+    private sealed class TestController(DavDatabaseClient dbClient) : GetHealthCheckHistoryController(dbClient)
+    {
+        protected override bool RequiresAuthentication => false;
+
+        public Task<IActionResult> InvokeAsync() => HandleApiRequest();
+    }
+}


### PR DESCRIPTION
## Summary
- Add a paginated Health repair history for automatic deleted and repaired files, including repair reasons and legacy path fallbacks.
- Snapshot the original NZB filename and release name for future automatic health actions.
- Add filtered paging to the health-history API and document retention behavior.

Closes #98

## Upgrade note
- Back up `/config` before upgrading. This PR includes an additive SQLite migration for persisted repair-history identity.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `cd frontend && npm run lint && npm run typecheck && npm test && npm run build`
- [x] `zensical build --clean --strict`
- [x] Browser-check the Health page at narrow width: empty history, filters, URL state, refresh, and repairs-disabled visibility.