### PR TITLE
fix(ui): play files from the web UI over plain HTTP

### DIFF
--- a/frontend/app/routes/explore/media-preview/media-preview.test.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.test.tsx
@@ -82,6 +82,23 @@ describe("MediaPreview", () => {
         expect(video!.hasAttribute("playsinline")).toBe(true);
     });
 
+    it("renders on plain HTTP when crypto.randomUUID is unavailable", () => {
+        vi.stubGlobal("crypto", {
+            randomUUID: undefined,
+            getRandomValues: (bytes: Uint8Array) => {
+                bytes.fill(0);
+                return bytes;
+            },
+        });
+
+        const { container } = renderPreview();
+        const video = container.querySelector("video");
+        expect(video).not.toBeNull();
+        expect(video!.getAttribute("src")).toContain(
+            "playerSession=00000000-0000-4000-8000-000000000000",
+        );
+    });
+
     it("renders an audio element for audio files", () => {
         const { container } = renderPreview({
             fileName: "song.flac",

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -5,6 +5,7 @@ import { isVideoFile } from "../file-kind/file-kind";
 import { MediaDiagnostics } from "./media-diagnostics";
 import { appendQueryParam, buildMediaSrc, formatClock } from "./media-utils";
 import { useMediaPlayer } from "./use-media-player";
+import { generateUuid } from "~/utils/uuid";
 
 export type MediaPreviewProps = {
     fileName: string;
@@ -26,7 +27,7 @@ export function MediaPreview(props: MediaPreviewProps) {
 
     // One non-secret correlation id per mounted player; stable across retries
     // so all range requests map to one backend read session.
-    const playerSession = useMemo(() => crypto.randomUUID(), []);
+    const playerSession = useMemo(() => generateUuid(), []);
     const src = useMemo(() => buildMediaSrc(previewUrl, playerSession), [previewUrl, playerSession]);
 
     const player = useMediaPlayer({ src });

--- a/frontend/app/routes/explore/media-preview/media-preview.tsx
+++ b/frontend/app/routes/explore/media-preview/media-preview.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from "react";
 import { Alert, Button, Icon, Modal } from "~/components/ui";
 import { formatFileSize } from "~/utils/file-size";
+import { generateUuid } from "~/utils/uuid";
 import { isVideoFile } from "../file-kind/file-kind";
 import { MediaDiagnostics } from "./media-diagnostics";
 import { appendQueryParam, buildMediaSrc, formatClock } from "./media-utils";
 import { useMediaPlayer } from "./use-media-player";
-import { generateUuid } from "~/utils/uuid";
 
 export type MediaPreviewProps = {
     fileName: string;
@@ -27,7 +27,7 @@ export function MediaPreview(props: MediaPreviewProps) {
 
     // One non-secret correlation id per mounted player; stable across retries
     // so all range requests map to one backend read session.
-    const playerSession = useMemo(() => generateUuid(), []);
+    const [playerSession] = useState(() => generateUuid());
     const src = useMemo(() => buildMediaSrc(previewUrl, playerSession), [previewUrl, playerSession]);
 
     const player = useMediaPlayer({ src });

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -15,6 +15,7 @@ import { ExpandingTextInput } from "~/components/expanding-text-input/expanding-
 import { MultiCheckboxInput } from "~/components/multi-checkbox-input/multi-checkbox-input";
 import { TagInput } from "~/components/tag-input/tag-input";
 import { Icon } from "~/components/ui/icon";
+import { generateUuid } from "~/utils/uuid";
 
 type SabnzbdSettingsProps = {
     config: Record<string, string>
@@ -524,7 +525,7 @@ export function isSabnzbdSettingsValid(config: Record<string, string>): boolean 
 }
 
 export function generateNewApiKey(): string {
-    return crypto.randomUUID().replaceAll("-", "");
+    return generateUuid().replaceAll("-", "");
 }
 
 function isValidCategories(categories: string): boolean {

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -2,6 +2,7 @@ import { type Dispatch, type SetStateAction, type ReactNode, type CSSProperties,
 import { Alert, Badge, Button, HelpText, Icon, Input, Label, ManagedSetting, Modal, Select, SettingsIntro, SettingsPage, Tooltip, Toggle } from "~/components/ui";
 import { subscribeWebsocketTopics, useWebsocketTopic } from "~/utils/shared-websocket";
 import { isMaskedSecret } from "~/utils/config-mask";
+import { generateUuid } from "~/utils/uuid";
 import { shouldWarnCleartextCredentials } from "./cleartext-credentials";
 import {
     DndContext,
@@ -416,19 +417,8 @@ function usagePollIdentityKey(item: ProviderUsage, providers: ConnectionDetails[
     return `${item.host}::${nickname}`;
 }
 
-// crypto.randomUUID requires a secure context, but self-hosted UIs are often
-// served over plain http on a LAN; fall back to a manual v4 from getRandomValues.
 function generateProviderId(): string {
-    if (typeof crypto.randomUUID === "function") {
-        return crypto.randomUUID();
-    }
-    const bytes = new Uint8Array(16);
-    crypto.getRandomValues(bytes);
-    // bytes is a 16-element array; indices 6 and 8 are always in bounds.
-    bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
-    bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
-    const hex = Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
-    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    return generateUuid();
 }
 
 type DragBits = {

--- a/frontend/app/utils/uuid.test.ts
+++ b/frontend/app/utils/uuid.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateUuid } from "./uuid";
+
+describe("generateUuid", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("uses crypto.randomUUID when available", () => {
+        const randomUUID = vi.fn(() => "native-uuid");
+        vi.stubGlobal("crypto", { randomUUID });
+
+        expect(generateUuid()).toBe("native-uuid");
+        expect(randomUUID).toHaveBeenCalledOnce();
+    });
+
+    it("generates a v4 UUID when randomUUID is unavailable", () => {
+        vi.stubGlobal("crypto", {
+            randomUUID: undefined,
+            getRandomValues: (bytes: Uint8Array) => {
+                bytes.fill(0);
+                return bytes;
+            },
+        });
+
+        expect(generateUuid()).toBe("00000000-0000-4000-8000-000000000000");
+    });
+});

--- a/frontend/app/utils/uuid.test.ts
+++ b/frontend/app/utils/uuid.test.ts
@@ -25,4 +25,12 @@ describe("generateUuid", () => {
 
         expect(generateUuid()).toBe("00000000-0000-4000-8000-000000000000");
     });
+
+    it("explains when no cryptographic random source is available", () => {
+        vi.stubGlobal("crypto", undefined);
+
+        expect(() => generateUuid()).toThrow(
+            "This browser does not provide the cryptographic random source required to generate a UUID.",
+        );
+    });
 });

--- a/frontend/app/utils/uuid.ts
+++ b/frontend/app/utils/uuid.ts
@@ -5,8 +5,15 @@
  */
 export function generateUuid(): string {
     const browserCrypto = globalThis.crypto;
+    if (!browserCrypto) {
+        throw new Error("This browser does not provide the cryptographic random source required to generate a UUID.");
+    }
+
     if (typeof browserCrypto.randomUUID === "function") {
         return browserCrypto.randomUUID();
+    }
+    if (typeof browserCrypto.getRandomValues !== "function") {
+        throw new Error("This browser does not provide the cryptographic random source required to generate a UUID.");
     }
 
     const bytes = new Uint8Array(16);

--- a/frontend/app/utils/uuid.ts
+++ b/frontend/app/utils/uuid.ts
@@ -1,0 +1,19 @@
+/**
+ * Generates a UUID v4 in both secure and insecure browser contexts.
+ * `crypto.randomUUID` requires a secure context, but self-hosted UIs are often
+ * served over plain HTTP on a LAN; `crypto.getRandomValues` remains available.
+ */
+export function generateUuid(): string {
+    const browserCrypto = globalThis.crypto;
+    if (typeof browserCrypto.randomUUID === "function") {
+        return browserCrypto.randomUUID();
+    }
+
+    const bytes = new Uint8Array(16);
+    browserCrypto.getRandomValues(bytes);
+    // bytes is a 16-element array; indices 6 and 8 are always in bounds.
+    bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+    bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+    const hex = Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary
- allow media-preview session IDs to be generated when the web UI is served over plain HTTP
- share the secure-context-compatible UUID generator with provider IDs and SAB API keys
- report a clear error only when the browser lacks all cryptographic randomness APIs
- cover the insecure-context player path with regression tests

Fixes #1034

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test -- app/utils/uuid.test.ts app/routes/explore/media-preview/media-preview.test.tsx`