### PR TITLE
feat(queue): recover missing articles using equivalent segments from other copies of the same release

### DIFF
--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -145,6 +145,9 @@ public static class ConfigKeys
     public const string VariantsMaxPerGroup = "variants.max-per-group";
     public const string VariantsMode = "variants.mode";
     public const string VariantsReplayStrategy = "variants.replay-strategy";
+    public const string VariantsSegmentDonorsEnabled = "variants.segment-donors-enabled";
+    public const string VariantsSegmentDonorsMaxPerSegment = "variants.segment-donors-max-per-segment";
+    public const string VariantsSegmentDonorsMaxSiblings = "variants.segment-donors-max-siblings";
     public const string VariantsTolerancePct = "variants.tolerance-pct";
 
     // preflight

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -364,6 +364,8 @@ public class ConfigManager
                 case ConfigKeys.VariantsTolerancePct:
                 case ConfigKeys.VariantsMaxPerGroup:
                 case ConfigKeys.VariantsEvictionActiveGraceSeconds:
+                case ConfigKeys.VariantsSegmentDonorsMaxSiblings:
+                case ConfigKeys.VariantsSegmentDonorsMaxPerSegment:
                 case ConfigKeys.PreflightMaxAttempts:
                 case ConfigKeys.PreflightTtlSeconds:
                 case ConfigKeys.PreflightIndexerMaxWaitSeconds:
@@ -432,6 +434,7 @@ public class ConfigManager
                 case ConfigKeys.PlayPreferSubtitles:
                 case ConfigKeys.GrabStallFailoverEnabled:
                 case ConfigKeys.VariantsFallbackOnFailure:
+                case ConfigKeys.VariantsSegmentDonorsEnabled:
                 case ConfigKeys.WatchtowerEnabled:
                 case ConfigKeys.WatchtowerAutoThroughput:
                 case ConfigKeys.WatchtowerVerboseLogging:
@@ -1431,6 +1434,26 @@ public class ConfigManager
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsFallbackOnFailure));
         return v == null || bool.Parse(v);
+    }
+
+    public bool IsVariantsSegmentDonorsEnabled()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsSegmentDonorsEnabled));
+        return v == null || bool.Parse(v);
+    }
+
+    public int GetVariantsSegmentDonorsMaxSiblings()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsSegmentDonorsMaxSiblings));
+        if (v == null) return 3;
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 0, 10) : 3;
+    }
+
+    public int GetVariantsSegmentDonorsMaxPerSegment()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.VariantsSegmentDonorsMaxPerSegment));
+        if (v == null) return 6;
+        return int.TryParse(v, out var n) ? Math.Clamp(n, 1, 32) : 6;
     }
 
     public string GetVariantsEvictionStrategy()

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -19,6 +19,7 @@ using NzbWebDAV.Queue.FileAggregators;
 using NzbWebDAV.Queue.FileProcessors;
 using NzbWebDAV.Queue.NestedRarExpansion;
 using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Queue.SiblingDonors;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Utils;
@@ -336,6 +337,10 @@ public class QueueItemProcessor(
         // https://github.com/infinidysk/infinidysk/issues/101
         var articlesToPrecheck = nzbFiles.SelectMany(x => x.Segments).Select(x => x.MessageId);
         HealthCheckService.CheckCachedMissingSegmentIds(articlesToPrecheck);
+
+        await RunStageAsync("sibling-donors",
+            () => SiblingDonorAttacher.AttachToNewImportAsync(
+                dbClient, queueItem, nzbFiles, configManager, ct)).ConfigureAwait(false);
 
         // step 1 -- get name and size of each nzb file
         var stepTimer = Stopwatch.StartNew();

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -518,6 +518,9 @@ public class QueueItemProcessor(
                     .CreateStrmFilesAsync()
                     .ConfigureAwait(false);
 
+            await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
+                dbClient, queueItem, nzb, configManager, ct).ConfigureAwait(false);
+
             return mountFolder;
         }).ConfigureAwait(false);
     }

--- a/backend/Queue/SiblingDonors/SiblingDonorAttacher.cs
+++ b/backend/Queue/SiblingDonors/SiblingDonorAttacher.cs
@@ -52,9 +52,8 @@ internal static class SiblingDonorAttacher
                 var added = 0;
                 foreach (var primary in nzbFiles)
                 {
-                    foreach (var donor in document.Files)
+                    foreach (var donor in document.Files.Where(donor => IsDonorMatch(primary, donor)))
                     {
-                        if (!IsDonorMatch(primary, donor)) continue;
                         added += MergeDonorIds(primary, donor, maxPerSegment);
                     }
                 }
@@ -137,7 +136,7 @@ internal static class SiblingDonorAttacher
     private static async Task BackfillSiblingBlobsAsync(
         DavDatabaseContext ctx,
         Guid siblingHistoryId,
-        Dictionary<string, NzbFile> siblingFilesByKey,
+        Dictionary<IReadOnlyList<string>, NzbFile> siblingFilesByKey,
         List<NzbFile> newFiles,
         int maxPerSegment,
         CancellationToken ct)
@@ -155,7 +154,7 @@ internal static class SiblingDonorAttacher
             var copy = await DeserializeDavNzbFileCopyAsync(davItem.FileBlobId!.Value, ct)
                 .ConfigureAwait(false);
             if (copy is null || copy.SegmentIds.Length == 0) continue;
-            if (!siblingFilesByKey.TryGetValue(SegmentKey(copy.SegmentIds), out var siblingFile))
+            if (!siblingFilesByKey.TryGetValue(copy.SegmentIds, out var siblingFile))
                 continue;
 
             var newFile = FindMatchingFile(newFiles, siblingFile);
@@ -175,17 +174,16 @@ internal static class SiblingDonorAttacher
 
     private static void MergeSiblingIntoPendingBlob(
         DavNzbFile pending,
-        Dictionary<string, NzbFile> newFilesByKey,
+        Dictionary<IReadOnlyList<string>, NzbFile> newFilesByKey,
         IReadOnlyList<NzbFile> siblingFiles,
         int maxPerSegment)
     {
         if (pending.SegmentIds.Length == 0) return;
-        if (!newFilesByKey.TryGetValue(SegmentKey(pending.SegmentIds), out var newFile))
+        if (!newFilesByKey.TryGetValue(pending.SegmentIds, out var newFile))
             return;
 
-        foreach (var siblingFile in siblingFiles)
+        foreach (var siblingFile in siblingFiles.Where(siblingFile => IsDonorMatch(newFile, siblingFile)))
         {
-            if (!IsDonorMatch(newFile, siblingFile)) continue;
             MergeDonorIdsIntoDavNzbFile(pending, siblingFile, maxPerSegment);
         }
     }
@@ -284,9 +282,6 @@ internal static class SiblingDonorAttacher
             yield return id;
     }
 
