### PR TITLE
feat(usenet): preserve confirmed article misses across restarts

### DIFF
--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Threading.Channels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Config;
@@ -30,14 +31,38 @@ namespace NzbWebDAV.Clients.Usenet;
 /// articles, auth/connect failures, protocol errors, or cancellation — only a
 /// definitive miss (<see cref="UsenetArticleAvailability.IsDefinitiveMissing"/>)
 /// belongs in this cache.
+///
+/// Persistence is queued on a bounded channel drained in FIFO order by a single
+/// background consumer (started in <see cref="StartAsync"/>), so provider-change
+/// clears cannot be reordered behind earlier marks. <see cref="StopAsync"/>
+/// completes the queue and waits for the drain, so graceful restarts lose neither
+/// recently confirmed misses nor a pending clear. Marks that arrive while the
+/// queue is full stay memory-only — safe, because the in-memory cache is
+/// authoritative for the running process.
 /// </summary>
 public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
 {
+    private const int PersistenceQueueCapacity = 4096;
+    private const int MaxPersistenceBatchSize = 256;
+
     private readonly ConfigManager _configManager;
     private readonly Func<DavDatabaseContext>? _contextFactory;
     private readonly ConcurrentDictionary<string, DateTimeOffset> _missingAt = new(StringComparer.Ordinal);
-    private readonly SemaphoreSlim _persistenceGate = new(1, 1);
+    private readonly Channel<PersistenceWorkItem>? _persistenceQueue;
+    private Task _persistenceLoop = Task.CompletedTask;
+    private volatile bool _persistenceLoopStarted;
     private long _hits;
+
+    private abstract record PersistenceWorkItem;
+
+    private sealed record MarkItem(string Key, long ConfirmedAtUnix) : PersistenceWorkItem;
+
+    private sealed record ClearItem : PersistenceWorkItem
+    {
+        public static readonly ClearItem Instance = new();
+    }
+
+    private sealed record BarrierItem(TaskCompletionSource Completion) : PersistenceWorkItem;
 
     public ArticleMissNegativeCache(
         ConfigManager configManager,
@@ -45,11 +70,22 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     {
         _configManager = configManager;
         _contextFactory = contextFactory;
+        if (contextFactory is not null)
+        {
+            _persistenceQueue = Channel.CreateBounded<PersistenceWorkItem>(
+                new BoundedChannelOptions(PersistenceQueueCapacity)
+                {
+                    SingleReader = true,
+                    SingleWriter = false,
+                    FullMode = BoundedChannelFullMode.DropWrite,
+                });
+        }
+
         configManager.OnConfigChanged += (_, args) =>
         {
             if (!args.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders)) return;
             Clear();
-            _ = ClearPersistedAsync();
+            EnqueueClear();
         };
     }
 
@@ -91,14 +127,15 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     {
         var now = DateTimeOffset.UtcNow;
         MarkMissingInMemory(key, now);
-        _ = PersistMissingAsync(key, now);
+        _persistenceQueue?.Writer.TryWrite(new MarkItem(key, now.ToUnixTimeMilliseconds()));
     }
 
     public void Clear() => _missingAt.Clear();
 
     /// <summary>
-    /// Hydrates unexpired misses before NNTP traffic starts. A DB failure leaves the
-    /// in-memory cache usable; definitive misses must never block streaming.
+    /// Hydrates unexpired misses before NNTP traffic starts, then starts the
+    /// background persistence consumer. A DB failure leaves the in-memory cache
+    /// usable; definitive misses must never block streaming.
     /// </summary>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -127,11 +164,27 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         {
             Log.Warning(e, "Unable to hydrate persistent article-miss cache; continuing with memory-only misses.");
         }
+
+        // The loop outlives startup; it stops when StopAsync/Dispose completes the queue.
+        _persistenceLoop = Task.Run(RunPersistenceLoopAsync, CancellationToken.None);
+        _persistenceLoopStarted = true;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_persistenceQueue is null) return;
+        _persistenceQueue.Writer.TryComplete();
+        try
+        {
+            await _persistenceLoop.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Warning("Timed out draining the article-miss persistence queue; recent definitive misses may be lost.");
+        }
+    }
 
