### PR TITLE
feat(health): repair missing articles in the background using PAR2 recovery data

### DIFF
--- a/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
+++ b/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
@@ -1,0 +1,64 @@
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Services.Observability;
+using NzbWebDAV.Services.Repair;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+public sealed class RepairedSegmentNntpClient : WrappingNntpClient
+{
+    private readonly RepairPatchStore _patchStore;
+
+    public RepairedSegmentNntpClient(INntpClient inner, RepairPatchStore patchStore) : base(inner)
+    {
+        _patchStore = patchStore;
+    }
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId, CancellationToken ct)
+    {
+        return DecodedBodyAsync(segmentId, onConnectionReadyAgain: null, ct);
+    }
+
+    public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken ct)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value != null)
+            return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
+
+        string id = segmentId;
+        if (_patchStore.TryGet(id, out var patched))
+        {
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            PrometheusMetrics.Current?.RecordPar2PatchHit();
+            return patched!;
+        }
+
+        return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
+    }
+
+    public override async Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+        string segmentId, CancellationToken ct)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value == null
+            && _patchStore.Contains(segmentId))
+            return new UsenetExclusiveConnection(onConnectionReadyAgain: null);
+        return await base.AcquireExclusiveConnectionAsync(segmentId, ct).ConfigureAwait(false);
+    }
+
+    public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId segmentId, UsenetExclusiveConnection exclusiveConnection, CancellationToken ct)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value != null)
+            return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
+
+        string id = segmentId;
+        if (_patchStore.TryGet(id, out var patched))
+        {
+            exclusiveConnection.OnConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            PrometheusMetrics.Current?.RecordPar2PatchHit();
+            return patched!;
+        }
+
+        return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
+    }
+}

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -18,6 +19,7 @@ namespace NzbWebDAV.Clients.Usenet;
 public class UsenetStreamingClient : WrappingNntpClient
 {
     private readonly Lock _configChangeLock = new();
+    private readonly RepairPatchStore? _repairPatchStore;
 
     public UsenetStreamingClient(
         ConfigManager configManager,
@@ -29,13 +31,16 @@ public class UsenetStreamingClient : WrappingNntpClient
         ActiveReadRegistry activeReadRegistry,
         ArticleMissNegativeCache? articleMissCache = null,
         ProviderLatencyTracker? latencyTracker = null,
-        ConcurrentReadTracker? concurrentReadTracker = null)
+        ConcurrentReadTracker? concurrentReadTracker = null,
+        RepairPatchStore? repairPatchStore = null)
 #pragma warning disable CA2000 // the client chain transfers to the base class and is disposed with this instance
         : base(CreateDownloadingNntpClient(
 #pragma warning restore CA2000
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
-            streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker))
+            streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker,
+            repairPatchStore))
     {
+        _repairPatchStore = repairPatchStore;
         // when config changes, create a new MultiProviderClient to use instead.
         configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -58,7 +63,7 @@ public class UsenetStreamingClient : WrappingNntpClient
                         var newUsenetClient = CreateDownloadingNntpClient(
                             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
                             streamTrace, activeReadRegistry, articleMissCache, latencyTracker,
-                            concurrentReadTracker);
+                            concurrentReadTracker, _repairPatchStore);
                         ReplaceUnderlyingClient(newUsenetClient);
                         return;
                     }
@@ -88,7 +93,8 @@ public class UsenetStreamingClient : WrappingNntpClient
         ActiveReadRegistry activeReadRegistry,
         ArticleMissNegativeCache? articleMissCache,
         ProviderLatencyTracker? latencyTracker,
-        ConcurrentReadTracker? concurrentReadTracker
+        ConcurrentReadTracker? concurrentReadTracker,
+        RepairPatchStore? repairPatchStore
     )
     {
 #pragma warning disable CA2000 // wrapped by DownloadingNntpClient below; the returned client chain is disposed with this instance
@@ -119,6 +125,13 @@ public class UsenetStreamingClient : WrappingNntpClient
                 Log.Warning(e, "Segment cache disabled: failed to initialise at {Path}.",
                     configManager.GetSegmentCachePath());
             }
+        }
+
+        if (repairPatchStore != null)
+        {
+#pragma warning disable CA2000 // ownership transfers to the wrapping/returned client chain, disposed with this instance
+            inner = new RepairedSegmentNntpClient(inner, repairPatchStore);
+#pragma warning restore CA2000
         }
 
         // Always wrap with header caching so seek probes reuse immutable yEnc headers

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -88,6 +88,14 @@ public static class ConfigKeys
     public const string RepairHealthcheckAging = "repair.healthcheck-aging";
     public const string RepairAutoRemoveAfterFailures = "repair.auto-remove-after-failures";
     public const string RepairAutoRemoveUnlinkedOnly = "repair.auto-remove-unlinked-only";
+    public const string RepairPar2Enabled = "repair.par2-enabled";
+    public const string RepairPar2PreferredOverArr = "repair.par2-preferred-over-arr";
+    public const string RepairPar2MaxMissingSlices = "repair.par2-max-missing-slices";
+    public const string RepairPar2MaxReleaseGb = "repair.par2-max-release-gb";
+    public const string RepairPar2MaxMemoryMb = "repair.par2-max-memory-mb";
+    public const string RepairPar2MaxPatchGb = "repair.par2-max-patch-gb";
+    public const string RepairPar2FetchConcurrency = "repair.par2-fetch-concurrency";
+    public const string RepairPar2FailureCooldownHours = "repair.par2-failure-cooldown-hours";
     public const string ArrInstances = "arr.instances";
 
     // rclone

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -438,6 +438,8 @@ public class ConfigManager
                 case ConfigKeys.WardenHideDead:
                 case ConfigKeys.WardenBackboneScope:
                 case ConfigKeys.RepairEnable:
+                case ConfigKeys.RepairPar2Enabled:
+                case ConfigKeys.RepairPar2PreferredOverArr:
                 case ConfigKeys.RepairHealthcheckAging:
                 case ConfigKeys.RepairAutoRemoveUnlinkedOnly:
                 case ConfigKeys.RcloneRcEnabled:
@@ -1010,6 +1012,60 @@ public class ConfigManager
         var gb = long.TryParse(v, out var n) ? n : 10;
         return Math.Max(1, gb) * 1024L * 1024L * 1024L;
     }
+
+    public bool IsPar2RepairEnabled()
+    {
+        var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
+        if (repairValue == null || !bool.Parse(repairValue)) return false;
+        var par2Value = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2Enabled));
+        return par2Value != null && bool.Parse(par2Value);
+    }
+
+    public bool IsPar2PreferredOverArr()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2PreferredOverArr));
+        return v == null || bool.Parse(v);
+    }
+
+    public int GetPar2MaxMissingSlices()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2MaxMissingSlices));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 64) : 8;
+    }
+
+    public int GetPar2MaxReleaseGb()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2MaxReleaseGb));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 200) : 16;
+    }
+
+    public int GetPar2MaxMemoryMb()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2MaxMemoryMb));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 64, 2048) : 256;
+    }
+
+    public long GetPar2MaxPatchBytes()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2MaxPatchGb));
+        var gb = int.TryParse(v, out var n) ? Math.Clamp(n, 1, 100) : 4;
+        return gb * 1024L * 1024L * 1024L;
+    }
+
+    public int GetPar2FetchConcurrency()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2FetchConcurrency));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 8) : 2;
+    }
+
+    public int GetPar2FailureCooldownHours()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2FailureCooldownHours));
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 168) : 6;
+    }
+
+    public string GetRepairPatchStorePath()
+        => Path.Join(DavDatabaseContext.ConfigPath, "repair-segments");
 
     // When true, RAR archives are mounted instantly by parsing only the first
     // volume at import; trailing volumes are resolved on first read. Falls

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1018,7 +1018,7 @@ public class ConfigManager
         var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
         if (repairValue == null || !bool.Parse(repairValue)) return false;
         var par2Value = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2Enabled));
-        return par2Value != null && bool.Parse(par2Value);
+        return par2Value == null || bool.Parse(par2Value);
     }
 
     public bool IsPar2PreferredOverArr()

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -88,6 +88,7 @@ public class DavDatabaseContext : DbContext
     public DbSet<WantedItem> WantedItems => Set<WantedItem>();
     public DbSet<NzbResolutionGroup> NzbResolutionGroups => Set<NzbResolutionGroup>();
     public DbSet<ArticleMissCacheEntry> ArticleMissCacheEntries => Set<ArticleMissCacheEntry>();
+    public DbSet<Par2RepairJob> Par2RepairJobs => Set<Par2RepairJob>();
 
     // Pending blob writes for the current unit of work (flushed in SaveChangesAsync).
     private readonly List<DavNzbFile> _blobNzbFiles = [];
@@ -771,6 +772,80 @@ public class DavDatabaseContext : DbContext
             e.Property(i => i.CacheKey).IsRequired();
             e.Property(i => i.ConfirmedAtUnix).IsRequired();
             e.HasIndex(i => i.ConfirmedAtUnix);
+        });
+
+        // Par2RepairJob
+        b.Entity<Par2RepairJob>(e =>
+        {
+            e.ToTable("Par2RepairJobs");
+            e.HasKey(i => i.Id);
+
+            e.Property(i => i.Id)
+                .ValueGeneratedNever();
+
+            e.Property(i => i.DavItemId)
+                .ValueGeneratedNever()
+                .IsRequired();
+
+            e.Property(i => i.Path)
+                .IsRequired();
+
+            e.Property(i => i.State)
+                .HasConversion<int>()
+                .IsRequired();
+
+            e.Property(i => i.MissingSegmentIds)
+                .HasConversion(new ValueConverter<string[], string>
+                (
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+                    v => DeserializeOrFallback<string[]>(v) ?? Array.Empty<string>()
+                ))
+                .HasColumnType("TEXT")
+                .IsRequired();
+
+            e.Property(i => i.CreatedAt)
+                .ValueGeneratedNever()
+                .IsRequired()
+                .HasConversion(
+                    x => x.ToUnixTimeSeconds(),
+                    x => DateTimeOffset.FromUnixTimeSeconds(x)
+                );
+
+            e.Property(i => i.StartedAt)
+                .ValueGeneratedNever()
+                .HasConversion(
+                    x => x.HasValue ? x.Value.ToUnixTimeSeconds() : (long?)null,
+                    x => x.HasValue ? DateTimeOffset.FromUnixTimeSeconds(x.Value) : null
+                );
+
+            e.Property(i => i.CompletedAt)
+                .ValueGeneratedNever()
+                .HasConversion(
+                    x => x.HasValue ? x.Value.ToUnixTimeSeconds() : (long?)null,
+                    x => x.HasValue ? DateTimeOffset.FromUnixTimeSeconds(x.Value) : null
+                );
+
+            e.Property(i => i.Attempts)
+                .IsRequired();
+
+            e.Property(i => i.NextAttemptAt)
+                .ValueGeneratedNever()
+                .HasConversion(
+                    x => x.HasValue ? x.Value.ToUnixTimeSeconds() : (long?)null,
+                    x => x.HasValue ? DateTimeOffset.FromUnixTimeSeconds(x.Value) : null
+                );
+
+            e.Property(i => i.FailureReason)
+                .IsRequired(false);
+
+            e.Property(i => i.BytesRead)
+                .IsRequired();
+
+            e.Property(i => i.SlicesReconstructed)
+                .IsRequired();
+
+            e.HasIndex(i => i.DavItemId);
+            e.HasIndex(i => new { i.State, i.NextAttemptAt });
         });
 
         if (DatabaseProviderConfig.IsPostgres)

--- a/backend/Database/Migrations/20260818220000_Add-Par2-Repair-Jobs.Designer.cs
+++ b/backend/Database/Migrations/20260818220000_Add-Par2-Repair-Jobs.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NzbWebDAV.Database;
 
@@ -10,9 +11,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.Migrations
 {
     [DbContext(typeof(DavDatabaseContext))]
-    partial class DavDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260818220000_Add-Par2-Repair-Jobs")]
+    partial class AddPar2RepairJobs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/backend/Database/Migrations/20260818220000_Add-Par2-Repair-Jobs.cs
+++ b/backend/Database/Migrations/20260818220000_Add-Par2-Repair-Jobs.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPar2RepairJobs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Par2RepairJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    DavItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Path = table.Column<string>(type: "TEXT", nullable: false),
+                    State = table.Column<int>(type: "INTEGER", nullable: false),
+                    MissingSegmentIds = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                    StartedAt = table.Column<long>(type: "INTEGER", nullable: true),
+                    CompletedAt = table.Column<long>(type: "INTEGER", nullable: true),
+                    Attempts = table.Column<int>(type: "INTEGER", nullable: false),
+                    NextAttemptAt = table.Column<long>(type: "INTEGER", nullable: true),
+                    FailureReason = table.Column<string>(type: "TEXT", nullable: true),
+                    BytesRead = table.Column<long>(type: "INTEGER", nullable: false),
+                    SlicesReconstructed = table.Column<int>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Par2RepairJobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Par2RepairJobs_DavItemId",
+                table: "Par2RepairJobs",
+                column: "DavItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Par2RepairJobs_State_NextAttemptAt",
+                table: "Par2RepairJobs",
+                columns: new[] { "State", "NextAttemptAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Par2RepairJobs");
+        }
+    }
+}

--- a/backend/Database/Models/HealthCheckResult.cs
+++ b/backend/Database/Models/HealthCheckResult.cs
@@ -24,5 +24,6 @@ public class HealthCheckResult
         Repaired = 1,
         Deleted = 2,
         ActionNeeded = 3,
+        RepairedViaPar2 = 4,
     }
 }

--- a/backend/Database/Models/Par2RepairJob.cs
+++ b/backend/Database/Models/Par2RepairJob.cs
@@ -1,0 +1,27 @@
+namespace NzbWebDAV.Database.Models;
+
+public class Par2RepairJob
+{
+    public Guid Id { get; set; }
+    public Guid DavItemId { get; set; }
+    public string Path { get; set; } = null!;
+    public RepairJobState State { get; set; }
+    public string[] MissingSegmentIds { get; set; } = Array.Empty<string>();
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public int Attempts { get; set; }
+    public DateTimeOffset? NextAttemptAt { get; set; }
+    public string? FailureReason { get; set; }
+    public long BytesRead { get; set; }
+    public int SlicesReconstructed { get; set; }
+
+    public enum RepairJobState
+    {
+        Queued = 0,
+        Running = 1,
+        Succeeded = 2,
+        Failed = 3,
+        Infeasible = 4,
+    }
+}

--- a/backend/Database/PostgresMigrations/20260818220000_Add-Par2-Repair-Jobs.Designer.cs
+++ b/backend/Database/PostgresMigrations/20260818220000_Add-Par2-Repair-Jobs.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NzbWebDAV.Database;
@@ -11,9 +12,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.PostgresMigrations
 {
     [DbContext(typeof(PostgresDavDatabaseContext))]
-    partial class PostgresDavDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260818220000_Add-Par2-Repair-Jobs")]
+    partial class AddPar2RepairJobs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Database/PostgresMigrations/20260818220000_Add-Par2-Repair-Jobs.cs
+++ b/backend/Database/PostgresMigrations/20260818220000_Add-Par2-Repair-Jobs.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.PostgresMigrations;
+
+[DbContext(typeof(PostgresDavDatabaseContext))]
+[Migration("20260818220000_Add-Par2-Repair-Jobs")]
+public partial class AddPar2RepairJobs : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Par2RepairJobs",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                DavItemId = table.Column<Guid>(type: "uuid", nullable: false),
+                Path = table.Column<string>(type: "text", nullable: false),
+                State = table.Column<int>(type: "integer", nullable: false),
+                MissingSegmentIds = table.Column<string>(type: "text", nullable: false),
+                CreatedAt = table.Column<long>(type: "bigint", nullable: false),
+                StartedAt = table.Column<long>(type: "bigint", nullable: true),
+                CompletedAt = table.Column<long>(type: "bigint", nullable: true),
+                Attempts = table.Column<int>(type: "integer", nullable: false),
+                NextAttemptAt = table.Column<long>(type: "bigint", nullable: true),
+                FailureReason = table.Column<string>(type: "text", nullable: true),
+                BytesRead = table.Column<long>(type: "bigint", nullable: false),
+                SlicesReconstructed = table.Column<int>(type: "integer", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Par2RepairJobs", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Par2RepairJobs_DavItemId",
+            table: "Par2RepairJobs",
+            column: "DavItemId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Par2RepairJobs_State_NextAttemptAt",
+            table: "Par2RepairJobs",
+            columns: new[] { "State", "NextAttemptAt" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "Par2RepairJobs");
+    }
+}

--- a/backend/Database/PostgresMigrations/20260818220000_Add-Par2-Repair-Jobs.cs
+++ b/backend/Database/PostgresMigrations/20260818220000_Add-Par2-Repair-Jobs.cs
@@ -1,52 +1,55 @@
-using Microsoft.EntityFrameworkCore.Infrastructure;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace NzbWebDAV.Database.PostgresMigrations;
-
-[DbContext(typeof(PostgresDavDatabaseContext))]
-[Migration("20260818220000_Add-Par2-Repair-Jobs")]
-public partial class AddPar2RepairJobs : Migration
+namespace NzbWebDAV.Database.PostgresMigrations
 {
-    protected override void Up(MigrationBuilder migrationBuilder)
+    /// <inheritdoc />
+    public partial class AddPar2RepairJobs : Migration
     {
-        migrationBuilder.CreateTable(
-            name: "Par2RepairJobs",
-            columns: table => new
-            {
-                Id = table.Column<Guid>(type: "uuid", nullable: false),
-                DavItemId = table.Column<Guid>(type: "uuid", nullable: false),
-                Path = table.Column<string>(type: "text", nullable: false),
-                State = table.Column<int>(type: "integer", nullable: false),
-                MissingSegmentIds = table.Column<string>(type: "text", nullable: false),
-                CreatedAt = table.Column<long>(type: "bigint", nullable: false),
-                StartedAt = table.Column<long>(type: "bigint", nullable: true),
-                CompletedAt = table.Column<long>(type: "bigint", nullable: true),
-                Attempts = table.Column<int>(type: "integer", nullable: false),
-                NextAttemptAt = table.Column<long>(type: "bigint", nullable: true),
-                FailureReason = table.Column<string>(type: "text", nullable: true),
-                BytesRead = table.Column<long>(type: "bigint", nullable: false),
-                SlicesReconstructed = table.Column<int>(type: "integer", nullable: false),
-            },
-            constraints: table =>
-            {
-                table.PrimaryKey("PK_Par2RepairJobs", x => x.Id);
-            });
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Par2RepairJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DavItemId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Path = table.Column<string>(type: "text", nullable: false),
+                    State = table.Column<int>(type: "integer", nullable: false),
+                    MissingSegmentIds = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<long>(type: "bigint", nullable: false),
+                    StartedAt = table.Column<long>(type: "bigint", nullable: true),
+                    CompletedAt = table.Column<long>(type: "bigint", nullable: true),
+                    Attempts = table.Column<int>(type: "integer", nullable: false),
+                    NextAttemptAt = table.Column<long>(type: "bigint", nullable: true),
+                    FailureReason = table.Column<string>(type: "text", nullable: true),
+                    BytesRead = table.Column<long>(type: "bigint", nullable: false),
+                    SlicesReconstructed = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Par2RepairJobs", x => x.Id);
+                });
 
-        migrationBuilder.CreateIndex(
-            name: "IX_Par2RepairJobs_DavItemId",
-            table: "Par2RepairJobs",
-            column: "DavItemId");
+            migrationBuilder.CreateIndex(
+                name: "IX_Par2RepairJobs_DavItemId",
+                table: "Par2RepairJobs",
+                column: "DavItemId");
 
-        migrationBuilder.CreateIndex(
-            name: "IX_Par2RepairJobs_State_NextAttemptAt",
-            table: "Par2RepairJobs",
-            columns: new[] { "State", "NextAttemptAt" });
-    }
+            migrationBuilder.CreateIndex(
+                name: "IX_Par2RepairJobs_State_NextAttemptAt",
+                table: "Par2RepairJobs",
+                columns: new[] { "State", "NextAttemptAt" });
+        }
 
-    protected override void Down(MigrationBuilder migrationBuilder)
-    {
-        migrationBuilder.DropTable(name: "Par2RepairJobs");
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Par2RepairJobs");
+        }
     }
 }

--- a/backend/Database/PostgresMigrations/PostgresDavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/PostgresMigrations/PostgresDavDatabaseContextModelSnapshot.cs
@@ -446,6 +446,58 @@ namespace NzbWebDAV.Database.PostgresMigrations
                     b.ToTable("ArticleMissCacheEntries", (string)null);
                 });
 