-    internal static string SegmentKey(IReadOnlyList<string> segmentIds) =>
-        string.Join("\u0001", segmentIds);
-
     internal static bool AppendIds(
         ref string[] existing,
         string ownPrimary,
@@ -300,9 +295,9 @@ internal static class SiblingDonorAttacher
 
         var seen = new HashSet<string>(existing, StringComparer.Ordinal) { ownPrimary };
         List<string>? extra = null;
-        foreach (var id in candidates)
+        foreach (var id in candidates.Where(id => !string.IsNullOrEmpty(id)))
         {
-            if (string.IsNullOrEmpty(id) || !seen.Add(id)) continue;
+            if (!seen.Add(id)) continue;
             extra ??= [.. existing];
             extra.Add(id);
             if (extra.Count >= maxPerSegment) break;
@@ -314,13 +309,12 @@ internal static class SiblingDonorAttacher
         return true;
     }
 
-    internal static Dictionary<string, NzbFile> IndexBySegmentIds(IEnumerable<NzbFile> files)
+    internal static Dictionary<IReadOnlyList<string>, NzbFile> IndexBySegmentIds(IEnumerable<NzbFile> files)
     {
-        var map = new Dictionary<string, NzbFile>(StringComparer.Ordinal);
-        foreach (var file in files)
+        var map = new Dictionary<IReadOnlyList<string>, NzbFile>(SegmentIdListComparer.Instance);
+        foreach (var file in files.Where(file => file.Segments.Count > 0))
         {
-            if (file.Segments.Count == 0) continue;
-            map.TryAdd(SegmentKey(file.GetSegmentIds()), file);
+            map.TryAdd(file.GetSegmentIds(), file);
         }
 
         return map;
@@ -328,12 +322,7 @@ internal static class SiblingDonorAttacher
 
     internal static NzbFile? FindMatchingFile(IEnumerable<NzbFile> files, NzbFile target)
     {
-        foreach (var file in files)
-        {
-            if (IsDonorMatch(file, target)) return file;
-        }
-
-        return null;
+        return files.FirstOrDefault(file => IsDonorMatch(file, target));
     }
 
     internal static bool MergePrimaryIdsIntoDavNzbFile(
@@ -420,6 +409,24 @@ internal static class SiblingDonorAttacher
         {
             Log.Debug(e, "Sibling DavNzbFile blob {BlobId} is unreadable; skipping donor backfill.", blobId);
             return null;
+        }
+    }
+
+    private sealed class SegmentIdListComparer : IEqualityComparer<IReadOnlyList<string>>
+    {
+        public static SegmentIdListComparer Instance { get; } = new();
+
+        public bool Equals(IReadOnlyList<string>? x, IReadOnlyList<string>? y)
+            => ReferenceEquals(x, y) ||
+               (x is not null && y is not null && x.Count == y.Count &&
+                x.SequenceEqual(y, StringComparer.Ordinal));
+
+        public int GetHashCode(IReadOnlyList<string> segmentIds)
+        {
+            var hash = new HashCode();
+            foreach (var segmentId in segmentIds)
+                hash.Add(segmentId, StringComparer.Ordinal);
+            return hash.ToHashCode();
         }
     }
 }

--- a/backend/Queue/SiblingDonors/SiblingDonorAttacher.cs
+++ b/backend/Queue/SiblingDonors/SiblingDonorAttacher.cs
@@ -1,3 +1,4 @@
+using MemoryPack;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -5,12 +6,14 @@ using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models.Nzb;
 using Serilog;
+using ZstdSharp;
 
 namespace NzbWebDAV.Queue.SiblingDonors;
 
 /// <summary>
 /// Precomputes cross-NZB donor MessageIds into per-segment fallback lists at import
-/// time so playback can recover holes through the existing fallback arrays.
+/// (forward) and completion (bidirectional backfill) so playback can recover holes
+/// through the existing fallback arrays.
 /// </summary>
 internal static class SiblingDonorAttacher
 {
@@ -71,6 +74,119 @@ internal static class SiblingDonorAttacher
         {
             e.LogWarningKnownOrStack(
                 "Sibling segment-donor attach skipped for {JobName}.", queueItem.JobName);
+        }
+    }
+
+    public static async Task BackfillCompletedSiblingsAsync(
+        DavDatabaseClient dbClient,
+        QueueItem queueItem,
+        NzbDocument nzb,
+        ConfigManager configManager,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (!configManager.IsVariantsSegmentDonorsEnabled()) return;
+            if (string.IsNullOrEmpty(queueItem.ContentGroupKey)) return;
+
+            var maxSiblings = configManager.GetVariantsSegmentDonorsMaxSiblings();
+            if (maxSiblings <= 0) return;
+            var maxPerSegment = configManager.GetVariantsSegmentDonorsMaxPerSegment();
+
+            var siblings = await LoadCompletedSiblingsAsync(
+                    dbClient.Ctx, queueItem.ContentGroupKey, maxSiblings, ct)
+                .ConfigureAwait(false);
+            if (siblings.Count == 0) return;
+
+            var newFiles = nzb.Files.Where(file => file.Segments.Count > 0).ToList();
+            var newFilesByKey = IndexBySegmentIds(newFiles);
+            // Snapshot before staging sibling clones so those pending writes are not
+            // mistaken for this import's FileAggregator blobs.
+            var pendingNewBlobs = dbClient.Ctx.BlobNzbFiles.ToArray();
+
+            foreach (var sibling in siblings)
+            {
+                ct.ThrowIfCancellationRequested();
+                var document = await LoadSiblingDocumentAsync(sibling.NzbBlobId!.Value, ct)
+                    .ConfigureAwait(false);
+                if (document is null) continue;
+
+                var siblingFilesByKey = IndexBySegmentIds(document.Files);
+                await BackfillSiblingBlobsAsync(
+                        dbClient.Ctx,
+                        sibling.Id,
+                        siblingFilesByKey,
+                        newFiles,
+                        maxPerSegment,
+                        ct)
+                    .ConfigureAwait(false);
+
+                foreach (var pending in pendingNewBlobs)
+                    MergeSiblingIntoPendingBlob(pending, newFilesByKey, document.Files, maxPerSegment);
+            }
+        }
+#pragma warning disable CA2016 // classify cancellation regardless of the ambient token
+        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+        {
+            e.LogWarningKnownOrStack(
+                "Sibling segment-donor backfill skipped for {JobName}.", queueItem.JobName);
+        }
+    }
+
+    private static async Task BackfillSiblingBlobsAsync(
+        DavDatabaseContext ctx,
+        Guid siblingHistoryId,
+        Dictionary<string, NzbFile> siblingFilesByKey,
+        List<NzbFile> newFiles,
+        int maxPerSegment,
+        CancellationToken ct)
+    {
+        var davItems = await ctx.Items
+            .Where(d => d.HistoryItemId == siblingHistoryId
+                        && d.SubType == DavItem.ItemSubType.NzbFile
+                        && d.FileBlobId != null)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        foreach (var davItem in davItems)
+        {
+            ct.ThrowIfCancellationRequested();
+            var copy = await DeserializeDavNzbFileCopyAsync(davItem.FileBlobId!.Value, ct)
+                .ConfigureAwait(false);
+            if (copy is null || copy.SegmentIds.Length == 0) continue;
+            if (!siblingFilesByKey.TryGetValue(SegmentKey(copy.SegmentIds), out var siblingFile))
+                continue;
+
+            var newFile = FindMatchingFile(newFiles, siblingFile);
+            if (newFile is null) continue;
+
+            var donorPrimaries = newFile.GetSegmentIds();
+            if (donorPrimaries.Length != copy.SegmentIds.Length) continue;
+            if (!MergePrimaryIdsIntoDavNzbFile(copy, donorPrimaries, maxPerSegment))
+                continue;
+
+            var newBlobId = Guid.NewGuid();
+            copy.Id = newBlobId;
+            ctx.AddBlob(copy);
+            davItem.FileBlobId = newBlobId;
+        }
+    }
+
+    private static void MergeSiblingIntoPendingBlob(
+        DavNzbFile pending,
+        Dictionary<string, NzbFile> newFilesByKey,
+        IReadOnlyList<NzbFile> siblingFiles,
+        int maxPerSegment)
+    {
+        if (pending.SegmentIds.Length == 0) return;
+        if (!newFilesByKey.TryGetValue(SegmentKey(pending.SegmentIds), out var newFile))
+            return;
+
+        foreach (var siblingFile in siblingFiles)
+        {
+            if (!IsDonorMatch(newFile, siblingFile)) continue;
+            MergeDonorIdsIntoDavNzbFile(pending, siblingFile, maxPerSegment);
         }
     }
 