-    public void Dispose() => _persistenceGate.Dispose();
+    public void Dispose() => _persistenceQueue?.Writer.TryComplete();
 
     /// <summary>Test helper: mark an entry as if it were recorded at <paramref name="at"/>.</summary>
     internal void MarkMissingAtForTests(string key, DateTimeOffset at)
@@ -141,9 +194,19 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
 
     internal async Task MarkMissingAndPersistForTestsAsync(string key)
     {
-        var now = DateTimeOffset.UtcNow;
-        MarkMissingInMemory(key, now);
-        await PersistMissingAsync(key, now).ConfigureAwait(false);
+        MarkMissing(key);
+        await FlushPersistenceForTestsAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>Test helper: wait until every work item queued so far has been applied.</summary>
+    internal async Task FlushPersistenceForTestsAsync()
+    {
+        if (_persistenceQueue is null) return;
+        if (!_persistenceLoopStarted)
+            throw new InvalidOperationException("StartAsync must be called before flushing persistence.");
+        var barrier = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await _persistenceQueue.Writer.WriteAsync(new BarrierItem(barrier)).ConfigureAwait(false);
+        await barrier.Task.ConfigureAwait(false);
     }
 
     private void MarkMissingInMemory(string key, DateTimeOffset at)
@@ -167,70 +230,100 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
             _missingAt.TryRemove(kv.Key, out _);
     }
 
-    private async Task PersistMissingAsync(string key, DateTimeOffset confirmedAt)
+    private void EnqueueClear()
     {
-        if (_contextFactory is null) return;
-
-        try
+        if (_persistenceQueue is null) return;
+        if (_persistenceQueue.Writer.TryWrite(ClearItem.Instance)) return;
+        // The queue is momentarily full of pending marks and drains quickly; wait
+        // for room so a provider-change clear is never dropped.
+        _ = Task.Run(async () =>
         {
-            await _persistenceGate.WaitAsync().ConfigureAwait(false);
             try
             {
-                await using var context = _contextFactory();
-                var existing = await context.ArticleMissCacheEntries.FindAsync([key])
-                    .ConfigureAwait(false);
-                if (existing is null)
-                {
-                    context.ArticleMissCacheEntries.Add(new ArticleMissCacheEntry
-                    {
-                        CacheKey = key,
-                        ConfirmedAtUnix = confirmedAt.ToUnixTimeMilliseconds(),
-                    });
-                }
-                else
-                {
-                    existing.ConfirmedAtUnix = confirmedAt.ToUnixTimeMilliseconds();
-                }
-
-                await context.SaveChangesAsync().ConfigureAwait(false);
-                var cutoffUnix = (DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl())
-                    .ToUnixTimeMilliseconds();
-                await TrimPersistedAsync(
-                    context, cutoffUnix, _configManager.GetArticleMissCacheMaxEntries(), CancellationToken.None)
-                    .ConfigureAwait(false);
+                await _persistenceQueue.Writer.WriteAsync(ClearItem.Instance).ConfigureAwait(false);
             }
-            finally
+            catch (ChannelClosedException)
             {
-                _persistenceGate.Release();
+                // Shutdown raced the config change; nothing left to drain into.
             }
-        }
-        catch (Exception e) when (e is not OutOfMemoryException)
+        });
+    }
+
+    private async Task RunPersistenceLoopAsync()
+    {
+        var reader = _persistenceQueue!.Reader;
+        while (await reader.WaitToReadAsync().ConfigureAwait(false))
         {
-            Log.Debug(e, "Unable to persist definitive article miss; retaining memory-only entry.");
+            var marks = new Dictionary<string, long>(StringComparer.Ordinal);
+            var clearPending = false;
+            TaskCompletionSource? barrier = null;
+            var itemsRead = 0;
+            while (itemsRead < MaxPersistenceBatchSize && reader.TryRead(out var item))
+            {
+                itemsRead++;
+                switch (item)
+                {
+                    case ClearItem:
+                        // Marks queued before the clear must not survive it.
+                        marks.Clear();
+                        clearPending = true;
+                        break;
+                    case MarkItem mark:
+                        marks[mark.Key] = mark.ConfirmedAtUnix;
+                        break;
+                    case BarrierItem b:
+                        barrier = b.Completion;
+                        break;
+                }
+                if (barrier is not null) break;
+            }
+
+            try
+            {
+                if (clearPending || marks.Count > 0)
+                    await ApplyBatchAsync(clearPending, marks).ConfigureAwait(false);
+                barrier?.TrySetResult();
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                Log.Debug(e, "Unable to persist definitive article misses; retaining memory-only entries.");
+                barrier?.TrySetException(e);
+            }
         }
     }
 