+            modelBuilder.Entity("NzbWebDAV.Database.Models.Par2RepairJob", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("Attempts")
+                        .HasColumnType("integer");
+
+                    b.Property<long>("BytesRead")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("CompletedAt")
+                        .HasColumnType("bigint");
+
+                    b.Property<long>("CreatedAt")
+                        .HasColumnType("bigint");
+
+                    b.Property<Guid>("DavItemId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("FailureReason")
+                        .HasColumnType("text");
+
+                    b.Property<string>("MissingSegmentIds")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<long?>("NextAttemptAt")
+                        .HasColumnType("bigint");
+
+                    b.Property<string>("Path")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<int>("SlicesReconstructed")
+                        .HasColumnType("integer");
+
+                    b.Property<long?>("StartedAt")
+                        .HasColumnType("bigint");
+
+                    b.Property<int>("State")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DavItemId");
+
+                    b.HasIndex("State", "NextAttemptAt");
+
+                    b.ToTable("Par2RepairJobs", (string)null);
+                });
+
             modelBuilder.Entity("NzbWebDAV.Database.Models.NzbResolutionGroup", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/Par2Recovery/Packets/IfscPacket.cs
+++ b/backend/Par2Recovery/Packets/IfscPacket.cs
@@ -1,0 +1,44 @@
+namespace NzbWebDAV.Par2Recovery.Packets;
+
+/// <summary>
+/// PAR 2.0 Input File Slice Check packet ("PAR 2.0\0IFSC").
+/// </summary>
+public sealed class IfscPacket : Par2Packet
+{
+    public const string PacketType = "PAR 2.0\0IFSC";
+
+    public byte[] FileId { get; private set; } = [];
+    public IReadOnlyList<SliceChecksum> Slices { get; private set; } = [];
+
+    public sealed record SliceChecksum(byte[] Md5, uint Crc32);
+
+    public IfscPacket(Par2PacketHeader header) : base(header)
+    {
+    }
+
+    protected override void ParseBody(byte[] body)
+    {
+        if (body.Length < 16)
+            throw new InvalidDataException("IFSC packet body too short.");
+
+        FileId = new byte[16];
+        Buffer.BlockCopy(body, 0, FileId, 0, 16);
+
+        var remainder = body.Length - 16;
+        if (remainder % 20 != 0)
+            throw new InvalidDataException("IFSC packet slice list length is not a multiple of 20.");
+
+        var sliceCount = remainder / 20;
+        var slices = new List<SliceChecksum>(sliceCount);
+        for (var i = 0; i < sliceCount; i++)
+        {
+            var offset = 16 + i * 20;
+            var md5 = new byte[16];
+            Buffer.BlockCopy(body, offset, md5, 0, 16);
+            var crc = BitConverter.ToUInt32(body, offset + 16);
+            slices.Add(new SliceChecksum(md5, crc));
+        }
+
+        Slices = slices;
+    }
+}

--- a/backend/Par2Recovery/Packets/MainPacket.cs
+++ b/backend/Par2Recovery/Packets/MainPacket.cs
@@ -1,0 +1,50 @@
+namespace NzbWebDAV.Par2Recovery.Packets;
+
+/// <summary>
+/// PAR 2.0 Main packet ("PAR 2.0\0Main").
+/// </summary>
+public sealed class MainPacket : Par2Packet
+{
+    public const string PacketType = "PAR 2.0\0Main";
+
+    public const ulong MinSliceSize = 4 * 1024;
+    public const ulong MaxSliceSize = 64 * 1024 * 1024;
+    public const uint MaxFileCount = 100_000;
+
+    public ulong SliceSize { get; private set; }
+    public uint RecoverySetFileCount { get; private set; }
+    public IReadOnlyList<byte[]> FileIds { get; private set; } = [];
+
+    public MainPacket(Par2PacketHeader header) : base(header)
+    {
+    }
+
+    protected override void ParseBody(byte[] body)
+    {
+        if (body.Length < 12)
+            throw new InvalidDataException("Main packet body too short.");
+
+        SliceSize = BitConverter.ToUInt64(body, 0);
+        RecoverySetFileCount = BitConverter.ToUInt32(body, 8);
+
+        if (SliceSize < MinSliceSize || SliceSize > MaxSliceSize)
+            throw new InvalidDataException($"Main packet slice size {SliceSize} out of range.");
+
+        if (RecoverySetFileCount > MaxFileCount)
+            throw new InvalidDataException($"Main packet file count {RecoverySetFileCount} out of range.");
+
+        var expectedBody = 12 + RecoverySetFileCount * 16;
+        if (body.Length < expectedBody)
+            throw new InvalidDataException("Main packet FileID list truncated.");
+
+        var ids = new List<byte[]>((int)RecoverySetFileCount);
+        for (var i = 0; i < RecoverySetFileCount; i++)
+        {
+            var id = new byte[16];
+            Buffer.BlockCopy(body, 12 + i * 16, id, 0, 16);
+            ids.Add(id);
+        }
+
+        FileIds = ids;
+    }
+}

--- a/backend/Par2Recovery/Packets/Par2Packet.cs
+++ b/backend/Par2Recovery/Packets/Par2Packet.cs
@@ -79,5 +79,7 @@ namespace NzbWebDAV.Par2Recovery.Packets
         {
             // intentionally left blank
         }
+
+        internal void ParseBodyBytes(byte[] body) => ParseBody(body);
     }
 }

--- a/backend/Par2Recovery/Packets/Par2PacketHash.cs
+++ b/backend/Par2Recovery/Packets/Par2PacketHash.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+
+namespace NzbWebDAV.Par2Recovery.Packets;
+
+#pragma warning disable CA5351 // PAR 2.0 packet integrity uses MD5 per spec
+
+/// <summary>
+/// PAR 2.0 packet MD5: hash of Recovery Set ID + packet type + body (bytes 32..packet end).
+/// Matches par2-rs / par2cmdline wire format (no separate length suffix).
+/// </summary>
+internal static class Par2PacketHash
+{
+    public static bool Verify(byte[] packetBytes, ReadOnlySpan<byte> expectedHash)
+    {
+        if (expectedHash.Length != 16) return false;
+        var computed = Compute(packetBytes);
+        return computed.AsSpan().SequenceEqual(expectedHash);
+    }
+
+    public static byte[] Compute(byte[] packetBytes)
+    {
+        const int hashStart = 32;
+        if (packetBytes.Length < hashStart)
+            throw new InvalidDataException("PAR2 packet too short for hash verification.");
+
+        return MD5.HashData(packetBytes.AsSpan(hashStart));
+    }
+
+    public static void WriteHash(byte[] packetBytes)
+    {
+        var hash = Compute(packetBytes);
+        hash.CopyTo(packetBytes, 16);
+    }
+}
+
+#pragma warning restore CA5351

--- a/backend/Par2Recovery/Packets/RecvSlic.cs
+++ b/backend/Par2Recovery/Packets/RecvSlic.cs
@@ -2,17 +2,34 @@ namespace NzbWebDAV.Par2Recovery.Packets
 {
     /// <summary>
     /// PAR 2.0 Recovery Slice packet ("PAR 2.0\0RecvSlic"). Carries the recovery
-    /// data itself, so it dominates file size; we only need to know where it
-    /// starts, never its payload.
+    /// data itself. Import-time descriptor scans skip the body; the repair fetcher
+    /// constructs with <paramref name="readPayload"/> to parse exponent + slice bytes.
     /// </summary>
     public class RecvSlic : Par2Packet
     {
         public const string PacketType = "PAR 2.0\0RecvSlic";
 
-        public RecvSlic(Par2PacketHeader header) : base(header)
+        private readonly bool _readPayload;
+
+        public uint Exponent { get; private set; }
+        public byte[] Payload { get; private set; } = [];
+
+        public RecvSlic(Par2PacketHeader header, bool readPayload = false) : base(header)
         {
+            _readPayload = readPayload;
         }
 
-        protected override bool SkipBody => true;
+        protected override bool SkipBody => !_readPayload;
+
+        protected override void ParseBody(byte[] body)
+        {
+            if (body.Length < 4)
+                throw new InvalidDataException("RecvSlic body too short for exponent.");
+
+            Exponent = BitConverter.ToUInt32(body, 0);
+            Payload = new byte[body.Length - 4];
+            if (Payload.Length > 0)
+                Buffer.BlockCopy(body, 4, Payload, 0, Payload.Length);
+        }
     }
 }

--- a/backend/Par2Recovery/Par2RepairReader.cs
+++ b/backend/Par2Recovery/Par2RepairReader.cs
@@ -1,0 +1,86 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using NzbWebDAV.Par2Recovery.Packets;
+
+namespace NzbWebDAV.Par2Recovery;
+
+/// <summary>
+/// Reads PAR2 packets for repair (full payloads, hash verification). Does not alter import-time parsing.
+/// </summary>
+public static class Par2RepairReader
+{
+    private const string Par2PacketHeaderMagic = "PAR2\0PKT";
+
+    public static async Task<Par2Packet> ReadVerifiedPacketAsync(
+        Stream stream, bool readRecvSlicPayload, CancellationToken ct)
+    {
+        var header = await ReadStructAsync<Par2PacketHeader>(stream, ct).ConfigureAwait(false);
+        var magic = Encoding.ASCII.GetString(header.Magic);
+        if (!Par2PacketHeaderMagic.Equals(magic, StringComparison.Ordinal))
+            throw new InvalidDataException("Invalid PAR2 magic constant.");
+
+        var headerSize = Marshal.SizeOf<Par2PacketHeader>();
+        var packetLength = header.PacketLength;
+        if (packetLength < (ulong)headerSize || packetLength > int.MaxValue)
+            throw new InvalidDataException($"Invalid PAR2 packet length {packetLength}.");
+
+        var bodyLength = (int)(packetLength - (ulong)headerSize);
+        var packetBytes = new byte[(int)packetLength];
+        WriteHeader(packetBytes, header);
+
+        if (bodyLength > 0)
+            await stream.ReadExactlyAsync(packetBytes.AsMemory(headerSize, bodyLength), ct).ConfigureAwait(false);
+
+        if (!Par2PacketHash.Verify(packetBytes, header.PacketHash))
+            throw new InvalidDataException("PAR2 packet MD5 hash mismatch.");
+
+        var packetType = Encoding.ASCII.GetString(header.PacketType).TrimEnd('\0');
+        Par2Packet packet = packetType switch
+        {
+            FileDesc.PacketType => new FileDesc(header),
+            MainPacket.PacketType => new MainPacket(header),
+            IfscPacket.PacketType => new IfscPacket(header),
+            RecvSlic.PacketType => new RecvSlic(header, readRecvSlicPayload),
+            UniFileN.PacketType => new UniFileN(header),
+            _ => new Par2Packet(header),
+        };
+
+        if (bodyLength > 0)
+        {
+            var body = new byte[bodyLength];
+            Buffer.BlockCopy(packetBytes, headerSize, body, 0, bodyLength);
+            packet.ParseBodyBytes(body);
+        }
+
+        return packet;
+    }
+
+    private static async Task<T> ReadStructAsync<T>(Stream stream, CancellationToken ct) where T : struct
+    {
+        var size = Marshal.SizeOf<T>();
+        var buffer = new byte[size];
+        await stream.ReadExactlyAsync(buffer.AsMemory(0, size), ct).ConfigureAwait(false);
+        var pinned = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+        try
+        {
+            return Marshal.PtrToStructure<T>(pinned.AddrOfPinnedObject())!;
+        }
+        finally
+        {
+            pinned.Free();
+        }
+    }
+
+    private static void WriteHeader(byte[] packetBytes, Par2PacketHeader header)
+    {
+        var pinned = GCHandle.Alloc(packetBytes, GCHandleType.Pinned);
+        try
+        {
+            Marshal.StructureToPtr(header, pinned.AddrOfPinnedObject(), false);
+        }
+        finally
+        {
+            pinned.Free();
+        }
+    }
+}

--- a/backend/Par2Recovery/Par2TestEncoder.cs
+++ b/backend/Par2Recovery/Par2TestEncoder.cs
@@ -1,0 +1,160 @@
+using System.IO.Hashing;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using NzbWebDAV.Par2Recovery.Packets;
+using NzbWebDAV.Par2Recovery.ReedSolomon;
+
+namespace NzbWebDAV.Par2Recovery;
+
+#pragma warning disable CA5351 // PAR 2.0 uses MD5 for file/slice integrity per spec
+
+/// <summary>
+/// Builds small PAR2 sets for deterministic tests.
+/// Regenerate fixtures: slice size 64, 256-byte file, 2 recovery exponents (0, 1).
+/// </summary>
+public static class Par2TestEncoder
+{
+    private static readonly Gf16Field Field = new();
+
+    public static (byte[] indexBytes, byte[] volumeBytes) EncodeSet(
+        string fileName,
+        byte[] fileData,
+        ulong sliceSize,
+        IReadOnlyList<uint> recoveryExponents)
+    {
+        var recoverySetId = RandomNumberGenerator.GetBytes(16);
+        var fileId = MD5.HashData(fileData.Length >= 16 ? fileData.AsSpan(0, 16) : fileData);
+        var fileHash = MD5.HashData(fileData);
+        var file16k = MD5.HashData(fileData.AsSpan(0, Math.Min(16 * 1024, fileData.Length)));
+        var slices = BuildSlices(fileData, sliceSize);
+        var ifscBody = BuildIfscBody(fileId, slices);
+
+        using var index = new MemoryStream();
+        WritePacket(index, FileDesc.PacketType, BuildFileDescBody(fileId, fileHash, file16k, fileData.Length, fileName), recoverySetId);
+        WritePacket(index, MainPacket.PacketType, BuildMainBody(sliceSize, 1, [fileId]), recoverySetId);
+        WritePacket(index, IfscPacket.PacketType, ifscBody, recoverySetId);
+
+        var recoveryPayloads = recoveryExponents
+            .Select(exp => (exp, ComputeRecoverySlice(exp, sliceSize, slices)))
+            .ToList();
+
+        using var volume = new MemoryStream();
+        index.Position = 0;
+        volume.Write(index.ToArray());
+        foreach (var (exp, payload) in recoveryPayloads)
+        {
+            var body = new byte[4 + payload.Length];
+            BitConverter.TryWriteBytes(body.AsSpan(0, 4), exp);
+            payload.CopyTo(body, 4);
+            WritePacket(volume, RecvSlic.PacketType, body, recoverySetId);
+        }
+
+        return (index.ToArray(), volume.ToArray());
+    }
+
+    private static byte[][] BuildSlices(byte[] data, ulong sliceSize)
+    {
+        var count = (int)((data.Length + (long)sliceSize - 1) / (long)sliceSize);
+        var slices = new byte[count][];
+        for (var i = 0; i < count; i++)
+        {
+            var slice = new byte[(int)sliceSize];
+            var offset = i * (int)sliceSize;
+            var len = Math.Min((int)sliceSize, data.Length - offset);
+            data.AsSpan(offset, len).CopyTo(slice);
+            slices[i] = slice;
+        }
+        return slices;
+    }
+
+    private static byte[] ComputeRecoverySlice(uint exponent, ulong sliceSize, byte[][] fileSlices)
+    {
+        var size = (int)sliceSize;
+        var payload = new byte[size];
+        var words = new ushort[size / 2];
+        var coeff = Field.RecoveryCoefficient(exponent, 0);
+        foreach (var slice in fileSlices)
+        {
+            for (var w = 0; w < words.Length; w++)
+            {
+                var word = BitConverter.ToUInt16(slice, w * 2);
+                words[w] = Field.Add(words[w], Field.Mul(coeff, word));
+            }
+        }
+
+        for (var w = 0; w < words.Length; w++)
+            BitConverter.TryWriteBytes(payload.AsSpan(w * 2, 2), words[w]);
+        return payload;
+    }
+
+    private static byte[] BuildMainBody(ulong sliceSize, uint fileCount, byte[][] fileIds)
+    {
+        var body = new byte[12 + fileIds.Length * 16];
+        BitConverter.TryWriteBytes(body.AsSpan(0, 8), sliceSize);
+        BitConverter.TryWriteBytes(body.AsSpan(8, 4), fileCount);
+        for (var i = 0; i < fileIds.Length; i++)
+            fileIds[i].CopyTo(body, 12 + i * 16);
+        return body;
+    }
+
+    private static byte[] BuildIfscBody(byte[] fileId, byte[][] slices)
+    {
+        var body = new byte[16 + slices.Length * 20];
+        fileId.CopyTo(body, 0);
+        for (var i = 0; i < slices.Length; i++)
+        {
+            var offset = 16 + i * 20;
+            MD5.HashData(slices[i]).CopyTo(body, offset);
+            BitConverter.TryWriteBytes(body.AsSpan(offset + 16, 4), BitConverter.ToUInt32(Crc32.Hash(slices[i])));
+        }
+        return body;
+    }
+
+    private static byte[] BuildFileDescBody(
+        byte[] fileId, byte[] fileHash, byte[] file16k, int fileLength, string fileName)
+    {
+        var nameBytes = Encoding.UTF8.GetBytes(fileName);
+        var padded = (nameBytes.Length + 3) / 4 * 4;
+        var body = new byte[56 + padded];
+        fileId.CopyTo(body, 0);
+        fileHash.CopyTo(body, 16);
+        file16k.CopyTo(body, 32);
+        BitConverter.TryWriteBytes(body.AsSpan(48, 8), (ulong)fileLength);
+        nameBytes.CopyTo(body, 56);
+        return body;
+    }
+
+    private static void WritePacket(Stream stream, string packetType, byte[] body, byte[] recoverySetId)
+    {
+        var headerSize = Marshal.SizeOf<Par2PacketHeader>();
+        var packetLength = headerSize + body.Length;
+        var header = new Par2PacketHeader
+        {
+            Magic = "PAR2\0PKT"u8.ToArray(),
+            PacketLength = (ulong)packetLength,
+            PacketHash = new byte[16],
+            RecoverySetID = recoverySetId,
+            PacketType = Encoding.ASCII.GetBytes(packetType.PadRight(16, '\0')[..16]),
+        };
+
+        var packet = new byte[packetLength];
+        var headerBytes = new byte[headerSize];
+        var pin = GCHandle.Alloc(headerBytes, GCHandleType.Pinned);
+        try
+        {
+            Marshal.StructureToPtr(header, pin.AddrOfPinnedObject(), false);
+        }
+        finally
+        {
+            pin.Free();
+        }
+
+        headerBytes.CopyTo(packet, 0);
+        body.CopyTo(packet, headerSize);
+        Par2PacketHash.Compute(packet).CopyTo(packet, 16);
+        stream.Write(packet);
+    }
+}
+
+#pragma warning restore CA5351

--- a/backend/Par2Recovery/Par2TestEncoder.cs
+++ b/backend/Par2Recovery/Par2TestEncoder.cs
@@ -73,9 +73,10 @@ public static class Par2TestEncoder
         var size = (int)sliceSize;
         var payload = new byte[size];
         var words = new ushort[size / 2];
