### PR TITLE
feat(api): add opt-in interactive admin API reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ cd frontend && npm install && npm run dev
 
 `npm run dev` silently runs `scripts/sync-dev-env.sh` via the `predev` hook; if the API key drifts, restart the backend with `scripts/run-backend.sh`. The manual `dotnet publish` / env-var flow below remains supported.
 
-`scripts/run-backend.sh` defaults `LOG_LEVEL=Debug` (and `LOG_BUFFER_SIZE=2000`) when unset so local playback debugging is verbose. Docker/production leave these unset and keep Information-level logging.
+`scripts/run-backend.sh` defaults `LOG_LEVEL=Debug` (and `LOG_BUFFER_SIZE=2000`) when unset so local playback debugging is verbose. Docker/production leave these unset and keep Information-level logging. It also enables the contributor-only admin API reference locally: open `http://localhost:5000/scalar/` directly, or sign in through the frontend and open `http://localhost:5173/scalar/`. Set `ENABLE_API_DOCS=false` to disable it; released Docker images keep it disabled unless explicitly enabled.
 
 Stream tracing is **opt-in** and off by default. Toggle it from **Settings → Support** for 15/30/60 minutes (no restart; it auto-expires and never survives a restart), or set `STREAM_TRACE_EVENTS` to a positive value for an always-on capture from startup. When tracing is off, no trace events are recorded and the trace APIs report `enabled: false`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ cd frontend && npm install && npm run dev
 
 `npm run dev` silently runs `scripts/sync-dev-env.sh` via the `predev` hook; if the API key drifts, restart the backend with `scripts/run-backend.sh`. The manual `dotnet publish` / env-var flow below remains supported.
 
-`scripts/run-backend.sh` defaults `LOG_LEVEL=Debug` (and `LOG_BUFFER_SIZE=2000`) when unset so local playback debugging is verbose. Docker/production leave these unset and keep Information-level logging. It also enables the contributor-only admin API reference locally: open `http://localhost:5000/scalar/` directly, or sign in through the frontend and open `http://localhost:5173/scalar/`. Set `ENABLE_API_DOCS=false` to disable it; released Docker images keep it disabled unless explicitly enabled.
+`scripts/run-backend.sh` defaults `LOG_LEVEL=Debug` (and `LOG_BUFFER_SIZE=2000`) when unset so local playback debugging is verbose. Docker/production leave these unset and keep Information-level logging. It also enables the contributor-only admin API reference locally; sign in through the frontend and open `http://localhost:5173/scalar/`. The backend's `/openapi/admin.json` endpoint requires `x-api-key` when accessed directly. Set `ENABLE_API_DOCS=false` to disable it; released Docker images keep it disabled unless explicitly enabled.
 
 Stream tracing is **opt-in** and off by default. Toggle it from **Settings → Support** for 15/30/60 minutes (no restart; it auto-expires and never survives a restart), or set `STREAM_TRACE_EVENTS` to a positive value for an always-on capture from startup. When tracing is off, no trace events are recorded and the trace APIs report `enabled: false`.
 

--- a/backend/Api/Controllers/BaseApiController.cs
+++ b/backend/Api/Controllers/BaseApiController.cs
@@ -7,6 +7,7 @@ using Serilog;
 
 namespace NzbWebDAV.Api.Controllers;
 
+[ApiExplorerSettings(GroupName = "admin")]
 public abstract class BaseApiController : ControllerBase
 {
     protected virtual bool RequiresAuthentication => true;

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationBaseController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationBaseController.cs
@@ -18,6 +18,7 @@ namespace NzbWebDAV.Api.Controllers.UsenetMigration;
 /// API-key check and error shape.
 /// </summary>
 [ApiController]
+[ApiExplorerSettings(GroupName = "admin")]
 public abstract class UsenetMigrationBaseController : ControllerBase
 {
     protected async Task<IActionResult> GuardedAsync(Func<Task<IActionResult>> handler)

--- a/backend/Api/OpenApi/AdminOpenApiDocumentTransformer.cs
+++ b/backend/Api/OpenApi/AdminOpenApiDocumentTransformer.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Api.OpenApi;
+
+internal sealed class AdminOpenApiDocumentTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        document.Info.Title = "InfiniDysk Admin API";
+        document.Info.Version = ConfigManager.AppVersion;
+        document.Info.Description =
+            "Contributor-facing reference for the InfiniDysk admin REST API. "
+            + "SABnzbd compatibility, WebDAV, streaming, adapters, and file-transfer routes are intentionally excluded.";
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
+        document.Components.SecuritySchemes["ApiKey"] = new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.ApiKey,
+            Name = "x-api-key",
+            In = ParameterLocation.Header,
+            Description = "Admin API key. Use FRONTEND_BACKEND_API_KEY for local development.",
+        };
+
+        document.Security ??= [];
+        document.Security.Add(new OpenApiSecurityRequirement
+        {
+            [new OpenApiSecuritySchemeReference("ApiKey", document)] = [],
+        });
+
+        // The document is served through a frontend proxy that can be mounted at
+        // NZBDAV_URL_BASE. An empty server URL makes Scalar target the origin and
+        // path from which the reference was loaded instead of an internal backend URL.
+        document.Servers = [new OpenApiServer { Url = "" }];
+        return Task.CompletedTask;
+    }
+}

