### PR TITLE
feat(health): add on-demand GC memory diagnostics

### DIFF
--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Api.Controllers.GcDiagnostics;
+
+[ApiController]
+[Route("api/gc-diagnostics")]
+public sealed class GcDiagnosticsController(
+    InFlightArticleBudget inFlightArticleBudget,
+    GcDiagnosticsStore store) : BaseApiController
+{
+    protected override Task<IActionResult> HandleRequest()
+    {
+        if (!HttpMethods.IsPost(HttpContext.Request.Method))
+        {
+            return Task.FromResult<IActionResult>(
+                StatusCode(StatusCodes.Status405MethodNotAllowed,
+                    new BaseApiResponse { Status = false, Error = "POST required" }));
+        }
+
+        if (!store.RunGate.Wait(0))
+        {
+            return Task.FromResult<IActionResult>(
+                StatusCode(StatusCodes.Status429TooManyRequests,
+                    new BaseApiResponse
+                    {
+                        Status = false,
+                        Error = "A GC diagnostics run is already in progress.",
+                    }));
+        }
+
+        try
+        {
+            var before = GcSnapshotBuilder.Capture();
+            var stopwatch = Stopwatch.StartNew();
+            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+            stopwatch.Stop();
+
+            var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
+            var result = new GcDiagnosticsResult(
+                DateTimeOffset.UtcNow,
+                before,
+                GcSnapshotBuilder.Capture(),
+                stopwatch.ElapsedMilliseconds,
+                new GcBufferRetention(
+                    inFlightArticleBudget.LeasedBytes,
+                    inFlightArticleBudget.CapBytes,
+                    inFlightArticleBudget.ThrottleEvents,
+                    bufferPool.Rents,
+                    bufferPool.Returns,
+                    bufferPool.Growths,
+                    bufferPool.CheckedOutBytes,
+                    bufferPool.RequestedBytes,
+                    bufferPool.RentedBytes,
+                    bufferPool.BucketWasteBytes));
+            store.Store(result);
+
+            return Task.FromResult<IActionResult>(Ok(GcDiagnosticsResponse.FromResult(result)));
+        }
+        finally
+        {
+            store.RunGate.Release();
+        }
+    }
+}

--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
@@ -21,7 +21,7 @@ public sealed class GcDiagnosticsController(
                     new BaseApiResponse { Status = false, Error = "POST required" }));
         }
 
