### PR TITLE
perf(queue): keep playback smooth during import bursts by parsing RAR/7z archive headers asynchronously

### DIFF
--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -54,7 +54,7 @@ public class LazyRarProcessor(
             await using var firstStream = usenetClient.GetFileStream(
                 firstInfo.NzbFile, firstFileSize, articleBufferSize: 0);
             first16KB = await VideoSignatureUtil.ReadFirst16KBAsync(firstStream, ct).ConfigureAwait(false);
-            // Stop as soon as the first file header lands. NzbDav.SharpCompress
+            // Stop as soon as the first file header lands. In-tree SharpCompress
             // deferred data-skip means this does not seek past packed payload.
             headers = await RarUtil.ReadHeadersUntilFirstFileAsync(firstStream, password, ct)
                 .ConfigureAwait(false);

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -194,7 +194,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         await using var stream = OpenVolumeStream(
             pending.SegmentIds, fileSize, pending.SegmentFallbackIds);
 
-        // Find-and-stop after the matching header. With NzbDav.SharpCompress
+        // Find-and-stop after the matching header. With in-tree SharpCompress
         // deferred data-skip, this no longer seeks past packed payload on
         // NzbFileStream (which previously triggered InterpolationSearch).
         // Measure-and-retry for understated Length remains as defense in depth.

--- a/backend/Streams/CancellableStream.cs
+++ b/backend/Streams/CancellableStream.cs
@@ -1,8 +1,11 @@
-﻿using System.Buffers;
-using UsenetSharp.Streams;
+﻿using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
 
+/// <summary>
+/// Async-only token boundary: every read is issued with the construction token
+/// (or a link of construction + caller tokens). Synchronous reads are not supported.
+/// </summary>
 public class CancellableStream(Stream innerStream, CancellationToken token) : FastReadOnlyStream
 {
     private readonly Stream _innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
@@ -29,35 +32,15 @@ public class CancellableStream(Stream innerStream, CancellationToken token) : Fa
         return _innerStream.FlushAsync(cancellationToken);
     }
 
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-        CheckDisposed();
-        // SharpCompress exposes synchronous RAR/7z header readers. Those readers run
-        // inside Task.Run in RarUtil/SevenZipUtil, and this bridge preserves the
-        // operation token until the library offers an async header-enumeration path.
-        return ReadAsync(buffer, offset, count, token)
-            .GetAwaiter()
-            .GetResult();
-    }
+    // Must override: deleting this would fall back to FastReadOnlyStream's
+    // CancellationToken.None bridge, which is uncancellable.
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException("CancellableStream supports asynchronous reads only.");
 
-    public override int Read(Span<byte> buffer)
-    {
-        CheckDisposed();
-        // Keep the construction token here too; FastReadOnlyStream's fallback uses
-        // CancellationToken.None and would make synchronous archive scans uncancellable.
-        var array = ArrayPool<byte>.Shared.Rent(buffer.Length);
-        try
-        {
-            var buffer1 = new Memory<byte>(array, 0, buffer.Length);
-            var result = this.ReadAsync(buffer1, token).AsTask().GetAwaiter().GetResult();
-            buffer1.Span[..result].CopyTo(buffer);
-            return result;
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(array);
-        }
-    }
+    // Must override: deleting this would fall back to FastReadOnlyStream's
+    // CancellationToken.None bridge, which is uncancellable.
+    public override int Read(Span<byte> buffer) =>
+        throw new NotSupportedException("CancellableStream supports asynchronous reads only.");
 
     public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -8,9 +8,9 @@ using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
 
