### PR TITLE
fix(nntp): providers no longer benched for minutes by brief network hiccups

### DIFF
--- a/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
+++ b/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
@@ -103,7 +103,7 @@ public sealed class CorrelatedTripDetector
         {
             Log.Warning(
                 "All {Count} NNTP providers tripped their circuit breakers within {WindowSeconds}s of each other ({Providers}). " +
-                "The shared network path may be degraded; shortening cooldowns so recovery probes can resume traffic.",
+                "The shared network path may be degraded; providers will probe recovery after their configured cooldown.",
                 providerCount,
                 _window.TotalSeconds,
                 providers);

--- a/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
+++ b/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
@@ -24,6 +24,7 @@ public sealed class CorrelatedTripDetector
 
     private readonly object _lock = new();
     private readonly Dictionary<string, string> _providers = new(StringComparer.Ordinal); // key -> host
+    private readonly Dictionary<string, Action> _onCorrelatedTrip = new(StringComparer.Ordinal);
     private readonly Dictionary<string, long> _openSinceMs = new(StringComparer.Ordinal);
     private readonly TimeSpan _window;
     private readonly TimeSpan _throttle;
@@ -43,10 +44,16 @@ public sealed class CorrelatedTripDetector
     /// Tracks a provider that can carry traffic. Disabled providers never trip, so
     /// registering them would wedge the "all providers tripped" condition forever.
     /// </summary>
-    public void Register(string providerKey, string host)
+    public void Register(string providerKey, string host, Action? onCorrelatedTrip = null)
     {
         lock (_lock)
+        {
             _providers[providerKey] = host;
+            if (onCorrelatedTrip is not null)
+                _onCorrelatedTrip[providerKey] = onCorrelatedTrip;
+            else
+                _onCorrelatedTrip.Remove(providerKey);
+        }
     }
 
     public void Unregister(string providerKey)
@@ -54,12 +61,17 @@ public sealed class CorrelatedTripDetector
         lock (_lock)
         {
             _providers.Remove(providerKey);
+            _onCorrelatedTrip.Remove(providerKey);
             _openSinceMs.Remove(providerKey);
         }
     }
 
     public void OnTransition(string providerKey, ProviderCircuitTransition transition)
     {
+        List<Action>? callbacks = null;
+        string? providers = null;
+        var providerCount = 0;
+        var shouldWarn = false;
         lock (_lock)
         {
             if (transition.State == ProviderCircuitTransitionState.Open)
@@ -75,17 +87,38 @@ public sealed class CorrelatedTripDetector
             var opens = _providers.Keys.Select(p => _openSinceMs[p]).ToList();
             if (opens.Max() - opens.Min() > (long)_window.TotalMilliseconds) return;
 
+            callbacks = _onCorrelatedTrip.Values.ToList();
+            providers = string.Join(", ", _providers.Values);
+            providerCount = _providers.Count;
             var now = Clock();
-            if (_lastWarningAtMs is { } lastWarning
-                && now - lastWarning < (long)_throttle.TotalMilliseconds) return;
-            _lastWarningAtMs = now;
+            if (_lastWarningAtMs is not { } lastWarning
+                || now - lastWarning >= (long)_throttle.TotalMilliseconds)
+            {
+                _lastWarningAtMs = now;
+                shouldWarn = true;
+            }
+        }
 
+        if (shouldWarn)
+        {
             Log.Warning(
                 "All {Count} NNTP providers tripped their circuit breakers within {WindowSeconds}s of each other ({Providers}). " +
-                "Simultaneous independent provider outages are unlikely — check local network, DNS, or TLS interception.",
-                _providers.Count,
+                "The shared network path may be degraded; shortening cooldowns so recovery probes can resume traffic.",
+                providerCount,
                 _window.TotalSeconds,
-                string.Join(", ", _providers.Values));
+                providers);
+        }
+
+        foreach (var callback in callbacks!)
+        {
+            try
+            {
+                callback();
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                Log.Warning(exception, "Correlated NNTP provider trip callback failed");
+            }
         }
     }
 }

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -29,14 +29,17 @@ public class ProviderCircuitBreaker
 
     private static readonly TimeSpan InitialCooldown = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan MaxCooldown = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan FailureBurstCoalesceWindow = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan DefaultProbeAbandonTimeout = TimeSpan.FromSeconds(60);
 
     private readonly string _providerName;
     private readonly Action<ProviderCircuitTransition>? _onTransition;
