### PR TITLE
feat(ui): search, filter, and sort queue and history

### DIFF
--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -24,14 +24,18 @@ public class GetHistoryController(
             query = query.Where(q => request.NzoIds.Contains(q.Id));
         if (request.Category != null)
             query = query.Where(q => q.Category == request.Category);
+        query = SabListQuery.ApplySearch(query, request.Search);
+        if (request.HasUnsupportedStatus)
+            query = query.Where(_ => false);
+        else if (request.Status is { } status)
+            query = query.Where(q => q.DownloadStatus == status);
 
         // get total count
         var totalCountPromise = query
             .CountAsync(request.CancellationToken);
 
         // get history items
-        var historyItemsPromise = query
-            .OrderByDescending(q => q.CreatedAt)
+        var historyItemsPromise = SabListQuery.ApplyHistorySort(query, request.Sort, request.Direction)
             .Skip(request.Start)
             .Take(request.Limit)
             .ToArrayAsync(request.CancellationToken);

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.SabControllers.GetHistory;
@@ -10,6 +11,12 @@ public class GetHistoryRequest
     public int Limit { get; init; } = int.MaxValue;
     public string? Category { get; init; }
     public List<Guid> NzoIds { get; init; } = [];
+    public string? Search { get; init; }
+    public HistoryItem.DownloadStatusOption? Status { get; init; }
+    public bool HasUnsupportedStatus { get; init; }
+    public bool FailedOnly { get; init; }
+    public string? Sort { get; init; }
+    public string? Direction { get; init; }
     public CancellationToken CancellationToken { get; set; }
 
 
@@ -20,6 +27,14 @@ public class GetHistoryRequest
         var pageSizeParam = context.GetRequestParam("pageSize");
         var nzoIdsParam = context.GetRequestParam("nzo_ids");
         Category = SabCategoryResolver.GetCategory(context, configManager);
+        Search = SabListQuery.NormalizeSearch(context.GetRequestParam("search"));
+        FailedOnly = IsEnabled(context.GetRequestParam("failed_only"));
+        var (parsedStatus, hasUnsupportedStatus) = ParseStatus(context.GetRequestParam("status"));
+        Status = parsedStatus;
+        HasUnsupportedStatus = !FailedOnly && hasUnsupportedStatus;
+        if (FailedOnly) Status = HistoryItem.DownloadStatusOption.Failed;
+        Sort = NormalizeSort(context.GetRequestParam("sort"));
+        Direction = SabListQuery.NormalizeDirection(context.GetRequestParam("dir"));
         CancellationToken = context.RequestAborted;
 
         if (startParam is not null)
@@ -92,4 +107,22 @@ public class GetHistoryRequest
             NzoIds = nzoIds;
         }
     }
+
+    private static bool IsEnabled(string? value) =>
+        value is "1" or "true" or "True";
+
+    private static (HistoryItem.DownloadStatusOption? status, bool unsupported) ParseStatus(string? value) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            null or "" => (null, false),
+            "completed" => (HistoryItem.DownloadStatusOption.Completed, false),
+            "failed" => (HistoryItem.DownloadStatusOption.Failed, false),
+            _ => (null, true),
+        };
+
+    private static string? NormalizeSort(string? value) => value?.Trim().ToLowerInvariant() switch
+    {
+        "name" or "category" or "status" or "size" or "completed" => value.Trim().ToLowerInvariant(),
+        _ => null,
+    };
 }

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -120,9 +120,9 @@ public class GetHistoryRequest
             _ => (null, true),
         };
 
-    private static string? NormalizeSort(string? value) => value?.Trim().ToLowerInvariant() switch
+    private static string? NormalizeSort(string? value)
     {
-        "name" or "category" or "status" or "size" or "completed" => value.Trim().ToLowerInvariant(),
-        _ => null,
-    };
+        var normalized = value?.Trim().ToLowerInvariant();
+        return normalized is "name" or "category" or "status" or "size" or "completed" ? normalized : null;
+    }
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -19,35 +20,68 @@ public class GetQueueController(
 {
     internal async Task<GetQueueResponse> GetQueueAsync(GetQueueRequest request)
     {
-        // Snapshot every in-progress item (primary first).
-        var inProgress = queueManager.GetInProgressQueueItems();
+        // Snapshot every in-progress item (primary first), then apply the same
+        // literal filters used for persisted queue rows.
+        var allInProgress = queueManager.GetInProgressQueueItems();
+        var activeIds = allInProgress.Select(x => x.QueueItem.Id).ToHashSet();
+        var inProgress = allInProgress;
         if (!string.IsNullOrEmpty(request.Category))
         {
             inProgress = inProgress
                 .Where(x => x.QueueItem.Category == request.Category)
                 .ToList();
         }
+        if (request.Search is not null)
+        {
+            inProgress = inProgress
+                .Where(x => MatchesSearch(x.QueueItem, request.Search))
+                .ToList();
+        }
+        if (request.Status is not null)
+        {
+            inProgress = request.Status == "Downloading" ? inProgress : [];
+        }
 
-        var inProgressIds = inProgress.Select(x => x.QueueItem.Id).ToHashSet();
         var inProgressById = inProgress.ToDictionary(x => x.QueueItem.Id);
-
-        // get total count
         var ct = request.CancellationToken;
-        var totalCount = await dbClient.GetQueueItemsCount(request.Category, ct).ConfigureAwait(false);
 
-        // get queued items, then merge active items ahead for the requested page
-        var fetchCount = request.Start + Math.Min(request.Limit, int.MaxValue - request.Start);
-        var getQueueItemsTask = dbClient.GetQueueItems(request.Category, 0, fetchCount, ct);
-        var queuedItems = (await getQueueItemsTask.ConfigureAwait(false))
-            .Where(x => !inProgressIds.Contains(x.Id))
-            .ToArray();
+        // Apply SQL-side filters before counting or paginating so noofslots is
+        // always the count for the displayed view.
+        IQueryable<QueueItem> queuedQuery = dbClient.Ctx.QueueItems.AsNoTracking();
+        if (request.Category is not null)
+            queuedQuery = queuedQuery.Where(x => x.Category == request.Category);
+        queuedQuery = SabListQuery.ApplySearch(queuedQuery, request.Search);
+        if (activeIds.Count > 0)
+            queuedQuery = queuedQuery.Where(x => !activeIds.Contains(x.Id));
+        queuedQuery = request.Status switch
+        {
+            "Paused" => queuedQuery.Where(x => x.Priority == QueueItem.PriorityOption.Paused),
+            "Queued" => queuedQuery.Where(x => x.Priority != QueueItem.PriorityOption.Paused),
+            "Downloading" or "Unsupported" => queuedQuery.Where(_ => false),
+            _ => queuedQuery,
+        };
 
-        var merged = inProgress
-            .Select(x => x.QueueItem)
-            .Concat(queuedItems)
+        var queuedCountTask = queuedQuery.CountAsync(ct);
+        var activeItems = inProgress.Select(x => x.QueueItem).ToList();
+        var activePage = activeItems
             .Skip(request.Start)
             .Take(request.Limit)
             .ToList();
+        var remainingLimit = request.Limit == int.MaxValue
+            ? int.MaxValue
+            : Math.Max(0, request.Limit - activePage.Count);
+        var queuedStart = Math.Max(0, request.Start - activeItems.Count);
+        var queuedItemsTask = remainingLimit == 0
+            ? Task.FromResult(Array.Empty<QueueItem>())
+            : SabListQuery.ApplyQueueSort(queuedQuery, request.Sort, request.Direction)
+                .Skip(queuedStart)
+                .Take(remainingLimit)
+                .ToArrayAsync(ct);
+
+        var queuedCount = await queuedCountTask.ConfigureAwait(false);
+        var queuedItems = await queuedItemsTask.ConfigureAwait(false);
+        var totalCount = checked(activeItems.Count + queuedCount);
+        var merged = activePage.Concat(queuedItems).ToList();
 
         // Metrics keys of every configured Usenet provider — used to show idle providers
         // alongside active ones for in-progress downloads.
@@ -131,4 +165,8 @@ public class GetQueueController(
         var request = new GetQueueRequest(Context, Config);
         return Ok(await GetQueueAsync(request).ConfigureAwait(false));
     }
+
+    private static bool MatchesSearch(QueueItem item, string search) =>
+        item.JobName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        item.FileName.Contains(search, StringComparison.OrdinalIgnoreCase);
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -51,9 +51,9 @@ public class GetQueueRequest
         _ => "Unsupported",
     };
 
-    private static string? NormalizeSort(string? value) => value?.Trim().ToLowerInvariant() switch
+    private static string? NormalizeSort(string? value)
     {
-        "name" or "category" or "status" or "size" => value.Trim().ToLowerInvariant(),
-        _ => null,
-    };
+        var normalized = value?.Trim().ToLowerInvariant();
+        return normalized is "name" or "category" or "status" or "size" ? normalized : null;
+    }
 }

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -9,6 +9,10 @@ public class GetQueueRequest
     public int Start { get; init; }
     public int Limit { get; init; } = int.MaxValue;
     public string? Category { get; init; }