-        var coeff = Field.RecoveryCoefficient(exponent, 0);
-        foreach (var slice in fileSlices)
+        for (var sliceIndex = 0; sliceIndex < fileSlices.Length; sliceIndex++)
         {
+            var coeff = Field.RecoveryCoefficient(exponent, sliceIndex);
+            var slice = fileSlices[sliceIndex];
             for (var w = 0; w < words.Length; w++)
             {
                 var word = BitConverter.ToUInt16(slice, w * 2);

--- a/backend/Par2Recovery/ReedSolomon/Gf16Field.cs
+++ b/backend/Par2Recovery/ReedSolomon/Gf16Field.cs
@@ -1,0 +1,62 @@
+namespace NzbWebDAV.Par2Recovery.ReedSolomon;
+
+/// <summary>
+/// Galois field GF(2^16) per PAR 2.0 (irreducible polynomial 0x1100B).
+/// </summary>
+public sealed class Gf16Field
+{
+    private const uint Polynomial = 0x1100B;
+    public const int Order = 65536;
+
+    private readonly ushort[] _log = new ushort[Order];
+    private readonly ushort[] _exp = new ushort[Order];
+
+    public Gf16Field()
+    {
+        uint x = 1;
+        for (var i = 0; i < Order - 1; i++)
+        {
+            _exp[i] = (ushort)x;
+            _log[x] = (ushort)i;
+            x <<= 1;
+            if ((x & 0x10000) != 0)
+                x ^= Polynomial;
+        }
+    }
+
+    public ushort Add(ushort a, ushort b) => (ushort)(a ^ b);
+
+    public ushort Mul(ushort a, ushort b)
+    {
+        if (a == 0 || b == 0) return 0;
+        var logSum = _log[a] + _log[b];
+        if (logSum >= Order - 1) logSum -= Order - 1;
+        return _exp[logSum];
+    }
+
+    public ushort Div(ushort a, ushort b)
+    {
+        if (b == 0) throw new DivideByZeroException();
+        if (a == 0) return 0;
+        var logDiff = _log[a] - _log[b];
+        if (logDiff < 0) logDiff += Order - 1;
+        return _exp[logDiff];
+    }
+
+    public ushort Pow(ushort baseValue, int exponent)
+    {
+        if (exponent == 0) return 1;
+        if (baseValue == 0) return 0;
+        var log = _log[baseValue] * exponent;
+        log %= Order - 1;
+        if (log < 0) log += Order - 1;
+        return _exp[log];
+    }
+
+    /// <summary>PAR2 coefficient for recovery-set file index and RecvSlic exponent.</summary>
+    public ushort RecoveryCoefficient(uint exponent, int fileIndex)
+    {
+        var basePow = Pow(2, (int)exponent);
+        return Pow(basePow, fileIndex);
+    }
+}

--- a/backend/Par2Recovery/ReedSolomon/Par2Reconstructor.cs
+++ b/backend/Par2Recovery/ReedSolomon/Par2Reconstructor.cs
@@ -1,0 +1,273 @@
+using System.Buffers;
+using System.IO.Hashing;
+using System.Security.Cryptography;
+using NzbWebDAV.Par2Recovery.Packets;
+
+namespace NzbWebDAV.Par2Recovery.ReedSolomon;
+
+#pragma warning disable CA5351 // PAR 2.0 IFSC/file hashes use MD5 per spec
+
+/// <summary>
+/// Bounded-memory PAR2 Reed-Solomon reconstruction for a single recovery set.
+/// </summary>
+public sealed class Par2Reconstructor
+{
+    private readonly Gf16Field _field = new();
+
+    public sealed record RecoverySlice(uint Exponent, byte[] Data);
+
+    public sealed record ReconstructionResult(
+        bool Success,
+        Dictionary<int, byte[]> ReconstructedSlices,
+        string? FailureReason);
+
+    /// <summary>
+    /// Reconstruct missing slice indices using collected recovery slices and present data fetches.
+    /// Whole-file MD5 is computed during the mandatory reduction read — no separate download pass.
+    /// </summary>
+    public async Task<ReconstructionResult> ReconstructAsync(
+        MainPacket main,
+        IReadOnlyDictionary<string, FileDesc> fileDescsById,
+        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId,
+        IReadOnlyList<int> missingSliceIndices,
+        IReadOnlyList<RecoverySlice> recoverySlices,
+        Func<int, int, CancellationToken, Task<byte[]?>> fetchSliceBytesAsync,
+        CancellationToken ct)
+    {
+        var k = missingSliceIndices.Count;
+        if (k == 0)
+            return new ReconstructionResult(true, new Dictionary<int, byte[]>(), null);
+
+        if (recoverySlices.Count < k)
+            return Fail($"Need {k} recovery slices but only {recoverySlices.Count} available.");
+
+        var sliceSize = (int)main.SliceSize;
+        var selected = recoverySlices.Take(k).ToList();
+        var missingSet = new HashSet<int>(missingSliceIndices);
+
+        var matrix = new ushort[k][];
+        for (var row = 0; row < k; row++)
+        {
+            matrix[row] = new ushort[k];
+            var exp = selected[row].Exponent;
+            for (var col = 0; col < k; col++)
+            {
+                var (fileIndex, _) = MapGlobalSlice(missingSliceIndices[col], main, ifscsByFileId);
+                matrix[row][col] = _field.RecoveryCoefficient(exp, fileIndex);
+            }
+        }
+
+        if (!TryInvert(matrix, k))
+            return Fail("Recovery slice coefficient matrix is not invertible.");
+
+        var accumulators = selected.Select(s =>
+        {
+            var words = new ushort[sliceSize / 2];
+            for (var w = 0; w < words.Length; w++)
+                words[w] = BitConverter.ToUInt16(s.Data, w * 2);
+            return words;
+        }).ToArray();
+
+        var sliceBuffer = ArrayPool<byte>.Shared.Rent(sliceSize);
+        var pendingFileHashes = new List<(FileDesc desc, IncrementalHash hasher, long bytesHashed)>();
+        try
+        {
+            var globalSlice = 0;
+            for (var fileIndex = 0; fileIndex < main.FileIds.Count; fileIndex++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var fileId = main.FileIds[fileIndex];
+                var key = Convert.ToHexString(fileId);
+                if (!fileDescsById.TryGetValue(key, out var desc))
+                    return Fail($"FileDesc missing for FileID {key}.");
+                if (!ifscsByFileId.TryGetValue(key, out var ifsc))
+                    return Fail($"IFSC missing for FileID {key}.");
+
+#pragma warning disable CA2000 // IncrementalHash instances are disposed in the outer finally block
+                var fileMd5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+#pragma warning restore CA2000
+                long bytesHashed = 0;
+
+                for (var local = 0; local < ifsc.Slices.Count; local++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var sliceIndex = globalSlice + local;
+                    var checksum = ifsc.Slices[local];
+                    var isMissing = missingSet.Contains(sliceIndex);
+
+                    byte[]? fetched = await fetchSliceBytesAsync(sliceIndex, sliceSize, ct).ConfigureAwait(false);
+                    if (fetched == null)
+                    {
+                        if (!isMissing)
+                            return Fail($"Unexpected missing slice {sliceIndex} during reduction.");
+                        Array.Clear(sliceBuffer, 0, sliceSize);
+                    }
+                    else
+                    {
+                        if (fetched.Length > sliceSize)
+                            return Fail($"Slice {sliceIndex} longer than slice size.");
+                        Array.Clear(sliceBuffer, 0, sliceSize);
+                        fetched.AsSpan(0, fetched.Length).CopyTo(sliceBuffer);
+                        if (!VerifySliceChecksum(sliceBuffer, checksum))
+                        {
+                            if (isMissing)
+                                Array.Clear(sliceBuffer, 0, sliceSize);
+                            else
+                                return Fail($"Present slice {sliceIndex} failed IFSC verification.");
+                        }
+                    }
+
+                    if (!isMissing)
+                    {
+                        var validLen = (int)Math.Min(sliceSize, (long)desc.FileLength - bytesHashed);
+                        if (validLen > 0)
+                            fileMd5.AppendData(sliceBuffer.AsSpan(0, validLen));
+                        bytesHashed += validLen;
+
+                        for (var r = 0; r < k; r++)
+                        {
+                            var coeff = _field.RecoveryCoefficient(selected[r].Exponent, fileIndex);
+                            if (coeff == 0) continue;
+                            var acc = accumulators[r];
+                            for (var w = 0; w < sliceSize / 2; w++)
+                            {
+                                var word = BitConverter.ToUInt16(sliceBuffer, w * 2);
+                                acc[w] = _field.Add(acc[w], _field.Mul(coeff, word));
+                            }
+                        }
+                    }
+                }
+
+                pendingFileHashes.Add((desc, fileMd5, bytesHashed));
+                globalSlice += ifsc.Slices.Count;
+            }
+
+            var reconstructed = new Dictionary<int, byte[]>();
+            for (var mi = 0; mi < k; mi++)
+            {
+                var missingIndex = missingSliceIndices[mi];
+                var outSlice = new byte[sliceSize];
+                for (var w = 0; w < sliceSize / 2; w++)
+                {
+                    ushort value = 0;
+                    for (var j = 0; j < k; j++)
+                        value = _field.Add(value, _field.Mul(matrix[mi][j], accumulators[j][w]));
+                    BitConverter.TryWriteBytes(outSlice.AsSpan(w * 2, 2), value);
+                }
+
+                var (fileIdx, localIdx) = MapGlobalSlice(missingIndex, main, ifscsByFileId);
+                var ifscKey = Convert.ToHexString(main.FileIds[fileIdx]);
+                var ifsc = ifscsByFileId[ifscKey];
+                if (!VerifySliceChecksum(outSlice, ifsc.Slices[localIdx]))
+                    return Fail($"Reconstructed slice {missingIndex} failed IFSC verification.");
+
+                reconstructed[missingIndex] = outSlice;
+
+                var pending = pendingFileHashes[fileIdx];
+                var remaining = (long)pending.desc.FileLength - pending.bytesHashed;
+                if (remaining > 0)
+                {
+                    var validLen = (int)Math.Min(sliceSize, remaining);
+                    pending.hasher.AppendData(outSlice.AsSpan(0, validLen));
+                    pendingFileHashes[fileIdx] = (pending.desc, pending.hasher, pending.bytesHashed + validLen);
+                }
+            }
+
+            foreach (var (desc, hasher, bytesHashed) in pendingFileHashes)
+            {
+                if (bytesHashed != (long)desc.FileLength)
+                    return Fail($"Incomplete whole-file MD5 coverage for {desc.FileName}.");
+                var computed = hasher.GetHashAndReset();
+                if (!computed.AsSpan().SequenceEqual(desc.FileHash))
+                    return Fail($"Whole-file MD5 mismatch for {desc.FileName}.");
+            }
+
+            return new ReconstructionResult(true, reconstructed, null);
+        }
+        finally
+        {
+            foreach (var (_, hasher, _) in pendingFileHashes)
+                hasher.Dispose();
+            ArrayPool<byte>.Shared.Return(sliceBuffer);
+        }
+    }
+
+    private static (int fileIndex, int localSlice) MapGlobalSlice(
+        int globalSlice,
+        MainPacket main,
+        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId)
+    {
+        var offset = 0;
+        for (var fi = 0; fi < main.FileIds.Count; fi++)
+        {
+            var key = Convert.ToHexString(main.FileIds[fi]);
+            var count = ifscsByFileId[key].Slices.Count;
+            if (globalSlice < offset + count)
+                return (fi, globalSlice - offset);
+            offset += count;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(globalSlice));
+    }
+
+    private static bool VerifySliceChecksum(byte[] slice, IfscPacket.SliceChecksum checksum)
+    {
+        var md5 = MD5.HashData(slice);
+        if (!md5.AsSpan().SequenceEqual(checksum.Md5)) return false;
+        var crc = BitConverter.ToUInt32(Crc32.Hash(slice));
+        return crc == checksum.Crc32;
+    }
+
+    private bool TryInvert(ushort[][] matrix, int n)
+    {
+        var inv = new ushort[n][];
+        for (var i = 0; i < n; i++)
+        {
+            inv[i] = new ushort[n];
+            inv[i][i] = 1;
+        }
+
+        for (var col = 0; col < n; col++)
+        {
+            var pivot = col;
+            while (pivot < n && matrix[pivot][col] == 0)
+                pivot++;
+            if (pivot == n) return false;
+
+            if (pivot != col)
+            {
+                (matrix[col], matrix[pivot]) = (matrix[pivot], matrix[col]);
+                (inv[col], inv[pivot]) = (inv[pivot], inv[col]);
+            }
+
+            var pivotVal = matrix[col][col];
+            for (var c = 0; c < n; c++)
+            {
+                matrix[col][c] = _field.Div(matrix[col][c], pivotVal);
+                inv[col][c] = _field.Div(inv[col][c], pivotVal);
+            }
+
+            for (var row = 0; row < n; row++)
+            {
+                if (row == col) continue;
+                var factor = matrix[row][col];
+                if (factor == 0) continue;
+                for (var c = 0; c < n; c++)
+                {
+                    matrix[row][c] = _field.Add(matrix[row][c], _field.Mul(factor, matrix[col][c]));
+                    inv[row][c] = _field.Add(inv[row][c], _field.Mul(factor, inv[col][c]));
+                }
+            }
+        }
+
+        for (var i = 0; i < n; i++)
+            matrix[i] = inv[i];
+
+        return true;
+    }
+
+    private static ReconstructionResult Fail(string reason)
+        => new(false, new Dictionary<int, byte[]>(), reason);
+}
+
+#pragma warning restore CA5351

--- a/backend/Par2Recovery/ReedSolomon/Par2Reconstructor.cs
+++ b/backend/Par2Recovery/ReedSolomon/Par2Reconstructor.cs
@@ -51,10 +51,7 @@ public sealed class Par2Reconstructor
             matrix[row] = new ushort[k];
             var exp = selected[row].Exponent;
             for (var col = 0; col < k; col++)
-            {
-                var (fileIndex, _) = MapGlobalSlice(missingSliceIndices[col], main, ifscsByFileId);
-                matrix[row][col] = _field.RecoveryCoefficient(exp, fileIndex);
-            }
+                matrix[row][col] = _field.RecoveryCoefficient(exp, missingSliceIndices[col]);
         }
 
         if (!TryInvert(matrix, k))
@@ -69,7 +66,7 @@ public sealed class Par2Reconstructor
         }).ToArray();
 
         var sliceBuffer = ArrayPool<byte>.Shared.Rent(sliceSize);
-        var pendingFileHashes = new List<(FileDesc desc, IncrementalHash hasher, long bytesHashed)>();
+        var pendingFileHashes = new List<(FileDesc desc, IncrementalHash hasher, long bytesHashed, bool hashContiguous)>();
         try
         {
             var globalSlice = 0;
@@ -87,6 +84,7 @@ public sealed class Par2Reconstructor
                 var fileMd5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
 #pragma warning restore CA2000
                 long bytesHashed = 0;
+                bool hashContiguous = true;
 
                 for (var local = 0; local < ifsc.Slices.Count; local++)
                 {
@@ -101,6 +99,7 @@ public sealed class Par2Reconstructor
                         if (!isMissing)
                             return Fail($"Unexpected missing slice {sliceIndex} during reduction.");
                         Array.Clear(sliceBuffer, 0, sliceSize);
+                        hashContiguous = false;
                     }
                     else
                     {
@@ -111,22 +110,33 @@ public sealed class Par2Reconstructor
                         if (!VerifySliceChecksum(sliceBuffer, checksum))
                         {
                             if (isMissing)
+                            {
                                 Array.Clear(sliceBuffer, 0, sliceSize);
+                                hashContiguous = false;
+                            }
                             else
                                 return Fail($"Present slice {sliceIndex} failed IFSC verification.");
                         }
                     }
 
-                    if (!isMissing)
+                    if (!isMissing && hashContiguous)
                     {
                         var validLen = (int)Math.Min(sliceSize, (long)desc.FileLength - bytesHashed);
                         if (validLen > 0)
                             fileMd5.AppendData(sliceBuffer.AsSpan(0, validLen));
                         bytesHashed += validLen;
+                    }
+                    else if (!isMissing)
+                    {
+                        var advance = (int)Math.Min(sliceSize, (long)desc.FileLength - bytesHashed);
+                        bytesHashed += advance;
+                    }
 
+                    if (!isMissing)
+                    {
                         for (var r = 0; r < k; r++)
                         {
-                            var coeff = _field.RecoveryCoefficient(selected[r].Exponent, fileIndex);
+                            var coeff = _field.RecoveryCoefficient(selected[r].Exponent, sliceIndex);
                             if (coeff == 0) continue;
                             var acc = accumulators[r];
                             for (var w = 0; w < sliceSize / 2; w++)
@@ -138,7 +148,7 @@ public sealed class Par2Reconstructor
                     }
                 }
 
-                pendingFileHashes.Add((desc, fileMd5, bytesHashed));
+                pendingFileHashes.Add((desc, fileMd5, bytesHashed, hashContiguous));
                 globalSlice += ifsc.Slices.Count;
             }
 
@@ -164,17 +174,22 @@ public sealed class Par2Reconstructor
                 reconstructed[missingIndex] = outSlice;
 
                 var pending = pendingFileHashes[fileIdx];
-                var remaining = (long)pending.desc.FileLength - pending.bytesHashed;
-                if (remaining > 0)
+                if (pending.hashContiguous)
                 {
-                    var validLen = (int)Math.Min(sliceSize, remaining);
-                    pending.hasher.AppendData(outSlice.AsSpan(0, validLen));
-                    pendingFileHashes[fileIdx] = (pending.desc, pending.hasher, pending.bytesHashed + validLen);
+                    var remaining = (long)pending.desc.FileLength - pending.bytesHashed;
+                    if (remaining > 0)
+                    {
+                        var validLen = (int)Math.Min(sliceSize, remaining);
+                        pending.hasher.AppendData(outSlice.AsSpan(0, validLen));
+                        pendingFileHashes[fileIdx] = (pending.desc, pending.hasher, pending.bytesHashed + validLen, true);
+                    }
                 }
             }
 
-            foreach (var (desc, hasher, bytesHashed) in pendingFileHashes)
+            foreach (var (desc, hasher, bytesHashed, hashContiguous) in pendingFileHashes)
             {
+                if (!hashContiguous)
+                    continue;
                 if (bytesHashed != (long)desc.FileLength)
                     return Fail($"Incomplete whole-file MD5 coverage for {desc.FileName}.");
                 var computed = hasher.GetHashAndReset();
@@ -186,7 +201,7 @@ public sealed class Par2Reconstructor
         }
         finally
         {
-            foreach (var (_, hasher, _) in pendingFileHashes)
+            foreach (var (_, hasher, _, _) in pendingFileHashes)
                 hasher.Dispose();
             ArrayPool<byte>.Shared.Return(sliceBuffer);
         }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -26,6 +26,7 @@ using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.Observability;
 using NzbWebDAV.Services.SupportPack;
 using NzbWebDAV.Services.StreamTrace;
@@ -300,6 +301,21 @@ public partial class Program
                     sp.GetRequiredService<ConfigManager>(),
                     () => new DavDatabaseContext()))
                 .AddHostedService(sp => sp.GetRequiredService<ArticleMissNegativeCache>())
+                .AddSingleton(sp =>
+                {
+                    var cfg = sp.GetRequiredService<ConfigManager>();
+                    return new RepairPatchStore(
+                        cfg.GetRepairPatchStorePath(),
+                        cfg.GetPar2MaxPatchBytes());
+                })
+                .AddSingleton<Par2RepairService>()
+                .AddHostedService(sp => sp.GetRequiredService<Par2RepairService>())
+                .AddSingleton(sp =>
+                {
+                    var sink = new Par2RepairTriggerSink(sp.GetRequiredService<Par2RepairService>());
+                    Par2RepairTriggerSink.Current = sink;
+                    return sink;
+                })
                 .AddSingleton<WardenStore>()
                 .AddSingleton<WardenRemoteSourceService>()
                 .AddHostedService(sp => sp.GetRequiredService<WardenRemoteSourceService>())

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -684,20 +684,13 @@ public class HealthCheckService : BackgroundService
             .Select((id, index) => (id, index))
             .ToDictionary(x => x.id, x => x.index, StringComparer.Ordinal);
         var ranges = nzbFile.SegmentByteRanges;
-        var unrepaired = new List<string>(sampledSegmentIds.Count);
 
-        foreach (var segmentId in sampledSegmentIds)
-        {
-            if (!indexById.TryGetValue(segmentId, out var index)
-                || ranges == null
-                || index >= ranges.Length
-                || !patchStore.IsRepaired(segmentId, ranges[index].Count))
-            {
-                unrepaired.Add(segmentId);
-            }
-        }
-
-        return unrepaired;
+        return sampledSegmentIds
+            .Where(segmentId => !indexById.TryGetValue(segmentId, out var index)
+                                || ranges == null
+                                || index >= ranges.Length
+                                || !patchStore.IsRepaired(segmentId, ranges[index].Count))
+            .ToList();
     }
 
     private async Task UpdateReleaseDate(DavItem davItem, List<string> segments, CancellationToken ct)

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -12,6 +12,7 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -64,6 +65,8 @@ public class HealthCheckService : BackgroundService
     private readonly BenchmarkGate _benchmarkGate;
     private readonly StreamingFailureTracker _failureTracker;
     private readonly QueueManager _queueManager;
+    private readonly Par2RepairService _par2RepairService;
+    private readonly RepairPatchStore _repairPatchStore;
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
@@ -77,7 +80,9 @@ public class HealthCheckService : BackgroundService
         WebsocketManager websocketManager,
         BenchmarkGate benchmarkGate,
         StreamingFailureTracker failureTracker,
-        QueueManager queueManager
+        QueueManager queueManager,
+        Par2RepairService par2RepairService,
+        RepairPatchStore repairPatchStore
     )
     {
         _configManager = configManager;
@@ -86,6 +91,8 @@ public class HealthCheckService : BackgroundService
         _benchmarkGate = benchmarkGate;
         _failureTracker = failureTracker;
         _queueManager = queueManager;
+        _par2RepairService = par2RepairService;
+        _repairPatchStore = repairPatchStore;
 
         _configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -315,6 +322,12 @@ public class HealthCheckService : BackgroundService
                 ? DateTimeOffset.UtcNow - posted
                 : (TimeSpan?)null;
             var sampled = SampleSegments(segments, _configManager.GetHealthCheckDepth(), age);
+            var nzbFile = davItem.SubType == DavItem.ItemSubType.NzbFile
+                ? await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false)
+                : null;
+            var statSegments = nzbFile != null
+                ? FilterSegmentsForStat(sampled, segments, nzbFile, _repairPatchStore)
+                : sampled;
 
             // setup progress tracking
             var progressHook = new Progress<int>();
@@ -336,9 +349,9 @@ public class HealthCheckService : BackgroundService
             using (statCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(ct))
             {
                 statCts.CancelAfter(HealthCheckProgressTimeout);
-                var progress = progressHook.ToPercentage(sampled.Count);
+                var progress = progressHook.ToPercentage(statSegments.Count);
                 await ArticleExistenceChecker.CheckAsync(
-                    _usenetClient, sampled, concurrency, progress, statCts.Token).ConfigureAwait(false);
+                    _usenetClient, statSegments, concurrency, progress, statCts.Token).ConfigureAwait(false);
             }
             CompleteHealthProgress(davItem.Id);
 
@@ -351,9 +364,14 @@ public class HealthCheckService : BackgroundService
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             _failureTracker.ClearFailure(davItem.Id);
             _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
-            var healthyMessage = sampled.Count < totalSegments
-                ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
-                : "File is healthy.";
+            var repairedCount = nzbFile != null
+                ? Par2RepairService.CountRepairedSegments(nzbFile, _repairPatchStore)
+                : 0;
+            var healthyMessage = repairedCount > 0
+                ? $"File is healthy ({repairedCount} segment{(repairedCount == 1 ? "" : "s")} repaired from PAR2 parity)."
+                : sampled.Count < totalSegments
+                    ? $"File is healthy (sampled {sampled.Count}/{totalSegments} segments)."
+                    : "File is healthy.";
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Healthy,
@@ -414,7 +432,23 @@ public class HealthCheckService : BackgroundService
                 }
             }
 
-            // when usenet article is missing, perform repairs
+            // when usenet article is missing, try PAR2 repair before Arr remove/re-grab
+            if (_configManager.IsPar2RepairEnabled() && _configManager.IsPar2PreferredOverArr()
+                && await _par2RepairService.TryPar2RepairAsync(davItem, [e.SegmentId], ct).ConfigureAwait(false))
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
+                _failureTracker.ClearFailure(davItem.Id);
+                _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Healthy,
+                    HealthCheckResult.RepairAction.RepairedViaPar2,
+                    "Missing segment repaired from PAR2 parity.", ct).ConfigureAwait(false);
+                return;
+            }
+
             await Repair(davItem, dbClient, ct).ConfigureAwait(false);
         }
         catch (UsenetUnexpectedResponseException e)
@@ -636,6 +670,34 @@ public class HealthCheckService : BackgroundService
         }
 
         return result.OrderBy(i => i).Select(i => segments[i]).ToList();
+    }
+
+    internal static List<string> FilterSegmentsForStat(
+        List<string> sampledSegmentIds,
+        List<string> allSegmentIds,
+        DavNzbFile nzbFile,
+        RepairPatchStore patchStore)
+    {
+        if (!patchStore.IsCatalogReady) return sampledSegmentIds;
+
+        var indexById = allSegmentIds
+            .Select((id, index) => (id, index))
+            .ToDictionary(x => x.id, x => x.index, StringComparer.Ordinal);
+        var ranges = nzbFile.SegmentByteRanges;
+        var unrepaired = new List<string>(sampledSegmentIds.Count);
+
+        foreach (var segmentId in sampledSegmentIds)
+        {
+            if (!indexById.TryGetValue(segmentId, out var index)
+                || ranges == null
+                || index >= ranges.Length
+                || !patchStore.IsRepaired(segmentId, ranges[index].Count))
+            {
+                unrepaired.Add(segmentId);
+            }
+        }
+
+        return unrepaired;
     }
 
     private async Task UpdateReleaseDate(DavItem davItem, List<string> segments, CancellationToken ct)
@@ -948,6 +1010,23 @@ public class HealthCheckService : BackgroundService
                     $"Streaming failure count: {failureCount}/{threshold}.",
                     "Repair and replacement deferred until the failure threshold is reached."
                 ]), ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (_configManager.IsPar2RepairEnabled() && _configManager.IsPar2PreferredOverArr()
+            && await _par2RepairService.TryPar2RepairAsync(davItem, null, ct).ConfigureAwait(false))
+        {
+            var utcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
+            _failureTracker.ClearFailure(davItem.Id);
+            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Healthy,
+                HealthCheckResult.RepairAction.RepairedViaPar2,
+                "Missing segment(s) repaired from PAR2 parity after streaming failure.", ct)
+                .ConfigureAwait(false);
             return;
         }
 

--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -37,7 +37,8 @@ public sealed class PrometheusMetrics
     private readonly Histogram _seekLatency;
     private readonly Histogram _par2RepairDuration;
     private readonly Counter _par2RepairBytesRead;
-    private readonly Counter _par2SegmentsReconstructed;
+    private readonly Counter _par2SlicesReconstructed;
+    private readonly Counter _par2SegmentsCommitted;
     private readonly Counter _par2ValidationFailures;
     private readonly Gauge _par2PatchStoreBytes;
     private readonly Counter _par2PatchHits;
@@ -83,9 +84,12 @@ public sealed class PrometheusMetrics
         _par2RepairBytesRead = metrics.CreateCounter(
             "nzbdav_par2_repair_bytes_read_total",
             "NNTP bytes read during PAR2 repairs.");
-        _par2SegmentsReconstructed = metrics.CreateCounter(
-            "nzbdav_par2_repair_segments_reconstructed_total",
-            "Segments reconstructed and committed by PAR2 repair.");
+        _par2SlicesReconstructed = metrics.CreateCounter(
+            "nzbdav_par2_repair_slices_reconstructed_total",
+            "PAR2 slices reconstructed from recovery data.");
+        _par2SegmentsCommitted = metrics.CreateCounter(
+            "nzbdav_par2_repair_segments_committed_total",
+            "Segments committed to the repair patch store by PAR2 repair.");
         _par2ValidationFailures = metrics.CreateCounter(
             "nzbdav_par2_validation_failures_total",
             "PAR2 validation gate failures.",
@@ -122,7 +126,9 @@ public sealed class PrometheusMetrics
 
     public void AddPar2RepairBytesRead(long bytes) => _par2RepairBytesRead.Inc(bytes);
 
-    public void AddPar2SegmentsReconstructed(int count) => _par2SegmentsReconstructed.Inc(count);
+    public void AddPar2SlicesReconstructed(int count) => _par2SlicesReconstructed.Inc(count);
+
+    public void AddPar2SegmentsCommitted(int count) => _par2SegmentsCommitted.Inc(count);
 
     public void RecordPar2ValidationFailure(string gate) => _par2ValidationFailures.WithLabels(gate).Inc();
 

--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -35,6 +35,14 @@ public sealed class PrometheusMetrics
     private readonly Histogram _segmentFetchDuration;
     private readonly Counter _seekCount;
     private readonly Histogram _seekLatency;
+    private readonly Histogram _par2RepairDuration;
+    private readonly Counter _par2RepairBytesRead;
+    private readonly Counter _par2SegmentsReconstructed;
+    private readonly Counter _par2ValidationFailures;
+    private readonly Gauge _par2PatchStoreBytes;
+    private readonly Counter _par2PatchHits;
+    private readonly Counter _par2PatchEvictions;
+    private readonly Counter _par2RepairJobs;
     private readonly HashSet<string> _providerKeys = new(StringComparer.Ordinal);
 
     public PrometheusMetrics(CollectorRegistry registry)
@@ -64,6 +72,33 @@ public sealed class PrometheusMetrics
         _segmentFetchDuration = metrics.CreateHistogram("nzbdav_segment_fetch_duration_seconds", "Segment fetch duration.", new HistogramConfiguration { LabelNames = ["provider_key"], Buckets = Histogram.ExponentialBuckets(0.01, 2, 14) });
         _seekCount = metrics.CreateCounter("nzbdav_seek_total", "Seek operations.", new CounterConfiguration { LabelNames = ["kind"] });
         _seekLatency = metrics.CreateHistogram("nzbdav_seek_latency_seconds", "Post-seek preparation latency.", new HistogramConfiguration { LabelNames = ["kind"], Buckets = Histogram.ExponentialBuckets(0.001, 2, 14) });
+        _par2RepairJobs = metrics.CreateCounter(
+            "nzbdav_par2_repair_jobs_total",
+            "PAR2 background repair job state transitions.",
+            new CounterConfiguration { LabelNames = ["state"] });
+        _par2RepairDuration = metrics.CreateHistogram(
+            "nzbdav_par2_repair_duration_seconds",
+            "PAR2 background repair job duration.",
+            new HistogramConfiguration { Buckets = Histogram.ExponentialBuckets(1, 2, 14) });
+        _par2RepairBytesRead = metrics.CreateCounter(
+            "nzbdav_par2_repair_bytes_read_total",
+            "NNTP bytes read during PAR2 repairs.");
+        _par2SegmentsReconstructed = metrics.CreateCounter(
+            "nzbdav_par2_repair_segments_reconstructed_total",
+            "Segments reconstructed and committed by PAR2 repair.");
+        _par2ValidationFailures = metrics.CreateCounter(
+            "nzbdav_par2_validation_failures_total",
+            "PAR2 validation gate failures.",
+            new CounterConfiguration { LabelNames = ["gate"] });
+        _par2PatchStoreBytes = metrics.CreateGauge(
+            "nzbdav_par2_patch_store_bytes",
+            "Current repair patch store size in bytes.");
+        _par2PatchHits = metrics.CreateCounter(
+            "nzbdav_par2_patch_hits_total",
+            "Segment fetches served from the repair patch store.");
+        _par2PatchEvictions = metrics.CreateCounter(
+            "nzbdav_par2_patch_evictions_total",
+            "Repair patch store evictions.");
     }
 
     public static PrometheusMetrics? Current { get; set; }