-// Nested RAR expansion still passes this stream to SharpCompress's synchronous
-// header reader. FastReadOnlyStream centralizes that compatibility fallback while
-// WebDAV GET/range handlers use the Memory<byte> async path below.
+// FastReadOnlyStream retains a synchronous Read fallback for out-of-repo
+// compatibility only. In-repo nested-RAR expansion and WebDAV GET/range handlers
+// use the Memory<byte> async path below.
 public class DavMultipartFileStream : FastReadOnlyStream
 {
     private readonly DavMultipartFile _mpf;

--- a/backend/Utils/RarUtil.cs
+++ b/backend/Utils/RarUtil.cs
@@ -18,74 +18,8 @@ public static class RarUtil
         CancellationToken ct
     )
     {
+        ct.ThrowIfCancellationRequested();
         await using var cancellableStream = new CancellableStream(stream, ct);
-        return await Task.Run(() => GetRarHeaders(cancellableStream, password), ct).ConfigureAwait(false);
-    }
-
-    // Stops iterating as soon as `predicate` matches a file header. With NzbDav.SharpCompress
-    // deferred data-skip, stopping after a match performs no packed-data seek on NzbFileStream.
-    public static async Task<IRarFileHeader?> FindFirstFileHeaderAsync
-    (
-        Stream stream,
-        string? password,
-        Func<IRarFileHeader, bool> predicate,
-        CancellationToken ct
-    )
-    {
-        await using var cancellableStream = new CancellableStream(stream, ct);
-        return await Task.Run(() => FindFirstFileHeader(cancellableStream, password, predicate), ct)
-            .ConfigureAwait(false);
-    }
-
-    private static IRarFileHeader? FindFirstFileHeader(
-        Stream stream,
-        string? password,
-        Func<IRarFileHeader, bool> predicate)
-    {
-        try
-        {
-            var readerOptions = new ReaderOptions
-            {
-                Password = password,
-                LeaveStreamOpen = true,
-            };
-            var headerFactory = new RarHeaderFactory(StreamingMode.Seekable, readerOptions);
-            foreach (var header in headerFactory.ReadHeaders(stream))
-            {
-                if (header.HeaderType != HeaderType.File) continue;
-                if (header is not IRarFileHeader fh || fh.IsDirectory) continue;
-                if (!fh.IsStored)
-                    throw new UnsupportedRarCompressionMethodException(
-                        "Only rar files with compression method m0 are supported.");
-                if (predicate(fh)) return fh;
-            }
-            return null;
-        }
-        catch (Exception e) when (TryMapHeaderParseFailure(e, stream, out var mapped) && e is not OutOfMemoryException)
-        {
-            throw mapped;
-        }
-    }
-
-    // Reads headers from the start of a RAR volume and stops as soon as the
-    // first file header is yielded. Deferred data-skip means this no longer
-    // seeks past packed payload. Returned list typically contains
-    // [archive_header, file_header]; callers use the archive header for the
-    // IsFirstVolume eligibility check and the file header for path/size/AES metadata.
-    public static async Task<List<IRarHeader>> ReadHeadersUntilFirstFileAsync
-    (
-        Stream stream,
-        string? password,
-        CancellationToken ct
-    )
-    {
-        await using var cancellableStream = new CancellableStream(stream, ct);
-        return await Task.Run(() => ReadHeadersUntilFirstFile(cancellableStream, password), ct)
-            .ConfigureAwait(false);
-    }
-
-    private static List<IRarHeader> ReadHeadersUntilFirstFile(Stream stream, string? password)
-    {
         try
         {
             var readerOptions = new ReaderOptions
@@ -95,36 +29,8 @@ public static class RarUtil
             };
             var headerFactory = new RarHeaderFactory(StreamingMode.Seekable, readerOptions);
             var headers = new List<IRarHeader>();
-            foreach (var header in headerFactory.ReadHeaders(stream))
-            {
-                headers.Add(header);
-                if (header.HeaderType != HeaderType.File) continue;
-                if (header is not IRarFileHeader fh || fh.IsDirectory) continue;
-                if (!fh.IsStored)
-                    throw new UnsupportedRarCompressionMethodException(
-                        "Only rar files with compression method m0 are supported.");
-                return headers;
-            }
-            return headers;
-        }
-        catch (Exception e) when (TryMapHeaderParseFailure(e, stream, out var mapped) && e is not OutOfMemoryException)
-        {
-            throw mapped;
-        }
-    }
-
-    private static List<IRarHeader> GetRarHeaders(Stream stream, string? password)
-    {
-        try
-        {
-            var readerOptions = new ReaderOptions
-            {
-                Password = password,
-                LeaveStreamOpen = true,
-            };
-            var headerFactory = new RarHeaderFactory(StreamingMode.Seekable, readerOptions);
-            var headers = new List<IRarHeader>();
-            foreach (var header in headerFactory.ReadHeaders(stream))
+            await foreach (var header in headerFactory
+                .ReadHeadersAsync(cancellableStream, ct).ConfigureAwait(false))
             {
                 // add archive headers
                 if (header.HeaderType is HeaderType.Archive or HeaderType.EndArchive)
@@ -156,7 +62,90 @@ public static class RarUtil
 
             return headers;
         }
-        catch (Exception e) when (TryMapHeaderParseFailure(e, stream, out var mapped) && e is not OutOfMemoryException)
+        catch (Exception e) when (TryMapHeaderParseFailure(e, cancellableStream, out var mapped)
+            && e is not OutOfMemoryException)
+        {
+            throw mapped;
+        }
+    }
+
+    // Stops iterating as soon as `predicate` matches a file header. With in-tree
+    // SharpCompress deferred data-skip, stopping after a match performs no packed-data seek on NzbFileStream.
+    public static async Task<IRarFileHeader?> FindFirstFileHeaderAsync
+    (
+        Stream stream,
+        string? password,
+        Func<IRarFileHeader, bool> predicate,
+        CancellationToken ct
+    )
+    {
+        ct.ThrowIfCancellationRequested();
+        await using var cancellableStream = new CancellableStream(stream, ct);
+        try
+        {
+            var readerOptions = new ReaderOptions
+            {
+                Password = password,
+                LeaveStreamOpen = true,
+            };
+            var headerFactory = new RarHeaderFactory(StreamingMode.Seekable, readerOptions);
+            await foreach (var header in headerFactory
+                .ReadHeadersAsync(cancellableStream, ct).ConfigureAwait(false))
+            {
+                if (header.HeaderType != HeaderType.File) continue;
+                if (header is not IRarFileHeader fh || fh.IsDirectory) continue;
+                if (!fh.IsStored)
+                    throw new UnsupportedRarCompressionMethodException(
+                        "Only rar files with compression method m0 are supported.");
+                if (predicate(fh)) return fh;
+            }
+            return null;
+        }
+        catch (Exception e) when (TryMapHeaderParseFailure(e, cancellableStream, out var mapped)
+            && e is not OutOfMemoryException)
+        {
+            throw mapped;
+        }
+    }
+
+    // Reads headers from the start of a RAR volume and stops as soon as the
+    // first file header is yielded. Deferred data-skip means this no longer
+    // seeks past packed payload. Returned list typically contains
+    // [archive_header, file_header]; callers use the archive header for the
+    // IsFirstVolume eligibility check and the file header for path/size/AES metadata.
+    public static async Task<List<IRarHeader>> ReadHeadersUntilFirstFileAsync
+    (
+        Stream stream,
+        string? password,
+        CancellationToken ct
+    )
+    {
+        ct.ThrowIfCancellationRequested();
+        await using var cancellableStream = new CancellableStream(stream, ct);
+        try
+        {
+            var readerOptions = new ReaderOptions
+            {
+                Password = password,
+                LeaveStreamOpen = true,
+            };
+            var headerFactory = new RarHeaderFactory(StreamingMode.Seekable, readerOptions);
+            var headers = new List<IRarHeader>();
+            await foreach (var header in headerFactory
+                .ReadHeadersAsync(cancellableStream, ct).ConfigureAwait(false))
+            {
+                headers.Add(header);
+                if (header.HeaderType != HeaderType.File) continue;
+                if (header is not IRarFileHeader fh || fh.IsDirectory) continue;
+                if (!fh.IsStored)
+                    throw new UnsupportedRarCompressionMethodException(
+                        "Only rar files with compression method m0 are supported.");
+                return headers;
+            }
+            return headers;
+        }
+        catch (Exception e) when (TryMapHeaderParseFailure(e, cancellableStream, out var mapped)
+            && e is not OutOfMemoryException)
         {
             throw mapped;
         }

--- a/backend/Utils/SevenZipUtil.cs
+++ b/backend/Utils/SevenZipUtil.cs
@@ -16,19 +16,17 @@ public static class SevenZipUtil
     )
     {
         await using var cancellableStream = new CancellableStream(stream, ct);
-        return await Task.Run(() => GetSevenZipEntries(cancellableStream, password), ct).ConfigureAwait(false);
-    }
-
-    public static List<SevenZipEntry> GetSevenZipEntries(Stream stream, string? password = null)
-    {
-        using var archive = (SevenZipArchive)SevenZipArchive.OpenArchive(
-            stream,
-            new ReaderOptions { Password = password, LeaveStreamOpen = true }
-        );
-        return archive.Entries
-            .Where(x => !x.IsDirectory)
-            .Select(entry => new SevenZipEntry(entry, password))
-            .ToList();
+        await using var archive = (SevenZipArchive)SevenZipArchive.OpenArchive(
+            cancellableStream,
+            new ReaderOptions { Password = password, LeaveStreamOpen = true });
+        var entries = new List<SevenZipEntry>();
+        await foreach (var entry in archive.EntriesAsync
+            .WithCancellation(ct).ConfigureAwait(false))
+        {
+            if (entry.IsDirectory) continue;
+            entries.Add(new SevenZipEntry(entry, password));
+        }
+        return entries;
     }
 
     public class SevenZipEntry(SevenZipArchiveEntry entry, string? password)

--- a/libs/SharpCompress/Common/Rar/Headers/MarkHeader.Async.cs
+++ b/libs/SharpCompress/Common/Rar/Headers/MarkHeader.Async.cs
@@ -140,6 +140,14 @@ internal partial class MarkHeader
             }
             throw;
         }
