### PR TITLE
perf(usenet): accelerate playback starts and sustained streaming

### DIFF
--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -9,7 +9,10 @@ using NzbWebDAV.Streams;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+if (args.SequenceEqual(["--streaming-report"], StringComparer.Ordinal))
+    await NzbWebDAV.Benchmarks.RepeatableStreamingReport.RunAsync();
+else
+    BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
 
 namespace NzbWebDAV.Benchmarks
@@ -243,8 +246,17 @@ namespace NzbWebDAV.Benchmarks
     }
 
     internal sealed class BenchmarkNntpClient(
-        IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+        IReadOnlyDictionary<string, byte[]> segments,
+        bool useCachedYencStreams = false,
+        IReadOnlyDictionary<string, LongRange>? segmentRanges = null) : NntpClient
     {
+        private int _bodyRequestCount;
+        private long _bodyBytesRequested;
+
+        public int BodyRequestCount => Volatile.Read(ref _bodyRequestCount);
+        public long BodyBytesRequested => Interlocked.Read(ref _bodyBytesRequested);
+        public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
+
         public override Task ConnectAsync(
             string host, int port, bool useSsl, CancellationToken cancellationToken) =>
             Task.CompletedTask;
@@ -271,6 +283,8 @@ namespace NzbWebDAV.Benchmarks
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            Interlocked.Increment(ref _bodyRequestCount);
+            RequestedSegmentIds.Add(segmentId.ToString());
             try
             {
                 var response = CreateResponse(segmentId);
@@ -344,14 +358,32 @@ namespace NzbWebDAV.Benchmarks
             var key = segmentId.ToString();
             if (!segments.TryGetValue(key, out var bytes))
                 throw new UsenetArticleNotFoundException(key, "430 No such article");
+            Interlocked.Add(ref _bodyBytesRequested, bytes.Length);
+
+            YencStream stream = useCachedYencStreams
+                ? new CachedYencStream(
+                    new UsenetYencHeader
+                    {
+                        FileName = "repeatable-streaming-benchmark.bin",
+                        FileSize = segmentRanges is { Count: > 0 }
+                            ? segmentRanges.Values.Max(range => range.EndExclusive)
+                            : bytes.Length,
+                        LineLength = 128,
+                        PartNumber = 1,
+                        TotalParts = segments.Count,
+                        PartOffset = segmentRanges?[key].StartInclusive ?? 0,
+                        PartSize = segmentRanges?[key].Count ?? bytes.Length,
+                    },
+                    new MemoryStream(bytes, writable: false))
+                : new YencStream(new MemoryStream(
+                    YencDecodeBenchmarks.EncodeYenc(bytes), writable: false));
 
             return new UsenetDecodedBodyResponse
             {
                 SegmentId = key,
                 ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
                 ResponseMessage = "222 benchmark body",
-                Stream = new YencStream(new MemoryStream(
-                    YencDecodeBenchmarks.EncodeYenc(bytes), writable: false))
+                Stream = stream,
             };
         }
     }

--- a/backend.Benchmarks/README.md
+++ b/backend.Benchmarks/README.md
@@ -12,3 +12,18 @@ dotnet run --project backend.Benchmarks -c Release
 
 Use the same machine and runtime when comparing results across UsenetSharp or
 streaming changes.
+
+## Repeatable streaming report
+
+Run the deterministic local streaming harness with:
+
+```bash
+dotnet run --project backend.Benchmarks -c Release -- --streaming-report
+```
+
+It uses generated in-memory segments and the local segment cache, so it makes
+no provider connections and is not intended for CI. The report verifies payload
+fidelity while printing cold sequential transport bytes/requests, first-byte
+latency, range and tail probes, warm cache re-reads, seeks, and a zero-filled
+dead-article read. Compare throughput and latency fields only on the same
+machine and runtime; transport fields remain deterministic across runs.

--- a/backend.Benchmarks/RepeatableStreamingReport.cs
+++ b/backend.Benchmarks/RepeatableStreamingReport.cs
@@ -1,0 +1,256 @@
+using System.Diagnostics;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Benchmarks;
+
+internal static class RepeatableStreamingReport
+{
+    private const int SegmentSize = 256 * 1024;
+    private const int SegmentCount = 12;
+    private const int ProbeSize = 64 * 1024;
+
+    public static async Task RunAsync()
+    {
+        var fixture = CreateFixture();
+        var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-repeatable-streaming-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            using var transport = fixture.CreateTransport();
+            using var cached = new SegmentCacheNntpClient(
+                transport,
+                cacheDir,
+                maxBytes: fixture.Source.Length * 2L);
+            await WaitForCatalogAsync(cached).ConfigureAwait(false);
+
+            var cold = await ReadAllAsync(transport, fixture).ConfigureAwait(false);
+            Print("cold-sequential", cold, fixture.Source.Length, transport.BodyRequestCount,
+                transport.BodyBytesRequested);
+
+            var requestsBeforePrime = transport.BodyRequestCount;
+            var bytesBeforePrime = transport.BodyBytesRequested;
+            var cachePrime = await PrimeCacheAsync(cached, fixture).ConfigureAwait(false);
+            Print("cache-prime", cachePrime, fixture.Source.Length,
+                transport.BodyRequestCount - requestsBeforePrime,
+                transport.BodyBytesRequested - bytesBeforePrime);
+
+            var requestsBeforeWarmRead = transport.BodyRequestCount;
+            var bytesBeforeWarmRead = transport.BodyBytesRequested;
+            var warm = await ReadAllAsync(cached, fixture).ConfigureAwait(false);
+            Print("warm-reread", warm, fixture.Source.Length,
+                transport.BodyRequestCount - requestsBeforeWarmRead,
+                transport.BodyBytesRequested - bytesBeforeWarmRead);
+
+            var requestsBeforeRangeProbe = transport.BodyRequestCount;
+            var bytesBeforeRangeProbe = transport.BodyBytesRequested;
+            var range = await ProbeAsync(cached, fixture, SegmentSize * 4L + 137, ProbeSize).ConfigureAwait(false);
+            Print("range-probe", range, ProbeSize,
+                transport.BodyRequestCount - requestsBeforeRangeProbe,
+                transport.BodyBytesRequested - bytesBeforeRangeProbe);
+
+            var requestsBeforeTailProbe = transport.BodyRequestCount;
+            var bytesBeforeTailProbe = transport.BodyBytesRequested;
+            var tail = await ProbeAsync(cached, fixture, fixture.Source.Length - ProbeSize, ProbeSize).ConfigureAwait(false);
+            Print("tail-probe", tail, ProbeSize,
+                transport.BodyRequestCount - requestsBeforeTailProbe,
+                transport.BodyBytesRequested - bytesBeforeTailProbe);
+
+            var requestsBeforeSeeks = transport.BodyRequestCount;
+            var bytesBeforeSeeks = transport.BodyBytesRequested;
+            var seeks = await SeekAsync(cached, fixture).ConfigureAwait(false);
+            Print("seeks", seeks, seeks.BytesRead,
+                transport.BodyRequestCount - requestsBeforeSeeks,
+                transport.BodyBytesRequested - bytesBeforeSeeks,
+                extra: $"seek_count={seeks.OperationCount}");
+
+            var dead = await DeadArticleAsync(fixture).ConfigureAwait(false);
+            Print("dead-article", dead.Metrics, dead.ZeroFilledBytes, dead.TransportRequests,
+                dead.TransportBytes, $"zero_filled_bytes={dead.ZeroFilledBytes}");
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    private static async Task<StreamingMetrics> ReadAllAsync(INntpClient client, Fixture fixture)
+    {
+        await using var stream = fixture.CreateStream(client);
+        var buffer = new byte[ProbeSize];
+        var stopwatch = Stopwatch.StartNew();
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true).ConfigureAwait(false);
+        var firstByte = stopwatch.Elapsed;
+        await stream.CopyToAsync(Stream.Null).ConfigureAwait(false);
+        stopwatch.Stop();
+        return new StreamingMetrics(stopwatch.Elapsed, firstByte, read, OperationCount: 1);
+    }
+
+    private static async Task<StreamingMetrics> PrimeCacheAsync(SegmentCacheNntpClient client, Fixture fixture)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var firstByte = TimeSpan.Zero;
+        var bytesRead = 0L;
+
+        foreach (var segmentId in fixture.SegmentIds)
+        {
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None).ConfigureAwait(false);
+            using var body = response.Stream
+                ?? throw new InvalidOperationException($"Cache prime returned no body for {segmentId}.");
+            var buffer = new byte[ProbeSize];
+            var read = await body.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true)
+                .ConfigureAwait(false);
+            if (bytesRead == 0) firstByte = stopwatch.Elapsed;
+            bytesRead += read;
+            await body.CopyToAsync(Stream.Null).ConfigureAwait(false);
+        }
+
+        stopwatch.Stop();
+        return new StreamingMetrics(stopwatch.Elapsed, firstByte, bytesRead, fixture.SegmentIds.Length);
+    }
+
+    private static async Task<StreamingMetrics> ProbeAsync(
+        INntpClient client,
+        Fixture fixture,
+        long offset,
+        int count)
+    {
+        await using var stream = fixture.CreateStream(client);
+        stream.Seek(offset, SeekOrigin.Begin);
+        var buffer = new byte[count];
+        var stopwatch = Stopwatch.StartNew();
+        var read = await stream.ReadAtLeastAsync(buffer, count, throwOnEndOfStream: true).ConfigureAwait(false);
+        stopwatch.Stop();
+        Verify(fixture.Source.AsSpan((int)offset, read), buffer.AsSpan(0, read), "probe");
+        return new StreamingMetrics(stopwatch.Elapsed, stopwatch.Elapsed, read, OperationCount: 1);
+    }
+
+    private static async Task<StreamingMetrics> SeekAsync(INntpClient client, Fixture fixture)
+    {
+        var offsets = new[] { 17L, SegmentSize * 3L + 91, SegmentSize * 8L + 7, SegmentSize * 2L + 511 };
+        await using var stream = fixture.CreateStream(client);
+        var buffer = new byte[ProbeSize];
+        var stopwatch = Stopwatch.StartNew();
+        var firstByte = TimeSpan.Zero;
+        var bytesRead = 0L;
+
+        foreach (var offset in offsets)
+        {
+            stream.Seek(offset, SeekOrigin.Begin);
+            var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true)
+                .ConfigureAwait(false);
+            if (bytesRead == 0) firstByte = stopwatch.Elapsed;
+            Verify(fixture.Source.AsSpan((int)offset, read), buffer.AsSpan(0, read), "seek");
+            bytesRead += read;
+        }
+
+        stopwatch.Stop();
+        return new StreamingMetrics(stopwatch.Elapsed, firstByte, bytesRead, offsets.Length);
+    }
+
+    private static async Task<DeadArticleResult> DeadArticleAsync(Fixture fixture)
+    {
+        var missingSegment = fixture.SegmentIds[5];
+        using var transport = new BenchmarkNntpClient(
+            fixture.Segments.Where(pair => pair.Key != missingSegment).ToDictionary(),
+            useCachedYencStreams: true,
+            fixture.RangesById);
+        await using var stream = fixture.CreateStream(transport);
+        stream.Seek(SegmentSize * 5L, SeekOrigin.Begin);
+        var buffer = new byte[SegmentSize];
+        var stopwatch = Stopwatch.StartNew();
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true).ConfigureAwait(false);
+        stopwatch.Stop();
+
+        if (buffer.AsSpan(0, read).IndexOfAnyExcept((byte)0) >= 0)
+            throw new InvalidOperationException("Dead-article probe did not return an all-zero gap.");
+
+        return new DeadArticleResult(
+            new StreamingMetrics(stopwatch.Elapsed, stopwatch.Elapsed, read, OperationCount: 1),
+            read,
+            transport.BodyRequestCount,
+            transport.BodyBytesRequested);
+    }
+
+    private static async Task WaitForCatalogAsync(SegmentCacheNntpClient client)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!client.IsCatalogReady && DateTime.UtcNow < deadline)
+            await Task.Delay(10).ConfigureAwait(false);
+
+        if (!client.IsCatalogReady)
+            throw new TimeoutException("Segment cache catalog did not become ready.");
+    }
+
+    private static void Print(
+        string scenario,
+        StreamingMetrics metrics,
+        long bytes,
+        int transportRequests,
+        long transportBytes,
+        string? extra = null)
+    {
+        var seconds = Math.Max(metrics.Elapsed.TotalSeconds, double.Epsilon);
+        var throughput = bytes / 1024d / 1024d / seconds;
+        Console.WriteLine(
+            $"{scenario} bytes={bytes} transport_requests={transportRequests} " +
+            $"transport_bytes={transportBytes} first_byte_ms={metrics.FirstByte.TotalMilliseconds:F3} " +
+            $"elapsed_ms={metrics.Elapsed.TotalMilliseconds:F3} throughput_mib_s={throughput:F3}" +
+            (extra is null ? string.Empty : $" {extra}"));
+    }
+
+    private static void Verify(ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual, string operation)
+    {
+        if (!expected.SequenceEqual(actual))
+            throw new InvalidOperationException($"Repeatable streaming {operation} read did not match its fixture.");
+    }
+
+    private static Fixture CreateFixture()
+    {
+        var source = new byte[SegmentSize * SegmentCount];
+        new Random(1025).NextBytes(source);
+        var segmentIds = Enumerable.Range(0, SegmentCount).Select(index => $"report-{index:D2}").ToArray();
+        var ranges = Enumerable.Range(0, SegmentCount)
+            .Select(index => new LongRange(index * SegmentSize, (index + 1L) * SegmentSize))
+            .ToArray();
+        var segments = segmentIds
+            .Select((id, index) => KeyValuePair.Create(
+                id, source.AsSpan(index * SegmentSize, SegmentSize).ToArray()))
+            .ToDictionary();
+        return new Fixture(
+            source,
+            segmentIds,
+            ranges,
+            segments,
+            segmentIds.Zip(ranges).ToDictionary(pair => pair.First, pair => pair.Second));
+    }
+
+    private sealed record Fixture(
+        byte[] Source,
+        string[] SegmentIds,
+        LongRange[] Ranges,
+        IReadOnlyDictionary<string, byte[]> Segments,
+        IReadOnlyDictionary<string, LongRange> RangesById)
+    {
+        public BenchmarkNntpClient CreateTransport() =>
+            new(Segments, useCachedYencStreams: true, RangesById);
+
+        public NzbFileStream CreateStream(INntpClient client) =>
+            new(SegmentIds, Source.Length, client, articleBufferSize: 0, segmentByteRanges: Ranges,
+                usePipelinedBodyRequests: false, fileName: "repeatable-streaming-benchmark.bin");
+    }
+
+    private readonly record struct StreamingMetrics(
+        TimeSpan Elapsed,
+        TimeSpan FirstByte,
+        long BytesRead,
+        int OperationCount);
+
+    private readonly record struct DeadArticleResult(
+        StreamingMetrics Metrics,
+        long ZeroFilledBytes,
+        int TransportRequests,
+        long TransportBytes);
+}

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -47,6 +47,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     public TimeSpan IdleTimeout { get; }
     public int MaxConnections => _maxConnections;
