### PR TITLE
fix(ui): queue provider labels no longer flicker during download progress

### DIFF
--- a/frontend/app/routes/queue/controllers/events-controller.test.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { adjustTotalCount } from "./events-controller";
+import { adjustTotalCount, applyQueueProvidersMessage, parseQueueProvidersPayload } from "./events-controller";
 
 describe("adjustTotalCount", () => {
     it("increments on add", () => {
@@ -35,5 +35,56 @@ describe("adjustTotalCount", () => {
         expect(total).toBe(0);
         total = adjustTotalCount(total, -1);
         expect(total).toBe(0);
+    });
+});
+
+describe("parseQueueProvidersPayload", () => {
+    it("parses host=segments pairs and sorts by segments descending", () => {
+        expect(parseQueueProvidersPayload("news.example.com=3,news.other.com=12")).toEqual([
+            { host: "news.other.com", segments: 12 },
+            { host: "news.example.com", segments: 3 },
+        ]);
+    });
+
+    it("returns an empty list for an empty payload", () => {
+        expect(parseQueueProvidersPayload("")).toEqual([]);
+    });
+});
+
+describe("applyQueueProvidersMessage", () => {
+    it("preserves nicknames from the previous provider list", () => {
+        const result = applyQueueProvidersMessage(
+            "slot-1|news.newsgroup.ninja=12",
+            [{ host: "news.newsgroup.ninja", nickname: "Newsgroup Ninja", segments: 5 }],
+        );
+        expect(result).toEqual({
+            nzo_id: "slot-1",
+            providers: [{ host: "news.newsgroup.ninja", nickname: "Newsgroup Ninja", segments: 12 }],
+        });
+    });
+
+    it("matches hosts case-insensitively when preserving nicknames", () => {
+        const result = applyQueueProvidersMessage(
+            "slot-1|NEWS.NEWSGROUP.NINJA=4",
+            [{ host: "news.newsgroup.ninja", nickname: "Newsgroup Ninja", segments: 0 }],
+        );
+        expect(result?.providers[0]?.nickname).toBe("Newsgroup Ninja");
+    });
+
+    it("leaves nicknames unset when the previous list had none", () => {
+        const result = applyQueueProvidersMessage(
+            "slot-1|news.newsgroup.ninja=12",
+            [{ host: "news.newsgroup.ninja", segments: 5 }],
+        );
+        expect(result?.providers).toEqual([{ host: "news.newsgroup.ninja", segments: 12 }]);
+    });
+
+    it("clears providers when the payload is empty", () => {
+        const result = applyQueueProvidersMessage("slot-1|", [{ host: "news.example.com", nickname: "Main", segments: 1 }]);
+        expect(result).toEqual({ nzo_id: "slot-1", providers: [] });
+    });
+
+    it("returns null for malformed messages", () => {
+        expect(applyQueueProvidersMessage("no-separator")).toBeNull();
     });
 });

--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type { HistorySlot, QueueSlot } from "~/clients/backend-client.server";
+import type { HistorySlot, ProviderUsage, QueueSlot } from "~/clients/backend-client.server";
 import type { PresentationHistorySlot, PresentationQueueSlot, UploadingFile } from "../route";
 
 export type QueueEvents = {
@@ -23,6 +23,42 @@ export type HistoryEvents = {
 /** Apply a delta to a live total, never going below zero. */
 export function adjustTotalCount(current: number, delta: number): number {
     return Math.max(0, current + delta);
+}
+
+/** Parse the compact `qpv` websocket payload (`host=segments,...`). */
+export function parseQueueProvidersPayload(payload: string): ProviderUsage[] {
+    if (!payload) return [];
+    return payload
+        .split(',')
+        .map(part => {
+            const eq = part.indexOf('=');
+            const host = eq < 0 ? part : part.slice(0, eq);
+            const segments = eq < 0 ? 0 : Number(part.slice(eq + 1));
+            return { host, segments: Number.isFinite(segments) ? segments : 0 };
+        })
+        .sort((a, b) => b.segments - a.segments);
+}
+
+/** Apply a `qpv` message to a slot, preserving nicknames from the previous provider list. */
+export function applyQueueProvidersMessage(
+    message: string,
+    previousProviders?: ProviderUsage[] | null | undefined,
+): { nzo_id: string, providers: ProviderUsage[] } | null {
+    const sep = message.indexOf('|');
+    if (sep < 0) return null;
+    const nzo_id = message.slice(0, sep);
+    const payload = message.slice(sep + 1);
+    const nicknamesByHost = new Map<string, string>();
+    for (const provider of previousProviders ?? []) {
+        const nickname = provider.nickname?.trim();
+        if (!nickname) continue;
+        nicknamesByHost.set(provider.host.toLowerCase(), nickname);
+    }
+    const providers = parseQueueProvidersPayload(payload).map(provider => {
+        const nickname = nicknamesByHost.get(provider.host.toLowerCase());
+        return nickname ? { ...provider, nickname } : provider;
+    });
+    return { nzo_id, providers };
 }
 
 export function useQueueEvents(
@@ -93,19 +129,11 @@ export function useQueueEvents(
     }, [setQueueSlots]);
 
     const onChangeQueueSlotProviders = useCallback((message: string) => {
-        const sep = message.indexOf('|');
-        if (sep < 0) return;
-        const nzo_id = message.slice(0, sep);
-        const payload = message.slice(sep + 1);
-        const providers = payload
-            ? payload.split(',').map(part => {
-                const eq = part.indexOf('=');
-                const host = eq < 0 ? part : part.slice(0, eq);
-                const segments = eq < 0 ? 0 : Number(part.slice(eq + 1));
-                return { host, segments: Number.isFinite(segments) ? segments : 0 };
-            }).sort((a, b) => b.segments - a.segments)
-            : [];
-        setQueueSlots(slots => slots.map(x => x.nzo_id === nzo_id ? { ...x, providers } : x));
+        setQueueSlots(slots => slots.map(slot => {
+            const update = applyQueueProvidersMessage(message, slot.providers);
+            if (!update || slot.nzo_id !== update.nzo_id) return slot;
+            return { ...slot, providers: update.providers };
+        }));
     }, [setQueueSlots]);
 
     return useStableEventHandlers({

--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -47,7 +47,7 @@ export function parseQueueProvidersMessage(message: string): { nzo_id: string, p
 
 export function preserveProviderNicknames(
     providers: ProviderUsage[],
-    previousProviders?: ProviderUsage[] | null | undefined,
+    previousProviders?: ProviderUsage[] | null,
 ): ProviderUsage[] {
     const nicknamesByHost = new Map<string, string>();
     for (const provider of previousProviders ?? []) {
@@ -64,7 +64,7 @@ export function preserveProviderNicknames(
 /** Apply a `qpv` message to a slot, preserving nicknames from the previous provider list. */
 export function applyQueueProvidersMessage(
     message: string,
-    previousProviders?: ProviderUsage[] | null | undefined,
+    previousProviders?: ProviderUsage[] | null,
 ): { nzo_id: string, providers: ProviderUsage[] } | null {
     const parsed = parseQueueProvidersMessage(message);
     if (!parsed) return null;

--- a/frontend/app/routes/queue/controllers/events-controller.ts
+++ b/frontend/app/routes/queue/controllers/events-controller.ts
@@ -39,26 +39,42 @@ export function parseQueueProvidersPayload(payload: string): ProviderUsage[] {
         .sort((a, b) => b.segments - a.segments);
 }
 
-/** Apply a `qpv` message to a slot, preserving nicknames from the previous provider list. */
-export function applyQueueProvidersMessage(
-    message: string,
-    previousProviders?: ProviderUsage[] | null | undefined,
-): { nzo_id: string, providers: ProviderUsage[] } | null {
+export function parseQueueProvidersMessage(message: string): { nzo_id: string, payload: string } | null {
     const sep = message.indexOf('|');
     if (sep < 0) return null;
-    const nzo_id = message.slice(0, sep);
-    const payload = message.slice(sep + 1);
+    return { nzo_id: message.slice(0, sep), payload: message.slice(sep + 1) };
+}
+
+export function preserveProviderNicknames(
+    providers: ProviderUsage[],
+    previousProviders?: ProviderUsage[] | null | undefined,
+): ProviderUsage[] {
     const nicknamesByHost = new Map<string, string>();
     for (const provider of previousProviders ?? []) {
         const nickname = provider.nickname?.trim();
         if (!nickname) continue;
         nicknamesByHost.set(provider.host.toLowerCase(), nickname);
     }
-    const providers = parseQueueProvidersPayload(payload).map(provider => {
+    return providers.map(provider => {
         const nickname = nicknamesByHost.get(provider.host.toLowerCase());
         return nickname ? { ...provider, nickname } : provider;
     });
-    return { nzo_id, providers };
+}
+
+/** Apply a `qpv` message to a slot, preserving nicknames from the previous provider list. */
+export function applyQueueProvidersMessage(
+    message: string,
+    previousProviders?: ProviderUsage[] | null | undefined,
+): { nzo_id: string, providers: ProviderUsage[] } | null {
+    const parsed = parseQueueProvidersMessage(message);
+    if (!parsed) return null;
+    return {
+        nzo_id: parsed.nzo_id,
+        providers: preserveProviderNicknames(
+            parseQueueProvidersPayload(parsed.payload),
+            previousProviders,
+        ),
+    };
 }
 
 export function useQueueEvents(
@@ -129,10 +145,15 @@ export function useQueueEvents(
     }, [setQueueSlots]);
 
     const onChangeQueueSlotProviders = useCallback((message: string) => {
+        const parsed = parseQueueProvidersMessage(message);
+        if (!parsed) return;
+        const providers = parseQueueProvidersPayload(parsed.payload);
         setQueueSlots(slots => slots.map(slot => {
-            const update = applyQueueProvidersMessage(message, slot.providers);
-            if (!update || slot.nzo_id !== update.nzo_id) return slot;
-            return { ...slot, providers: update.providers };
+            if (slot.nzo_id !== parsed.nzo_id) return slot;
+            return {
+                ...slot,
+                providers: preserveProviderNicknames(providers, slot.providers),
+            };
         }));
     }, [setQueueSlots]);
 


### PR DESCRIPTION
## Summary
- Preserve configured provider nicknames when applying live `qpv` websocket progress updates on the queue page
- Live updates only send host and segment counts; without this, labels alternated between nicknames (e.g. "Newsgroup Ninja") and hostname-derived fallbacks (e.g. "newsgroup")

## Test plan
- [x] `cd frontend && npm test -- app/routes/queue/controllers/events-controller.test.ts`
- [ ] Open queue page with a download in progress and a provider nickname configured; confirm the Provider column label stays stable as progress updates
- [ ] Confirm provider segment percentages still update live