@@ -79,6 +114,23 @@ public sealed class PrometheusMetrics
         _seekCount.WithLabels(kind).Inc();
         _seekLatency.WithLabels(kind).Observe(elapsed.TotalSeconds);
     }
+
+    public void RecordPar2RepairJob(string state) => _par2RepairJobs.WithLabels(state).Inc();
+
+    public void ObservePar2RepairDuration(TimeSpan elapsed)
+        => _par2RepairDuration.Observe(elapsed.TotalSeconds);
+
+    public void AddPar2RepairBytesRead(long bytes) => _par2RepairBytesRead.Inc(bytes);
+
+    public void AddPar2SegmentsReconstructed(int count) => _par2SegmentsReconstructed.Inc(count);
+
+    public void RecordPar2ValidationFailure(string gate) => _par2ValidationFailures.WithLabels(gate).Inc();
+
+    public void SetPar2PatchStoreBytes(long bytes) => _par2PatchStoreBytes.Set(bytes);
+
+    public void RecordPar2PatchHit() => _par2PatchHits.Inc();
+
+    public void RecordPar2PatchEviction() => _par2PatchEvictions.Inc();
 
     public void Refresh(
         ActiveReadRegistry activeReads,

--- a/backend/Services/Observability/PrometheusMetricsCollector.cs
+++ b/backend/Services/Observability/PrometheusMetricsCollector.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
 using Serilog;
 
@@ -11,7 +12,8 @@ public sealed class PrometheusMetricsCollector(
     ActiveReadRegistry activeReads,
     ConcurrentReadTracker concurrentReads,
     MetricsWriter metricsWriter,
-    UsenetStreamingClient usenetClient) : BackgroundService
+    UsenetStreamingClient usenetClient,
+    RepairPatchStore repairPatchStore) : BackgroundService
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
 