+    public int WarmConnectionFloor => _warmConnectionFloor;
     public int EffectiveMaxConnections => Volatile.Read(ref _effectiveMaxConnections);
     public int? LearnedConnectionLimit => _learnedConnectionLimit;
     public int LiveConnections => _live;
@@ -59,6 +60,8 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     private readonly Func<CancellationToken, ValueTask<T>> _factory;
     private readonly int _maxConnections;
+    private readonly int _warmConnectionFloor;
+    private readonly Func<T, CancellationToken, Task>? _keepAlive;
     private readonly Func<Exception, int?>? _connectionLimitDetector;
     private readonly Action<int, int>? _onConnectionLimitLearned;
 
@@ -104,7 +107,9 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         TimeSpan? idleTimeout = null,
         SemaphorePriorityOdds? priorityOdds = null,
         Func<Exception, int?>? connectionLimitDetector = null,
-        Action<int, int>? onConnectionLimitLearned = null)
+        Action<int, int>? onConnectionLimitLearned = null,
+        int warmConnectionFloor = 0,
+        Func<T, CancellationToken, Task>? keepAlive = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConnections);
 
@@ -117,6 +122,8 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             throw new ArgumentOutOfRangeException(nameof(idleTimeout));
 
         _maxConnections = maxConnections;
+        _warmConnectionFloor = Math.Clamp(warmConnectionFloor, 0, maxConnections);
+        _keepAlive = _warmConnectionFloor > 0 ? keepAlive : null;
         _effectiveMaxConnections = maxConnections;
         _connectionLimitDetector = connectionLimitDetector;
         _onConnectionLimitLearned = onConnectionLimitLearned;
@@ -137,10 +144,17 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     /// Waits until at least (`reservedCount` + 1) slots are free before acquiring one,
     /// ensuring that after acquisition at least `reservedCount` remain available.
     /// </summary>
