### PR TITLE
feat(health): re-check library health after changing Usenet providers

### DIFF
--- a/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Api.Controllers.ResetHealthCheckQueue;
+
+[ApiController]
+[Route("api/reset-health-check-queue")]
+public class ResetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var resetCount = await dbClient.Ctx.Items
+            .Where(x => x.Type == DavItem.ItemType.UsenetFile)
+            .Where(x => x.NextHealthCheck != null && x.NextHealthCheck != DateTimeOffset.UnixEpoch)
+            .ExecuteUpdateAsync(
+                x => x.SetProperty(item => item.NextHealthCheck, (DateTimeOffset?)null),
+                HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        return Ok(new ResetHealthCheckQueueResponse
+        {
+            Status = true,
+            ResetCount = resetCount,
+        });
+    }
+}

--- a/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
@@ -11,6 +12,13 @@ public class ResetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseA
 {
     protected override async Task<IActionResult> HandleRequest()
     {
+        if (!HttpMethods.IsPost(HttpContext.Request.Method))
+        {
+            return StatusCode(
+                StatusCodes.Status405MethodNotAllowed,
+                new BaseApiResponse { Status = false, Error = "POST required" });
+        }
+
         var resetCount = await dbClient.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile)
             .Where(x => x.NextHealthCheck != null && x.NextHealthCheck != DateTimeOffset.UnixEpoch)

--- a/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueResponse.cs
+++ b/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.Controllers.ResetHealthCheckQueue;
+
+public class ResetHealthCheckQueueResponse : BaseApiResponse
+{
+    [JsonPropertyName("resetCount")]
+    public required int ResetCount { get; init; }
+}

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -19,6 +19,12 @@ Background health monitoring and replacement of unhealthy library items.
 | Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items are removed and blocklisted through *Arr instead of force-deleted |
 | Library Directory | `media.library-dir` | empty | Organized library root in the container — parent of your Arr root folders. Never the rclone mount or `/completed-symlinks` |
 
+## Re-check after provider changes [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+Changing Usenet providers can affect which library files are available. After saving provider changes,
+InfiniDysk offers to queue your library for a health re-check. This requires Background Repairs to be
+enabled; urgent repairs already queued from streaming failures keep their priority.
+
 !!! note "Streaming failure repair requires Background Repairs"
 
     **Repair After Streaming Failures** (`repair.auto-remove-after-failures`) only takes effect when

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -237,6 +237,10 @@ function Body(props: BodyProps) {
     const [isSaving, setIsSaving] = useState(false);
     const [isSaved, setIsSaved] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
+    const [showProviderChangeNotice, setShowProviderChangeNotice] = useState(false);
+    const [isResettingHealthQueue, setIsResettingHealthQueue] = useState(false);
+    const [healthQueueResetCount, setHealthQueueResetCount] = useState<number | null>(null);
+    const [healthQueueResetError, setHealthQueueResetError] = useState<string | null>(null);
     const managedCount = useMemo(() => Object.keys(managedEnv).length, [managedEnv]);
 
     const iseUsenetUpdated = isUsenetSettingsUpdated(config, newConfig);
@@ -327,6 +331,11 @@ function Body(props: BodyProps) {
             await postConfigUpdate(changedConfig);
             setConfig(newConfig);
             setIsSaved(true);
+            if ("usenet.providers" in changedConfig) {
+                setShowProviderChangeNotice(true);
+                setHealthQueueResetCount(null);
+                setHealthQueueResetError(null);
+            }
         } catch {
             setSaveError("Could not save settings. Check the server logs and try again.");
         } finally {
@@ -353,6 +362,11 @@ function Body(props: BodyProps) {
 
         if (Object.keys(changedConfig).length > 0) {
             await postConfigUpdate(changedConfig);
+            if ("usenet.providers" in changedConfig) {
+                setShowProviderChangeNotice(true);
+                setHealthQueueResetCount(null);
+                setHealthQueueResetError(null);
+            }
         }
 
         const nextSaved = { ...config };
@@ -367,6 +381,23 @@ function Body(props: BodyProps) {
         );
         setIsSaved(Object.keys(remaining).length === 0);
     }, [config, newConfig, managedEnv, postConfigUpdate]);
+
+    const resetHealthCheckQueue = useCallback(async () => {
+        setIsResettingHealthQueue(true);
+        setHealthQueueResetError(null);
+        try {
+            const response = await fetch(withUrlBase("/api/reset-health-check-queue"), { method: "POST" });
+            if (!response.ok) {
+                throw new Error(`Health check queue reset failed with status ${response.status}`);
+            }
+            const result = await response.json() as { resetCount?: number };
+            setHealthQueueResetCount(result.resetCount ?? 0);
+        } catch {
+            setHealthQueueResetError("Could not queue library health checks. Check the server logs and try again.");
+        } finally {
+            setIsResettingHealthQueue(false);
+        }
+    }, []);
 
     const applySyncedConfig = useCallback((patch: Record<string, string>) => {
         const nextSaved = { ...config, ...patch };
@@ -436,6 +467,42 @@ function Body(props: BodyProps) {
             {saveError && (
                 <Alert variant="danger" className="sticky bottom-20 z-10 text-sm">
                     {saveError}
+                </Alert>
+            )}
+            {showProviderChangeNotice && (
+                <Alert variant="warning" className="sticky bottom-20 z-10 items-center justify-between gap-3 text-sm">
+                    <div className="flex min-w-0 items-start gap-2">
+                        <Icon name="warning" className="mt-0.5 shrink-0 !text-[20px]" />
+                        <span>
+                            Your Usenet provider changes can affect which library files are healthy.{" "}
+                            <a className="link font-medium" href={withUrlBase("/health")}>View Health</a>
+                            {healthQueueResetCount !== null && ` ${healthQueueResetCount.toLocaleString()} files queued for re-check.`}
+                            {healthQueueResetError && ` ${healthQueueResetError}`}
+                            {newConfig["repair.enable"] !== "true" && " Enable Background Repairs to re-check library health."}
+                        </span>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                        {!isReadOnly && newConfig["repair.enable"] === "true" && healthQueueResetCount === null && (
+                            <Button
+                                variant="ghost"
+                                size="small"
+                                className="text-warning-content hover:bg-warning-content/10"
+                                disabled={isResettingHealthQueue}
+                                onClick={() => void resetHealthCheckQueue()}
+                            >
+                                {isResettingHealthQueue ? "Queueing..." : healthQueueResetError ? "Try again" : "Re-check library health"}
+                            </Button>
+                        )}
+                        <Button
+                            variant="ghost"
+                            size="rounded"
+                            className="text-warning-content hover:bg-warning-content/10"
+                            aria-label="Dismiss provider health notice"
+                            onClick={() => setShowProviderChangeNotice(false)}
+                        >
+                            <Icon name="close" className="!text-[18px]" />
+                        </Button>
+                    </div>
                 </Alert>
             )}
             {!isReadOnly && ((activeTab !== "support" && activeTab !== "migration") || isUpdated) && <div className="sticky bottom-0 z-10 -mx-4 flex flex-wrap justify-end gap-2 border-t border-base-content/10 bg-base-300/95 px-4 py-3 backdrop-blur md:-mx-8 md:px-8">

--- a/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Controllers.ResetHealthCheckQueue;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Api;
+
+public sealed class ResetHealthCheckQueueControllerTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-reset-health-queue-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task ResetAsync_NullsScheduledUsenetFiles_WhilePreservingUrgentAndDirectories()
+    {
+        var scheduled = NewItem("scheduled.mkv", DavItem.ItemType.UsenetFile, DateTimeOffset.UtcNow.AddDays(1));
+        var uncheckedFile = NewItem("unchecked.mkv", DavItem.ItemType.UsenetFile, null);
+        var urgent = NewItem("urgent.mkv", DavItem.ItemType.UsenetFile, DateTimeOffset.UnixEpoch);
+        var directory = NewItem("directory", DavItem.ItemType.Directory, DateTimeOffset.UtcNow.AddDays(1));
+        _context.Items.AddRange(scheduled, uncheckedFile, urgent, directory);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var response = await InvokeAsync();
+
+        Assert.Equal(1, response.ResetCount);
+        var updated = await _context.Items.ToDictionaryAsync(x => x.Id);
+        Assert.Null(updated[scheduled.Id].NextHealthCheck);
+        Assert.Null(updated[uncheckedFile.Id].NextHealthCheck);
+        Assert.Equal(DateTimeOffset.UnixEpoch, updated[urgent.Id].NextHealthCheck);
+        Assert.NotNull(updated[directory.Id].NextHealthCheck);
+    }
+
+    private async Task<ResetHealthCheckQueueResponse> InvokeAsync()
+    {
+        var controller = new TestController(_dbClient)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        var result = await controller.InvokeAsync();
+        return Assert.IsType<OkObjectResult>(result).Value as ResetHealthCheckQueueResponse
+            ?? throw new Xunit.Sdk.XunitException("Expected reset health check queue response.");
+    }
+
+    private static DavItem NewItem(string name, DavItem.ItemType type, DateTimeOffset? nextHealthCheck)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            name,
+            fileSize: type == DavItem.ItemType.UsenetFile ? 100 : null,
+            type,
+            type == DavItem.ItemType.UsenetFile ? DavItem.ItemSubType.NzbFile : DavItem.ItemSubType.Directory,
+            releaseDate: null,
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: null);
+        item.NextHealthCheck = nextHealthCheck;
+        return item;
+    }
+
+    private sealed class TestController(DavDatabaseClient dbClient) : ResetHealthCheckQueueController(dbClient)
+    {
+        protected override bool RequiresAuthentication => false;
+
+        public Task<IActionResult> InvokeAsync() => HandleApiRequest();
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
@@ -58,7 +58,30 @@ public sealed class ResetHealthCheckQueueControllerTests : IAsyncLifetime
         Assert.NotNull(updated[directory.Id].NextHealthCheck);
     }
 
+    [Fact]
+    public async Task ResetAsync_GetRequestReturnsMethodNotAllowedWithoutUpdatingItems()
+    {
+        var scheduled = NewItem("scheduled.mkv", DavItem.ItemType.UsenetFile, DateTimeOffset.UtcNow.AddDays(1));
+        _context.Items.Add(scheduled);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var result = await InvokeActionAsync(HttpMethods.Get);
+
+        var response = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status405MethodNotAllowed, response.StatusCode);
+        var updated = await _context.Items.SingleAsync(x => x.Id == scheduled.Id);
+        Assert.NotNull(updated.NextHealthCheck);
+    }
+
     private async Task<ResetHealthCheckQueueResponse> InvokeAsync()
+    {
+        var result = await InvokeActionAsync(HttpMethods.Post);
+        return Assert.IsType<OkObjectResult>(result).Value as ResetHealthCheckQueueResponse
+            ?? throw new Xunit.Sdk.XunitException("Expected reset health check queue response.");
+    }
+
+    private Task<IActionResult> InvokeActionAsync(string method)
     {
         var controller = new TestController(_dbClient)
         {
@@ -67,10 +90,9 @@ public sealed class ResetHealthCheckQueueControllerTests : IAsyncLifetime
                 HttpContext = new DefaultHttpContext()
             }
         };
+        controller.HttpContext.Request.Method = method;
 
-        var result = await controller.InvokeAsync();
-        return Assert.IsType<OkObjectResult>(result).Value as ResetHealthCheckQueueResponse
-            ?? throw new Xunit.Sdk.XunitException("Expected reset health check queue response.");
+        return controller.InvokeAsync();
     }
 
     private static DavItem NewItem(string name, DavItem.ItemType type, DateTimeOffset? nextHealthCheck)


### PR DESCRIPTION
## Summary
- notify operators after saving a Usenet provider change, including modal saves
- add a one-click library health re-check that preserves urgent streaming repairs
- document the provider-change re-check flow

Closes #80

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~ResetHealthCheckQueueControllerTests\"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (one unrelated, isolation-sensitive `OomDiagnosticsTests.LogHeapStateOnOom_NonOom_IsNoOp` failure; passes in isolation)
- [x] `zensical build --clean --strict`