+        catch (OperationCanceledException)
+        {
+            if (!leaveStreamOpen)
+            {
+                await stream.DisposeAsync().ConfigureAwait(false);
+            }
+            throw;
+        }
         catch (Exception e) when (e is not OutOfMemoryException)
         {
             if (!leaveStreamOpen)

--- a/libs/SharpCompress/Common/Rar/Headers/RarHeaderFactory.Async.cs
+++ b/libs/SharpCompress/Common/Rar/Headers/RarHeaderFactory.Async.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using SharpCompress.Common.Rar;
@@ -12,7 +13,10 @@ namespace SharpCompress.Common.Rar.Headers;
 public partial class RarHeaderFactory
 {
     /// <inheritdoc cref="ReadHeaders"/>
-    public async IAsyncEnumerable<IRarHeader> ReadHeadersAsync(Stream stream)
+    public async IAsyncEnumerable<IRarHeader> ReadHeadersAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         _pendingSkipPosition = null;
         var markHeader = await MarkHeader
@@ -20,7 +24,7 @@ public partial class RarHeaderFactory
                 stream,
                 Options.LeaveStreamOpen,
                 Options.LookForHeader,
-                CancellationToken.None
+                cancellationToken
             )
             .ConfigureAwait(false);
         _isRar5 = markHeader.IsRar5;
@@ -29,7 +33,7 @@ public partial class RarHeaderFactory
         RarHeader? header;
         while (
             (
-                header = await TryReadNextHeaderAsync(stream, CancellationToken.None)
+                header = await TryReadNextHeaderAsync(stream, cancellationToken)
                     .ConfigureAwait(false)
             ) != null
         )

--- a/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
@@ -221,14 +221,74 @@ public class BasicStreamTests
     }
 
     [Fact]