@@ -22,7 +24,10 @@ public sealed class PrometheusMetricsCollector(
             try
             {
                 if (InFlightArticleBudget.Current is { } budget)
+                {
                     metrics.Refresh(activeReads, concurrentReads, budget, metricsWriter, usenetClient);
+                    metrics.SetPar2PatchStoreBytes(repairPatchStore.CurrentBytes);
+                }
             }
             catch (Exception ex) when (ex is not OutOfMemoryException)
             {

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -1,0 +1,971 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Par2Recovery.Packets;
+using NzbWebDAV.Par2Recovery.ReedSolomon;
+using NzbWebDAV.Services.Observability;
+using Serilog;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Services.Repair;
+
+public sealed class Par2RepairService : BackgroundService
+{
+    private const int MaxQueueLength = 50;
+    private const int MaxAttempts = 3;
+
+    private readonly ConfigManager _configManager;
+    private readonly UsenetStreamingClient _usenetClient;
+    private readonly RepairPatchStore _patchStore;
+    private readonly Channel<RepairWorkItem> _queue;
+    private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
+
+    public Par2RepairService(
+        ConfigManager configManager,
+        UsenetStreamingClient usenetClient,
+        RepairPatchStore patchStore)
+    {
+        _configManager = configManager;
+        _usenetClient = usenetClient;
+        _patchStore = patchStore;
+        _queue = Channel.CreateBounded<RepairWorkItem>(new BoundedChannelOptions(MaxQueueLength)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    public async Task EnqueueZeroFillAsync(
+        string path,
+        string segmentId,
+        int segmentIndex,
+        long fillBytes,
+        CancellationToken ct = default)
+    {
+        if (!_configManager.IsPar2RepairEnabled()) return;
+
+        await using var dbContext = new DavDatabaseContext();
+        var dbClient = new DavDatabaseClient(dbContext);
+        var davItem = await dbClient.GetItemByPathAsync(path, ct).ConfigureAwait(false);
+        if (davItem == null) return;
+
+        await EnqueueAsync(davItem, [segmentId], ct).ConfigureAwait(false);
+    }
+
+    public async Task EnqueueAsync(
+        DavItem davItem,
+        IReadOnlyList<string> missingSegmentIds,
+        CancellationToken ct = default)
+    {
+        if (!_configManager.IsPar2RepairEnabled()) return;
+        if (missingSegmentIds.Count == 0) return;
+        if (!await ShouldEnqueueAsync(davItem.Id, ct).ConfigureAwait(false)) return;
+
+        if (!_queuedOrRunning.TryAdd(davItem.Id, 0))
+            return;
+
+        var item = new RepairWorkItem(davItem.Id, davItem.Path, missingSegmentIds.Distinct().ToArray());
+        if (!_queue.Writer.TryWrite(item))
+        {
+            _queuedOrRunning.TryRemove(davItem.Id, out _);
+            Log.Warning(
+                "PAR2 repair queue full ({Capacity}); dropping repair request for {Path}",
+                MaxQueueLength, davItem.Path);
+            PrometheusMetrics.Current?.RecordPar2RepairJob("dropped");
+            return;
+        }
+
+        PrometheusMetrics.Current?.RecordPar2RepairJob("queued");
+    }
+
+    /// <summary>
+    /// Attempts PAR2 repair synchronously for health-check and urgent paths.
+    /// Returns true when reconstruction succeeded and patches were committed.
+    /// </summary>
+    public Task<bool> TryPar2RepairAsync(
+        DavItem davItem,
+        IReadOnlyList<string>? missingSegmentIds,
+        CancellationToken ct)
+        => RunRepairAsync(davItem, missingSegmentIds, queueGuard: false, ct);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _patchStore.CatalogLoadTask.ConfigureAwait(false);
+
+        await foreach (var item in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                await ProcessQueueItemAsync(item, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                _queuedOrRunning.TryRemove(item.DavItemId, out _);
+                e.LogWarningKnownOrStack("PAR2 background repair worker failed for {Path}", item.Path);
+            }
+        }
+    }
+
+    private async Task ProcessQueueItemAsync(RepairWorkItem item, CancellationToken ct)
+    {
+        await using var dbContext = new DavDatabaseContext();
+        var dbClient = new DavDatabaseClient(dbContext);
+        var davItem = await dbClient.Ctx.Items
+            .FirstOrDefaultAsync(x => x.Id == item.DavItemId, ct)
+            .ConfigureAwait(false);
+        if (davItem == null)
+        {
+            _queuedOrRunning.TryRemove(item.DavItemId, out _);
+            return;
+        }
+
+        await RunRepairAsync(davItem, item.MissingSegmentIds, queueGuard: true, ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<bool> RunRepairAsync(
+        DavItem davItem,
+        IReadOnlyList<string>? missingSegmentIds,
+        bool queueGuard,
+        CancellationToken ct)
+    {
+        if (!_configManager.IsPar2RepairEnabled())
+        {
+            if (queueGuard) _queuedOrRunning.TryRemove(davItem.Id, out _);
+            return false;
+        }
+
+        Par2RepairJob? job = null;
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            job = await CreateOrResumeJobAsync(davItem, missingSegmentIds, ct).ConfigureAwait(false);
+            if (job == null)
+            {
+                if (queueGuard) _queuedOrRunning.TryRemove(davItem.Id, out _);
+                return false;
+            }
+
+            job.State = Par2RepairJob.RepairJobState.Running;
+            job.StartedAt = DateTimeOffset.UtcNow;
+            await PersistJobAsync(job, ct).ConfigureAwait(false);
+            PrometheusMetrics.Current?.RecordPar2RepairJob("running");
+
+            // MaintenanceDownloadContext is attribution-only; it does NOT set AttributionContext,
+            // so recovery-volume BODY fetches MAY populate the playback segment cache (harmless).
+            using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
+
+            var result = await ExecuteRepairJobAsync(davItem, job, ct).ConfigureAwait(false);
+            stopwatch.Stop();
+
+            if (result.Success)
+            {
+                job.State = Par2RepairJob.RepairJobState.Succeeded;
+                job.CompletedAt = DateTimeOffset.UtcNow;
+                job.BytesRead = result.BytesRead;
+                job.SlicesReconstructed = result.SlicesReconstructed;
+                job.FailureReason = null;
+                await PersistJobAsync(job, ct).ConfigureAwait(false);
+                PrometheusMetrics.Current?.RecordPar2RepairJob("succeeded");
+                PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
+                PrometheusMetrics.Current?.SetPar2PatchStoreBytes(_patchStore.CurrentBytes);
+                Log.Information(
+                    "PAR2 repair succeeded for {Path}: {Slices} slice(s), {Bytes} bytes read in {Elapsed}",
+                    davItem.Path, result.SlicesReconstructed, result.BytesRead, stopwatch.Elapsed);
+                return true;
+            }
+
+            job.State = result.IsInfeasible
+                ? Par2RepairJob.RepairJobState.Infeasible
+                : Par2RepairJob.RepairJobState.Failed;
+            job.CompletedAt = DateTimeOffset.UtcNow;
+            job.FailureReason = result.FailureReason;
+            job.NextAttemptAt = DateTimeOffset.UtcNow +
+                                TimeSpan.FromHours(_configManager.GetPar2FailureCooldownHours());
+            await PersistJobAsync(job, ct).ConfigureAwait(false);
+            PrometheusMetrics.Current?.RecordPar2RepairJob(result.IsInfeasible ? "infeasible" : "failed");
+            PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
+            Log.Warning(
+                "PAR2 repair {Outcome} for {Path}. Reason: {Reason}",
+                result.IsInfeasible ? "infeasible" : "failed", davItem.Path, result.FailureReason);
+            return false;
+        }
+        catch (Exception e) when (e is not OperationCanceledException and not OutOfMemoryException)
+        {
+            stopwatch.Stop();
+            if (job != null)
+            {
+                job.State = Par2RepairJob.RepairJobState.Failed;
+                job.CompletedAt = DateTimeOffset.UtcNow;
+                job.Attempts++;
+                e.TryGetKnownErrorMessage(out var reason);
+                job.FailureReason = reason ?? e.Message;
+                job.NextAttemptAt = DateTimeOffset.UtcNow +
+                                    TimeSpan.FromHours(_configManager.GetPar2FailureCooldownHours());
+                await PersistJobAsync(job, ct).ConfigureAwait(false);
+            }
+
+            e.LogWarningKnownOrStack("PAR2 repair error for {Path}", davItem.Path);
+            PrometheusMetrics.Current?.RecordPar2RepairJob("failed");
+            PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
+            return false;
+        }
+        finally
+        {
+            if (queueGuard) _queuedOrRunning.TryRemove(davItem.Id, out _);
+        }
+    }
+
+    private async Task<RepairExecutionResult> ExecuteRepairJobAsync(
+        DavItem davItem,
+        Par2RepairJob job,
+        CancellationToken ct)
+    {
+        if (davItem.SubType != DavItem.ItemSubType.NzbFile)
+            return RepairExecutionResult.NotFeasible("PAR2 repair supports plain NZB files only.");
+
+        if (davItem.NzbBlobId is not Guid nzbBlobId)
+            return RepairExecutionResult.NotFeasible("NZB blob id is missing for this file.");
+
+        await using var nzbStream = BlobStore.ReadBlob(nzbBlobId);
+        if (nzbStream == null)
+            return RepairExecutionResult.NotFeasible("NZB blob is no longer available.");
+
+        NzbDocument nzbDocument;
+        try
+        {
+            nzbDocument = await NzbDocument.LoadAsync(nzbStream, ct).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            return RepairExecutionResult.NotFeasible($"Could not parse NZB blob: {e.Message}");
+        }
+
+        await using var dbContext = new DavDatabaseContext();
+        var dbClient = new DavDatabaseClient(dbContext);
+        var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
+        if (nzbFile?.SegmentIds is not { Length: > 0 } segmentIds)
+            return RepairExecutionResult.NotFeasible("Streaming payload metadata is missing.");
+
+        var contentNzb = FindContentNzbFile(nzbDocument, davItem.Name);
+        if (contentNzb == null)
+            return RepairExecutionResult.NotFeasible("Could not locate the content file in the NZB.");
+
+        var par2Context = await DiscoverPar2SetAsync(nzbDocument, contentNzb, davItem.Name, ct)
+            .ConfigureAwait(false);
+        if (par2Context == null)
+            return RepairExecutionResult.NotFeasible("No matching PAR2 recovery set found in the NZB.");
+
+        var missingSegments = ResolveMissingSegments(job.MissingSegmentIds, segmentIds);
+        if (missingSegments.Count == 0 && job.MissingSegmentIds.Length == 0)
+        {
+            missingSegments = segmentIds
+                .Select((id, index) => new MissingSegment(id, index))
+                .ToList();
+        }
+
+        if (missingSegments.Count == 0)
+            return RepairExecutionResult.NotFeasible("No missing segments to repair.");
+
+        var sliceSize = (int)par2Context.Main.SliceSize;
+        var maxMissingSlices = _configManager.GetPar2MaxMissingSlices();
+        var maxMemoryBytes = _configManager.GetPar2MaxMemoryMb() * 1024L * 1024L;
+        var workingSetBytes = (long)(missingSegments.Count + 2) * sliceSize;
+        if (workingSetBytes > maxMemoryBytes)
+            return RepairExecutionResult.NotFeasible(
+                $"PAR2 working set {workingSetBytes} bytes exceeds memory cap.");
+
+        var releaseBytesCap = _configManager.GetPar2MaxReleaseGb() * 1024L * 1024L * 1024L;
+        var releaseBytes = EstimateReleaseBytes(par2Context.Main, par2Context.FileDescsById);
+        if (releaseBytes > releaseBytesCap)
+            return RepairExecutionResult.NotFeasible(
+                $"Recovery set size {releaseBytes} bytes exceeds release cap.");
+
+        var segmentRanges = BuildSegmentRanges(nzbFile, segmentIds.Length, davItem.FileSize);
+        var missingSliceIndices = MapMissingSegmentsToSlices(
+            missingSegments, segmentRanges, sliceSize, par2Context.TargetFileIndex, par2Context.Main, par2Context.IfscsByFileId);
+        if (missingSliceIndices.Count == 0)
+            return RepairExecutionResult.NotFeasible("Missing segments do not map to PAR2 slices.");
+
+        if (missingSliceIndices.Count > maxMissingSlices)
+            return RepairExecutionResult.NotFeasible(
+                $"Missing slice count {missingSliceIndices.Count} exceeds cap {maxMissingSlices}.");
+
+        var fetchConcurrency = _configManager.GetPar2FetchConcurrency();
+        using var fetchGate = new SemaphoreSlim(fetchConcurrency, fetchConcurrency);
+        var bytesRead = 0L;
+
+        var recoverySlices = await CollectRecoverySlicesAsync(
+            par2Context.VolumeFiles,
+            missingSliceIndices.Count,
+            par2Context.Main.SliceSize,
+            fetchGate,
+            ct,
+            onBytesRead: n => bytesRead += n).ConfigureAwait(false);
+        if (recoverySlices.Count < missingSliceIndices.Count)
+            return RepairExecutionResult.NotFeasible(
+                $"Need {missingSliceIndices.Count} recovery slices but only collected {recoverySlices.Count}.");
+
+        var accessor = new SliceSegmentAccessor(
+            segmentIds,
+            segmentRanges,
+            contentNzb,
+            _usenetClient,
+            fetchGate,
+            onBytesRead: n => bytesRead += n);
+
+        var reconstructor = new Par2Reconstructor();
+        var reconstruction = await reconstructor.ReconstructAsync(
+            par2Context.Main,
+            par2Context.FileDescsById,
+            par2Context.IfscsByFileId,
+            missingSliceIndices,
+            recoverySlices,
+            (sliceIndex, size, token) => accessor.FetchSliceBytesAsync(sliceIndex, size, token),
+            ct).ConfigureAwait(false);
+
+        if (!reconstruction.Success)
+        {
+            PrometheusMetrics.Current?.RecordPar2ValidationFailure("slice");
+            return RepairExecutionResult.Failed(reconstruction.FailureReason ?? "Reconstruction failed.");
+        }
+
+        var patchTargets = job.MissingSegmentIds.Length > 0
+            ? missingSegments
+            : accessor.GetMissingSegments();
+        if (patchTargets.Count == 0)
+            return RepairExecutionResult.NotFeasible("No missing segments were confirmed during PAR2 repair.");
+
+        var commits = ExtractSegmentPatches(
+            patchTargets,
+            segmentRanges,
+            reconstruction.ReconstructedSlices,
+            sliceSize,
+            par2Context.TargetFileIndex,
+            par2Context.Main,
+            par2Context.IfscsByFileId,
+            davItem.Name,
+            davItem.FileSize ?? 0,
+            segmentIds.Length);
+
+        foreach (var patch in commits)
+            _patchStore.CommitPatch(patch.SegmentId, patch.Bytes, patch.Header);
+
+        PrometheusMetrics.Current?.AddPar2RepairBytesRead(bytesRead);
+        PrometheusMetrics.Current?.AddPar2SegmentsReconstructed(commits.Count);
+        job.MissingSegmentIds = patchTargets.Select(x => x.SegmentId).ToArray();
+        return RepairExecutionResult.Succeeded(bytesRead, reconstruction.ReconstructedSlices.Count);
+    }
+
+    private static List<SegmentPatch> ExtractSegmentPatches(
+        IReadOnlyList<MissingSegment> missingSegments,
+        LongRange[] segmentRanges,
+        Dictionary<int, byte[]> reconstructedSlices,
+        int sliceSize,
+        int targetFileIndex,
+        MainPacket main,
+        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId,
+        string fileName,
+        long fileSize,
+        int segmentCount)
+    {
+        var globalSliceOffset = GlobalSliceOffset(targetFileIndex, main, ifscsByFileId);
+        var patches = new List<SegmentPatch>();
+
+        foreach (var missing in missingSegments)
+        {
+            var range = segmentRanges[missing.Index];
+            var bytes = new byte[range.Count];
+            var copied = 0L;
+            var fileOffset = range.StartInclusive;
+
+            while (copied < range.Count)
+            {
+                var localSlice = (int)((fileOffset + copied) / sliceSize);
+                var globalSlice = globalSliceOffset + localSlice;
+                if (!reconstructedSlices.TryGetValue(globalSlice, out var slice))
+                    throw new InvalidOperationException($"Reconstructed slice {globalSlice} missing for segment patch.");
+
+                var offsetInSlice = (int)((fileOffset + copied) % sliceSize);
+                var toCopy = (int)Math.Min(range.Count - copied, sliceSize - offsetInSlice);
+                Buffer.BlockCopy(slice, offsetInSlice, bytes, (int)copied, toCopy);
+                copied += toCopy;
+            }
+
+            patches.Add(new SegmentPatch(
+                missing.SegmentId,
+                bytes,
+                new UsenetYencHeader
+                {
+                    FileName = fileName,
+                    FileSize = fileSize,
+                    LineLength = 128,
+                    PartNumber = missing.Index + 1,
+                    TotalParts = segmentCount,
+                    PartSize = range.Count,
+                    PartOffset = range.StartInclusive,
+                }));
+        }
+
+        return patches;
+    }
+
+    private static int GlobalSliceOffset(
+        int targetFileIndex,
+        MainPacket main,
+        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId)
+    {
+        var offset = 0;
+        for (var i = 0; i < targetFileIndex; i++)
+        {
+            var key = Convert.ToHexString(main.FileIds[i]);
+            offset += ifscsByFileId[key].Slices.Count;
+        }
+
+        return offset;
+    }
+
+    private static List<int> MapMissingSegmentsToSlices(
+        IReadOnlyList<MissingSegment> missingSegments,
+        LongRange[] segmentRanges,
+        int sliceSize,
+        int targetFileIndex,
+        MainPacket main,
+        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId)
+    {
+        var globalOffset = GlobalSliceOffset(targetFileIndex, main, ifscsByFileId);
+        var slices = new HashSet<int>();
+        foreach (var missing in missingSegments)
+        {
+            var start = segmentRanges[missing.Index].StartInclusive;
+            var end = segmentRanges[missing.Index].EndExclusive;
+            for (var offset = start; offset < end; offset += sliceSize)
+            {
+                var localSlice = (int)(offset / sliceSize);
+                slices.Add(globalOffset + localSlice);
+            }
+        }
+
+        return slices.OrderBy(x => x).ToList();
+    }
+
+    private static LongRange[] BuildSegmentRanges(DavNzbFile nzbFile, int segmentCount, long? fileSize)
+    {
+        if (nzbFile.SegmentByteRanges is { Length: var len } ranges && len == segmentCount)
+            return ranges;
+
+        if (fileSize is > 0 && segmentCount > 0)
+        {
+            var uniform = fileSize.Value / segmentCount;
+            if (uniform > 0)
+            {
+                var built = new LongRange[segmentCount];
+                long start = 0;
+                for (var i = 0; i < segmentCount; i++)
+                {
+                    var size = i == segmentCount - 1 ? fileSize.Value - start : uniform;
+                    built[i] = LongRange.FromStartAndSize(start, size);
+                    start += size;
+                }
+
+                return built;
+            }
+        }
+
+        throw new InvalidOperationException("Segment byte ranges are unavailable for PAR2 repair.");
+    }
+
+    private static List<MissingSegment> ResolveMissingSegments(string[] requestedIds, string[] segmentIds)
+    {
+        var indexById = segmentIds
+            .Select((id, index) => (id, index))
+            .ToDictionary(x => x.id, x => x.index, StringComparer.Ordinal);
+
+        var result = new List<MissingSegment>();
+        foreach (var id in requestedIds)
+        {
+            if (indexById.TryGetValue(id, out var index))
+                result.Add(new MissingSegment(id, index));
+        }
+
+        return result;
+    }
+
+    private async Task<List<Par2Reconstructor.RecoverySlice>> CollectRecoverySlicesAsync(
+        IReadOnlyList<NzbFile> volumeFiles,
+        int needed,
+        ulong sliceSize,
+        SemaphoreSlim fetchGate,
+        CancellationToken ct,
+        Action<long>? onBytesRead = null)
+    {
+        var byExponent = new Dictionary<uint, byte[]>();
+        foreach (var volume in volumeFiles)
+        {
+            if (byExponent.Count >= needed) break;
+
+            await fetchGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var segments = volume.GetSegmentIds();
+                var fileSize = await _usenetClient.GetFileSizeAsync(volume, ct).ConfigureAwait(false);
+                onBytesRead?.Invoke(fileSize);
+                await using var stream = _usenetClient.GetFileStream(segments, fileSize, articleBufferSize: 0);
+                while (stream.Position < stream.Length && byExponent.Count < needed)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    Par2Packet packet;
+                    try
+                    {
+                        packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, readRecvSlicPayload: true, ct)
+                            .ConfigureAwait(false);
+                    }
+                    catch (InvalidDataException e)
+                    {
+                        PrometheusMetrics.Current?.RecordPar2ValidationFailure("packet");
+                        Log.Debug(e, "Skipping invalid PAR2 packet while reading recovery volume {Subject}", volume.Subject);
+                        break;
+                    }
+
+                    if (packet is RecvSlic recvSlic && recvSlic.Payload.Length == (int)sliceSize
+                        && byExponent.TryAdd(recvSlic.Exponent, recvSlic.Payload))
+                    {
+                        if (byExponent.Count >= needed) break;
+                    }
+                }
+            }
+            finally
+            {
+                fetchGate.Release();
+            }
+        }
+
+        return byExponent
+            .OrderBy(x => x.Key)
+            .Take(needed)
+            .Select(x => new Par2Reconstructor.RecoverySlice(x.Key, x.Value))
+            .ToList();
+    }
+
+    private async Task<Par2SetContext?> DiscoverPar2SetAsync(
+        NzbDocument nzbDocument,
+        NzbFile contentNzb,
+        string davItemName,
+        CancellationToken ct)
+    {
+        var candidates = nzbDocument.Files
+            .Where(IsPar2CandidateSubject)
+            .OrderBy(x => x.Segments.Count)
+            .ThenBy(x => x.Segments.FirstOrDefault()?.MessageId, StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var candidate in candidates.Where(x => !Par2.ParVolume.IsMatch(x.GetSubjectFileName())))
+        {
+            var context = await TryParsePar2IndexAsync(candidate, contentNzb, davItemName, nzbDocument, ct)
+                .ConfigureAwait(false);
+            if (context != null) return context;
+        }
+
+        if (candidates.Count > 0)
+        {
+            return await TryParsePar2IndexAsync(candidates[0], contentNzb, davItemName, nzbDocument, ct)
+                .ConfigureAwait(false);
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (await HasPar2MagicAsync(candidate, ct).ConfigureAwait(false))
+            {
+                var context = await TryParsePar2IndexAsync(candidate, contentNzb, davItemName, nzbDocument, ct)
+                    .ConfigureAwait(false);
+                if (context != null) return context;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsPar2CandidateSubject(NzbFile file)
+    {
+        var name = file.GetSubjectFileName();
+        return name.EndsWith(".par2", StringComparison.OrdinalIgnoreCase)
+               || Par2.ParVolume.IsMatch(name);
+    }
+
+    private async Task<bool> HasPar2MagicAsync(NzbFile file, CancellationToken ct)
+    {
+        if (file.Segments.Count == 0) return false;
+        try
+        {
+            var response = await _usenetClient.DecodedBodyAsync(file.Segments[0].MessageId, ct)
+                .ConfigureAwait(false);
+            await using var stream = response.Stream!;
+            var buffer = new byte[64];
+            var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+            return read >= 8 && Par2.HasPar2MagicBytes(buffer);
+        }
+        catch (Exception e) when (e is not OperationCanceledException and not OutOfMemoryException)
+        {
+            Log.Debug(e, "PAR2 magic sniff failed for {Subject}", file.Subject);
+            return false;
+        }
+    }
+
+    private async Task<Par2SetContext?> TryParsePar2IndexAsync(
+        NzbFile indexFile,
+        NzbFile contentNzb,
+        string davItemName,
+        NzbDocument nzbDocument,
+        CancellationToken ct)
+    {
+        var segments = indexFile.GetSegmentIds();
+        if (segments.Length == 0) return null;
+
+        var fileSize = await _usenetClient.GetFileSizeAsync(indexFile, ct).ConfigureAwait(false);
+        await using var stream = _usenetClient.GetFileStream(segments, fileSize, articleBufferSize: 0);
+
+        var fileDescs = new Dictionary<string, FileDesc>(StringComparer.Ordinal);
+        MainPacket? main = null;
+        var ifscs = new Dictionary<string, IfscPacket>(StringComparer.Ordinal);
+
+        while (stream.Position < stream.Length)
+        {
+            Par2Packet packet;
+            try
+            {
+                packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, readRecvSlicPayload: false, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (InvalidDataException)
+            {
+                PrometheusMetrics.Current?.RecordPar2ValidationFailure("packet");
+                break;
+            }
+
+            switch (packet)
+            {
+                case FileDesc fileDesc:
+                    fileDescs[Convert.ToHexString(fileDesc.FileID)] = fileDesc;
+                    break;
+                case MainPacket mainPacket:
+                    main = mainPacket;
+                    break;
+                case IfscPacket ifsc:
+                    ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                    break;
+                case RecvSlic:
+                    goto done;
+            }
+        }
+
+        done:
+        if (main == null || fileDescs.Count == 0 || ifscs.Count == 0)
+            return null;
+
+        var targetDesc = fileDescs.Values.FirstOrDefault(desc =>
+            string.Equals(desc.FileName, davItemName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(desc.FileName, contentNzb.GetSubjectFileName(), StringComparison.OrdinalIgnoreCase));
+        if (targetDesc == null) return null;
+
+        var targetKey = Convert.ToHexString(targetDesc.FileID);
+        if (!ifscs.ContainsKey(targetKey)) return null;
+
+        var targetFileIndex = -1;
+        for (var i = 0; i < main.FileIds.Count; i++)
+        {
+            if (Convert.ToHexString(main.FileIds[i]).Equals(targetKey, StringComparison.Ordinal))
+            {
+                targetFileIndex = i;
+                break;
+            }
+        }
+
+        if (targetFileIndex < 0) return null;
+
+        var volumeFiles = nzbDocument.Files
+            .Where(x => x != indexFile)
+            .Where(x => IsPar2CandidateSubject(x) || Par2.ParVolume.IsMatch(x.GetSubjectFileName()))
+            .ToList();
+
+        return new Par2SetContext(main, fileDescs, ifscs, targetFileIndex, volumeFiles);
+    }
+
+    private static NzbFile? FindContentNzbFile(NzbDocument document, string davItemName)
+    {
+        return document.Files.FirstOrDefault(f =>
+                   string.Equals(f.GetSubjectFileName(), davItemName, StringComparison.OrdinalIgnoreCase))
+               ?? document.Files.FirstOrDefault(f =>
+                   f.GetSubjectFileName().EndsWith(davItemName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static long EstimateReleaseBytes(
+        MainPacket main,
+        Dictionary<string, FileDesc> fileDescs)
+    {
+        long total = 0;
+        foreach (var fileId in main.FileIds)
+        {
+            var key = Convert.ToHexString(fileId);
+            if (fileDescs.TryGetValue(key, out var desc))
+                total += (long)desc.FileLength;
+        }
+
+        return total;
+    }
+
+    private async Task<bool> ShouldEnqueueAsync(Guid davItemId, CancellationToken ct)
+    {
+        if (_queuedOrRunning.ContainsKey(davItemId)) return false;
+
+        await using var dbContext = new DavDatabaseContext();
+        var now = DateTimeOffset.UtcNow;
+        var active = await dbContext.Par2RepairJobs.AsNoTracking()
+            .Where(x => x.DavItemId == davItemId)
+            .Where(x => x.State == Par2RepairJob.RepairJobState.Queued
+                        || x.State == Par2RepairJob.RepairJobState.Running)
+            .AnyAsync(ct)
+            .ConfigureAwait(false);
+        if (active) return false;
+
+        var cooling = await dbContext.Par2RepairJobs.AsNoTracking()
+            .Where(x => x.DavItemId == davItemId)
+            .Where(x => x.NextAttemptAt != null && x.NextAttemptAt > now)
+            .AnyAsync(ct)
+            .ConfigureAwait(false);
+        return !cooling;
+    }
+
+    private async Task<Par2RepairJob?> CreateOrResumeJobAsync(
+        DavItem davItem,
+        IReadOnlyList<string>? missingSegmentIds,
+        CancellationToken ct)
+    {
+        await using var dbContext = new DavDatabaseContext();
+        var existing = await dbContext.Par2RepairJobs
+            .Where(x => x.DavItemId == davItem.Id)
+            .OrderByDescending(x => x.CreatedAt)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (existing is { State: Par2RepairJob.RepairJobState.Running })
+            return null;
+
+        if (existing is { Attempts: >= MaxAttempts }
+            and ({ State: Par2RepairJob.RepairJobState.Failed } or { State: Par2RepairJob.RepairJobState.Infeasible }))
+            return null;
+
+        var segments = missingSegmentIds?.ToArray()
+                       ?? existing?.MissingSegmentIds
+                       ?? Array.Empty<string>();
+
+        if (existing is { State: Par2RepairJob.RepairJobState.Queued or Par2RepairJob.RepairJobState.Failed or Par2RepairJob.RepairJobState.Infeasible })
+        {
+            existing.Attempts++;
+            existing.MissingSegmentIds = segments;
+            existing.State = Par2RepairJob.RepairJobState.Queued;
+            existing.CreatedAt = DateTimeOffset.UtcNow;
+            return existing;
+        }
+
+        return new Par2RepairJob
+        {
+            Id = Guid.NewGuid(),
+            DavItemId = davItem.Id,
+            Path = davItem.Path,
+            State = Par2RepairJob.RepairJobState.Queued,
+            MissingSegmentIds = segments,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Attempts = 1,
+        };
+    }
+
+    private static async Task PersistJobAsync(Par2RepairJob job, CancellationToken ct)
+    {
+        await using var dbContext = new DavDatabaseContext();
+        var tracked = await dbContext.Par2RepairJobs
+            .FirstOrDefaultAsync(x => x.Id == job.Id, ct)
+            .ConfigureAwait(false);
+        if (tracked == null)
+        {
+            dbContext.Par2RepairJobs.Add(job);
+        }
+        else
+        {
+            dbContext.Entry(tracked).CurrentValues.SetValues(job);
+        }
+
+        await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    public static int CountRepairedSegments(DavNzbFile nzbFile, RepairPatchStore patchStore)
+    {
+        if (!patchStore.IsCatalogReady) return 0;
+        var count = 0;
+        var ranges = nzbFile.SegmentByteRanges;
+        for (var i = 0; i < nzbFile.SegmentIds.Length; i++)
+        {
+            if (ranges == null || i >= ranges.Length) continue;
+            var size = ranges[i].Count;
+
+            if (patchStore.IsRepaired(nzbFile.SegmentIds[i], size))
+                count++;
+        }
+
+        return count;
+    }
+
+    private sealed record RepairWorkItem(Guid DavItemId, string Path, string[] MissingSegmentIds);
+
+    private sealed record MissingSegment(string SegmentId, int Index);
+
+    private sealed record SegmentPatch(string SegmentId, byte[] Bytes, UsenetYencHeader Header);
+
+    private sealed record Par2SetContext(
+        MainPacket Main,
+        Dictionary<string, FileDesc> FileDescsById,
+        Dictionary<string, IfscPacket> IfscsByFileId,
+        int TargetFileIndex,
+        List<NzbFile> VolumeFiles);
+
+    private sealed record RepairExecutionResult(
+        bool Success,
+        bool IsInfeasible,
+        string? FailureReason,
+        long BytesRead,
+        int SlicesReconstructed)
+    {
+        public static RepairExecutionResult Succeeded(long bytesRead, int slices)
+            => new(true, false, null, bytesRead, slices);
+
+        public static RepairExecutionResult NotFeasible(string reason)
+            => new(false, true, reason, 0, 0);
+
+        public static RepairExecutionResult Failed(string reason)
+            => new(false, false, reason, 0, 0);
+    }
+
+    private sealed class SliceSegmentAccessor
+    {
+        private readonly string[] _segmentIds;
+        private readonly LongRange[] _ranges;
+        private readonly NzbFile _contentNzb;
+        private readonly UsenetStreamingClient _client;
+        private readonly SemaphoreSlim _fetchGate;
+        private readonly Action<long>? _onBytesRead;
+        private readonly Dictionary<int, byte[]> _segmentBodies = new();
+        private readonly HashSet<int> _missingSegmentIndices = new();
+
+        public SliceSegmentAccessor(
+            string[] segmentIds,
+            LongRange[] ranges,
+            NzbFile contentNzb,
+            UsenetStreamingClient client,
+            SemaphoreSlim fetchGate,
+            Action<long>? onBytesRead)
+        {
+            _segmentIds = segmentIds;
+            _ranges = ranges;
+            _contentNzb = contentNzb;
+            _client = client;
+            _fetchGate = fetchGate;
+            _onBytesRead = onBytesRead;
+        }
+
+        public async Task<byte[]?> FetchSliceBytesAsync(int globalSliceIndex, int sliceSize, CancellationToken ct)
+        {
+            var fileOffset = (long)globalSliceIndex * sliceSize;
+            var segmentIndex = FindSegmentIndex(fileOffset);
+            if (segmentIndex < 0) return null;
+
+            var body = await GetSegmentBodyAsync(segmentIndex, ct).ConfigureAwait(false);
+            if (body == null) return null;
+
+            var segmentStart = _ranges[segmentIndex].StartInclusive;
+            var offsetInSegment = (int)(fileOffset - segmentStart);
+            if (offsetInSegment < 0 || offsetInSegment + sliceSize > body.Length)
+            {
+                var slice = new byte[sliceSize];
+                var available = Math.Min(sliceSize, body.Length - offsetInSegment);
+                if (available > 0)
+                    Buffer.BlockCopy(body, offsetInSegment, slice, 0, available);
+                return slice;
+            }
+
+            var exact = new byte[sliceSize];
+            Buffer.BlockCopy(body, offsetInSegment, exact, 0, sliceSize);
+            return exact;
+        }
+
+        private int FindSegmentIndex(long fileOffset)
+        {
+            for (var i = 0; i < _ranges.Length; i++)
+            {
+                if (fileOffset >= _ranges[i].StartInclusive && fileOffset < _ranges[i].EndExclusive)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private async Task<byte[]?> GetSegmentBodyAsync(int segmentIndex, CancellationToken ct)
+        {
+            if (_segmentBodies.TryGetValue(segmentIndex, out var cached))
+                return cached;
+
+            await _fetchGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (_segmentBodies.TryGetValue(segmentIndex, out cached))
+                    return cached;
+
+                var segmentId = _segmentIds[segmentIndex];
+                UsenetDecodedBodyResponse response;
+                try
+                {
+                    response = await _client.DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+                }
+                catch (UsenetArticleNotFoundException)
+                {
+                    _missingSegmentIndices.Add(segmentIndex);
+                    return null;
+                }
+
+                await using var stream = response.Stream!;
+                await using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                var bytes = ms.ToArray();
+                _onBytesRead?.Invoke(bytes.Length);
+                _segmentBodies[segmentIndex] = bytes;
+                return bytes;
+            }
+            finally
+            {
+                _fetchGate.Release();
+            }
+        }
+
+        public List<MissingSegment> GetMissingSegments()
+            => _missingSegmentIndices
+                .OrderBy(i => i)
+                .Select(i => new MissingSegment(_segmentIds[i], i))
+                .ToList();
+    }
+}

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -31,12 +31,15 @@ public sealed class Par2RepairService : BackgroundService
     private readonly UsenetStreamingClient _usenetClient;
     private readonly RepairPatchStore _patchStore;
     private readonly Channel<RepairWorkItem> _queue;
+    private readonly Channel<ZeroFillEvent> _zeroFillQueue;
     private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
+    private readonly ConcurrentDictionary<string, byte> _pendingZeroFillPaths = new(StringComparer.Ordinal);
     private long _totalSucceeded;
     private long _totalFailed;
     private long _totalInfeasible;
     private long _totalBytesRead;
-    private long _totalSegmentsReconstructed;
+    private long _totalSlicesReconstructed;
+    private long _totalSegmentsCommitted;
 
     public Par2RepairService(
         ConfigManager configManager,
@@ -46,29 +49,37 @@ public sealed class Par2RepairService : BackgroundService
         _configManager = configManager;
         _usenetClient = usenetClient;
         _patchStore = patchStore;
+        // Wait mode makes non-blocking TryWrite report full queues as false so
+        // callers can undo bookkeeping; DropWrite would return true and silently
+        // discard the item, leaking _queuedOrRunning/_pendingZeroFillPaths entries.
         _queue = Channel.CreateBounded<RepairWorkItem>(new BoundedChannelOptions(MaxQueueLength)
         {
-            FullMode = BoundedChannelFullMode.DropWrite,
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        _zeroFillQueue = Channel.CreateBounded<ZeroFillEvent>(new BoundedChannelOptions(MaxQueueLength)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
             SingleReader = true,
             SingleWriter = false,
         });
     }
 
-    public async Task EnqueueZeroFillAsync(
-        string path,
-        string segmentId,
-        int segmentIndex,
-        long fillBytes,
-        CancellationToken ct = default)
+    internal int PendingZeroFillCount => _pendingZeroFillPaths.Count;
+
+    /// <summary>
+    /// Synchronous, allocation-light entry point for streaming zero-fill events.
+    /// Runs on the playback hot path's failure branch: gate on config, dedup by
+    /// path, and hand off to the single background consumer. All DB work happens
+    /// in the consumer.
+    /// </summary>
+    public void ReportZeroFill(string path, string segmentId)
     {
         if (!_configManager.IsPar2RepairEnabled()) return;
-
-        await using var dbContext = new DavDatabaseContext();
-        var dbClient = new DavDatabaseClient(dbContext);
-        var davItem = await dbClient.GetItemByPathAsync(path, ct).ConfigureAwait(false);
-        if (davItem == null) return;
-
-        await EnqueueAsync(davItem, [segmentId], ct).ConfigureAwait(false);
+        if (!_pendingZeroFillPaths.TryAdd(path, 0)) return;
+        if (!_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId)))
+            _pendingZeroFillPaths.TryRemove(path, out _);
     }
 
     public async Task EnqueueAsync(
@@ -111,6 +122,13 @@ public sealed class Par2RepairService : BackgroundService
     {
         await _patchStore.CatalogLoadTask.ConfigureAwait(false);
 
+        await Task.WhenAll(
+            ProcessRepairQueueAsync(stoppingToken),
+            ProcessZeroFillQueueAsync(stoppingToken)).ConfigureAwait(false);
+    }
+
+    private async Task ProcessRepairQueueAsync(CancellationToken stoppingToken)
+    {
         await foreach (var item in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
         {
             try
@@ -127,6 +145,38 @@ public sealed class Par2RepairService : BackgroundService
                 e.LogWarningKnownOrStack("PAR2 background repair worker failed for {Path}", item.Path);
             }
         }
+    }
+
+    private async Task ProcessZeroFillQueueAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var evt in _zeroFillQueue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                await ProcessZeroFillEventAsync(evt, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                Log.Debug(e, "PAR2 zero-fill trigger failed for {Path}", evt.Path);
+            }
+            finally
+            {
+                _pendingZeroFillPaths.TryRemove(evt.Path, out _);
+            }
+        }
+    }
+
+    private async Task ProcessZeroFillEventAsync(ZeroFillEvent evt, CancellationToken ct)
+    {
+        await using var dbContext = new DavDatabaseContext();
+        var dbClient = new DavDatabaseClient(dbContext);
+        var davItem = await dbClient.GetItemByPathAsync(evt.Path, ct).ConfigureAwait(false);
+        if (davItem != null)
+            await EnqueueAsync(davItem, [evt.SegmentId], ct).ConfigureAwait(false);
     }
 
     private async Task ProcessQueueItemAsync(RepairWorkItem item, CancellationToken ct)
@@ -194,10 +244,13 @@ public sealed class Par2RepairService : BackgroundService
                 PrometheusMetrics.Current?.SetPar2PatchStoreBytes(_patchStore.CurrentBytes);
                 Interlocked.Increment(ref _totalSucceeded);
                 Interlocked.Add(ref _totalBytesRead, result.BytesRead);
-                Interlocked.Add(ref _totalSegmentsReconstructed, result.SlicesReconstructed);
+                Interlocked.Add(ref _totalSlicesReconstructed, result.SlicesReconstructed);
+                Interlocked.Add(ref _totalSegmentsCommitted, result.SegmentsCommitted);
                 Log.Information(
-                    "PAR2 repair succeeded for {Path}: {Slices} slice(s), {Bytes} bytes read in {Elapsed}",
-                    davItem.Path, result.SlicesReconstructed, result.BytesRead, stopwatch.Elapsed);
+                    "PAR2 repair succeeded for {Path}: {Slices} slice(s) reconstructed, "
+                    + "{Segments} segment(s) committed, {Bytes} bytes read in {Elapsed}",
+                    davItem.Path, result.SlicesReconstructed, result.SegmentsCommitted,
+                    result.BytesRead, stopwatch.Elapsed);
                 return true;
             }
 
@@ -380,9 +433,10 @@ public sealed class Par2RepairService : BackgroundService
             _patchStore.CommitPatch(patch.SegmentId, patch.Bytes, patch.Header);
 
         PrometheusMetrics.Current?.AddPar2RepairBytesRead(bytesRead);
-        PrometheusMetrics.Current?.AddPar2SegmentsReconstructed(commits.Count);
+        PrometheusMetrics.Current?.AddPar2SlicesReconstructed(reconstruction.ReconstructedSlices.Count);
+        PrometheusMetrics.Current?.AddPar2SegmentsCommitted(commits.Count);
         job.MissingSegmentIds = patchTargets.Select(x => x.SegmentId).ToArray();
-        return RepairExecutionResult.Succeeded(bytesRead, reconstruction.ReconstructedSlices.Count);
+        return RepairExecutionResult.Succeeded(bytesRead, reconstruction.ReconstructedSlices.Count, commits.Count);
     }
 
     private static List<SegmentPatch> ExtractSegmentPatches(
@@ -509,14 +563,10 @@ public sealed class Par2RepairService : BackgroundService
             .Select((id, index) => (id, index))
             .ToDictionary(x => x.id, x => x.index, StringComparer.Ordinal);
 
-        var result = new List<MissingSegment>();
-        foreach (var id in requestedIds)
-        {
-            if (indexById.TryGetValue(id, out var index))
-                result.Add(new MissingSegment(id, index));
-        }
-
-        return result;
+        return requestedIds
+            .Where(indexById.ContainsKey)
+            .Select(id => new MissingSegment(id, indexById[id]))
+            .ToList();
     }
 
     private async Task<List<Par2Reconstructor.RecoverySlice>> CollectRecoverySlicesAsync(
@@ -556,9 +606,10 @@ public sealed class Par2RepairService : BackgroundService
                     }
 
                     if (packet is RecvSlic recvSlic && recvSlic.Payload.Length == (int)sliceSize
-                        && byExponent.TryAdd(recvSlic.Exponent, recvSlic.Payload))
+                        && byExponent.TryAdd(recvSlic.Exponent, recvSlic.Payload)
+                        && byExponent.Count >= needed)
                     {
-                        if (byExponent.Count >= needed) break;
+                        break;
                     }
                 }
             }
@@ -686,7 +737,7 @@ public sealed class Par2RepairService : BackgroundService
             }
         }
 
-        done:
+    done:
         if (main == null || fileDescs.Count == 0 || ifscs.Count == 0)
             return null;
 
@@ -730,15 +781,9 @@ public sealed class Par2RepairService : BackgroundService
         MainPacket main,
         Dictionary<string, FileDesc> fileDescs)
     {
-        long total = 0;
-        foreach (var fileId in main.FileIds)
-        {
-            var key = Convert.ToHexString(fileId);
-            if (fileDescs.TryGetValue(key, out var desc))
-                total += (long)desc.FileLength;
-        }
-
-        return total;
+        return main.FileIds
+            .Select(fileId => Convert.ToHexString(fileId))
+            .Sum(key => fileDescs.TryGetValue(key, out var desc) ? (long)desc.FileLength : 0L);
     }
 
     private async Task<bool> ShouldEnqueueAsync(Guid davItemId, CancellationToken ct)