+    private readonly bool _coalesceFailureBursts;
     private readonly object _lock = new();
     private readonly Queue<(long AtMs, bool Failed)> _window = new();
 
     private long _trippedUntilMs;
+    private long _failureBurstStartedAtMs = long.MinValue;
     private TimeSpan _currentCooldown = InitialCooldown;
     private int _halfOpenProbeInFlight; // 0/1
     private long _probeStartedMs;
@@ -47,14 +50,19 @@ public class ProviderCircuitBreaker
 
     public ProviderCircuitBreaker(
         string providerName,
-        Action<ProviderCircuitTransition>? onTransition = null)
+        Action<ProviderCircuitTransition>? onTransition = null,
+        bool coalesceFailureBursts = false)
     {
         _providerName = providerName;
         _onTransition = onTransition;
+        _coalesceFailureBursts = coalesceFailureBursts;
     }
 
     /// <summary>How long an unanswered half-open probe may hold the slot. For tests.</summary>
     internal TimeSpan ProbeAbandonTimeout { get; set; } = DefaultProbeAbandonTimeout;
+
+    /// <summary>Monotonic clock, injectable for tests.</summary>
+    internal Func<long> Clock { get; set; } = () => Environment.TickCount64;
 
     public bool IsTripped
     {
@@ -62,13 +70,13 @@ public class ProviderCircuitBreaker
         {
             var trippedUntil = Volatile.Read(ref _trippedUntilMs);
             if (trippedUntil == 0) return false;
-            if (Environment.TickCount64 < trippedUntil) return true;
+            if (Clock() < trippedUntil) return true;
 
             // Cooldown expired → half-open: exactly one caller wins the probe slot.
             TryReclaimAbandonedProbe();
             if (Interlocked.CompareExchange(ref _halfOpenProbeInFlight, 1, 0) == 0)
             {
-                Volatile.Write(ref _probeStartedMs, Environment.TickCount64);
+                Volatile.Write(ref _probeStartedMs, Clock());
                 return false; // this caller is the probe
             }
 
@@ -101,7 +109,7 @@ public class ProviderCircuitBreaker
         lock (_lock)
         {
             if (_trippedUntilMs > 0)
-                _trippedUntilMs = Environment.TickCount64 - 1;
+                _trippedUntilMs = Clock() - 1;
         }
     }
 
@@ -123,7 +131,7 @@ public class ProviderCircuitBreaker
             // Commands that started before a trip can still complete while the
             // provider is cooling down. They are not half-open probes and must
             // not return the provider to normal rotation early.
-            if (_trippedUntilMs > Environment.TickCount64)
+            if (_trippedUntilMs > Clock())
                 return;
 
             // Only a circuit that opened can recover. Failures that cleared without tripping
@@ -134,6 +142,7 @@ public class ProviderCircuitBreaker
                 Log.Information("Provider {Provider} recovered — circuit breaker reset.", _providerName);
 
             _window.Clear();
+            _failureBurstStartedAtMs = long.MinValue;
             _trippedUntilMs = 0;
             if (resetsCooldownLadder)
                 _currentCooldown = InitialCooldown;
@@ -167,6 +176,7 @@ public class ProviderCircuitBreaker
                 return;
 
             _window.Clear();
+            _failureBurstStartedAtMs = long.MinValue;
         }
     }
 
@@ -175,7 +185,7 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
-            var now = Environment.TickCount64;
+            var now = Clock();
             var trippedUntil = _trippedUntilMs;
             var probeInFlight = Volatile.Read(ref _halfOpenProbeInFlight) == 1;
 
@@ -214,7 +224,7 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
-            var now = Environment.TickCount64;
+            var now = Clock();
 
             // Ignore failures already in flight when the provider first tripped.
             if (_trippedUntilMs > 0 && now < _trippedUntilMs)
