### PR TITLE
perf(streams): lower streaming memory use with bounded 256 KB segment buffers

### DIFF
--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -115,9 +115,8 @@ namespace NzbWebDAV.Benchmarks
             var pool = new SegmentBufferPool(MaxIdleBytes);
             var diagnostics = new BufferPoolDiagnostics();
             long bytesRead = 0;
-            foreach (var index in _mixedSchedule)
+            foreach (var payload in _mixedSchedule.Select(index => _mixedPayloads[index]))
             {
-                var payload = _mixedPayloads[index];
                 using var buffer = new PooledBufferStream(payload.Length, pool, diagnostics);
                 buffer.Write(payload);
                 buffer.Position = 0;

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -80,6 +80,94 @@ namespace NzbWebDAV.Benchmarks
     }
 
     [MemoryDiagnoser]
+    public class SegmentBufferPoolScenarioBenchmarks
+    {
+        private static readonly int[] MixedSizes = [700_000, 750_000, 800_000];
+        private const int BurstCount = 64;
+        private const int GrowthHintBytes = 64 * 1024;
+        private const int GrowthPayloadBytes = 8 * 1024 * 1024;
+
+        private byte[][] _mixedPayloads = null!;
+        private int[] _mixedSchedule = null!;
+
+        // Production derivation is clamp(startup budget / 2, 32 MiB, 256 MiB).
+        [Params(32L * 1024 * 1024, 128L * 1024 * 1024, 256L * 1024 * 1024)]
+        public long MaxIdleBytes { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var random = new Random(42);
+            _mixedPayloads = MixedSizes.Select(size =>
+            {
+                var payload = new byte[size];
+                random.NextBytes(payload);
+                return payload;
+            }).ToArray();
+            _mixedSchedule = Enumerable.Range(0, 24)
+                .Select(_ => random.Next(MixedSizes.Length))
+                .ToArray();
+        }
+
+        [Benchmark]
+        public long MixedSizes_Drain()
+        {
+            var pool = new SegmentBufferPool(MaxIdleBytes);
+            var diagnostics = new BufferPoolDiagnostics();
+            long bytesRead = 0;
+            foreach (var index in _mixedSchedule)
+            {
+                var payload = _mixedPayloads[index];
+                using var buffer = new PooledBufferStream(payload.Length, pool, diagnostics);
+                buffer.Write(payload);
+                buffer.Position = 0;
+                buffer.CopyTo(Stream.Null);
+                bytesRead += buffer.Length;
+            }
+
+            return bytesRead;
+        }
+
+        [Benchmark]
+        public long BurstThenIdle_RespectsByteCap()
+        {
+            var pool = new SegmentBufferPool(MaxIdleBytes);
+            var buffers = new byte[BurstCount][];
+            for (var i = 0; i < BurstCount; i++)
+                buffers[i] = pool.Rent(MixedSizes[i % MixedSizes.Length]);
+
+            foreach (var buffer in buffers)
+                pool.Return(buffer);
+
+            var snapshot = pool.Snapshot();
+            if (snapshot.IdleBytes > MaxIdleBytes)
+                throw new InvalidOperationException(
+                    $"IdleBytes {snapshot.IdleBytes} exceeded maxIdleBytes {MaxIdleBytes}.");
+            if (snapshot.RentCount != snapshot.ReturnCount)
+                throw new InvalidOperationException(
+                    $"Rent/return imbalance: {snapshot.RentCount}/{snapshot.ReturnCount}.");
+            return snapshot.IdleBytes + snapshot.TrimmedBytes + snapshot.ReuseCount;
+        }
+
+        [Benchmark]
+        public long GrowthAmplification_SmallHintToMultiMiB()
+        {
+            var pool = new SegmentBufferPool(MaxIdleBytes);
+            var diagnostics = new BufferPoolDiagnostics();
+            using var stream = new PooledBufferStream(GrowthHintBytes, pool, diagnostics);
+            var chunk = new byte[GrowthHintBytes];
+            for (var written = 0; written < GrowthPayloadBytes; written += chunk.Length)
+                stream.Write(chunk);
+
+            var snapshot = diagnostics.Snapshot();
+            if (snapshot.Rents > 15)
+                throw new InvalidOperationException(
+                    $"Growth was not log-bounded: {snapshot.Rents} rents for 64 KiB hint → 8 MiB.");
+            return snapshot.Rents;
+        }
+    }
+
+    [MemoryDiagnoser]
     public class YencDecodeBenchmarks
     {
         private byte[] _decoded = null!;

--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
@@ -42,6 +42,7 @@ public sealed class GcDiagnosticsController(
             stopwatch.Stop();
 
             var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
+            var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.Snapshot();
             var result = new GcDiagnosticsResult(
                 DateTimeOffset.UtcNow,
                 before,
@@ -57,7 +58,8 @@ public sealed class GcDiagnosticsController(
                     bufferPool.CheckedOutBytes,
                     bufferPool.RequestedBytes,
                     bufferPool.RentedBytes,
-                    bufferPool.BucketWasteBytes));
+                    bufferPool.BucketWasteBytes),
+                segmentPool);
             store.Store(result);
 
             return Task.FromResult<IActionResult>(Ok(GcDiagnosticsResponse.FromResult(result)));

--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsResponse.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsResponse.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Streams;
 
 namespace NzbWebDAV.Api.Controllers.GcDiagnostics;
 
@@ -9,6 +10,7 @@ public sealed class GcDiagnosticsResponse : BaseApiResponse
     public required GcSnapshot After { get; init; }
     public required long PauseMs { get; init; }
     public required GcBufferRetention Retention { get; init; }
+    public SegmentBufferPoolSnapshot? SegmentBufferPool { get; init; }
     public required string Warning { get; init; }
 
     internal static GcDiagnosticsResponse FromResult(GcDiagnosticsResult result) => new()
@@ -18,6 +20,7 @@ public sealed class GcDiagnosticsResponse : BaseApiResponse
         After = result.After,
         PauseMs = result.PauseMs,
         Retention = result.Retention,
+        SegmentBufferPool = result.SegmentBufferPool,
         Warning = "Forced a blocking compacting GC; managed threads were paused. Do not poll this endpoint.",
     };
 }

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -2,6 +2,7 @@
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
 using UsenetSharp.Clients;
 using UsenetSharp.Models;
@@ -39,6 +40,8 @@ public class BaseNntpClient : NntpClient
             ? YencCrcValidationMode.Off
             : YencCrcValidationMode.WhenPresent,
         SkipTlsVerification = skipTlsVerification,
+        DecodedBodyBufferedBytesObserver = static delta =>
+            InFlightArticleBudget.Current?.AccountBufferedPipeBytes(delta),
     }))
     {
     }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -182,6 +182,22 @@ public partial class Program
                 return;
             }
 