@@ -196,5 +312,114 @@ internal static class SiblingDonorAttacher
         updated = extra.ToArray();
         existing = updated;
         return true;
+    }
+
+    internal static Dictionary<string, NzbFile> IndexBySegmentIds(IEnumerable<NzbFile> files)
+    {
+        var map = new Dictionary<string, NzbFile>(StringComparer.Ordinal);
+        foreach (var file in files)
+        {
+            if (file.Segments.Count == 0) continue;
+            map.TryAdd(SegmentKey(file.GetSegmentIds()), file);
+        }
+
+        return map;
+    }
+
+    internal static NzbFile? FindMatchingFile(IEnumerable<NzbFile> files, NzbFile target)
+    {
+        foreach (var file in files)
+        {
+            if (IsDonorMatch(file, target)) return file;
+        }
+
+        return null;
+    }
+
+    internal static bool MergePrimaryIdsIntoDavNzbFile(
+        DavNzbFile target,
+        string[] donorPrimaries,
+        int maxPerSegment)
+    {
+        EnsureFallbackSlots(target);
+        var added = false;
+        var count = Math.Min(target.SegmentIds.Length, donorPrimaries.Length);
+        for (var i = 0; i < count; i++)
+        {
+            var existing = target.SegmentFallbackIds![i];
+            if (!AppendIds(ref existing, target.SegmentIds[i], [donorPrimaries[i]], maxPerSegment, out var updated))
+                continue;
+            target.SegmentFallbackIds[i] = updated;
+            added = true;
+        }
+
+        return added;
+    }
+
+    internal static bool MergeDonorIdsIntoDavNzbFile(
+        DavNzbFile target,
+        NzbFile donor,
+        int maxPerSegment)
+    {
+        EnsureFallbackSlots(target);
+        var added = false;
+        var count = Math.Min(target.SegmentIds.Length, donor.Segments.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var existing = target.SegmentFallbackIds![i];
+            if (!AppendIds(
+                    ref existing,
+                    target.SegmentIds[i],
+                    DonorIds(donor.Segments[i]),
+                    maxPerSegment,
+                    out var updated))
+                continue;
+            target.SegmentFallbackIds[i] = updated;
+            added = true;
+        }
+
+        return added;
+    }
+
+    internal static void EnsureFallbackSlots(DavNzbFile file)
+    {
+        var n = file.SegmentIds.Length;
+        if (file.SegmentFallbackIds is { Length: var len } && len == n)
+        {
+            for (var i = 0; i < n; i++)
+                file.SegmentFallbackIds[i] ??= [];
+            return;
+        }
+
+        var aligned = new string[n][];
+        for (var i = 0; i < n; i++)
+        {
+            aligned[i] = file.SegmentFallbackIds is { Length: var l } && i < l
+                ? file.SegmentFallbackIds[i] ?? []
+                : [];
+        }
+
+        file.SegmentFallbackIds = aligned;
+    }
+
+    internal static async Task<DavNzbFile?> DeserializeDavNzbFileCopyAsync(Guid blobId, CancellationToken ct)
+    {
+        await using var stream = BlobStore.ReadBlob(blobId);
+        if (stream is null) return null;
+
+        try
+        {
+            await using var decompression = new DecompressionStream(stream);
+            return await MemoryPackSerializer
+                .DeserializeAsync<DavNzbFile>(decompression, cancellationToken: ct)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA2016 // classify cancellation regardless of the ambient token
+        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+        {
+            Log.Debug(e, "Sibling DavNzbFile blob {BlobId} is unreadable; skipping donor backfill.", blobId);
+            return null;
+        }
     }
 }

