### PR TITLE
feat(queue): reorder waiting jobs with up/down controls

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -138,11 +138,25 @@ public class AddFileController(
                     exception);
             }
 
+            // Keep enqueues after any manually moved item in their priority band.
+            // CreatedAt remains the immutable enqueue timestamp; SortOrder owns
+            // user-directed positioning.
+            var createdAt = DateTime.Now;
+            var bandMax = await dbClient.Ctx.QueueItems
+                .Where(item => item.Priority == request.Priority)
+                .Select(item => (long?)item.SortOrder)
+                .MaxAsync(request.CancellationToken)
+                .ConfigureAwait(false) ?? 0;
+            var sortOrder = Math.Max(
+                createdAt.Ticks,
+                checked(bandMax + QueueItem.SortOrderStride));
+
             // create the queue item record
             queueItem = new QueueItem
             {
                 Id = id,
-                CreatedAt = DateTime.Now,
+                CreatedAt = createdAt,
+                SortOrder = sortOrder,
                 FileName = request.FileName,
                 JobName = FilenameUtil.GetJobName(request.FileName),
                 NzbFileSize = nzbFileStream.Length,
@@ -198,7 +212,13 @@ public class AddFileController(
         }
 
         // inform the frontend that a new item was added to the queue
-        var message = GetQueueResponse.QueueSlot.FromQueueItem(queueItem).ToJson();
+        var activeIds = queueManager.GetInProgressQueueItems()
+            .Select(item => item.QueueItem.Id)
+            .ToList();
+        var position = await dbClient
+            .GetQueueItemPositionAsync(queueItem.Id, activeIds, request.CancellationToken)
+            .ConfigureAwait(false);
+        var message = GetQueueResponse.QueueSlot.FromQueueItem(queueItem, Math.Max(0, position)).ToJson();
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemAdded, message);
 
         // awaken the queue if it is sleeping

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -212,13 +212,7 @@ public class AddFileController(
         }
 
         // inform the frontend that a new item was added to the queue
-        var activeIds = queueManager.GetInProgressQueueItems()
-            .Select(item => item.QueueItem.Id)
-            .ToList();
-        var position = await dbClient
-            .GetQueueItemPositionAsync(queueItem.Id, activeIds, request.CancellationToken)
-            .ConfigureAwait(false);
-        var message = GetQueueResponse.QueueSlot.FromQueueItem(queueItem, Math.Max(0, position)).ToJson();
+        var message = GetQueueResponse.QueueSlot.FromQueueItem(queueItem).ToJson();
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemAdded, message);
 
         // awaken the queue if it is sleeping

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -117,7 +117,7 @@ public class GetQueueController(
                     providerUsage = mergedUsage;
                 }
                 return GetQueueResponse.QueueSlot.FromQueueItem(
-                    queueItem, index, percentage, status, eta, providerUsage, displayByMetricsKey);
+                    queueItem, request.Start + index, percentage, status, eta, providerUsage, displayByMetricsKey);
             })
             .ToList();
 