-    public async Task<ConnectionLock<T>> GetConnectionLockAsync
+    public Task<ConnectionLock<T>> GetConnectionLockAsync
     (
         SemaphorePriority priority,
         CancellationToken cancellationToken = default
+    ) => GetConnectionLockCoreAsync(priority, preferIdle: true, cancellationToken);
+
+    private async Task<ConnectionLock<T>> GetConnectionLockCoreAsync
+    (
+        SemaphorePriority priority,
+        bool preferIdle,
+        CancellationToken cancellationToken
     )
     {
         // Make caller cancellation also cancel the wait on the gate.
@@ -160,9 +174,12 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             if (_disposed == 1)
                 ThrowDisposed();
 
-            reusedConnection = TryTakeIdleConnection(out reused!);
-            if (reusedConnection)
-                Interlocked.Increment(ref _connectionsReused);
+            if (preferIdle)
+            {
+                reusedConnection = TryTakeIdleConnection(out reused!);
+                if (reusedConnection)
+                    Interlocked.Increment(ref _connectionsReused);
+            }
         }
         if (reusedConnection)
         {
@@ -194,9 +211,12 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
                 if (_disposed == 1)
                     ThrowDisposed();
 
-                reusedConnection = TryTakeIdleConnection(out reused!);
-                if (reusedConnection)
-                    Interlocked.Increment(ref _connectionsReused);
+                if (preferIdle)
+                {
+                    reusedConnection = TryTakeIdleConnection(out reused!);
+                    if (reusedConnection)
+                        Interlocked.Increment(ref _connectionsReused);
+                }
             }
             if (reusedConnection)
             {
@@ -397,9 +417,10 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     {
         try
         {
+            await EnsureWarmFloorAsync(_sweepCts.Token).ConfigureAwait(false);
             using var timer = new PeriodicTimer(IdleTimeout / 2);
             while (await timer.WaitForNextTickAsync(_sweepCts.Token).ConfigureAwait(false))
-                SweepOnce();
+                await SweepOnceAsync(cancellationToken: _sweepCts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -407,23 +428,63 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         }
     }
 
-    private void SweepOnce()
+    internal Task SweepOnceForTestsAsync(
+        long? nowMillis = null,
+        CancellationToken cancellationToken = default) =>
+        SweepOnceAsync(nowMillis, cancellationToken);
+
+    private async Task SweepOnceAsync(long? nowMillis = null, CancellationToken cancellationToken = default)
     {
-        var now = Environment.TickCount64;
+        var now = nowMillis ?? Environment.TickCount64;
         var survivors = new List<Pooled>();
         var isAnyConnectionFreed = false;
+        var effectiveWarmFloor = Math.Min(_warmConnectionFloor, EffectiveMaxConnections);
 
         while (_idleConnections.TryPop(out var item))
         {
-            if (item.IsExpired(IdleTimeout, now))
+            if (item.IsExpired(IdleTimeout, now) && Volatile.Read(ref _live) > effectiveWarmFloor)
             {
                 DisposeConnection(item.Connection);
                 Interlocked.Decrement(ref _live);
+                Interlocked.Increment(ref _connectionsDestroyed);
                 isAnyConnectionFreed = true;
             }
             else
             {
                 survivors.Add(item);
+            }
+        }
+
+        // Ping idle warm connections before they reach their provider's own idle timeout.
+        // These connections are popped from the stack while the ping is in flight, so no
+        // borrower can receive a connection with a command already on the wire.
+        if (_keepAlive is not null)
+        {
+            var warmCount = Math.Min(effectiveWarmFloor, survivors.Count);
+            for (var i = 0; i < warmCount;)
+            {
+                var item = survivors[i];
+                try
+                {
+                    await _keepAlive(item.Connection, cancellationToken).ConfigureAwait(false);
+                    survivors[i] = item with { LastTouchedMillis = Environment.TickCount64 };
+                    i++;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // An idle DATE failure only proves this socket is stale. Dispose it
+                    // and let the floor refill; it is deliberately not provider traffic.
+                    DisposeConnection(item.Connection);
+                    Interlocked.Decrement(ref _live);
+                    Interlocked.Increment(ref _connectionsDestroyed);
+                    survivors.RemoveAt(i);
+                    warmCount--;
+                    isAnyConnectionFreed = true;
+                }
             }
         }
 
@@ -433,6 +494,36 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
         if (isAnyConnectionFreed)
             TriggerConnectionPoolChangedEvent();
+
+        await EnsureWarmFloorAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnsureWarmFloorAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested &&
+               Volatile.Read(ref _live) < Math.Min(_warmConnectionFloor, EffectiveMaxConnections))
+        {
+            try
+            {
+                // A warm connection is borrowed only while it is being opened, then
+                // returned immediately. Cached warm connections never retain a gate permit.
+                using (await GetConnectionLockCoreAsync(
+                           SemaphorePriority.Low, preferIdle: false, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    // Returning the lock to the pool establishes one idle warm connection.
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch
+            {
+                // Do not spin on a provider that is unavailable at startup. The next
+                // sweep retries the floor; connection-limit learning still applies.
+                return;
+            }
+        }
     }
 
     /* ------------------------- dispose helpers ------------------------------------ */

--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -474,7 +474,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
                 {
                     throw;
                 }
-                catch
+                catch (Exception e) when (e is not OutOfMemoryException)
                 {
                     // An idle DATE failure only proves this socket is stale. Dispose it
                     // and let the floor refill; it is deliberately not provider traffic.
@@ -517,7 +517,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             {
                 return;
             }
-            catch
+            catch (Exception e) when (e is not OutOfMemoryException)
             {
                 // Do not spin on a provider that is unavailable at startup. The next
                 // sweep retries the floor; connection-limit learning still applies.

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -11,6 +11,7 @@ using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Websocket;
 using Serilog;
+using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
 
@@ -183,6 +184,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                 provider,
                 connectionPoolStats.GetOnConnectionPoolChanged(index),
                 idleTimeoutSeconds,
+                configManager.IsWarmConnectionsEnabled()
+                    ? configManager.GetWarmConnectionsFloor(provider.MaxConnections)
+                    : 0,
                 metricsWriter,
                 streamingPriority,
                 latencyTracker,
@@ -205,6 +209,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         UsenetProviderConfig.ConnectionDetails connectionDetails,
         EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
         int idleTimeoutSeconds,
+        int warmConnectionFloor,
         MetricsWriter metricsWriter,
         SemaphorePriorityOdds? streamingPriority = null,
         ProviderLatencyTracker? latencyTracker = null,
@@ -250,6 +255,7 @@ public class UsenetStreamingClient : WrappingNntpClient
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
             onConnectionPoolChanged,
             idleTimeoutSeconds,
+            warmConnectionFloor,
             streamingPriority,
             connectionLimitDetector: ex =>
                 UsenetConnectionLimitDetector.TryLearn(ex, out var learned) ? learned : null,
@@ -312,6 +318,7 @@ public class UsenetStreamingClient : WrappingNntpClient
         Func<CancellationToken, ValueTask<INntpClient>> connectionFactory,
         EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
         int idleTimeoutSeconds,
+        int warmConnectionFloor,
         SemaphorePriorityOdds? streamingPriority = null,
         Func<Exception, int?>? connectionLimitDetector = null,
         Action<int, int>? onConnectionLimitLearned = null
@@ -319,15 +326,26 @@ public class UsenetStreamingClient : WrappingNntpClient
     {
         var idleTimeout = TimeSpan.FromSeconds(idleTimeoutSeconds);
         Log.Information(
-            "Creating NNTP connection pool max={Max} idleTimeout={IdleTimeoutSeconds}s streamingPriority={StreamingPriority}",
-            maxConnections, idleTimeoutSeconds, streamingPriority?.HighPriorityOdds);
+            "Creating NNTP connection pool max={Max} idleTimeout={IdleTimeoutSeconds}s warmFloor={WarmFloor} streamingPriority={StreamingPriority}",
+            maxConnections, idleTimeoutSeconds, warmConnectionFloor, streamingPriority?.HighPriorityOdds);
         var connectionPool = new ConnectionPool<INntpClient>(
             maxConnections, connectionFactory, idleTimeout, streamingPriority,
-            connectionLimitDetector, onConnectionLimitLearned);
+            connectionLimitDetector, onConnectionLimitLearned, warmConnectionFloor,
+            KeepAliveAsync);
         connectionPool.OnConnectionPoolChanged += onConnectionPoolChanged;
         var args = new ConnectionPoolStats.ConnectionPoolChangedEventArgs(0, 0, maxConnections);
         onConnectionPoolChanged(connectionPool, args);
         return connectionPool;
+    }
+
+    private static async Task KeepAliveAsync(INntpClient connection, CancellationToken cancellationToken)
+    {
+        var response = await connection.DateAsync(cancellationToken).ConfigureAwait(false);
+        if (response.ResponseType != UsenetResponseType.DateAndTime)
+        {
+            throw new RetryableDownloadException(
+                $"Unexpected NNTP response to idle DATE keepalive: {response.ResponseMessage}");
+        }
     }
 
     // Hard ceiling for TCP/TLS connect + AUTHINFO. Long enough for slow providers,

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -42,6 +42,8 @@ public static class ConfigKeys
     public const string UsenetCascadeEnabled = "usenet.cascade.enabled";
     public const string UsenetCascadeRetryPrimaryOnMiss = "usenet.cascade.retry-primary-on-miss";
     public const string UsenetIdleConnectionTimeoutSeconds = "usenet.idle-connection-timeout-seconds";
+    public const string UsenetWarmConnectionsEnabled = "usenet.warm-connections.enabled";
+    public const string UsenetWarmConnectionsFloor = "usenet.warm-connections.floor";
     public const string UsenetMaxDownloadConnections = "usenet.max-download-connections";
     public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -287,6 +287,7 @@ public class ConfigManager
                 case ConfigKeys.UsenetArticleBufferSize:
                 case ConfigKeys.UsenetInFlightArticleBudgetMb:
                 case ConfigKeys.UsenetIdleConnectionTimeoutSeconds:
+                case ConfigKeys.UsenetWarmConnectionsFloor:
                 case ConfigKeys.UsenetArticleMissCacheTtlSeconds:
                 case ConfigKeys.UsenetArticleMissCacheMaxEntries:
                 case ConfigKeys.UsenetSegmentCacheMaxGb:
@@ -365,6 +366,7 @@ public class ConfigManager
                 case ConfigKeys.UsenetPipeliningEnabled:
                 case ConfigKeys.UsenetCascadeEnabled:
                 case ConfigKeys.UsenetCascadeRetryPrimaryOnMiss:
+                case ConfigKeys.UsenetWarmConnectionsEnabled:
                 case ConfigKeys.UsenetContainerAwareFill:
                 case ConfigKeys.UsenetPipelinedBodyRequests:
                 case ConfigKeys.UsenetSegmentCacheEnabled:
@@ -863,6 +865,29 @@ public class ConfigManager
     }
 
     /// <summary>
+    /// Whether each NNTP provider keeps a small pool of pre-connected sockets ready
+    /// after idle periods. Enabled by default to keep playback off the TLS ramp.
+    /// </summary>
+    public bool IsWarmConnectionsEnabled()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetWarmConnectionsEnabled));
+        return configured is null || bool.Parse(configured);
+    }
+
+    /// <summary>
+    /// Idle NNTP sockets to keep ready per provider. An unset value derives a small
+    /// floor from the provider width; explicit values are clamped to that width.
+    /// </summary>
+    public int GetWarmConnectionsFloor(int maxConnections)
+    {
+        maxConnections = Math.Max(1, maxConnections);
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetWarmConnectionsFloor));
+        if (configured is null || !int.TryParse(configured, out var value))
+            return Math.Clamp(maxConnections / 6, 1, 8);
+        return Math.Clamp(value, 1, maxConnections);
+    }
+
+    /// <summary>
     /// How long a definitive per-provider (or per-storage-group) article miss stays
     /// cached before it is re-probed. Default 300s; clamped to [30, 86400].
     /// </summary>