--- a/backend/Api/OpenApi/AdminOpenApiDocumentTransformer.cs
+++ b/backend/Api/OpenApi/AdminOpenApiDocumentTransformer.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.OpenApi;
+using Microsoft.AspNetCore.Http;
 using Microsoft.OpenApi;
 using NzbWebDAV.Config;
 
@@ -6,6 +7,13 @@ namespace NzbWebDAV.Api.OpenApi;
 
 internal sealed class AdminOpenApiDocumentTransformer : IOpenApiDocumentTransformer
 {
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public AdminOpenApiDocumentTransformer(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
     public Task TransformAsync(
         OpenApiDocument document,
         OpenApiDocumentTransformerContext context,
@@ -36,7 +44,18 @@ internal sealed class AdminOpenApiDocumentTransformer : IOpenApiDocumentTransfor
         // The document is served through a frontend proxy that can be mounted at
         // NZBDAV_URL_BASE. An empty server URL makes Scalar target the origin and
         // path from which the reference was loaded instead of an internal backend URL.
-        document.Servers = [new OpenApiServer { Url = "" }];
+        var forwardedPrefix = _httpContextAccessor.HttpContext?
+            .Request.Headers["X-Forwarded-Prefix"]
+            .FirstOrDefault();
+        document.Servers =
+        [
+            new OpenApiServer
+            {
+                Url = string.IsNullOrWhiteSpace(forwardedPrefix)
+                    ? ""
+                    : forwardedPrefix.TrimEnd('/') + "/",
+            },
+        ];
         return Task.CompletedTask;
     }
 }

--- a/backend/Api/OpenApi/AdminOpenApiExtensions.cs
+++ b/backend/Api/OpenApi/AdminOpenApiExtensions.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
+using NzbWebDAV.Api.Controllers;
+using NzbWebDAV.Api.Controllers.UsenetMigration;
+
+namespace NzbWebDAV.Api.OpenApi;
+
+internal static class AdminOpenApiExtensions
+{
+    internal const string DocumentName = "admin";
+
+    private static readonly HashSet<string> ExcludedPaths = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "api/db.sqlite",
+        "api/db-backup-download",
+        "api/db-backup-upload",
+        "api/download-logs",
+        "api/download-nzb",
+        "api/download-support-pack",
+        "api/warden-export",
+        "api/warden-import",
+        "api/warden-sources-export",
+        "api/warden-sources-import",
+    };
+
+    internal static bool IsEnabled(IHostEnvironment environment)
+    {
+        return environment.IsDevelopment() || Utils.EnvironmentUtil.IsVariableTrue("ENABLE_API_DOCS");
+    }
+
+    internal static void Configure(OpenApiOptions options)
+    {
+        options.ShouldInclude = ShouldInclude;
+        options.AddDocumentTransformer<AdminOpenApiDocumentTransformer>();
+        options.AddOperationTransformer<AdminOpenApiOperationTransformer>();
+    }
+
+    private static bool ShouldInclude(ApiDescription description)
+    {
+        if (!string.Equals(description.GroupName, DocumentName, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var relativePath = description.RelativePath?.TrimStart('/');
+        if (string.IsNullOrWhiteSpace(relativePath) || ExcludedPaths.Contains(relativePath))
+            return false;
+
+        return description.ActionDescriptor is ControllerActionDescriptor descriptor
+            && (typeof(BaseApiController).IsAssignableFrom(descriptor.ControllerTypeInfo)
+                || typeof(UsenetMigrationBaseController).IsAssignableFrom(descriptor.ControllerTypeInfo));
+    }
+}

--- a/backend/Api/OpenApi/AdminOpenApiExtensions.cs
+++ b/backend/Api/OpenApi/AdminOpenApiExtensions.cs
@@ -28,7 +28,10 @@ internal static class AdminOpenApiExtensions
 
     internal static bool IsEnabled(IHostEnvironment environment)
     {
-        return environment.IsDevelopment() || Utils.EnvironmentUtil.IsVariableTrue("ENABLE_API_DOCS");
+        var configured = Utils.EnvironmentUtil.GetEnvironmentVariable("ENABLE_API_DOCS");
+        return configured is null
+            ? environment.IsDevelopment()
+            : Utils.EnvironmentUtil.IsVariableTrue("ENABLE_API_DOCS");
     }
 
     internal static void Configure(OpenApiOptions options)

--- a/backend/Api/OpenApi/AdminOpenApiOperationTransformer.cs
+++ b/backend/Api/OpenApi/AdminOpenApiOperationTransformer.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace NzbWebDAV.Api.OpenApi;
+
+internal sealed class AdminOpenApiOperationTransformer : IOpenApiOperationTransformer
+{
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        if (context.Description.ActionDescriptor is not ControllerActionDescriptor descriptor)
+            return Task.CompletedTask;
+
+        var route = context.Description.RelativePath?.TrimStart('/') ?? descriptor.ControllerName;
+        var verb = context.Description.HttpMethod?.ToLowerInvariant() ?? "request";
+        var routeName = route
+            .Replace('/', '-')
+            .Replace('{', '-')
+            .Replace('}', '-')
+            .Replace("--", "-", StringComparison.Ordinal)
+            .Trim('-');
+
+        operation.OperationId = $"{verb}-{routeName}";
+        operation.Summary = HumanizeControllerName(descriptor.ControllerName);
+        AddKnownFormRequestBody(operation, route, verb);
+        operation.Responses ??= [];
+        if (!operation.Responses.ContainsKey("200"))
+            operation.Responses["200"] = new OpenApiResponse { Description = "Success." };
+
+        return Task.CompletedTask;
+    }
+
+    private static string HumanizeControllerName(string controllerName)
+    {
+        return string.Concat(controllerName.Select((character, index) =>
+            index > 0 && char.IsUpper(character) && !char.IsUpper(controllerName[index - 1])
+                ? $" {character}"
+                : character.ToString()));
+    }
+
+    private static void AddKnownFormRequestBody(OpenApiOperation operation, string route, string verb)
+    {
+        if (verb != "post") return;
+
+        string[]? fields = route switch
+        {
+            "api/authenticate" or "api/create-account" => ["username", "password", "type"],
+            "api/get-config" => ["config-keys"],
+            "api/list-webdav-directory" => ["directory"],
+            "api/search-indexers" => ["q", "limit"],
+            "api/test-usenet-connection" =>
+                ["host", "user", "pass", "port", "use-ssl", "skip-tls-verification"],
+            "api/test-arr-connection" => ["host", "apiKey"],
+            "api/test-indexer-connection" =>
+                ["url", "apiKey", "userAgent", "proxyUrl", "timeoutSeconds", "skipTlsVerification"],
+            "api/test-prowlarr-connection" => ["url", "apiKey"],
+            "api/test-rclone-connection" => ["host", "user", "pass"],
+            _ => null,
+        };
+
+        if (fields is null) return;
+
+        operation.RequestBody = new OpenApiRequestBody
+        {
+            Required = true,
+            Description = "Submit the fields as multipart form data.",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                ["multipart/form-data"] = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchema
+                    {
+                        Type = JsonSchemaType.Object,
+                        Properties = fields.ToDictionary(
+                            field => field,
+                            _ => (IOpenApiSchema)new OpenApiSchema { Type = JsonSchemaType.String }),
+                    },
+                },
+            },
+        };
+    }
+}