--- a/backend/Api/SabControllers/MoveInQueue/MoveInQueueController.cs
+++ b/backend/Api/SabControllers/MoveInQueue/MoveInQueueController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Queue;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Api.SabControllers.MoveInQueue;
@@ -10,6 +11,7 @@ public class MoveInQueueController(
     HttpContext httpContext,
     DavDatabaseClient dbClient,
     ConfigManager configManager,
+    QueueManager queueManager,
     WebsocketManager websocketManager
 ) : SabApiController.BaseController(httpContext, configManager)
 {
@@ -21,8 +23,8 @@ public class MoveInQueueController(
         if (!request.MoveToTop)
             throw new BadHttpRequestException("Only move-to-top is supported.");
 
-        var movedIds = await dbClient
-            .MoveQueueItemsToTopAsync(request.NzoIds, request.CancellationToken)
+        var movedIds = await queueManager
+            .MoveQueueItemsToTopAsync(request.NzoIds, dbClient, request.CancellationToken)
             .ConfigureAwait(false);
 
         if (movedIds.Count > 0)

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -20,6 +20,7 @@ using NzbWebDAV.Api.SabControllers.SetQueueCategory;
 using NzbWebDAV.Api.SabControllers.SetQueuePriority;
 using NzbWebDAV.Api.SabControllers.RetryHistory;
 using NzbWebDAV.Api.SabControllers.SpeedLimit;
+using NzbWebDAV.Api.SabControllers.SwitchQueue;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -121,7 +122,7 @@ public class SabApiController(
                     HttpContext, dbClient, queueManager, configManager, websocketManager);
             case "queue" when HttpContext.GetRequestParam("name") == "move":
                 return new MoveInQueueController(
-                    HttpContext, dbClient, configManager, websocketManager);
+                    HttpContext, dbClient, configManager, queueManager, websocketManager);
             case "queue" when HttpContext.GetRequestParam("name") == "priority":
                 return new SetQueuePriorityController(
                     HttpContext, dbClient, configManager, queueManager, websocketManager);
@@ -132,6 +133,10 @@ public class SabApiController(
             case "queue":
                 return new GetQueueController(
                     HttpContext, dbClient, queueManager, configManager, providerUsageTracker);
+
+            case "switch":
+                return new SwitchQueueController(
+                    HttpContext, dbClient, configManager, queueManager, websocketManager);
 
             case "history" when HttpContext.GetRequestParam("name") == "delete":
                 return new RemoveFromHistoryController(

--- a/backend/Api/SabControllers/SwitchQueue/SwitchQueueController.cs
+++ b/backend/Api/SabControllers/SwitchQueue/SwitchQueueController.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.SabControllers.SwitchQueue;
+
+public sealed class SwitchQueueController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    ConfigManager configManager,
+    QueueManager queueManager,
+    WebsocketManager websocketManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<SwitchQueueResponse> SwitchAsync(SwitchQueueRequest request)
+    {
+        var result = await queueManager
+            .SwitchQueueItemAsync(request.SourceId, request.Target, dbClient, request.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.Position >= 0)
+            _ = websocketManager.SendMessage(
+                WebsocketTopic.QueueOrderChanged, $"{request.SourceId}|{result.Position}");
+
+        return new SwitchQueueResponse
+        {
+            Result = new SwitchQueueResponse.ResultObject
+            {
+                Position = result.Position,
+                Priority = result.Priority,
+            },
+        };
+    }
+
+    protected override Task<IActionResult> Handle()
+    {
+        var request = SwitchQueueRequest.New(Context);
+        return HandleAsync(request);
+    }
+
+    private async Task<IActionResult> HandleAsync(SwitchQueueRequest request) =>
+        Ok(await SwitchAsync(request).ConfigureAwait(false));
+}

--- a/backend/Api/SabControllers/SwitchQueue/SwitchQueueRequest.cs
+++ b/backend/Api/SabControllers/SwitchQueue/SwitchQueueRequest.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.SabControllers.SwitchQueue;
+
+public sealed class SwitchQueueRequest
+{
+    public Guid SourceId { get; init; }
+    public string Target { get; init; } = "";
+    public CancellationToken CancellationToken { get; init; }
+
+    public static SwitchQueueRequest New(HttpContext context)
+    {
+        var value = context.GetRequestParam("value");
+        var value2 = context.GetRequestParam("value2");
+        if (!Guid.TryParse(value, out var sourceId) || string.IsNullOrWhiteSpace(value2))
+            throw new BadHttpRequestException("Switch expects two parameters.");
+
+        return new SwitchQueueRequest
+        {
+            SourceId = sourceId,
+            Target = value2,
+            CancellationToken = context.RequestAborted,
+        };
+    }
+}

--- a/backend/Api/SabControllers/SwitchQueue/SwitchQueueResponse.cs
+++ b/backend/Api/SabControllers/SwitchQueue/SwitchQueueResponse.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.SabControllers.SwitchQueue;
+
+public sealed class SwitchQueueResponse
+{
+    [JsonPropertyName("result")]
+    public ResultObject Result { get; init; } = new();
+
+    public sealed class ResultObject
+    {
+        [JsonPropertyName("position")]
+        public int Position { get; init; }
+
+        [JsonPropertyName("priority")]
+        public int Priority { get; init; }
+    }
+}

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -185,7 +185,9 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var nowTime = DateTime.Now;
         var query = Ctx.QueueItems
             .OrderByDescending(q => q.Priority)
+            .ThenBy(q => q.SortOrder)
             .ThenBy(q => q.CreatedAt)
+            .ThenBy(q => q.Id)
             .Where(q => q.PauseUntil == null || nowTime >= q.PauseUntil)
             .Where(q => q.Priority != QueueItem.PriorityOption.Paused);
 
@@ -244,7 +246,9 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         return queueItems
             .AsNoTracking()
             .OrderByDescending(q => q.Priority)
+            .ThenBy(q => q.SortOrder)
             .ThenBy(q => q.CreatedAt)
+            .ThenBy(q => q.Id)
             .Skip(start)
             .Take(limit)
             .ToArrayAsync(cancellationToken: ct);
@@ -256,6 +260,17 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             ? Ctx.QueueItems.Where(q => q.Category == category)
             : Ctx.QueueItems;
         return queueItems.CountAsync(cancellationToken: ct);
+    }
+
+    public async Task<int> GetQueueItemPositionAsync(
+        Guid id,
+        IReadOnlyCollection<Guid> activeIds,
+        CancellationToken ct = default)
+    {
+        var items = await GetQueueItems(null, ct: ct).ConfigureAwait(false);
+        var queued = items.Where(item => !activeIds.Contains(item.Id)).ToList();
+        var position = queued.FindIndex(item => item.Id == id);
+        return position < 0 ? -1 : activeIds.Count + position;
     }
 
     public async Task RemoveQueueItemsAsync(List<Guid> ids, CancellationToken ct = default)
@@ -278,19 +293,22 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     /// <summary>
     /// Moves the given queue items to the front of the queue by setting
     /// <see cref="QueueItem.PriorityOption.Force"/> and assigning earlier
-    /// <see cref="QueueItem.CreatedAt"/> values. Preserves the relative order
+    /// persistent sort-order values. Preserves the relative order
     /// of <paramref name="ids"/> (first id becomes the absolute top among
     /// moved items). Does not preempt an already in-progress download.
     /// </summary>
     /// <returns>The ids that were actually updated (unknown ids are skipped).</returns>
-    public async Task<List<Guid>> MoveQueueItemsToTopAsync(List<Guid> ids, CancellationToken ct = default)
+    public async Task<List<Guid>> MoveQueueItemsToTopAsync(
+        List<Guid> ids,
+        IReadOnlyCollection<Guid>? excludedIds = null,
+        CancellationToken ct = default)
     {
         if (ids.Count == 0)
             return [];
 
         var idSet = ids.ToHashSet();
         var items = await Ctx.QueueItems
-            .Where(q => idSet.Contains(q.Id))
+            .Where(q => idSet.Contains(q.Id) && (excludedIds == null || !excludedIds.Contains(q.Id)))
             .ToListAsync(ct)
             .ConfigureAwait(false);
         if (items.Count == 0)
@@ -300,20 +318,98 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var ordered = ids.Where(byId.ContainsKey).Distinct().ToList();
 
         var earliest = await Ctx.QueueItems
-            .MinAsync(q => q.CreatedAt, ct)
-            .ConfigureAwait(false);
+            .Where(q => q.Priority == QueueItem.PriorityOption.Force)
+            .Select(q => (long?)q.SortOrder)
+            .MinAsync(ct)
+            .ConfigureAwait(false) ?? 0;
         // Place moved items strictly before every other queue item.
-        var baseTime = earliest.AddTicks(-ordered.Count);
+        var baseOrder = earliest - QueueItem.SortOrderStride * ordered.Count;
 
         for (var i = 0; i < ordered.Count; i++)
         {
             var item = byId[ordered[i]];
             item.Priority = QueueItem.PriorityOption.Force;
-            item.CreatedAt = baseTime.AddTicks(i);
+            item.SortOrder = baseOrder + QueueItem.SortOrderStride * i;
+            item.PauseUntil = null;
         }
 
         await Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
         return ordered;
+    }
+
+    public sealed record QueueSwitchResult(int Position, int Priority)
+    {
+        public static readonly QueueSwitchResult NotMoved = new(-1, 0);
+    }
+
+    /// <summary>
+    /// Moves one non-active queue item to a peer's original position, or an
+    /// absolute visible position. The caller serializes this with queue claims.
+    /// </summary>
+    public async Task<QueueSwitchResult> SwitchQueueItemAsync(
+        Guid sourceId,
+        string target,
+        IReadOnlyList<Guid> activeIds,
+        CancellationToken ct = default)
+    {
+        if (activeIds.Contains(sourceId) || string.IsNullOrWhiteSpace(target))
+            return QueueSwitchResult.NotMoved;
+
+        var items = await Ctx.QueueItems
+            .OrderByDescending(q => q.Priority)
+            .ThenBy(q => q.SortOrder)
+            .ThenBy(q => q.CreatedAt)
+            .ThenBy(q => q.Id)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        var queued = items.Where(item => !activeIds.Contains(item.Id)).ToList();
+        var sourceIndex = queued.FindIndex(item => item.Id == sourceId);
+        if (sourceIndex < 0)
+            return QueueSwitchResult.NotMoved;
+
+        QueueItem? targetItem;
+        var activeCount = activeIds.Count;
+        if (Guid.TryParse(target, out var targetId))
+        {
+            if (activeIds.Contains(targetId))
+                targetItem = queued.FirstOrDefault();
+            else
+                targetItem = queued.FirstOrDefault(item => item.Id == targetId);
+        }
+        else if (int.TryParse(target, out var targetPosition) && targetPosition >= 0)
+        {
+            var queuedPosition = Math.Max(0, targetPosition - activeCount);
+            targetItem = queuedPosition < queued.Count ? queued[queuedPosition] : null;
+        }
+        else
+        {
+            return QueueSwitchResult.NotMoved;
+        }
+
+        if (targetItem is null || targetItem.Id == sourceId)
+            return QueueSwitchResult.NotMoved;
+
+        // SAB's switch inserts the source at the target's original index. The
+        // list removal naturally gives "before" when promoting and "after"
+        // when demoting.
+        var targetIndex = queued.FindIndex(item => item.Id == targetItem.Id);
+        queued.RemoveAt(sourceIndex);
+        var source = items.Single(item => item.Id == sourceId);
+        source.Priority = targetItem.Priority;
+        if (source.Priority != QueueItem.PriorityOption.Paused)
+            source.PauseUntil = null;
+        queued.Insert(targetIndex, source);
+
+        // Dense reassignment is deliberately limited to the destination band.
+        // SortOrder has a generous stride, and this makes repeated moves
+        // deterministic even when adjacent gaps have been exhausted.
+        var band = queued.Where(item => item.Priority == source.Priority).ToList();
+        for (var index = 0; index < band.Count; index++)
+            band[index].SortOrder = QueueItem.SortOrderStride * (index + 1);
+
+        await Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+        var position = activeCount + queued.FindIndex(item => item.Id == sourceId);
+        return new QueueSwitchResult(position, (int)source.Priority);
     }
 
     // Delete watchdog attempts that were tied to the deleted queue/history items.

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -262,17 +262,6 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         return queueItems.CountAsync(cancellationToken: ct);
     }
 