-    private async Task ClearPersistedAsync()
+    private async Task ApplyBatchAsync(bool clearPending, Dictionary<string, long> marks)
     {
-        if (_contextFactory is null) return;
+        await using var context = _contextFactory!();
+        if (clearPending)
+            await context.ArticleMissCacheEntries.ExecuteDeleteAsync().ConfigureAwait(false);
 
-        try
+        if (marks.Count > 0)
         {
-            await _persistenceGate.WaitAsync().ConfigureAwait(false);
-            try
+            var keys = marks.Keys.ToList();
+            var existing = await context.ArticleMissCacheEntries
+                .Where(x => keys.Contains(x.CacheKey))
+                .ToDictionaryAsync(x => x.CacheKey)
+                .ConfigureAwait(false);
+            foreach (var (key, confirmedAtUnix) in marks)
             {
-                await using var context = _contextFactory();
-                await context.ArticleMissCacheEntries.ExecuteDeleteAsync().ConfigureAwait(false);
+                if (existing.TryGetValue(key, out var entry))
+                    entry.ConfirmedAtUnix = confirmedAtUnix;
+                else
+                    context.ArticleMissCacheEntries.Add(new ArticleMissCacheEntry
+                    {
+                        CacheKey = key,
+                        ConfirmedAtUnix = confirmedAtUnix,
+                    });
             }
-            finally
-            {
-                _persistenceGate.Release();
-            }
+            await context.SaveChangesAsync().ConfigureAwait(false);
         }
-        catch (Exception e) when (e is not OutOfMemoryException)
-        {
-            Log.Debug(e, "Unable to clear persistent article-miss cache after provider configuration changed.");
-        }
+
+        var cutoffUnix = (DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl())
+            .ToUnixTimeMilliseconds();
+        await TrimPersistedAsync(
+            context, cutoffUnix, _configManager.GetArticleMissCacheMaxEntries(), CancellationToken.None)
+            .ConfigureAwait(false);
     }
 
     private static async Task TrimPersistedAsync(
@@ -239,28 +332,17 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         int maxEntries,
         CancellationToken cancellationToken)
     {
+        // Single round-trip: drop expired rows and, when over capacity, everything
+        // outside the newest maxEntries rows. Expired rows inside the keep-set are
+        // still removed by the first condition.
+        var keepKeys = context.ArticleMissCacheEntries
+            .OrderByDescending(x => x.ConfirmedAtUnix)
+            .ThenByDescending(x => x.CacheKey)
+            .Take(maxEntries)
+            .Select(x => x.CacheKey);
         await context.ArticleMissCacheEntries
-            .Where(x => x.ConfirmedAtUnix < cutoffUnix)
+            .Where(x => x.ConfirmedAtUnix < cutoffUnix || !keepKeys.Contains(x.CacheKey))
             .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
-
-        var overflow = await context.ArticleMissCacheEntries.CountAsync(cancellationToken)
-            .ConfigureAwait(false) - maxEntries;
-        if (overflow <= 0) return;
-
-        var oldestKeys = await context.ArticleMissCacheEntries
-            .OrderBy(x => x.ConfirmedAtUnix)
-            .ThenBy(x => x.CacheKey)
-            .Take(overflow)
-            .Select(x => x.CacheKey)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-        if (oldestKeys.Count > 0)
-        {
-            await context.ArticleMissCacheEntries
-                .Where(x => oldestKeys.Contains(x.CacheKey))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
     }
 }

