### PR TITLE
chore(health): filter damage-classifier indices explicitly with Where

### DIFF
--- a/backend/Services/Repair/SegmentDamageClassifier.cs
+++ b/backend/Services/Repair/SegmentDamageClassifier.cs
@@ -44,9 +44,8 @@ public static class SegmentDamageClassifier
         // The run/head checks below assume sorted, unique, in-range indices; normalize
         // defensively so a mis-ordered or duplicated list cannot misclassify.
         var missing = missingIndices.Distinct().OrderBy(index => index).ToArray();
-        foreach (var index in missing)
-            if (index < 0 || index >= totalSegments)
-                throw new ArgumentOutOfRangeException(nameof(missingIndices), index, "Missing segment index out of range.");
+        foreach (var index in missing.Where(index => index < 0 || index >= totalSegments))
+            throw new ArgumentOutOfRangeException(nameof(missingIndices), index, "Missing segment index out of range.");
 
         var missingBytes = missing.Sum(index => exactSegmentSizes[index]);
         var totalBytes = exactSegmentSizes.Sum();


### PR DESCRIPTION
## Summary
- Follow-up to #1035 addressing the remaining code-quality review nit: the out-of-range validation loop in `SegmentDamageClassifier.Classify` now filters the sequence explicitly with `.Where(...)` instead of an `if` inside the `foreach`.
- No behavior change; same exception for the same inputs.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests -c Release --filter FullyQualifiedName~SegmentDamageClassifierTests` (22/22 pass, including the out-of-range cases added in #1035)
- [ ] CI green