@@ -239,7 +249,7 @@ public class ProviderCircuitBreaker
     {
         lock (_lock)
         {
-            var now = Environment.TickCount64;
+            var now = Clock();
 
             // Already latched open: ignore in-flight failures from the same burst
             // so they cannot extend the window, double the cooldown, or spam logs.
@@ -261,9 +271,20 @@ public class ProviderCircuitBreaker
                 return;
             }
 
-            EvictOldEntries(now);
-            _window.Enqueue((now, true));
             Interlocked.Increment(ref _failureCount);
+
+            EvictOldEntries(now);
+            if (!_coalesceFailureBursts
+                || _failureBurstStartedAtMs == long.MinValue
+                || now - _failureBurstStartedAtMs >= (long)FailureBurstCoalesceWindow.TotalMilliseconds)
+            {
+                _failureBurstStartedAtMs = now;
+                _window.Enqueue((now, true));
+            }
+            else
+            {
+                return;
+            }
 
             var failures = 0;
             foreach (var entry in _window.Where(entry => entry.Failed))
@@ -292,6 +313,7 @@ public class ProviderCircuitBreaker
         NotifyTransition(ProviderCircuitTransitionState.Open, appliedCooldown);
 
         _window.Clear();
+        _failureBurstStartedAtMs = long.MinValue;
         _currentCooldown = TimeSpan.FromMilliseconds(
             Math.Min(_currentCooldown.TotalMilliseconds * 2, MaxCooldown.TotalMilliseconds));
     }
@@ -331,7 +353,7 @@ public class ProviderCircuitBreaker
         if (Volatile.Read(ref _halfOpenProbeInFlight) != 1) return;
         var started = Volatile.Read(ref _probeStartedMs);
         if (started == 0) return;
-        if (Environment.TickCount64 - started < (long)ProbeAbandonTimeout.TotalMilliseconds) return;
+        if (Clock() - started < (long)ProbeAbandonTimeout.TotalMilliseconds) return;
 
         // Abandoned probe (cancelled request, etc.): free the slot so another
         // caller can retry. CompareExchange so we don't clear a just-resolved probe.

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -103,6 +103,24 @@ public class ProviderCircuitBreaker
         }
     }
 
+    /// <summary>
+    /// Limits the remaining open cooldown without resetting the escalation ladder.
+    /// Used when all providers fail together and no provider remains to serve traffic.
+    /// </summary>
+    internal void CapCooldown(TimeSpan maximumRemaining)
+    {
+        lock (_lock)
+        {
+            var now = Clock();
+            if (_trippedUntilMs <= now)
+                return;
+
+            var cappedUntil = now + (long)maximumRemaining.TotalMilliseconds;
+            if (_trippedUntilMs > cappedUntil)
+                _trippedUntilMs = cappedUntil;
+        }
+    }
+
     /// <summary>Force the open cooldown into the past so half-open tests can proceed.</summary>
     internal void ExpireCooldownForTests()
     {

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -269,10 +269,6 @@ public class UsenetStreamingClient : WrappingNntpClient
         if (connectionDetails.ProviderId == Guid.Empty)
             connectionDetails.ProviderId = Guid.NewGuid();
         var metricsKey = UsenetProviderIdentity.MetricsKey(connectionDetails);
-        // Only providers that can carry traffic participate in correlation; a Disabled
-        // provider never trips and would wedge the "all tripped" condition forever.
-        if (connectionDetails.Type != ProviderType.Disabled)
-            tripDetector?.Register(metricsKey, connectionDetails.Host);
         var circuitBreaker = new ProviderCircuitBreaker(
             connectionDetails.Host,
             transition =>
@@ -290,7 +286,17 @@ public class UsenetStreamingClient : WrappingNntpClient
                         : null,
                 });
                 tripDetector?.OnTransition(metricsKey, transition);
-            });
+            },
+            coalesceFailureBursts: true);
+        // Only providers that can carry traffic participate in correlation; a Disabled
+        // provider never trips and would wedge the "all tripped" condition forever.
+        if (connectionDetails.Type != ProviderType.Disabled)
+        {
+            tripDetector?.Register(
+                metricsKey,
+                connectionDetails.Host,
+                () => circuitBreaker.CapCooldown(TimeSpan.FromSeconds(10)));
+        }
         return new MultiConnectionNntpClient(
             connectionPool,
             connectionDetails.Type,

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
@@ -51,7 +51,7 @@ public class CorrelatedTripDetectorTests
         detector.OnTransition("a", Open(atMs: 1_000));
         detector.OnTransition("b", Open(atMs: 2_000));
 
-        Assert.Equal(["a", "b"], callbacks);
+        Assert.Equal(["a", "b"], callbacks.Order());
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
@@ -38,6 +38,44 @@ public class CorrelatedTripDetectorTests
     }
 
     [Fact]