-    public void CancellableStream_SynchronousArchiveReadHonorsConstructionToken()
+    public void CancellableStream_SynchronousReadsAreNotSupported()
     {
-        using var cts = new CancellationTokenSource();
         using var stream = new CancellableStream(
-            new MemoryStream(new byte[] { 1, 2, 3 }), cts.Token);
-        cts.Cancel();
+            new MemoryStream(new byte[] { 1, 2, 3 }), CancellationToken.None);
 
-        Assert.ThrowsAny<OperationCanceledException>(
+        var arrayEx = Assert.Throws<NotSupportedException>(
             () => stream.Read(new byte[1], 0, 1));
+        Assert.Equal("CancellableStream supports asynchronous reads only.", arrayEx.Message);
+
+        var spanEx = Assert.Throws<NotSupportedException>(
+            () => stream.Read((Span<byte>)new byte[1]));
+        Assert.Equal("CancellableStream supports asynchronous reads only.", spanEx.Message);
+    }
+
+    [Fact]
+    public async Task CancellableStream_ReadAsyncHonorsConstructionTokenWhenCallerTokenIsLinked()
+    {
+        using var constructionCts = new CancellationTokenSource();
+        using var callerCts = new CancellationTokenSource();
+        var hang = new HangUntilCancelledStream();
+        await using var stream = new CancellableStream(hang, constructionCts.Token);
+
+        var readTask = stream.ReadAsync(new byte[1], callerCts.Token).AsTask();
+        Assert.True(hang.Started.Wait(TimeSpan.FromSeconds(5)));
+        await constructionCts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask);
+    }
+
+    private sealed class HangUntilCancelledStream : Stream
+    {
+        public ManualResetEventSlim Started { get; } = new();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Started.Set();
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) Started.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Utils/RarUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/RarUtilTests.cs
@@ -1,8 +1,14 @@
+using System.Buffers.Binary;
+using System.Text;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Utils;
 using SharpCompress.Common;
 using SharpCompress.Common.Rar;
+using SharpCompress.Common.Rar.Headers;
 
 namespace NzbWebDAV.Tests.Utils;
 
@@ -89,6 +95,100 @@ public class RarUtilTests
             .IsNonRetryableDownloadException());
     }
 