-    public async Task<int> GetQueueItemPositionAsync(
-        Guid id,
-        IReadOnlyCollection<Guid> activeIds,
-        CancellationToken ct = default)
-    {
-        var items = await GetQueueItems(null, ct: ct).ConfigureAwait(false);
-        var queued = items.Where(item => !activeIds.Contains(item.Id)).ToList();
-        var position = queued.FindIndex(item => item.Id == id);
-        return position < 0 ? -1 : activeIds.Count + position;
-    }
-
     public async Task RemoveQueueItemsAsync(List<Guid> ids, CancellationToken ct = default)
     {
         // Capture group keys before delete so we can cascade-clean orphaned
@@ -371,10 +360,9 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         var activeCount = activeIds.Count;
         if (Guid.TryParse(target, out var targetId))
         {
-            if (activeIds.Contains(targetId))
-                targetItem = queued.FirstOrDefault();
-            else
-                targetItem = queued.FirstOrDefault(item => item.Id == targetId);
+            targetItem = activeIds.Contains(targetId)
+                ? queued.FirstOrDefault()
+                : queued.FirstOrDefault(item => item.Id == targetId);
         }
         else if (int.TryParse(target, out var targetPosition) && targetPosition >= 0)
         {

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -309,6 +309,10 @@ public sealed class DavDatabaseContext : DbContext
                 .ValueGeneratedNever()
                 .IsRequired();
 
+            e.Property(i => i.SortOrder)
+                .ValueGeneratedNever()
+                .IsRequired();
+
             e.Property(i => i.FileName)
                 .IsRequired();
 
@@ -353,10 +357,10 @@ public sealed class DavDatabaseContext : DbContext
             e.HasIndex(i => new { i.Category })
                 .IsUnique(false);
 
-            e.HasIndex(i => new { i.Priority, i.CreatedAt })
+            e.HasIndex(i => new { i.Priority, i.SortOrder })
                 .IsUnique(false);
 
-            e.HasIndex(i => new { i.Category, i.Priority, i.CreatedAt })
+            e.HasIndex(i => new { i.Category, i.Priority, i.SortOrder })
                 .IsUnique(false);
 
             e.HasIndex(i => i.ContentGroupKey)

--- a/backend/Database/Migrations/20260817160000_Add-QueueItem-SortOrder.cs
+++ b/backend/Database/Migrations/20260817160000_Add-QueueItem-SortOrder.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    [DbContext(typeof(DavDatabaseContext))]
+    [Migration("20260817160000_Add-QueueItem-SortOrder")]
+    public partial class AddQueueItemSortOrder : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "SortOrder",
+                table: "QueueItems",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE QueueItems
+                SET SortOrder = (
+                    SELECT ranked.SortOrder
+                    FROM (
+                        SELECT Id, ROW_NUMBER() OVER (
+                            PARTITION BY Priority
+                            ORDER BY CreatedAt, Id
+                        ) * 1024 AS SortOrder
+                        FROM QueueItems
+                    ) AS ranked
+                    WHERE ranked.Id = QueueItems.Id
+                );
+                """);
+
+            migrationBuilder.DropIndex(
+                name: "IX_QueueItems_Priority_CreatedAt",
+                table: "QueueItems");
+            migrationBuilder.DropIndex(
+                name: "IX_QueueItems_Category_Priority_CreatedAt",
+                table: "QueueItems");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueItems_Priority_SortOrder",
+                table: "QueueItems",
+                columns: new[] { "Priority", "SortOrder" });
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueItems_Category_Priority_SortOrder",
+                table: "QueueItems",
+                columns: new[] { "Category", "Priority", "SortOrder" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_QueueItems_Priority_SortOrder",
+                table: "QueueItems");
+            migrationBuilder.DropIndex(
+                name: "IX_QueueItems_Category_Priority_SortOrder",
+                table: "QueueItems");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueItems_Priority_CreatedAt",
+                table: "QueueItems",
+                columns: new[] { "Priority", "CreatedAt" });
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueItems_Category_Priority_CreatedAt",
+                table: "QueueItems",
+                columns: new[] { "Category", "Priority", "CreatedAt" });
+
+            migrationBuilder.DropColumn(name: "SortOrder", table: "QueueItems");
+        }
+    }
+}

--- a/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
@@ -497,6 +497,9 @@ namespace NzbWebDAV.Database.Migrations
                     b.Property<int>("Priority")
                         .HasColumnType("INTEGER");
 
+                    b.Property<long>("SortOrder")
+                        .HasColumnType("INTEGER");
+
                     b.Property<long>("TotalSegmentBytes")
                         .HasColumnType("INTEGER");
 
@@ -513,9 +516,9 @@ namespace NzbWebDAV.Database.Migrations
                     b.HasIndex("Category", "FileName")
                         .IsUnique();
 
-                    b.HasIndex("Priority", "CreatedAt");
+                    b.HasIndex("Priority", "SortOrder");
 
-                    b.HasIndex("Category", "Priority", "CreatedAt");
+                    b.HasIndex("Category", "Priority", "SortOrder");
 
                     b.ToTable("QueueItems", (string)null);
                 });

--- a/backend/Database/Models/QueueItem.cs
+++ b/backend/Database/Models/QueueItem.cs
@@ -2,8 +2,12 @@
 
 public class QueueItem
 {
+    public const long SortOrderStride = 1024;
+
     public Guid Id { get; set; }
     public DateTime CreatedAt { get; set; }
+    /// <summary>Persistent position within a priority band.</summary>
+    public long SortOrder { get; set; }
     public string FileName { get; set; } = null!;
     public string JobName { get; set; } = null!;
     public long NzbFileSize { get; set; }

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -345,6 +345,57 @@ public sealed class QueueManager : IDisposable
         AwakenQueue();
     }
 
+    /// <summary>
+    /// Serializes a queue reorder with worker admission. Reordering never
+    /// cancels or changes an in-progress worker.
+    /// </summary>
+    public async Task<DavDatabaseClient.QueueSwitchResult> SwitchQueueItemAsync(
+        Guid sourceId,
+        string target,
+        DavDatabaseClient dbClient,
+        CancellationToken ct = default)
+    {
+        DavDatabaseClient.QueueSwitchResult result = DavDatabaseClient.QueueSwitchResult.NotMoved;
+        await LockAsync(async () =>
+        {
+            await using var transaction = await dbClient.Ctx.Database
+                .BeginTransactionAsync(ct)
+                .ConfigureAwait(false);
+            result = await dbClient.SwitchQueueItemAsync(
+                    sourceId, target, _inProgress.Keys.ToList(), ct)
+                .ConfigureAwait(false);
+            if (result.Position >= 0)
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+
+        if (result.Position >= 0)
+            AwakenQueue();
+        return result;
+    }
+
+    public async Task<List<Guid>> MoveQueueItemsToTopAsync(
+        List<Guid> queueItemIds,
+        DavDatabaseClient dbClient,
+        CancellationToken ct = default)
+    {
+        List<Guid> moved = [];
+        await LockAsync(async () =>
+        {
+            await using var transaction = await dbClient.Ctx.Database
+                .BeginTransactionAsync(ct)
+                .ConfigureAwait(false);
+            moved = await dbClient.MoveQueueItemsToTopAsync(
+                    queueItemIds, _inProgress.Keys.ToList(), ct)
+                .ConfigureAwait(false);
+            if (moved.Count > 0)
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+
+        if (moved.Count > 0)
+            AwakenQueue();
+        return moved;
+    }
+
     public async Task<List<Guid>> SetQueueItemsCategoryAsync(
         List<Guid> queueItemIds,
         string category,

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -26,6 +26,7 @@ public class WebsocketTopic
     public static readonly WebsocketTopic QueueItemAdded = new("qa", TopicType.Event);
     public static readonly WebsocketTopic QueueItemRemoved = new("qr", TopicType.Event);
     public static readonly WebsocketTopic QueueItemMoved = new("qm", TopicType.Event);
+    public static readonly WebsocketTopic QueueOrderChanged = new("qo", TopicType.Event);
     public static readonly WebsocketTopic HistoryItemAdded = new("ha", TopicType.Event);
     public static readonly WebsocketTopic HistoryItemRemoved = new("hr", TopicType.Event);
     public static readonly WebsocketTopic LogEntryAdded = new("log", TopicType.Event);

--- a/docs/configuration/queue.md
+++ b/docs/configuration/queue.md
@@ -44,6 +44,18 @@ The resume threshold adds hysteresis after the maximum is reached. Set it to
 submissions that replace an existing queue item remain allowed because they do
 not increase queue depth.
 
+## Reordering [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+Use the Queue page's up, down, or top controls to change waiting-job order.
+Controls work across page boundaries and preserve the selected job while the
+list refreshes. Queue priority remains the primary ordering rule: placing a job
+beside a different priority adopts that priority. Moving a paused job into a
+non-paused priority resumes it.
+
+Active downloads remain pinned and are never interrupted by reordering. A job
+can be promoted to the first waiting position, but cannot displace an active
+worker.
+
 ## Stuck-item watchdog [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 
 Each active queue worker runs a progress watchdog. A worker is treated as stuck

--- a/docs/features/sab-api.md
+++ b/docs/features/sab-api.md
@@ -8,6 +8,7 @@ InfiniDysk implements the SABnzbd-compatible operations used by Sonarr, Radarr, 
 - `server_stats` and `warnings` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 - `addfile` and `addurl`
 - `queue` listing and `queue&name=delete`, `queue&name=pause`, `queue&name=resume`, `queue&name=priority`, `queue&name=move`, and `queue&name=change_cat` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
+- `switch` for placing one queued job at another job's position or an absolute queue index [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
 - `pause` / `resume` (also `queue&name=pause` / `queue&name=resume`) and `speedlimit` [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
 - `change_cat` for per-job category changes on queued items [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since }
 - `retry` for failed history re-queue (single or bulk) [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
@@ -39,6 +40,13 @@ Per-job pause and resume accept UUID(s) via `value` (comma-separated or repeated
 
 `mode=queue&name=priority` sets priority for one or more jobs. Pass the SAB priority code as `value2` (or `priority`): `-2` Paused, `-1` Low, `0` Normal, `1` High, `2` Force. Paused uses the same per-job pause path as `queue&name=pause`.
 
+`mode=switch&value=<nzo_id>&value2=<nzo_id-or-index>` moves one queued job to the
+target's original position and returns `{"result":{"position":N,"priority":P}}`.
+Moving across priority bands adopts the target priority. Moving a paused job into
+a non-paused band resumes it by clearing its scheduled retry delay. The
+InfiniDysk-specific `queue&name=move&value2=0|top` bulk action remains the
+shortcut for move-to-top.
+
 `mode=change_cat` sets category for queued jobs (not actively downloading). Pass `cat` / `category` plus job id(s) in `value` or `nzo_ids`. Categories must match configured API categories.
 
 `mode=retry` re-queues failed history items. Accepts a single `value` id or multiple ids (comma-separated / repeated `value`, or `nzo_ids` JSON). Bulk retry returns `nzo_ids` for successes and a `failed` array with per-item errors when some items cannot be retried. History bulk actions in the admin UI do not change category on retry (category is copied from the history row).
@@ -55,6 +63,9 @@ Queue JSON reports live throughput for in-progress jobs [since 1.1.0](https://gi
 - History has no separate archive tier. `history&name=delete` permanently removes matching history rows.
 - **Ignore SAB history limit** can ignore a client's `limit`; InfiniDysk still enforces a server-side maximum page size.
 - Authentication failures use HTTP error status codes instead of always returning HTTP 200 with an error body.
+- Active queue workers stay pinned at the front and are never preempted. A switch
+  targeting that pinned prefix lands at the first waiting job; active sources
+  cannot be moved. Negative queue indexes are rejected.
 - `server_stats` aggregates provider bandwidth from retained `ProviderHourly` rollups (plus folded lifetime totals for all-time bytes). The per-server `daily` map and article counters are bounded by the hourly retention window — pruned buckets are not reconstructed.
 - `warnings` returns recent Warning-and-above log entries from the in-memory buffer. `name=clear` is accepted for SAB client compatibility but does not clear the buffer (support packs rely on it). Use Settings → Support to collect the full warning log.
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -400,6 +400,7 @@ export type QueueResponse = {
 }
 
 export type QueueSlot = {
+    index?: number,
     nzo_id: string,
     priority: string,
     filename: string,

--- a/frontend/app/routes/queue/components/action-button/action-button.tsx
+++ b/frontend/app/routes/queue/components/action-button/action-button.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Button, Icon } from "~/components/ui";
 
 export type ActionButtonProps = {
-    type: "delete" | "explore" | "menu" | "move-top" | "retry" | "pause" | "resume",
+    type: "delete" | "explore" | "menu" | "move-top" | "move-up" | "move-down" | "retry" | "pause" | "resume",
     text?: string,
     disabled?: boolean,
     selected?: boolean,
@@ -14,6 +14,8 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
     const icon = type === "delete" ? "delete"
         : type === "explore" ? "folder"
         : type === "move-top" ? "vertical_align_top"
+        : type === "move-up" ? "keyboard_arrow_up"
+        : type === "move-down" ? "keyboard_arrow_down"
         : type === "retry" ? "refresh"
         : type === "pause" ? "pause"
         : type === "resume" ? "play_arrow"
@@ -25,7 +27,7 @@ export function ActionButton({ type, text, disabled, selected, onClick }: Action
             size="xsmall"
             disabled={disabled}
             aria-pressed={type === "menu" ? selected : undefined}
-            aria-label={!text ? (type === "move-top" ? "Move to top" : type === "retry" ? "Retry" : type === "pause" ? "Pause" : type === "resume" ? "Resume" : type) : undefined}
+            aria-label={!text ? (type === "move-top" ? "Move to top" : type === "move-up" ? "Move up" : type === "move-down" ? "Move down" : type === "retry" ? "Retry" : type === "pause" ? "Pause" : type === "resume" ? "Resume" : type) : undefined}
             className={`${type === "menu" ? "w-[30px] px-1" : ""} ${selected ? "bg-base-content/20 text-base-content" : ""}`}
             onClick={onClick}
         >

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -451,7 +451,7 @@ export const QueueRow = memo(({ slot, previousSlot, nextSlot, onIsSelectedChange
     }, [slot.isUploading, slot.nzo_id, isMoving, onMovedToTop]);
 
     const moveRelative = useCallback(async (target?: PresentationQueueSlot) => {
-        if (!target || slot.isUploading || isMoving || target.status === "Downloading") return;
+        if (!target || slot.isUploading || isMoving || target.isUploading || target.status === "Downloading") return;
         setIsMoving(true);
         try {
             await switchQueueItem(slot.nzo_id, target.nzo_id);
@@ -479,14 +479,14 @@ export const QueueRow = memo(({ slot, previousSlot, nextSlot, onIsSelectedChange
                                 <Tooltip content="Move up">
                                     <ActionButton
                                         type="move-up"
-                                        disabled={!!slot.isRemoving || isMoving || !previousSlot || previousSlot.status === "Downloading"}
+                                        disabled={!!slot.isRemoving || isMoving || !previousSlot || previousSlot.isUploading || previousSlot.status === "Downloading"}
                                         onClick={() => void moveRelative(previousSlot)}
                                     />
                                 </Tooltip>
                                 <Tooltip content="Move down">
                                     <ActionButton
                                         type="move-down"
-                                        disabled={!!slot.isRemoving || isMoving || !nextSlot || nextSlot.status === "Downloading"}
+                                        disabled={!!slot.isRemoving || isMoving || !nextSlot || nextSlot.isUploading || nextSlot.status === "Downloading"}
                                         onClick={() => void moveRelative(nextSlot)}
                                     />
                                 </Tooltip>

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -39,6 +39,8 @@ export type QueueTableProps = {
     onIsRemovingChanged: (nzo_ids: Set<string>, isRemoving: boolean) => void,
     onRemoved: (nzo_ids: Set<string>) => void,
     onMovedToTop: (nzo_ids: Set<string>) => void,
+    previousQueueSlot?: PresentationQueueSlot | undefined,
+    nextQueueSlot?: PresentationQueueSlot | undefined,
     listParams: QueueListParams,
     searchDraft: string,
     onSearchDraftChange: (value: string) => void,
@@ -67,6 +69,20 @@ async function moveQueueItemsToTop(nzoIds: string[]): Promise<boolean> {
     }
 }
 
+async function switchQueueItem(sourceId: string, targetId: string): Promise<boolean> {
+    try {
+        const response = await fetch(
+            `/api?mode=switch&value=${encodeURIComponent(sourceId)}&value2=${encodeURIComponent(targetId)}`,
+            { method: "POST" },
+        );
+        if (!response.ok) return false;
+        const data = await response.json() as { result?: { position?: number } };
+        return (data.result?.position ?? -1) >= 0;
+    } catch {
+        return false;
+    }
+}
+
 export function QueueTable({
     queueSlots,
     totalQueueCount,
@@ -83,6 +99,8 @@ export function QueueTable({
     onIsRemovingChanged,
     onRemoved,
     onMovedToTop,
+    previousQueueSlot,
+    nextQueueSlot,
     listParams,
     searchDraft,
     onSearchDraftChange,
@@ -332,10 +350,12 @@ export function QueueTable({
                     direction={listParams.direction}
                     onSort={onSort}
                 >
-                    {queueSlots.map(slot =>
+                    {queueSlots.map((slot, index) =>
                         <QueueRow
                             key={slot.nzo_id}
                             slot={slot}
+                            previousSlot={index > 0 ? queueSlots[index - 1] : previousQueueSlot}
+                            nextSlot={index < queueSlots.length - 1 ? queueSlots[index + 1] : nextQueueSlot}
                             onIsSelectedChanged={onRowIsSelectedChanged}
                             onIsRemovingChanged={onRowIsRemovingChanged}
                             onRemoved={onRowRemoved}
@@ -373,9 +393,11 @@ type QueueRowProps = {
     onIsRemovingChanged: (nzo_id: string, isRemoving: boolean) => void,
     onRemoved: (nzo_id: string) => void,
     onMovedToTop: (nzo_id: string) => void,
+    previousSlot?: PresentationQueueSlot | undefined,
+    nextSlot?: PresentationQueueSlot | undefined,
 }
 
-export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, onRemoved, onMovedToTop }: QueueRowProps) => {
+export const QueueRow = memo(({ slot, previousSlot, nextSlot, onIsSelectedChanged, onIsRemovingChanged, onRemoved, onMovedToTop }: QueueRowProps) => {
     const isReadOnly = useIsReadOnly();
     // state
     const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false);
@@ -428,6 +450,16 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
         }
     }, [slot.isUploading, slot.nzo_id, isMoving, onMovedToTop]);
 
+    const moveRelative = useCallback(async (target?: PresentationQueueSlot) => {
+        if (!target || slot.isUploading || isMoving || target.status === "Downloading") return;
+        setIsMoving(true);
+        try {
+            await switchQueueItem(slot.nzo_id, target.nzo_id);
+        } finally {
+            setIsMoving(false);
+        }
+    }, [slot.isUploading, slot.nzo_id, isMoving]);
+
     // view
     return (
         <>
@@ -442,6 +474,24 @@ export const QueueRow = memo(({ slot, onIsSelectedChanged, onIsRemovingChanged, 
                 fileSizeBytes={Number(slot.mb) * 1024 * 1024}
                 actions={isReadOnly ? null : (
                     <div className="flex items-center justify-center gap-1">
+                        {!slot.isUploading &&
+                            <>
+                                <Tooltip content="Move up">
+                                    <ActionButton
+                                        type="move-up"
+                                        disabled={!!slot.isRemoving || isMoving || !previousSlot || previousSlot.status === "Downloading"}
+                                        onClick={() => void moveRelative(previousSlot)}
+                                    />
+                                </Tooltip>
+                                <Tooltip content="Move down">
+                                    <ActionButton
+                                        type="move-down"
+                                        disabled={!!slot.isRemoving || isMoving || !nextSlot || nextSlot.status === "Downloading"}
+                                        onClick={() => void moveRelative(nextSlot)}
+                                    />
+                                </Tooltip>
+                            </>
+                        }
                         {!slot.isUploading &&
                             <Tooltip content="Move to top">
                                 <ActionButton

--- a/frontend/app/routes/queue/controllers/websocket-controller.ts
+++ b/frontend/app/routes/queue/controllers/websocket-controller.ts
@@ -11,6 +11,7 @@ const topicNames = {
     queueItemAdded: 'qa',
     queueItemRemoved: 'qr',
     queueItemMoved: 'qm',
+    queueOrderChanged: 'qo',
     historyItemAdded: 'ha',
     historyItemRemoved: 'hr',
 };
@@ -22,6 +23,7 @@ const topicSubscriptions = {
     [topicNames.queueItemAdded]: 'event',
     [topicNames.queueItemRemoved]: 'event',
     [topicNames.queueItemMoved]: 'event',
+    [topicNames.queueOrderChanged]: 'event',
     [topicNames.historyItemAdded]: 'event',
     [topicNames.historyItemRemoved]: 'event',
 } as const;
@@ -54,22 +56,24 @@ export function useQueueHistoryWebsocket(
             if (isQueueLive) setTotalQueueCount(count => adjustTotalCount(count, 1));
             // 'qa' websocket payload carries a JSON-serialized QueueSlot (backend contract)
             if (isQueueLive) queueEvents.onAddQueueSlot(JSON.parse(message) as QueueSlot);
-            else scheduleRefresh();
+            scheduleRefresh();
         }
         else if (topic == topicNames.queueItemRemoved) {
             const ids = message.split(',').filter(Boolean);
             if (isQueueLive) setTotalQueueCount(count => adjustTotalCount(count, -ids.length));
             if (isQueueLive) queueEvents.onRemoveQueueSlots(new Set<string>(ids));
-            else scheduleRefresh();
+            scheduleRefresh();
         }
         else if (topic == topicNames.queueItemMoved) {
             queueEvents.onMoveQueueSlotsToTop(new Set<string>(message.split(',').filter(Boolean)));
-            if (!isQueueLive) scheduleRefresh();
+            scheduleRefresh();
         }
         else if (topic == topicNames.queueItemStatus) {
             queueEvents.onChangeQueueSlotStatus(message);
-            if (!isQueueLive) scheduleRefresh();
+            scheduleRefresh();
         }
+        else if (topic == topicNames.queueOrderChanged)
+            scheduleRefresh();
         else if (topic == topicNames.queueItemPercentage)
             queueEvents.onChangeQueueSlotPercentage(message);
         else if (topic == topicNames.queueItemProviders)
@@ -96,5 +100,5 @@ export function useQueueHistoryWebsocket(
         scheduleRefresh,
     ]);
 
-    useWebsocketTopics(topicSubscriptions, onWebsocketMessage);
+    useWebsocketTopics(topicSubscriptions, onWebsocketMessage, { onOpen: scheduleRefresh });
 }

--- a/frontend/app/routes/queue/route.test.ts
+++ b/frontend/app/routes/queue/route.test.ts
@@ -62,9 +62,10 @@ describe("queue route loader", () => {
   });
 
   it("loads the requested queue and history pages with configured categories", async () => {
-    const queueSlots = [{ nzo_id: "queue-1" }];
+    const queueSlots = [{ nzo_id: "queue-1" }, { nzo_id: "queue-2" }];
+    const fetchedQueueSlots = [{ nzo_id: "queue-before" }, ...queueSlots, { nzo_id: "queue-after" }];
     const historySlots = [{ nzo_id: "history-1" }];
-    getQueueMock.mockResolvedValueOnce({ slots: queueSlots, noofslots: 30 });
+    getQueueMock.mockResolvedValueOnce({ slots: fetchedQueueSlots, noofslots: 30 });
     getHistoryMock.mockResolvedValueOnce({ slots: historySlots, noofslots: 700 });
     getConfigMock.mockResolvedValueOnce([
       { configName: "api.categories", configValue: "tv, movies" },
@@ -73,7 +74,7 @@ describe("queue route loader", () => {
 
     const result = await loader(loaderRequest("?qp=2&hp=3&qps=25&hps=250"));
 
-    expect(getQueueMock).toHaveBeenCalledWith(25, 25, {
+    expect(getQueueMock).toHaveBeenCalledWith(27, 24, {
       search: "", category: "", status: "", sort: undefined, direction: undefined,
     });
     expect(getHistoryMock).toHaveBeenCalledWith(250, 500, {
@@ -84,7 +85,9 @@ describe("queue route loader", () => {
       "api.manual-category",
     ]);
     expect(result).toEqual({
-      queueSlots,
+      queueSlots: fetchedQueueSlots.slice(1),
+      previousQueueSlot: fetchedQueueSlots[0],
+      nextQueueSlot: undefined,
       historySlots,
       totalQueueCount: 30,
       totalHistoryCount: 700,
@@ -106,7 +109,7 @@ describe("queue route loader", () => {
 
     const result = await loader(loaderRequest("?qp=0&hp=invalid&qps=10&hps=999"));
 
-    expect(getQueueMock).toHaveBeenCalledWith(100, 0, {
+    expect(getQueueMock).toHaveBeenCalledWith(101, 0, {
       search: "", category: "", status: "", sort: undefined, direction: undefined,
     });
     expect(getHistoryMock).toHaveBeenCalledWith(100, 0, {

--- a/frontend/app/routes/queue/route.test.ts
+++ b/frontend/app/routes/queue/route.test.ts
@@ -136,7 +136,7 @@ describe("queue route loader", () => {
 
     await loader(loaderRequest("?qq=show&qcat=tv&qstatus=Paused&qsort=size:desc&hq=film&hcat=movies&hstatus=Failed&hsort=completed:asc"));
 
-    expect(getQueueMock).toHaveBeenCalledWith(100, 0, {
+    expect(getQueueMock).toHaveBeenCalledWith(101, 0, {
       search: "show", category: "tv", status: "Paused", sort: "size", direction: "desc",
     });
     expect(getHistoryMock).toHaveBeenCalledWith(100, 0, {

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -33,8 +33,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     const historyPageSize = parsePageSize(url.searchParams.get("hps"));
     const queueParams = parseQueueListParams(url.searchParams);
     const historyParams = parseHistoryListParams(url.searchParams);
+    const queueStart = (queuePage - 1) * queuePageSize;
+    const queueFetchStart = Math.max(0, queueStart - 1);
+    const queueFetchLimit = queuePageSize + (queuePage > 1 ? 2 : 1);
     const [queue, history, config] = await Promise.all([
-        backendClient.getQueue(queuePageSize, (queuePage - 1) * queuePageSize, {
+        backendClient.getQueue(queueFetchLimit, queueFetchStart, {
             search: queueParams.query, category: queueParams.category, status: queueParams.status,
             sort: queueParams.sort ?? undefined, direction: queueParams.direction ?? undefined,
         }),
@@ -56,7 +59,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
 
     return {
-        queueSlots: queue?.slots || [],
+        queueSlots: (queue?.slots || []).slice(
+            queuePage > 1 ? 1 : 0,
+            (queuePage > 1 ? 1 : 0) + queuePageSize,
+        ),
+        previousQueueSlot: queuePage > 1 ? queue?.slots?.[0] : undefined,
+        nextQueueSlot: queue?.slots?.[(queuePage > 1 ? 1 : 0) + queuePageSize],
         historySlots: history?.slots || [],
         totalQueueCount: queue?.noofslots || 0,
         totalHistoryCount: history?.noofslots || 0,
@@ -229,6 +237,8 @@ export default function Queue(props: Route.ComponentProps) {
                         onIsRemovingChanged={queueEvents.onRemovingQueueSlots}
                         onRemoved={queueEvents.onRemoveQueueSlots}
                         onMovedToTop={queueEvents.onMoveQueueSlotsToTop}
+                        previousQueueSlot={props.loaderData.previousQueueSlot}
+                        nextQueueSlot={props.loaderData.nextQueueSlot}
                     />
                 </div>
             </div>

--- a/tests/NzbWebDAV.Tests/Api/SwitchQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SwitchQueueRequestTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.SwitchQueue;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class SwitchQueueRequestTests
+{
+    [Fact]
+    public void New_ParsesPeerTarget()
+    {
+        var source = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?value={source}&value2={target}");
+
+        var request = SwitchQueueRequest.New(context);
+
+        Assert.Equal(source, request.SourceId);
+        Assert.Equal(target.ToString(), request.Target);
+    }
+
+    [Theory]
+    [InlineData("?value2=0")]
+    [InlineData("?value=not-a-guid&value2=0")]
+    [InlineData("?value=00000000-0000-0000-0000-000000000000")]
+    public void New_RequiresSourceAndTarget(string query)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(query);
+
+        Assert.Throws<BadHttpRequestException>(() => SwitchQueueRequest.New(context));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -120,6 +120,36 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SwitchQueueItemAsync_MovesSourceToPeerOriginalPosition()
+    {
+        var first = CreateQueueItem("first.nzb", DateTime.UtcNow.AddMinutes(-3), QueueItem.PriorityOption.Normal);
+        var second = CreateQueueItem("second.nzb", DateTime.UtcNow.AddMinutes(-2), QueueItem.PriorityOption.Normal);
+        var third = CreateQueueItem("third.nzb", DateTime.UtcNow.AddMinutes(-1), QueueItem.PriorityOption.Normal);
+        _context.QueueItems.AddRange(first, second, third);
+        await _context.SaveChangesAsync();
+
+        var result = await _client.SwitchQueueItemAsync(third.Id, first.Id.ToString(), []);
+        _context.ChangeTracker.Clear();
+
+        Assert.Equal(0, result.Position);
+        Assert.Equal(0, result.Priority);
+        var ordered = await _client.GetQueueItems(null);
+        Assert.Equal([third.Id, first.Id, second.Id], ordered.Select(item => item.Id));
+    }
+
+    [Fact]
+    public async Task SwitchQueueItemAsync_ReturnsSentinelForInvalidTarget()
+    {
+        var item = CreateQueueItem("item.nzb", DateTime.UtcNow, QueueItem.PriorityOption.Normal);
+        _context.QueueItems.Add(item);
+        await _context.SaveChangesAsync();
+
+        var result = await _client.SwitchQueueItemAsync(item.Id, "-1", []);
+
+        Assert.Equal(DavDatabaseClient.QueueSwitchResult.NotMoved, result);
+    }
+
+    [Fact]
     public async Task CompletedSymlinkCategoryChildren_AreDistinctAndOrdered()
     {
         var zetaDirectory = DavItem.New(

--- a/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
@@ -46,44 +46,6 @@ public sealed class FixEmptyCategoriesMigrationTests
 
         ctx.Items.AddRange(uncategorizedFolder, emptyFolder, mount, collisionMount, existingMount);
 
-        ctx.QueueItems.AddRange(
-            new QueueItem
-            {
-                Id = emptyQueueId,
-                CreatedAt = DateTime.UtcNow,
-                FileName = "empty.nzb",
-                JobName = "empty",
-                NzbFileSize = 10,
-                TotalSegmentBytes = 20,
-                Category = "",
-                Priority = QueueItem.PriorityOption.Normal,
-                PostProcessing = QueueItem.PostProcessingOption.None,
-            },
-            new QueueItem
-            {
-                Id = collidingQueueId,
-                CreatedAt = DateTime.UtcNow,
-                FileName = "shared.nzb",
-                JobName = "shared-empty",
-                NzbFileSize = 10,
-                TotalSegmentBytes = 20,
-                Category = "",
-                Priority = QueueItem.PriorityOption.Normal,
-                PostProcessing = QueueItem.PostProcessingOption.None,
-            },
-            new QueueItem
-            {
-                Id = existingQueueId,
-                CreatedAt = DateTime.UtcNow,
-                FileName = "shared.nzb",
-                JobName = "shared-existing",
-                NzbFileSize = 10,
-                TotalSegmentBytes = 20,
-                Category = "uncategorized",
-                Priority = QueueItem.PriorityOption.Normal,
-                PostProcessing = QueueItem.PostProcessingOption.None,
-            });
-
         ctx.HistoryItems.AddRange(
             new HistoryItem
             {
@@ -109,6 +71,14 @@ public sealed class FixEmptyCategoriesMigrationTests
             });
 
         await ctx.SaveChangesAsync();
+        var createdAt = DateTime.UtcNow;
+        await ctx.Database.ExecuteSqlInterpolatedAsync($"""
+            INSERT INTO QueueItems (Id, CreatedAt, FileName, JobName, NzbFileSize, TotalSegmentBytes, Category, Priority, PostProcessing)
+            VALUES
+              ({emptyQueueId}, {createdAt}, {"empty.nzb"}, {"empty"}, 10, 20, {""}, 0, 0),
+              ({collidingQueueId}, {createdAt}, {"shared.nzb"}, {"shared-empty"}, 10, 20, {""}, 0, 0),
+              ({existingQueueId}, {createdAt}, {"shared.nzb"}, {"shared-existing"}, 10, 20, {"uncategorized"}, 0, 0);
+            """);
         ctx.ChangeTracker.Clear();
 
         await ctx.Database.MigrateAsync();


### PR DESCRIPTION
## Summary
- add durable sparse queue ordering and an additive SQLite migration
- implement SAB-compatible `mode=switch` plus queued-job up/down controls
- keep active workers pinned while refreshing queue views after structural updates

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`
- [x] `zensical build --clean --strict`

## Upgrade note
This release includes an additive database migration. Back up `/config` before upgrading.