### PR TITLE
feat(health): expose Prometheus metrics for streaming and providers

### DIFF
--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -11,6 +11,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.Observability;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
 using Serilog;
@@ -1029,6 +1030,10 @@ public class MultiProviderNntpClient(
             Status = status,
             Retries = retries,
         };
+        PrometheusMetrics.Current?.RecordSegmentFetch(
+            metricsKey,
+            status.ToString().ToLowerInvariant(),
+            TimeSpan.FromMilliseconds(durationMs));
         if (enqueue)
             metricsWriter?.RecordFetch(fetch);
         return fetch;

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.Observability;
 using NzbWebDAV.Streams;
 using Serilog;
 using UsenetSharp.Models;
@@ -176,6 +177,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private void RecordCacheHit()
     {
         _usageTracker?.RecordSuccess(CacheProviderName);
+        PrometheusMetrics.Current?.RecordSegmentFetch(CacheProviderName, "ok", TimeSpan.Zero);
         _metricsWriter?.RecordFetch(new SegmentFetch
         {
             At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),

--- a/backend/Extensions/NWebDavOptionsExtensions.cs
+++ b/backend/Extensions/NWebDavOptionsExtensions.cs
@@ -11,6 +11,7 @@ public static class NWebDavOptionsExtensions
                           !context.Request.Path.StartsWithSegments("/view", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/health", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/ready", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/metrics", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/ws", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/p", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/adapters", StringComparison.Ordinal);

--- a/backend/Middlewares/MetricsAuthenticationMiddleware.cs
+++ b/backend/Middlewares/MetricsAuthenticationMiddleware.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Auth;
+using NzbWebDAV.Config;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Middlewares;
+
+public sealed class MetricsAuthenticationMiddleware(RequestDelegate next, ConfigManager configManager)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.Equals("/metrics", StringComparison.OrdinalIgnoreCase) ||
+            !EnvironmentUtil.IsVariableTrue("METRICS_REQUIRE_API_KEY"))
+        {
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            ApiKeyValidator.Validate(context, configManager);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.ContentType = "text/plain; charset=utf-8";
+            await context.Response.WriteAsync("Metrics authentication required.").ConfigureAwait(false);
+            return;
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -19,6 +19,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+      <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
       <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
       <PackageReference Include="NWebDav.Server" Version="0.2.0-beta.2" />
       <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -23,6 +23,7 @@ using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.Observability;
 using NzbWebDAV.Services.SupportPack;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
@@ -31,6 +32,7 @@ using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
 using NzbWebDAV.WebDav.Base;
 using NzbWebDAV.Websocket;
+using Prometheus;
 using Serilog;
 using Serilog.Events;
 using Serilog.Templates;
@@ -221,6 +223,19 @@ public partial class Program
             builder.Services
                 .AddWebdavBasicAuthentication(configManager)
                 .AddSingleton(configManager)
+                .AddSingleton(_ =>
+                {
+                    var registry = new CollectorRegistry();
+                    DotNetStats.Register(registry);
+                    return registry;
+                })
+                .AddSingleton<PrometheusMetrics>(sp =>
+                {
+                    var metrics = new PrometheusMetrics(sp.GetRequiredService<CollectorRegistry>());
+                    PrometheusMetrics.Current = metrics;
+                    return metrics;
+                })
+                .AddHostedService<PrometheusMetricsCollector>()
                 .AddSingleton(websocketManager)
                 .AddSingleton(logBufferSink)
                 .AddSingleton(warningLogBuffer)
@@ -354,6 +369,7 @@ public partial class Program
             // Must run before anything that reads Scheme/Host/RemoteIpAddress.
             app.UseForwardedHeaders();
             app.UseMiddleware<ExceptionMiddleware>();
+            app.UseMiddleware<MetricsAuthenticationMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
             app.MapHealthChecks("/health", new HealthCheckOptions
             {
@@ -365,6 +381,7 @@ public partial class Program
             });
             app.Map("/ws", websocketManager.HandleRoute);
             app.MapControllers();
+            app.MapMetrics("/metrics", app.Services.GetRequiredService<CollectorRegistry>());
             app.UseWebdavBasicAuthentication();
             app.UseNWebDav();
             // TestServer hosts share a process, so stopping one must not trip the

--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -1,0 +1,181 @@
+using Prometheus;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Services.Observability;
+
+/// <summary>
+/// Bounded Prometheus metrics for live streaming and provider health.
+/// </summary>
+public sealed class PrometheusMetrics
+{
+    private readonly Gauge _activeReads;
+    private readonly Counter _bytesServed;
+    private readonly Counter _readStarts;
+    private readonly Counter _readOverlaps;
+    private readonly Counter _duplicateSegmentFetches;
+    private readonly Gauge _overlappingPaths;
+    private readonly Gauge _inFlightSegmentFetches;
+    private readonly Gauge _articleBudgetBytes;
+    private readonly Gauge _articleBudgetCapBytes;
+    private readonly Counter _articleBudgetThrottleEvents;
+    private readonly Gauge _metricsQueueLength;
+    private readonly Counter _metricsDropped;
+    private readonly Gauge _poolConnections;
+    private readonly Gauge _poolMaxConnections;
+    private readonly Gauge _poolChurn;
+    private readonly Gauge _circuitState;
+    private readonly Gauge _circuitCooldownSeconds;
+    private readonly Gauge _circuitTrips;
+    private readonly Gauge _circuitFailures;
+    private readonly Gauge _circuitArticleMisses;
+    private readonly Counter _segmentFetches;
+    private readonly Histogram _segmentFetchDuration;
+    private readonly Counter _seekCount;
+    private readonly Histogram _seekLatency;
+    private readonly HashSet<string> _providerKeys = new(StringComparer.Ordinal);
+
+    public PrometheusMetrics(CollectorRegistry registry)
+    {
+        var metrics = Prometheus.Metrics.WithCustomRegistry(registry);
+        _activeReads = metrics.CreateGauge("nzbdav_active_reads", "Current active read sessions.");
+        _bytesServed = metrics.CreateCounter("nzbdav_bytes_served_total", "Bytes served to readers.");
+        _readStarts = metrics.CreateCounter("nzbdav_concurrent_read_starts_total", "Read starts.", new CounterConfiguration { LabelNames = ["region"] });
+        _readOverlaps = metrics.CreateCounter("nzbdav_concurrent_read_overlap_events_total", "Overlapping read opportunities.");
+        _duplicateSegmentFetches = metrics.CreateCounter("nzbdav_concurrent_read_duplicate_segment_fetches_total", "Duplicate in-flight segment fetches.");
+        _overlappingPaths = metrics.CreateGauge("nzbdav_concurrent_overlapping_paths", "Current paths with overlapping readers.");
+        _inFlightSegmentFetches = metrics.CreateGauge("nzbdav_concurrent_in_flight_segment_fetches", "Current in-flight segment fetches.");
+        _articleBudgetBytes = metrics.CreateGauge("nzbdav_inflight_article_bytes", "Article bytes currently leased.");
+        _articleBudgetCapBytes = metrics.CreateGauge("nzbdav_inflight_article_budget_bytes", "Configured in-flight article byte budget.");
+        _articleBudgetThrottleEvents = metrics.CreateCounter("nzbdav_inflight_article_throttle_events_total", "Article budget throttle events.");
+        _metricsQueueLength = metrics.CreateGauge("nzbdav_metrics_queue_length", "Queued internal metric rows.", new GaugeConfiguration { LabelNames = ["queue"] });
+        _metricsDropped = metrics.CreateCounter("nzbdav_metrics_dropped_total", "Dropped internal metric rows.", new CounterConfiguration { LabelNames = ["queue"] });
+        _poolConnections = metrics.CreateGauge("nzbdav_nntp_pool_connections", "NNTP pool connection state.", new GaugeConfiguration { LabelNames = ["provider_key", "state"] });
+        _poolMaxConnections = metrics.CreateGauge("nzbdav_nntp_pool_max_connections", "NNTP pool connection limits.", new GaugeConfiguration { LabelNames = ["provider_key", "limit"] });
+        _poolChurn = metrics.CreateGauge("nzbdav_nntp_pool_churn_total", "NNTP pool lifetime churn.", new GaugeConfiguration { LabelNames = ["provider_key", "event"] });
+        _circuitState = metrics.CreateGauge("nzbdav_circuit_state", "Circuit state: 0=closed, 1=open, 2=half_open.", new GaugeConfiguration { LabelNames = ["provider_key"] });
+        _circuitCooldownSeconds = metrics.CreateGauge("nzbdav_circuit_cooldown_remaining_seconds", "Circuit cooldown remaining.", new GaugeConfiguration { LabelNames = ["provider_key"] });
+        _circuitTrips = metrics.CreateGauge("nzbdav_circuit_trips_total", "Circuit trips.", new GaugeConfiguration { LabelNames = ["provider_key"] });
+        _circuitFailures = metrics.CreateGauge("nzbdav_circuit_failures_total", "Circuit failures.", new GaugeConfiguration { LabelNames = ["provider_key"] });
+        _circuitArticleMisses = metrics.CreateGauge("nzbdav_circuit_article_misses_total", "Circuit article misses.", new GaugeConfiguration { LabelNames = ["provider_key"] });
+        _segmentFetches = metrics.CreateCounter("nzbdav_segment_fetches_total", "Segment fetch outcomes.", new CounterConfiguration { LabelNames = ["provider_key", "status"] });
+        _segmentFetchDuration = metrics.CreateHistogram("nzbdav_segment_fetch_duration_seconds", "Segment fetch duration.", new HistogramConfiguration { LabelNames = ["provider_key"], Buckets = Histogram.ExponentialBuckets(0.01, 2, 14) });
+        _seekCount = metrics.CreateCounter("nzbdav_seek_total", "Seek operations.", new CounterConfiguration { LabelNames = ["kind"] });
+        _seekLatency = metrics.CreateHistogram("nzbdav_seek_latency_seconds", "Post-seek preparation latency.", new HistogramConfiguration { LabelNames = ["kind"], Buckets = Histogram.ExponentialBuckets(0.001, 2, 14) });
+    }
+
+    public static PrometheusMetrics? Current { get; set; }
+
+    public void RecordSegmentFetch(string providerKey, string status, TimeSpan duration)
+    {
+        _segmentFetches.WithLabels(providerKey, status).Inc();
+        _segmentFetchDuration.WithLabels(providerKey).Observe(duration.TotalSeconds);
+    }
+
+    public void RecordSeek(string kind, TimeSpan elapsed)
+    {
+        _seekCount.WithLabels(kind).Inc();
+        _seekLatency.WithLabels(kind).Observe(elapsed.TotalSeconds);
+    }
+
+    public void Refresh(
+        ActiveReadRegistry activeReads,
+        ConcurrentReadTracker concurrentReads,
+        InFlightArticleBudget articleBudget,
+        MetricsWriter metricsWriter,
+        UsenetStreamingClient usenetClient)
+    {
+        _activeReads.Set(activeReads.Count);
+        _bytesServed.IncTo(activeReads.TotalBytesServed);
+
+        var reads = concurrentReads.Snapshot();
+        _readStarts.WithLabels("full").IncTo(reads.FullReads);
+        _readStarts.WithLabels("start_range").IncTo(reads.StartRangeReads);
+        _readStarts.WithLabels("offset_range").IncTo(reads.OffsetRangeReads);
+        _readStarts.WithLabels("suffix_range").IncTo(reads.SuffixRangeReads);
+        _readOverlaps.IncTo(reads.OverlapEvents);
+        _duplicateSegmentFetches.IncTo(reads.DuplicateInFlightSegmentFetches);
+        _overlappingPaths.Set(reads.CurrentOverlappingPaths);
+        _inFlightSegmentFetches.Set(reads.CurrentInFlightSegmentFetches);
+
+        _articleBudgetBytes.Set(articleBudget.LeasedBytes);
+        _articleBudgetCapBytes.Set(articleBudget.CapBytes);
+        _articleBudgetThrottleEvents.IncTo(articleBudget.ThrottleEvents);
+
+        var writer = metricsWriter.Stats;
+        _metricsQueueLength.WithLabels("fetches").Set(writer.QueuedFetches);
+        _metricsQueueLength.WithLabels("events").Set(writer.QueuedEvents);
+        _metricsQueueLength.WithLabels("sessions").Set(writer.QueuedSessions);
+        _metricsQueueLength.WithLabels("failover_misses").Set(writer.QueuedFailoverMisses);
+        _metricsDropped.WithLabels("fetches").IncTo(writer.DroppedFetches);
+        _metricsDropped.WithLabels("events").IncTo(writer.DroppedEvents);
+        _metricsDropped.WithLabels("sessions").IncTo(writer.DroppedSessions);
+        _metricsDropped.WithLabels("failover_misses").IncTo(writer.DroppedFailoverMisses);
+
+        var currentKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var pool in usenetClient.GetProviderConnectionSnapshots())
+        {
+            currentKeys.Add(pool.MetricsKey);
+            SetPool(pool);
+        }
+        foreach (var circuit in usenetClient.GetProviderCircuitSnapshots())
+        {
+            currentKeys.Add(circuit.MetricsKey);
+            SetCircuit(circuit);
+        }
+        foreach (var stale in _providerKeys.Except(currentKeys).ToArray())
+            RemoveProvider(stale);
+        _providerKeys.Clear();
+        _providerKeys.UnionWith(currentKeys);
+    }
+
+    private void SetPool(ProviderConnectionSnapshot pool)
+    {
+        var key = pool.MetricsKey;
+        _poolConnections.WithLabels(key, "live").Set(pool.LiveConnections);
+        _poolConnections.WithLabels(key, "idle").Set(pool.IdleConnections);
+        _poolConnections.WithLabels(key, "active").Set(pool.ActiveConnections);
+        _poolConnections.WithLabels(key, "available").Set(pool.AvailableConnections);
+        _poolConnections.WithLabels(key, "pending").Set(pool.PendingSelections);
+        _poolMaxConnections.WithLabels(key, "effective").Set(pool.EffectiveMaxConnections);
+        if (pool.LearnedConnectionLimit is { } learned)
+            _poolMaxConnections.WithLabels(key, "learned").Set(learned);
+        _poolChurn.WithLabels(key, "opened").Set(pool.Churn.ConnectionsOpened);
+        _poolChurn.WithLabels(key, "reused").Set(pool.Churn.ConnectionsReused);
+        _poolChurn.WithLabels(key, "destroyed").Set(pool.Churn.ConnectionsDestroyed);
+        _poolChurn.WithLabels(key, "stale_eviction").Set(pool.Churn.StaleEvictions);
+        _poolChurn.WithLabels(key, "handshake_failure").Set(pool.Churn.HandshakeFailures);
+    }
+
+    private void SetCircuit(ProviderCircuitRuntimeSnapshot circuit)
+    {
+        var breaker = circuit.Breaker;
+        _circuitState.WithLabels(circuit.MetricsKey).Set(breaker.State switch
+        {
+            ProviderCircuitState.Open => 1,
+            ProviderCircuitState.HalfOpen => 2,
+            _ => 0,
+        });
+        _circuitCooldownSeconds.WithLabels(circuit.MetricsKey).Set(breaker.CooldownRemainingSeconds ?? 0);
+        _circuitTrips.WithLabels(circuit.MetricsKey).Set(breaker.TripCount);
+        _circuitFailures.WithLabels(circuit.MetricsKey).Set(breaker.FailureCount);
+        _circuitArticleMisses.WithLabels(circuit.MetricsKey).Set(breaker.ArticleMissCount);
+    }
+
+    private void RemoveProvider(string key)
+    {
+        foreach (var state in new[] { "live", "idle", "active", "available", "pending" })
+            _poolConnections.RemoveLabelled(key, state);
+        foreach (var limit in new[] { "effective", "learned" })
+            _poolMaxConnections.RemoveLabelled(key, limit);
+        foreach (var churn in new[] { "opened", "reused", "destroyed", "stale_eviction", "handshake_failure" })
+            _poolChurn.RemoveLabelled(key, churn);
+        _circuitState.RemoveLabelled(key);
+        _circuitCooldownSeconds.RemoveLabelled(key);
+        _circuitTrips.RemoveLabelled(key);
+        _circuitFailures.RemoveLabelled(key);
+        _circuitArticleMisses.RemoveLabelled(key);
+    }
+}

--- a/backend/Services/Observability/PrometheusMetricsCollector.cs
+++ b/backend/Services/Observability/PrometheusMetricsCollector.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Streams;
+using Serilog;
+
+namespace NzbWebDAV.Services.Observability;
+
+public sealed class PrometheusMetricsCollector(
+    PrometheusMetrics metrics,
+    ActiveReadRegistry activeReads,
+    ConcurrentReadTracker concurrentReads,
+    MetricsWriter metricsWriter,
+    UsenetStreamingClient usenetClient) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (InFlightArticleBudget.Current is { } budget)
+                    metrics.Refresh(activeReads, concurrentReads, budget, metricsWriter, usenetClient);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                Log.Debug(ex, "Prometheus metrics snapshot refresh failed");
+            }
+
+            await Task.Delay(Interval, stoppingToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -1,9 +1,11 @@
-﻿using NzbWebDAV.Clients.Usenet;
+﻿using System.Diagnostics;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Services.Observability;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Utils;
 using Serilog;
@@ -35,6 +37,8 @@ public class NzbFileStream(
     // stream — otherwise rapid scrubbing overlaps generations and pins the article
     // budget (#840 scrub wedge).
     private Task? _pendingInnerDispose;
+    private Stopwatch? _pendingSeekStopwatch;
+    private string? _pendingSeekKind;
     private readonly LongRange[]? _segmentByteRanges =
         AreSegmentByteRangesValid(segmentByteRanges, fileSegmentIds.Length, fileSize)
             ? segmentByteRanges
@@ -114,6 +118,13 @@ public class NzbFileStream(
             }
         }
 
+        if (_pendingSeekStopwatch is { } seekStopwatch && _pendingSeekKind is { } seekKind)
+        {
+            PrometheusMetrics.Current?.RecordSeek(seekKind, seekStopwatch.Elapsed);
+            _pendingSeekStopwatch = null;
+            _pendingSeekKind = null;
+        }
+
         var read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         _position += read;
         return read;
@@ -140,11 +151,16 @@ public class NzbFileStream(
         if (absoluteOffset < 0 || absoluteOffset > fileSize)
             throw new ArgumentOutOfRangeException(nameof(offset), offset, "Seek position is outside stream bounds.");
 
-        if (_position == absoluteOffset) return _position;
+        if (_position == absoluteOffset)
+        {
+            PrometheusMetrics.Current?.RecordSeek("noop", TimeSpan.Zero);
+            return _position;
+        }
         if (_innerStream is not null &&
             absoluteOffset > _position &&
             absoluteOffset - _position <= MaximumForwardDrainBytes)
         {
+            BeginSeekMeasurement("warm");
             _pendingForwardDrain += absoluteOffset - _position;
             _position = absoluteOffset;
             if (MultiProviderNntpClient.CurrentReadSessionId is { } drainSession)
@@ -153,6 +169,7 @@ public class NzbFileStream(
         }
 
         _position = absoluteOffset;
+        BeginSeekMeasurement(_innerStream is null ? "fresh" : "cold");
         if (_innerStream is { } replaced)
         {
             // Start the inner stream's async teardown without blocking (Seek is sync),
@@ -164,6 +181,12 @@ public class NzbFileStream(
         if (MultiProviderNntpClient.CurrentReadSessionId is { } seekSession)
             StreamTrace.TrySeek(seekSession, _position);
         return _position;
+    }
+
+    private void BeginSeekMeasurement(string kind)
+    {
+        _pendingSeekStopwatch = Stopwatch.StartNew();
+        _pendingSeekKind = kind;
     }
 
     private async Task<InterpolationSearch.Result> SeekSegment(long byteOffset, CancellationToken ct)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -17,6 +17,7 @@ Advanced reference for **process / container** wiring and **legacy Settings fall
 | `TZ` | unset | Schedules and log timestamps |
 | `BACKEND_URL` | `http://localhost:8080` | Frontend → backend (set by entrypoint if empty) |
 | `FRONTEND_BACKEND_API_KEY` | random if unset | Shared API key; also seeds `api.key` when empty |
+| `METRICS_REQUIRE_API_KEY` | `false` | Require `x-api-key` for direct backend `/metrics` scrapes |
 | `MAX_BACKEND_HEALTH_RETRIES` | `30` | Entrypoint health wait |
 | `MAX_BACKEND_HEALTH_RETRY_DELAY` | `1` | Seconds between health probes |
 

--- a/docs/operations/prometheus.md
+++ b/docs/operations/prometheus.md
@@ -1,0 +1,45 @@
+# Prometheus metrics [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+InfiniDysk exposes Prometheus metrics at `/metrics`. The endpoint includes standard
+.NET process/runtime metrics plus `nzbdav_` metrics for active streaming, seek
+latency, NNTP provider pools, circuit breakers, article outcomes, and internal
+metrics-pipeline health.
+
+Metric labels are deliberately bounded. Provider metrics use the configured provider
+identity; other labels are fixed enums such as `region`, `kind`, `state`, and
+`status`. Paths, release names, filenames, client addresses, and article IDs are
+never exported as labels.
+
+## Authentication
+
+By default, direct backend scrapes are anonymous. Set
+`METRICS_REQUIRE_API_KEY=true` to require the normal `x-api-key` header for direct
+scrapes. Requests through the frontend `/metrics` proxy always require an
+authenticated InfiniDysk UI session and automatically receive the internal key.
+
+Do not publish the backend port to untrusted networks when direct scraping is
+anonymous.
+
+## Prometheus configuration
+
+For the normal frontend endpoint:
+
+```yaml
+scrape_configs:
+  - job_name: infinidysk
+    static_configs:
+      - targets: ["infinidysk:3000"]
+```
+
+On the same Docker network, scrape the backend directly on port 8080. When
+`METRICS_REQUIRE_API_KEY=true`, Prometheus 3 can send the API key:
+
+```yaml
+scrape_configs:
+  - job_name: infinidysk-backend
+    static_configs:
+      - targets: ["infinidysk:8080"]
+    http_headers:
+      x-api-key:
+        values: ["replace-with-your-api-key"]
+```

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -8,7 +8,7 @@ import { websocketServer } from "./websocket.server";
 import { safeDecodePath, shouldProxyToBackend } from "./proxy-path";
 import { logger } from "./logger";
 import { authMiddleware } from "~/auth/auth-middleware.server";
-import { getSessionUser } from "~/auth/authentication.server";
+import { getSessionUser, isAuthenticated } from "~/auth/authentication.server";
 import { setApiKeyForAuthenticatedRequests } from "./inject-api-key.server";
 import {
   BACKEND_FAILURE_LOG_THROTTLE_MS,
@@ -130,9 +130,14 @@ const credentialRateLimiter = rateLimit({
 
 app.use(async (req, res, next) => {
   if (shouldProxyToBackend(req.method, req.path)) {
+    const decodedPath = safeDecodePath(req.path);
+    if (decodedPath === "/metrics" && !await isAuthenticated(req)) {
+      res.status(401).type("text/plain").send("Metrics authentication required.");
+      return;
+    }
+
     await setApiKeyForAuthenticatedRequests(req);
 
-    const decodedPath = safeDecodePath(req.path);
     if (
       decodedPath !== null
       && req.method.toUpperCase() === "POST"

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -118,6 +118,7 @@ const credentialRateLimiter = rateLimit({
     return !(
       (method === "POST" && credentialPostPaths.has(decodedPath))
       || (method === "GET" && oidcGetPaths.has(decodedPath))
+      || (method === "GET" && decodedPath === "/metrics")
     );
   },
   handler: (req, res, _next, options) => {
@@ -127,6 +128,9 @@ const credentialRateLimiter = rateLimit({
     res.status(options.statusCode).send(options.message);
   },
 });
+
+// Limit credential attempts and protected metrics scrapes before the early backend proxy.
+app.use(credentialRateLimiter);
 
 app.use(async (req, res, next) => {
   if (shouldProxyToBackend(req.method, req.path)) {
@@ -158,9 +162,6 @@ app.use(async (req, res, next) => {
   }
   next();
 });
-
-// Limit credential attempts without throttling WebDAV, API, or regular UI traffic.
-app.use(credentialRateLimiter);
 
 // OIDC endpoints must remain public so the provider can complete the callback.
 app.use(oidcRouter);

--- a/frontend/server/inject-api-key.server.ts
+++ b/frontend/server/inject-api-key.server.ts
@@ -1,16 +1,16 @@
 import type express from "express";
 import { isAuthenticated } from "~/auth/authentication.server";
-import { isBackendApiPath } from "./proxy-path";
+import { isBackendApiPath, isBackendMetricsPath } from "./proxy-path";
 
 /**
  * Inject the frontend→backend API key for authenticated UI sessions that proxy
- * `/api` without supplying their own key.
+ * `/api` or `/metrics` without supplying their own key.
  */
 export async function setApiKeyForAuthenticatedRequests(
   req: express.Request,
 ): Promise<void> {
-  // if the path is not /api (decoded, segment-bounded), do nothing
-  if (!isBackendApiPath(req.path)) return;
+  // if the path is not a protected backend endpoint, do nothing
+  if (!isBackendApiPath(req.path) && !isBackendMetricsPath(req.path)) return;
 
   const apikey = req.query["apikey"] || req.query["apiKey"] || req.headers["x-api-key"];
   const hasApiKey = apikey && typeof apikey === "string";

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -1,6 +1,7 @@
 const BACKEND_PATH_PREFIXES = [
   "/api",
   "/ready",
+  "/metrics",
   "/view",
   "/.ids",
   "/nzbs",
@@ -31,6 +32,12 @@ export function isBackendApiPath(pathname: string): boolean {
   const decodedPath = safeDecodePath(pathname);
   if (decodedPath === null) return false;
   return decodedPath === "/api" || decodedPath.startsWith("/api/");
+}
+
+/** True when the path is the Prometheus metrics endpoint. */
+export function isBackendMetricsPath(pathname: string): boolean {
+  const decodedPath = safeDecodePath(pathname);
+  return decodedPath === "/metrics";
 }
 
 export function shouldProxyToBackend(method: string, pathname: string): boolean {

--- a/tests/NzbWebDAV.Tests/Api/MetricsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/MetricsHttpIntegrationTests.cs
@@ -19,4 +19,27 @@ public sealed class MetricsHttpIntegrationTests(NzbDavWebApplicationFactory fact
         Assert.Contains("# HELP", content);
         Assert.Contains("nzbdav_active_reads", content);
     }
+
+    [Fact]
+    public async Task MetricsEndpoint_RequiresApiKeyWhenEnabled()
+    {
+        var original = Environment.GetEnvironmentVariable("METRICS_REQUIRE_API_KEY");
+        Environment.SetEnvironmentVariable("METRICS_REQUIRE_API_KEY", "true");
+        try
+        {
+            using var client = factory.CreateClient();
+
+            using var rejected = await client.GetAsync("/metrics");
+            Assert.Equal(HttpStatusCode.Unauthorized, rejected.StatusCode);
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/metrics");
+            request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+            using var accepted = await client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, accepted.StatusCode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("METRICS_REQUIRE_API_KEY", original);
+        }
+    }
 }

--- a/tests/NzbWebDAV.Tests/Api/MetricsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/MetricsHttpIntegrationTests.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class MetricsHttpIntegrationTests(NzbDavWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task MetricsEndpoint_IsPrometheusTextAndBypassesWebDavAuthentication()
+    {
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/metrics");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.StartsWith("text/plain", response.Content.Headers.ContentType?.MediaType);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("# HELP", content);
+        Assert.Contains("nzbdav_active_reads", content);
+    }
+}

--- a/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
+++ b/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
@@ -1,0 +1,29 @@
+using System.Text;
+using NzbWebDAV.Services.Observability;
+using Prometheus;
+
+namespace NzbWebDAV.Tests.Services.Observability;
+
+public sealed class PrometheusMetricsTests
+{
+    [Fact]
+    public async Task RecordsOnlyBoundedSeekAndFetchLabels()
+    {
+        var registry = new CollectorRegistry();
+        var metrics = new PrometheusMetrics(registry);
+
+        metrics.RecordSeek("warm", TimeSpan.FromMilliseconds(12));
+        metrics.RecordSegmentFetch("provider-a", "ok", TimeSpan.FromMilliseconds(20));
+
+        await using var stream = new MemoryStream();
+        await registry.CollectAndExportAsTextAsync(stream);
+        var exposition = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.Contains("nzbdav_seek_total", exposition);
+        Assert.Contains("kind=\"warm\"", exposition);
+        Assert.Contains("nzbdav_segment_fetches_total", exposition);
+        Assert.Contains("provider_key=\"provider-a\"", exposition);
+        Assert.DoesNotContain("path=", exposition);
+        Assert.DoesNotContain("filename=", exposition);
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -81,6 +81,7 @@ nav = [
   ]},
   { "Operations" = [
     { "Health and repairs" = "operations/health-repairs.md" },
+    { "Prometheus metrics" = "operations/prometheus.md" },
     { "Retention and cleanup" = "operations/retention-cleanup.md" },
     { "Logs and crash dumps" = "operations/logs-crash-dumps.md" },
     { "Deletion audit" = "operations/deletion-audit.md" },


### PR DESCRIPTION
## Summary
- expose a Prometheus `/metrics` endpoint with bounded streaming, NNTP pool, circuit, seek, and fetch signals
- support optional API-key protection for direct scrapes and session-protected frontend proxying
- document configuration and add endpoint/cardinality coverage

Closes #757

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `npm run typecheck`
- [x] `npm test -- --run`
- [x] `npm run build`
- [x] `zensical build --clean --strict`