+    [Fact]
+    public async Task GetRarHeadersAsync_ReturnsArchiveAndStoredFileHeaders()
+    {
+        var payload = "hello-rar"u8.ToArray();
+        var rarBytes = BuildStoredRar4(("movie.mkv", payload));
+        await using var stream = new MemoryStream(rarBytes);
+
+        var headers = await RarUtil.GetRarHeadersAsync(stream, password: null, CancellationToken.None);
+
+        Assert.Contains(headers, header => header.HeaderType == HeaderType.Archive);
+        var file = Assert.Single(headers.OfType<IRarFileHeader>());
+        Assert.Equal("movie.mkv", file.FileName);
+        Assert.Equal(payload.Length, file.UncompressedSize);
+        Assert.True(file.IsStored);
+    }
+
+    [Fact]
+    public async Task FindFirstFileHeaderAsync_StopsAfterMatchWithoutSkippingPackedData()
+    {
+        var rarBytes = BuildStoredRar4(
+            ("first.bin", "aaaa"u8.ToArray()),
+            ("second.bin", "bbbbbbbb"u8.ToArray()));
+        var counting = new SeekCountingStream(new MemoryStream(rarBytes));
+
+        var match = await RarUtil.FindFirstFileHeaderAsync(
+            counting,
+            password: null,
+            header => header.FileName == "first.bin",
+            CancellationToken.None);
+
+        Assert.NotNull(match);
+        Assert.Equal("first.bin", match.FileName);
+        Assert.DoesNotContain(
+            match.DataStartPosition + match.CompressedSize,
+            counting.SeekTargets);
+    }
+
+    [Fact]
+    public async Task GetRarHeadersAsync_CancellationAfterSignatureThrowsOperationCanceledException()
+    {
+        var rarBytes = BuildStoredRar4(("movie.mkv", "payload"u8.ToArray()));
+        using var cts = new CancellationTokenSource();
+        using var enteredGate = new ManualResetEventSlim(false);
+        await using var stream = new GateAfterReadsStream(
+            new MemoryStream(rarBytes),
+            passThroughReads: 7,
+            enteredGate);
+
+        var parseTask = RarUtil.GetRarHeadersAsync(stream, password: null, cts.Token);
+        Assert.True(enteredGate.Wait(TimeSpan.FromSeconds(5)));
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => parseTask);
+    }
+
+    [Fact]
+    public async Task GetRarHeadersAsync_ParallelFakeNntpStreamsCompleteWithoutError()
+    {
+        var rarBytes = BuildStoredRar4(("movie.mkv", "payload"u8.ToArray()));
+        const int parallelism = 8;
+        var segments = Enumerable.Range(0, parallelism)
+            .ToDictionary(i => $"seg-{i}", _ => rarBytes);
+        using var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (_, bytes) => new DelayedReadStream(
+                new MemoryStream(bytes, writable: false),
+                TimeSpan.FromMilliseconds(5)));
+
+        var tasks = Enumerable.Range(0, parallelism).Select(async i =>
+        {
+            var nzbFile = new NzbFile
+            {
+                Subject = $"\"vol{i}.rar\" yEnc",
+                Segments =
+                {
+                    new NzbSegment
+                    {
+                        MessageId = $"seg-{i}",
+                        Bytes = rarBytes.Length,
+                        ByteRange = LongRange.FromStartAndSize(0, rarBytes.Length),
+                    }
+                },
+            };
+            await using var stream = client.GetFileStream(
+                nzbFile, rarBytes.Length, articleBufferSize: 0, usePipelinedBodyRequests: false);
+            var headers = await RarUtil.GetRarHeadersAsync(
+                stream, password: null, CancellationToken.None);
+            Assert.Contains(headers, header => header.HeaderType == HeaderType.File);
+        });
+
+        await Task.WhenAll(tasks);
+    }
+
     // Mirrors ExceptionMiddleware.IsKnownDownloadException chain walk.
     private static bool IsKnownDownloadStyle(Exception e, out string message)
     {
@@ -103,5 +203,241 @@ public class RarUtilTests
 
         message = string.Empty;
         return false;
+    }
+
+    private static byte[] BuildStoredRar4(params (string FileName, byte[] Payload)[] files)
+    {
+        using var ms = new MemoryStream();
+        ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
+
+        {
+            Span<byte> body = stackalloc byte[11];
+            body[0] = 0x73;
+            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], 0x0000);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
+            BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
+            WriteRar4Header(ms, body);
+        }
+
+        foreach (var (fileName, payload) in files)
+        {
+            var nameBytes = Encoding.ASCII.GetBytes(fileName);
+            var headSize = (ushort)(32 + nameBytes.Length);
+            var body = new byte[headSize - 2];
+            var o = 0;
+            body[o++] = 0x74;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), 0x8000); // HAS_DATA
+            o += 2;
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)payload.Length);
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)payload.Length);
+            o += 4;
+            body[o++] = 2; // HostOS Unix
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0);
+            o += 4;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0);
+            o += 4;
+            body[o++] = 20; // UnpVer
+            body[o++] = 0x30; // store
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), (ushort)nameBytes.Length);
+            o += 2;
+            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0);
+            o += 4;
+            nameBytes.CopyTo(body.AsSpan(o));
+            WriteRar4Header(ms, body);
+            ms.Write(payload);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static void WriteRar4Header(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
+    {
+        var crc = RarCrc16(bodyWithoutCrc);
+        Span<byte> hdr = stackalloc byte[bodyWithoutCrc.Length + 2];
+        BinaryPrimitives.WriteUInt16LittleEndian(hdr, crc);
+        bodyWithoutCrc.CopyTo(hdr[2..]);
+        stream.Write(hdr);
+    }
+
+    private static ushort RarCrc16(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (var i = 0; i < 8; i++)
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+        }
+
+        return (ushort)(~crc);
+    }
+
+    private sealed class SeekCountingStream(Stream inner) : Stream
+    {
+        public List<long> SeekTargets { get; } = [];
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set
+            {
+                SeekTargets.Add(value);
+                inner.Position = value;
+            }
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            var result = inner.Seek(offset, origin);
+            SeekTargets.Add(result);
+            return result;
+        }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Lets the first <paramref name="passThroughReads"/> async reads complete, then
+    /// waits until the caller cancels so tests can cancel after the RAR signature.
+    /// </summary>
+    private sealed class GateAfterReadsStream(
+        Stream inner,
+        int passThroughReads,
+        ManualResetEventSlim enteredGate) : Stream
+    {
+        private int _reads;
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer.AsMemory(offset, count), CancellationToken.None)
+                .AsTask().GetAwaiter().GetResult();
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var n = Interlocked.Increment(ref _reads);
+            if (n > passThroughReads)
+            {
+                enteredGate.Set();
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(10, cancellationToken);
+                }
+            }
+
+            return await inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+
+    private sealed class DelayedReadStream(Stream inner, TimeSpan delay) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            inner.Read(buffer, offset, count);
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(delay, cancellationToken);
+            return await inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Utils/SevenZipUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/SevenZipUtilTests.cs
@@ -10,13 +10,15 @@ public class SevenZipUtilTests
         "N3q8ryccAARez7gsaAAAAAAAAAAUAAAAAAAAAJeoNbBzdG9yZWQtc2V2ZW56aXAtZW50cnkBAE4BBAYAAQkVAAcLAQABAQAMFQAICgHuw9/ZAAAFARkBABEXAHMAYQBtAHAAbABlAC4AdAB4AHQAAAAUCgEAwGcQ9pEQ3QEVBgEAIICAgQAAABcGFQEJUwAHCwEAASEhARgMTwAA";
 
     [Fact]
