### PR TITLE
feat(queue): upload NZBs at any time from the queue page

### DIFF
--- a/frontend/app/routes/queue/components/empty-queue/empty-queue.tsx
+++ b/frontend/app/routes/queue/components/empty-queue/empty-queue.tsx
@@ -1,15 +1,6 @@
-import { useCallback } from "react";
-import { Button, Icon } from "~/components/ui";
+import { Icon } from "~/components/ui";
 
-interface EmptyQueueProps {
-    onUploadClicked?: () => void;
-}
-
-export function EmptyQueue(props: EmptyQueueProps) {
-    const onUploadClicked = useCallback(() => {
-        props.onUploadClicked?.call(null);
-    }, [props.onUploadClicked]);
-
+export function EmptyQueue() {
     return (
         <div className="hero min-h-[300px] -translate-y-5 py-8">
             <div className="hero-content">
@@ -18,13 +9,8 @@ export function EmptyQueue(props: EmptyQueueProps) {
                         <Icon name="celebration" className="!text-[48px] text-base-content/40" />
                         <h2 className="card-title text-lg">Empty Queue!</h2>
                         <p className="text-base-content/60 max-w-sm text-xs leading-relaxed">
-                            Upload an nzb file to get started.
+                            Use the Upload NZB button above to get started.
                         </p>
-                        <div className="card-actions justify-center">
-                            <Button variant="primary" size="small" onClick={onUploadClicked}>
-                                Upload an nzb file
-                            </Button>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -39,7 +39,6 @@ export type QueueTableProps = {
     onIsRemovingChanged: (nzo_ids: Set<string>, isRemoving: boolean) => void,
     onRemoved: (nzo_ids: Set<string>) => void,
     onMovedToTop: (nzo_ids: Set<string>) => void,
-    onUploadClicked?: () => void;
     listParams: QueueListParams,
     searchDraft: string,
     onSearchDraftChange: (value: string) => void,
@@ -84,7 +83,6 @@ export function QueueTable({
     onIsRemovingChanged,
     onRemoved,
     onMovedToTop,
-    onUploadClicked,
     listParams,
     searchDraft,
     onSearchDraftChange,
@@ -226,8 +224,7 @@ export function QueueTable({
     const sectionTitle = (
         <div className="flex flex-wrap items-center gap-2.5">
             <h2
-                className={`${isReadOnly ? "" : "cursor-pointer"} text-xl font-semibold text-base-content`}
-                onClick={isReadOnly ? undefined : onUploadClicked}
+                className="text-xl font-semibold text-base-content"
             >
                 Queue
             </h2>
@@ -324,7 +321,7 @@ export function QueueTable({
                 onClear={onClearFilters}
             />
             {queueSlots?.length == 0 ? (
-                <EmptyQueue {...(!isReadOnly && onUploadClicked ? { onUploadClicked } : {})} />
+                <EmptyQueue />
             ) : (
                 <PageTable
                     headerCheckboxState={headerCheckboxState}

--- a/frontend/app/routes/queue/route.component.test.tsx
+++ b/frontend/app/routes/queue/route.component.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isReadOnlyMock, openMock } = vi.hoisted(() => ({
+    isReadOnlyMock: vi.fn(),
+    openMock: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+    useRevalidator: () => ({ revalidate: vi.fn() }),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock("./components/history-table/history-table", () => ({
+    HistoryTable: () => <div data-testid="history-table" />,
+}));
+
+vi.mock("./components/queue-table/queue-table", () => ({
+    QueueTable: () => <div data-testid="queue-table" />,
+}));
+
+vi.mock("./controllers/events-controller", () => ({
+    useHistoryEvents: () => ({
+        onSelectHistorySlots: vi.fn(),
+        onRemovingHistorySlots: vi.fn(),
+        onRemoveHistorySlots: vi.fn(),
+    }),
+    useQueueEvents: () => ({
+        onSelectQueueSlots: vi.fn(),
+        onRemovingQueueSlots: vi.fn(),
+        onRemoveQueueSlots: vi.fn(),
+        onMoveQueueSlotsToTop: vi.fn(),
+    }),
+}));
+
+vi.mock("./controllers/websocket-controller", () => ({
+    useQueueHistoryWebsocket: vi.fn(),
+}));
+
+vi.mock("./controllers/nzb-upload-controller", () => ({
+    useUploadController: vi.fn(),
+}));
+
+vi.mock("./controllers/dropzone-controller", () => ({
+    useQueueDropzone: () => ({
+        getRootProps: () => ({}),
+        getInputProps: () => ({}),
+        isDragActive: false,
+        open: openMock,
+    }),
+}));
+
+vi.mock("~/components/ui", () => ({
+    Alert: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Button: ({ children, onClick }: { children: ReactNode, onClick: () => void }) => (
+        <button type="button" onClick={onClick}>{children}</button>
+    ),
+}));
+
+vi.mock("~/auth/authorization", () => ({
+    useIsReadOnly: isReadOnlyMock,
+}));
+
+import Queue from "./route";
+
+afterEach(cleanup);
+
+function renderQueue(queueSlots: Array<{ nzo_id: string }> = []) {
+    return render(
+        <Queue
+            {...({
+                loaderData: {
+                    queueSlots,
+                    historySlots: [],
+                    totalQueueCount: queueSlots.length,
+                    totalHistoryCount: 0,
+                    categories: ["uncategorized"],
+                    manualCategory: "uncategorized",
+                    queuePage: 1,
+                    historyPage: 1,
+                    queuePageSize: 100,
+                    historyPageSize: 100,
+                    queueParams: { query: "", category: "", status: "", sort: null, direction: null },
+                    historyParams: { query: "", category: "", status: "", sort: null, direction: null },
+                },
+            } as unknown as Parameters<typeof Queue>[0])}
+        />,
+    );
+}
+
+describe("Queue upload control", () => {
+    beforeEach(() => {
+        isReadOnlyMock.mockReset();
+        isReadOnlyMock.mockReturnValue(false);
+        openMock.mockReset();
+    });
+
+    it.each([
+        ["the queue is empty", []],
+        ["the queue has items", [{ nzo_id: "queue-1" }]],
+    ])("renders Upload NZB when %s", (_, queueSlots) => {
+        renderQueue(queueSlots);
+
+        expect(screen.getByRole("button", { name: "Upload NZB" })).toBeTruthy();
+    });
+
+    it("opens the file picker from the page-level action", () => {
+        renderQueue([{ nzo_id: "queue-1" }]);
+
+        screen.getByRole("button", { name: "Upload NZB" }).click();
+
+        expect(openMock).toHaveBeenCalledOnce();
+    });
+
+    it("hides Upload NZB for read-only users", () => {
+        isReadOnlyMock.mockReturnValue(true);
+
+        renderQueue([{ nzo_id: "queue-1" }]);
+
+        expect(screen.queryByRole("button", { name: "Upload NZB" })).toBeNull();
+    });
+});

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -8,7 +8,7 @@ import { useHistoryEvents, useQueueEvents } from "./controllers/events-controlle
 import { useQueueHistoryWebsocket } from "./controllers/websocket-controller";
 import { useUploadController } from "./controllers/nzb-upload-controller";
 import { useQueueDropzone } from "./controllers/dropzone-controller";
-import { Alert } from "~/components/ui";
+import { Alert, Button } from "~/components/ui";
 import { useIsReadOnly } from "~/auth/authorization";
 import { isDefaultList, parseHistoryListParams, parseQueueListParams } from "./list-params";
 
@@ -197,6 +197,13 @@ export default function Queue(props: Route.ComponentProps) {
 
             {/* queue */}
             <div className="min-h-[413.9px] min-[450px]:min-h-[382.9px]">
+                {!isReadOnly && (
+                    <div className="mb-3 flex justify-end">
+                        <Button variant="primary" size="small" onClick={dropzone.open}>
+                            Upload NZB
+                        </Button>
+                    </div>
+                )}
                 <div className="relative" {...(isReadOnly ? {} : dropzone.getRootProps())}>
                     {dropzone.isDragActive && <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded border-2 border-dashed border-primary bg-primary/10" />}
                     {!isReadOnly && <input {...dropzone.getInputProps()} />}
@@ -222,7 +229,6 @@ export default function Queue(props: Route.ComponentProps) {
                         onIsRemovingChanged={queueEvents.onRemovingQueueSlots}
                         onRemoved={queueEvents.onRemoveQueueSlots}
                         onMovedToTop={queueEvents.onMoveQueueSlotsToTop}
-                        {...(!isReadOnly ? { onUploadClicked: dropzone.open } : {})}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a persistent Upload NZB action above the queue table
- preserve read-only restrictions and drag-and-drop uploads
- cover empty, populated, and read-only queue states

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`