### PR TITLE
chore(test): fix flaky consecutive-missing-article prefetch test

### DIFF
--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -64,6 +64,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     /// <summary>Current adaptive BODY batch width (or the fixed pipeline size when not adaptive).</summary>
     internal int PrefetchBatchWidth => _batchSizer?.Current ?? _bodyPipelineBatchSize;
 
+    /// <summary>
+    /// Test hook: completes when the producer loop has exited (e.g. after observing
+    /// the consecutive-zero-fill cancellation), so tests can assert on the final
+    /// request count without racing the prefetch top-up.
+    /// </summary>
+    internal Task DownloadTaskForTests => _downloadTask;
+
     public static Stream Create(
         Memory<string> segmentIds,
         INntpClient usenetClient,

--- a/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentFallbackTests.cs
@@ -80,7 +80,13 @@ public class SegmentFallbackTests
     public async Task MultiSegmentStream_ConsecutiveMissingArticlesStopPrefetch(
         bool usePipelinedBodyRequests)
     {
-        var segmentIds = Enumerable.Range(0, 20)
+        // The consumer aborts on the third consecutive zero-fill, but each consumed
+        // zero-fill releases prefetch-ceiling bytes first, so the producer may legally
+        // top up one more batch before it observes the cancellation. With a window of
+        // articleBufferSize * batchWidth (16) plus that top-up, up to ~24 requests can
+        // fire; use enough segments that even the worst-case interleaving stays below
+        // the total, keeping this assertion deterministic (see #1031).
+        var segmentIds = Enumerable.Range(0, 40)
             .Select(index => $"missing-{index}")
             .ToArray();
         var client = new RawBodyNntpClient(new Dictionary<string, byte[]>());
@@ -102,7 +108,12 @@ public class SegmentFallbackTests
                 using var destination = new MemoryStream();
                 return stream.CopyToAsync(destination);
             });
-        await Task.Delay(50);
+
+        // Wait for the producer loop to exit instead of sleeping: if the
+        // consecutive-zero-fill cancellation regresses, the producer blocks at the
+        // prefetch ceiling and this times out instead of passing vacuously.
+        var multiSegmentStream = Assert.IsType<MultiSegmentStream>(stream);
+        await multiSegmentStream.DownloadTaskForTests.WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.True(
             client.BodyRequestCount < segmentIds.Length,


### PR DESCRIPTION
## Summary
- Fixes #1031.
- Root cause of the flake: the consumer aborts on the third consecutive zero-fill, but consuming each zero-fill releases prefetch-ceiling bytes first, so the producer may legally top up **one more batch** before it observes the cancellation. With the pipelined task window at `articleBufferSize * batchWidth` (16 of the test's 20 segments) plus that top-up batch, all 20 articles could be requested. On an idle machine this races the producer's way **deterministically** (isolated runs failed 8/8 on `main`); under CI load it lands either way — the intermittent failure tracked in #1031.
- Test-level fix (the one-extra-batch top-up is bounded and acceptable in production): use 40 segments so the worst-case window + top-up (~24 requests) stays below the total under any interleaving, and await the producer loop's exit via a new internal test accessor instead of `Task.Delay(50)` — if the consecutive-zero-fill cancellation ever regresses, the producer blocks at the prefetch ceiling and the test times out instead of passing vacuously.

## Test plan
- [x] `MultiSegmentStream_ConsecutiveMissingArticlesStopPrefetch` isolated x10: 10/10 pass (was 0/8 on `main`)
- [x] Full backend suite: 3014 passed, 0 failed