--- a/backend/Extensions/NWebDavOptionsExtensions.cs
+++ b/backend/Extensions/NWebDavOptionsExtensions.cs
@@ -14,6 +14,8 @@ public static class NWebDavOptionsExtensions
                           !context.Request.Path.StartsWithSegments("/metrics", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/ws", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/p", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/openapi", StringComparison.Ordinal) &&
+                          !context.Request.Path.StartsWithSegments("/scalar", StringComparison.Ordinal) &&
                           !context.Request.Path.StartsWithSegments("/adapters", StringComparison.Ordinal);
     }
 }

--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -14,12 +14,14 @@
 
     <ItemGroup>
       <PackageReference Include="MemoryPack" Version="1.21.4" />
+      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
+      <PackageReference Include="Scalar.AspNetCore" Version="2.16.20" />
       <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
       <PackageReference Include="NWebDav.Server" Version="0.2.0-beta.2" />
       <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -381,7 +381,8 @@ public partial class Program
             app.Use(async (context, next) =>
             {
                 if (apiDocsEnabled
-                    && context.Request.Path.StartsWithSegments("/openapi", StringComparison.Ordinal))
+                    && (context.Request.Path.StartsWithSegments("/openapi", StringComparison.Ordinal)
+                        || context.Request.Path.StartsWithSegments("/scalar", StringComparison.Ordinal)))
                 {
                     try
                     {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -206,6 +207,7 @@ public partial class Program
             builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = maxRequestBodySize);
             builder.Host.UseSerilog();
             builder.Services.AddControllers();
+            builder.Services.AddHttpContextAccessor();
             if (apiDocsEnabled)
                 builder.Services.AddOpenApi(AdminOpenApiExtensions.DocumentName, AdminOpenApiExtensions.Configure);
             builder.Services.AddHealthChecks()
@@ -376,6 +378,29 @@ public partial class Program
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseMiddleware<MetricsAuthenticationMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
+            app.Use(async (context, next) =>
+            {
+                if (apiDocsEnabled
+                    && context.Request.Path.StartsWithSegments("/openapi", StringComparison.Ordinal))
+                {
+                    try
+                    {
+                        ApiKeyValidator.Validate(context, configManager);
+                    }
+                    catch (UnauthorizedAccessException exception)
+                    {
+                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        await context.Response.WriteAsJsonAsync(new
+                        {
+                            status = false,
+                            error = exception.Message,
+                        }).ConfigureAwait(false);
+                        return;
+                    }
+                }
+
+                await next().ConfigureAwait(false);
+            });
             app.MapHealthChecks("/health", new HealthCheckOptions
             {
                 Predicate = check => !check.Tags.Contains("ready"),

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
+using Scalar.AspNetCore;
+using NzbWebDAV.Api.OpenApi;
 using NzbWebDAV.Api.SabControllers;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Clients.Rclone;
@@ -199,10 +201,13 @@ public partial class Program
 
             // initialize webapp
             var builder = WebApplication.CreateBuilder(args);
+            var apiDocsEnabled = AdminOpenApiExtensions.IsEnabled(builder.Environment);
             var maxRequestBodySize = EnvironmentUtil.GetLongVariable("MAX_REQUEST_BODY_SIZE") ?? 100 * 1024 * 1024;
             builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = maxRequestBodySize);
             builder.Host.UseSerilog();
             builder.Services.AddControllers();
+            if (apiDocsEnabled)
+                builder.Services.AddOpenApi(AdminOpenApiExtensions.DocumentName, AdminOpenApiExtensions.Configure);
             builder.Services.AddHealthChecks()
                 .AddCheck<StreamingReadinessCheck>(
                     "streaming_readiness",
@@ -381,6 +386,16 @@ public partial class Program
             });
             app.Map("/ws", websocketManager.HandleRoute);
             app.MapControllers();
+            if (apiDocsEnabled)
+            {
+                app.MapOpenApi();
+                app.MapScalarApiReference(options => options
+                    .WithTitle("InfiniDysk Admin API")
+                    .AddDocument(AdminOpenApiExtensions.DocumentName, "Admin REST API")
+                    .AddPreferredSecuritySchemes("ApiKey")
+                    .DisableAgent()
+                    .DisableDefaultFonts());
+            }
             app.MapMetrics("/metrics", app.Services.GetRequiredService<CollectorRegistry>());
             app.UseWebdavBasicAuthentication();
             app.UseNWebDav();

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -28,7 +28,7 @@ cd frontend && npm install && npm run dev
 
 UI: `http://localhost:5173` → proxies to backend `:5000`.
 
-`run-backend.sh` defaults `LOG_LEVEL=Debug` and `LOG_BUFFER_SIZE=2000` for local debugging. Docker leaves these unset. The script also enables the contributor-only admin API reference locally: use `http://localhost:5000/scalar/` directly, or sign in and use `http://localhost:5173/scalar/` through the frontend. Set `ENABLE_API_DOCS=false` to disable it; Docker keeps the reference disabled unless explicitly enabled. Stream tracing is off by default — toggle it from Settings → Support, or export `STREAM_TRACE_EVENTS=20000` for an always-on capture.
+`run-backend.sh` defaults `LOG_LEVEL=Debug` and `LOG_BUFFER_SIZE=2000` for local debugging. Docker leaves these unset. The script also enables the contributor-only admin API reference locally: sign in and use `http://localhost:5173/scalar/` through the frontend. The backend's `/openapi/admin.json` endpoint requires `x-api-key` when accessed directly. Set `ENABLE_API_DOCS=false` to disable it; Docker keeps the reference disabled unless explicitly enabled. Stream tracing is off by default — toggle it from Settings → Support, or export `STREAM_TRACE_EVENTS=20000` for an always-on capture.
 
 ## Real-provider playback
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -28,7 +28,7 @@ cd frontend && npm install && npm run dev
 
 UI: `http://localhost:5173` → proxies to backend `:5000`.
 
-`run-backend.sh` defaults `LOG_LEVEL=Debug` and `LOG_BUFFER_SIZE=2000` for local debugging. Docker leaves these unset. Stream tracing is off by default — toggle it from Settings → Support, or export `STREAM_TRACE_EVENTS=20000` for an always-on capture.
+`run-backend.sh` defaults `LOG_LEVEL=Debug` and `LOG_BUFFER_SIZE=2000` for local debugging. Docker leaves these unset. The script also enables the contributor-only admin API reference locally: use `http://localhost:5000/scalar/` directly, or sign in and use `http://localhost:5173/scalar/` through the frontend. Set `ENABLE_API_DOCS=false` to disable it; Docker keeps the reference disabled unless explicitly enabled. Stream tracing is off by default — toggle it from Settings → Support, or export `STREAM_TRACE_EVENTS=20000` for an always-on capture.
 
 ## Real-provider playback
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -90,6 +90,7 @@ or restrict backend capabilities when enforcement is required.
 | `LOG_LEVEL` | Information | Serilog minimum level |
 | `LOG_BUFFER_SIZE` | `2000` | In-memory log buffer for UI (100–50000) |
 | `STREAM_TRACE_EVENTS` | `0` (off) | Opt-in stream trace capacity, always-on with no expiry; the Settings → Support toggle can also set capacity (20k–200k) for timed captures |
+| `ENABLE_API_DOCS` [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `false` | Enables the contributor-facing Scalar reference at `/scalar/` and its admin-only OpenAPI document at `/openapi/admin.json`; never enabled by default in Docker |
 | `TRUSTED_PROXY_CIDRS` | loopback | Comma-separated IPs/CIDRs trusted for forwarded headers |
 | `DISABLE_WEBDAV_AUTH` | unset | Disables WebDAV auth (**dangerous**) |
 | `RESET_ADMIN_PASSWORD` | unset | `true` deletes the admin account on next startup, forcing re-onboarding. **Remove after use.** |

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -71,7 +71,10 @@ const forwardToBackend = createProxyMiddleware({
   ...backendProxyTimeoutOptions,
   on: {
     proxyReq: (proxyReq, req) => {
-      applyCanonicalForwardedHeaders(proxyReq, req as express.Request, { trustProxy });
+      applyCanonicalForwardedHeaders(proxyReq, req as express.Request, {
+        trustProxy,
+        pathBase: URL_BASE,
+      });
     },
     error: (error, req, res) => {
       logProxyFailure(
@@ -173,8 +176,11 @@ app.use(authMiddleware);
 // session when accessed through the public UI port. Do not move this beside the
 // early backend proxy above: that middleware intentionally runs before auth for
 // WebDAV and API clients.
-app.use((req, res, next) => {
-  if (isBackendApiDocsPath(req.path)) return forwardToBackend(req, res, next);
+app.use(async (req, res, next) => {
+  if (isBackendApiDocsPath(req.path)) {
+    await setApiKeyForAuthenticatedRequests(req);
+    return forwardToBackend(req, res, next);
+  }
   next();
 });
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -5,7 +5,7 @@ import express from "express";
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { websocketServer } from "./websocket.server";
-import { safeDecodePath, shouldProxyToBackend } from "./proxy-path";
+import { isBackendApiDocsPath, safeDecodePath, shouldProxyToBackend } from "./proxy-path";
 import { logger } from "./logger";
 import { authMiddleware } from "~/auth/auth-middleware.server";
 import { getSessionUser, isAuthenticated } from "~/auth/authentication.server";
@@ -168,6 +168,15 @@ app.use(oidcRouter);
 
 // Require authentication for all React Router routes
 app.use(authMiddleware);
+
+// API documentation is opt-in on the backend, and is protected by the frontend
+// session when accessed through the public UI port. Do not move this beside the
+// early backend proxy above: that middleware intentionally runs before auth for
+// WebDAV and API clients.
+app.use((req, res, next) => {
+  if (isBackendApiDocsPath(req.path)) return forwardToBackend(req, res, next);
+  next();
+});
 
 // Let frontend handle all other requests
 app.use(

--- a/frontend/server/forwarded-headers.test.ts
+++ b/frontend/server/forwarded-headers.test.ts
@@ -58,4 +58,23 @@ describe("applyCanonicalForwardedHeaders", () => {
 
     expect(set["X-Forwarded-For"]).toBe("203.0.113.10");
   });
+
+  it("forwards the configured URL base for backend-generated links", () => {
+    const set: Record<string, string> = {};
+    const proxyReq = {
+      removeHeader: () => {},
+      setHeader: (name: string, value: string) => {
+        set[name] = value;
+      },
+    };
+    const req = {
+      protocol: "https",
+      get: () => "nzbdav.example",
+      socket: { remoteAddress: "10.0.0.2" },
+    } as unknown as express.Request;
+
+    applyCanonicalForwardedHeaders(proxyReq, req, { pathBase: "/nzbdav" });
+
+    expect(set["X-Forwarded-Prefix"]).toBe("/nzbdav");
+  });
 });

--- a/frontend/server/forwarded-headers.ts
+++ b/frontend/server/forwarded-headers.ts
@@ -7,13 +7,14 @@ import type express from "express";
 export function applyCanonicalForwardedHeaders(
   proxyReq: { removeHeader: (name: string) => void; setHeader: (name: string, value: string) => void },
   req: express.Request,
-  options?: { trustProxy?: boolean },
+  options?: { trustProxy?: boolean; pathBase?: string },
 ): void {
   for (const header of [
     "x-forwarded-for",
     "x-forwarded-host",
     "x-forwarded-proto",
     "x-forwarded-port",
+    "x-forwarded-prefix",
     "forwarded",
   ]) {
     proxyReq.removeHeader(header);
@@ -26,4 +27,5 @@ export function applyCanonicalForwardedHeaders(
   const trustProxy = options?.trustProxy ?? false;
   const clientIp = trustProxy ? req.ip : req.socket.remoteAddress;
   if (clientIp) proxyReq.setHeader("X-Forwarded-For", clientIp);
+  if (options?.pathBase) proxyReq.setHeader("X-Forwarded-Prefix", options.pathBase);
 }

--- a/frontend/server/inject-api-key.server.test.ts
+++ b/frontend/server/inject-api-key.server.test.ts
@@ -72,6 +72,13 @@ describe("setApiKeyForAuthenticatedRequests", () => {
     expect(req.headers["x-api-key"]).toBe("injected-key");
   });
 
+  it("injects FRONTEND_BACKEND_API_KEY for authenticated API docs requests", async () => {
+    isAuthenticatedMock.mockResolvedValueOnce(true);
+    const req = mockReq({ path: "/openapi/admin.json" });
+    await setApiKeyForAuthenticatedRequests(req);
+    expect(req.headers["x-api-key"]).toBe("injected-key");
+  });
+
   it("treats query apikey as already present", async () => {
     const req = mockReq({
       path: "/api",

--- a/frontend/server/inject-api-key.server.ts
+++ b/frontend/server/inject-api-key.server.ts
@@ -1,6 +1,6 @@
 import type express from "express";
 import { isAuthenticated } from "~/auth/authentication.server";
-import { isBackendApiPath, isBackendMetricsPath } from "./proxy-path";
+import { isBackendApiDocsPath, isBackendApiPath, isBackendMetricsPath } from "./proxy-path";
 
 /**
  * Inject the frontend→backend API key for authenticated UI sessions that proxy
@@ -10,7 +10,9 @@ export async function setApiKeyForAuthenticatedRequests(
   req: express.Request,
 ): Promise<void> {
   // if the path is not a protected backend endpoint, do nothing
-  if (!isBackendApiPath(req.path) && !isBackendMetricsPath(req.path)) return;
+  if (!isBackendApiPath(req.path)
+    && !isBackendMetricsPath(req.path)
+    && !isBackendApiDocsPath(req.path)) return;
 
   const apikey = req.query["apikey"] || req.query["apiKey"] || req.headers["x-api-key"];
   const hasApiKey = apikey && typeof apikey === "string";

--- a/frontend/server/proxy-path.test.ts
+++ b/frontend/server/proxy-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isBackendApiDocsPath,
   isBackendApiPath,
   matchesBackendPathPrefix,
   safeDecodePath,
@@ -60,6 +61,25 @@ describe("isBackendApiPath", () => {
   });
 });
 
+describe("isBackendApiDocsPath", () => {
+  it.each([
+    "/openapi",
+    "/openapi/admin.json",
+    "/scalar",
+    "/scalar/",
+    "/scalar/admin",
+  ])("matches API docs path %s", (path) => {
+    expect(isBackendApiDocsPath(path)).toBe(true);
+  });
+
+  it.each(["/openapifoo", "/scalarfoo", "/api/get-config", "/%zz"])(
+    "rejects non-docs path %s",
+    (path) => {
+      expect(isBackendApiDocsPath(path)).toBe(false);
+    },
+  );
+});
+
 describe("shouldProxyToBackend", () => {
   it.each(["PROPFIND", "propfind", "OPTIONS", "options"])(
     "proxies %s requests regardless of path",
@@ -115,6 +135,8 @@ describe("shouldSkipCompression", () => {
   it("skips compression for backend paths", () => {
     expect(shouldSkipCompression("/view/movies")).toBe(true);
     expect(shouldSkipCompression("/api/get-config")).toBe(true);
+    expect(shouldSkipCompression("/openapi/admin.json")).toBe(true);
+    expect(shouldSkipCompression("/scalar/")).toBe(true);
   });
 
   it("does not skip for frontend paths, false positives, or malformed encoding", () => {

--- a/frontend/server/proxy-path.test.ts
+++ b/frontend/server/proxy-path.test.ts
@@ -144,4 +144,8 @@ describe("shouldSkipCompression", () => {
     expect(shouldSkipCompression("/viewport.css")).toBe(false);
     expect(shouldSkipCompression("/%zz")).toBe(false);
   });
+
+  it("does not double-decode API documentation paths", () => {
+    expect(shouldSkipCompression("/scalar/%25")).toBe(true);
+  });
 });

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -40,6 +40,15 @@ export function isBackendMetricsPath(pathname: string): boolean {
   return decodedPath === "/metrics";
 }
 
+/** True when the path is an opt-in backend API documentation endpoint. */
+export function isBackendApiDocsPath(pathname: string): boolean {
+  const decodedPath = safeDecodePath(pathname);
+  return decodedPath === "/openapi"
+    || decodedPath?.startsWith("/openapi/") === true
+    || decodedPath === "/scalar"
+    || decodedPath?.startsWith("/scalar/") === true;
+}
+
 export function shouldProxyToBackend(method: string, pathname: string): boolean {
   const normalizedMethod = method.toUpperCase();
   if (normalizedMethod === "PROPFIND" || normalizedMethod === "OPTIONS") {
@@ -56,5 +65,5 @@ export function shouldProxyToBackend(method: string, pathname: string): boolean 
 export function shouldSkipCompression(pathname: string): boolean {
   const decodedPath = safeDecodePath(pathname);
   if (decodedPath === null) return false;
-  return matchesBackendPathPrefix(decodedPath);
+  return matchesBackendPathPrefix(decodedPath) || isBackendApiDocsPath(decodedPath);
 }

--- a/frontend/server/proxy-path.ts
+++ b/frontend/server/proxy-path.ts
@@ -65,5 +65,5 @@ export function shouldProxyToBackend(method: string, pathname: string): boolean 
 export function shouldSkipCompression(pathname: string): boolean {
   const decodedPath = safeDecodePath(pathname);
   if (decodedPath === null) return false;
-  return matchesBackendPathPrefix(decodedPath) || isBackendApiDocsPath(decodedPath);
+  return matchesBackendPathPrefix(decodedPath) || isBackendApiDocsPath(pathname);
 }

--- a/scripts/run-backend.sh
+++ b/scripts/run-backend.sh
@@ -74,6 +74,10 @@ export ASPNETCORE_URLS="${ASPNETCORE_URLS:-$BACKEND_URL}"
 # Local-dev defaults only (Docker/entrypoint leave LOG_LEVEL unset → Information).
 export LOG_LEVEL="${LOG_LEVEL:-Debug}"
 export LOG_BUFFER_SIZE="${LOG_BUFFER_SIZE:-2000}"
+# The interactive admin API reference is contributor tooling. Docker keeps it
+# disabled unless explicitly enabled, while the preferred local workflow makes
+# it available at /scalar without extra setup.
+export ENABLE_API_DOCS="${ENABLE_API_DOCS:-true}"
 # STREAM_TRACE_EVENTS is deliberately not defaulted: tracing is togglable from
 # Settings -> Support, and forcing it on here hid that path during local testing.
 

--- a/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
@@ -65,7 +65,12 @@ public sealed class AdminOpenApiIntegrationTests(NzbDavWebApplicationFactory fac
             Assert.Equal("x-api-key", apiKey.GetProperty("name").GetString());
             Assert.Equal("header", apiKey.GetProperty("in").GetString());
 
-            using var scalar = await client.GetAsync("/scalar/");
+            using var scalarRejected = await client.GetAsync("/scalar/");
+            Assert.Equal(HttpStatusCode.Unauthorized, scalarRejected.StatusCode);
+
+            using var scalarRequest = new HttpRequestMessage(HttpMethod.Get, "/scalar/");
+            scalarRequest.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+            using var scalar = await client.SendAsync(scalarRequest);
             Assert.Equal(HttpStatusCode.OK, scalar.StatusCode);
         }
         finally

--- a/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
@@ -28,7 +28,12 @@ public sealed class AdminOpenApiIntegrationTests(NzbDavWebApplicationFactory fac
         {
             using var docsFactory = factory.WithWebHostBuilder(_ => { });
             using var client = docsFactory.CreateClient();
-            using var response = await client.GetAsync("/openapi/admin.json");
+            using var rejected = await client.GetAsync("/openapi/admin.json");
+            Assert.Equal(HttpStatusCode.Unauthorized, rejected.StatusCode);
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/openapi/admin.json");
+            request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+            using var response = await client.SendAsync(request);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());

--- a/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Text.Json;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class AdminOpenApiIntegrationTests(NzbDavWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task DocsAreNotMappedWithoutTheExplicitOptIn()
+    {
+        using var client = factory.CreateClient();
+
+        using var document = await client.GetAsync("/openapi/admin.json");
+        using var scalar = await client.GetAsync("/scalar/");
+
+        Assert.Equal(HttpStatusCode.NotFound, document.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, scalar.StatusCode);
+    }
+
+    [Fact]
+    public async Task OptedInDocumentIncludesOnlyAdminApiAndApiKeySecurity()
+    {
+        var previous = Environment.GetEnvironmentVariable("ENABLE_API_DOCS");
+        Environment.SetEnvironmentVariable("ENABLE_API_DOCS", "true");
+        try
+        {
+            using var docsFactory = factory.WithWebHostBuilder(_ => { });
+            using var client = docsFactory.CreateClient();
+            using var response = await client.GetAsync("/openapi/admin.json");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            var root = json.RootElement;
+            var paths = root.GetProperty("paths");
+
+            Assert.True(paths.TryGetProperty("/api/get-config", out var getConfig));
+            Assert.True(getConfig.TryGetProperty("get", out _));
+            var getConfigPost = getConfig.GetProperty("post");
+            Assert.True(getConfigPost.GetProperty("requestBody")
+                .GetProperty("content")
+                .GetProperty("multipart/form-data")
+                .GetProperty("schema")
+                .GetProperty("properties")
+                .TryGetProperty("config-keys", out _));
+            Assert.True(paths.TryGetProperty("/api/migration/altmount/categories", out var categories));
+            Assert.True(categories.TryGetProperty("get", out _));
+            Assert.True(categories.TryGetProperty("put", out _));
+
+            Assert.False(paths.TryGetProperty("/api", out _));
+            Assert.False(paths.TryGetProperty("/view/{path}", out _));
+            Assert.False(paths.TryGetProperty("/api/search/{token}/lookup", out _));
+            Assert.False(paths.TryGetProperty("/api/download-support-pack", out _));
+
+            var apiKey = root.GetProperty("components")
+                .GetProperty("securitySchemes")
+                .GetProperty("ApiKey");
+            Assert.Equal("apiKey", apiKey.GetProperty("type").GetString());
+            Assert.Equal("x-api-key", apiKey.GetProperty("name").GetString());
+            Assert.Equal("header", apiKey.GetProperty("in").GetString());
+
+            using var scalar = await client.GetAsync("/scalar/");
+            Assert.Equal(HttpStatusCode.OK, scalar.StatusCode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ENABLE_API_DOCS", previous);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Extensions/NWebDavOptionsFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/NWebDavOptionsFilterTests.cs
@@ -21,6 +21,8 @@ public class NWebDavOptionsFilterTests
     [InlineData("/ready")]
     [InlineData("/ws")]
     [InlineData("/p")]
+    [InlineData("/openapi/admin.json")]
+    [InlineData("/scalar/")]
     [InlineData("/adapters")]
     [InlineData("/adapters/addon/token/manifest.json")]
     public void LeavesApplicationRoutesAlone(string path)


### PR DESCRIPTION
## Summary
- add an opt-in Scalar reference and scoped OpenAPI document for the admin REST API
- document API-key authentication and common multipart form contracts while excluding SAB, streaming, adapters, and file-transfer endpoints
- make the reference available to authenticated frontend users and enabled by default in the local contributor script

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `npm run typecheck && npm test && npm run build` (frontend)
- [x] `zensical build --clean --strict`
- [x] `dotnet restore backend/NzbWebDAV.csproj --force-evaluate`

Closes #322