--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -1,5 +1,10 @@
 using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using Serilog;
 
 namespace NzbWebDAV.Clients.Usenet;
 
@@ -26,19 +31,25 @@ namespace NzbWebDAV.Clients.Usenet;
 /// definitive miss (<see cref="UsenetArticleAvailability.IsDefinitiveMissing"/>)
 /// belongs in this cache.
 /// </summary>
-public sealed class ArticleMissNegativeCache
+public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
 {
     private readonly ConfigManager _configManager;
+    private readonly Func<DavDatabaseContext>? _contextFactory;
     private readonly ConcurrentDictionary<string, DateTimeOffset> _missingAt = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _persistenceGate = new(1, 1);
     private long _hits;
 
-    public ArticleMissNegativeCache(ConfigManager configManager)
+    public ArticleMissNegativeCache(
+        ConfigManager configManager,
+        Func<DavDatabaseContext>? contextFactory = null)
     {
         _configManager = configManager;
+        _contextFactory = contextFactory;
         configManager.OnConfigChanged += (_, args) =>
         {
             if (!args.ChangedConfig.ContainsKey(ConfigKeys.UsenetProviders)) return;
             Clear();
+            _ = ClearPersistedAsync();
         };
     }
 
@@ -78,15 +89,64 @@ public sealed class ArticleMissNegativeCache
 
     public void MarkMissing(string key)
     {
-        _missingAt[key] = DateTimeOffset.UtcNow;
-        var maxEntries = _configManager.GetArticleMissCacheMaxEntries();
-        if (_missingAt.Count > maxEntries) Cleanup(maxEntries);
+        var now = DateTimeOffset.UtcNow;
+        MarkMissingInMemory(key, now);
+        _ = PersistMissingAsync(key, now);
     }
 
     public void Clear() => _missingAt.Clear();
 
+    /// <summary>
+    /// Hydrates unexpired misses before NNTP traffic starts. A DB failure leaves the
+    /// in-memory cache usable; definitive misses must never block streaming.
+    /// </summary>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_contextFactory is null) return;
+
+        try
+        {
+            var cutoff = DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl();
+            var cutoffUnix = cutoff.ToUnixTimeMilliseconds();
+            var maxEntries = _configManager.GetArticleMissCacheMaxEntries();
+            await using var context = _contextFactory();
+            var entries = await context.ArticleMissCacheEntries
+                .AsNoTracking()
+                .Where(x => x.ConfirmedAtUnix >= cutoffUnix)
+                .OrderByDescending(x => x.ConfirmedAtUnix)
+                .Take(maxEntries)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            foreach (var entry in entries)
+                _missingAt[entry.CacheKey] = DateTimeOffset.FromUnixTimeMilliseconds(entry.ConfirmedAtUnix);
+
+            await TrimPersistedAsync(context, cutoffUnix, maxEntries, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is not OperationCanceledException and not OutOfMemoryException)
+        {
+            Log.Warning(e, "Unable to hydrate persistent article-miss cache; continuing with memory-only misses.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public void Dispose() => _persistenceGate.Dispose();
+
     /// <summary>Test helper: mark an entry as if it were recorded at <paramref name="at"/>.</summary>
     internal void MarkMissingAtForTests(string key, DateTimeOffset at)
+    {
+        MarkMissingInMemory(key, at);
+    }
+
+    internal async Task MarkMissingAndPersistForTestsAsync(string key)
+    {
+        var now = DateTimeOffset.UtcNow;
+        MarkMissingInMemory(key, now);
+        await PersistMissingAsync(key, now).ConfigureAwait(false);
+    }
+
+    private void MarkMissingInMemory(string key, DateTimeOffset at)
     {
         _missingAt[key] = at;
         var maxEntries = _configManager.GetArticleMissCacheMaxEntries();
@@ -105,5 +165,102 @@ public sealed class ArticleMissNegativeCache
         // (approximate LRU) so runaway cardinality can't grow unbounded.
         foreach (var kv in _missingAt.OrderBy(kv => kv.Value).Take(overflow))
             _missingAt.TryRemove(kv.Key, out _);
+    }
+
+    private async Task PersistMissingAsync(string key, DateTimeOffset confirmedAt)
+    {
+        if (_contextFactory is null) return;
+
+        try
+        {
+            await _persistenceGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using var context = _contextFactory();
+                var existing = await context.ArticleMissCacheEntries.FindAsync([key])
+                    .ConfigureAwait(false);
+                if (existing is null)
+                {
+                    context.ArticleMissCacheEntries.Add(new ArticleMissCacheEntry
+                    {
+                        CacheKey = key,
+                        ConfirmedAtUnix = confirmedAt.ToUnixTimeMilliseconds(),
+                    });
+                }
+                else
+                {
+                    existing.ConfirmedAtUnix = confirmedAt.ToUnixTimeMilliseconds();
+                }
+
+                await context.SaveChangesAsync().ConfigureAwait(false);
+                var cutoffUnix = (DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl())
+                    .ToUnixTimeMilliseconds();
+                await TrimPersistedAsync(
+                    context, cutoffUnix, _configManager.GetArticleMissCacheMaxEntries(), CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                _persistenceGate.Release();
+            }
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(e, "Unable to persist definitive article miss; retaining memory-only entry.");
+        }
+    }
+
+    private async Task ClearPersistedAsync()
+    {
+        if (_contextFactory is null) return;
+
+        try
+        {
+            await _persistenceGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using var context = _contextFactory();
+                await context.ArticleMissCacheEntries.ExecuteDeleteAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _persistenceGate.Release();
+            }
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(e, "Unable to clear persistent article-miss cache after provider configuration changed.");
+        }
+    }
+
+    private static async Task TrimPersistedAsync(
+        DavDatabaseContext context,
+        long cutoffUnix,
+        int maxEntries,
+        CancellationToken cancellationToken)
+    {
+        await context.ArticleMissCacheEntries
+            .Where(x => x.ConfirmedAtUnix < cutoffUnix)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var overflow = await context.ArticleMissCacheEntries.CountAsync(cancellationToken)
+            .ConfigureAwait(false) - maxEntries;
+        if (overflow <= 0) return;
+
+        var oldestKeys = await context.ArticleMissCacheEntries
+            .OrderBy(x => x.ConfirmedAtUnix)
+            .ThenBy(x => x.CacheKey)
+            .Take(overflow)
+            .Select(x => x.CacheKey)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (oldestKeys.Count > 0)
+        {
+            await context.ArticleMissCacheEntries
+                .Where(x => oldestKeys.Contains(x.CacheKey))
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -87,6 +87,7 @@ public class DavDatabaseContext : DbContext
     public DbSet<ListSource> ListSources => Set<ListSource>();
     public DbSet<WantedItem> WantedItems => Set<WantedItem>();
     public DbSet<NzbResolutionGroup> NzbResolutionGroups => Set<NzbResolutionGroup>();
+    public DbSet<ArticleMissCacheEntry> ArticleMissCacheEntries => Set<ArticleMissCacheEntry>();
 
     // Pending blob writes for the current unit of work (flushed in SaveChangesAsync).
     private readonly List<DavNzbFile> _blobNzbFiles = [];
@@ -760,6 +761,16 @@ public class DavDatabaseContext : DbContext
             e.Property(i => i.CreatedAtUnix).IsRequired();
 
             e.HasIndex(i => i.CreatedAtUnix);
+        });
+
+        // ArticleMissCacheEntry
+        b.Entity<ArticleMissCacheEntry>(e =>
+        {
+            e.ToTable("ArticleMissCacheEntries");
+            e.HasKey(i => i.CacheKey);
+            e.Property(i => i.CacheKey).IsRequired();
+            e.Property(i => i.ConfirmedAtUnix).IsRequired();
+            e.HasIndex(i => i.ConfirmedAtUnix);
         });
 
         if (DatabaseProviderConfig.IsPostgres)

--- a/backend/Database/Migrations/20260818200000_Add-ArticleMiss-Cache.cs
+++ b/backend/Database/Migrations/20260818200000_Add-ArticleMiss-Cache.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations;
+
+[DbContext(typeof(DavDatabaseContext))]
+[Migration("20260818200000_Add-ArticleMiss-Cache")]
+public partial class AddArticleMissCache : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "ArticleMissCacheEntries",
+            columns: table => new
+            {
+                CacheKey = table.Column<string>(type: "TEXT", nullable: false),
+                ConfirmedAtUnix = table.Column<long>(type: "INTEGER", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ArticleMissCacheEntries", x => x.CacheKey);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ArticleMissCacheEntries_ConfirmedAtUnix",
+            table: "ArticleMissCacheEntries",
+            column: "ConfirmedAtUnix");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "ArticleMissCacheEntries");
+    }
+}

--- a/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
@@ -424,6 +424,21 @@ namespace NzbWebDAV.Database.Migrations
                     b.ToTable("NzbNames", (string)null);
                 });
 