+    public string? Search { get; init; }
+    public string? Status { get; init; }
+    public string? Sort { get; init; }
+    public string? Direction { get; init; }
     public CancellationToken CancellationToken { get; init; }
 
 
@@ -17,6 +21,10 @@ public class GetQueueRequest
         var startParam = context.GetRequestParam("start");
         var limitParam = context.GetRequestParam("limit");
         Category = SabCategoryResolver.GetCategory(context, configManager);
+        Search = SabListQuery.NormalizeSearch(context.GetRequestParam("search"));
+        Status = NormalizeStatus(context.GetRequestParam("status"));
+        Sort = NormalizeSort(context.GetRequestParam("sort"));
+        Direction = SabListQuery.NormalizeDirection(context.GetRequestParam("dir"));
         CancellationToken = context.RequestAborted;
 
         if (startParam is not null)
@@ -33,4 +41,19 @@ public class GetQueueRequest
             Limit = limit > 0 ? limit : int.MaxValue;
         }
     }
+
+    private static string? NormalizeStatus(string? value) => value?.Trim().ToLowerInvariant() switch
+    {
+        null or "" => null,
+        "downloading" => "Downloading",
+        "queued" => "Queued",
+        "paused" => "Paused",
+        _ => "Unsupported",
+    };
+
+    private static string? NormalizeSort(string? value) => value?.Trim().ToLowerInvariant() switch
+    {
+        "name" or "category" or "status" or "size" => value.Trim().ToLowerInvariant(),
+        _ => null,
+    };
 }

--- a/backend/Api/SabControllers/SabListQuery.cs
+++ b/backend/Api/SabControllers/SabListQuery.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+internal static class SabListQuery
+{
+    internal static string? NormalizeSearch(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    internal static string? NormalizeDirection(string? value) =>
+        string.Equals(value, "asc", StringComparison.OrdinalIgnoreCase) ? "asc"
+        : string.Equals(value, "desc", StringComparison.OrdinalIgnoreCase) ? "desc"
+        : null;
+
+    internal static string EscapeLikePattern(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+
+    internal static IQueryable<QueueItem> ApplySearch(IQueryable<QueueItem> query, string? search)
+    {
+        if (search is null) return query;
+        var pattern = $"%{EscapeLikePattern(search)}%";
+        return query.Where(x =>
+            EF.Functions.Like(x.JobName, pattern, "\\") ||
+            EF.Functions.Like(x.FileName, pattern, "\\"));
+    }
+
+    internal static IQueryable<HistoryItem> ApplySearch(IQueryable<HistoryItem> query, string? search)
+    {
+        if (search is null) return query;
+        var pattern = $"%{EscapeLikePattern(search)}%";
+        return query.Where(x =>
+            EF.Functions.Like(x.JobName, pattern, "\\") ||
+            EF.Functions.Like(x.FileName, pattern, "\\"));
+    }
+
+    internal static IQueryable<QueueItem> ApplyQueueSort(IQueryable<QueueItem> query, string? sort, string? dir)
+    {
+        var ascending = dir == "asc";
+        return sort switch
+        {
+            "name" => ascending
+                ? query.OrderBy(x => EF.Functions.Collate(x.FileName, "NOCASE")).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => EF.Functions.Collate(x.FileName, "NOCASE")).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id),
+            "category" => ascending
+                ? query.OrderBy(x => EF.Functions.Collate(x.Category, "NOCASE")).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => EF.Functions.Collate(x.Category, "NOCASE")).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id),
+            "status" => ascending
+                ? query.OrderBy(x => x.Priority == QueueItem.PriorityOption.Paused ? 1 : 0).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => x.Priority == QueueItem.PriorityOption.Paused ? 1 : 0).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id),
+            "size" => ascending
+                ? query.OrderBy(x => x.TotalSegmentBytes).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => x.TotalSegmentBytes).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id),
+            _ => query.OrderByDescending(x => x.Priority).ThenBy(x => x.CreatedAt).ThenBy(x => x.Id),
+        };
+    }
+
+    internal static IQueryable<HistoryItem> ApplyHistorySort(IQueryable<HistoryItem> query, string? sort, string? dir)
+    {
+        var ascending = dir == "asc";
+        return sort switch
+        {
+            "name" => ascending
+                ? query.OrderBy(x => EF.Functions.Collate(x.JobName, "NOCASE")).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => EF.Functions.Collate(x.JobName, "NOCASE")).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+            "category" => ascending
+                ? query.OrderBy(x => EF.Functions.Collate(x.Category, "NOCASE")).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => EF.Functions.Collate(x.Category, "NOCASE")).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+            "status" => ascending
+                ? query.OrderBy(x => x.DownloadStatus).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => x.DownloadStatus).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+            "size" => ascending
+                ? query.OrderBy(x => x.TotalSegmentBytes).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => x.TotalSegmentBytes).ThenByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+            "completed" => ascending
+                ? query.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id)
+                : query.OrderByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+            _ => query.OrderByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+        };
+    }
+}

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -15,6 +15,21 @@ InfiniDysk implements the SABnzbd-compatible operations used by Sonarr, Radarr, 
 
 Queue and history filters accept both `cat` and `category`. The default category sentinel returned by `get_cats` is `*`.
 