-    public void GetSevenZipEntries_ReturnsStoredEntryByteRange()
+    public async Task GetSevenZipEntriesAsync_ReturnsStoredEntryByteRange()
     {
         var archiveBytes = Convert.FromBase64String(StoredArchiveBase64);
         var expectedEntryBytes = Encoding.UTF8.GetBytes("stored-sevenzip-entry");
-        using var archiveStream = new MemoryStream(archiveBytes);
+        await using var archiveStream = new MemoryStream(archiveBytes);
 
-        var entry = Assert.Single(SevenZipUtil.GetSevenZipEntries(archiveStream));
+        var entry = Assert.Single(
+            await SevenZipUtil.GetSevenZipEntriesAsync(
+                archiveStream, password: null, CancellationToken.None));
 
         Assert.Equal("sample.txt", entry.PathWithinArchive);
         Assert.Equal(CompressionType.None, entry.CompressionType);
@@ -31,19 +33,108 @@ public class SevenZipUtilTests
             .ToArray();
 
         Assert.Equal(expectedEntryBytes, storedEntryBytes);
-        Assert.True(archiveStream.CanRead);
     }
 
     [Fact]
-    public void GetSevenZipEntries_ThrowsInvalidFormatException_OnCorruptSignature()
+    public async Task GetSevenZipEntriesAsync_ThrowsInvalidFormatException_OnCorruptSignature()
     {
         // Import must fail as a managed InvalidFormatException so the queue marks
         // the item failed instead of crashing the process (audit F3 / #477).
         var archiveBytes = Convert.FromBase64String(StoredArchiveBase64);
         archiveBytes[0] ^= 0xFF;
-        using var archiveStream = new MemoryStream(archiveBytes);
+        await using var archiveStream = new MemoryStream(archiveBytes);
 
-        Assert.Throws<InvalidFormatException>(() =>
-            SevenZipUtil.GetSevenZipEntries(archiveStream));
+        await Assert.ThrowsAsync<InvalidFormatException>(() =>
+            SevenZipUtil.GetSevenZipEntriesAsync(
+                archiveStream, password: null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSevenZipEntriesAsync_PreCancelledTokenThrowsOperationCanceledException()
+    {
+        var archiveBytes = Convert.FromBase64String(StoredArchiveBase64);
+        await using var archiveStream = new MemoryStream(archiveBytes);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            SevenZipUtil.GetSevenZipEntriesAsync(
+                archiveStream, password: null, cts.Token));
+    }
+
+    [Fact]
+    public async Task GetSevenZipEntriesAsync_CancellationMidLoadThrowsOperationCanceledException()
+    {
+        var archiveBytes = Convert.FromBase64String(StoredArchiveBase64);
+        using var cts = new CancellationTokenSource();
+        // 7z signature is 6 bytes; cancel after that so the failure is OCE, not
+        // InvalidFormatException from a truncated signature scan.
+        await using var archiveStream = new CancelAfterBytesReadStream(
+            new MemoryStream(archiveBytes),
+            cts,
+            cancelAfterBytes: 16);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            SevenZipUtil.GetSevenZipEntriesAsync(
+                archiveStream, password: null, cts.Token));
+    }
+
+    private sealed class CancelAfterBytesReadStream(
+        Stream inner,
+        CancellationTokenSource cancellationTokenSource,
+        long cancelAfterBytes) : Stream
+    {
+        private long _bytesRead;
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("Use async reads for this test stream.");
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = await inner.ReadAsync(buffer, cancellationToken);
+            _bytesRead += read;
+            if (_bytesRead > cancelAfterBytes)
+            {
+                await cancellationTokenSource.CancelAsync();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
     }
 }

--- a/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
+++ b/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using SharpCompress.Archives;
 using SharpCompress.Archives.Tar;
 using SharpCompress.Common;
+using SharpCompress.Common.Rar.Headers;
+using SharpCompress.IO;
 using SharpCompress.Readers;
 using SharpCompress.Test.Mocks;
 using SharpCompress.Writers;
@@ -190,6 +192,101 @@ public class AsyncParityAndCancellationTests : TestBase
         }
     }
 