-        if (!store.RunGate.Wait(0))
+        if (!store.TryBegin())
         {
             return Task.FromResult<IActionResult>(
                 StatusCode(StatusCodes.Status429TooManyRequests,
@@ -64,7 +64,7 @@ public sealed class GcDiagnosticsController(
         }
         finally
         {
-            store.RunGate.Release();
+            store.End();
         }
     }
 }

--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsResponse.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsResponse.cs
@@ -1,0 +1,23 @@
+using NzbWebDAV.Services.Diagnostics;
+
+namespace NzbWebDAV.Api.Controllers.GcDiagnostics;
+
+public sealed class GcDiagnosticsResponse : BaseApiResponse
+{
+    public required DateTimeOffset RunAtUtc { get; init; }
+    public required GcSnapshot Before { get; init; }
+    public required GcSnapshot After { get; init; }
+    public required long PauseMs { get; init; }
+    public required GcBufferRetention Retention { get; init; }
+    public required string Warning { get; init; }
+
+    internal static GcDiagnosticsResponse FromResult(GcDiagnosticsResult result) => new()
+    {
+        RunAtUtc = result.RunAtUtc,
+        Before = result.Before,
+        After = result.After,
+        PauseMs = result.PauseMs,
+        Retention = result.Retention,
+        Warning = "Forced a blocking compacting GC; managed threads were paused. Do not poll this endpoint.",
+    };
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -250,6 +250,7 @@ public partial class Program
                 .AddSingleton<ConcurrentReadTracker>()
                 .AddSingleton<StreamingReadinessCheck>()
                 .AddSingleton(_ => new RuntimeUsageTracker())
+                .AddSingleton<GcDiagnosticsStore>()
                 .AddHostedService<RuntimeUsageSampler>()
                 .AddSingleton<ProviderUsageTracker>(sp =>
                     new ProviderUsageTracker(sp.GetRequiredService<ActiveReadRegistry>()))

--- a/backend/Services/Diagnostics/GcDiagnosticsStore.cs
+++ b/backend/Services/Diagnostics/GcDiagnosticsStore.cs
@@ -6,7 +6,10 @@ public sealed class GcDiagnosticsStore : IDisposable
     private readonly SemaphoreSlim _runGate = new(1, 1);
 
     public GcDiagnosticsResult? LastResult => Volatile.Read(ref _lastResult);
-    public SemaphoreSlim RunGate => _runGate;
+
+    public bool TryBegin() => _runGate.Wait(0);
+
+    public void End() => _runGate.Release();
 
     public void Store(GcDiagnosticsResult result)
     {

--- a/backend/Services/Diagnostics/GcDiagnosticsStore.cs
+++ b/backend/Services/Diagnostics/GcDiagnosticsStore.cs
@@ -1,0 +1,57 @@
+namespace NzbWebDAV.Services.Diagnostics;
+
+public sealed class GcDiagnosticsStore : IDisposable
+{
+    private GcDiagnosticsResult? _lastResult;
+    private readonly SemaphoreSlim _runGate = new(1, 1);
+
+    public GcDiagnosticsResult? LastResult => Volatile.Read(ref _lastResult);
+    public SemaphoreSlim RunGate => _runGate;
+
+    public void Store(GcDiagnosticsResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        Volatile.Write(ref _lastResult, result);
+    }
+
+    public void Dispose()
+    {
+        _runGate.Dispose();
+    }
+}
+
+public sealed record GcDiagnosticsResult(
+    DateTimeOffset RunAtUtc,
+    GcSnapshot Before,
+    GcSnapshot After,
+    long PauseMs,
+    GcBufferRetention Retention);
+
+public sealed record GcSnapshot(
+    IReadOnlyList<GcGenerationInfo> Generations,
+    int Gen0Collections,
+    int Gen1Collections,
+    int Gen2Collections,
+    long TotalAllocatedBytes,
+    long HeapSizeBytes,
+    long TotalCommittedBytes,
+    long TotalAvailableMemoryBytes,
+    long FragmentationBytes,
+    double PauseTimePercentage);
+
+public sealed record GcGenerationInfo(
+    string Name,
+    long SizeAfterBytes,
+    long FragmentationAfterBytes);
+
+public sealed record GcBufferRetention(
+    long InFlightArticleBytes,
+    long InFlightArticleBudgetBytes,
+    long InFlightArticleThrottleEvents,
+    long SegmentBufferRents,
+    long SegmentBufferReturns,
+    long SegmentBufferGrowths,
+    long SegmentBufferCheckedOutBytes,
+    long SegmentBufferRequestedBytes,
+    long SegmentBufferRentedBytes,
+    long SegmentBufferBucketWasteBytes);

--- a/backend/Services/Diagnostics/GcSnapshotBuilder.cs
+++ b/backend/Services/Diagnostics/GcSnapshotBuilder.cs
@@ -1,0 +1,40 @@
+namespace NzbWebDAV.Services.Diagnostics;
+
+internal static class GcSnapshotBuilder
+{
+    public static GcSnapshot Capture()
+    {
+        var info = GC.GetGCMemoryInfo();
+        var generations = new List<GcGenerationInfo>(info.GenerationInfo.Length);
+        for (var generation = 0; generation < info.GenerationInfo.Length; generation++)
+        {
+            var entry = info.GenerationInfo[generation];
+            generations.Add(new GcGenerationInfo(
+                GenerationName(generation),
+                entry.SizeAfterBytes,
+                entry.FragmentationAfterBytes));
+        }
+
+        return new GcSnapshot(
+            generations,
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2),
+            GC.GetTotalAllocatedBytes(precise: false),
+            info.HeapSizeBytes,
+            info.TotalCommittedBytes,
+            info.TotalAvailableMemoryBytes,
+            info.FragmentedBytes,
+            info.PauseTimePercentage);
+    }
+
+    private static string GenerationName(int generation) => generation switch
+    {
+        0 => "gen0",
+        1 => "gen1",
+        2 => "gen2",
+        3 => "loh",
+        4 => "poh",
+        _ => $"gen{generation}",
+    };
+}

--- a/backend/Services/Diagnostics/OomDiagnostics.cs
+++ b/backend/Services/Diagnostics/OomDiagnostics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using NzbWebDAV.Streams;
 using Serilog;
 
@@ -5,6 +6,10 @@ namespace NzbWebDAV.Services.Diagnostics;
 
 internal static class OomDiagnostics
 {
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Diagnostic logging must not replace the original OutOfMemoryException.")]
     public static void LogHeapStateOnOom(Exception exception, string context)
     {
         if (exception is not OutOfMemoryException) return;

--- a/backend/Services/Diagnostics/OomDiagnostics.cs
+++ b/backend/Services/Diagnostics/OomDiagnostics.cs
@@ -1,0 +1,33 @@
+using NzbWebDAV.Streams;
+using Serilog;
+
+namespace NzbWebDAV.Services.Diagnostics;
+
+internal static class OomDiagnostics
+{
+    public static void LogHeapStateOnOom(Exception exception, string context)
+    {
+        if (exception is not OutOfMemoryException) return;
+
+        try
+        {
+            var info = GC.GetGCMemoryInfo();
+            Log.Warning(
+                exception,
+                "OutOfMemoryException during {Context}. Heap={Heap:N0} Committed={Committed:N0} " +
+                "Available={Available:N0} Fragmentation={Fragmentation:N0} " +
+                "InFlight={InFlight:N0} Cap={Cap:N0}",
+                context,
+                info.HeapSizeBytes,
+                info.TotalCommittedBytes,
+                info.TotalAvailableMemoryBytes,
+                info.FragmentedBytes,
+                InFlightArticleBudget.Current?.LeasedBytes ?? -1,
+                InFlightArticleBudget.Current?.CapBytes ?? -1);
+        }
+        catch
+        {
+            // Memory diagnostics must never mask the original OOM.
+        }
+    }
+}

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -30,6 +30,7 @@ public sealed class SupportPackService(
     InFlightArticleBudget inFlightArticleBudget,
     StreamTraceBuffer streamTraceBuffer,
     RuntimeUsageTracker runtimeUsage,
+    GcDiagnosticsStore gcDiagnosticsStore,
     ConcurrentReadTracker? concurrentReadTracker = null)
 {
     private const long MinuteMs = 60_000;
@@ -369,6 +370,7 @@ public sealed class SupportPackService(
             runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),
             cpu,
             gc = BuildGcDiagnostics(usage),
+            gcDiagnostics = gcDiagnosticsStore.LastResult,
             threadPool = new
             {
                 minWorkerThreads,

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.StreamTrace;
 using Serilog;
 using UsenetSharp.Models;
@@ -195,6 +196,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             _streamTasks.Writer.TryComplete();
+        }
+        catch (OutOfMemoryException oom)
+        {
+            OomDiagnostics.LogHeapStateOnOom(oom, "segment download pipeline");
+            throw;
         }
         catch (Exception exception) when (exception is not OutOfMemoryException)
         {
@@ -475,6 +481,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (OutOfMemoryException oom)
+            {
+                OomDiagnostics.LogHeapStateOnOom(oom, "segment body retry");
+                throw;
+            }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)
             {
                 lease?.Dispose();
@@ -567,6 +578,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     persistent);
             }
         }
+        catch (OutOfMemoryException oom)
+        {
+            OomDiagnostics.LogHeapStateOnOom(oom, "pipelined segment batch");
+            throw;
+        }
         catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)
         {
             lease?.Dispose();
@@ -652,6 +668,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch (UsenetArticleNotFoundException)
             {
+                throw;
+            }
+            catch (OutOfMemoryException oom)
+            {
+                OomDiagnostics.LogHeapStateOnOom(oom, "individual segment rescue");
                 throw;
             }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
 using Serilog;
@@ -203,6 +204,11 @@ public class NzbFileStream(
                     var end = Math.Min(fileSize, start + avg);
                     return new LongRange(start, end);
                 }
+                catch (OutOfMemoryException oom)
+                {
+                    OomDiagnostics.LogHeapStateOnOom(oom, "seek probe");
+                    throw;
+                }
                 catch (Exception e) when (articleBufferSize > 0 && !ct.IsCancellationRequested && e is not OutOfMemoryException)
                 {
                     e.LogWarningKnownOrStack(
@@ -295,6 +301,11 @@ public class NzbFileStream(
             {
                 response = await usenetClient.DecodedBodyAsync(fileSegmentIds[index], ct).ConfigureAwait(false);
             }
+            catch (OutOfMemoryException oom)
+            {
+                OomDiagnostics.LogHeapStateOnOom(oom, "fast-seek body fetch");
+                throw;
+            }
             catch
             {
                 return null;
@@ -305,6 +316,11 @@ public class NzbFileStream(
             try
             {
                 header = await body.GetYencHeadersAsync(ct).ConfigureAwait(false);
+            }
+            catch (OutOfMemoryException oom)
+            {
+                OomDiagnostics.LogHeapStateOnOom(oom, "fast-seek header read");
+                throw;
             }
             catch
             {
@@ -349,6 +365,11 @@ public class NzbFileStream(
                     // left to return the rented array.
                     bodyDisposeAttempted = true;
                     await body.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (OutOfMemoryException oom)
+                {
+                    OomDiagnostics.LogHeapStateOnOom(oom, "fast-seek body drain");
+                    throw;
                 }
                 catch (Exception e) when (!ct.IsCancellationRequested && e is not OutOfMemoryException)
                 {

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -214,7 +214,7 @@ public sealed class PooledBufferStream : Stream
         if (required <= RunawayThresholdBytes || previous > RunawayThresholdBytes) return;
 
         Log.Warning(
-            "Segment buffer grew past {ThresholdMB} MB. Required={Required:N0} Previous={Previous:N0}. " +
+            "Segment buffer allocation or growth exceeded {ThresholdMB} MB. Required={Required:N0} Previous={Previous:N0}. " +
             "The segment read may not be terminating.",
             RunawayThresholdBytes / (1024 * 1024),
             required,

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -1,3 +1,5 @@
+using Serilog;
+
 namespace NzbWebDAV.Streams;
 
 /// <summary>
@@ -7,6 +9,8 @@ namespace NzbWebDAV.Streams;
 /// </summary>
 public sealed class PooledBufferStream : Stream
 {
+    private const int RunawayThresholdBytes = 32 * 1024 * 1024;
+
     private readonly ISegmentBufferPool _pool;
     private readonly BufferPoolDiagnostics _diagnostics;
     private byte[]? _buffer;
@@ -26,6 +30,7 @@ public sealed class PooledBufferStream : Stream
 
         if (capacityHint > 0)
         {
+            WarnIfRunawayCapacity(capacityHint, 0);
             _buffer = RentBuffer(capacityHint);
             _diagnostics.RecordRent(capacityHint, _buffer.Length);
         }
@@ -192,6 +197,7 @@ public sealed class PooledBufferStream : Stream
         var current = _buffer!;
         if (required <= current.Length) return;
 
+        WarnIfRunawayCapacity(required, current.Length);
         var next = RentBuffer(required);
         if (_length > 0)
             current.AsSpan(0, _length).CopyTo(next);
@@ -201,6 +207,18 @@ public sealed class PooledBufferStream : Stream
 
         _diagnostics.RecordGrowth(required, current.Length, next.Length);
         _buffer = next;
+    }
+
+    private static void WarnIfRunawayCapacity(int required, int previous)
+    {
+        if (required <= RunawayThresholdBytes || previous > RunawayThresholdBytes) return;
+
+        Log.Warning(
+            "Segment buffer grew past {ThresholdMB} MB. Required={Required:N0} Previous={Previous:N0}. " +
+            "The segment read may not be terminating.",
+            RunawayThresholdBytes / (1024 * 1024),
+            required,
+            previous);
     }
 
     private void ReturnBuffer()

--- a/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class GcDiagnosticsHttpIntegrationTests(NzbDavWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task GcDiagnostics_RejectsMissingApiKey()
+    {
+        using var client = factory.CreateClient();
+        using var response = await client.PostAsync("/api/gc-diagnostics", content: null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GcDiagnostics_RejectsGet()
+    {
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/gc-diagnostics");
+        request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GcDiagnostics_AuthorizedPost_ReturnsSnapshotsAndStoresResult()
+    {
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/gc-diagnostics");
+        request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        var root = json.RootElement;
+        Assert.True(root.GetProperty("status").GetBoolean());
+        Assert.True(root.GetProperty("pauseMs").GetInt64() >= 0);
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("warning").GetString()));
+        Assert.Equal(JsonValueKind.Object, root.GetProperty("before").ValueKind);
+        Assert.Equal(JsonValueKind.Object, root.GetProperty("after").ValueKind);
+        Assert.Equal(JsonValueKind.Object, root.GetProperty("retention").ValueKind);
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("after").GetProperty("generations").ValueKind);
+
+        var store = factory.Services.GetRequiredService<GcDiagnosticsStore>();
+        Assert.NotNull(store.LastResult);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
@@ -1,0 +1,70 @@
+using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class OomDiagnosticsTests
+{
+    [Fact]
+    public void LogHeapStateOnOom_LogsWarning()
+    {
+        var events = CaptureLogs(() =>
+            OomDiagnostics.LogHeapStateOnOom(new OutOfMemoryException("test"), "test operation"));
+
+        var entry = Assert.Single(events);
+        Assert.Equal(LogEventLevel.Warning, entry.Level);
+        Assert.Contains("OutOfMemoryException during", entry.MessageTemplate.Text);
+    }
+
+    [Fact]
+    public void LogHeapStateOnOom_NonOom_IsNoOp()
+    {
+        var events = CaptureLogs(() =>
+            OomDiagnostics.LogHeapStateOnOom(new InvalidOperationException("test"), "test operation"));
+
+        Assert.Empty(events);
+    }
+
+    private static IReadOnlyList<LogEvent> CaptureLogs(Action action)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -600,6 +600,7 @@ public sealed class SupportPackContentsTests : IDisposable
             streamTraceBuffer,
             new ActiveReadRegistry());
 
+        using var gcDiagnosticsStore = new GcDiagnosticsStore();
         var service = new SupportPackService(
             logBuffer,
             warningBuffer,
@@ -612,7 +613,7 @@ public sealed class SupportPackContentsTests : IDisposable
             new InFlightArticleBudget(64 * 1024 * 1024),
             streamTraceBuffer,
             runtimeUsage ?? new RuntimeUsageTracker(),
-            new GcDiagnosticsStore(),
+            gcDiagnosticsStore,
             concurrentReadTracker);
 
         using var memory = new MemoryStream();

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -612,6 +612,7 @@ public sealed class SupportPackContentsTests : IDisposable
             new InFlightArticleBudget(64 * 1024 * 1024),
             streamTraceBuffer,
             runtimeUsage ?? new RuntimeUsageTracker(),
+            new GcDiagnosticsStore(),
             concurrentReadTracker);
 
         using var memory = new MemoryStream();

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -150,7 +150,7 @@ public class PooledBufferStreamTests
 
         Assert.Contains(events, entry =>
             entry.Level == LogEventLevel.Warning &&
-            entry.MessageTemplate.Text.Contains("Segment buffer grew past", StringComparison.Ordinal));
+            entry.MessageTemplate.Text.Contains("Segment buffer allocation or growth exceeded", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class PooledBufferStreamTests
         });
 
         Assert.DoesNotContain(events, entry =>
-            entry.MessageTemplate.Text.Contains("Segment buffer grew past", StringComparison.Ordinal));
+            entry.MessageTemplate.Text.Contains("Segment buffer allocation or growth exceeded", StringComparison.Ordinal));
     }
 
     private static IReadOnlyList<LogEvent> CaptureLogs(Action action)

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -1,7 +1,12 @@
 using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace NzbWebDAV.Tests.Streams;
 
+[Collection(nameof(GlobalLoggerCollection))]
 public class PooledBufferStreamTests
 {
     [Fact]
@@ -133,6 +138,70 @@ public class PooledBufferStreamTests
         Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
         Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(2));
         Assert.Throws<ObjectDisposedException>(() => _ = stream.Length);
+    }
+
+    [Fact]
+    public void Constructor_CapacityPast32Mb_LogsRunawayWarning()
+    {
+        var events = CaptureLogs(() =>
+        {
+            using var stream = new PooledBufferStream((32 * 1024 * 1024) + 1);
+        });
+
+        Assert.Contains(events, entry =>
+            entry.Level == LogEventLevel.Warning &&
+            entry.MessageTemplate.Text.Contains("Segment buffer grew past", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Constructor_CapacityUnder32Mb_DoesNotLogRunawayWarning()
+    {
+        var events = CaptureLogs(() =>
+        {
+            using var stream = new PooledBufferStream(1024);
+        });
+
+        Assert.DoesNotContain(events, entry =>
+            entry.MessageTemplate.Text.Contains("Segment buffer grew past", StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<LogEvent> CaptureLogs(Action action)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add an authenticated, explicitly invoked compacting GC diagnostics endpoint with before/after heap and buffer-retention snapshots
- retain the latest diagnostic result in support packs and prevent concurrent forced collections
- log heap state for streaming OOMs and warn before segment buffers exceed 32 MB

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~GcDiagnosticsHttpIntegrationTests|FullyQualifiedName~OomDiagnosticsTests|FullyQualifiedName~PooledBufferStreamTests|FullyQualifiedName~SupportPackContentsTests" --nologo`