+## Queue and history search [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+Queue and history listing accept a literal, case-insensitive `search` term over
+both the job name and NZB filename. Search is not regular-expression syntax.
+They also accept one `cat`/`category` and one `status`; comma-separated filter
+lists are not supported. Queue statuses are `Downloading`, `Queued`, and
+`Paused`; history statuses are `Completed` and `Failed`. History additionally
+accepts `failed_only=1` as shorthand for `status=Failed`.
+
+The admin UI uses InfiniDysk-specific `sort` and `dir=asc|desc` parameters for
+display-only ordering. Queue supports `name`, `category`, `status`, and `size`;
+history also supports `completed`. Text sorting is case-insensitive. Unknown
+sort values retain the endpoint's normal order. Queue display sorting never
+changes download priority or physical queue order.
+
 ## Pause, resume, and speed limit [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
 
 `mode=pause` / `mode=resume` stop and restart **new** queue dequeues. Workers already downloading finish naturally unless a per-job pause cancels them. WebDAV mounts keep serving — pause does not interrupt playback. Queue JSON reports `paused` accurately. Items added with SAB priority `-2` (Paused) are skipped until their priority changes; queue slots report `status: Paused` for those jobs.

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -74,6 +74,20 @@ describe("BackendClient", () => {
     ]);
   });
 