--- a/backend/Queue/SiblingDonors/SiblingDonorAttacher.cs
+++ b/backend/Queue/SiblingDonors/SiblingDonorAttacher.cs
@@ -1,0 +1,200 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Models.Nzb;
+using Serilog;
+
+namespace NzbWebDAV.Queue.SiblingDonors;
+
+/// <summary>
+/// Precomputes cross-NZB donor MessageIds into per-segment fallback lists at import
+/// time so playback can recover holes through the existing fallback arrays.
+/// </summary>
+internal static class SiblingDonorAttacher
+{
+    public static async Task AttachToNewImportAsync(
+        DavDatabaseClient dbClient,
+        QueueItem queueItem,
+        List<NzbFile> nzbFiles,
+        ConfigManager configManager,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (!configManager.IsVariantsSegmentDonorsEnabled()) return;
+            if (string.IsNullOrEmpty(queueItem.ContentGroupKey)) return;
+            if (nzbFiles.Count == 0) return;
+
+            var maxSiblings = configManager.GetVariantsSegmentDonorsMaxSiblings();
+            if (maxSiblings <= 0) return;
+            var maxPerSegment = configManager.GetVariantsSegmentDonorsMaxPerSegment();
+
+            var siblings = await LoadCompletedSiblingsAsync(
+                    dbClient.Ctx, queueItem.ContentGroupKey, maxSiblings, ct)
+                .ConfigureAwait(false);
+            if (siblings.Count == 0) return;
+
+            var contributing = 0;
+            foreach (var sibling in siblings)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (contributing >= maxSiblings) break;
+
+                var document = await LoadSiblingDocumentAsync(sibling.NzbBlobId!.Value, ct)
+                    .ConfigureAwait(false);
+                if (document is null) continue;
+
+                var added = 0;
+                foreach (var primary in nzbFiles)
+                {
+                    foreach (var donor in document.Files)
+                    {
+                        if (!IsDonorMatch(primary, donor)) continue;
+                        added += MergeDonorIds(primary, donor, maxPerSegment);
+                    }
+                }
+
+                if (added > 0)
+                {
+                    contributing++;
+                    Log.Debug(
+                        "Attached {Count} sibling donor MessageId(s) to {JobName} from sibling {SiblingJob}.",
+                        added, queueItem.JobName, sibling.JobName);
+                }
+            }
+        }
+#pragma warning disable CA2016 // classify cancellation regardless of the ambient token
+        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+        {
+            e.LogWarningKnownOrStack(
+                "Sibling segment-donor attach skipped for {JobName}.", queueItem.JobName);
+        }
+    }
+
+    internal static async Task<List<HistoryItem>> LoadCompletedSiblingsAsync(
+        DavDatabaseContext ctx,
+        string contentGroupKey,
+        int maxSiblings,
+        CancellationToken ct)
+    {
+        if (maxSiblings <= 0) return [];
+
+        // Fetch a window larger than maxSiblings so identical postings (zero new IDs)
+        // and unparseable blobs can be skipped without consuming the contributing cap.
+        var fetch = Math.Min(32, Math.Max(maxSiblings * 4, maxSiblings));
+        return await ctx.HistoryItems.AsNoTracking()
+            .Where(h => h.ContentGroupKey == contentGroupKey
+                        && h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed
+                        && h.NzbBlobId != null)
+            .OrderByDescending(h => h.CreatedAt)
+            .Take(fetch)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    internal static async Task<NzbDocument?> LoadSiblingDocumentAsync(Guid nzbBlobId, CancellationToken ct)
+    {
+        await using var stream = BlobStore.ReadBlob(nzbBlobId);
+        if (stream is null)
+        {
+            Log.Debug("Sibling NZB blob {NzbBlobId} is missing; skipping donor attach.", nzbBlobId);
+            return null;
+        }
+
+        try
+        {
+            return await NzbDocument.LoadAsync(stream, ct).ConfigureAwait(false);
+        }
+#pragma warning disable CA2016 // classify cancellation regardless of the ambient token
+        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+        {
+            Log.Debug(e, "Sibling NZB blob {NzbBlobId} is unparseable; skipping donor attach.", nzbBlobId);
+            return null;
+        }
+    }
+
+    internal static bool IsDonorMatch(NzbFile primary, NzbFile donor)
+    {
+        if (primary.Segments.Count == 0 || primary.Segments.Count != donor.Segments.Count)
+            return false;
+        if (primary.GetTotalYencodedSize() != donor.GetTotalYencodedSize())
+            return false;
+
+        for (var i = 0; i < primary.Segments.Count; i++)
+        {
+            if (primary.Segments[i].Bytes != donor.Segments[i].Bytes)
+                return false;
+        }
+
+        var primaryName = primary.GetSubjectFileName();
+        var donorName = donor.GetSubjectFileName();
+        if (string.IsNullOrEmpty(primaryName) || string.IsNullOrEmpty(donorName))
+            return false;
+
+        return string.Equals(primaryName, donorName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static int MergeDonorIds(NzbFile primary, NzbFile donor, int maxPerSegment)
+    {
+        var added = 0;
+        for (var i = 0; i < primary.Segments.Count; i++)
+        {
+            var segment = primary.Segments[i];
+            var existing = segment.FallbackMessageIds;
+            var before = existing.Length;
+            if (!AppendIds(
+                    ref existing,
+                    segment.MessageId,
+                    DonorIds(donor.Segments[i]),
+                    maxPerSegment,
+                    out var updated))
+                continue;
+
+            segment.FallbackMessageIds = updated;
+            added += updated.Length - before;
+        }
+
+        return added;
+    }
+
+    internal static IEnumerable<string> DonorIds(NzbSegment segment)
+    {
+        yield return segment.MessageId;
+        foreach (var id in segment.FallbackMessageIds)
+            yield return id;
+    }
+
+    internal static string SegmentKey(IReadOnlyList<string> segmentIds) =>
+        string.Join("\u0001", segmentIds);
+
+    internal static bool AppendIds(
+        ref string[] existing,
+        string ownPrimary,
+        IEnumerable<string> candidates,
+        int maxPerSegment,
+        out string[] updated)
+    {
+        existing ??= [];
+        updated = existing;
+        if (existing.Length >= maxPerSegment) return false;
+
+        var seen = new HashSet<string>(existing, StringComparer.Ordinal) { ownPrimary };
+        List<string>? extra = null;
+        foreach (var id in candidates)
+        {
+            if (string.IsNullOrEmpty(id) || !seen.Add(id)) continue;
+            extra ??= [.. existing];
+            extra.Add(id);
+            if (extra.Count >= maxPerSegment) break;
+        }
+
+        if (extra is null) return false;
+        updated = extra.ToArray();
+        existing = updated;
+        return true;
+    }
+}

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -885,8 +885,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         .DecodedBodyAsync(fallbackId, cancellationToken)
                         .ConfigureAwait(false);
                     await ThrowOnSegmentIdMismatchAsync(fallbackId, bodyResponse).ConfigureAwait(false);
-                    if (!await IsFallbackPartSizeCompatibleAsync(
-                            bodyResponse.Stream!, segmentIndex, cancellationToken)
+                    if (!await SegmentResponseValidator.IsFallbackPartSizeCompatibleAsync(
+                            bodyResponse.Stream!, _segmentSizes, segmentIndex, cancellationToken)
                         .ConfigureAwait(false))
                     {
                         Log.Debug(
@@ -925,28 +925,6 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return null;
-    }
-
-    private async ValueTask<bool> IsFallbackPartSizeCompatibleAsync(
-        Stream bodyStream, int segmentIndex, CancellationToken ct)
-    {
-        if (!_segmentSizes.TryGetExactSize(segmentIndex, out var exact)) return true;
-        if (bodyStream is not YencStream yenc) return true;
-        UsenetYencHeader? header;
-        try
-        {
-            header = await yenc.GetYencHeadersAsync(ct).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception e) when (e is InvalidDataException or IOException)
-        {
-            return true;
-        }
-
-        return header is null || header.PartSize <= 0 || header.PartSize == exact;
     }
 
     private string[] GetFallbacks(int segmentIndex)

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -885,6 +885,16 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         .DecodedBodyAsync(fallbackId, cancellationToken)
                         .ConfigureAwait(false);
                     await ThrowOnSegmentIdMismatchAsync(fallbackId, bodyResponse).ConfigureAwait(false);
+                    if (!await IsFallbackPartSizeCompatibleAsync(
+                            bodyResponse.Stream!, segmentIndex, cancellationToken)
+                        .ConfigureAwait(false))
+                    {
+                        Log.Debug(
+                            "Fallback MessageId {FallbackId} for segment {PrimaryIndex} of {FileName} has a mismatched yEnc part size; skipping.",
+                            fallbackId, segmentIndex, _fileName);
+                        await bodyResponse.Stream!.DisposeAsync().ConfigureAwait(false);
+                        continue;
+                    }
                     Log.Debug(
                         "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
                         segmentIndex, fallbackId, _fileName);
@@ -915,6 +925,28 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return null;
+    }
+
+    private async ValueTask<bool> IsFallbackPartSizeCompatibleAsync(
+        Stream bodyStream, int segmentIndex, CancellationToken ct)
+    {
+        if (!_segmentSizes.TryGetExactSize(segmentIndex, out var exact)) return true;
+        if (bodyStream is not YencStream yenc) return true;
+        UsenetYencHeader? header;
+        try
+        {
+            header = await yenc.GetYencHeadersAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e) when (e is InvalidDataException or IOException)
+        {
+            return true;
+        }
+
+        return header is null || header.PartSize <= 0 || header.PartSize == exact;
     }
 
     private string[] GetFallbacks(int segmentIndex)

--- a/backend/Streams/SegmentResponseValidator.cs
+++ b/backend/Streams/SegmentResponseValidator.cs
@@ -2,6 +2,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Exceptions;
 using Serilog;
 using UsenetSharp.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
 
@@ -35,5 +36,26 @@ internal static class SegmentResponseValidator
         throw new UsenetUnexpectedResponseException(
             segmentId,
             $"Response carried segment {actualId} instead of {segmentId}.");
+    }
+
+    public static async ValueTask<bool> IsFallbackPartSizeCompatibleAsync(
+        Stream bodyStream, SegmentSizes segmentSizes, int segmentIndex, CancellationToken ct)
+    {
+        if (!segmentSizes.TryGetExactSize(segmentIndex, out var exact)) return true;
+        if (bodyStream is not YencStream yenc) return true;
+
+        try
+        {
+            var header = await yenc.GetYencHeadersAsync(ct).ConfigureAwait(false);
+            return header is null || header.PartSize <= 0 || header.PartSize == exact;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e) when (e is InvalidDataException or IOException)
+        {
+            return true;
+        }
     }
 }

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.StreamTrace;
 using Serilog;
+using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
@@ -245,6 +246,15 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 await SegmentResponseValidator
                     .ThrowOnSegmentIdMismatchAsync(fallbackId, body)
                     .ConfigureAwait(false);
+                if (!await IsFallbackPartSizeCompatibleAsync(body.Stream!, segmentIndex, cancellationToken)
+                        .ConfigureAwait(false))
+                {
+                    Log.Debug(
+                        "Fallback MessageId {FallbackId} for segment {PrimaryIndex} of {FileName} has a mismatched yEnc part size; skipping.",
+                        fallbackId, segmentIndex, _fileName);
+                    await body.Stream!.DisposeAsync().ConfigureAwait(false);
+                    continue;
+                }
                 return body.Stream!;
             }
             catch (UsenetArticleNotFoundException)