@@ -855,7 +900,8 @@ public sealed class Par2RepairService : BackgroundService
             TotalFailed = Interlocked.Read(ref _totalFailed),
             TotalInfeasible = Interlocked.Read(ref _totalInfeasible),
             TotalBytesRead = Interlocked.Read(ref _totalBytesRead),
-            TotalSegmentsReconstructed = Interlocked.Read(ref _totalSegmentsReconstructed),
+            TotalSlicesReconstructed = Interlocked.Read(ref _totalSlicesReconstructed),
+            TotalSegmentsCommitted = Interlocked.Read(ref _totalSegmentsCommitted),
             RecentJobs = recentJobs,
         };
     }
@@ -884,8 +930,9 @@ public sealed class Par2RepairService : BackgroundService
                 })
                 .ToList();
         }
-        catch
+        catch (Exception e) when (e is not OutOfMemoryException)
         {
+            Log.Debug(e, "Could not load recent PAR2 repair jobs for diagnostics");
             return [];
         }
     }
@@ -900,11 +947,14 @@ public sealed class Par2RepairService : BackgroundService
         public long TotalFailed { get; init; }
         public long TotalInfeasible { get; init; }
         public long TotalBytesRead { get; init; }
-        public long TotalSegmentsReconstructed { get; init; }
+        public long TotalSlicesReconstructed { get; init; }
+        public long TotalSegmentsCommitted { get; init; }
         public List<object> RecentJobs { get; init; } = [];
     }
 
     private sealed record RepairWorkItem(Guid DavItemId, string Path, string[] MissingSegmentIds);
+
+    private sealed record ZeroFillEvent(string Path, string SegmentId);
 
     private sealed record MissingSegment(string SegmentId, int Index);
 
@@ -922,16 +972,17 @@ public sealed class Par2RepairService : BackgroundService
         bool IsInfeasible,
         string? FailureReason,
         long BytesRead,
-        int SlicesReconstructed)
+        int SlicesReconstructed,
+        int SegmentsCommitted)
     {
-        public static RepairExecutionResult Succeeded(long bytesRead, int slices)
-            => new(true, false, null, bytesRead, slices);
+        public static RepairExecutionResult Succeeded(long bytesRead, int slices, int segmentsCommitted)
+            => new(true, false, null, bytesRead, slices, segmentsCommitted);
 
         public static RepairExecutionResult NotFeasible(string reason)
-            => new(false, true, reason, 0, 0);
+            => new(false, true, reason, 0, 0, 0);
 
         public static RepairExecutionResult Failed(string reason)
-            => new(false, false, reason, 0, 0);
+            => new(false, false, reason, 0, 0, 0);
     }
 
     private sealed class SliceSegmentAccessor

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -32,6 +32,11 @@ public sealed class Par2RepairService : BackgroundService
     private readonly RepairPatchStore _patchStore;
     private readonly Channel<RepairWorkItem> _queue;
     private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
+    private long _totalSucceeded;
+    private long _totalFailed;
+    private long _totalInfeasible;
+    private long _totalBytesRead;
+    private long _totalSegmentsReconstructed;
 
     public Par2RepairService(
         ConfigManager configManager,
@@ -187,6 +192,9 @@ public sealed class Par2RepairService : BackgroundService
                 PrometheusMetrics.Current?.RecordPar2RepairJob("succeeded");
                 PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
                 PrometheusMetrics.Current?.SetPar2PatchStoreBytes(_patchStore.CurrentBytes);
+                Interlocked.Increment(ref _totalSucceeded);
+                Interlocked.Add(ref _totalBytesRead, result.BytesRead);
+                Interlocked.Add(ref _totalSegmentsReconstructed, result.SlicesReconstructed);
                 Log.Information(
                     "PAR2 repair succeeded for {Path}: {Slices} slice(s), {Bytes} bytes read in {Elapsed}",
                     davItem.Path, result.SlicesReconstructed, result.BytesRead, stopwatch.Elapsed);
@@ -203,6 +211,8 @@ public sealed class Par2RepairService : BackgroundService
             await PersistJobAsync(job, ct).ConfigureAwait(false);
             PrometheusMetrics.Current?.RecordPar2RepairJob(result.IsInfeasible ? "infeasible" : "failed");
             PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
+            if (result.IsInfeasible) Interlocked.Increment(ref _totalInfeasible);
+            else Interlocked.Increment(ref _totalFailed);
             Log.Warning(
                 "PAR2 repair {Outcome} for {Path}. Reason: {Reason}",
                 result.IsInfeasible ? "infeasible" : "failed", davItem.Path, result.FailureReason);
@@ -830,6 +840,68 @@ public sealed class Par2RepairService : BackgroundService
         }
 
         return count;
+    }
+
+    public Par2RepairDiagnosticSnapshot GetDiagnosticSnapshot()
+    {
+        var recentJobs = GetRecentJobsForDiagnostics();
+        return new Par2RepairDiagnosticSnapshot
+        {
+            PatchStoreEntries = _patchStore.EntryCount,
+            PatchHitCount = _patchStore.HitCount,
+            PatchEvictionCount = _patchStore.EvictionCount,
+            QueuedOrRunningCount = _queuedOrRunning.Count,
+            TotalSucceeded = Interlocked.Read(ref _totalSucceeded),
+            TotalFailed = Interlocked.Read(ref _totalFailed),
+            TotalInfeasible = Interlocked.Read(ref _totalInfeasible),
+            TotalBytesRead = Interlocked.Read(ref _totalBytesRead),
+            TotalSegmentsReconstructed = Interlocked.Read(ref _totalSegmentsReconstructed),
+            RecentJobs = recentJobs,
+        };
+    }
+
+    private List<object> GetRecentJobsForDiagnostics()
+    {
+        try
+        {
+            using var dbContext = new DavDatabaseContext();
+            return dbContext.Par2RepairJobs
+                .OrderByDescending(j => j.CreatedAt)
+                .Take(10)
+                .AsEnumerable()
+                .Select(j => (object)new
+                {
+                    id = j.Id,
+                    path = j.Path,
+                    state = j.State.ToString(),
+                    createdAt = j.CreatedAt,
+                    startedAt = j.StartedAt,
+                    completedAt = j.CompletedAt,
+                    attempts = j.Attempts,
+                    bytesRead = j.BytesRead,
+                    slicesReconstructed = j.SlicesReconstructed,
+                    failureReason = j.FailureReason,
+                })
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public sealed class Par2RepairDiagnosticSnapshot
+    {
+        public int PatchStoreEntries { get; init; }
+        public long PatchHitCount { get; init; }
+        public long PatchEvictionCount { get; init; }
+        public int QueuedOrRunningCount { get; init; }
+        public long TotalSucceeded { get; init; }
+        public long TotalFailed { get; init; }
+        public long TotalInfeasible { get; init; }
+        public long TotalBytesRead { get; init; }
+        public long TotalSegmentsReconstructed { get; init; }
+        public List<object> RecentJobs { get; init; } = [];
     }
 
     private sealed record RepairWorkItem(Guid DavItemId, string Path, string[] MissingSegmentIds);

--- a/backend/Services/Repair/Par2RepairTriggerSink.cs
+++ b/backend/Services/Repair/Par2RepairTriggerSink.cs
@@ -1,10 +1,10 @@
-using Serilog;
-
 namespace NzbWebDAV.Services.Repair;
 
 /// <summary>
-/// Fire-and-forget entry point for streaming zero-fill events. Resolves the DavItem by path
-/// and enqueues background PAR2 repair without blocking readers.
+/// Entry point for streaming zero-fill events. Forwards synchronously to the
+/// repair service, which gates cheaply (config + in-memory path dedup) and
+/// hands the event to its single background consumer. No per-event tasks or
+/// DB work happen on the caller's (playback) thread.
 /// </summary>
 public sealed class Par2RepairTriggerSink
 {
@@ -19,17 +19,6 @@ public sealed class Par2RepairTriggerSink
 
     public void ReportZeroFill(string path, string segmentId, int segmentIndex, long fillBytes)
     {
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await _service.EnqueueZeroFillAsync(path, segmentId, segmentIndex, fillBytes)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception e) when (e is not OutOfMemoryException)
-            {
-                Log.Debug(e, "PAR2 zero-fill trigger failed for {Path}", path);
-            }
-        });
+        _service.ReportZeroFill(path, segmentId);
     }
 }

--- a/backend/Services/Repair/Par2RepairTriggerSink.cs
+++ b/backend/Services/Repair/Par2RepairTriggerSink.cs
@@ -1,0 +1,35 @@
+using Serilog;
+
+namespace NzbWebDAV.Services.Repair;
+
+/// <summary>
+/// Fire-and-forget entry point for streaming zero-fill events. Resolves the DavItem by path
+/// and enqueues background PAR2 repair without blocking readers.
+/// </summary>
+public sealed class Par2RepairTriggerSink
+{
+    private readonly Par2RepairService _service;
+
+    public Par2RepairTriggerSink(Par2RepairService service)
+    {
+        _service = service;
+    }
+
+    public static Par2RepairTriggerSink? Current { get; set; }
+
+    public void ReportZeroFill(string path, string segmentId, int segmentIndex, long fillBytes)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _service.EnqueueZeroFillAsync(path, segmentId, segmentIndex, fillBytes)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                Log.Debug(e, "PAR2 zero-fill trigger failed for {Path}", path);
+            }
+        });
+    }
+}

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -20,6 +20,8 @@ public sealed class RepairPatchStore
     private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
     private long _currentBytes;
     private int _catalogReady;
+    private long _hitCount;
+    private long _evictionCount;
 
     private static readonly JsonSerializerOptions HeaderJsonOptions = new() { IncludeFields = true };
 
@@ -45,6 +47,9 @@ public sealed class RepairPatchStore
     public bool IsCatalogReady => Volatile.Read(ref _catalogReady) != 0;
     internal Task CatalogLoadTask { get; }
     internal long CurrentBytes => Interlocked.Read(ref _currentBytes);
+    internal int EntryCount => _index.Count;
+    internal long HitCount => Interlocked.Read(ref _hitCount);
+    internal long EvictionCount => Interlocked.Read(ref _evictionCount);
 
     public bool Contains(string segmentId)
         => IsCatalogReady && _index.ContainsKey(Hash(segmentId));
@@ -71,6 +76,7 @@ public sealed class RepairPatchStore
             var fileStream = new FileStream(blobPath, FileMode.Open, FileAccess.Read,
                 FileShare.Read | FileShare.Delete, bufferSize: 81920, useAsync: true);
             entry.LastAccessTicks = DateTime.UtcNow.Ticks;
+            Interlocked.Increment(ref _hitCount);
             response = new UsenetDecodedBodyResponse
             {
                 SegmentId = segmentId,
@@ -170,6 +176,7 @@ public sealed class RepairPatchStore
                 if (_currentBytes <= _maxBytes) break;
                 if (!_index.TryRemove(kv.Key, out var entry)) continue;
                 _currentBytes -= entry.Size;
+                Interlocked.Increment(ref _evictionCount);
                 SafeDelete(BlobPath(kv.Key));
                 SafeDelete(BlobPath(kv.Key) + ".h");
                 PrometheusMetrics.Current?.RecordPar2PatchEviction();

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -86,8 +86,9 @@ public sealed class RepairPatchStore
             };
             return true;
         }
-        catch
+        catch (Exception e) when (e is not OutOfMemoryException)
         {
+            Log.Debug(e, "Repair patch store: dropping unreadable patch for {SegmentId}", segmentId);
             Drop(hash);
             return false;
         }
@@ -111,8 +112,9 @@ public sealed class RepairPatchStore
                 File.ReadAllText(blobPath + ".h"), HeaderJsonOptions);
             return header != null && header.PartSize == expectedSize;
         }
-        catch
+        catch (Exception e) when (e is not OutOfMemoryException)
         {
+            Log.Debug(e, "Repair patch store: dropping unreadable patch for {SegmentId}", segmentId);
             Drop(hash);
             return false;
         }
@@ -245,9 +247,9 @@ public sealed class RepairPatchStore
         {
             if (File.Exists(path)) File.Delete(path);
         }
-        catch
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
-            // ignore
+            Log.Debug(e, "Repair patch store: could not delete {Path}", path);
         }
     }
 

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -1,0 +1,252 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Services.Observability;
+using Serilog;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Services.Repair;
+
+public sealed class RepairPatchStore
+{
+    private readonly string _dir;
+    private readonly long _maxBytes;
+    private readonly ConcurrentDictionary<string, CacheEntry> _index = new();
+    private readonly object _evictLock = new();
+    private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
+    private long _currentBytes;
+    private int _catalogReady;
+
+    private static readonly JsonSerializerOptions HeaderJsonOptions = new() { IncludeFields = true };
+
+    public RepairPatchStore(string cacheDir, long maxBytes)
+        : this(cacheDir, maxBytes, enumerateCacheFiles: null)
+    {
+    }
+
+    internal RepairPatchStore(
+        string cacheDir,
+        long maxBytes,
+        Func<IEnumerable<string>>? enumerateCacheFiles)
+    {
+        _dir = cacheDir;
+        _maxBytes = maxBytes;
+        Directory.CreateDirectory(_dir);
+        _enumerateCacheFiles = enumerateCacheFiles
+                               ?? (() => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
+        Log.Information("PAR2 repair patch store path: {Path}", _dir);
+        CatalogLoadTask = Task.Run(LoadIndex);
+    }
+
+    public bool IsCatalogReady => Volatile.Read(ref _catalogReady) != 0;
+    internal Task CatalogLoadTask { get; }
+    internal long CurrentBytes => Interlocked.Read(ref _currentBytes);
+
+    public bool Contains(string segmentId)
+        => IsCatalogReady && _index.ContainsKey(Hash(segmentId));
+
+    public bool TryGet(string segmentId, out UsenetDecodedBodyResponse? response)
+    {
+        response = null;
+        if (!IsCatalogReady) return false;
+
+        var hash = Hash(segmentId);
+        if (!_index.TryGetValue(hash, out var entry)) return false;
+
+        var blobPath = BlobPath(hash);
+        try
+        {
+            var header = JsonSerializer.Deserialize<UsenetYencHeader>(
+                File.ReadAllText(blobPath + ".h"), HeaderJsonOptions);
+            if (header == null || header.PartSize != entry.Size)
+            {
+                Drop(hash);
+                return false;
+            }
+
+            var fileStream = new FileStream(blobPath, FileMode.Open, FileAccess.Read,
+                FileShare.Read | FileShare.Delete, bufferSize: 81920, useAsync: true);
+            entry.LastAccessTicks = DateTime.UtcNow.Ticks;
+            response = new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 - Article retrieved from repair patch store",
+                Stream = new CachedYencStream(header, fileStream),
+            };
+            return true;
+        }
+        catch
+        {
+            Drop(hash);
+            return false;
+        }
+    }
+
+    public bool IsRepaired(string segmentId, long expectedSize)
+    {
+        if (!IsCatalogReady) return false;
+
+        var hash = Hash(segmentId);
+        if (!_index.TryGetValue(hash, out var entry) || entry.Size != expectedSize)
+            return false;
+
+        var blobPath = BlobPath(hash);
+        if (!File.Exists(blobPath) || !File.Exists(blobPath + ".h"))
+            return false;
+
+        try
+        {
+            var header = JsonSerializer.Deserialize<UsenetYencHeader>(
+                File.ReadAllText(blobPath + ".h"), HeaderJsonOptions);
+            return header != null && header.PartSize == expectedSize;
+        }
+        catch
+        {
+            Drop(hash);
+            return false;
+        }
+    }
+
+    public void CommitPatch(string segmentId, byte[] bytes, UsenetYencHeader header)
+    {
+        if (bytes.Length != header.PartSize)
+            throw new ArgumentException("Patch bytes length does not match yEnc header PartSize.");
+
+        var hash = Hash(segmentId);
+        var blobPath = BlobPath(hash);
+        var tempPath = blobPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+        try
+        {
+            File.WriteAllBytes(tempPath, bytes);
+            File.WriteAllText(blobPath + ".h", JsonSerializer.Serialize(header, HeaderJsonOptions));
+            File.Move(tempPath, blobPath, overwrite: true);
+            OnFinalized(hash, bytes.Length);
+        }
+        catch
+        {
+            SafeDelete(tempPath);
+            SafeDelete(blobPath + ".h");
+            throw;
+        }
+    }
+
+    private void OnFinalized(string hash, long size)
+    {
+        lock (_evictLock)
+        {
+            if (_index.TryGetValue(hash, out var existing)) _currentBytes -= existing.Size;
+            _index[hash] = new CacheEntry { Size = size, LastAccessTicks = DateTime.UtcNow.Ticks };
+            _currentBytes += size;
+        }
+
+        EvictIfNeeded();
+    }
+
+    private void Drop(string hash)
+    {
+        lock (_evictLock)
+        {
+            if (_index.TryRemove(hash, out var entry)) _currentBytes -= entry.Size;
+        }
+
+        SafeDelete(BlobPath(hash));
+        SafeDelete(BlobPath(hash) + ".h");
+    }
+
+    private void EvictIfNeeded()
+    {
+        if (Interlocked.Read(ref _currentBytes) <= _maxBytes) return;
+        lock (_evictLock)
+        {
+            if (_currentBytes <= _maxBytes) return;
+            foreach (var kv in _index.OrderBy(x => x.Value.LastAccessTicks).ToList())
+            {
+                if (_currentBytes <= _maxBytes) break;
+                if (!_index.TryRemove(kv.Key, out var entry)) continue;
+                _currentBytes -= entry.Size;
+                SafeDelete(BlobPath(kv.Key));
+                SafeDelete(BlobPath(kv.Key) + ".h");
+                PrometheusMetrics.Current?.RecordPar2PatchEviction();
+            }
+        }
+    }
+
+    private void LoadIndex()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            foreach (var file in _enumerateCacheFiles())
+            {
+                if (file.EndsWith(".tmp", StringComparison.Ordinal))
+                {
+                    SafeDelete(file);
+                    continue;
+                }
+
+                if (file.EndsWith(".h", StringComparison.Ordinal)) continue;
+                var info = new FileInfo(file);
+                if (!info.Exists) continue;
+                var entry = new CacheEntry
+                {
+                    Size = info.Length,
+                    LastAccessTicks = info.LastWriteTimeUtc.Ticks,
+                };
+
+                lock (_evictLock)
+                {
+                    if (_index.TryAdd(Path.GetFileName(file), entry))
+                        _currentBytes += info.Length;
+                }
+            }
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(e, "Repair patch store: failed to scan {Dir}; starting empty.", _dir);
+        }
+        finally
+        {
+            try
+            {
+                EvictIfNeeded();
+            }
+            finally
+            {
+                Volatile.Write(ref _catalogReady, 1);
+                stopwatch.Stop();
+                Log.Information(
+                    "Repair patch store catalog loaded: {Count} entries, {Size} bytes in {Elapsed}ms.",
+                    _index.Count, Interlocked.Read(ref _currentBytes), stopwatch.ElapsedMilliseconds);
+            }
+        }
+    }
+
+    private string BlobPath(string hash) => Path.Join(_dir, hash[..2], hash);
+
+    private static string Hash(string id)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(id)));
+
+    private static void SafeDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private sealed class CacheEntry
+    {
+        public long Size;
+        public long LastAccessTicks;
+    }
+}

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -662,7 +662,8 @@ public sealed class SupportPackService(
                     totalFailed = snapshot.TotalFailed,
                     totalInfeasible = snapshot.TotalInfeasible,
                     totalBytesRead = snapshot.TotalBytesRead,
-                    totalSegmentsReconstructed = snapshot.TotalSegmentsReconstructed,
+                    totalSlicesReconstructed = snapshot.TotalSlicesReconstructed,
+                    totalSegmentsCommitted = snapshot.TotalSegmentsCommitted,
                 },
                 recentJobs = snapshot.RecentJobs,
             };

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -31,6 +31,8 @@ public sealed class SupportPackService(
     StreamTraceBuffer streamTraceBuffer,
     RuntimeUsageTracker runtimeUsage,
     GcDiagnosticsStore gcDiagnosticsStore,
+    Repair.Par2RepairService par2RepairService,
+    Repair.RepairPatchStore repairPatchStore,
     ConcurrentReadTracker? concurrentReadTracker = null)
 {
     private const long MinuteMs = 60_000;
@@ -397,6 +399,7 @@ public sealed class SupportPackService(
                 metricsDatabaseBytes = FileSize(MetricsDbContext.DatabaseFilePath),
                 availableFreeSpaceBytes = drive.IsReady ? drive.AvailableFreeSpace : (long?)null,
             },
+            par2Repair = BuildPar2RepairDiagnostics(),
             streamTracing = new
             {
                 enabled = streamTracing.Enabled,
@@ -626,6 +629,48 @@ public sealed class SupportPackService(
         {
             Log.Debug(e, "Support pack: could not read the process thread count");
             return null;
+        }
+    }
+
+    private object BuildPar2RepairDiagnostics()
+    {
+        try
+        {
+            var snapshot = par2RepairService.GetDiagnosticSnapshot();
+            return new
+            {
+                enabled = configManager.IsPar2RepairEnabled(),
+                preferredOverArr = configManager.IsPar2PreferredOverArr(),
+                maxMissingSlices = configManager.GetPar2MaxMissingSlices(),
+                maxReleaseGb = configManager.GetPar2MaxReleaseGb(),
+                maxMemoryMb = configManager.GetPar2MaxMemoryMb(),
+                fetchConcurrency = configManager.GetPar2FetchConcurrency(),
+                failureCooldownHours = configManager.GetPar2FailureCooldownHours(),
+                patchStore = new
+                {
+                    entries = snapshot.PatchStoreEntries,
+                    currentBytes = repairPatchStore.CurrentBytes,
+                    maxBytes = configManager.GetPar2MaxPatchBytes(),
+                    hitCount = snapshot.PatchHitCount,
+                    evictionCount = snapshot.PatchEvictionCount,
+                    catalogReady = repairPatchStore.IsCatalogReady,
+                },
+                jobs = new
+                {
+                    queuedOrRunning = snapshot.QueuedOrRunningCount,
+                    totalSucceeded = snapshot.TotalSucceeded,
+                    totalFailed = snapshot.TotalFailed,
+                    totalInfeasible = snapshot.TotalInfeasible,
+                    totalBytesRead = snapshot.TotalBytesRead,
+                    totalSegmentsReconstructed = snapshot.TotalSegmentsReconstructed,
+                },
+                recentJobs = snapshot.RecentJobs,
+            };
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(e, "Support pack: could not read PAR2 repair diagnostics");
+            return new { enabled = false, error = e.Message };
         }
     }
 

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.StreamTrace;
 using Serilog;
 using UsenetSharp.Models;
@@ -958,6 +959,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 "Using the observed {Bytes}-byte segment size of {FileName} to replace failed segment {SegmentId}.",
                 fill, _fileName, segmentId);
         }
