### PR TITLE
fix(webdav): repair files that cannot seek through missing tail articles

### DIFF
--- a/backend/Exceptions/SeekPositionNotFoundException.cs
+++ b/backend/Exceptions/SeekPositionNotFoundException.cs
@@ -1,5 +1,6 @@
 ﻿namespace NzbWebDAV.Exceptions;
 
-public class SeekPositionNotFoundException(string message) : NonRetryableDownloadException(message)
+public class SeekPositionNotFoundException(string message, Exception? innerException = null)
+    : NonRetryableDownloadException(message, innerException)
 {
 }

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -115,7 +115,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
-        catch (SeekPositionNotFoundException)
+        catch (SeekPositionNotFoundException e)
         {
             if (!context.Response.HasStarted)
             {
@@ -140,6 +140,15 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
                         filePath,
                         seekPosition);
             });
+
+            // Only a short segment proves the release cannot serve this range. Other seek
+            // failures can be transient header-probe errors or corrupt local metadata and
+            // must not trigger Arr removal or blocklisting.
+            if (e.InnerException is EndOfStreamException &&
+                context.Items["DavItem"] is DavItem davItem)
+            {
+                ScheduleRepair(davItem);
+            }
 
             AbortStartedResponse(context);
         }

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -202,47 +202,56 @@ public class NzbFileStream(
         }
 
         var avg = EstimatedSegmentSize;
-        return await InterpolationSearch.Find(
-            byteOffset,
-            new LongRange(0, fileSegmentIds.Length),
-            new LongRange(0, fileSize),
-            async (guess) =>
-            {
-                try
+        UsenetArticleNotFoundException? missingProbeArticle = null;
+        try
+        {
+            return await InterpolationSearch.Find(
+                byteOffset,
+                new LongRange(0, fileSegmentIds.Length),
+                new LongRange(0, fileSize),
+                async (guess) =>
                 {
-                    var header = await usenetClient.GetYencHeadersAsync(fileSegmentIds[guess], ct).ConfigureAwait(false);
-                    return new LongRange(header.PartOffset, header.PartOffset + header.PartSize);
-                }
-                catch (UsenetArticleNotFoundException e)
-                {
-                    // The probe segment itself is missing — fall back to a
-                    // synthetic uniform-size range so interpolation can still
-                    // converge. The actual body read of this segment (if it
-                    // turns out to be the seek target) gets a same-length gap from
-                    // MultiSegmentStream.
-                    Log.Warning(
-                        "Seek probe hit missing article {SegmentId} (segment index {Index}) while reading {FileName}. Using estimated range.",
-                        e.SegmentId, guess, string.IsNullOrEmpty(fileName) ? "unknown" : fileName);
-                    var start = guess * avg;
-                    var end = Math.Min(fileSize, start + avg);
-                    return new LongRange(start, end);
-                }
-                catch (OutOfMemoryException oom)
-                {
-                    OomDiagnostics.LogHeapStateOnOom(oom, "seek probe");
-                    throw;
-                }
-                catch (Exception e) when (articleBufferSize > 0 && !ct.IsCancellationRequested && e is not OutOfMemoryException)
-                {
-                    e.LogWarningKnownOrStack(
-                        "Seek probe transient failure on segment index {Index}. Using estimated range.", guess);
-                    var start = guess * avg;
-                    var end = Math.Min(fileSize, start + avg);
-                    return new LongRange(start, end);
-                }
-            },
-            ct
-        ).ConfigureAwait(false);
+                    try
+                    {
+                        var header = await usenetClient.GetYencHeadersAsync(fileSegmentIds[guess], ct).ConfigureAwait(false);
+                        return new LongRange(header.PartOffset, header.PartOffset + header.PartSize);
+                    }
+                    catch (UsenetArticleNotFoundException e)
+                    {
+                        // The probe segment itself is missing — fall back to a
+                        // synthetic uniform-size range so interpolation can still
+                        // converge. The actual body read of this segment (if it
+                        // turns out to be the seek target) gets a same-length gap from
+                        // MultiSegmentStream.
+                        missingProbeArticle = e;
+                        Log.Warning(
+                            "Seek probe hit missing article {SegmentId} (segment index {Index}) while reading {FileName}. Using estimated range.",
+                            e.SegmentId, guess, string.IsNullOrEmpty(fileName) ? "unknown" : fileName);
+                        var start = guess * avg;
+                        var end = Math.Min(fileSize, start + avg);
+                        return new LongRange(start, end);
+                    }
+                    catch (OutOfMemoryException oom)
+                    {
+                        OomDiagnostics.LogHeapStateOnOom(oom, "seek probe");
+                        throw;
+                    }
+                    catch (Exception e) when (articleBufferSize > 0 && !ct.IsCancellationRequested && e is not OutOfMemoryException)
+                    {
+                        e.LogWarningKnownOrStack(
+                            "Seek probe transient failure on segment index {Index}. Using estimated range.", guess);
+                        var start = guess * avg;
+                        var end = Math.Min(fileSize, start + avg);
+                        return new LongRange(start, end);
+                    }
+                },
+                ct
+            ).ConfigureAwait(false);
+        }
+        catch (SeekPositionNotFoundException e) when (missingProbeArticle is not null)
+        {
+            throw new SeekPositionNotFoundException(e.Message, missingProbeArticle);
+        }
     }
 
     private static bool AreSegmentByteRangesValid(LongRange[]? ranges, int segmentCount, long expectedFileSize)