+            var poolOverride = EnvironmentUtil.GetEnvironmentVariable("NZBDAV_SEGMENT_BUFFER_POOL");
+            if (string.Equals(poolOverride, "shared", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.Information(
+                    "Segment buffer pool override active: using ArrayPool<byte>.Shared " +
+                    "(NZBDAV_SEGMENT_BUFFER_POOL=shared).");
+            }
+            else
+            {
+                PooledBufferStream.DefaultPool = new SegmentBufferPool(
+                    maxIdleBytes: Math.Clamp(
+                        configManager.GetInFlightArticleBudgetBytes() / 2,
+                        32L * 1024 * 1024,
+                        256L * 1024 * 1024));
+            }
+
             // WebApplicationFactory runs from the test output directory, where the
             // backend's published rapidyenc native asset is not present.
             if (!string.Equals(

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -185,6 +185,11 @@ public partial class Program
             var poolOverride = EnvironmentUtil.GetEnvironmentVariable("NZBDAV_SEGMENT_BUFFER_POOL");
             if (string.Equals(poolOverride, "shared", StringComparison.OrdinalIgnoreCase))
             {
+                // Explicit assignment is deliberate: DefaultPool is documented as
+                // set-once-at-startup, and this is the one sanctioned alternate
+                // assignment so tests or later refactors cannot leave it on the
+                // custom pool despite NZBDAV_SEGMENT_BUFFER_POOL=shared.
+                PooledBufferStream.DefaultPool = SharedArrayPoolAdapter.Instance;
                 Log.Information(
                     "Segment buffer pool override active: using ArrayPool<byte>.Shared " +
                     "(NZBDAV_SEGMENT_BUFFER_POOL=shared).");

--- a/backend/Services/Diagnostics/GcDiagnosticsStore.cs
+++ b/backend/Services/Diagnostics/GcDiagnosticsStore.cs
@@ -1,3 +1,5 @@
+using NzbWebDAV.Streams;
+
 namespace NzbWebDAV.Services.Diagnostics;
 
 public sealed class GcDiagnosticsStore : IDisposable
@@ -28,7 +30,8 @@ public sealed record GcDiagnosticsResult(
     GcSnapshot Before,
     GcSnapshot After,
     long PauseMs,
-    GcBufferRetention Retention);
+    GcBufferRetention Retention,
+    SegmentBufferPoolSnapshot? SegmentBufferPool);
 
 public sealed record GcSnapshot(
     IReadOnlyList<GcGenerationInfo> Generations,

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -320,6 +320,7 @@ public sealed class SupportPackService(
         var usage = runtimeUsage.Snapshot();
         var concurrentReads = concurrentReadTracker?.Snapshot() ?? default;
         var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
+        var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.Snapshot();
         var cpu = await BuildCpuDiagnosticsAsync(usage, uptime, cancellationToken).ConfigureAwait(false);
 
         return new
@@ -373,6 +374,23 @@ public sealed class SupportPackService(
                 segmentBufferRentedBytes = bufferPool.RentedBytes,
                 segmentBufferBucketWasteBytes = bufferPool.BucketWasteBytes,
                 timeZone = TimeZoneInfo.Local.Id,
+            },
+            segmentBufferPool = segmentPool is null ? null : new
+            {
+                idleBytes = segmentPool.Value.IdleBytes,
+                trimmedBytes = segmentPool.Value.TrimmedBytes,
+                checkedOutBytes = segmentPool.Value.CheckedOutBytes,
+                rentCount = segmentPool.Value.RentCount,
+                returnCount = segmentPool.Value.ReturnCount,
+                rejectedReturnCount = segmentPool.Value.RejectedReturnCount,
+                reuseCount = segmentPool.Value.ReuseCount,
+                allocationCount = segmentPool.Value.AllocationCount,
+                sizeClasses = segmentPool.Value.SizeClasses.Select(c => new
+                {
+                    bufferSize = c.BufferSize,
+                    bufferCount = c.BufferCount,
+                    idleBytes = c.IdleBytes,
+                }),
             },
             runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),
             cpu,

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -18,6 +18,7 @@ public sealed class InFlightArticleBudget
     private long _capBytes;
     private long _throttleEvents;
     private long _lastWarningTicks;
+    private long _lastPipeOverReleaseWarningTicks;
     private readonly ProviderLatencyTracker? _latencyTracker;
     private readonly object _gate = new();
     private readonly LinkedList<Waiter> _waiters = new();
@@ -172,11 +173,40 @@ public sealed class InFlightArticleBudget
     /// copy of each in-flight segment. Positive deltas never block or wake waiters;
     /// negative deltas release and wake the FIFO head. Deltas sum to zero per body,
     /// so the counter self-balances across success, cancellation, and dispose.
+    /// Over-release is clamped at zero so a stray negative delta cannot break the cap
+    /// invariant used by <see cref="TryLease"/>.
     /// </summary>
     public void AccountBufferedPipeBytes(long delta)
     {
-        if (delta > 0) AccountExtra(delta);
-        else if (delta < 0) Release(-delta);
+        if (delta > 0)
+        {
+            AccountExtra(delta);
+            return;
+        }
+
+        if (delta == 0) return;
+
+        var requested = -delta;
+        long released;
+        while (true)
+        {
+            var current = Interlocked.Read(ref _leased);
+            if (current <= 0)
+            {
+                released = 0;
+                break;
+            }
+
+            released = Math.Min(current, requested);
+            if (Interlocked.CompareExchange(ref _leased, current - released, current) == current)
+                break;
+        }
+
+        if (released > 0)
+            SignalWaiters();
+
+        if (released < requested)
+            MaybeWarnPipeOverRelease(requested, released);
     }
 
     /// <summary>
@@ -201,6 +231,19 @@ public sealed class InFlightArticleBudget
         Log.Warning(
             "In-flight article memory budget saturated. Leased={Leased:N0} Cap={Cap:N0} Requested={Requested:N0}. Reason: {Reason}",
             LeasedBytes, CapBytes, requested, "backpressure");
+    }
+
+    private void MaybeWarnPipeOverRelease(long requested, long released)
+    {
+        var nowTicks = DateTimeOffset.UtcNow.UtcTicks;
+        var last = Interlocked.Read(ref _lastPipeOverReleaseWarningTicks);
+        if (nowTicks - last < TimeSpan.FromSeconds(30).Ticks) return;
+        if (Interlocked.CompareExchange(ref _lastPipeOverReleaseWarningTicks, nowTicks, last) != last)
+            return;
+
+        Log.Warning(
+            "In-flight article pipe-byte accounting clamped an over-release. Requested={Requested:N0} Released={Released:N0} Leased={Leased:N0} Cap={Cap:N0}. Reason: {Reason}",
+            requested, released, LeasedBytes, CapBytes, "pipe-accounting-over-release");
     }
 
     private sealed class Waiter(long bytes)

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -6,7 +6,9 @@ using Serilog;
 namespace NzbWebDAV.Streams;
 
 /// <summary>
-/// Process-wide cap on decoded article bytes retained in RAM (WebDAV segment drains).
+/// Process-wide cap on decoded article bytes retained in RAM, including pipe copies
+/// from all workloads (streaming, queue, health, benchmark, and seek). Streaming
+/// leases gate admission; queue/health/seek pipe bytes are accounted but not gated.
 /// Connection semaphores bound concurrency; this bounds retained bytes so concurrent
 /// streams cannot OOM the host.
 /// </summary>
@@ -163,6 +165,18 @@ public sealed class InFlightArticleBudget
     {
         if (bytes <= 0) return;
         Interlocked.Add(ref _leased, bytes);
+    }
+
+    /// <summary>
+    /// Accounts decoded bytes buffered in UsenetSharp body pipes — the second resident
+    /// copy of each in-flight segment. Positive deltas never block or wake waiters;
+    /// negative deltas release and wake the FIFO head. Deltas sum to zero per body,
+    /// so the counter self-balances across success, cancellation, and dispose.
+    /// </summary>
+    public void AccountBufferedPipeBytes(long delta)
+    {
+        if (delta > 0) AccountExtra(delta);
+        else if (delta < 0) Release(-delta);
     }
 
     /// <summary>

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1059,6 +1059,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 ?? (expected is > 0 and <= int.MaxValue ? expected : _estimatedSegmentSize);
             if (estimate < 0) estimate = 0;
 
+            // Never lease while holding an open body pipe: a waiter in LeaseAsync must
+            // not hold pipe bytes. All production call sites lease before issuing the
+            // BODY request; this branch is defensive and currently unreachable. Future
+            // callers must also lease before BODY, not here after the pipe exists.
             if (lease is null)
                 lease = await LeaseSegmentBytesAsync(estimate, cancellationToken).ConfigureAwait(false);
 

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -11,6 +11,14 @@ public sealed class PooledBufferStream : Stream
 {
     private const int RunawayThresholdBytes = 32 * 1024 * 1024;
 
+    /// <summary>
+    /// Pool used when no explicit pool is passed. Set once by the composition root
+    /// before the server handles traffic and never mutated afterwards; each stream
+    /// captures the reference at construction, so buffers always return to the pool
+    /// that rented them (per-request pool mutation was rejected in PR #776 review).
+    /// </summary>
+    internal static ISegmentBufferPool DefaultPool { get; set; } = SharedArrayPoolAdapter.Instance;
+
     private readonly ISegmentBufferPool _pool;
     private readonly BufferPoolDiagnostics _diagnostics;
     private byte[]? _buffer;
@@ -25,7 +33,7 @@ public sealed class PooledBufferStream : Stream
     {
         ArgumentOutOfRangeException.ThrowIfNegative(capacityHint);
 
-        _pool = pool ?? SharedArrayPoolAdapter.Instance;
+        _pool = pool ?? DefaultPool;
         _diagnostics = diagnostics ?? BufferPoolDiagnostics.Shared;
 
         if (capacityHint > 0)

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -198,7 +198,10 @@ public sealed class PooledBufferStream : Stream
         if (required <= current.Length) return;
 
         WarnIfRunawayCapacity(required, current.Length);
-        var next = RentBuffer(required);
+        var target = (int)Math.Min(
+            Math.Max((long)required, current.Length + (long)current.Length / 2),
+            Array.MaxLength);
+        var next = RentBuffer(target);
         if (_length > 0)
             current.AsSpan(0, _length).CopyTo(next);
 

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -478,6 +478,17 @@ public partial class UsenetClient
     private void AdjustBufferedDecodedBodyBytes(long delta)
     {
         Interlocked.Add(ref _bufferedDecodedBodyBytes, delta);
+        var observer = _options.DecodedBodyBufferedBytesObserver;
+        if (observer is null) return;
+        try
+        {
+            observer(delta);
+        }
+        catch
+        {
+            // Observer exceptions must never fault the transport or consumer paths
+            // (completion callbacks must fire exactly once regardless).
+        }
     }
 
     private static void ValidateDecodedBodyCrc32(

--- a/libs/UsenetSharp/Clients/UsenetClientOptions.cs
+++ b/libs/UsenetSharp/Clients/UsenetClientOptions.cs
@@ -57,6 +57,15 @@ public sealed record UsenetClientOptions
     public long DecodedBodyResumeWriterThreshold { get; init; } = 512 * 1024;
 
     /// <summary>
+    /// Observer invoked with every decoded-body buffered-byte delta: positive as bytes
+    /// enter a body pipe, negative as the consumer drains them. Deltas sum to zero over
+    /// each body's lifetime, including cancellation and dispose. Invoked on the decode
+    /// hot path under a per-body lock: implementations must be allocation-free,
+    /// non-blocking, and must not throw.
+    /// </summary>
+    public Action<long>? DecodedBodyBufferedBytesObserver { get; init; }
+
+    /// <summary>
     /// Gets how cancelled body transfers release the connection.
     /// </summary>
     /// <remarks>

--- a/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
@@ -47,6 +47,10 @@ public sealed class GcDiagnosticsHttpIntegrationTests(NzbDavWebApplicationFactor
         Assert.Equal(JsonValueKind.Object, root.GetProperty("after").ValueKind);
         Assert.Equal(JsonValueKind.Object, root.GetProperty("retention").ValueKind);
         Assert.Equal(JsonValueKind.Array, root.GetProperty("after").GetProperty("generations").ValueKind);
+        Assert.True(root.TryGetProperty("segmentBufferPool", out var segmentPool));
+        Assert.True(
+            segmentPool.ValueKind is JsonValueKind.Object or JsonValueKind.Null,
+            $"segmentBufferPool should be an object or null, was {segmentPool.ValueKind}");
 
         var store = factory.Services.GetRequiredService<GcDiagnosticsStore>();
         Assert.NotNull(store.LastResult);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -176,6 +176,65 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_ReportsSegmentBufferPoolSnapshotWhenCustomPoolIsDefault()
+    {
+        var previous = PooledBufferStream.DefaultPool;
+        var pool = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        var buffer = pool.Rent(750_000);
+        pool.Return(buffer);
+        PooledBufferStream.DefaultPool = pool;
+        try
+        {
+            var entries = await ReadPackEntriesAsync(
+                new LogBufferSink(10),
+                new WarningLogBuffer(new LogBufferSink(50)));
+
+            using var environment = JsonDocument.Parse(entries["environment.json"]);
+            var snapshot = environment.RootElement.GetProperty("segmentBufferPool");
+            Assert.Equal(JsonValueKind.Object, snapshot.ValueKind);
+            Assert.Equal(buffer.Length, snapshot.GetProperty("idleBytes").GetInt64());
+            Assert.Equal(0, snapshot.GetProperty("checkedOutBytes").GetInt64());
+            Assert.Equal(1, snapshot.GetProperty("rentCount").GetInt64());
+            Assert.Equal(1, snapshot.GetProperty("returnCount").GetInt64());
+            Assert.True(snapshot.TryGetProperty("trimmedBytes", out _));
+            Assert.True(snapshot.TryGetProperty("rejectedReturnCount", out _));
+            Assert.True(snapshot.TryGetProperty("reuseCount", out _));
+            Assert.True(snapshot.TryGetProperty("allocationCount", out _));
+
+            var sizeClass = Assert.Single(snapshot.GetProperty("sizeClasses").EnumerateArray());
+            Assert.Equal(buffer.Length, sizeClass.GetProperty("bufferSize").GetInt32());
+            Assert.Equal(1, sizeClass.GetProperty("bufferCount").GetInt32());
+            Assert.Equal(buffer.Length, sizeClass.GetProperty("idleBytes").GetInt64());
+        }
+        finally
+        {
+            PooledBufferStream.DefaultPool = previous;
+        }
+    }
+
+    [Fact]
+    public async Task Pack_ReportsNullSegmentBufferPoolWhenOverrideUsesSharedPool()
+    {
+        var previous = PooledBufferStream.DefaultPool;
+        PooledBufferStream.DefaultPool = SharedArrayPoolAdapter.Instance;
+        try
+        {
+            var entries = await ReadPackEntriesAsync(
+                new LogBufferSink(10),
+                new WarningLogBuffer(new LogBufferSink(50)));
+
+            using var environment = JsonDocument.Parse(entries["environment.json"]);
+            Assert.Equal(
+                JsonValueKind.Null,
+                environment.RootElement.GetProperty("segmentBufferPool").ValueKind);
+        }
+        finally
+        {
+            PooledBufferStream.DefaultPool = previous;
+        }
+    }
+
+    [Fact]
     public async Task Pack_ReportsPeakCpuAttributedToPlaybackRatherThanOnlyAnIdleSnapshot()
     {
         // Packs are collected after the symptom has passed, so an instantaneous sample

--- a/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
@@ -88,4 +88,64 @@ public class InFlightArticleBudgetTests
         budget.AccountBufferedPipeBytes(-200);
         Assert.Equal(0, budget.LeasedBytes);
     }
+
+    [Fact]
+    public void AccountBufferedPipeBytes_OverReleaseLargerThanLeased_ClampsAtZero()
+    {
+        var budget = new InFlightArticleBudget(10_000);
+        budget.AccountBufferedPipeBytes(100);
+
+        budget.AccountBufferedPipeBytes(-500);
+
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public void AccountBufferedPipeBytes_FullyClampedNoOp_LeavesZeroLeased()
+    {
+        var budget = new InFlightArticleBudget(1_000);
+
+        budget.AccountBufferedPipeBytes(-100);
+
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task AccountBufferedPipeBytes_AfterOverReleaseClamp_LeasingStillWorks()
+    {
+        var budget = new InFlightArticleBudget(1_000);
+        budget.AccountBufferedPipeBytes(200);
+        budget.AccountBufferedPipeBytes(-1_000);
+        Assert.Equal(0, budget.LeasedBytes);
+
+        using var lease = await budget.LeaseAsync(400, CancellationToken.None);
+        Assert.Equal(400, budget.LeasedBytes);
+
+        lease.Dispose();
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task AccountBufferedPipeBytes_OverReleaseWhileSaturated_WakesWaiter()
+    {
+        const long cap = 1_000;
+        var budget = new InFlightArticleBudget(cap);
+        budget.AccountBufferedPipeBytes(cap);
+        Assert.Equal(cap, budget.LeasedBytes);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var waiter = budget.LeaseAsync(100, cts.Token).AsTask();
+        for (var i = 0; i < 50 && budget.ThrottleEvents == 0; i++)
+            await Task.Delay(10);
+
+        Assert.True(budget.ThrottleEvents > 0);
+        Assert.False(waiter.IsCompleted);
+
+        budget.AccountBufferedPipeBytes(-(cap + 5_000));
+        using var lease = await waiter.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(100, budget.LeasedBytes);
+
+        lease.Dispose();
+        Assert.Equal(0, budget.LeasedBytes);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
@@ -1,0 +1,91 @@
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class InFlightArticleBudgetTests
+{
+    [Fact]
+    public void AccountBufferedPipeBytes_PositiveNegativeAndZero_MatchLeaseCounter()
+    {
+        var budget = new InFlightArticleBudget(10_000);
+        Assert.Equal(0, budget.LeasedBytes);
+
+        budget.AccountBufferedPipeBytes(4_000);
+        Assert.Equal(4_000, budget.LeasedBytes);
+
+        budget.AccountBufferedPipeBytes(0);
+        Assert.Equal(4_000, budget.LeasedBytes);
+
+        budget.AccountBufferedPipeBytes(-1_500);
+        Assert.Equal(2_500, budget.LeasedBytes);
+
+        budget.AccountBufferedPipeBytes(-2_500);
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public void AccountBufferedPipeBytes_SimulatedBodyLifecycle_ReturnsToBaseline()
+    {
+        var budget = new InFlightArticleBudget(8_192);
+        const int bodyBytes = 3_500;
+
+        budget.AccountBufferedPipeBytes(bodyBytes);
+        Assert.Equal(bodyBytes, budget.LeasedBytes);
+
+        budget.AccountBufferedPipeBytes(-(bodyBytes / 2));
+        budget.AccountBufferedPipeBytes(-(bodyBytes - bodyBytes / 2));
+
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task AccountBufferedPipeBytes_PipeChargeSaturation_WakesFifoWaiterOnNegativeDelta()
+    {
+        const long cap = 1_000;
+        var budget = new InFlightArticleBudget(cap);
+        budget.AccountBufferedPipeBytes(cap);
+        Assert.Equal(cap, budget.LeasedBytes);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var waiter = budget.LeaseAsync(100, cts.Token).AsTask();
+        for (var i = 0; i < 50 && budget.ThrottleEvents == 0; i++)
+            await Task.Delay(10);
+
+        Assert.True(budget.ThrottleEvents > 0);
+        Assert.False(waiter.IsCompleted);
+
+        budget.AccountBufferedPipeBytes(-400);
+        using var lease = await waiter.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(700, budget.LeasedBytes);
+
+        lease.Dispose();
+        budget.AccountBufferedPipeBytes(-(cap - 400));
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task AccountBufferedPipeBytes_PositiveDeltaDoesNotWakeWaiter()
+    {
+        var budget = new InFlightArticleBudget(1_000);
+        using var held = await budget.LeaseAsync(1_000, CancellationToken.None);
+        var waiter = budget.LeaseAsync(100, CancellationToken.None).AsTask();
+        for (var i = 0; i < 50 && budget.ThrottleEvents == 0; i++)
+            await Task.Delay(10);
+
+        Assert.True(budget.ThrottleEvents > 0);
+        Assert.False(waiter.IsCompleted);
+
+        budget.AccountBufferedPipeBytes(200);
+        await Task.Delay(50);
+        Assert.False(waiter.IsCompleted);
+        Assert.Equal(1_200, budget.LeasedBytes);
+
+        held.Dispose();
+        using var lease = await waiter.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(300, budget.LeasedBytes);
+
+        lease.Dispose();
+        budget.AccountBufferedPipeBytes(-200);
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -512,11 +512,11 @@ public class MultiSegmentStreamPrefetchBudgetTests
     }
 
     [Fact]
-    public async Task PipeAccounting_TinyBudget_CompletesFullReadIncludingRetry()
+    public async Task PipeAccounting_TinyBudget_CompletesFullReadWithoutDeadlock()
     {
         // FakeNntpClient cannot emit real UsenetSharp pipe deltas. Wrap each body in a
         // stream that charges/releases the budget the same way DecodedBodyReadStream does,
-        // so a tiny cap plus a retry cannot deadlock a waiter that holds no pipe.
+        // so a tiny cap plus pipe occupancy cannot deadlock a waiter that holds no pipe.
         const int segmentCount = 6;
         const int segmentSize = 2_000;
         var budget = new InFlightArticleBudget(segmentSize + 500);
@@ -524,15 +524,10 @@ public class MultiSegmentStreamPrefetchBudgetTests
         var segments = keys.ToDictionary(
             key => key,
             key => Enumerable.Repeat((byte)(key[^1] - '0'), segmentSize).ToArray());
-        var retryAttempts = new int[1];
         var client = new FakeNntpClient(
             segments,
             useCachedYencStreams: true,
-            decodedStreamFactory: (key, bytes) =>
-            {
-                var failOnce = key == "seg-2" && Interlocked.Increment(ref retryAttempts[0]) == 1;
-                return new PipeDeltaReportingStream(bytes, budget, failOnce);
-            });
+            decodedStreamFactory: (_, bytes) => new PipeDeltaReportingStream(bytes, budget));
 
         await using var stream = MultiSegmentStream.Create(
             keys.AsMemory(),
@@ -548,12 +543,55 @@ public class MultiSegmentStreamPrefetchBudgetTests
             inFlightArticleBudget: budget);
 
         using var output = new MemoryStream();
-        await stream.CopyToAsync(output).WaitAsync(TimeSpan.FromSeconds(30));
+        await stream.CopyToAsync(output).WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.Equal(keys.SelectMany(key => segments[key]).ToArray(), output.ToArray());
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task PipeAccounting_TinyBudget_CompletesRetryWithoutDeadlock()
+    {
+        // Window of 1 so the producer cannot lease a later segment while the ordered
+        // consumer is blocked on this retry — the pre-existing retry-under-saturation
+        // window. Pipe charges still apply; the retry waiter holds no open pipe.
+        const int segmentCount = 4;
+        const int segmentSize = 2_000;
+        var budget = new InFlightArticleBudget(segmentSize + 500);
+        var keys = Enumerable.Range(0, segmentCount).Select(i => $"seg-{i}").ToArray();
+        var segments = keys.ToDictionary(
+            key => key,
+            key => Enumerable.Repeat((byte)(key[^1] - '0'), segmentSize).ToArray());
+        var retryAttempts = new int[1];
+        var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (key, bytes) =>
+            {
+                var failOnce = key == "seg-1" && Interlocked.Increment(ref retryAttempts[0]) == 1;
+                return new PipeDeltaReportingStream(bytes, budget, failOnce);
+            });
+
+        await using var stream = MultiSegmentStream.Create(
+            keys.AsMemory(),
+            client,
+            articleBufferSize: 1,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "pipe-budget-retry.bin",
+            readBudget: null,
+            exactSegmentSizes: Enumerable.Repeat((long)segmentSize, segmentCount).ToArray(),
+            inFlightArticleBudget: budget);
+
+        using var output = new MemoryStream();
+        await stream.CopyToAsync(output).WaitAsync(TimeSpan.FromSeconds(15));
 
         Assert.Equal(keys.SelectMany(key => segments[key]).ToArray(), output.ToArray());
         Assert.Equal(0, budget.LeasedBytes);
         Assert.True(retryAttempts[0] >= 2);
-        Assert.True(client.BodyRequestCounts.GetValueOrDefault("seg-2") >= 2);
+        Assert.True(client.BodyRequestCounts.GetValueOrDefault("seg-1") >= 2);
     }
 
     private sealed class ThrowingCorruptStream(string segmentId) : Stream

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamPrefetchBudgetTests.cs
@@ -511,6 +511,51 @@ public class MultiSegmentStreamPrefetchBudgetTests
         Assert.Equal(0, budget.LeasedBytes);
     }
 
+    [Fact]
+    public async Task PipeAccounting_TinyBudget_CompletesFullReadIncludingRetry()
+    {
+        // FakeNntpClient cannot emit real UsenetSharp pipe deltas. Wrap each body in a
+        // stream that charges/releases the budget the same way DecodedBodyReadStream does,
+        // so a tiny cap plus a retry cannot deadlock a waiter that holds no pipe.
+        const int segmentCount = 6;
+        const int segmentSize = 2_000;
+        var budget = new InFlightArticleBudget(segmentSize + 500);
+        var keys = Enumerable.Range(0, segmentCount).Select(i => $"seg-{i}").ToArray();
+        var segments = keys.ToDictionary(
+            key => key,
+            key => Enumerable.Repeat((byte)(key[^1] - '0'), segmentSize).ToArray());
+        var retryAttempts = new int[1];
+        var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (key, bytes) =>
+            {
+                var failOnce = key == "seg-2" && Interlocked.Increment(ref retryAttempts[0]) == 1;
+                return new PipeDeltaReportingStream(bytes, budget, failOnce);
+            });
+
+        await using var stream = MultiSegmentStream.Create(
+            keys.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "pipe-budget.bin",
+            readBudget: null,
+            exactSegmentSizes: Enumerable.Repeat((long)segmentSize, segmentCount).ToArray(),
+            inFlightArticleBudget: budget);
+
+        using var output = new MemoryStream();
+        await stream.CopyToAsync(output).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Equal(keys.SelectMany(key => segments[key]).ToArray(), output.ToArray());
+        Assert.Equal(0, budget.LeasedBytes);
+        Assert.True(retryAttempts[0] >= 2);
+        Assert.True(client.BodyRequestCounts.GetValueOrDefault("seg-2") >= 2);
+    }
+
     private sealed class ThrowingCorruptStream(string segmentId) : Stream
     {
         public override bool CanRead => true;
@@ -573,5 +618,98 @@ public class MultiSegmentStreamPrefetchBudgetTests
         {
             lock (_events) _events.Add(logEvent);
         }
+    }
+
+    /// <summary>
+    /// Simulates UsenetSharp pipe occupancy: charge the full body on production, release
+    /// as the consumer reads or on dispose so deltas zero-balance.
+    /// </summary>
+    private sealed class PipeDeltaReportingStream : Stream
+    {
+        private readonly MemoryStream _inner;
+        private readonly InFlightArticleBudget _budget;
+        private readonly bool _failOnce;
+        private long _remaining;
+        private int _failed;
+        private int _completed;
+
+        public PipeDeltaReportingStream(byte[] bytes, InFlightArticleBudget budget, bool failOnce = false)
+        {
+            _inner = new MemoryStream(bytes, writable: false);
+            _budget = budget;
+            _failOnce = failOnce;
+            _remaining = bytes.Length;
+            if (_remaining > 0)
+                _budget.AccountBufferedPipeBytes(_remaining);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ThrowIfFailOnce();
+            var read = _inner.Read(buffer, offset, count);
+            Consume(read);
+            return read;
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfFailOnce();
+            var read = _inner.Read(buffer.Span);
+            Consume(read);
+            return ValueTask.FromResult(read);
+        }
+
+        private void ThrowIfFailOnce()
+        {
+            if (_failOnce && Interlocked.Exchange(ref _failed, 1) == 0)
+                throw new IOException("simulated transient body failure");
+        }
+
+        private void Consume(int count)
+        {
+            if (count <= 0) return;
+            var release = Math.Min(_remaining, count);
+            if (release <= 0) return;
+            _remaining -= release;
+            _budget.AccountBufferedPipeBytes(-release);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && Interlocked.Exchange(ref _completed, 1) == 0 && _remaining > 0)
+            {
+                _budget.AccountBufferedPipeBytes(-_remaining);
+                _remaining = 0;
+            }
+
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -41,6 +41,28 @@ public class PooledBufferStreamTests
     }
 
     [Fact]
+    public void EnsureCapacity_GrowsGeometrically_NotOneSizeClassAtATime()
+    {
+        const int hint = 64 * 1024;
+        const int payloadBytes = 8 * 1024 * 1024;
+        const int chunk = 64 * 1024;
+        var pool = new ExactSizeCountingPool();
+        using var stream = new PooledBufferStream(hint, pool);
+
+        var chunkBytes = new byte[chunk];
+        for (var written = 0; written < payloadBytes; written += chunk)
+            stream.Write(chunkBytes);
+
+        Assert.Equal(payloadBytes, stream.Length);
+        Assert.True(
+            pool.RentCount <= 15,
+            $"Expected log-bounded growth (≤15 rents for 64 KiB → 8 MiB), got {pool.RentCount}");
+        Assert.True(
+            pool.RentCount < 32,
+            $"Geometric growth must not walk 256 KiB classes linearly (~32 rents), got {pool.RentCount}");
+    }
+
+    [Fact]
     public void SetLength_Growth_ExposesZerosIncludingTruncateThenGrow()
     {
         using var stream = new PooledBufferStream(16);
@@ -201,6 +223,21 @@ public class PooledBufferStreamTests
         public void Emit(LogEvent logEvent)
         {
             lock (_events) _events.Add(logEvent);
+        }
+    }
+
+    private sealed class ExactSizeCountingPool : ISegmentBufferPool
+    {
+        public int RentCount { get; private set; }
+
+        public byte[] Rent(int minimumLength)
+        {
+            RentCount++;
+            return new byte[minimumLength];
+        }
+
+        public void Return(byte[] buffer)
+        {
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -63,6 +63,24 @@ public class PooledBufferStreamTests
     }
 
     [Fact]
+    public void Constructor_WithoutPool_UsesDefaultPool()
+    {
+        var previous = PooledBufferStream.DefaultPool;
+        var probe = new CountingSharedPoolProbe();
+        PooledBufferStream.DefaultPool = probe;
+        try
+        {
+            using var stream = new PooledBufferStream(64);
+            stream.WriteByte(1);
+            Assert.True(probe.RentCount > 0);
+        }
+        finally
+        {
+            PooledBufferStream.DefaultPool = previous;
+        }
+    }
+
+    [Fact]
     public void SetLength_Growth_ExposesZerosIncludingTruncateThenGrow()
     {
         using var stream = new PooledBufferStream(16);
@@ -239,6 +257,20 @@ public class PooledBufferStreamTests
         public void Return(byte[] buffer)
         {
         }
+    }
+
+    private sealed class CountingSharedPoolProbe : ISegmentBufferPool
+    {
+        private int _rentCount;
+        public int RentCount => _rentCount;
+
+        public byte[] Rent(int minimumLength)
+        {
+            Interlocked.Increment(ref _rentCount);
+            return SharedArrayPoolAdapter.Instance.Rent(minimumLength);
+        }
+
+        public void Return(byte[] buffer) => SharedArrayPoolAdapter.Instance.Return(buffer);
     }
 }
 

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -149,6 +149,75 @@ public class SegmentBufferPoolTests
     }
 
     [Fact]
+    public void MixedClassBurst_HonorsByteCapViaCrossClassEviction()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);
+        var rented = new[]
+        {
+            pool.Rent(256 * 1024),
+            pool.Rent(512 * 1024),
+            pool.Rent(768 * 1024),
+            pool.Rent(256 * 1024),
+            pool.Rent(512 * 1024),
+        };
+
+        foreach (var buffer in rented)
+            pool.Return(buffer);
+
+        var snapshot = pool.Snapshot();
+        Assert.True(snapshot.IdleBytes <= 1024 * 1024);
+        Assert.True(snapshot.TrimmedBytes > 0);
+        Assert.Equal(0, snapshot.CheckedOutBytes);
+        Assert.Equal(snapshot.RentCount, snapshot.ReturnCount);
+        Assert.Equal(snapshot.IdleBytes, snapshot.SizeClasses.Sum(c => c.IdleBytes));
+    }
+
+    [Fact]
+    public void RepeatedSameSizeRentReturn_ReusesBuffers()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        byte[]? last = null;
+        for (var i = 0; i < 50; i++)
+        {
+            var buffer = pool.Rent(750_000);
+            if (last is not null)
+                Assert.Same(last, buffer);
+            last = buffer;
+            pool.Return(buffer);
+        }
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(50, snapshot.RentCount);
+        Assert.Equal(50, snapshot.ReturnCount);
+        Assert.Equal(49, snapshot.ReuseCount);
+        Assert.Equal(1, snapshot.AllocationCount);
+        Assert.Equal(0, snapshot.CheckedOutBytes);
+        Assert.True(snapshot.ReuseCount / (double)snapshot.RentCount >= 0.9);
+    }
+
+    [Fact]
+    public void Snapshot_PerClassAccountingUnderConcurrency_QuiescesWithBalancedRents()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 16 * 1024 * 1024);
+        var sizes = new[] { 256 * 1024, 512 * 1024, 768 * 1024 };
+        Parallel.For(0, 120, i =>
+        {
+            var buffer = pool.Rent(sizes[i % sizes.Length]);
+            pool.Return(buffer);
+        });
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(0, snapshot.CheckedOutBytes);
+        Assert.Equal(snapshot.RentCount, snapshot.ReturnCount);
+        Assert.Equal(snapshot.IdleBytes, snapshot.SizeClasses.Sum(c => c.IdleBytes));
+        foreach (var sizeClass in snapshot.SizeClasses)
+        {
+            Assert.Equal((long)sizeClass.BufferSize * sizeClass.BufferCount, sizeClass.IdleBytes);
+            Assert.True(sizeClass.BufferCount > 0);
+        }
+    }
+
+    [Fact]
     public void TypicalSegment_UsesLessCapacityThanSharedArrayPoolBucket()
     {
         const int requested = 750_000;

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -266,7 +266,9 @@ public class BufferPoolDiagnosticsTests
         Assert.Equal(2, grown.Rents);
         Assert.Equal(1, grown.Returns);
         Assert.Equal(1, grown.Growths);
-        Assert.Equal(1024 * 1024, grown.CheckedOutBytes);
+        var expectedGrownCapacity = SegmentBufferPool.RoundToSizeClass(
+            (int)Math.Max(900_000L, 768 * 1024 + (768 * 1024) / 2));
+        Assert.Equal(expectedGrownCapacity, grown.CheckedOutBytes);
 
         stream.Dispose();
         var disposed = diagnostics.Snapshot();

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -1099,6 +1099,7 @@ public class UsenetClientDeterministicTests
         Assert.ThrowsAsync<OperationCanceledException>(async () => await copyTask);
         Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
             Is.EqualTo(ArticleBodyResult.Cancelled));
+        await response.Stream!.DisposeAsync();
         Assert.Multiple(() =>
         {
             Assert.That(client.BufferedDecodedBodyBytes, Is.Zero);

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -1003,6 +1003,257 @@ public class UsenetClientDeterministicTests
     }
 
     [Test]
+    public async Task DecodedBodyBufferedBytesObserver_SuccessDeltasSumToZero()
+    {
+        var expected = Enumerable.Range(0, 128).Select(static value => (byte)value).ToArray();
+        var observer = new RecordingBufferedBytesObserver();
+        await using var server = new ScriptedNntpServer(async (command, writer, _) =>
+        {
+            if (command == "BODY <article@example.com>")
+            {
+                await WriteSimpleYencArticleAsync(writer, expected, $"size={expected.Length}");
+                return;
+            }
+
+            Assert.That(command, Is.EqualTo("DATE"));
+            await writer.WriteLineAsync("111 20260709213000");
+        });
+        await using var client = new UsenetClient(new UsenetClientOptions
+        {
+            DecodedBodyPauseWriterThreshold = 32,
+            DecodedBodyResumeWriterThreshold = 16,
+            DecodedBodyBufferedBytesObserver = observer.OnDelta,
+        });
+        observer.Attach(client);
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var response = await client.DecodedBodyAsync(
+            "article@example.com", CancellationToken.None);
+        var stream = response.Stream!;
+        try
+        {
+            await WaitForConditionAsync(
+                () => client.BufferedDecodedBodyBytes == expected.Length);
+            Assert.That(observer.Sum, Is.EqualTo(expected.Length));
+
+            var consumed = new byte[120];
+            await stream.ReadExactlyAsync(consumed);
+            Assert.That(observer.Sum, Is.EqualTo(expected.Length - consumed.Length));
+            Assert.That(client.BufferedDecodedBodyBytes, Is.EqualTo(observer.Sum));
+        }
+        finally
+        {
+            await stream.DisposeAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.BufferedDecodedBodyBytes, Is.Zero);
+            Assert.That(observer.Sum, Is.Zero);
+            Assert.That(observer.Mismatch, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task DecodedBodyBufferedBytesObserver_CancellationDeltasSumToZero()
+    {
+        var firstLineSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observer = new RecordingBufferedBytesObserver();
+        await using var server = new ScriptedNntpServer(async (command, writer, _) =>
+        {
+            if (command.StartsWith("BODY", StringComparison.Ordinal))
+            {
+                await writer.WriteAsync(
+                    "222 body follows\r\n" +
+                    "=ybegin line=128 size=2 name=cancel.bin\r\n" +
+                    "k\r\n");
+                firstLineSent.SetResult();
+                await continueBody.Task;
+                await writer.WriteAsync("l\r\n=yend size=2\r\n.\r\n");
+            }
+            else if (command == "DATE")
+            {
+                await writer.WriteLineAsync("111 20260709213000");
+            }
+        });
+        await using var client = new UsenetClient(new UsenetClientOptions
+        {
+            ReadTimeout = TimeSpan.FromSeconds(1),
+            AbandonedBodyDrainLimit = 1024,
+            DecodedBodyBufferedBytesObserver = observer.OnDelta,
+        });
+        observer.Attach(client);
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        using var cts = new CancellationTokenSource();
+        var completion = new TaskCompletionSource<ArticleBodyResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var response = await client.DecodedBodyAsync(
+            "article@example.com", (result, _) => completion.SetResult(result), cts.Token);
+        var copyTask = response.Stream!.CopyToAsync(Stream.Null);
+        await firstLineSent.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cts.Cancel();
+        continueBody.SetResult();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await copyTask);
+        Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
+            Is.EqualTo(ArticleBodyResult.Cancelled));
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.BufferedDecodedBodyBytes, Is.Zero);
+            Assert.That(observer.Sum, Is.Zero);
+            Assert.That(observer.Mismatch, Is.Null);
+        });
+        var date = await client.DateAsync(CancellationToken.None);
+        Assert.That(date.ResponseCode, Is.EqualTo((int)UsenetResponseType.DateAndTime));
+    }
+
+    [Test]
+    public async Task DecodedBodyBufferedBytesObserver_DisposeWithoutReadDeltasSumToZero()
+    {
+        var expected = Enumerable.Range(0, 128).Select(static value => (byte)value).ToArray();
+        var observer = new RecordingBufferedBytesObserver();
+        await using var server = new ScriptedNntpServer(async (command, writer, _) =>
+        {
+            if (command == "BODY <article@example.com>")
+            {
+                await WriteSimpleYencArticleAsync(writer, expected, $"size={expected.Length}");
+                return;
+            }
+
+            Assert.That(command, Is.EqualTo("DATE"));
+            await writer.WriteLineAsync("111 20260709213000");
+        });
+        await using var client = new UsenetClient(new UsenetClientOptions
+        {
+            DecodedBodyPauseWriterThreshold = 32,
+            DecodedBodyResumeWriterThreshold = 16,
+            DecodedBodyBufferedBytesObserver = observer.OnDelta,
+        });
+        observer.Attach(client);
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var response = await client.DecodedBodyAsync(
+            "article@example.com", CancellationToken.None);
+        await WaitForConditionAsync(
+            () => client.BufferedDecodedBodyBytes == expected.Length);
+        await response.Stream!.DisposeAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.BufferedDecodedBodyBytes, Is.Zero);
+            Assert.That(observer.Sum, Is.Zero);
+            Assert.That(observer.Mismatch, Is.Null);
+        });
+        var date = await client.DateAsync(CancellationToken.None);
+        Assert.That(date.ResponseCode, Is.EqualTo((int)UsenetResponseType.DateAndTime));
+    }
+
+    [Test]
+    public async Task DecodedBodyBufferedBytesObserver_AbandonedBodyDeltasSumToZero()
+    {
+        var firstBody = Enumerable.Range(0, 128)
+            .Select(static value => (byte)value)
+            .ToArray();
+        var observer = new RecordingBufferedBytesObserver();
+        await using var server = ScriptedNntpServer.StartConnectionScript(
+            async (reader, writer, cancellationToken) =>
+            {
+                _ = await reader.ReadLineAsync(cancellationToken);
+                _ = await reader.ReadLineAsync(cancellationToken);
+                await WriteSimpleYencArticleAsync(
+                    writer, firstBody, $"size={firstBody.Length}", "first.bin");
+                await WriteSimpleYencArticleAsync(
+                    writer, [1], "size=1", "second.bin");
+
+                Assert.That(
+                    await reader.ReadLineAsync(cancellationToken),
+                    Is.EqualTo("DATE"));
+                await writer.WriteLineAsync("111 20260709213000");
+            });
+        await using var client = new UsenetClient(new UsenetClientOptions
+        {
+            DecodedBodyBufferedBytesObserver = observer.OnDelta,
+        });
+        observer.Attach(client);
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        var completion = new TaskCompletionSource<ArticleBodyResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await foreach (var _ in client.EnumerateDecodedBodiesAsync(
+                           new SegmentId[] { "first@example.com", "second@example.com" },
+                           (result, _) => completion.SetResult(result),
+                           CancellationToken.None))
+        {
+            await WaitForConditionAsync(
+                () => client.BufferedDecodedBodyBytes == firstBody.Length);
+            break;
+        }
+
+        Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
+            Is.EqualTo(ArticleBodyResult.Cancelled));
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.BufferedDecodedBodyBytes, Is.Zero);
+            Assert.That(observer.Sum, Is.Zero);
+            Assert.That(observer.Mismatch, Is.Null);
+        });
+        var date = await client.DateAsync(CancellationToken.None);
+        Assert.That(date.ResponseCode, Is.EqualTo((int)UsenetResponseType.DateAndTime));
+        Assert.That(client.IsHealthy, Is.True);
+    }
+
+    [Test]
+    public async Task DecodedBodyBufferedBytesObserver_ThrowingObserverIsContained()
+    {
+        var expected = Enumerable.Range(0, 32).Select(static value => (byte)value).ToArray();
+        var callbackCount = 0;
+        await using var server = new ScriptedNntpServer(async (command, writer, _) =>
+        {
+            if (command == "BODY <article@example.com>")
+            {
+                await WriteSimpleYencArticleAsync(writer, expected, $"size={expected.Length}");
+                return;
+            }
+
+            Assert.That(command, Is.EqualTo("DATE"));
+            await writer.WriteLineAsync("111 20260709213000");
+        });
+        await using var client = new UsenetClient(new UsenetClientOptions
+        {
+            DecodedBodyBufferedBytesObserver = static _ =>
+                throw new InvalidOperationException("observer must not fault transport"),
+        });
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        var completion = new TaskCompletionSource<ArticleBodyResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var response = await client.DecodedBodyAsync(
+            "article@example.com",
+            (result, _) =>
+            {
+                Interlocked.Increment(ref callbackCount);
+                completion.TrySetResult(result);
+            },
+            CancellationToken.None);
+        using var decoded = new MemoryStream();
+        await response.Stream!.CopyToAsync(decoded);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(decoded.ToArray(), Is.EqualTo(expected));
+            Assert.That(client.BufferedDecodedBodyBytes, Is.Zero);
+            Assert.That(callbackCount, Is.EqualTo(1));
+        });
+        Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
+            Is.EqualTo(ArticleBodyResult.Retrieved));
+        var date = await client.DateAsync(CancellationToken.None);
+        Assert.That(date.ResponseCode, Is.EqualTo((int)UsenetResponseType.DateAndTime));
+        Assert.That(client.IsHealthy, Is.True);
+    }
+
+    [Test]
     public async Task DecodedBodiesAsync_MissingBodyContinuesInProtocolOrder()
     {
         var expected = Array.Empty<byte>();
@@ -3126,6 +3377,36 @@ public class UsenetClientDeterministicTests
         while (!condition())
         {
             await Task.Delay(TimeSpan.FromMilliseconds(10), timeout.Token);
+        }
+    }
+
+    private sealed class RecordingBufferedBytesObserver
+    {
+        private readonly object _gate = new();
+        private readonly List<long> _deltas = [];
+        private long _sum;
+        private UsenetClient? _client;
+
+        public long Sum
+        {
+            get { lock (_gate) return _sum; }
+        }
+
+        public string? Mismatch { get; private set; }
+
+        public void Attach(UsenetClient client) => _client = client;
+
+        public void OnDelta(long delta)
+        {
+            lock (_gate)
+            {
+                _deltas.Add(delta);
+                _sum += delta;
+                if (_client is null) return;
+                var buffered = _client.BufferedDecodedBodyBytes;
+                if (buffered != _sum && Mismatch is null)
+                    Mismatch = $"observer sum {_sum} != BufferedDecodedBodyBytes {buffered}";
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Resolves #783.

- Segment buffers now default to the byte-bounded 256 KiB size-class pool (built and benchmarked in #776), cutting bucket-rounding waste on typical ~755 KB articles from ~27% to single digits and capping idle retention deterministically regardless of host GC pressure (strict byte cap + per-class cap + 2-minute stale expiry).
- Decoded pipe-buffered bytes now count against the in-flight article budget, closing the ~2× under-accounting gap on constrained hosts identified in the sibling-fork investigation — a waiter in `LeaseAsync` never holds an open pipe, so accounting can delay admission but cannot deadlock (invariant documented in-code and covered by tests).
- Pooled buffers now grow geometrically (≥1.5×), preserving the log-bounded copy behavior ArrayPool's power-of-2 buckets previously provided implicitly.
- Support packs (`environment.json` → `segmentBufferPool`) and the GC-diagnostics endpoint now report pool idle/trim/reuse/allocation counters and per-class rows. Undocumented `NZBDAV_SEGMENT_BUFFER_POOL=shared` reverts to `ArrayPool<byte>.Shared` at startup.

**Notes for operators:**
- **Support-pack counter step change:** `segmentBufferBucketWasteBytes` share drops from ~27% to single digits after this release — expected; don't read it as a measurement artifact when comparing packs across versions.
- **Earlier budget saturation:** pipe copies from all workloads (streaming, queue, health, seek, benchmark) now count, so floor-budget (64 MiB) hosts may see the existing 30s-throttled "budget saturated" warning slightly earlier under heavy concurrent activity (bounded ≤ ~1.09 MiB × connections). Remedy unchanged: raise `usenet.in-flight-article-budget-mb` or reduce max connections. These bytes were always resident — they were just invisible.
- **maxIdleBytes fixed at startup:** derived as clamp(budget ÷ 2, 32 MiB, 256 MiB) from the startup budget; live changes to `usenet.in-flight-article-budget-mb` re-cap the budget but the pool's idle cap applies on next restart.
- **Pre-existing retry-under-saturation window** (documented, empirically confirmed during test development, unchanged by this PR): a mid-file retry under a saturated budget can stall behind later drained-but-unread segments' leases when the ordered consumer is blocked on the retrying segment. Pipe accounting does not create this cycle — at the stall point pipe charges are zero — it only shifts saturation onset marginally. Tracked as a follow-up alongside the unbudgeted seek head.

## Test plan

- [x] Backend suite: 3185 passed / 10 skipped / 0 failed
- [x] UsenetSharp suite: 236 passed / 69 skipped / 0 failed (observer delta symmetry across success/cancel/dispose/abandon; throwing observer contained with exactly-once completion)
- [x] Budget: pipe-charge saturation wakes FIFO waiters; positive deltas never wake; zero-balance lifecycle
- [x] Integration: tiny-budget full read and retry-path read complete under simulated pipe charges (no deadlock)
- [x] Pool: byte-cap via cross-class eviction; ≥90% reuse on repeated same-size rents; concurrent snapshot consistency; rents == returns at quiescence
- [x] Geometric growth log-bounded (≤15 rents for 64 KiB hint → 8 MiB); `dotnet build backend.Benchmarks -c Release` clean
- [ ] Manual: `SegmentBufferPoolScenarioBenchmarks` run — throughput within 5% of `ArrayPoolShared` at 1 and 8 streams
- [ ] Manual: 512 MB constrained-heap run (`DOTNET_GCHeapHardLimit=0x20000000`), sequential + random-seek — 100% of reads complete
- [ ] Manual: real-provider playback soak with before/after support packs (bucket-waste share, LOH, working set, pool reuse/trim) and an rclone scrub session
- [ ] Manual: queue-heavy period on a default-budget host — no persistent "budget saturated" warnings