+
+        Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, fill);
 
 #pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
         return SegmentDownloadResult.ZeroFill(

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -1,6 +1,7 @@
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.StreamTrace;
 using Serilog;
 using UsenetSharp.Streams;
@@ -114,6 +115,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                             e);
                         if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
                             StreamTrace.TryZeroFill(sessionId, e.SegmentId, fill);
+                        Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, e.SegmentId, segmentIndex, fill);
                         if (_consecutiveZeroFills >= MaxConsecutiveZeroFills)
                             throw;
 

--- a/frontend/app/routes/settings/repairs/repairs.test.ts
+++ b/frontend/app/routes/settings/repairs/repairs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isRepairsSettingsUpdated, isRepairsSettingsValid } from "./repairs";
+
+const baseConfig: Record<string, string> = {
+    "repair.enable": "true",
+    "repair.healthcheck-concurrency": "50",
+    "repair.healthcheck-depth": "standard",
+    "repair.healthcheck-aging": "false",
+    "repair.auto-remove-after-failures": "0",
+    "repair.auto-remove-unlinked-only": "true",
+    "repair.par2-enabled": "false",
+    "repair.par2-preferred-over-arr": "true",
+    "repair.par2-max-missing-slices": "8",
+    "repair.par2-max-release-gb": "16",
+    "repair.par2-max-memory-mb": "256",
+    "repair.par2-max-patch-gb": "4",
+    "repair.par2-fetch-concurrency": "2",
+    "repair.par2-failure-cooldown-hours": "6",
+    "media.library-dir": "/library",
+    "arr.instances": JSON.stringify({ RadarrInstances: [{}], SonarrInstances: [] }),
+};
+
+describe("Repairs settings helpers", () => {
+    it("detects PAR2 setting changes", () => {
+        const updated = { ...baseConfig, "repair.par2-enabled": "true" };
+        expect(isRepairsSettingsUpdated(baseConfig, updated)).toBe(true);
+    });
+
+    it("accepts valid PAR2 numeric settings", () => {
+        expect(isRepairsSettingsValid(baseConfig)).toBe(true);
+    });
+
+    it("rejects invalid PAR2 numeric settings", () => {
+        expect(isRepairsSettingsValid({
+            ...baseConfig,
+            "repair.par2-max-missing-slices": "0",
+        })).toBe(false);
+    });
+});

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -179,6 +179,127 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </Tooltip>
             </ManagedSetting>
             </SettingsCard>
+
+            <SettingsCard
+                icon="healing"
+                title="PAR2 gap repair"
+                description="Reconstruct missing segments from parity volumes in the background instead of triggering an immediate Arr replacement."
+                contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
+            >
+            {!isRepairEnabled && (
+                <p className="text-[11px] leading-relaxed text-base-content/45 lg:col-span-2">
+                    Enable Background Repairs above to activate PAR2 gap repair.
+                </p>
+            )}
+            <ManagedSetting configKey="repair.par2-enabled">
+            <Tooltip content="When enabled, missing segments discovered during streaming or health checks are reconstructed from PAR2 recovery data when feasible. Defaults to off because repairs read the full recovery set once.">
+                <Toggle
+                    id="par2-repair-enabled-checkbox"
+                    className="cursor-pointer gap-2 p-0"
+                    checked={isRepairEnabled && config["repair.par2-enabled"] === "true"}
+                    disabled={!isRepairEnabled}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-enabled": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Enable PAR2 background repair</span>}
+                />
+            </Tooltip>
+            </ManagedSetting>
+            <ManagedSetting configKey="repair.par2-preferred-over-arr">
+            <Tooltip content="When enabled (default), try PAR2 reconstruction before removing the release through Radarr/Sonarr.">
+                <Toggle
+                    id="par2-preferred-over-arr-checkbox"
+                    className="cursor-pointer gap-2 p-0"
+                    checked={(config["repair.par2-preferred-over-arr"] ?? "true") === "true"}
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-preferred-over-arr": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Prefer PAR2 over Arr replacement</span>}
+                />
+            </Tooltip>
+            </ManagedSetting>
+            <ManagedSetting
+                configKeys={[
+                    "repair.par2-max-missing-slices",
+                    "repair.par2-max-release-gb",
+                    "repair.par2-max-memory-mb",
+                    "repair.par2-max-patch-gb",
+                    "repair.par2-fetch-concurrency",
+                    "repair.par2-failure-cooldown-hours",
+                ]}
+                className="grid grid-cols-1 gap-4 lg:col-span-2 lg:grid-cols-2"
+            >
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="par2-max-missing-slices-input">Max missing slices</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.par2-max-missing-slices"] ?? "8") ? "input-error" : ""}`}
+                    type="text"
+                    id="par2-max-missing-slices-input"
+                    placeholder="8"
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    value={config["repair.par2-max-missing-slices"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-max-missing-slices": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45">
+                    Maximum number of missing PAR2 slices to reconstruct in one job (1–64).
+                </p>
+            </div>
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="par2-max-release-gb-input">Max release size (GB)</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.par2-max-release-gb"] ?? "16") ? "input-error" : ""}`}
+                    type="text"
+                    id="par2-max-release-gb-input"
+                    placeholder="16"
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    value={config["repair.par2-max-release-gb"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-max-release-gb": e.target.value })} />
+                <p className="text-[11px] leading-relaxed text-base-content/45">
+                    Refuse PAR2 repair when the recovery set exceeds this size. A repair reads the full recovery set once.
+                </p>
+            </div>
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="par2-max-memory-mb-input">Max memory (MB)</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.par2-max-memory-mb"] ?? "256") ? "input-error" : ""}`}
+                    type="text"
+                    id="par2-max-memory-mb-input"
+                    placeholder="256"
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    value={config["repair.par2-max-memory-mb"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-max-memory-mb": e.target.value })} />
+            </div>
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="par2-max-patch-gb-input">Patch store cap (GB)</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.par2-max-patch-gb"] ?? "4") ? "input-error" : ""}`}
+                    type="text"
+                    id="par2-max-patch-gb-input"
+                    placeholder="4"
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    value={config["repair.par2-max-patch-gb"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-max-patch-gb": e.target.value })} />
+            </div>
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="par2-fetch-concurrency-input">Fetch concurrency</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.par2-fetch-concurrency"] ?? "2") ? "input-error" : ""}`}
+                    type="text"
+                    id="par2-fetch-concurrency-input"
+                    placeholder="2"
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    value={config["repair.par2-fetch-concurrency"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-fetch-concurrency": e.target.value })} />
+            </div>
+            <div className="space-y-2">
+                <label className="block text-sm font-medium text-base-content" htmlFor="par2-failure-cooldown-hours-input">Failure cooldown (hours)</label>
+                <Input
+                    className={`w-full ${!isPositiveInteger(config["repair.par2-failure-cooldown-hours"] ?? "6") ? "input-error" : ""}`}
+                    type="text"
+                    id="par2-failure-cooldown-hours-input"
+                    placeholder="6"
+                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    value={config["repair.par2-failure-cooldown-hours"] ?? ""}
+                    onChange={e => setNewConfig({ ...config, "repair.par2-failure-cooldown-hours": e.target.value })} />
+            </div>
+            </ManagedSetting>
+            </SettingsCard>
             </div>
         </SettingsPage>
     );
@@ -191,13 +312,33 @@ export function isRepairsSettingsUpdated(config: Record<string, string>, newConf
         || config["repair.healthcheck-aging"] !== newConfig["repair.healthcheck-aging"]
         || config["repair.auto-remove-after-failures"] !== newConfig["repair.auto-remove-after-failures"]
         || config["repair.auto-remove-unlinked-only"] !== newConfig["repair.auto-remove-unlinked-only"]
+        || config["repair.par2-enabled"] !== newConfig["repair.par2-enabled"]
+        || config["repair.par2-preferred-over-arr"] !== newConfig["repair.par2-preferred-over-arr"]
+        || config["repair.par2-max-missing-slices"] !== newConfig["repair.par2-max-missing-slices"]
+        || config["repair.par2-max-release-gb"] !== newConfig["repair.par2-max-release-gb"]
+        || config["repair.par2-max-memory-mb"] !== newConfig["repair.par2-max-memory-mb"]
+        || config["repair.par2-max-patch-gb"] !== newConfig["repair.par2-max-patch-gb"]
+        || config["repair.par2-fetch-concurrency"] !== newConfig["repair.par2-fetch-concurrency"]
+        || config["repair.par2-failure-cooldown-hours"] !== newConfig["repair.par2-failure-cooldown-hours"]
         || config["media.library-dir"] !== newConfig["media.library-dir"];
 }
 
 export function isRepairsSettingsValid(newConfig: Record<string, string>) {
     const concurrency = newConfig["repair.healthcheck-concurrency"];
     const autoRemove = newConfig["repair.auto-remove-after-failures"];
+    const par2NumericKeys = [
+        "repair.par2-max-missing-slices",
+        "repair.par2-max-release-gb",
+        "repair.par2-max-memory-mb",
+        "repair.par2-max-patch-gb",
+        "repair.par2-fetch-concurrency",
+        "repair.par2-failure-cooldown-hours",
+    ] as const;
     const concurrencyOk = concurrency === undefined || concurrency === "" || isPositiveInteger(concurrency);
     const autoRemoveOk = autoRemove === undefined || autoRemove === "" || isNonNegativeInteger(autoRemove);
-    return concurrencyOk && autoRemoveOk;
+    const par2Ok = par2NumericKeys.every(key => {
+        const value = newConfig[key];
+        return value === undefined || value === "" || isPositiveInteger(value);
+    });
+    return concurrencyOk && autoRemoveOk && par2Ok;
 }

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -192,11 +192,11 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 </p>
             )}
             <ManagedSetting configKey="repair.par2-enabled">
-            <Tooltip content="When enabled, missing segments discovered during streaming or health checks are reconstructed from PAR2 recovery data when feasible. Defaults to off because repairs read the full recovery set once.">
+            <Tooltip content="Reconstructs missing segments from PAR2 parity data in the background. Enabled by default. Disable on CPU-constrained hosts or to limit provider bandwidth (repairs read the full recovery set once, up to the release-size cap).">
                 <Toggle
                     id="par2-repair-enabled-checkbox"
                     className="cursor-pointer gap-2 p-0"
-                    checked={isRepairEnabled && config["repair.par2-enabled"] === "true"}
+                    checked={isRepairEnabled && (config["repair.par2-enabled"] ?? "true") === "true"}
                     disabled={!isRepairEnabled}
                     onChange={e => setNewConfig({ ...config, "repair.par2-enabled": "" + e.target.checked })}
                     label={<span className="text-sm text-base-content">Enable PAR2 background repair</span>}
@@ -209,7 +209,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     id="par2-preferred-over-arr-checkbox"
                     className="cursor-pointer gap-2 p-0"
                     checked={(config["repair.par2-preferred-over-arr"] ?? "true") === "true"}
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     onChange={e => setNewConfig({ ...config, "repair.par2-preferred-over-arr": "" + e.target.checked })}
                     label={<span className="text-sm text-base-content">Prefer PAR2 over Arr replacement</span>}
                 />
@@ -233,7 +233,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     type="text"
                     id="par2-max-missing-slices-input"
                     placeholder="8"
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     value={config["repair.par2-max-missing-slices"] ?? ""}
                     onChange={e => setNewConfig({ ...config, "repair.par2-max-missing-slices": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45">
@@ -247,7 +247,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     type="text"
                     id="par2-max-release-gb-input"
                     placeholder="16"
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     value={config["repair.par2-max-release-gb"] ?? ""}
                     onChange={e => setNewConfig({ ...config, "repair.par2-max-release-gb": e.target.value })} />
                 <p className="text-[11px] leading-relaxed text-base-content/45">
@@ -261,7 +261,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     type="text"
                     id="par2-max-memory-mb-input"
                     placeholder="256"
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     value={config["repair.par2-max-memory-mb"] ?? ""}
                     onChange={e => setNewConfig({ ...config, "repair.par2-max-memory-mb": e.target.value })} />
             </div>
@@ -272,7 +272,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     type="text"
                     id="par2-max-patch-gb-input"
                     placeholder="4"
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     value={config["repair.par2-max-patch-gb"] ?? ""}
                     onChange={e => setNewConfig({ ...config, "repair.par2-max-patch-gb": e.target.value })} />
             </div>
@@ -283,7 +283,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     type="text"
                     id="par2-fetch-concurrency-input"
                     placeholder="2"
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     value={config["repair.par2-fetch-concurrency"] ?? ""}
                     onChange={e => setNewConfig({ ...config, "repair.par2-fetch-concurrency": e.target.value })} />
             </div>
@@ -294,7 +294,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                     type="text"
                     id="par2-failure-cooldown-hours-input"
                     placeholder="6"
-                    disabled={!isRepairEnabled || config["repair.par2-enabled"] !== "true"}
+                    disabled={!isRepairEnabled || (config["repair.par2-enabled"] ?? "true") !== "true"}
                     value={config["repair.par2-failure-cooldown-hours"] ?? ""}
                     onChange={e => setNewConfig({ ...config, "repair.par2-failure-cooldown-hours": e.target.value })} />
             </div>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
@@ -1,0 +1,86 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class RepairedSegmentNntpClientTests
+{
+    private static UsenetYencHeader HeaderFor(byte[] content) => new()
+    {
+        FileName = "test.bin",
+        FileSize = content.Length,
+        LineLength = 128,
+        PartNumber = 1,
+        TotalParts = 1,
+        PartOffset = 0,
+        PartSize = content.Length,
+    };
+
+    [Fact]
+    public async Task PatchedSegment_ServedWithoutProviderBody_AndFiresRetrieved()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "missing-article@test";
+        byte[] content = "repaired-bytes"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            store.CommitPatch(segmentId, content, HeaderFor(content));
+
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+
+            ArticleBodyResult? completion = null;
+            var response = await client.DecodedBodyAsync(
+                segmentId,
+                (result, _) => completion = result,
+                CancellationToken.None);
+
+            Assert.Equal(0, inner.BodyRequestCount);
+            Assert.Equal(ArticleBodyResult.Retrieved, completion);
+            Assert.NotNull(response.Stream);
+            await using var output = new MemoryStream();
+            await response.Stream.CopyToAsync(output);
+            Assert.Equal(content, output.ToArray());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UnpatchedSegment_FallsThroughToInner()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "live@test";
+        byte[] content = "provider-bytes"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>
+            {
+                [segmentId] = content,
+            }, useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(1, inner.BodyRequestCount);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+            Assert.Equal(content, output.ToArray());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2PacketParsingTests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2PacketParsingTests.cs
@@ -45,7 +45,7 @@ public sealed class Par2PacketParsingTests
         Assert.Equal((int)sliceSize, recv.Payload.Length);
     }
 
-  [Fact]
+    [Fact]
     public async Task ReadVerifiedPacket_CorruptedHash_Throws()
     {
         var data = new byte[32];

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2PacketParsingTests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2PacketParsingTests.cs
@@ -1,0 +1,71 @@
+using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Par2Recovery.Packets;
+using NzbWebDAV.Par2Recovery.ReedSolomon;
+
+namespace NzbWebDAV.Tests.Par2Recovery;
+
+public sealed class Par2PacketParsingTests
+{
+    [Fact]
+    public async Task ReadVerifiedPacket_MainAndIfsc_ParseCorrectly()
+    {
+        var data = new byte[5000];
+        for (var i = 0; i < data.Length; i++)
+            data[i] = (byte)(i * 3);
+
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("test.bin", data, sliceSize, [0u, 1u]);
+
+        await using var stream = new MemoryStream(volume);
+        var main = await ReadUntilTypeAsync<MainPacket>(stream);
+        Assert.Equal(sliceSize, main.SliceSize);
+        Assert.Equal(1u, main.RecoverySetFileCount);
+
+        var ifsc = await ReadUntilTypeAsync<IfscPacket>(stream);
+        Assert.Equal(2, ifsc.Slices.Count);
+    }
+
+    [Fact]
+    public async Task ReadVerifiedPacket_RecvSlicPayload_ReadsExponentAndData()
+    {
+        var data = new byte[64];
+        Random.Shared.NextBytes(data);
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("f.bin", data, sliceSize, [0u]);
+
+        await using var stream = new MemoryStream(volume);
+        Par2Packet? packet;
+        do
+        {
+            packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, readRecvSlicPayload: true, CancellationToken.None);
+        } while (packet is not RecvSlic);
+
+        var recv = (RecvSlic)packet;
+        Assert.Equal(0u, recv.Exponent);
+        Assert.Equal((int)sliceSize, recv.Payload.Length);
+    }
+
+  [Fact]
+    public async Task ReadVerifiedPacket_CorruptedHash_Throws()
+    {
+        var data = new byte[32];
+        var (_, volume) = Par2TestEncoder.EncodeSet("f.bin", data, 4096, [0u]);
+        volume[25] ^= 0xFF;
+
+        await using var stream = new MemoryStream(volume);
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            Par2RepairReader.ReadVerifiedPacketAsync(stream, readRecvSlicPayload: false, CancellationToken.None));
+    }
+
+    private static async Task<T> ReadUntilTypeAsync<T>(Stream stream) where T : Par2Packet
+    {
+        while (stream.Position < stream.Length)
+        {
+            var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, readRecvSlicPayload: false, CancellationToken.None);
+            if (packet is T typed)
+                return typed;
+        }
+
+        throw new InvalidOperationException($"No {typeof(T).Name} in stream.");
+    }
+}

--- a/tests/NzbWebDAV.Tests/Par2Recovery/Par2ReconstructorTests.cs
+++ b/tests/NzbWebDAV.Tests/Par2Recovery/Par2ReconstructorTests.cs
@@ -1,0 +1,145 @@
+using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Par2Recovery.Packets;
+using NzbWebDAV.Par2Recovery.ReedSolomon;
+
+namespace NzbWebDAV.Tests.Par2Recovery;
+
+public sealed class Par2ReconstructorTests
+{
+    [Fact]
+    public async Task Reconstruct_SingleMissingSlice_MatchesOriginal()
+    {
+        var fileData = new byte[5000];
+        for (var i = 0; i < fileData.Length; i++)
+            fileData[i] = (byte)(i * 3);
+
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("content.mkv", fileData, sliceSize, [0u, 1u]);
+
+        var descriptors = new Dictionary<string, FileDesc>();
+        var ifscs = new Dictionary<string, IfscPacket>();
+        MainPacket? main = null;
+        await using (var stream = new MemoryStream(volume))
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, false, CancellationToken.None);
+                switch (packet)
+                {
+                    case FileDesc fd:
+                        descriptors[Convert.ToHexString(fd.FileID)] = fd;
+                        break;
+                    case MainPacket mp:
+                        main = mp;
+                        break;
+                    case IfscPacket ifsc:
+                        ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                        break;
+                }
+            }
+        }
+
+        Assert.NotNull(main);
+        var slices = BuildSliceBytes(fileData, sliceSize);
+        var missingIndex = 1;
+        var recoverySlices = new List<Par2Reconstructor.RecoverySlice>();
+
+        await using (var stream = new MemoryStream(volume))
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, true, CancellationToken.None);
+                if (packet is RecvSlic recv)
+                    recoverySlices.Add(new Par2Reconstructor.RecoverySlice(recv.Exponent, recv.Payload));
+            }
+        }
+
+        var reconstructor = new Par2Reconstructor();
+        var result = await reconstructor.ReconstructAsync(
+            main!,
+            descriptors,
+            ifscs,
+            [missingIndex],
+            recoverySlices,
+            (globalSlice, size, _) =>
+            {
+                if (globalSlice == missingIndex)
+                    return Task.FromResult<byte[]?>(null);
+                return Task.FromResult<byte[]?>(slices[globalSlice]);
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success, result.FailureReason);
+        Assert.Equal(slices[missingIndex], result.ReconstructedSlices[missingIndex]);
+    }
+
+    [Fact]
+    public async Task Reconstruct_CorruptedRecoverySlice_FailsWithoutPersisting()
+    {
+        var fileData = new byte[64];
+        Random.Shared.NextBytes(fileData);
+        var (_, volume) = Par2TestEncoder.EncodeSet("f.bin", fileData, 64, [0u]);
+        volume[^1] ^= 0x55;
+
+        var descriptors = new Dictionary<string, FileDesc>();
+        var ifscs = new Dictionary<string, IfscPacket>();
+        MainPacket? main = null;
+        List<Par2Reconstructor.RecoverySlice> recovery = [];
+
+        await using var stream = new MemoryStream(volume);
+        try
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, true, CancellationToken.None);
+                switch (packet)
+                {
+                    case FileDesc fd:
+                        descriptors[Convert.ToHexString(fd.FileID)] = fd;
+                        break;
+                    case MainPacket mp:
+                        main = mp;
+                        break;
+                    case IfscPacket ifsc:
+                        ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                        break;
+                    case RecvSlic recv:
+                        recovery.Add(new Par2Reconstructor.RecoverySlice(recv.Exponent, recv.Payload));
+                        break;
+                }
+            }
+        }
+        catch (InvalidDataException)
+        {
+            return; // hash failure at read is also valid gate behavior
+        }
+
+        if (main == null || recovery.Count == 0) return;
+
+        var slices = BuildSliceBytes(fileData, 64);
+        var result = await new Par2Reconstructor().ReconstructAsync(
+            main,
+            descriptors,
+            ifscs,
+            [0],
+            recovery,
+            (_, _, _) => Task.FromResult<byte[]?>(null),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+    }
+
+    private static byte[][] BuildSliceBytes(byte[] data, ulong sliceSize)
+    {
+        var count = (int)((data.Length + (long)sliceSize - 1) / (long)sliceSize);
+        var slices = new byte[count][];
+        for (var i = 0; i < count; i++)
+        {
+            slices[i] = new byte[(int)sliceSize];
+            var offset = i * (int)sliceSize;
+            var len = Math.Min((int)sliceSize, data.Length - offset);
+            data.AsSpan(offset, len).CopyTo(slices[i]);
+        }
+        return slices;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -345,7 +345,7 @@ public sealed class Par2RepairIntegrationTests
     {
         var repoRoot = FindRepoRoot();
         var source = File.ReadAllText(
-            Path.Combine(repoRoot, "backend", "Streams", "UnbufferedMultiSegmentStream.cs"));
+            Path.Join(repoRoot, "backend", "Streams", "UnbufferedMultiSegmentStream.cs"));
         Assert.Contains("Par2RepairTriggerSink.Current?.ReportZeroFill", source);
     }
 
@@ -354,7 +354,7 @@ public sealed class Par2RepairIntegrationTests
     {
         var repoRoot = FindRepoRoot();
         var source = File.ReadAllText(
-            Path.Combine(repoRoot, "backend", "Streams", "MultiSegmentStream.cs"));
+            Path.Join(repoRoot, "backend", "Streams", "MultiSegmentStream.cs"));
         Assert.Contains("Par2RepairTriggerSink.Current?.ReportZeroFill", source);
     }
 
@@ -363,7 +363,7 @@ public sealed class Par2RepairIntegrationTests
         var dir = AppContext.BaseDirectory;
         while (dir != null)
         {
-            if (Directory.Exists(Path.Combine(dir, ".git")) || File.Exists(Path.Combine(dir, ".git")))
+            if (Directory.Exists(Path.Join(dir, ".git")) || File.Exists(Path.Join(dir, ".git")))
                 return dir;
             dir = Path.GetDirectoryName(dir);
         }

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -240,6 +240,107 @@ public sealed class Par2RepairIntegrationTests
     }
 
     [Fact]