@@ -258,6 +268,28 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return null;
+    }
+
+    private async ValueTask<bool> IsFallbackPartSizeCompatibleAsync(
+        Stream bodyStream, int segmentIndex, CancellationToken ct)
+    {
+        if (!_segmentSizes.TryGetExactSize(segmentIndex, out var exact)) return true;
+        if (bodyStream is not YencStream yenc) return true;
+        UsenetYencHeader? header;
+        try
+        {
+            header = await yenc.GetYencHeadersAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e) when (e is InvalidDataException or IOException)
+        {
+            return true;
+        }
+
+        return header is null || header.PartSize <= 0 || header.PartSize == exact;
     }
 
     private void ThrowIfDisposed()

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -4,7 +4,6 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.StreamTrace;
 using Serilog;
-using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
@@ -246,7 +245,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 await SegmentResponseValidator
                     .ThrowOnSegmentIdMismatchAsync(fallbackId, body)
                     .ConfigureAwait(false);
-                if (!await IsFallbackPartSizeCompatibleAsync(body.Stream!, segmentIndex, cancellationToken)
+                if (!await SegmentResponseValidator.IsFallbackPartSizeCompatibleAsync(
+                        body.Stream!, _segmentSizes, segmentIndex, cancellationToken)
                         .ConfigureAwait(false))
                 {
                     Log.Debug(
@@ -268,28 +268,6 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return null;
-    }
-
-    private async ValueTask<bool> IsFallbackPartSizeCompatibleAsync(
-        Stream bodyStream, int segmentIndex, CancellationToken ct)
-    {
-        if (!_segmentSizes.TryGetExactSize(segmentIndex, out var exact)) return true;
-        if (bodyStream is not YencStream yenc) return true;
-        UsenetYencHeader? header;
-        try
-        {
-            header = await yenc.GetYencHeadersAsync(ct).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception e) when (e is InvalidDataException or IOException)
-        {
-            return true;
-        }
-
-        return header is null || header.PartSize <= 0 || header.PartSize == exact;
     }
 
     private void ThrowIfDisposed()

--- a/docs/configuration/watchdog.md
+++ b/docs/configuration/watchdog.md
@@ -41,5 +41,10 @@ Playback failover, stall failover, and size-variant retention when a release can
 | Fallback on fetch failure | `variants.fallback-on-failure` | on | Use closest existing |
 | Eviction strategy | `variants.eviction-strategy` | `lru` | lru / size / never |
 | Active-use grace (seconds) | `variants.eviction-active-grace-seconds` | `60` | Skip eviction if recently used |
+| Segment donors [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `variants.segment-donors-enabled` | on | Borrow equivalent MessageIds from same-group copies |
+| Max donor siblings [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `variants.segment-donors-max-siblings` | `3` | Newest completed copies considered (0–10) |
+| Max donor IDs per segment [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `variants.segment-donors-max-per-segment` | `6` | Cap including intra-NZB fallbacks (1–32) |
+
+Segment donors require a content-grouped sibling (profile-play, variants, or retry flows). Plain Sonarr/Radarr SAB adds never set a group key, so they do not donate or receive donors. Donation only happens between same-segmentation postings whose subject filenames match; obfuscated posts (unparseable names) do not match. An existing damaged item gains donors when a new same-group copy completes.
 
 [Warden, Watchdog, Preflight](../features/warden-watchdog-preflight.md)

--- a/tests/NzbWebDAV.Tests/Queue/SiblingDonorAttacherTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/SiblingDonorAttacherTests.cs
@@ -6,6 +6,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.SiblingDonors;
 using NzbWebDAV.Tests.Database;
@@ -236,6 +237,134 @@ public sealed class SiblingDonorAttacherTests : IAsyncLifetime
         Assert.DoesNotContain("failed@example", primary.Segments[0].FallbackMessageIds);
     }
 
+    [Fact]
+    public async Task Backfill_SwapsBlobIdAndMergesPrimariesOnly()
+    {
+        var sibling = await SeedSiblingWithDavFileAsync(
+            "sibling.nzb",
+            FileXml("movie.mkv", Seg(100, 1, "s1@example"), Seg(200, 2, "s2@example")),
+            ["s1@example", "s2@example"],
+            extra =>
+            {
+                extra.SegmentByteRanges =
+                [
+                    LongRange.FromStartAndSize(0, 80),
+                    LongRange.FromStartAndSize(80, 160),
+                ];
+                extra.MissingSegmentIndices = [1];
+                extra.ContainerClass = 2;
+                extra.CriticalHeadEndExclusive = 42;
+            });
+
+        var incoming = MovieFile(
+            ("n1@example", 100, ["contaminated@example"]),
+            ("n2@example", 200, []));
+        var document = NewDocument(incoming);
+
+        await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
+            _dbClient, NewQueueItem(), document, _config, CancellationToken.None);
+        await _context.SaveChangesAsync();
+
+        var reloaded = await _context.Items.AsNoTracking().SingleAsync(d => d.Id == sibling.DavItemId);
+        Assert.NotNull(reloaded.FileBlobId);
+        Assert.NotEqual(sibling.FileBlobId, reloaded.FileBlobId);
+        Assert.Contains(await _context.BlobCleanupItems.AsNoTracking().ToListAsync(),
+            x => x.Id == sibling.FileBlobId);
+
+        var updated = await BlobStore.ReadBlob<DavNzbFile>(reloaded.FileBlobId!.Value);
+        Assert.NotNull(updated);
+        Assert.Equal(reloaded.FileBlobId, updated.Id);
+        Assert.Equal(["s1@example", "s2@example"], updated.SegmentIds);
+        Assert.Equal(["n1@example"], updated.SegmentFallbackIds![0]);
+        Assert.Equal(["n2@example"], updated.SegmentFallbackIds[1]);
+        Assert.DoesNotContain("contaminated@example", updated.SegmentFallbackIds.SelectMany(x => x));
+        Assert.Equal(sibling.Original.SegmentByteRanges, updated.SegmentByteRanges);
+        Assert.Equal(sibling.Original.MissingSegmentIndices, updated.MissingSegmentIndices);
+        Assert.Equal(sibling.Original.ContainerClass, updated.ContainerClass);
+        Assert.Equal(sibling.Original.CriticalHeadEndExclusive, updated.CriticalHeadEndExclusive);
+    }
+
+    [Fact]
+    public async Task Backfill_DoesNotMutateCachedInstance()
+    {
+        var sibling = await SeedSiblingWithDavFileAsync(
+            "sibling.nzb",
+            FileXml("movie.mkv", Seg(100, 1, "s1@example")),
+            ["s1@example"]);
+
+        var cached = await BlobStore.ReadBlob<DavNzbFile>(sibling.FileBlobId);
+        Assert.NotNull(cached);
+        var cachedFallbacks = cached.SegmentFallbackIds;
+
+        var incoming = MovieFile(("n1@example", 100, []));
+        await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
+            _dbClient, NewQueueItem(), NewDocument(incoming), _config, CancellationToken.None);
+        await _context.SaveChangesAsync();
+
+        Assert.Same(cachedFallbacks, cached.SegmentFallbackIds);
+        Assert.True(cached.SegmentFallbackIds is null or { Length: 0 }
+                    || cached.SegmentFallbackIds.All(x => x is null || x.Length == 0));
+    }
+
+    [Fact]
+    public async Task Backfill_SkipsBlobSwap_WhenNoNewIds()
+    {
+        var sibling = await SeedSiblingWithDavFileAsync(
+            "sibling.nzb",
+            FileXml("movie.mkv", Seg(100, 1, "s1@example")),
+            ["s1@example"]);
+
+        var incoming = MovieFile(("s1@example", 100, []));
+        await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
+            _dbClient, NewQueueItem(), NewDocument(incoming), _config, CancellationToken.None);
+        await _context.SaveChangesAsync();
+
+        var reloaded = await _context.Items.AsNoTracking().SingleAsync(d => d.Id == sibling.DavItemId);
+        Assert.Equal(sibling.FileBlobId, reloaded.FileBlobId);
+        Assert.Empty(await _context.BlobCleanupItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Backfill_LeavesSiblingUntouched_WhenGatesFail()
+    {
+        var sibling = await SeedSiblingWithDavFileAsync(
+            "sibling.nzb",
+            FileXml("other.mkv", Seg(100, 1, "s1@example")),
+            ["s1@example"]);
+
+        var incoming = MovieFile(("n1@example", 100, []));
+        await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
+            _dbClient, NewQueueItem(), NewDocument(incoming), _config, CancellationToken.None);
+        await _context.SaveChangesAsync();
+
+        var reloaded = await _context.Items.AsNoTracking().SingleAsync(d => d.Id == sibling.DavItemId);
+        Assert.Equal(sibling.FileBlobId, reloaded.FileBlobId);
+    }
+
+    [Fact]
+    public async Task Backfill_MergesSiblingIdsIntoPendingNewBlobs()
+    {
+        await SeedSiblingWithDavFileAsync(
+            "sibling.nzb",
+            FileXml("movie.mkv", Seg(100, 1, "s1@example", "s1-alt@example")),
+            ["s1@example"]);
+
+        var incoming = MovieFile(("n1@example", 100, []));
+        var pending = new DavNzbFile
+        {
+            Id = Guid.NewGuid(),
+            SegmentIds = incoming.GetSegmentIds(),
+            SegmentFallbackIds = [[]],
+        };
+        _context.AddBlob(pending);
+
+        await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
+            _dbClient, NewQueueItem(), NewDocument(incoming), _config, CancellationToken.None);
+
+        Assert.Equal(["s1@example", "s1-alt@example"], pending.SegmentFallbackIds![0]);
+        Assert.Contains(_context.BlobNzbFiles, blob => blob.Id == pending.Id);
+    }
+
     private Task AttachAsync(NzbFile primary) =>
         SiblingDonorAttacher.AttachToNewImportAsync(
             _dbClient, NewQueueItem(), [primary], _config, CancellationToken.None);
@@ -267,10 +396,52 @@ public sealed class SiblingDonorAttacherTests : IAsyncLifetime
         return file;
     }
 