+            modelBuilder.Entity("NzbWebDAV.Database.Models.ArticleMissCacheEntry", b =>
+                {
+                    b.Property<string>("CacheKey")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("ConfirmedAtUnix")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("CacheKey");
+
+                    b.HasIndex("ConfirmedAtUnix");
+
+                    b.ToTable("ArticleMissCacheEntries", (string)null);
+                });
+
             modelBuilder.Entity("NzbWebDAV.Database.Models.NzbResolutionGroup", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/Database/Models/ArticleMissCacheEntry.cs
+++ b/backend/Database/Models/ArticleMissCacheEntry.cs
@@ -1,0 +1,10 @@
+namespace NzbWebDAV.Database.Models;
+
+/// <summary>
+/// A definitive, provider- or storage-group-scoped NNTP article miss.
+/// </summary>
+public sealed class ArticleMissCacheEntry
+{
+    public required string CacheKey { get; init; }
+    public long ConfirmedAtUnix { get; set; }
+}

--- a/backend/Database/PostgresMigrations/20260818200000_Add-ArticleMiss-Cache.cs
+++ b/backend/Database/PostgresMigrations/20260818200000_Add-ArticleMiss-Cache.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.PostgresMigrations;
+
+[DbContext(typeof(PostgresDavDatabaseContext))]
+[Migration("20260818200000_Add-ArticleMiss-Cache")]
+public partial class AddArticleMissCache : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "ArticleMissCacheEntries",
+            columns: table => new
+            {
+                CacheKey = table.Column<string>(type: "text", nullable: false),
+                ConfirmedAtUnix = table.Column<long>(type: "bigint", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ArticleMissCacheEntries", x => x.CacheKey);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ArticleMissCacheEntries_ConfirmedAtUnix",
+            table: "ArticleMissCacheEntries",
+            column: "ConfirmedAtUnix");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "ArticleMissCacheEntries");
+    }
+}