+    [Theory]
+    [InlineData("Rar.none.rar")]
+    [InlineData("Rar5.none.rar")]
+    public async Task RarHeaderFactory_ReadHeadersAsync_ShouldMatchSyncHeaders(string archiveName)
+    {
+        var syncHeaders = ReadRarHeaders(archiveName);
+        var asyncHeaders = await ReadRarHeadersAsync(archiveName);
+
+        Assert.Equal(syncHeaders, asyncHeaders);
+    }
+
+    [Theory]
+    [InlineData("Rar.none.rar")]
+    [InlineData("Rar5.none.rar")]
+    public async Task RarHeaderFactory_ReadHeadersAsync_ShouldRespectCancellationAfterSignature(
+        string archiveName
+    )
+    {
+        var archiveBytes = await File.ReadAllBytesAsync(
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
+        );
+        using var cts = new CancellationTokenSource();
+        // RAR4 signature is 7 bytes and RAR5 is 8; cancel after that so MarkHeader
+        // does not wrap the cancellation into RarHeaderReadException.
+        await using var stream = new CancelAfterBytesReadStream(
+            new MemoryStream(archiveBytes),
+            cts,
+            cancelAfterBytes: 16
+        );
+        var factory = CreateRarHeaderFactory();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in factory.ReadHeadersAsync(stream, cts.Token)) { }
+        });
+    }
+
+    [Theory]
+    [InlineData("Rar.none.rar")]
+    [InlineData("Rar5.none.rar")]
+    [InlineData("Rar.comment.rar")]
+    [InlineData("Rar5.comment.rar")]
+    public async Task RarHeaderFactory_ReadHeadersAsync_StopAfterFirstFile_SkipsNoPackedData(
+        string archiveName
+    )
+    {
+        var archiveBytes = await File.ReadAllBytesAsync(
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
+        );
+        await using var stream = new SeekCountingStream(new MemoryStream(archiveBytes));
+        var factory = CreateRarHeaderFactory();
+        IRarFileHeader? firstFile = null;
+        var seeksAtYield = -1;
+
+        await foreach (var header in factory.ReadHeadersAsync(stream))
+        {
+            if (header.HeaderType != HeaderType.File || header is not IRarFileHeader fileHeader)
+            {
+                continue;
+            }
+
+            if (fileHeader.IsDirectory)
+            {
+                continue;
+            }
+
+            firstFile = fileHeader;
+            seeksAtYield = stream.SeekCount;
+            break;
+        }
+
+        Assert.NotNull(firstFile);
+        Assert.Equal(firstFile.DataStartPosition, stream.Position);
+        Assert.Equal(seeksAtYield, stream.SeekCount);
+        Assert.DoesNotContain(
+            firstFile.DataStartPosition + firstFile.CompressedSize,
+            stream.SeekTargets
+        );
+    }
+
+    [Theory]
+    [InlineData("Rar.encrypted_filesAndHeader.rar")]
+    [InlineData("Rar5.encrypted_filesAndHeader.rar")]
+    public async Task RarHeaderFactory_ReadHeadersAsync_EncryptedHeaders_ShouldMatchSync(
+        string archiveName
+    )
+    {
+        const string password = "test";
+        var syncHeaders = ReadRarHeaders(archiveName, password);
+        var asyncHeaders = await ReadRarHeadersAsync(archiveName, password);
+
+        Assert.Equal(syncHeaders, asyncHeaders);
+        Assert.Contains(asyncHeaders, header => header.HeaderType == HeaderType.File);
+    }
+
     [Fact]
     public async Task OpenAsyncArchive_CallerProvidedStream_ShouldRemainOpenByDefault()
     {
@@ -335,10 +432,134 @@ public class AsyncParityAndCancellationTests : TestBase
         return stream.ToArray();
     }
 
+    private static RarHeaderFactory CreateRarHeaderFactory(string? password = null) =>
+        new(
+            StreamingMode.Seekable,
+            ReaderOptions.ForExternalStream with
+            {
+                Password = password,
+            }
+        );
+
+    private static List<HeaderFieldSnapshot> ReadRarHeaders(
+        string archiveName,
+        string? password = null
+    )
+    {
+        using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
+        var factory = CreateRarHeaderFactory(password);
+        return factory.ReadHeaders(stream).Select(SnapshotHeader).ToList();
+    }
+
+    private static async Task<List<HeaderFieldSnapshot>> ReadRarHeadersAsync(
+        string archiveName,
+        string? password = null
+    )
+    {
+        await using var stream = File.OpenRead(Path.Join(TEST_ARCHIVES_PATH, archiveName));
+        var factory = CreateRarHeaderFactory(password);
+        var headers = new List<HeaderFieldSnapshot>();
+        await foreach (var header in factory.ReadHeadersAsync(stream))
+        {
+            headers.Add(SnapshotHeader(header));
+        }
+
+        return headers;
+    }
+
+    private static HeaderFieldSnapshot SnapshotHeader(IRarHeader header)
+    {
+        if (header is IRarFileHeader fileHeader)
+        {
+            return new HeaderFieldSnapshot(
+                header.HeaderType,
+                fileHeader.FileName,
+                fileHeader.DataStartPosition,
+                fileHeader.CompressedSize,
+                fileHeader.AdditionalDataSize
+            );
+        }
+
+        return new HeaderFieldSnapshot(header.HeaderType, null, null, null, null);
+    }
+
     private sealed record EntrySnapshot(
         string Key,
         long Size,
         CompressionType CompressionType,
         string Content
     );