+  it("encodes queue and history list filters", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ queue: { slots: [], noofslots: 0 } }))
+      .mockResolvedValueOnce(jsonResponse({ history: { slots: [], noofslots: 0 } }));
+
+    await backendClient.getQueue(25, 50, { search: "A & B", category: "tv", status: "Paused", sort: "name", direction: "asc" });
+    await backendClient.getHistory(10, 20, { search: "movie", status: "Failed", sort: "completed", direction: "desc" });
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "http://backend/api?mode=queue&start=50&limit=25&search=A+%26+B&cat=tv&status=Paused&sort=name&dir=asc",
+      "http://backend/api?mode=history&start=20&pageSize=10&search=movie&status=Failed&sort=completed&dir=desc",
+    ]);
+  });
+
   it("gets, updates, and defaults config items", async () => {
     const configItems = [
       {

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -5,6 +5,30 @@ import {
 
 export type { StreamTracingStatus };
 
+export type ListOptions = {
+    search?: string | undefined;
+    category?: string | undefined;
+    status?: string | undefined;
+    sort?: string | undefined;
+    direction?: "asc" | "desc" | undefined;
+};
+
+function listParams(
+    mode: "queue" | "history",
+    limit: number,
+    start: number,
+    options: ListOptions,
+    limitKey: "limit" | "pageSize",
+): string {
+    const params = new URLSearchParams({ mode, start: String(start), [limitKey]: String(limit) });
+    if (options.search) params.set("search", options.search);
+    if (options.category) params.set("cat", options.category);
+    if (options.status) params.set("status", options.status);
+    if (options.sort) params.set("sort", options.sort);
+    if (options.direction) params.set("dir", options.direction);
+    return params.toString();
+}
+
 export class WebdavDirectoryNotFoundError extends Error {
     public constructor(public readonly directory: string) {
         super("The WebDAV directory does not exist.");
@@ -130,13 +154,15 @@ class BackendClient {
         return data.authenticated;
     }
 
-    public async getQueue(limit: number, start: number = 0): Promise<QueueResponse> {
-        const data = await call<{ queue: QueueResponse }>(`/api?mode=queue&start=${start}&limit=${limit}`, "Failed to get queue");
+    public async getQueue(limit: number, start: number = 0, options: ListOptions = {}): Promise<QueueResponse> {
+        const params = listParams("queue", limit, start, options, "limit");
+        const data = await call<{ queue: QueueResponse }>(`/api?${params}`, "Failed to get queue");
         return data.queue;
     }
 
-    public async getHistory(limit: number, start: number = 0): Promise<HistoryResponse> {
-        const data = await call<{ history: HistoryResponse }>(`/api?mode=history&start=${start}&pageSize=${limit}`, "Failed to get history");
+    public async getHistory(limit: number, start: number = 0, options: ListOptions = {}): Promise<HistoryResponse> {
+        const params = listParams("history", limit, start, options, "pageSize");
+        const data = await call<{ history: HistoryResponse }>(`/api?${params}`, "Failed to get history");
         return data.history;
     }
 

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -13,6 +13,9 @@ import { ExportNzb, Remove } from "~/routes/explore/item-menu/item-menu"
 import { canRetryHistorySlot, retryHistoryItem, retryHistoryItems, shouldAcceptRetryClick } from "./history-retry"
 import { useIsReadOnly } from "~/auth/authorization"
 import { Button, Tooltip } from "~/components/ui"
+import type { HistoryListParams } from "../../list-params"
+import { sortValue } from "../../list-params"
+import { ListToolbar } from "../list-toolbar/list-toolbar"
 
 export type HistoryTableProps = {
     historySlots: PresentationHistorySlot[],
@@ -27,6 +30,13 @@ export type HistoryTableProps = {
     onIsSelectedChanged: (nzo_ids: Set<string>, isSelected: boolean) => void,
     onIsRemovingChanged: (nzo_ids: Set<string>, isRemoving: boolean) => void,
     onRemoved: (nzo_ids: Set<string>) => void,
+    categories: string[],
+    listParams: HistoryListParams,
+    searchDraft: string,
+    onSearchDraftChange: (value: string) => void,
+    onFilterChange: (key: string, value: string) => void,
+    onClearFilters: () => void,
+    onSort: (field: string) => void,
 }
 
 export function HistoryTable({
@@ -42,6 +52,13 @@ export function HistoryTable({
     onIsSelectedChanged,
     onIsRemovingChanged,
     onRemoved,
+    categories,
+    listParams,
+    searchDraft,
+    onSearchDraftChange,
+    onFilterChange,
+    onClearFilters,
+    onSort,
 }: HistoryTableProps) {
     const isReadOnly = useIsReadOnly();
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
@@ -161,12 +178,31 @@ export function HistoryTable({
             title={sectionTitle}
             {...(totalHistoryCount > 0 ? { badgeText: String(totalHistoryCount) } : {})}
         >
+            <ListToolbar
+                label="History"
+                query={searchDraft}
+                category={listParams.category}
+                status={listParams.status}
+                sort={sortValue(listParams)}
+                categories={categories}
+                statuses={[{ value: "Completed", label: "Completed" }, { value: "Failed", label: "Failed" }]}
+                sorts={[{ value: "completed:desc", label: "Newest first" }, { value: "completed:asc", label: "Oldest first" }, { value: "name:asc", label: "Name A–Z" }, { value: "name:desc", label: "Name Z–A" }, { value: "size:desc", label: "Size largest" }, { value: "size:asc", label: "Size smallest" }, { value: "status:asc", label: "Status" }, { value: "category:asc", label: "Category" }]}
+                isFiltered={!!(listParams.query || listParams.category || listParams.status || listParams.sort)}
+                onQueryChange={onSearchDraftChange}
+                onCategoryChange={value => onFilterChange("hcat", value)}
+                onStatusChange={value => onFilterChange("hstatus", value)}
+                onSortChange={value => onFilterChange("hsort", value)}
+                onClear={onClearFilters}
+            />
             <PageTable
                 headerCheckboxState={headerCheckboxState}
                 onHeaderCheckboxChange={onSelectAll}
                 footer={footer}
                 showCompleted
                 selectable={!isReadOnly}
+                sort={listParams.sort ?? undefined}
+                direction={listParams.direction}
+                onSort={onSort}
             >
                 {historySlots.map(slot =>
                     <HistoryRow

--- a/frontend/app/routes/queue/components/list-toolbar/list-toolbar.tsx
+++ b/frontend/app/routes/queue/components/list-toolbar/list-toolbar.tsx
@@ -1,0 +1,64 @@
+import { Input, Select, Button, Icon } from "~/components/ui";
+
+export type SortOption = { value: string; label: string };
+
+export function ListToolbar({
+  label,
+  query,
+  category,
+  status,
+  sort,
+  categories,
+  statuses,
+  sorts,
+  isFiltered,
+  onQueryChange,
+  onCategoryChange,
+  onStatusChange,
+  onSortChange,
+  onClear,
+}: {
+  label: string;
+  query: string;
+  category: string;
+  status: string;
+  sort: string;
+  categories: string[];
+  statuses: SortOption[];
+  sorts: SortOption[];
+  isFiltered: boolean;
+  onQueryChange: (value: string) => void;
+  onCategoryChange: (value: string) => void;
+  onStatusChange: (value: string) => void;
+  onSortChange: (value: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-t border-base-content/10 pt-4">
+      <label className="input input-sm flex min-w-48 flex-1 items-center gap-2">
+        <Icon name="search" className="!text-[18px] text-base-content/50" />
+        <Input
+          type="search"
+          className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 focus:outline-none"
+          value={query}
+          onChange={event => onQueryChange(event.target.value)}
+          aria-label={`Search ${label.toLowerCase()}`}
+          placeholder={`Search ${label.toLowerCase()}`}
+        />
+      </label>
+      <Select className="select-sm" value={category} onChange={event => onCategoryChange(event.target.value)} aria-label={`Filter ${label.toLowerCase()} by category`}>
+        <option value="">All categories</option>
+        {categories.map(value => <option key={value} value={value}>{value}</option>)}
+      </Select>
+      <Select className="select-sm" value={status} onChange={event => onStatusChange(event.target.value)} aria-label={`Filter ${label.toLowerCase()} by status`}>
+        <option value="">All statuses</option>
+        {statuses.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+      </Select>
+      <Select className="select-sm max-[899px]:flex" value={sort} onChange={event => onSortChange(event.target.value)} aria-label={`Sort ${label.toLowerCase()}`}>
+        <option value="">Default order</option>
+        {sorts.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+      </Select>
+      {isFiltered && <Button variant="ghost" size="xsmall" onClick={onClear}>Clear</Button>}
+    </div>
+  );
+}

--- a/frontend/app/routes/queue/components/page-table/page-table.tsx
+++ b/frontend/app/routes/queue/components/page-table/page-table.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from "../status-badge/status-badge";
 import { formatFileSize } from "~/utils/file-size";
 import type { ProviderUsage } from "~/clients/backend-client.server";
 import { Badge } from "~/components/ui";
+import { Icon } from "~/components/ui";
 
 const desktopHeaderClass = "hidden min-[900px]:table-cell w-[120px] text-center text-xs font-semibold uppercase tracking-wide";
 const desktopCellClass = "hidden min-[900px]:table-cell max-w-[200px] min-w-0 overflow-hidden whitespace-nowrap px-1 py-3 text-center align-middle";
@@ -19,9 +20,19 @@ export type PageTableProps = {
     footer?: ReactNode,
     showCompleted?: boolean,
     selectable?: boolean,
+    sort?: string | undefined,
+    direction?: "asc" | "desc" | null | undefined,
+    onSort?: (field: string) => void,
 }
 
-export function PageTable({ children, headerCheckboxState, onHeaderCheckboxChange, footer, showCompleted, selectable = true }: PageTableProps) {
+export function PageTable({ children, headerCheckboxState, onHeaderCheckboxChange, footer, showCompleted, selectable = true, sort, direction, onSort }: PageTableProps) {
+    const sortableHeader = (label: string, field: string, className = desktopHeaderClass) => (
+        <th className={className} aria-sort={sort === field ? (direction === "asc" ? "ascending" : "descending") : "none"}>
+            {onSort ? <button type="button" className="inline-flex items-center gap-1 hover:text-primary" onClick={() => onSort(field)}>
+                {label}<Icon name={sort === field && direction === "asc" ? "arrow_upward" : "arrow_downward"} className={`!text-[14px] ${sort === field ? "" : "opacity-30"}`} />
+            </button> : label}
+        </th>
+    );
     return (
         <div className="-mx-4 overflow-x-auto sm:-mx-6">
             <table className="table table-zebra table-sm mb-0 w-full min-w-0 text-base-content min-[900px]:min-w-[880px]">
@@ -29,15 +40,19 @@ export function PageTable({ children, headerCheckboxState, onHeaderCheckboxChang
                     <tr className="border-base-content/10 [&_th]:bg-base-200 [&_th]:text-base-content/70">
                         <th className="min-[900px]:w-1/2 w-auto py-4 pl-0 text-left text-xs font-semibold uppercase tracking-wide">
                             {selectable
-                                ? <TriCheckbox state={headerCheckboxState} onChange={onHeaderCheckboxChange}>Name</TriCheckbox>
-                                : "Name"}
+                                ? <TriCheckbox state={headerCheckboxState} onChange={onHeaderCheckboxChange}>
+                                    {onSort ? <button type="button" className="inline-flex items-center gap-1 hover:text-primary" onClick={event => { event.stopPropagation(); onSort("name"); }}>
+                                        Name<Icon name={sort === "name" && direction === "asc" ? "arrow_upward" : "arrow_downward"} className={`!text-[14px] ${sort === "name" ? "" : "opacity-30"}`} />
+                                    </button> : "Name"}
+                                </TriCheckbox>
+                                : sortableHeader("Name", "name", "min-[900px]:w-1/2 w-auto py-4 pl-0 text-left text-xs font-semibold uppercase tracking-wide")}
                         </th>
-                        <th className={desktopHeaderClass}>Category</th>
+                        {sortableHeader("Category", "category")}
                         <th className={desktopHeaderClass}>Indexer</th>
                         <th className={desktopHeaderClass}>Provider</th>
-                        <th className={desktopHeaderClass}>Status</th>
-                        <th className={desktopHeaderClass}>Size</th>
-                        {showCompleted && <th className={desktopHeaderClass}>Completed</th>}
+                        {sortableHeader("Status", "status")}
+                        {sortableHeader("Size", "size")}
+                        {showCompleted && sortableHeader("Completed", "completed")}
                         <th className="w-[100px] py-4 text-center text-xs font-semibold">Actions</th>
                     </tr>
                 </thead>

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -10,6 +10,9 @@ import { EmptyQueue } from "../empty-queue/empty-queue"
 import { SimpleDropdown } from "../simple-dropdown/simple-dropdown"
 import { Button, Tooltip } from "~/components/ui"
 import { useIsReadOnly } from "~/auth/authorization"
+import type { QueueListParams } from "../../list-params"
+import { sortValue } from "../../list-params"
+import { ListToolbar } from "../list-toolbar/list-toolbar"
 import {
     canPauseQueueSlot,
     canResumeQueueSlot,
@@ -37,6 +40,12 @@ export type QueueTableProps = {
     onRemoved: (nzo_ids: Set<string>) => void,
     onMovedToTop: (nzo_ids: Set<string>) => void,
     onUploadClicked?: () => void;
+    listParams: QueueListParams,
+    searchDraft: string,
+    onSearchDraftChange: (value: string) => void,
+    onFilterChange: (key: string, value: string) => void,
+    onClearFilters: () => void,
+    onSort: (field: string) => void,
 }
 
 async function moveQueueItemsToTop(nzoIds: string[]): Promise<boolean> {
@@ -76,6 +85,12 @@ export function QueueTable({
     onRemoved,
     onMovedToTop,
     onUploadClicked,
+    listParams,
+    searchDraft,
+    onSearchDraftChange,
+    onFilterChange,
+    onClearFilters,
+    onSort,
 }: QueueTableProps) {
     const isReadOnly = useIsReadOnly();
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
@@ -292,6 +307,22 @@ export function QueueTable({
             subTitle={sectionSubTitle}
             {...(totalQueueCount > 0 ? { badgeText: String(totalQueueCount) } : {})}
         >
+            <ListToolbar
+                label="Queue"
+                query={searchDraft}
+                category={listParams.category}
+                status={listParams.status}
+                sort={sortValue(listParams)}
+                categories={categories}
+                statuses={[{ value: "Downloading", label: "Downloading" }, { value: "Queued", label: "Queued" }, { value: "Paused", label: "Paused" }]}
+                sorts={[{ value: "name:asc", label: "Name A–Z" }, { value: "name:desc", label: "Name Z–A" }, { value: "size:desc", label: "Size largest" }, { value: "size:asc", label: "Size smallest" }, { value: "status:asc", label: "Status" }, { value: "category:asc", label: "Category" }]}
+                isFiltered={!!(listParams.query || listParams.category || listParams.status || listParams.sort)}
+                onQueryChange={onSearchDraftChange}
+                onCategoryChange={value => onFilterChange("qcat", value)}
+                onStatusChange={value => onFilterChange("qstatus", value)}
+                onSortChange={value => onFilterChange("qsort", value)}
+                onClear={onClearFilters}
+            />
             {queueSlots?.length == 0 ? (
                 <EmptyQueue {...(!isReadOnly && onUploadClicked ? { onUploadClicked } : {})} />
             ) : (
@@ -300,6 +331,9 @@ export function QueueTable({
                     onHeaderCheckboxChange={onSelectAll}
                     footer={footer}
                     selectable={!isReadOnly}
+                    sort={listParams.sort ?? undefined}
+                    direction={listParams.direction}
+                    onSort={onSort}
                 >
                     {queueSlots.map(slot =>
                         <QueueRow

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { HistoryEvents, QueueEvents } from "./events-controller";
 import { adjustTotalCount } from "./events-controller";
 import type { HistorySlot, QueueSlot } from "~/clients/backend-client.server";
@@ -33,39 +33,59 @@ export function useQueueHistoryWebsocket(
     isHistoryLive: boolean,
     setTotalQueueCount: (value: React.SetStateAction<number>) => void,
     setTotalHistoryCount: (value: React.SetStateAction<number>) => void,
+    onDeferredRefresh: () => void,
 ) {
+    const refreshTimer = useRef<number | undefined>(undefined);
+    const scheduleRefresh = useCallback(() => {
+        if (refreshTimer.current !== undefined) window.clearTimeout(refreshTimer.current);
+        refreshTimer.current = window.setTimeout(() => {
+            refreshTimer.current = undefined;
+            onDeferredRefresh();
+        }, 350);
+    }, [onDeferredRefresh]);
+    useEffect(() => () => {
+        if (refreshTimer.current !== undefined) window.clearTimeout(refreshTimer.current);
+    }, []);
+
     const onWebsocketMessage = useCallback((topic: string, message: string) => {
         if (topic == topicNames.queueItemAdded) {
             // Totals always; slot window only on live page 1.
             // Count updates live here (not in UI handlers) so optimistic UI remove + qr
             // do not double-decrement.
-            setTotalQueueCount(count => adjustTotalCount(count, 1));
+            if (isQueueLive) setTotalQueueCount(count => adjustTotalCount(count, 1));
             // 'qa' websocket payload carries a JSON-serialized QueueSlot (backend contract)
             if (isQueueLive) queueEvents.onAddQueueSlot(JSON.parse(message) as QueueSlot);
+            else scheduleRefresh();
         }
         else if (topic == topicNames.queueItemRemoved) {
             const ids = message.split(',').filter(Boolean);
-            setTotalQueueCount(count => adjustTotalCount(count, -ids.length));
+            if (isQueueLive) setTotalQueueCount(count => adjustTotalCount(count, -ids.length));
             if (isQueueLive) queueEvents.onRemoveQueueSlots(new Set<string>(ids));
+            else scheduleRefresh();
         }
         else if (topic == topicNames.queueItemMoved) {
             queueEvents.onMoveQueueSlotsToTop(new Set<string>(message.split(',').filter(Boolean)));
+            if (!isQueueLive) scheduleRefresh();
         }
-        else if (topic == topicNames.queueItemStatus)
+        else if (topic == topicNames.queueItemStatus) {
             queueEvents.onChangeQueueSlotStatus(message);
+            if (!isQueueLive) scheduleRefresh();
+        }
         else if (topic == topicNames.queueItemPercentage)
             queueEvents.onChangeQueueSlotPercentage(message);
         else if (topic == topicNames.queueItemProviders)
             queueEvents.onChangeQueueSlotProviders(message);
         else if (topic == topicNames.historyItemAdded) {
-            setTotalHistoryCount(count => adjustTotalCount(count, 1));
+            if (isHistoryLive) setTotalHistoryCount(count => adjustTotalCount(count, 1));
             // 'ha' websocket payload carries a JSON-serialized HistorySlot (backend contract)
             if (isHistoryLive) historyEvents.onAddHistorySlot(JSON.parse(message) as HistorySlot);
+            else scheduleRefresh();
         }
         else if (topic == topicNames.historyItemRemoved) {
             const ids = message.split(',').filter(Boolean);
-            setTotalHistoryCount(count => adjustTotalCount(count, -ids.length));
+            if (isHistoryLive) setTotalHistoryCount(count => adjustTotalCount(count, -ids.length));
             if (isHistoryLive) historyEvents.onRemoveHistorySlots(new Set<string>(ids));
+            else scheduleRefresh();
         }
     }, [
         queueEvents,
@@ -74,6 +94,7 @@ export function useQueueHistoryWebsocket(
         isHistoryLive,
         setTotalQueueCount,
         setTotalHistoryCount,
+        scheduleRefresh,
     ]);
 
     useWebsocketTopics(topicSubscriptions, onWebsocketMessage);

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -49,9 +49,8 @@ export function useQueueHistoryWebsocket(
 
     const onWebsocketMessage = useCallback((topic: string, message: string) => {
         if (topic == topicNames.queueItemAdded) {
-            // Totals always; slot window only on live page 1.
-            // Count updates live here (not in UI handlers) so optimistic UI remove + qr
-            // do not double-decrement.
+            // The immediate page-1 view updates its count and slot window locally.
+            // Other views refresh from the server so their filtered count stays correct.
             if (isQueueLive) setTotalQueueCount(count => adjustTotalCount(count, 1));
             // 'qa' websocket payload carries a JSON-serialized QueueSlot (backend contract)
             if (isQueueLive) queueEvents.onAddQueueSlot(JSON.parse(message) as QueueSlot);

--- a/frontend/app/routes/queue/list-params.ts
+++ b/frontend/app/routes/queue/list-params.ts
@@ -1,0 +1,55 @@
+export type SortDirection = "asc" | "desc";
+export type QueueSortField = "name" | "category" | "status" | "size";
+export type HistorySortField = QueueSortField | "completed";
+
+export type ListParams<TSort extends string> = {
+  query: string;
+  category: string;
+  status: string;
+  sort: TSort | null;
+  direction: SortDirection | null;
+};
+
+export type QueueListParams = ListParams<QueueSortField>;
+export type HistoryListParams = ListParams<HistorySortField>;
+
+const queueSorts = new Set<QueueSortField>(["name", "category", "status", "size"]);
+const historySorts = new Set<HistorySortField>(["name", "category", "status", "size", "completed"]);
+
+function parseSort<TSort extends string>(value: string | null, supported: Set<TSort>): Pick<ListParams<TSort>, "sort" | "direction"> {
+  if (!value) return { sort: null, direction: null };
+  const [field, direction] = value.split(":");
+  if (!field || !supported.has(field as TSort) || (direction !== "asc" && direction !== "desc")) {
+    return { sort: null, direction: null };
+  }
+  return { sort: field as TSort, direction };
+}
+
+function parseList<TSort extends string>(
+  searchParams: URLSearchParams,
+  keys: { query: string; category: string; status: string; sort: string },
+  supported: Set<TSort>,
+): ListParams<TSort> {
+  return {
+    query: searchParams.get(keys.query)?.trim() ?? "",
+    category: searchParams.get(keys.category)?.trim() ?? "",
+    status: searchParams.get(keys.status)?.trim() ?? "",
+    ...parseSort(searchParams.get(keys.sort), supported),
+  };
+}
+
+export function parseQueueListParams(searchParams: URLSearchParams): QueueListParams {
+  return parseList(searchParams, { query: "qq", category: "qcat", status: "qstatus", sort: "qsort" }, queueSorts);
+}
+
+export function parseHistoryListParams(searchParams: URLSearchParams): HistoryListParams {
+  return parseList(searchParams, { query: "hq", category: "hcat", status: "hstatus", sort: "hsort" }, historySorts);
+}
+
+export function isDefaultList(params: ListParams<string>): boolean {
+  return !params.query && !params.category && !params.status && !params.sort;
+}
+
+export function sortValue(params: ListParams<string>): string {
+  return params.sort && params.direction ? `${params.sort}:${params.direction}` : "";
+}

--- a/frontend/app/routes/queue/route.test.ts
+++ b/frontend/app/routes/queue/route.test.ts
@@ -73,8 +73,12 @@ describe("queue route loader", () => {
 
     const result = await loader(loaderRequest("?qp=2&hp=3&qps=25&hps=250"));
 
-    expect(getQueueMock).toHaveBeenCalledWith(25, 25);
-    expect(getHistoryMock).toHaveBeenCalledWith(250, 500);
+    expect(getQueueMock).toHaveBeenCalledWith(25, 25, {
+      search: "", category: "", status: "", sort: undefined, direction: undefined,
+    });
+    expect(getHistoryMock).toHaveBeenCalledWith(250, 500, {
+      search: "", category: "", status: "", sort: undefined, direction: undefined,
+    });
     expect(getConfigMock).toHaveBeenCalledWith([
       "api.categories",
       "api.manual-category",
@@ -90,6 +94,8 @@ describe("queue route loader", () => {
       historyPage: 3,
       queuePageSize: 25,
       historyPageSize: 250,
+      queueParams: { query: "", category: "", status: "", sort: null, direction: null },
+      historyParams: { query: "", category: "", status: "", sort: null, direction: null },
     });
   });
 
@@ -100,8 +106,12 @@ describe("queue route loader", () => {
 
     const result = await loader(loaderRequest("?qp=0&hp=invalid&qps=10&hps=999"));
 
-    expect(getQueueMock).toHaveBeenCalledWith(100, 0);
-    expect(getHistoryMock).toHaveBeenCalledWith(100, 0);
+    expect(getQueueMock).toHaveBeenCalledWith(100, 0, {
+      search: "", category: "", status: "", sort: undefined, direction: undefined,
+    });
+    expect(getHistoryMock).toHaveBeenCalledWith(100, 0, {
+      search: "", category: "", status: "", sort: undefined, direction: undefined,
+    });
     expect(result).toMatchObject({
       queueSlots: [],
       historySlots: [],
@@ -113,6 +123,21 @@ describe("queue route loader", () => {
       historyPage: 1,
       queuePageSize: 100,
       historyPageSize: 100,
+    });
+  });
+
+  it("passes independent queue and history filters to the server", async () => {
+    getQueueMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getHistoryMock.mockResolvedValueOnce({ slots: [], noofslots: 0 });
+    getConfigMock.mockResolvedValueOnce([]);
+
+    await loader(loaderRequest("?qq=show&qcat=tv&qstatus=Paused&qsort=size:desc&hq=film&hcat=movies&hstatus=Failed&hsort=completed:asc"));
+
+    expect(getQueueMock).toHaveBeenCalledWith(100, 0, {
+      search: "show", category: "tv", status: "Paused", sort: "size", direction: "desc",
+    });
+    expect(getHistoryMock).toHaveBeenCalledWith(100, 0, {
+      search: "film", category: "movies", status: "Failed", sort: "completed", direction: "asc",
     });
   });
 

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router";
+import { useRevalidator, useSearchParams } from "react-router";
 import type { Route } from "./+types/route";
 import { backendClient, type HistorySlot, type QueueSlot } from "~/clients/backend-client.server";
 import { HistoryTable } from "./components/history-table/history-table";
@@ -10,6 +10,7 @@ import { useUploadController } from "./controllers/nzb-upload-controller";
 import { useQueueDropzone } from "./controllers/dropzone-controller";
 import { Alert } from "~/components/ui";
 import { useIsReadOnly } from "~/auth/authorization";
+import { isDefaultList, parseHistoryListParams, parseQueueListParams } from "./list-params";
 
 export const PAGE_SIZE_OPTIONS = [25, 50, 100, 250] as const;
 const DEFAULT_PAGE_SIZE = 100;
@@ -30,9 +31,17 @@ export async function loader({ request }: Route.LoaderArgs) {
     const historyPage = parsePage(url.searchParams.get("hp"));
     const queuePageSize = parsePageSize(url.searchParams.get("qps"));
     const historyPageSize = parsePageSize(url.searchParams.get("hps"));
+    const queueParams = parseQueueListParams(url.searchParams);
+    const historyParams = parseHistoryListParams(url.searchParams);
     const [queue, history, config] = await Promise.all([
-        backendClient.getQueue(queuePageSize, (queuePage - 1) * queuePageSize),
-        backendClient.getHistory(historyPageSize, (historyPage - 1) * historyPageSize),
+        backendClient.getQueue(queuePageSize, (queuePage - 1) * queuePageSize, {
+            search: queueParams.query, category: queueParams.category, status: queueParams.status,
+            sort: queueParams.sort ?? undefined, direction: queueParams.direction ?? undefined,
+        }),
+        backendClient.getHistory(historyPageSize, (historyPage - 1) * historyPageSize, {
+            search: historyParams.query, category: historyParams.category, status: historyParams.status,
+            sort: historyParams.sort ?? undefined, direction: historyParams.direction ?? undefined,
+        }),
         backendClient.getConfig(["api.categories", "api.manual-category"]),
     ]);
     const categoriesValue = config
@@ -57,12 +66,14 @@ export async function loader({ request }: Route.LoaderArgs) {
         historyPage: historyPage,
         queuePageSize,
         historyPageSize,
+        queueParams,
+        historyParams,
     };
 }
 
 export default function Queue(props: Route.ComponentProps) {
     const isReadOnly = useIsReadOnly();
-    const { queuePageSize, historyPageSize, queuePage, historyPage } = props.loaderData;
+    const { queuePageSize, historyPageSize, queuePage, historyPage, queueParams, historyParams } = props.loaderData;
     const [queueSlots, setQueueSlots] = useState<PresentationQueueSlot[]>(props.loaderData.queueSlots);
     const [historySlots, setHistorySlots] = useState<PresentationHistorySlot[]>(props.loaderData.historySlots);
     const [totalQueueCount, setTotalQueueCount] = useState(props.loaderData.totalQueueCount);
@@ -72,16 +83,49 @@ export default function Queue(props: Route.ComponentProps) {
     const manualCategoryRef = useRef<string>(props.loaderData.manualCategory);
     const isUploadingRef = useRef(false);
     const [, setSearchParams] = useSearchParams();
+    const revalidator = useRevalidator();
+    const [queueQueryDraft, setQueueQueryDraft] = useState(queueParams.query);
+    const [historyQueryDraft, setHistoryQueryDraft] = useState(historyParams.query);
 
-    useEffect(() => { setQueueSlots(props.loaderData.queueSlots); }, [props.loaderData.queueSlots]);
-    useEffect(() => { setHistorySlots(props.loaderData.historySlots); }, [props.loaderData.historySlots]);
+    useEffect(() => { setQueueSlots(previous => mergePresentationSlots(props.loaderData.queueSlots, previous)); }, [props.loaderData.queueSlots]);
+    useEffect(() => { setHistorySlots(previous => mergePresentationSlots(props.loaderData.historySlots, previous)); }, [props.loaderData.historySlots]);
     useEffect(() => { setTotalQueueCount(props.loaderData.totalQueueCount); }, [props.loaderData.totalQueueCount]);
     useEffect(() => { setTotalHistoryCount(props.loaderData.totalHistoryCount); }, [props.loaderData.totalHistoryCount]);
 
     const queueTotalPages = Math.max(1, Math.ceil(totalQueueCount / queuePageSize));
     const historyTotalPages = Math.max(1, Math.ceil(totalHistoryCount / historyPageSize));
-    const isQueueLive = queuePage === 1;
-    const isHistoryLive = historyPage === 1;
+    useEffect(() => { setQueueQueryDraft(queueParams.query); }, [queueParams.query]);
+    useEffect(() => { setHistoryQueryDraft(historyParams.query); }, [historyParams.query]);
+    const isQueueLive = queuePage === 1 && isDefaultList(queueParams);
+    const isHistoryLive = historyPage === 1 && isDefaultList(historyParams);
+
+    const updateListParams = useCallback((kind: "queue" | "history", mutator: (params: URLSearchParams) => void) => {
+        const pageKey = kind === "queue" ? "qp" : "hp";
+        setSearchParams(previous => {
+            const next = new URLSearchParams(previous);
+            mutator(next);
+            next.set(pageKey, "1");
+            return next;
+        }, { preventScrollReset: true });
+    }, [setSearchParams]);
+
+    const setQueueParam = useCallback((key: string, value: string) => updateListParams("queue", params => {
+        if (value) params.set(key, value); else params.delete(key);
+    }), [updateListParams]);
+    const setHistoryParam = useCallback((key: string, value: string) => updateListParams("history", params => {
+        if (value) params.set(key, value); else params.delete(key);
+    }), [updateListParams]);
+
+    useEffect(() => {
+        if (queueQueryDraft.trim() === queueParams.query) return;
+        const timer = window.setTimeout(() => setQueueParam("qq", queueQueryDraft.trim()), 300);
+        return () => window.clearTimeout(timer);
+    }, [queueQueryDraft, queueParams.query, setQueueParam]);
+    useEffect(() => {
+        if (historyQueryDraft.trim() === historyParams.query) return;
+        const timer = window.setTimeout(() => setHistoryParam("hq", historyQueryDraft.trim()), 300);
+        return () => window.clearTimeout(timer);
+    }, [historyQueryDraft, historyParams.query, setHistoryParam]);
 
     const setPageParam = useCallback((key: string, page: number) => {
         setSearchParams(prev => {
@@ -92,6 +136,13 @@ export default function Queue(props: Route.ComponentProps) {
     }, [setSearchParams]);
     const onQueuePageSelected = useCallback((page: number) => setPageParam("qp", page), [setPageParam]);
     const onHistoryPageSelected = useCallback((page: number) => setPageParam("hp", page), [setPageParam]);
+
+    useEffect(() => {
+        if (queuePage > queueTotalPages) onQueuePageSelected(queueTotalPages);
+    }, [queuePage, queueTotalPages, onQueuePageSelected]);
+    useEffect(() => {
+        if (historyPage > historyTotalPages) onHistoryPageSelected(historyTotalPages);
+    }, [historyPage, historyTotalPages, onHistoryPageSelected]);
 
     const setPageSizeParam = useCallback((sizeKey: string, pageKey: string, size: number) => {
         setSearchParams(prev => {
@@ -110,9 +161,7 @@ export default function Queue(props: Route.ComponentProps) {
         [setPageSizeParam],
     );
 
-    const combinedQueueSlots = isQueueLive
-        ? [...uploadingFiles.map(file => file.queueSlot), ...queueSlots]
-        : queueSlots;
+    const combinedQueueSlots = [...uploadingFiles.map(file => file.queueSlot), ...queueSlots];
 
     // queue/history events
     const queueEvents = useQueueEvents(setUploadingFiles, setQueueSlots, uploadQueueRef, queuePageSize, isQueueLive);
@@ -126,6 +175,7 @@ export default function Queue(props: Route.ComponentProps) {
         isHistoryLive,
         setTotalQueueCount,
         setTotalHistoryCount,
+        () => revalidator.revalidate(),
     );
 
     // uploads
@@ -155,6 +205,12 @@ export default function Queue(props: Route.ComponentProps) {
                         pageSizeOptions={PAGE_SIZE_OPTIONS}
                         totalPages={queueTotalPages}
                         isLive={isQueueLive}
+                        listParams={queueParams}
+                        searchDraft={queueQueryDraft}
+                        onSearchDraftChange={setQueueQueryDraft}
+                        onFilterChange={(key, value) => setQueueParam(key, value)}
+                        onClearFilters={() => updateListParams("queue", params => ["qq", "qcat", "qstatus", "qsort"].forEach(key => params.delete(key)))}
+                        onSort={(field) => setQueueParam("qsort", nextSortValue(queueParams, field))}
                         onPageSelected={onQueuePageSelected}
                         onPageSizeSelected={onQueuePageSizeSelected}
                         categories={props.loaderData.categories}
@@ -169,7 +225,7 @@ export default function Queue(props: Route.ComponentProps) {
             </div>
 
             {/* history */}
-            {(totalHistoryCount > 0 || historySlots.length > 0) &&
+            {(totalHistoryCount > 0 || historySlots.length > 0 || !isDefaultList(historyParams)) &&
                 <HistoryTable
                     historySlots={historySlots}
                     totalHistoryCount={totalHistoryCount}
@@ -178,6 +234,13 @@ export default function Queue(props: Route.ComponentProps) {
                     pageSizeOptions={PAGE_SIZE_OPTIONS}
                     totalPages={historyTotalPages}
                     isLive={isHistoryLive}
+                    categories={props.loaderData.categories}
+                    listParams={historyParams}
+                    searchDraft={historyQueryDraft}
+                    onSearchDraftChange={setHistoryQueryDraft}
+                    onFilterChange={(key, value) => setHistoryParam(key, value)}
+                    onClearFilters={() => updateListParams("history", params => ["hq", "hcat", "hstatus", "hsort"].forEach(key => params.delete(key)))}
+                    onSort={(field) => setHistoryParam("hsort", nextSortValue(historyParams, field))}
                     onPageSelected={onHistoryPageSelected}
                     onPageSizeSelected={onHistoryPageSizeSelected}
                     onIsSelectedChanged={historyEvents.onSelectHistorySlots}
@@ -187,6 +250,22 @@ export default function Queue(props: Route.ComponentProps) {
             }
         </div >
     );
+}
+
+function nextSortValue(params: { sort: string | null, direction: "asc" | "desc" | null }, field: string): string {
+    if (params.sort !== field) return `${field}:asc`;
+    return params.direction === "asc" ? `${field}:desc` : "";
+}
+
+function mergePresentationSlots<T extends { nzo_id: string, isSelected?: boolean, isRemoving?: boolean }>(
+    loaded: T[],
+    previous: T[],
+): T[] {
+    const flags = new Map(previous.map(row => [row.nzo_id, {
+        isSelected: row.isSelected,
+        isRemoving: row.isRemoving,
+    }]));
+    return loaded.map(row => ({ ...row, ...flags.get(row.nzo_id) }));
 }
 
 export type PresentationHistorySlot = HistorySlot & {

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -168,6 +168,7 @@ export default function Queue(props: Route.ComponentProps) {
     const historyEvents = useHistoryEvents(setHistorySlots, historyPageSize);
 
     // websocket
+    const revalidate = useCallback(() => revalidator.revalidate(), [revalidator.revalidate]);
     useQueueHistoryWebsocket(
         queueEvents,
         historyEvents,
@@ -175,7 +176,7 @@ export default function Queue(props: Route.ComponentProps) {
         isHistoryLive,
         setTotalQueueCount,
         setTotalHistoryCount,
-        () => revalidator.revalidate(),
+        revalidate,
     );
 
     // uploads

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -168,7 +168,9 @@ export default function Queue(props: Route.ComponentProps) {
     const historyEvents = useHistoryEvents(setHistorySlots, historyPageSize);
 
     // websocket
-    const revalidate = useCallback(() => revalidator.revalidate(), [revalidator.revalidate]);
+    const revalidate = useCallback((): void => {
+        void revalidator.revalidate();
+    }, [revalidator]);
     useQueueHistoryWebsocket(
         queueEvents,
         historyEvents,

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -204,6 +204,19 @@ public class GetHistoryRequestTests
         Assert.Equal(100_000, clamped.GetHistoryMaxPageSize());
     }
 
+    [Fact]
+    public void FailedOnlyOverridesHistoryStatusAndParsesSort()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?status=Completed&failed_only=1&sort=completed&dir=asc");
+
+        var request = new GetHistoryRequest(context, CreateConfig(ignoreLimit: true));
+
+        Assert.Equal(HistoryItem.DownloadStatusOption.Failed, request.Status);
+        Assert.Equal("completed", request.Sort);
+        Assert.Equal("asc", request.Direction);
+    }
+
     private static ConfigManager CreateConfig(bool ignoreLimit, string? maxPageSize = null)
     {
         var items = new List<ConfigItem>

--- a/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
@@ -53,4 +53,18 @@ public class GetQueueRequestTests
         var ex = Assert.Throws<BadHttpRequestException>(() => new GetQueueRequest(context, new ConfigManager()));
         Assert.Equal("Invalid limit parameter", ex.Message);
     }
+
+    [Fact]
+    public void ParsesListFiltersAndDisplaySort()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?search=The%20Show&status=paused&sort=name&dir=asc");
+
+        var request = new GetQueueRequest(context, new ConfigManager());
+
+        Assert.Equal("The Show", request.Search);
+        Assert.Equal("Paused", request.Status);
+        Assert.Equal("name", request.Sort);
+        Assert.Equal("asc", request.Direction);
+    }
 }


### PR DESCRIPTION
## Summary
- add server-paginated queue and history search, category/status filters, and display sorting
- persist independent table controls in the URL and keep filtered views refreshed from websocket activity
- document the supported SAB listing extensions and cover request/client wiring

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`