--- a/backend/Database/PostgresMigrations/PostgresDavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/PostgresMigrations/PostgresDavDatabaseContextModelSnapshot.cs
@@ -431,6 +431,21 @@ namespace NzbWebDAV.Database.PostgresMigrations
                     b.ToTable("NzbNames", (string)null);
                 });
 
+            modelBuilder.Entity("NzbWebDAV.Database.Models.ArticleMissCacheEntry", b =>
+                {
+                    b.Property<string>("CacheKey")
+                        .HasColumnType("text");
+
+                    b.Property<long>("ConfirmedAtUnix")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("CacheKey");
+
+                    b.HasIndex("ConfirmedAtUnix");
+
+                    b.ToTable("ArticleMissCacheEntries", (string)null);
+                });
+
             modelBuilder.Entity("NzbWebDAV.Database.Models.NzbResolutionGroup", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -294,7 +294,12 @@ public partial class Program
                 .AddSingleton<NzbFetchCoalescer>()
                 .AddSingleton<PlayResolutionCoalescer>()
                 .AddSingleton<CandidateNegativeCache>()
-                .AddSingleton<ArticleMissNegativeCache>()
+                // The cache owns its short-lived DbContexts directly so the singleton
+                // NNTP client never depends on scoped database services.
+                .AddSingleton(sp => new ArticleMissNegativeCache(
+                    sp.GetRequiredService<ConfigManager>(),
+                    () => new DavDatabaseContext()))
+                .AddHostedService(sp => sp.GetRequiredService<ArticleMissNegativeCache>())
                 .AddSingleton<WardenStore>()
                 .AddSingleton<WardenRemoteSourceService>()
                 .AddHostedService(sp => sp.GetRequiredService<WardenRemoteSourceService>())

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
@@ -149,7 +149,10 @@ public class ArticleMissNegativeCacheTests
         var config = CreateConfig(ttlSeconds: 30, maxEntries: 100);
         var key = ArticleMissNegativeCache.BuildKey("segment", "a.example", null);
         using (var first = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options)))