+
+    private sealed record HeaderFieldSnapshot(
+        HeaderType HeaderType,
+        string? FileName,
+        long? DataStartPosition,
+        long? CompressedSize,
+        long? AdditionalDataSize
+    );
+
+    /// <summary>
+    /// Counts explicit <see cref="Stream.Seek"/> calls and <see cref="Stream.Position"/>
+    /// assignments so stop-after-first-file can prove packed data was not skipped.
+    /// </summary>
+    private sealed class SeekCountingStream(Stream inner) : Stream
+    {
+        public int SeekCount { get; private set; }
+        public List<long> SeekTargets { get; } = [];
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set
+            {
+                SeekCount++;
+                SeekTargets.Add(value);
+                inner.Position = value;
+            }
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            inner.Read(buffer, offset, count);
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default
+        ) => await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            SeekCount++;
+            var result = inner.Seek(offset, origin);
+            SeekTargets.Add(result);
+            return result;
+        }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
 }

--- a/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
+++ b/tests/SharpCompress.Tests/AsyncParityAndCancellationTests.cs
@@ -232,6 +232,30 @@ public class AsyncParityAndCancellationTests : TestBase
     [Theory]
     [InlineData("Rar.none.rar")]
     [InlineData("Rar5.none.rar")]
+    public async Task RarHeaderFactory_ReadHeadersAsync_ShouldRespectCancellationDuringSignature(
+        string archiveName
+    )
+    {
+        var archiveBytes = await File.ReadAllBytesAsync(
+            Path.Join(TEST_ARCHIVES_PATH, archiveName)
+        );
+        using var cts = new CancellationTokenSource();
+        await using var stream = new CancelAfterBytesReadStream(
+            new MemoryStream(archiveBytes),
+            cts,
+            cancelAfterBytes: 0
+        );
+        var factory = CreateRarHeaderFactory();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in factory.ReadHeadersAsync(stream, cts.Token)) { }
+        });
+    }
+
+    [Theory]
+    [InlineData("Rar.none.rar")]
+    [InlineData("Rar5.none.rar")]
     [InlineData("Rar.comment.rar")]
     [InlineData("Rar5.comment.rar")]
     public async Task RarHeaderFactory_ReadHeadersAsync_StopAfterFirstFile_SkipsNoPackedData(
@@ -263,11 +287,11 @@ public class AsyncParityAndCancellationTests : TestBase
             break;
         }
 
-        Assert.NotNull(firstFile);
-        Assert.Equal(firstFile.DataStartPosition, stream.Position);
+        var yieldedFile = Assert.IsAssignableFrom<IRarFileHeader>(firstFile);
+        Assert.Equal(yieldedFile.DataStartPosition, stream.Position);
         Assert.Equal(seeksAtYield, stream.SeekCount);
         Assert.DoesNotContain(
-            firstFile.DataStartPosition + firstFile.CompressedSize,
+            yieldedFile.DataStartPosition + yieldedFile.CompressedSize,
             stream.SeekTargets
         );
     }


### PR DESCRIPTION
## Summary

Closes #317.

- RAR and 7z header parsing during imports and lazy-RAR opens now awaits I/O directly instead of pinning a thread-pool worker inside `Task.Run` for every Usenet round trip — under import bursts, workers stay free for playback requests.
- Cancellation is now threaded through the in-tree SharpCompress async RAR header enumeration, so aborting a queue item stops header scans immediately (and is no longer misreported as a corrupt archive).
- `CancellableStream` rejects synchronous reads outright, making any future reintroduction of a blocking archive scan fail fast in tests rather than silently stalling a worker.
- No changes to the steady-state playback read path, the Usenet transport, database schema, or the ThreadPool configuration.

## Test plan

- [x] Backend suite: 3179 passed / 10 skipped / 0 failed
- [x] SharpCompress suite (`format!=stress`): 2135 passed / 0 failed — incl. new async/sync header parity (plain, comment, encrypted-header RAR4/RAR5), post-signature cancellation, and deferred data-skip proofs
- [x] Frontend: typecheck, build, 655 Vitest passed (no frontend source changes)
- [x] Final greps: no `GetAwaiter().GetResult()`/`Task.Run` in `RarUtil`/`SevenZipUtil`; no in-repo sync `CancellableStream` consumer
- [ ] Manual: parallel-playback load test during an import burst (verify no stutter while multiple RAR/7z items queue)
- [ ] Manual: encrypted-archive seek/scrub playback check
- [ ] Manual: cancel an in-flight import mid-header-scan; verify queue marks it cancelled (not "corrupt RAR")