@@ -903,7 +928,7 @@ public class ConfigManager
     public bool IsSegmentCacheEnabled()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheEnabled));
-        return v != null && bool.Parse(v);
+        return v == null || bool.Parse(v);
     }
 
     public string GetSegmentCachePath()

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -37,6 +37,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly ContextualCancellationTokenSource _cts;
     private readonly long? _readBudget;
     private readonly long _prefetchByteCeiling;
+    private readonly int _taskWindowSize;
     private readonly InFlightArticleBudget? _budget;
     private long _inFlightPrefetchBytes;
     private TaskCompletionSource _prefetchSpace =
@@ -123,7 +124,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return articleBufferSize == 0
             ? new UnbufferedMultiSegmentStream(
                 segmentIds, usenetClient, estimatedSegmentSize, fileName, segmentFallbacks,
-                exactSegmentSizes, useContainerAwareFill, firstSegmentFileOffset)
+                exactSegmentSizes, useContainerAwareFill, firstSegmentFileOffset,
+                failFastOnFirstSegment)
             : new MultiSegmentStream(
                 segmentIds,
                 usenetClient,
@@ -139,6 +141,75 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 useContainerAwareFill,
                 firstSegmentFileOffset,
                 cancellationToken);
+    }
+
+    /// <summary>
+    /// Starts the first segment directly from its decoded BODY, then lazily creates the
+    /// normal buffered pipeline at the segment boundary. This lets a player receive its
+    /// first bytes without waiting for a whole decoded segment to drain, while retaining
+    /// the established prefetch, retry, fill, and lifecycle behavior for sustained reads.
+    /// </summary>
+    public static Stream CreateFirstSegmentHybrid(
+        Memory<string> segmentIds,
+        INntpClient usenetClient,
+        int articleBufferSize,
+        long estimatedSegmentSize,
+        bool failFastOnFirstSegment,
+        bool usePipelinedBodyRequests,
+        CancellationToken cancellationToken,
+        string? fileName = null,
+        long? readBudget = null,
+        string[][]? segmentFallbacks = null,
+        ReadOnlyMemory<long> exactSegmentSizes = default,
+        InFlightArticleBudget? inFlightArticleBudget = null,
+        bool useContainerAwareFill = false,
+        long? firstSegmentFileOffset = null)
+    {
+        if (articleBufferSize == 0 || segmentIds.Length <= 1)
+        {
+            return Create(
+                segmentIds, usenetClient, articleBufferSize, estimatedSegmentSize,
+                failFastOnFirstSegment, usePipelinedBodyRequests, cancellationToken, fileName,
+                readBudget, segmentFallbacks, exactSegmentSizes, inFlightArticleBudget,
+                useContainerAwareFill, firstSegmentFileOffset);
+        }
+
+        var effectiveReadBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        var firstExactSizes = exactSegmentSizes.Length == segmentIds.Length
+            ? exactSegmentSizes[..1]
+            : default;
+        var remainingExactSizes = exactSegmentSizes.Length == segmentIds.Length
+            ? exactSegmentSizes[1..]
+            : default;
+        var firstFallbacks = segmentFallbacks is { Length: > 0 } ? segmentFallbacks[..1] : null;
+        var remainingFallbacks = segmentFallbacks is { Length: > 1 } ? segmentFallbacks[1..] : null;
+        var remainingOffset = firstSegmentFileOffset;
+        if (remainingOffset is not null && firstExactSizes.Length == 1)
+        {
+            try { remainingOffset = checked(remainingOffset.Value + firstExactSizes.Span[0]); }
+            catch (OverflowException) { remainingOffset = null; }
+        }
+
+        var remainingBudget = effectiveReadBudget;
+        if (remainingBudget is not null && firstExactSizes.Length == 1)
+            remainingBudget = Math.Max(0, remainingBudget.Value - firstExactSizes.Span[0]);
+
+        return new CombinedStream(CreateFirstSegmentThenBufferedRest());
+
+        IEnumerable<Task<Stream>> CreateFirstSegmentThenBufferedRest()
+        {
+#pragma warning disable CA2000 // ownership transfers to CombinedStream when the yielded task becomes current
+            yield return Task.FromResult<Stream>(new UnbufferedMultiSegmentStream(
+                segmentIds[..1], usenetClient, estimatedSegmentSize, fileName, firstFallbacks,
+                firstExactSizes, useContainerAwareFill, firstSegmentFileOffset,
+                failFastOnFirstSegment));
+#pragma warning restore CA2000
+            yield return Task.FromResult(Create(
+                segmentIds[1..], usenetClient, articleBufferSize, estimatedSegmentSize,
+                failFastOnFirstSegment: false, usePipelinedBodyRequests, cancellationToken,
+                fileName, remainingBudget, remainingFallbacks, remainingExactSizes,
+                inFlightArticleBudget, useContainerAwareFill, remainingOffset));
+        }
     }
 
     private MultiSegmentStream
@@ -170,16 +241,36 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _readBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         _budget = inFlightArticleBudget ?? InFlightArticleBudget.Current;
-        _prefetchByteCeiling = articleBufferSize > 0 && estimatedSegmentSize > 0
-            ? (long)articleBufferSize * estimatedSegmentSize
+        _taskWindowSize = CalculateTaskWindowSize(articleBufferSize, usePipelinedBodyRequests);
+        _prefetchByteCeiling = _taskWindowSize > 0 && estimatedSegmentSize > 0
+            ? (long)_taskWindowSize * estimatedSegmentSize
             : 0;
         _bodyPipelineBatchSize = Math.Min(BodyPipelineBatchSize, articleBufferSize);
         _batchSizer = usePipelinedBodyRequests
             ? new AdaptiveBodyBatchSizer(_bodyPipelineBatchSize)
             : null;