+        {
+            await first.StartAsync(CancellationToken.None);
             await first.MarkMissingAndPersistForTestsAsync(key);
+        }
 
         using var restarted = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options));
         await restarted.StartAsync(CancellationToken.None);
@@ -201,6 +204,88 @@ public class ArticleMissNegativeCacheTests
         Assert.True(cache.IsMissing("segment-100\u0001p:provider"));
         await using var verify = new DavDatabaseContext(options);
         Assert.Equal(100, await verify.ArticleMissCacheEntries.CountAsync());
+    }
+
+    [Fact]
+    public async Task MarkMissing_PersistsAsynchronously_AndStopAsyncDrainsQueue()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using (var context = new DavDatabaseContext(options))
+            await context.Database.EnsureCreatedAsync();
+
+        var config = CreateConfig(ttlSeconds: 300, maxEntries: 100);
+        var key = ArticleMissNegativeCache.BuildKey("segment", "a.example", null);
+        using (var cache = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options)))
+        {
+            await cache.StartAsync(CancellationToken.None);
+            cache.MarkMissing(key);
+            await cache.StopAsync(CancellationToken.None);
+        }
+
+        await using var verify = new DavDatabaseContext(options);
+        Assert.Equal(key, (await verify.ArticleMissCacheEntries.SingleAsync()).CacheKey);
+    }
+
+    [Fact]
+    public async Task ProviderConfigChange_ClearsPersistedEntries()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using (var context = new DavDatabaseContext(options))
+            await context.Database.EnsureCreatedAsync();
+
+        var config = CreateConfig(ttlSeconds: 300, maxEntries: 100);
+        using var cache = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options));
+        await cache.StartAsync(CancellationToken.None);
+        await cache.MarkMissingAndPersistForTestsAsync(
+            ArticleMissNegativeCache.BuildKey("segment", "a.example", null));
+
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = """{"Providers":[]}""",
+            },
+        ]);
+        await cache.FlushPersistenceForTestsAsync();
+
+        Assert.Equal(0, cache.Entries);
+        await using var verify = new DavDatabaseContext(options);
+        Assert.Empty(await verify.ArticleMissCacheEntries.ToListAsync());
+    }
+
+    [Fact]
+    public async Task PersistedTrim_EnforcesMaxEntries()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using (var context = new DavDatabaseContext(options))
+            await context.Database.EnsureCreatedAsync();
+
+        var config = CreateConfig(ttlSeconds: 300, maxEntries: 100);
+        using var cache = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options));
+        await cache.StartAsync(CancellationToken.None);
+        for (var i = 0; i < 150; i++)
+            cache.MarkMissing(ArticleMissNegativeCache.BuildKey($"art-{i}", "p", null));
+        await cache.FlushPersistenceForTestsAsync();
+
+        await using var verify = new DavDatabaseContext(options);
+        Assert.Equal(100, await verify.ArticleMissCacheEntries.CountAsync());
+        Assert.Null(await verify.ArticleMissCacheEntries
+            .FindAsync(ArticleMissNegativeCache.BuildKey("art-0", "p", null)));
+        Assert.NotNull(await verify.ArticleMissCacheEntries
+            .FindAsync(ArticleMissNegativeCache.BuildKey("art-149", "p", null)));
     }
 
     private static ConfigManager CreateConfig(int ttlSeconds, int maxEntries)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