+    private static NzbDocument NewDocument(NzbFile file)
+    {
+        var document = new NzbDocument();
+        document.Files.Add(file);
+        return document;
+    }
+
     private Task SeedCompletedSiblingAsync(string fileName, DateTime createdAt, string nzbXml) =>
         SeedHistoryAsync(fileName, createdAt, HistoryItem.DownloadStatusOption.Completed, nzbXml);
 
-    private async Task SeedHistoryAsync(
+    private async Task<(Guid HistoryId, Guid DavItemId, Guid FileBlobId, DavNzbFile Original)> SeedSiblingWithDavFileAsync(
+        string fileName,
+        string nzbXml,
+        string[] segmentIds,
+        Action<DavNzbFile>? configure = null)
+    {
+        var historyId = await SeedHistoryAsync(
+            fileName, DateTime.UtcNow.AddHours(-1), HistoryItem.DownloadStatusOption.Completed, nzbXml);
+
+        var fileBlobId = Guid.NewGuid();
+        var davNzbFile = new DavNzbFile
+        {
+            Id = fileBlobId,
+            SegmentIds = segmentIds,
+        };
+        configure?.Invoke(davNzbFile);
+        await BlobStore.WriteBlob(fileBlobId, davNzbFile);
+
+        var davItem = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            fileName,
+            fileSize: 100,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+            lastHealthCheck: null,
+            historyItemId: historyId,
+            fileBlobId: fileBlobId);
+        _context.Items.Add(davItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return (historyId, davItem.Id, fileBlobId, davNzbFile);
+    }
+
+    private async Task<Guid> SeedHistoryAsync(
         string fileName,
         DateTime createdAt,
         HistoryItem.DownloadStatusOption status,
@@ -298,6 +469,7 @@ public sealed class SiblingDonorAttacherTests : IAsyncLifetime
         });
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
+        return id;
     }
 
     private static string FileXml(string fileName, params string[] segments) =>