+    public void AllProvidersTrippingWithinTheWindow_InvokesEachRegisteredCallback()
+    {
+        var callbacks = new List<string>();
+        var detector = new CorrelatedTripDetector(window: Window, throttle: Throttle)
+        {
+            Clock = () => 2_000,
+        };
+        detector.Register("a", "a.example.com", () => callbacks.Add("a"));
+        detector.Register("b", "b.example.com", () => callbacks.Add("b"));
+
+        detector.OnTransition("a", Open(atMs: 1_000));
+        detector.OnTransition("b", Open(atMs: 2_000));
+
+        Assert.Equal(["a", "b"], callbacks);
+    }
+
+    [Fact]
+    public void CorrelationsWithinTheWarningThrottle_StillInvokeCallbacks()
+    {
+        var callbacks = 0;
+        var detector = new CorrelatedTripDetector(window: Window, throttle: Throttle)
+        {
+            Clock = () => 2_000,
+        };
+        detector.Register("a", "a.example.com", () => callbacks++);
+        detector.Register("b", "b.example.com", () => callbacks++);
+
+        detector.OnTransition("a", Open(atMs: 1_000));
+        detector.OnTransition("b", Open(atMs: 2_000));
+        detector.OnTransition("a", Closed(atMs: 3_000));
+        detector.OnTransition("b", Closed(atMs: 3_000));
+        detector.OnTransition("a", Open(atMs: 4_000));
+        detector.OnTransition("b", Open(atMs: 5_000));
+
+        Assert.Equal(4, callbacks);
+    }
+
+    [Fact]
     public void TripsOutsideTheWindow_DoNotWarn()
     {
         var events = Capture((d, _) =>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerBurstTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerBurstTests.cs
@@ -53,6 +53,37 @@ public class ProviderCircuitBreakerBurstTests
         Assert.InRange(clock.Now, 4_000, 6_000);
     }
 
+    [Fact]
+    public void CapCooldown_ShortensOpenCooldownWithoutResettingTheLadder()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock);
+        breaker.RecordFailure();
+        clock.Advance(milliseconds: 2_000);
+        breaker.RecordFailure();
+        clock.Advance(milliseconds: 2_000);
+        breaker.RecordFailure();
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+
+        breaker.CapCooldown(TimeSpan.FromSeconds(10));
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.InRange(snapshot.CooldownRemainingSeconds ?? 0, 9, 10);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void CapCooldown_DoesNotExtendOrOpenTheCircuit()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock);
+
+        breaker.CapCooldown(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+    }
+
     private static ProviderCircuitBreaker CreateBreaker(TestClock clock) =>
         new("burst-test", coalesceFailureBursts: true) { Clock = () => clock.Now };
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerBurstTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerBurstTests.cs
@@ -1,0 +1,65 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ProviderCircuitBreakerBurstTests
+{
+    [Fact]
+    public void FailuresWithinOneBurst_DoNotTripTheBreaker()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock);
+
+        breaker.RecordFailure();
+        clock.Advance(milliseconds: 500);
+        breaker.RecordFailure();
+        clock.Advance(milliseconds: 500);
+        breaker.RecordFailure();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Closed, snapshot.State);
+        Assert.Equal(3, snapshot.FailureCount);
+    }
+
+    [Fact]
+    public void FailuresAcrossThreeBursts_TripTheBreaker()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock);
+
+        breaker.RecordFailure();
+        clock.Advance(milliseconds: 2_000);
+        breaker.RecordFailure();
+        clock.Advance(milliseconds: 2_000);
+        breaker.RecordFailure();
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+    }
+
+    [Fact]
+    public void ContinuousFailures_StillTripTheBreaker()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock);
+
+        for (var attempt = 0; attempt < 12 && !breaker.IsTripped; attempt++)
+        {
+            breaker.RecordFailure();
+            clock.Advance(milliseconds: 500);
+        }
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.InRange(clock.Now, 4_000, 6_000);
+    }
+
+    private static ProviderCircuitBreaker CreateBreaker(TestClock clock) =>
+        new("burst-test", coalesceFailureBursts: true) { Clock = () => clock.Now };
+
+    private sealed class TestClock
+    {
+        public long Now { get; private set; }
+
+        public void Advance(long milliseconds) => Now += milliseconds;
+    }
+}


### PR DESCRIPTION
## Summary
- Coalesce tightly clustered BODY failure callbacks into a bounded burst while retaining diagnostics and promptly tripping persistently failing providers.
- Shorten open cooldowns when every active provider trips together, allowing recovery probes to restore service instead of leaving all providers unavailable.
- Add circuit-breaker and correlation tests for burst behavior, cooldown caps, and repeated correlated events.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`