@@ -1,5 +1,8 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -130,6 +133,74 @@ public class ArticleMissNegativeCacheTests
         Assert.True(cache.Entries <= 100);
         Assert.False(cache.IsMissing(ArticleMissNegativeCache.BuildKey("art-0", "p", null)));
         Assert.True(cache.IsMissing(ArticleMissNegativeCache.BuildKey("art-149", "p", null)));
+    }
+
+    [Fact]
+    public async Task PersistentCache_HydratesFreshMisses_AndPurgesExpiredRows()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using (var context = new DavDatabaseContext(options))
+            await context.Database.EnsureCreatedAsync();
+
+        var config = CreateConfig(ttlSeconds: 30, maxEntries: 100);
+        var key = ArticleMissNegativeCache.BuildKey("segment", "a.example", null);
+        using (var first = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options)))
+            await first.MarkMissingAndPersistForTestsAsync(key);
+
+        using var restarted = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options));
+        await restarted.StartAsync(CancellationToken.None);
+        Assert.True(restarted.IsMissing(key));
+
+        await using (var context = new DavDatabaseContext(options))
+        {
+            var persisted = await context.ArticleMissCacheEntries.SingleAsync();
+            persisted.ConfirmedAtUnix = DateTimeOffset.UtcNow.AddSeconds(-31).ToUnixTimeMilliseconds();
+            await context.SaveChangesAsync();
+        }
+
+        using var afterExpiry = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options));
+        await afterExpiry.StartAsync(CancellationToken.None);
+        Assert.False(afterExpiry.IsMissing(key));
+        await using var verify = new DavDatabaseContext(options);
+        Assert.Empty(await verify.ArticleMissCacheEntries.ToListAsync());
+    }
+
+    [Fact]
+    public async Task PersistentCache_Hydration_EvictsOldestRowsBeyondCap()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using (var context = new DavDatabaseContext(options))
+        {
+            await context.Database.EnsureCreatedAsync();
+            var now = DateTimeOffset.UtcNow;
+            for (var i = 0; i < 101; i++)
+            {
+                context.ArticleMissCacheEntries.Add(new ArticleMissCacheEntry
+                {
+                    CacheKey = $"segment-{i}\u0001p:provider",
+                    ConfirmedAtUnix = now.AddMilliseconds(i).ToUnixTimeMilliseconds(),
+                });
+            }
+            await context.SaveChangesAsync();
+        }
+
+        var config = CreateConfig(ttlSeconds: 300, maxEntries: 100);
+        using var cache = new ArticleMissNegativeCache(config, () => new DavDatabaseContext(options));
+        await cache.StartAsync(CancellationToken.None);
+
+        Assert.Equal(100, cache.Entries);
+        Assert.False(cache.IsMissing("segment-0\u0001p:provider"));
+        Assert.True(cache.IsMissing("segment-100\u0001p:provider"));
+        await using var verify = new DavDatabaseContext(options);
+        Assert.Equal(100, await verify.ArticleMissCacheEntries.CountAsync());
     }
 
     private static ConfigManager CreateConfig(int ttlSeconds, int maxEntries)


### PR DESCRIPTION
## Summary
- persist definitive 430/451 article misses with provider/storage-group scoping
- hydrate the bounded cache before NNTP traffic and revalidate entries after TTL expiry
- add SQLite and PostgreSQL migrations plus persistence tests

Closes #1026

Note: the migrations are additive — back up `/config` before upgrading as a precaution.

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj --no-restore --maxcpucount:1`
- [x] fresh SQLite `--db-migration` smoke test
- [x] persistence tests pass in the full backend suite (the earlier `FakeNntpClient.BodyRequestCounts` compile error was fixed on `perf/streaming-benchmark-response`)