--- a/tests/NzbWebDAV.Tests/Queue/SiblingDonorAttacherTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/SiblingDonorAttacherTests.cs
@@ -1,0 +1,326 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.SiblingDonors;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Queue;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class SiblingDonorAttacherTests : IAsyncLifetime
+{
+    private const string GroupKey = "movie:511";
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-sibling-donors-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private ConfigManager _config = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+        _config = new ConfigManager();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Attach_Donates_WhenNameAndSegmentationMatch()
+    {
+        await SeedCompletedSiblingAsync(
+            "older.nzb",
+            DateTime.UtcNow.AddHours(-2),
+            FileXml("movie.mkv",
+                Seg(100, 1, "b1@example", "b1-alt@example"),
+                Seg(200, 2, "b2@example")));
+
+        var primary = MovieFile(
+            ("a1@example", 100, ["a1-existing@example"]),
+            ("a2@example", 200, []));
+
+        await SiblingDonorAttacher.AttachToNewImportAsync(
+            _dbClient, NewQueueItem(), [primary], _config, CancellationToken.None);
+
+        Assert.Equal(["a1-existing@example", "b1@example", "b1-alt@example"], primary.Segments[0].FallbackMessageIds);
+        Assert.Equal(["b2@example"], primary.Segments[1].FallbackMessageIds);
+    }
+
+    [Fact]
+    public async Task Attach_Skips_WhenSegmentCountsDiffer()
+    {
+        await SeedCompletedSiblingAsync(
+            "sibling.nzb",
+            DateTime.UtcNow.AddHours(-1),
+            FileXml("movie.mkv", Seg(100, 1, "b1@example"), Seg(100, 2, "b2@example")));
+
+        var primary = MovieFile(("a1@example", 100, []));
+        await AttachAsync(primary);
+
+        Assert.Empty(primary.Segments[0].FallbackMessageIds);
+    }
+
+    [Fact]
+    public async Task Attach_Skips_WhenDeclaredBytesDiffer()
+    {
+        await SeedCompletedSiblingAsync(
+            "sibling.nzb",
+            DateTime.UtcNow.AddHours(-1),
+            FileXml("movie.mkv", Seg(100, 1, "b1@example"), Seg(200, 2, "b2@example")));
+
+        var primary = MovieFile(("a1@example", 100, []), ("a2@example", 201, []));
+        await AttachAsync(primary);
+
+        Assert.Empty(primary.Segments[0].FallbackMessageIds);
+        Assert.Empty(primary.Segments[1].FallbackMessageIds);
+    }
+
+    [Fact]
+    public async Task Attach_Skips_WhenFilenamesDifferOrObfuscated()
+    {
+        await SeedCompletedSiblingAsync(
+            "other-name.nzb",
+            DateTime.UtcNow.AddHours(-1),
+            FileXml("other.mkv", Seg(100, 1, "b1@example")));
+        var differentName = MovieFile(("a1@example", 100, []));
+        await AttachAsync(differentName);
+        Assert.Empty(differentName.Segments[0].FallbackMessageIds);
+
+        await SeedCompletedSiblingAsync(
+            "obfuscated.nzb",
+            DateTime.UtcNow.AddMinutes(-30),
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+              <file subject="abc123 yEnc (1/1)">
+                <groups><group>alt.binaries.test</group></groups>
+                <segments>
+                  <segment bytes="100" number="1">obf@example</segment>
+                </segments>
+              </file>
+            </nzb>
+            """);
+        var obfuscatedPrimary = new NzbFile
+        {
+            Subject = "xyz789 yEnc (1/1)",
+            Segments = { new NzbSegment { MessageId = "a1@example", Bytes = 100, Number = 1 } },
+        };
+        await AttachAsync(obfuscatedPrimary);
+        Assert.Empty(obfuscatedPrimary.Segments[0].FallbackMessageIds);
+    }
+
+    [Fact]
+    public async Task Attach_RespectsPerSegmentCap()
+    {
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.VariantsSegmentDonorsMaxPerSegment, ConfigValue = "2" },
+        ]);
+        await SeedCompletedSiblingAsync(
+            "sibling.nzb",
+            DateTime.UtcNow.AddHours(-1),
+            FileXml("movie.mkv",
+                Seg(100, 1, "b1@example", "b1-alt1@example", "b1-alt2@example")));
+
+        var primary = MovieFile(("a1@example", 100, ["a1-existing@example"]));
+        await AttachAsync(primary);
+
+        Assert.Equal(["a1-existing@example", "b1@example"], primary.Segments[0].FallbackMessageIds);
+    }
+
+    [Theory]
+    [InlineData(true, null)]
+    [InlineData(false, GroupKey)]
+    public async Task Attach_NoOp_WhenContentGroupKeyNullOrDisabled(bool enabled, string? groupKey)
+    {
+        _config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.VariantsSegmentDonorsEnabled,
+                ConfigValue = enabled ? "true" : "false",
+            },
+        ]);
+        await SeedCompletedSiblingAsync(
+            "sibling.nzb",
+            DateTime.UtcNow.AddHours(-1),
+            FileXml("movie.mkv", Seg(100, 1, "b1@example")));
+
+        var primary = MovieFile(("a1@example", 100, []));
+        var queueItem = NewQueueItem();
+        queueItem.ContentGroupKey = groupKey;
+        await SiblingDonorAttacher.AttachToNewImportAsync(
+            _dbClient, queueItem, [primary], _config, CancellationToken.None);
+
+        Assert.Empty(primary.Segments[0].FallbackMessageIds);
+    }
+
+    [Fact]
+    public async Task Attach_PrefersNewestSiblingFirst()
+    {
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.VariantsSegmentDonorsMaxSiblings, ConfigValue = "1" },
+        ]);
+        await SeedCompletedSiblingAsync(
+            "older.nzb",
+            DateTime.UtcNow.AddHours(-2),
+            FileXml("movie.mkv", Seg(100, 1, "old@example")));
+        await SeedCompletedSiblingAsync(
+            "newer.nzb",
+            DateTime.UtcNow.AddHours(-1),
+            FileXml("movie.mkv", Seg(100, 1, "new@example")));
+
+        var primary = MovieFile(("a1@example", 100, []));
+        await AttachAsync(primary);
+
+        Assert.Equal(["new@example"], primary.Segments[0].FallbackMessageIds);
+        Assert.DoesNotContain("old@example", primary.Segments[0].FallbackMessageIds);
+    }
+
+    [Fact]
+    public async Task Attach_SkipsFailedBloblessAndZeroContributionSiblings()
+    {
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.VariantsSegmentDonorsMaxSiblings, ConfigValue = "1" },
+        ]);
+
+        await SeedHistoryAsync(
+            "failed.nzb",
+            DateTime.UtcNow.AddMinutes(-10),
+            HistoryItem.DownloadStatusOption.Failed,
+            FileXml("movie.mkv", Seg(100, 1, "failed@example")));
+        await SeedHistoryAsync(
+            "blobless.nzb",
+            DateTime.UtcNow.AddMinutes(-9),
+            HistoryItem.DownloadStatusOption.Completed,
+            nzbXml: null);
+        await SeedCompletedSiblingAsync(
+            "identical.nzb",
+            DateTime.UtcNow.AddMinutes(-5),
+            FileXml("movie.mkv", Seg(100, 1, "a1@example")));
+        await SeedCompletedSiblingAsync(
+            "useful.nzb",
+            DateTime.UtcNow.AddHours(-2),
+            FileXml("movie.mkv", Seg(100, 1, "useful@example")));
+
+        var primary = MovieFile(("a1@example", 100, []));
+        await AttachAsync(primary);
+
+        Assert.Equal(["useful@example"], primary.Segments[0].FallbackMessageIds);
+        Assert.DoesNotContain("failed@example", primary.Segments[0].FallbackMessageIds);
+    }
+
+    private Task AttachAsync(NzbFile primary) =>
+        SiblingDonorAttacher.AttachToNewImportAsync(
+            _dbClient, NewQueueItem(), [primary], _config, CancellationToken.None);
+
+    private static QueueItem NewQueueItem() => new()
+    {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        FileName = "new.nzb",
+        JobName = "new",
+        Category = "movies",
+        ContentGroupKey = GroupKey,
+    };
+
+    private static NzbFile MovieFile(params (string id, long bytes, string[] fallbacks)[] segments)
+    {
+        var file = new NzbFile { Subject = """[1/1] - "movie.mkv" yEnc 12345 (1/1)""" };
+        for (var i = 0; i < segments.Length; i++)
+        {
+            file.Segments.Add(new NzbSegment
+            {
+                MessageId = segments[i].id,
+                Bytes = segments[i].bytes,
+                Number = i + 1,
+                FallbackMessageIds = segments[i].fallbacks,
+            });
+        }
+
+        return file;
+    }
+
+    private Task SeedCompletedSiblingAsync(string fileName, DateTime createdAt, string nzbXml) =>
+        SeedHistoryAsync(fileName, createdAt, HistoryItem.DownloadStatusOption.Completed, nzbXml);
+
+    private async Task SeedHistoryAsync(
+        string fileName,
+        DateTime createdAt,
+        HistoryItem.DownloadStatusOption status,
+        string? nzbXml)
+    {
+        var id = Guid.NewGuid();
+        if (nzbXml is not null)
+        {
+            await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(nzbXml));
+            await BlobStore.WriteBlob(id, stream);
+        }
+
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = id,
+            CreatedAt = createdAt,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = "movies",
+            DownloadStatus = status,
+            TotalSegmentBytes = 100,
+            DownloadTimeSeconds = 1,
+            NzbBlobId = nzbXml is null ? null : id,
+            ContentGroupKey = GroupKey,
+        });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+    }
+
+    private static string FileXml(string fileName, params string[] segments) =>
+        $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+          <file subject="[1/1] - &quot;{fileName}&quot; yEnc 12345 (1/1)">
+            <groups><group>alt.binaries.test</group></groups>
+            <segments>
+              {string.Join("\n              ", segments)}
+            </segments>
+          </file>
+        </nzb>
+        """;
+
+    private static string Seg(long bytes, int number, string primary, params string[] fallbacks)
+    {
+        var parts = new List<string>
+        {
+            $"<segment bytes=\"{bytes}\" number=\"{number}\">{primary}</segment>",
+        };
+        parts.AddRange(fallbacks.Select(
+            id => $"<segment bytes=\"{bytes}\" number=\"{number}\">{id}</segment>"));
+        return string.Join("\n              ", parts);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/FallbackSizeVerificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/FallbackSizeVerificationTests.cs
@@ -1,0 +1,307 @@
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class FallbackSizeVerificationTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public async Task Fallback_WithMismatchedYencPartSize_IsSkipped_ThenNextDonorServed(int articleBufferSize)
+    {
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["bad"] = Encoding.ASCII.GetBytes("XXXXX"),
+                ["good"] = Encoding.ASCII.GetBytes("hello"),
+            },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange>
+            {
+                ["bad"] = LongRange.FromStartAndSize(0, 99),
+                ["good"] = LongRange.FromStartAndSize(0, 5),
+            });
+
+        await using var stream = CreateStream(
+            client,
+            articleBufferSize,
+            fallbacks: [["bad", "good"]],
+            exactSegmentSizes: [5]);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal("hello", Encoding.ASCII.GetString(destination.ToArray()));
+        Assert.Contains("missing", client.RequestedSegmentIds);
+        Assert.Contains("bad", client.RequestedSegmentIds);
+        Assert.Contains("good", client.RequestedSegmentIds);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public async Task Fallback_WithMismatchedPartSize_AllDonorsBad_ZeroFills(int articleBufferSize)
+    {
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["bad-1"] = Encoding.ASCII.GetBytes("XXXXX"),
+                ["bad-2"] = Encoding.ASCII.GetBytes("YYYYY"),
+            },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange>
+            {
+                ["bad-1"] = LongRange.FromStartAndSize(0, 99),
+                ["bad-2"] = LongRange.FromStartAndSize(0, 77),
+            });
+
+        await using var stream = CreateStream(
+            client,
+            articleBufferSize,
+            fallbacks: [["bad-1", "bad-2"]],
+            exactSegmentSizes: [5]);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal(new byte[5], destination.ToArray());
+        Assert.Contains("bad-1", client.RequestedSegmentIds);
+        Assert.Contains("bad-2", client.RequestedSegmentIds);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public async Task Fallback_WithMatchingYencPartSize_IsServed(int articleBufferSize)
+    {
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["good"] = Encoding.ASCII.GetBytes("hello"),
+            },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange>
+            {
+                ["good"] = LongRange.FromStartAndSize(0, 5),
+            });
+
+        await using var stream = CreateStream(
+            client,
+            articleBufferSize,
+            fallbacks: [["good"]],
+            exactSegmentSizes: [5]);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal("hello", Encoding.ASCII.GetString(destination.ToArray()));
+        Assert.Contains("good", client.RequestedSegmentIds);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public async Task Fallback_WithUnknownExactSize_BypassesVerification(int articleBufferSize)
+    {
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["odd-size"] = Encoding.ASCII.GetBytes("hello"),
+            },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange>
+            {
+                ["odd-size"] = LongRange.FromStartAndSize(0, 99),
+            });
+
+        await using var stream = CreateStream(
+            client,
+            articleBufferSize,
+            fallbacks: [["odd-size"]]);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal("hello", Encoding.ASCII.GetString(destination.ToArray()));
+        Assert.Contains("odd-size", client.RequestedSegmentIds);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public async Task Fallback_NonYencBody_BypassesVerification(int articleBufferSize)
+    {
+        var client = new PlainBodyNntpClient(new Dictionary<string, byte[]>
+        {
+            ["plain"] = Encoding.ASCII.GetBytes("hello"),
+        });
+
+        await using var stream = CreateStream(
+            client,
+            articleBufferSize,
+            fallbacks: [["plain"]],
+            exactSegmentSizes: [5]);
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+
+        Assert.Equal("hello", Encoding.ASCII.GetString(destination.ToArray()));
+        Assert.Contains("plain", client.RequestedSegmentIds);
+    }
+
+    private static Stream CreateStream(
+        NntpClient client,
+        int articleBufferSize,
+        string[][] fallbacks,
+        long[]? exactSegmentSizes = null) =>
+        MultiSegmentStream.Create(
+            new[] { "missing" }.AsMemory(),
+            client,
+            articleBufferSize,
+            estimatedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            cancellationToken: CancellationToken.None,
+            fileName: "verify.bin",
+            segmentFallbacks: fallbacks,
+            exactSegmentSizes: exactSegmentSizes);
+
+    /// <summary>
+    /// Returns already-decoded <see cref="MemoryStream"/> bodies that are not
+    /// <c>YencStream</c>, so size verification must bypass rather than peek headers.
+    /// </summary>
+    private sealed class PlainBodyNntpClient(
+        IReadOnlyDictionary<string, byte[]> segments) : NntpClient
+    {
+        public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var key = segmentId.ToString();
+            RequestedSegmentIds.Add(key);
+            if (!segments.TryGetValue(key, out var bytes))
+            {
+                onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotFound);
+                return Task.FromException<UsenetDecodedBodyResponse>(
+                    new UsenetArticleNotFoundException(key, "430 No such article"));
+            }
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 fake body",
+                Stream = new NonYencBodyStream(bytes),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(segmentId => DecodedBodyAsync(segmentId, cancellationToken))
+                .ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodiesAsync(
+                segmentIds, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Already-decoded payload typed as <see cref="YencStream"/> (the BODY response
+    /// surface) but not yEnc-encoded, so header peeking is unverifiable and must accept.
+    /// </summary>
+    private sealed class NonYencBodyStream(byte[] bytes) : YencStream(new MemoryStream(bytes, writable: false))
+    {
+        private int _offset;
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_offset >= bytes.Length) return 0;
+            var count = Math.Min(buffer.Length, bytes.Length - _offset);
+            bytes.AsSpan(_offset, count).CopyTo(buffer.Span);
+            _offset += count;
+            return await Task.FromResult(count).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Refs #511.

- When a content-grouped download (profile-play, variants, retry flows) imports, equivalent MessageIds from up to 3 recently completed same-group copies are attached as per-segment fallbacks — playback then heals missing-article holes through the existing fallback path instead of zero-filling.
- Donation is bidirectional: when a new copy completes, its MessageIds are also backfilled into previously completed siblings (new blob + atomic ID swap; old blobs are queue-cleaned), so already-damaged items gain donors retroactively.
- Donors only attach between postings with identical segmentation (count, per-segment declared bytes, total size) and matching subject filenames; a decode-time yEnc part-size check rejects any donor whose decoded size wouldn't match before a single byte is emitted.
- New settings under `variants.*`: `segment-donors-enabled` (default on), `segment-donors-max-siblings` (3, 0–10), `segment-donors-max-per-segment` (6, 1–32); documented in the Watchdog page. Plain Sonarr/Radarr SAB adds have no group key and are unaffected.

Note: donor IDs in `SegmentFallbackIds` automatically count as hole-covering alternates in the fallback-aware health sweeps shipped in #1035 — the intended compounding of the two features.

## Test plan

- [x] Backend: 3172 passed / 10 skipped / 0 failed (includes 15 new attacher tests and 10 new fallback-size-verification theories across buffered + unbuffered streams)
- [x] `HealthCheckDegradedClassificationTests` pass unmodified (16/16) — donor IDs compound correctly with #1035 fallback-aware hole confirmation
- [x] Frontend: typecheck, build, and 651 Vitest tests pass (no frontend changes)
- [ ] Manual: play a damaged item after importing a healthy same-group copy — verify holes serve donor bytes (log: "recovered via fallback MessageId") instead of zero-fill
- [ ] Manual: seek/scrub across a donor-recovered region over rclone — verify correct offsets and no stalls
- [ ] Manual: play a fully healthy item with donors attached — verify byte-identical output and no added latency
- [ ] Manual: complete a new copy while a sibling's damaged item exists — verify the sibling's health re-check clears false holes