@@ -295,7 +304,8 @@ public class NzbFileStream(
             await stream.DisposeAsync().ConfigureAwait(false);
             throw new SeekPositionNotFoundException(
                 $"Byte position {rangeStart} of \"{fileName ?? "unknown"}\" is past the data " +
-                $"available in segment {foundSegment.FoundIndex + 1}. {e.Message}");
+                $"available in segment {foundSegment.FoundIndex + 1}. {e.Message}",
+                e);
         }
         catch
         {

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -28,12 +28,12 @@ Background health monitoring and replacement of unhealthy library items.
     urgent repair.
 
 `repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
-articles and corrupt archives. With a value greater than `0`, InfiniDysk waits for that many
-consecutive failures before it starts an urgent repair. At the threshold, linked library items are
-removed and their original downloads are marked failed in *Arr when **Auto-remove unlinked files
-only** is enabled. *Arr blocklists those releases and applies its configured failed-download
-redownload policy. Unlinked files are removed. Disable that option to force-delete linked items at
-the threshold.
+articles, corrupt archives, and seeks that find missing or truncated article data. With a value
+greater than `0`, InfiniDysk waits for that many consecutive failures before it starts an urgent
+repair. At the threshold, linked library items are removed and their original downloads are marked
+failed in *Arr when **Auto-remove unlinked files only** is enabled. *Arr blocklists those releases
+and applies its configured failed-download redownload policy. Unlinked files are removed. Disable
+that option to force-delete linked items at the threshold.
 
 Successful full-file playback and a successful background health check reset the in-memory failure
 count. The count resets when InfiniDysk restarts, so it is intentionally not a durable replacement for

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -101,6 +101,83 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task SeekFailureWithMissingArticleCause_RecordsFailureAndSeedsFailFastCache()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new SeekPositionNotFoundException(
+                "Corrupt file. Cannot find byte position 50.",
+                new UsenetArticleNotFoundException(segmentId)),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+        Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+    }
+
+    [Fact]
+    public async Task SeekFailureWithShortSegment_RecordsStreamingFailure()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new SeekPositionNotFoundException(
+                "Byte position 50 is past the data available in segment 1.",
+                new EndOfStreamException("Segment ended early.")),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(lifetimeFeature.Aborted);
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    [Fact]
+    public async Task SeekFailureWithShortSegmentAfterResponseStarted_AbortsConnection()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new SeekPositionNotFoundException(
+                "Byte position 50 is past the data available in segment 1.",
+                new EndOfStreamException("Segment ended early.")));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task BareSeekFailure_DoesNotRecordStreamingFailure()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new SeekPositionNotFoundException(
+                "Corrupt file. Invalid multipart ranges while reading movie.mkv."),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    [Fact]
     public async Task CorruptRarAfterResponseStarted_AbortsConnection()
     {
         var lifetimeFeature = new TestHttpRequestLifetimeFeature();

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -444,8 +444,43 @@ public class NzbFileStreamTests
 
         Assert.Contains("Byte position 4", exception.Message, StringComparison.Ordinal);
         Assert.Contains("segment 1", exception.Message, StringComparison.Ordinal);
+        Assert.IsType<EndOfStreamException>(exception.InnerException);
         Assert.NotEmpty(openedBodies);
         Assert.All(openedBodies, body => Assert.True(body.Disposed));
+    }
+
+    [Fact]
+    public async Task Seek_WhenHeaderProbeMissCausesSearchFailure_PreservesMissingArticle()
+    {
+        string[] segmentIds = ["zero", "one", "missing"];
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["zero"] = new byte[20],
+                ["one"] = new byte[20],
+            },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange>
+            {
+                ["zero"] = new(0, 20),
+                ["one"] = new(0, 20),
+            });
+        await using var stream = new NzbFileStream(
+            segmentIds,
+            fileSize: 100,
+            client,
+            articleBufferSize: 0,
+            segmentByteRanges: null,
+            usePipelinedBodyRequests: false,
+            fileName: "missing-probe.bin");
+        stream.Seek(50, SeekOrigin.Begin);
+
+        var exception = await Assert.ThrowsAsync<SeekPositionNotFoundException>(
+            async () => await stream.ReadAtLeastAsync(
+                new byte[1], 1, throwOnEndOfStream: false));
+
+        var missing = Assert.IsType<UsenetArticleNotFoundException>(exception.InnerException);
+        Assert.Equal("missing", missing.SegmentId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve confirmed missing-article and short-segment causes when an in-bounds seek cannot be satisfied
- count only those integrity-proven seek failures toward streaming repair, retaining protection against transient or local-metadata failures
- add coverage for cause propagation, strike behavior, fail-fast seeding, and response handling

## Known residual gap (out of scope)
For imports with recorded segment byte ranges, a dead-tail probe read is silently served zero-fill (gap fill preserves offsets; `MaxConsecutiveZeroFills` only trips when a single read spans more than 3 dead segments) — no error, no strike. That garbage-serving path relates to #461 (fatal-vs-degraded classification) and is separate from this fix.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ExceptionMiddlewareTests|FullyQualifiedName~NzbFileStreamTests|FullyQualifiedName~StreamingFailureTrackerTests|FullyQualifiedName~UtilityTests"`