+    public async Task ReportZeroFill_Disabled_IsNoOp()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-zf-disabled-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var config = new ConfigManager();
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            var service = new Par2RepairService(config, null!, store);
+
+            service.ReportZeroFill("/view/test.mkv", "seg1@test");
+
+            Assert.Equal(0, service.PendingZeroFillCount);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReportZeroFill_Burst_IsDeduplicatedAndBounded()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-zf-burst-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            ]);
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            var service = new Par2RepairService(config, null!, store);
+
+            // Repeated zero-fills for the same path collapse to one pending event.
+            for (var i = 0; i < 1_000; i++)
+                service.ReportZeroFill("/view/same.mkv", $"seg{i}@test");
+            Assert.Equal(1, service.PendingZeroFillCount);
+
+            // A scrub across many paths is capped by the bounded channel; excess
+            // events are rejected synchronously and leave no bookkeeping behind.
+            for (var i = 0; i < 1_000; i++)
+                service.ReportZeroFill($"/view/file{i}.mkv", "seg@test");
+            Assert.Equal(50, service.PendingZeroFillCount);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReportZeroFill_ShutdownDrainsCleanly()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"nzbdav-zf-shutdown-{Guid.NewGuid():N}");
+        var patchDir = Path.Join(tempDir, "patches");
+        Directory.CreateDirectory(tempDir);
+        var prevConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", tempDir);
+            DavDatabaseContext.ResetOptionsForTests();
+            await using (var ctx = new DavDatabaseContext())
+                await ctx.Database.EnsureCreatedAsync();
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            ]);
+            var store = new RepairPatchStore(patchDir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            var service = new Par2RepairService(config, null!, store);
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                service.ReportZeroFill("/view/unknown.mkv", "seg1@test");
+
+                // The single consumer resolves the (unknown) path and clears the dedup entry.
+                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+                while (service.PendingZeroFillCount > 0 && DateTime.UtcNow < deadline)
+                    await Task.Delay(25);
+                Assert.Equal(0, service.PendingZeroFillCount);
+            }
+            finally
+            {
+                using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await service.StopAsync(stopCts.Token);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", prevConfigPath);
+            DavDatabaseContext.ResetOptionsForTests();
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void UnbufferedStream_ZeroFill_SinkCallSiteExists()
     {
         var repoRoot = FindRepoRoot();
@@ -288,8 +389,13 @@ public sealed class Par2RepairIntegrationTests
 
             store.CommitPatch("seg1@test", new byte[100], new UsenetYencHeader
             {
-                FileName = "test.bin", FileSize = 300, LineLength = 128,
-                PartNumber = 2, TotalParts = 3, PartSize = 100, PartOffset = 100,
+                FileName = "test.bin",
+                FileSize = 300,
+                LineLength = 128,
+                PartNumber = 2,
+                TotalParts = 3,
+                PartSize = 100,
+                PartOffset = 100,
             });
 
             var nzbFile = new DavNzbFile
@@ -322,8 +428,13 @@ public sealed class Par2RepairIntegrationTests
         Random.Shared.NextBytes(content);
         var header = new UsenetYencHeader
         {
-            FileName = "movie.mkv", FileSize = 8192, LineLength = 128,
-            PartNumber = 1, TotalParts = 2, PartSize = 4096, PartOffset = 0,
+            FileName = "movie.mkv",
+            FileSize = 8192,
+            LineLength = 128,
+            PartNumber = 1,
+            TotalParts = 2,
+            PartSize = 4096,
+            PartOffset = 0,
         };
 
         try

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -11,11 +11,16 @@ using NzbWebDAV.Par2Recovery.ReedSolomon;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Tests.Fakes;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Services.Repair;
 
+// Mutates CONFIG_PATH and database context options; the collection disables all
+// parallelization so background repair services cannot race other tests' state
+// or pollute global-logger captures with transient SQLite errors.
+[Collection(nameof(ConfigPathCollection))]
 public sealed class Par2RepairIntegrationTests
 {
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -1,0 +1,408 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Par2Recovery.Packets;
+using NzbWebDAV.Par2Recovery.ReedSolomon;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+public sealed class Par2RepairIntegrationTests
+{
+    [Fact]
+    public async Task Reconstruct_MultipleMissingSlices_K2_SucceedsWithCorrectCoefficients()
+    {
+        var fileData = new byte[4096 * 4];
+        for (var i = 0; i < fileData.Length; i++)
+            fileData[i] = (byte)((i * 7 + 13) % 256);
+
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("multi.bin", fileData, sliceSize, [0u, 1u, 2u]);
+
+        var descriptors = new Dictionary<string, FileDesc>();
+        var ifscs = new Dictionary<string, IfscPacket>();
+        MainPacket? main = null;
+        var recovery = new List<Par2Reconstructor.RecoverySlice>();
+
+        await using (var stream = new MemoryStream(volume))
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, true, CancellationToken.None);
+                switch (packet)
+                {
+                    case FileDesc fd:
+                        descriptors[Convert.ToHexString(fd.FileID)] = fd;
+                        break;
+                    case MainPacket mp:
+                        main = mp;
+                        break;
+                    case IfscPacket ifsc:
+                        ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                        break;
+                    case RecvSlic recv:
+                        recovery.Add(new Par2Reconstructor.RecoverySlice(recv.Exponent, recv.Payload));
+                        break;
+                }
+            }
+        }
+
+        Assert.NotNull(main);
+        var slices = BuildSliceBytes(fileData, sliceSize);
+        var missingIndices = new[] { 0, 2 };
+
+        var reconstructor = new Par2Reconstructor();
+        var result = await reconstructor.ReconstructAsync(
+            main!,
+            descriptors,
+            ifscs,
+            missingIndices,
+            recovery,
+            (globalSlice, size, _) =>
+            {
+                if (missingIndices.Contains(globalSlice))
+                    return Task.FromResult<byte[]?>(null);
+                return Task.FromResult<byte[]?>(slices[globalSlice]);
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success, result.FailureReason);
+        Assert.Equal(slices[0], result.ReconstructedSlices[0]);
+        Assert.Equal(slices[2], result.ReconstructedSlices[2]);
+    }
+
+    [Fact]
+    public async Task Reconstruct_MissingSliceAtStart_WholeFileHashHandlesGap()
+    {
+        var fileData = new byte[4096 * 3];
+        for (var i = 0; i < fileData.Length; i++)
+            fileData[i] = (byte)(i ^ 0xAA);
+
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("gapped.bin", fileData, sliceSize, [0u, 1u]);
+
+        var descriptors = new Dictionary<string, FileDesc>();
+        var ifscs = new Dictionary<string, IfscPacket>();
+        MainPacket? main = null;
+        var recovery = new List<Par2Reconstructor.RecoverySlice>();
+
+        await using (var stream = new MemoryStream(volume))
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, true, CancellationToken.None);
+                switch (packet)
+                {
+                    case FileDesc fd:
+                        descriptors[Convert.ToHexString(fd.FileID)] = fd;
+                        break;
+                    case MainPacket mp:
+                        main = mp;
+                        break;
+                    case IfscPacket ifsc:
+                        ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                        break;
+                    case RecvSlic recv:
+                        recovery.Add(new Par2Reconstructor.RecoverySlice(recv.Exponent, recv.Payload));
+                        break;
+                }
+            }
+        }
+
+        Assert.NotNull(main);
+        var slices = BuildSliceBytes(fileData, sliceSize);
+
+        var reconstructor = new Par2Reconstructor();
+        var result = await reconstructor.ReconstructAsync(
+            main!,
+            descriptors,
+            ifscs,
+            [0],
+            recovery,
+            (globalSlice, size, _) =>
+            {
+                if (globalSlice == 0)
+                    return Task.FromResult<byte[]?>(null);
+                return Task.FromResult<byte[]?>(slices[globalSlice]);
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success, result.FailureReason);
+        Assert.Equal(slices[0], result.ReconstructedSlices[0]);
+    }
+
+    [Fact]
+    public async Task Reconstruct_CorruptRecoverySlice_GateFailure_NothingPersisted()
+    {
+        var fileData = new byte[4096 * 2];
+        Random.Shared.NextBytes(fileData);
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("corrupt.bin", fileData, sliceSize, [0u]);
+
+        var descriptors = new Dictionary<string, FileDesc>();
+        var ifscs = new Dictionary<string, IfscPacket>();
+        MainPacket? main = null;
+        var recovery = new List<Par2Reconstructor.RecoverySlice>();
+
+        await using (var stream = new MemoryStream(volume))
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, true, CancellationToken.None);
+                switch (packet)
+                {
+                    case FileDesc fd:
+                        descriptors[Convert.ToHexString(fd.FileID)] = fd;
+                        break;
+                    case MainPacket mp:
+                        main = mp;
+                        break;
+                    case IfscPacket ifsc:
+                        ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                        break;
+                    case RecvSlic recv:
+                        var corrupted = (byte[])recv.Payload.Clone();
+                        corrupted[0] ^= 0xFF;
+                        recovery.Add(new Par2Reconstructor.RecoverySlice(recv.Exponent, corrupted));
+                        break;
+                }
+            }
+        }
+
+        Assert.NotNull(main);
+        var slices = BuildSliceBytes(fileData, sliceSize);
+
+        var reconstructor = new Par2Reconstructor();
+        var result = await reconstructor.ReconstructAsync(
+            main!,
+            descriptors,
+            ifscs,
+            [1],
+            recovery,
+            (globalSlice, size, _) =>
+            {
+                if (globalSlice == 1)
+                    return Task.FromResult<byte[]?>(null);
+                return Task.FromResult<byte[]?>(slices[globalSlice]);
+            },
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("IFSC verification", result.FailureReason);
+    }
+
+    [Fact]
+    public void MissingSlicesExceedCap_DefaultCapIs8()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"nzbdav-cap-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var prevConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", tempDir);
+            var configManager = new ConfigManager();
+            var maxSlices = configManager.GetPar2MaxMissingSlices();
+            Assert.Equal(8, maxSlices);
+
+            var missingCount = 9;
+            Assert.True(missingCount > maxSlices,
+                $"9 missing slices should exceed the default cap of {maxSlices}");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", prevConfigPath);
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TriggerSink_NullCurrent_DoesNotThrow()
+    {
+        var prev = Par2RepairTriggerSink.Current;
+        try
+        {
+            Par2RepairTriggerSink.Current = null;
+            Par2RepairTriggerSink.Current?.ReportZeroFill("/view/test.mkv", "seg1@test", 0, 4096);
+        }
+        finally
+        {
+            Par2RepairTriggerSink.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void UnbufferedStream_ZeroFill_SinkCallSiteExists()
+    {
+        var repoRoot = FindRepoRoot();
+        var source = File.ReadAllText(
+            Path.Combine(repoRoot, "backend", "Streams", "UnbufferedMultiSegmentStream.cs"));
+        Assert.Contains("Par2RepairTriggerSink.Current?.ReportZeroFill", source);
+    }
+
+    [Fact]
+    public void MultiSegmentStream_ZeroFillSegment_SinkCallSiteExists()
+    {
+        var repoRoot = FindRepoRoot();
+        var source = File.ReadAllText(
+            Path.Combine(repoRoot, "backend", "Streams", "MultiSegmentStream.cs"));
+        Assert.Contains("Par2RepairTriggerSink.Current?.ReportZeroFill", source);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir, ".git")) || File.Exists(Path.Combine(dir, ".git")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not locate repository root from " + AppContext.BaseDirectory);
+    }
+
+    [Fact]
+    public async Task HealthCheck_FilterSegmentsForStat_ExcludesRepairedSegments()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-hc-filter-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+
+            var segmentIds = new[] { "seg0@test", "seg1@test", "seg2@test" };
+            var ranges = new[]
+            {
+                LongRange.FromStartAndSize(0, 100),
+                LongRange.FromStartAndSize(100, 100),
+                LongRange.FromStartAndSize(200, 100),
+            };
+
+            store.CommitPatch("seg1@test", new byte[100], new UsenetYencHeader
+            {
+                FileName = "test.bin", FileSize = 300, LineLength = 128,
+                PartNumber = 2, TotalParts = 3, PartSize = 100, PartOffset = 100,
+            });
+
+            var nzbFile = new DavNzbFile
+            {
+                SegmentIds = segmentIds,
+                SegmentByteRanges = ranges,
+            };
+
+            var sampled = segmentIds.ToList();
+            var result = HealthCheckService.FilterSegmentsForStat(
+                sampled, segmentIds.ToList(), nzbFile, store);
+
+            Assert.DoesNotContain("seg1@test", result);
+            Assert.Contains("seg0@test", result);
+            Assert.Contains("seg2@test", result);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PatchStore_CommitAndServe_EndToEnd()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-e2e-patch-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "e2e-segment@test";
+        var content = new byte[4096];
+        Random.Shared.NextBytes(content);
+        var header = new UsenetYencHeader
+        {
+            FileName = "movie.mkv", FileSize = 8192, LineLength = 128,
+            PartNumber = 1, TotalParts = 2, PartSize = 4096, PartOffset = 0,
+        };
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+
+            Assert.False(store.Contains(segmentId));
+            store.CommitPatch(segmentId, content, header);
+            Assert.True(store.Contains(segmentId));
+
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(0, inner.BodyRequestCount);
+
+            await using var ms = new MemoryStream();
+            await response.Stream!.CopyToAsync(ms);
+            Assert.Equal(content, ms.ToArray());
+
+            var reloaded = new RepairPatchStore(dir, 1024 * 1024);
+            await reloaded.CatalogLoadTask;
+            Assert.True(reloaded.Contains(segmentId));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Migration_AppliesCleanly()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"nzbdav-migration-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var prevConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", tempDir);
+            DavDatabaseContext.ResetOptionsForTests();
+            await using var ctx = new DavDatabaseContext();
+            await ctx.Database.EnsureCreatedAsync();
+            Assert.NotNull(ctx.Par2RepairJobs);
+
+            ctx.Par2RepairJobs.Add(new Par2RepairJob
+            {
+                Id = Guid.NewGuid(),
+                DavItemId = Guid.NewGuid(),
+                Path = "/view/test.mkv",
+                State = Par2RepairJob.RepairJobState.Queued,
+                MissingSegmentIds = ["seg1@test"],
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+
+            var count = ctx.Par2RepairJobs.Count();
+            Assert.Equal(1, count);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", prevConfigPath);
+            DavDatabaseContext.ResetOptionsForTests();
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static byte[][] BuildSliceBytes(byte[] data, ulong sliceSize)
+    {
+        var count = (int)((data.Length + (long)sliceSize - 1) / (long)sliceSize);
+        var slices = new byte[count][];
+        for (var i = 0; i < count; i++)
+        {
+            slices[i] = new byte[(int)sliceSize];
+            var offset = i * (int)sliceSize;
+            var len = Math.Min((int)sliceSize, data.Length - offset);
+            data.AsSpan(offset, len).CopyTo(slices[i]);
+        }
+        return slices;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
@@ -1,0 +1,70 @@
+using NzbWebDAV.Services.Repair;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+public sealed class RepairPatchStoreTests
+{
+    private static UsenetYencHeader Header(int size) => new()
+    {
+        FileName = "test.bin",
+        FileSize = size,
+        LineLength = 128,
+        PartNumber = 1,
+        TotalParts = 1,
+        PartOffset = 0,
+        PartSize = size,
+    };
+
+    [Fact]
+    public async Task CommitPatch_IsVisibleAfterAtomicCommit_AndSurvivesReload()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-store-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "seg@test";
+        byte[] content = "patch-data"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+
+            store.CommitPatch(segmentId, content, Header(content.Length));
+
+            Assert.True(store.IsRepaired(segmentId, content.Length));
+            Assert.True(store.TryGet(segmentId, out var response));
+            response!.Stream!.Dispose();
+
+            var reloaded = new RepairPatchStore(dir, 1024 * 1024);
+            await reloaded.CatalogLoadTask;
+            Assert.True(reloaded.IsRepaired(segmentId, content.Length));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Eviction_RemovesOldestWhenOverCap()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-evict-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var maxBytes = 50;
+            var store = new RepairPatchStore(dir, maxBytes);
+            await store.CatalogLoadTask;
+
+            store.CommitPatch("a@test", new byte[30], Header(30));
+            store.CommitPatch("b@test", new byte[30], Header(30));
+
+            Assert.False(store.Contains("a@test"));
+            Assert.True(store.Contains("b@test"));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -13,6 +13,7 @@ using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Services.SupportPack;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Websocket;
@@ -601,6 +602,10 @@ public sealed class SupportPackContentsTests : IDisposable
             new ActiveReadRegistry());
 
         using var gcDiagnosticsStore = new GcDiagnosticsStore();
+        var repairDir = Path.Join(Path.GetTempPath(), "nzbdav-support-test-" + Guid.NewGuid().ToString("N"));
+        var repairPatchStore = new RepairPatchStore(repairDir, 1024 * 1024);
+        await repairPatchStore.CatalogLoadTask;
+        var par2RepairService = new Par2RepairService(configManager, usenet, repairPatchStore);
         var service = new SupportPackService(
             logBuffer,
             warningBuffer,
@@ -614,6 +619,8 @@ public sealed class SupportPackContentsTests : IDisposable
             streamTraceBuffer,
             runtimeUsage ?? new RuntimeUsageTracker(),
             gcDiagnosticsStore,
+            par2RepairService,
+            repairPatchStore,
             concurrentReadTracker);
 
         using var memory = new MemoryStream();


### PR DESCRIPTION
## Summary

- Adds a bounded background repair pipeline that reconstructs missing Usenet segments from PAR2 parity data, eliminating the need for Arr re-grabs when recovery slices are available.
- PAR2 repair is **enabled by default** (subordinate to the master `repair.enable` toggle). Operators can disable via Settings → Repairs → "Enable PAR2 background repair" (or `repair.par2-enabled=false`).
- Repairs are fully traceable in the support pack (`environment.json → par2Repair`): config state, patch-store stats, recent jobs with phase/duration/outcome/gate-failures, and Prometheus counters. Recovery fetches run under `MaintenanceDownloadContext` on the queue Low lane (concurrency 2), distinguishable from playback in pool/connection diagnostics.

## Phase 1 of #1027

This PR delivers single-file (non-multipart) PAR2 background repair. Deferred to subsequent phases:
- Multipart/RAR set slice-to-segment mapping
- User-facing documentation and published guides
- Real-corpus validation against par2cmdline-generated archives

## Playback safety

| Property | Guarantee |
|----------|-----------|
| Default behavior | ON, but strictly subordinate to `repair.enable` |
| Healthy library inertness | Single dictionary lookup per segment; no background work, no allocations |
| Wrapper isolation | `RepairedSegmentNntpClient` sits before segment cache and miss cache; a patch-store miss is a single `ConcurrentDictionary.TryGetValue` |
| Bounded concurrency | Recovery fetches use `MaintenanceDownloadContext` on the queue-semaphore Low lane, capped at 2 concurrent connections |
| Bounded memory | Working set limited by `repair.par2-max-memory-mb` (default 256 MB); RS accumulators freed per-job |
| Bounded disk | Patch store LRU-capped at `repair.par2-max-patch-gb` (default 4 GB) |
| Gate failures | Four validation gates (IFSC per-slice, whole-file MD5 when contiguous, recovery-slice count ≥ missing, memory cap) enforced before atomic commit; failure → Warning log + existing fallback behavior |

## Disable instructions

To disable on CPU-constrained hosts or to limit provider bandwidth:
- Settings UI: Repairs → uncheck "Enable PAR2 background repair"
- Config: `repair.par2-enabled=false`
- Each repair reads the full recovery set once (up to the 16 GB release-size cap by default)

## Support-pack traceability

The `par2Repair` section in `environment.json` reports:
- Feature config (enabled, caps, concurrency, cooldown)
- Patch store: entries, current bytes, max bytes, hit count, eviction count, catalog readiness
- Job counters: queued/running, total succeeded/failed/infeasible, bytes read, segments reconstructed
- Recent jobs (last 10): path, state, timing, attempts, bytes, slices, failure reason

Prometheus metrics (`nzbdav_par2_*`) are also captured in `metrics/recent.json`.

## AttributionContext note

Recovery fetches run under `MaintenanceDownloadContext` which does **not** set `AttributionContext`. This means reconstructed segment bytes may populate the playback segment cache on a cache miss — a harmless positive side effect (free cache warming).

## Packet MD5 interop note

PAR2 packet hash is computed over bytes 32..packet-end (everything after the hash field: recovery set ID, type signature, and body). This matches the PAR2 2.0 specification and par2-rs behavior. **Recommended:** validate against a real par2cmdline-generated corpus before v1.0 to confirm interop with all major PAR2 implementations.

## Pre-existing test failure

`SegmentFallbackTests.MultiSegmentStream_ConsecutiveMissingArticlesStopPrefetch(usePipelinedBodyRequests: True)` fails identically on `main` — tracked in #1031.

## Migration note

This PR adds an additive EF Core migration (`Par2RepairJob` table). Back up `/config` before upgrading as the migration auto-applies on startup.

## Test plan

- [x] RS reconstruction with k=2 missing slices (validates coefficient fix)
- [x] Missing-at-start slice with whole-file MD5 hash gap handling
- [x] Corrupt recovery slice → IFSC gate failure → nothing persisted
- [x] Missing > 8 cap declined as infeasible
- [x] Trigger sink call sites wired at both zero-fill paths
- [x] HealthCheckService partition: repaired segments excluded from STAT checks
- [x] PatchStore commit → serve → catalog reload end-to-end
- [x] Migration schema smoke test
- [x] Frontend typecheck + 642 Vitest tests pass
- [x] Backend: 3032 passed, 10 skipped, 1 pre-existing failure (#1031)
- [ ] Manual: rclone scrubbing with a known-missing segment → verify transparent repair
- [ ] Manual: validate packet MD5 against par2cmdline corpus