-        _streamTasks = Channel.CreateBounded<Task<SegmentDownloadResult>>(articleBufferSize);
+        _streamTasks = Channel.CreateBounded<Task<SegmentDownloadResult>>(_taskWindowSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _downloadTask = DownloadSegments(usePipelinedBodyRequests, _cts.Token);
+    }
+
+    /// <summary>
+    /// Computes the number of ordered segment tasks that may wait ahead of the consumer.
+    /// Pipelined BODY requests retain one connection per batch, not per segment, so a
+    /// segment-only window of <paramref name="articleBufferSize"/> could use only a quarter
+    /// of the per-stream connection budget at the normal four-article batch width. Expand
+    /// the task window by that width; the connection semaphore remains the concurrency
+    /// authority and <see cref="InFlightArticleBudget"/> remains the decoded-byte authority.
+    /// </summary>
+    internal static int CalculateTaskWindowSize(int articleBufferSize, bool usePipelinedBodyRequests)
+    {
+        if (articleBufferSize <= 0) return 0;
+        if (!usePipelinedBodyRequests) return articleBufferSize;
+
+        var initialBatchWidth = Math.Min(BodyPipelineBatchSize, articleBufferSize);
+        return articleBufferSize > int.MaxValue / initialBatchWidth
+            ? int.MaxValue
+            : articleBufferSize * initialBatchWidth;
     }
 
     private async Task DownloadSegments(
@@ -360,8 +451,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
     /// <summary>
     /// When <see cref="_readBudget"/> is null, pause the producer once in-flight planned
-    /// bytes reach article-buffer-size × estimated segment size so full-file GETs cannot
-    /// retain unbounded decoded bytes ahead of the consumer.
+    /// bytes reach task-window-size × estimated segment size so full-file GETs cannot retain
+    /// unbounded decoded bytes ahead of the consumer. For pipelined BODY requests the task
+    /// window accounts for every segment needed to keep the connection budget occupied.
     /// </summary>
     private async Task WaitForPrefetchCeilingAsync(CancellationToken cancellationToken)
     {

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -28,6 +28,9 @@ public class NzbFileStream(
 ) : FastReadOnlyStream
 {
     private const long MaximumForwardDrainBytes = 1024 * 1024;
+    // A range in this size class is commonly an initial probe or a scrub preview.
+    // Avoid draining its target segment into a pooled buffer before returning bytes.
+    private const long MaximumDirectRangeBytes = 1024 * 1024;
     private long _position;
     private long _pendingForwardDrain;
     private bool _disposed;
@@ -286,8 +289,11 @@ public class NzbFileStream(
     private async Task<Stream> GetFileStream(long rangeStart, CancellationToken cancellationToken)
     {
         if (rangeStart == 0) return GetMultiSegmentStream(0, failFastOnFirstSegment: true, cancellationToken);
-        var fast = await TryGetSeekStreamFast(rangeStart, cancellationToken).ConfigureAwait(false);
-        if (fast != null) return fast;
+        if (!ShouldUseDirectRangePath())
+        {
+            var fast = await TryGetSeekStreamFast(rangeStart, cancellationToken).ConfigureAwait(false);
+            if (fast != null) return fast;
+        }
 
         var foundSegment = await SeekSegment(rangeStart, cancellationToken).ConfigureAwait(false);
         var stream = GetMultiSegmentStream(foundSegment.FoundIndex, failFastOnFirstSegment: false, cancellationToken);
@@ -316,6 +322,12 @@ public class NzbFileStream(
         }
 
         return stream;
+    }
+
+    private static bool ShouldUseDirectRangePath()
+    {
+        var budget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        return budget is > 0 and <= MaximumDirectRangeBytes;
     }
 
     private const int MaxSeekGuessCorrection = 3;
@@ -477,7 +489,7 @@ public class NzbFileStream(
             : default;
         var firstSegmentFileOffset = _segmentByteRanges?[firstSegmentIndex].StartInclusive;
 
-        return MultiSegmentStream.Create(
+        return MultiSegmentStream.CreateFirstSegmentHybrid(
             segmentIds,
             usenetClient,
             articleBufferSize,

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -18,6 +18,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly string _fileName;
     private readonly bool _useContainerAwareFill;
     private readonly long? _firstSegmentFileOffset;
+    private readonly bool _failFastOnFirstSegment;
     private Stream? _stream;
     private int _currentIndex;
     private int _openSegmentIndex = -1;
@@ -35,7 +36,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         string[][]? segmentFallbacks = null,
         ReadOnlyMemory<long> exactSegmentSizes = default,
         bool useContainerAwareFill = false,
-        long? firstSegmentFileOffset = null)
+        long? firstSegmentFileOffset = null,
+        bool failFastOnFirstSegment = false)
     {
         _segmentIds = segmentIds;
         _segmentFallbacks = segmentFallbacks;
@@ -44,6 +46,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _useContainerAwareFill = useContainerAwareFill;
         _firstSegmentFileOffset = firstSegmentFileOffset;
+        _failFastOnFirstSegment = failFastOnFirstSegment;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -95,6 +98,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                     }
                     else
                     {
+                        if (_failFastOnFirstSegment && segmentIndex == 0)
+                            throw;
                         // Only an exactly-known length may stand in for missing data:
                         // anything else shifts every following byte of the file.
                         if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out _))

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -182,6 +182,24 @@ public class GetAndHeadHandlerPatch : IRequestHandler
                 ContentHeaderUtil.GetContentDisposition(friendlyIdFile.FriendlyName, shouldDownload: false);
         }
 
+        // Every in-tree file exposes its persisted size as metadata. HEAD must
+        // not create a streaming read just to retrieve that already-known value.
+        // Other IStoreItem implementations retain the stream-based fallback below
+        // because their length may only be available from the opened stream.
+        if (isHeadRequest && entry is BaseStoreItem file)
+        {
+            response.SetStatus(DavStatusCode.Ok);
+            response.ContentLength = file.FileSize;
+
+            if (etag != null && request.Headers.IfNoneMatch == etag)
+            {
+                response.ContentLength = 0;
+                response.SetStatus(DavStatusCode.NotModified);
+            }
+
+            return true;
+        }
+
         // Stream the actual entry
         var stream = await entry.GetReadableStreamAsync(ct).ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -33,7 +33,7 @@ is saturated.
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
-| Enable Segment Cache | `usenet.segment-cache.enabled` | off | Cache decoded segments on disk; restart required |
+| Enable Segment Cache | `usenet.segment-cache.enabled` | on | Cache decoded segments on disk; restart required |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | Segment-cache directory |
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | Segment-cache size limit |
 | Streaming Segment Timeout | `usenet.streaming-segment-timeout-seconds` | `8` | Per-segment deadline, 2–40 seconds |
@@ -45,6 +45,15 @@ is saturated.
 | Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | Close unused connections after 15–300 seconds |
 | Pipelined article downloads | `usenet.pipelined-body-requests` | on | Fetch WebDAV BODY requests in small batches |
 | Container-aware gap fill [since 0.10.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | on | Experimental MPEG-TS null-packet fill for confirmed gaps |
+
+### Segment-cache storage
+
+Segment Cache is **enabled by default**. It can improve repeated reads and seeks, but
+also writes decoded segments to the cache path. InfiniDysk does not automatically
+classify that storage, so verify that `/config/segment-cache` (or your configured
+path) is local SSD/NVMe or other storage that can safely absorb the extra writes.
+Disable the cache for slow disks, network mounts, or flash storage with limited
+write endurance; alternatively, point **Cache path** at suitable local storage.
 
 ## Article buffer and adaptive prefetch
 

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -66,7 +66,7 @@ const defaultConfig = {
     "usenet.in-flight-article-budget-mb": "",
     "usenet.idle-connection-timeout-seconds": "60",
     "usenet.pipelined-body-requests": "true",
-    "usenet.segment-cache.enabled": "false",
+    "usenet.segment-cache.enabled": "true",
     "usenet.segment-cache.path": "/config/segment-cache",
     "usenet.segment-cache.max-gb": "10",
     "usenet.pipelining.enabled": "false",

--- a/frontend/app/routes/settings/streaming/streaming.test.ts
+++ b/frontend/app/routes/settings/streaming/streaming.test.ts
@@ -24,7 +24,7 @@ const validConfig = {
     "usenet.idle-connection-timeout-seconds": "60",
     "usenet.pipelined-body-requests": "true",
     "usenet.container-aware-fill": "true",
-    "usenet.segment-cache.enabled": "false",
+    "usenet.segment-cache.enabled": "true",
     "usenet.segment-cache.path": "/config/segment-cache",
     "usenet.segment-cache.max-gb": "10",
 };
@@ -73,9 +73,12 @@ describe("Streaming settings", () => {
         const user = userEvent.setup();
         render(createElement(StreamingHarness));
 
-        await user.click(screen.getByRole("checkbox", {
-            name: "Enable Segment Cache",
-        }));
+        expect(screen.getByText(/Segment Cache is enabled by default/i)).toBeTruthy();
+        expect(screen.getByText(/cannot automatically determine/i)).toBeTruthy();
+        const segmentCache = screen.getByRole<HTMLInputElement>("checkbox", {
+            name: "Enable Segment Cache (fast storage)",
+        });
+        expect(segmentCache.checked).toBe(true);
         const cachePath = screen.getByRole<HTMLInputElement>("textbox", {
             name: "Cache path",
         });
@@ -89,6 +92,9 @@ describe("Streaming settings", () => {
         await user.clear(cacheSize);
         await user.type(cacheSize, "25");
         expect(cacheSize.value).toBe("25");
+
+        await user.click(segmentCache);
+        expect(segmentCache.checked).toBe(false);
 
         const numericUpdates: Array<[string, string]> = [
             ["Streaming Segment Timeout", "10"],

--- a/frontend/app/routes/settings/streaming/streaming.tsx
+++ b/frontend/app/routes/settings/streaming/streaming.tsx
@@ -1,5 +1,6 @@
 import { type Dispatch, type SetStateAction } from "react";
 import {
+    Alert,
     Badge,
     Input,
     ManagedSetting,
@@ -144,7 +145,7 @@ export function StreamingSettings({ config, setNewConfig }: StreamingSettingsPro
                     "usenet.segment-cache.max-gb",
                 ]}>
                     <div className="space-y-2">
-                        <Tooltip placement="bottom" content="Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart.">
+                        <Tooltip placement="bottom" content="Cache decoded segments on disk so repeat reads and seeks avoid provider traffic. Takes effect after restart. Enable it only when the cache path is on storage that can handle the extra writes.">
                             <Toggle
                                 id="segment-cache-enabled-checkbox"
                                 className="cursor-pointer gap-2 p-0"
@@ -153,9 +154,14 @@ export function StreamingSettings({ config, setNewConfig }: StreamingSettingsPro
                                     ...config,
                                     "usenet.segment-cache.enabled": String(e.target.checked),
                                 })}
-                                label={<span className="text-sm text-base-content">Enable Segment Cache</span>}
+                                label={<span className="text-sm text-base-content">Enable Segment Cache (fast storage)</span>}
                             />
                         </Tooltip>
+                        <Alert className="alert-soft items-start text-xs" variant="warning">
+                            InfiniDysk cannot automatically determine whether the configured path is slow storage or
+                            flash with limited write endurance. Segment Cache is enabled by default; disable it or set
+                            Cache path to local SSD/NVMe or other storage where the additional writes are acceptable.
+                        </Alert>
                         {config["usenet.segment-cache.enabled"] === "true" && (
                             <div className="grid gap-4 border-l border-base-content/10 pl-4 sm:grid-cols-2">
                                 <label className="space-y-2 text-sm text-base-content/80">

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -209,15 +209,12 @@ public partial class UsenetClient
         DecodedBodyReadStream decodedStream,
         bool releaseCommandLock = true,
         CoalescedReadTimeout? sharedReadTimeout = null,
-        BatchDecodeBuffer? sharedEncodedBuffer = null,
         CancellationToken callerCancellationToken = default)
     {
         Exception? failure = null;
         var connectionReusable = true;
-        byte[]? encodedBuffer = null;
         byte[]? ybeginBuffer = null;
         CoalescedReadTimeout? ownedReadTimeout = null;
-        var ownsEncodedBuffer = sharedEncodedBuffer == null;
         try
         {
             if (_reader == null)
@@ -226,16 +223,7 @@ public partial class UsenetClient
                     "The NNTP connection closed before the article body was read.");
             }
 
-            if (sharedEncodedBuffer != null)
-            {
-                encodedBuffer = sharedEncodedBuffer.Buffer;
-            }
-            else
-            {
-                encodedBuffer = ArrayPool<byte>.Shared.Rent(DecodedBodyChunkSize + 2);
-            }
-
-            var encodedLength = 0;
+            var unflushedDecodedBytes = 0;
             var shouldWrite = true;
             var dataEnded = false;
             var headersRead = false;
@@ -288,18 +276,10 @@ public partial class UsenetClient
                             YencStream.ParseYencHeaders(ybeginBuffer.AsSpan(0, ybeginLength)));
                     }
 
-                    if (shouldWrite && encodedLength > 0)
+                    if (shouldWrite && unflushedDecodedBytes > 0)
                     {
-                        var flush = await DecodeAndFlushAsync(
-                            writer,
-                            encodedBuffer.AsMemory(0, encodedLength),
-                            decoderState,
-                            decodedCrc32,
-                            _options.CrcValidation != YencCrcValidationMode.Off,
-                            decodedStream,
-                            cancellationToken).ConfigureAwait(false);
-                        decoderState = flush.DecoderState;
-                        decodedCrc32 = flush.Crc32;
+                        var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        shouldWrite = !result.IsCompleted && !result.IsCanceled;
                     }
 
                     if (_options.CrcValidation == YencCrcValidationMode.Require && !dataEnded)
@@ -376,20 +356,10 @@ public partial class UsenetClient
                 if (YencStream.StartsWithYEnd(lineBytes.Span))
                 {
                     dataEnded = true;
-                    if (encodedLength > 0)
+                    if (shouldWrite && unflushedDecodedBytes > 0)
                     {
-                        var flush = await DecodeAndFlushAsync(
-                            writer,
-                            encodedBuffer.AsMemory(0, encodedLength),
-                            decoderState,
-                            decodedCrc32,
-                            _options.CrcValidation != YencCrcValidationMode.Off,
-                            decodedStream,
-                            cancellationToken).ConfigureAwait(false);
-                        encodedLength = 0;
-                        decoderState = flush.DecoderState;
-                        decodedCrc32 = flush.Crc32;
-                        shouldWrite = !flush.Result.IsCompleted && !flush.Result.IsCanceled;
+                        var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        shouldWrite = !result.IsCompleted && !result.IsCanceled;
                     }
 
                     if (_options.CrcValidation != YencCrcValidationMode.Off && shouldWrite)
@@ -401,57 +371,33 @@ public partial class UsenetClient
                     continue;
                 }
 
-                var requiredLength = lineBytes.Length + 2;
-                if (encodedLength > 0 &&
-                    encodedLength + requiredLength > encodedBuffer.Length)
+                var encodedLine = lineBytes.Span;
+                if (encodedLine.Length >= 2 &&
+                    encodedLine[0] == (byte)'.' &&
+                    encodedLine[1] == (byte)'.')
                 {
-                    var flush = await DecodeAndFlushAsync(
-                        writer,
-                        encodedBuffer.AsMemory(0, encodedLength),
-                        decoderState,
-                        decodedCrc32,
-                        _options.CrcValidation != YencCrcValidationMode.Off,
-                        decodedStream,
-                        cancellationToken).ConfigureAwait(false);
-                    encodedLength = 0;
-                    decoderState = flush.DecoderState;
-                    decodedCrc32 = flush.Crc32;
-                    shouldWrite = !flush.Result.IsCompleted && !flush.Result.IsCanceled;
-                    if (!shouldWrite)
-                    {
-                        continue;
-                    }
+                    encodedLine = encodedLine[1..];
                 }
 
-                if (requiredLength > encodedBuffer.Length)
+                // NntpLineReader already obtains 64 KiB raw chunks and returns line views into
+                // that buffer. Decode those views directly into the pipe instead of copying every
+                // line into a second encoded staging buffer solely to reconstruct CRLF framing.
+                var destination = writer.GetSpan(encodedLine.Length);
+                var decodedLength = YencDecoder.DecodeEx(
+                    encodedLine, destination, ref decoderState, isRaw: false);
+                if (_options.CrcValidation != YencCrcValidationMode.Off)
                 {
-                    ArrayPool<byte>.Shared.Return(encodedBuffer);
-                    encodedBuffer = ArrayPool<byte>.Shared.Rent(requiredLength);
-                    if (sharedEncodedBuffer != null)
-                    {
-                        sharedEncodedBuffer.Buffer = encodedBuffer;
-                    }
+                    decodedCrc32 = Crc32.Compute(destination[..decodedLength], decodedCrc32);
                 }
+                decodedStream.AddBufferedBytes(decodedLength);
+                writer.Advance(decodedLength);
+                unflushedDecodedBytes += decodedLength;
 
-                lineBytes.Span.CopyTo(encodedBuffer.AsSpan(encodedLength));
-                encodedLength += lineBytes.Length;
-                encodedBuffer[encodedLength++] = (byte)'\r';
-                encodedBuffer[encodedLength++] = (byte)'\n';
-
-                if (encodedLength >= DecodedBodyChunkSize)
+                if (unflushedDecodedBytes >= DecodedBodyChunkSize)
                 {
-                    var flush = await DecodeAndFlushAsync(
-                        writer,
-                        encodedBuffer.AsMemory(0, encodedLength),
-                        decoderState,
-                        decodedCrc32,
-                        _options.CrcValidation != YencCrcValidationMode.Off,
-                        decodedStream,
-                        cancellationToken).ConfigureAwait(false);
-                    encodedLength = 0;
-                    decoderState = flush.DecoderState;
-                    decodedCrc32 = flush.Crc32;
-                    shouldWrite = !flush.Result.IsCompleted && !flush.Result.IsCanceled;
+                    var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    unflushedDecodedBytes = 0;
+                    shouldWrite = !result.IsCompleted && !result.IsCanceled;
                 }
             }
         }
@@ -481,11 +427,6 @@ public partial class UsenetClient
         }
         finally
         {
-            if (ownsEncodedBuffer && encodedBuffer != null)
-            {
-                ArrayPool<byte>.Shared.Return(encodedBuffer);
-            }
-
             if (ybeginBuffer != null)
             {
                 ArrayPool<byte>.Shared.Return(ybeginBuffer);
@@ -530,40 +471,9 @@ public partial class UsenetClient
         return new DecodedBodyReadResult(failure, connectionReusable);
     }
 
-    private sealed class BatchDecodeBuffer
-    {
-        public required byte[] Buffer;
-    }
-
     private readonly record struct DecodedBodyReadResult(
         Exception? Failure,
         bool ConnectionReusable);
-
-    private static async ValueTask<(
-        FlushResult Result,
-        RapidYencDecoderState? DecoderState,
-        uint Crc32)> DecodeAndFlushAsync(
-        PipeWriter writer,
-        ReadOnlyMemory<byte> encoded,
-        RapidYencDecoderState? decoderState,
-        uint crc32,
-        bool computeCrc32,
-        DecodedBodyReadStream decodedStream,
-        CancellationToken cancellationToken)
-    {
-        var destination = writer.GetSpan(encoded.Length);
-        var decodedLength = YencDecoder.DecodeEx(
-            encoded.Span, destination, ref decoderState, isRaw: true);
-        if (computeCrc32)
-        {
-            crc32 = Crc32.Compute(destination[..decodedLength], crc32);
-        }
-
-        decodedStream.AddBufferedBytes(decodedLength);
-        writer.Advance(decodedLength);
-        var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-        return (result, decoderState, crc32);
-    }
 
     private void AdjustBufferedDecodedBodyBytes(long delta)
     {

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -356,7 +356,7 @@ public partial class UsenetClient
                 if (YencStream.StartsWithYEnd(lineBytes.Span))
                 {
                     dataEnded = true;
-                    if (shouldWrite && unflushedDecodedBytes > 0)
+                    if (unflushedDecodedBytes > 0)
                     {
                         var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
                         shouldWrite = !result.IsCompleted && !result.IsCanceled;

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -266,11 +266,6 @@ public partial class UsenetClient
         var nextResponseIndex = 0;
         using var operationCts = CreateOperationTokenSource(callerCancellationToken);
         using var sharedReadTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
-        var sharedEncodedBuffer = new BatchDecodeBuffer
-        {
-            Buffer = ArrayPool<byte>.Shared.Rent(DecodedBodyChunkSize + 2)
-        };
-
         try
         {
             while (nextResponseIndex < segmentIds.Length)
@@ -326,7 +321,6 @@ public partial class UsenetClient
                         decodedStream: decodedStream,
                         releaseCommandLock: false,
                         sharedReadTimeout: sharedReadTimeout,
-                        sharedEncodedBuffer: sharedEncodedBuffer,
                         callerCancellationToken: callerCancellationToken)
                     .ConfigureAwait(false);
                 if (bodyReadResult.Failure == null)
@@ -411,7 +405,6 @@ public partial class UsenetClient
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(sharedEncodedBuffer.Buffer);
             if (failure != null)
             {
                 for (var index = nextResponseIndex; index < completions.Length; index++)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolWarmConnectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolWarmConnectionTests.cs
@@ -1,0 +1,99 @@
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Connections;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ConnectionPoolWarmConnectionTests
+{
+    [Fact]
+    public async Task Startup_PrewarmesFloorWithoutRetainingBorrowerPermits()
+    {
+        var created = 0;
+        await using var pool = new ConnectionPool<TestConnection>(
+            maxConnections: 3,
+            connectionFactory: _ => ValueTask.FromResult(new TestConnection(Interlocked.Increment(ref created))),
+            idleTimeout: TimeSpan.FromMinutes(1),
+            warmConnectionFloor: 2);
+
+        await WaitUntilAsync(() => pool.LiveConnections == 2 && pool.IdleConnections == 2);
+
+        var locks = new List<ConnectionLock<TestConnection>>();
+        for (var i = 0; i < 3; i++)
+            locks.Add(await pool.GetConnectionLockAsync(SemaphorePriority.High).WaitAsync(TimeSpan.FromSeconds(1)));
+
+        Assert.Equal(3, pool.ActiveConnections);
+        Assert.Equal(3, created);
+
+        foreach (var connectionLock in locks)
+            connectionLock.Dispose();
+    }
+
+    [Fact]
+    public async Task Sweeper_KeepsExpiredFloorAndPingsIt()
+    {
+        var keepAliveCalls = 0;
+        await using var pool = new ConnectionPool<TestConnection>(
+            maxConnections: 3,
+            connectionFactory: _ => ValueTask.FromResult(new TestConnection(0)),
+            idleTimeout: TimeSpan.FromMinutes(1),
+            warmConnectionFloor: 2,
+            keepAlive: (_, _) =>
+            {
+                Interlocked.Increment(ref keepAliveCalls);
+                return Task.CompletedTask;
+            });
+
+        await WaitUntilAsync(() => pool.LiveConnections == 2 && pool.IdleConnections == 2);
+        await pool.SweepOnceForTestsAsync(
+            nowMillis: Environment.TickCount64 + (long)pool.IdleTimeout.TotalMilliseconds + 1);
+
+        Assert.Equal(2, pool.LiveConnections);
+        Assert.Equal(2, pool.IdleConnections);
+        Assert.Equal(2, keepAliveCalls);
+    }
+
+    [Fact]
+    public async Task FailedIdleKeepAlive_RecyclesConnectionAndRefillsFloor()
+    {
+        var first = new TestConnection(1) { FailKeepAlive = true };
+        var created = 0;
+        await using var pool = new ConnectionPool<TestConnection>(
+            maxConnections: 1,
+            connectionFactory: _ => ValueTask.FromResult(
+                Interlocked.Increment(ref created) == 1 ? first : new TestConnection(created)),
+            idleTimeout: TimeSpan.FromMinutes(1),
+            warmConnectionFloor: 1,
+            keepAlive: (connection, _) => connection.FailKeepAlive
+                ? Task.FromException(new IOException("idle socket closed"))
+                : Task.CompletedTask);
+
+        await WaitUntilAsync(() => pool.LiveConnections == 1 && pool.IdleConnections == 1);
+        await pool.SweepOnceForTestsAsync();
+
+        Assert.True(first.Disposed);
+        Assert.Equal(2, created);
+        Assert.Equal(1, pool.LiveConnections);
+        Assert.Equal(1, pool.IdleConnections);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        await Task.WhenAny(
+            Task.Run(async () =>
+            {
+                while (!condition())
+                    await Task.Delay(10);
+            }),
+            Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.True(condition(), "Timed out waiting for connection-pool state.");
+    }
+
+    private sealed class TestConnection(int id) : IDisposable
+    {
+        public int Id { get; } = id;
+        public bool FailKeepAlive { get; init; }
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
@@ -74,6 +74,25 @@ public class StreamingPriorityConfigTests
     }
 
     [Fact]
+    public void IsSegmentCacheEnabled_DefaultsOnUntilExplicitlyDisabled()
+    {
+        var config = new ConfigManager();
+
+        Assert.True(config.IsSegmentCacheEnabled());
+
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetSegmentCacheEnabled,
+                ConfigValue = "false",
+            },
+        ]);
+
+        Assert.False(config.IsSegmentCacheEnabled());
+    }
+
+    [Fact]
     public void ValidateConfigItems_RejectsNonNumericStreamingPriority()
     {
         var ex = Assert.Throws<ArgumentException>(() =>

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -17,6 +17,7 @@ internal sealed class FakeNntpClient(
 {
     public int BatchRequestCount { get; private set; }
     public int BodyRequestCount { get; private set; }
+    public Dictionary<string, int> BodyRequestCounts { get; } = new(StringComparer.Ordinal);
     public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
 
     public override Task ConnectAsync(
@@ -60,7 +61,9 @@ internal sealed class FakeNntpClient(
     {
         cancellationToken.ThrowIfCancellationRequested();
         BodyRequestCount++;
-        RequestedSegmentIds.Add(segmentId.ToString());
+        var segmentKey = segmentId.ToString();
+        RequestedSegmentIds.Add(segmentKey);
+        BodyRequestCounts[segmentKey] = BodyRequestCounts.GetValueOrDefault(segmentKey) + 1;
         try
         {
             var response = CreateBodyResponse(segmentId);

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamAdaptiveWidthTests.cs
@@ -13,11 +13,28 @@ public class MultiSegmentStreamAdaptiveWidthTests
 {
     private const int BodyPipelineBatchSize = 4;
 
+    [Theory]
+    [InlineData(0, false, 0)]
+    [InlineData(1, false, 1)]
+    [InlineData(40, false, 40)]
+    [InlineData(1, true, 1)]
+    [InlineData(2, true, 4)]
+    [InlineData(40, true, 160)]
+    public void TaskWindowSize_ExpandsPipelinedSegmentsWithoutChangingIndividualMode(
+        int articleBufferSize,
+        bool pipelined,
+        int expected)
+    {
+        Assert.Equal(
+            expected,
+            MultiSegmentStream.CalculateTaskWindowSize(articleBufferSize, pipelined));
+    }
+
     [Fact]
-    public async Task DiscriminatingBaseline_Buffer32FixedBatch4_AllowsEightOutstandingBatches()
+    public async Task TaskWindow_Buffer32FixedBatch4_AllowsThirtyTwoOutstandingBatches()
     {
         const int articleBufferSize = 32;
-        const int segmentCount = 64;
+        const int segmentCount = 128;
         const int segmentSize = 16;
 
         var client = new ControlledBatchNntpClient(segmentCount, segmentSize);
@@ -26,19 +43,21 @@ public class MultiSegmentStreamAdaptiveWidthTests
 
         // Leave all responses gated so permits stay held while the producer fills.
         await client.WaitUntilAsync(
-            () => client.MaxActiveBatches >= articleBufferSize / BodyPipelineBatchSize,
+            () => client.MaxActiveBatches >= articleBufferSize,
             TimeSpan.FromSeconds(5));
 
-        Assert.Equal(8, client.MaxActiveBatches);
+        Assert.Equal(articleBufferSize, client.MaxActiveBatches);
         Assert.Contains(4, client.ObservedBatchSizes);
-        Assert.All(client.ObservedBatchSizes.Take(8), size => Assert.Equal(4, size));
+        Assert.All(client.ObservedBatchSizes.Take(articleBufferSize), size => Assert.Equal(4, size));
     }
 
     [Fact]
     public async Task Starvation_EventuallyNarrowsBatchSizesToFourTwoAndOne()
     {
         const int articleBufferSize = 32;
-        const int segmentCount = 96;
+        // The expanded task window holds 128 segment tasks at width four. Go beyond
+        // it so starvation can affect subsequently issued batches.
+        const int segmentCount = 192;
         const int segmentSize = 8;
 
         var client = new ControlledBatchNntpClient(segmentCount, segmentSize);
@@ -176,7 +195,9 @@ public class MultiSegmentStreamAdaptiveWidthTests
     public async Task FifoFidelity_SurvivesWidthTransitionsInBothDirections()
     {
         const int articleBufferSize = 32;
-        const int segmentCount = 120;
+        // As above, exceed the expanded task window so width changes affect issued
+        // batches rather than only the already-enqueued initial window.
+        const int segmentCount = 256;
         const int segmentSize = 4;
 
         var client = new ControlledBatchNntpClient(segmentCount, segmentSize, uniqueBytes: true);

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -53,6 +53,59 @@ public class NzbFileStreamTests
         if (articleBufferSize > 0) Assert.True(client.BatchRequestCount > 0);
     }
 
+    [Fact]
+    public async Task PlaybackStart_DeliversFirstSegmentBeforeStartingBufferedPrefetch()
+    {
+        var client = new FakeNntpClient(
+            SegmentIds.Zip(SegmentBytes).ToDictionary(pair => pair.First, pair => pair.Second),
+            useCachedYencStreams: true,
+            segmentRanges: SegmentIds.Zip(SegmentRanges).ToDictionary(pair => pair.First, pair => pair.Second));
+        await using var stream = new NzbFileStream(
+            SegmentIds, 15, client, articleBufferSize: 4, segmentByteRanges: SegmentRanges);
+
+        var firstByte = new byte[1];
+        Assert.Equal(1, await stream.ReadAsync(firstByte));
+
+        Assert.Equal("a", Encoding.ASCII.GetString(firstByte));
+        Assert.Equal(0, client.BatchRequestCount);
+
+        var restOfFirstSegment = new byte[4];
+        Assert.Equal(4, await stream.ReadAsync(restOfFirstSegment));
+        Assert.Equal("bcde", Encoding.ASCII.GetString(restOfFirstSegment));
+        Assert.Equal(0, client.BatchRequestCount);
+
+        Assert.Equal(1, await stream.ReadAsync(firstByte));
+        Assert.True(client.BatchRequestCount > 0);
+        Assert.Equal("f", Encoding.ASCII.GetString(firstByte));
+    }
+
+    [Fact]
+    public async Task SmallClosedRange_StreamsTargetSegmentWithoutDrainingItFirst()
+    {
+        var client = new FakeNntpClient(
+            SegmentIds.Zip(SegmentBytes).ToDictionary(pair => pair.First, pair => pair.Second),
+            useCachedYencStreams: true,
+            segmentRanges: SegmentIds.Zip(SegmentRanges).ToDictionary(pair => pair.First, pair => pair.Second));
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(2);
+        try
+        {
+            await using var stream = new NzbFileStream(
+                SegmentIds, 15, client, articleBufferSize: 4, segmentByteRanges: SegmentRanges);
+            stream.Seek(6, SeekOrigin.Begin);
+            var buffer = new byte[2];
+
+            Assert.Equal(2, await stream.ReadAsync(buffer));
+            Assert.Equal("gh", Encoding.ASCII.GetString(buffer));
+            Assert.Equal(0, client.BatchRequestCount);
+            Assert.Equal(1, client.BodyRequestCounts["two"]);
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -630,7 +683,10 @@ public class NzbFileStreamTests
             fileName: "seek-dispose.bin",
             inFlightArticleBudget: budget);
 
-        var buffer = new byte[segmentSize / 2];
+        var buffer = new byte[segmentSize];
+        _ = await stream.ReadAsync(buffer);
+        // The first segment uses the direct first-byte path; reading into the next
+        // segment creates the buffered prefetch stream that owns byte-budget leases.
         _ = await stream.ReadAsync(buffer);
         Assert.True(budget.LeasedBytes > 0);
 

--- a/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
@@ -1,0 +1,139 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public sealed class RepeatableStreamingBenchmarkCoverageTests
+{
+    private const int SegmentSize = 8 * 1024;
+    private const int SegmentCount = 6;
+
+    [Fact]
+    public async Task DeterministicFixture_CoversColdWarmRangeTailSeekAndDeadArticlePaths()
+    {
+        var fixture = CreateFixture();
+        var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-streaming-benchmark-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var transport = fixture.CreateClient();
+            using var cached = new SegmentCacheNntpClient(
+                transport,
+                cacheDir,
+                maxBytes: fixture.Source.Length * 2L);
+            await WaitForCatalogAsync(cached);
+
+            await AssertReadMatchesAsync(transport, fixture, offset: 0, count: fixture.Source.Length);
+            var coldTransportRequests = transport.BodyRequestCount;
+            var coldTransportBytes = transport.RequestedSegmentIds.Sum(id => fixture.Segments[id].Length);
+            Assert.Equal(SegmentCount, coldTransportRequests);
+            Assert.Equal(fixture.Source.Length, coldTransportBytes);
+
+            await PrimeCacheAsync(cached, fixture);
+            var requestsBeforeWarmRead = transport.BodyRequestCount;
+            await AssertReadMatchesAsync(cached, fixture, offset: 0, count: fixture.Source.Length);
+            Assert.Equal(requestsBeforeWarmRead, transport.BodyRequestCount);
+
+            await AssertReadMatchesAsync(cached, fixture, offset: SegmentSize + 127, count: 1024);
+            await AssertReadMatchesAsync(cached, fixture, offset: fixture.Source.Length - 257, count: 257);
+
+            await using (var stream = fixture.CreateStream(cached))
+            {
+                foreach (var offset in new[] { 17, SegmentSize * 3 + 91, SegmentSize * 2 + 7 })
+                {
+                    stream.Seek(offset, SeekOrigin.Begin);
+                    var buffer = new byte[513];
+                    var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true);
+                    Assert.Equal(fixture.Source.AsSpan(offset, read).ToArray(), buffer);
+                }
+            }
+
+            var deadSegments = fixture.Segments
+                .Where(pair => pair.Key != fixture.SegmentIds[2])
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+            var deadTransport = new FakeNntpClient(
+                deadSegments,
+                useCachedYencStreams: true,
+                segmentRanges: fixture.RangesById);
+            await using var deadStream = fixture.CreateStream(deadTransport);
+            deadStream.Seek(SegmentSize * 2, SeekOrigin.Begin);
+            var deadBuffer = new byte[SegmentSize];
+            Assert.Equal(SegmentSize, await deadStream.ReadAtLeastAsync(
+                deadBuffer, deadBuffer.Length, throwOnEndOfStream: true));
+            Assert.Equal(new byte[SegmentSize], deadBuffer);
+            Assert.Contains(fixture.SegmentIds[2], deadTransport.RequestedSegmentIds);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    private static async Task AssertReadMatchesAsync(
+        INntpClient client,
+        Fixture fixture,
+        int offset,
+        int count)
+    {
+        await using var stream = fixture.CreateStream(client);
+        stream.Seek(offset, SeekOrigin.Begin);
+        var buffer = new byte[count];
+        var read = await stream.ReadAtLeastAsync(buffer, count, throwOnEndOfStream: true);
+        Assert.Equal(count, read);
+        Assert.Equal(fixture.Source.AsSpan(offset, count).ToArray(), buffer);
+    }
+
+    private static async Task PrimeCacheAsync(SegmentCacheNntpClient client, Fixture fixture)
+    {
+        foreach (var segmentId in fixture.SegmentIds)
+        {
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            using var body = response.Stream
+                ?? throw new InvalidOperationException($"Cache prime returned no body for {segmentId}.");
+            await body.CopyToAsync(Stream.Null);
+        }
+    }
+
+    private static async Task WaitForCatalogAsync(SegmentCacheNntpClient client)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!client.IsCatalogReady && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        Assert.True(client.IsCatalogReady, "Segment cache catalog did not become ready.");
+    }
+
+    private static Fixture CreateFixture()
+    {
+        var source = new byte[SegmentSize * SegmentCount];
+        new Random(1025).NextBytes(source);
+        var segmentIds = Enumerable.Range(0, SegmentCount).Select(index => $"benchmark-{index:D2}").ToArray();
+        var ranges = Enumerable.Range(0, SegmentCount)
+            .Select(index => new LongRange(index * SegmentSize, (index + 1L) * SegmentSize))
+            .ToArray();
+        var segments = segmentIds
+            .Select((id, index) => KeyValuePair.Create(
+                id, source.AsSpan(index * SegmentSize, SegmentSize).ToArray()))
+            .ToDictionary();
+        var rangesById = segmentIds.Zip(ranges).ToDictionary(pair => pair.First, pair => pair.Second);
+        return new Fixture(source, segmentIds, ranges, segments, rangesById);
+    }
+
+    private sealed record Fixture(
+        byte[] Source,
+        string[] SegmentIds,
+        LongRange[] Ranges,
+        IReadOnlyDictionary<string, byte[]> Segments,
+        IReadOnlyDictionary<string, LongRange> RangesById)
+    {
+        public FakeNntpClient CreateClient() =>
+            new(Segments, useCachedYencStreams: true, segmentRanges: RangesById);
+
+        public NzbFileStream CreateStream(INntpClient client) =>
+            new(SegmentIds, Source.Length, client, articleBufferSize: 0, segmentByteRanges: Ranges,
+                usePipelinedBodyRequests: false, fileName: "repeatable-streaming-benchmark.bin");
+    }
+}

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -145,7 +145,7 @@ public class GetAndHeadHandlerRangeTests
         public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
         {
             OpenCount++;
-            return Task.FromResult<Stream>(new MemoryStream());
+            return Task.FromResult(Stream.Null);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -1,6 +1,11 @@
+using Microsoft.AspNetCore.Http;
+using NWebDav.Server.Stores;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.WebDav.Base;
 
 namespace NzbWebDAV.Tests.WebDav;
@@ -44,6 +49,33 @@ public class GetAndHeadHandlerRangeTests
     public void TryResolveRange_IgnoresRangeOnHead(string header)
     {
         Assert.Null(GetAndHeadHandlerPatch.TryResolveRange(isHeadRequest: true, header));
+    }
+
+    [Fact]
+    public async Task Head_KnownSizeFile_UsesMetadataWithoutOpeningStream()
+    {
+        var item = new CountingStoreItem(fileSize: 1234);
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Head;
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("localhost");
+        context.Request.Path = "/movie.mkv";
+
+        var handler = new GetAndHeadHandlerPatch(
+            new SingleItemStore(item),
+            new ConfigManager(),
+            new ProviderUsageTracker(),
+            new ActiveReadRegistry(),
+            new ConcurrentReadTracker(),
+            new StreamTraceBuffer(100, enabled: false),
+            new StreamingFailureTracker());
+
+        var handled = await handler.HandleRequestAsync(context);
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal(1234, context.Response.ContentLength);
+        Assert.Equal(0, item.OpenCount);
     }
 
     [Fact]
@@ -100,6 +132,33 @@ public class GetAndHeadHandlerRangeTests
     private static DavItem NewDavItem()
     {
         return new DavItem { Id = Guid.NewGuid() };
+    }
+
+    private sealed class CountingStoreItem(long fileSize) : BaseStoreReadonlyItem
+    {
+        public int OpenCount { get; private set; }
+        public override string Name => "movie.mkv";
+        public override string UniqueKey => "movie";
+        public override long FileSize => fileSize;
+        public override DateTime CreatedAt => DateTime.UnixEpoch;
+
+        public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
+        {
+            OpenCount++;
+            return Task.FromResult<Stream>(new MemoryStream());
+        }
+    }
+
+    private sealed class SingleItemStore(IStoreItem item) : IStore
+    {
+        public Task<IStoreItem?> GetItemAsync(string path, CancellationToken cancellationToken)
+            => Task.FromResult<IStoreItem?>(item);
+
+        public Task<IStoreItem?> GetItemAsync(Uri uri, CancellationToken cancellationToken)
+            => Task.FromResult<IStoreItem?>(item);
+
+        public Task<IStoreCollection?> GetCollectionAsync(Uri uri, CancellationToken cancellationToken)
+            => Task.FromResult<IStoreCollection?>(null);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- reduce yEnc staging copies, stream the first segment before full buffering, and expand pipelined prefetch capacity
- keep a bounded floor of warm NNTP connections, enable segment caching by default with fast-storage guidance, and avoid opening streams for known-size HEAD probes
- add deterministic streaming performance report coverage for cold reads, probes, cache hits, seeks, and missing articles

The related persisted article-miss cache is submitted separately in #1028.

## Closes on merge
- Closes #1019 — streaming prefetch capacity
- Closes #1020 — first-segment delivery before full buffering
- Closes #1021 — metadata-only HEAD requests
- Closes #1022 — segment cache default policy
- Closes #1025 — repeatable streaming benchmark coverage
- Closes #988 — warm connection floor

Related but NOT closed by this PR: #1023 (yEnc decode overhead — partially addressed here: the per-line staging copy is gone, but chunked reads/in-buffer scanning and profiling remain), #1024 (pipeline setting clarity — stacked follow-up PR), #1026 (persistent misses — see #1028), #1027 (PAR2 repair — planned).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] Focused streaming regression suite (48 tests)
- [x] Focused streaming settings Vitest suite
- [x] `git diff --check`