### PR TITLE
fix(health): background health scans start correctly on dev and rc

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -236,50 +236,62 @@ public class HealthCheckService : BackgroundService
     /// (images, subtitles, NFOs, etc.) that were queued before the media-type filter was added.
     /// Urgent repairs (<c>UnixEpoch</c> sentinel) are never cleared.
     /// </summary>
-    private static async Task ClearNonMediaHealthCheckEntries(CancellationToken ct)
+    internal static async Task ClearNonMediaHealthCheckEntries(CancellationToken ct)
     {
         try
         {
             await using var dbContext = new DavDatabaseContext();
-            var urgent = DateTimeOffset.UnixEpoch;
-            const int batchSize = 1000;
-            var cleared = 0;
-
-            while (true)
-            {
-                ct.ThrowIfCancellationRequested();
-                var batch = await dbContext.Items
-                    .Where(x => x.Type == DavItem.ItemType.UsenetFile)
-                    .Where(x => x.NextHealthCheck != urgent)
-                    .Where(x => x.NextHealthCheck != null || x.LastHealthCheck != null)
-                    .OrderBy(x => x.Id)
-                    .Take(batchSize)
-                    .ToListAsync(ct).ConfigureAwait(false);
-
-                if (batch.Count == 0) break;
-
-                foreach (var item in batch.Where(x => !FilenameUtil.IsHealthCheckCandidate(x.Name)))
-                {
-                    item.NextHealthCheck = null;
-                    item.LastHealthCheck = null;
-                    cleared++;
-                }
-
-                await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
-                dbContext.ChangeTracker.Clear();
-            }
-
-            if (cleared > 0)
-            {
-                Log.Information(
-                    "Cleared health-check schedule for {Count} non-media file(s) " +
-                    "(images, subtitles, NFOs, and other non-playable files are no longer health-checked)",
-                    cleared);
-            }
+            await ClearNonMediaHealthCheckEntries(dbContext, ct).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException and not OutOfMemoryException)
         {
             Log.Warning(e, "Could not clear non-media health-check entries: {Message}", e.Message);
+        }
+    }
+
+    internal static async Task ClearNonMediaHealthCheckEntries(
+        DavDatabaseContext dbContext,
+        CancellationToken ct)
+    {
+        var urgent = DateTimeOffset.UnixEpoch;
+        const int batchSize = 1000;
+        var cleared = 0;
+        var lastId = Guid.Empty;
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var query = dbContext.Items
+                .Where(x => x.Type == DavItem.ItemType.UsenetFile)
+                .Where(x => x.NextHealthCheck != urgent)
+                .Where(x => x.NextHealthCheck != null || x.LastHealthCheck != null);
+            if (lastId != Guid.Empty) query = query.Where(x => x.Id > lastId);
+
+            var batch = await query
+                .OrderBy(x => x.Id)
+                .Take(batchSize)
+                .ToListAsync(ct).ConfigureAwait(false);
+
+            if (batch.Count == 0) break;
+            lastId = batch[^1].Id;
+
+            foreach (var item in batch.Where(x => !FilenameUtil.IsHealthCheckCandidate(x.Name)))
+            {
+                item.NextHealthCheck = null;
+                item.LastHealthCheck = null;
+                cleared++;
+            }
+
+            await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+            dbContext.ChangeTracker.Clear();
+        }
+
+        if (cleared > 0)
+        {
+            Log.Information(
+                "Cleared health-check schedule for {Count} non-media file(s) " +
+                "(images, subtitles, NFOs, and other non-playable files are no longer health-checked)",
+                cleared);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckNonMediaCleanupTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckNonMediaCleanupTests.cs
@@ -122,6 +122,6 @@ public sealed class HealthCheckNonMediaCleanupTests : IAsyncLifetime
     private static void AssertScheduled(DateTimeOffset? actual, DateTimeOffset expected)
     {
         Assert.NotNull(actual);
-        Assert.Equal(expected.ToUnixTimeSeconds(), actual.Value.ToUnixTimeSeconds());
+        Assert.Equal(expected.ToUnixTimeSeconds(), actual.GetValueOrDefault().ToUnixTimeSeconds());
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckNonMediaCleanupTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckNonMediaCleanupTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class HealthCheckNonMediaCleanupTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-health-cleanup-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Cleanup_ClearsScheduledNonMedia_AndPreservesMediaUrgentAndUncheckedFiles()
+    {
+        var scheduledAt = DateTimeOffset.UtcNow.AddHours(1);
+        var media = NewUsenetFile("movie.mkv", scheduledAt);
+        var subtitle = NewUsenetFile("movie.srt", scheduledAt);
+        var nfo = NewUsenetFile("movie.nfo", scheduledAt);
+        var urgentImage = NewUsenetFile("cover.jpg", DateTimeOffset.UnixEpoch);
+        urgentImage.LastHealthCheck = scheduledAt;
+        var uncheckedMedia = NewUsenetFile("unseen.mkv", null);
+
+        _context.Items.AddRange(media, subtitle, nfo, urgentImage, uncheckedMedia);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await HealthCheckService.ClearNonMediaHealthCheckEntries(_context, cancellation.Token);
+
+        var items = await _context.Items.ToDictionaryAsync(x => x.Id);
+
+        AssertScheduled(items[media.Id].NextHealthCheck, scheduledAt);
+        AssertScheduled(items[media.Id].LastHealthCheck, scheduledAt);
+        Assert.Null(items[subtitle.Id].NextHealthCheck);
+        Assert.Null(items[subtitle.Id].LastHealthCheck);
+        Assert.Null(items[nfo.Id].NextHealthCheck);
+        Assert.Null(items[nfo.Id].LastHealthCheck);
+        Assert.Equal(DateTimeOffset.UnixEpoch, items[urgentImage.Id].NextHealthCheck);
+        AssertScheduled(items[urgentImage.Id].LastHealthCheck, scheduledAt);
+        Assert.Null(items[uncheckedMedia.Id].NextHealthCheck);
+        Assert.Null(items[uncheckedMedia.Id].LastHealthCheck);
+    }
+
+    [Fact]
+    public async Task Cleanup_AdvancesPastScheduledMediaAcrossBatches()
+    {
+        var scheduledAt = DateTimeOffset.UtcNow.AddHours(1);
+        var items = Enumerable.Range(0, 1205)
+            .Select(index => NewUsenetFile(
+                index % 5 == 0 ? $"metadata-{index}.nfo" : $"movie-{index}.mkv",
+                scheduledAt))
+            .ToList();
+
+        _context.Items.AddRange(items);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await HealthCheckService.ClearNonMediaHealthCheckEntries(_context, cancellation.Token);
+
+        var persistedItems = await _context.Items.ToDictionaryAsync(x => x.Id);
+        foreach (var item in items)
+        {
+            var persisted = persistedItems[item.Id];
+            if (item.Name.EndsWith(".nfo", StringComparison.Ordinal))
+            {
+                Assert.Null(persisted.NextHealthCheck);
+                Assert.Null(persisted.LastHealthCheck);
+            }
+            else
+            {
+                AssertScheduled(persisted.NextHealthCheck, scheduledAt);
+                AssertScheduled(persisted.LastHealthCheck, scheduledAt);
+            }
+        }
+    }
+
+    private static DavItem NewUsenetFile(string name, DateTimeOffset? nextHealthCheck)
+    {
+        var item = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            name,
+            fileSize: 100,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: null);
+        item.NextHealthCheck = nextHealthCheck;
+        item.LastHealthCheck = nextHealthCheck is { } && nextHealthCheck != DateTimeOffset.UnixEpoch
+            ? nextHealthCheck
+            : null;
+        return item;
+    }
+
+    private static void AssertScheduled(DateTimeOffset? actual, DateTimeOffset expected)
+    {
+        Assert.NotNull(actual);
+        Assert.Equal(expected.ToUnixTimeSeconds(), actual.Value.ToUnixTimeSeconds());
+    }
+}


### PR DESCRIPTION
## Summary
- advance the one-time non-media health cleanup past scheduled media rows instead of selecting the same batch forever
- retain media and urgent repair schedules while clearing stale non-media schedules
- add SQLite regression coverage for mixed rows and cleanup across multiple batches

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`