### PR TITLE
chore(ci): guard streaming and SAB API performance against regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,13 +146,36 @@ jobs:
           dotnet restore tests/RapidYencSharp.Tests/RapidYencSharp.Tests.csproj
           dotnet restore backend.Benchmarks/NzbWebDAV.Benchmarks.csproj
 
-      # Benchmarks are first-party code under the warnings-as-errors gate but
-      # are not exercised by any test project; build them explicitly.
+      # Benchmarks are first-party code under the warnings-as-errors gate.
+      # Deterministic streaming/SAB reports are compared in this job; timing
+      # comparisons stay off the PR path (see performance.yml).
       - name: Build benchmarks (warning gate)
         run: dotnet build backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-restore
 
+      - name: Performance deterministic gate
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/nzbdav-perf
+          dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-build -- \
+            --streaming-report --json /tmp/nzbdav-perf/streaming.json
+          dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-build -- \
+            --sab-api-report --json /tmp/nzbdav-perf/sab-api.json
+          python3 scripts/check-performance-baseline.py \
+            --baseline backend.Benchmarks/Baselines/streaming-baseline.json \
+            --candidates /tmp/nzbdav-perf/streaming.json \
+            --deterministic-only \
+            --summary "${GITHUB_STEP_SUMMARY}"
+          python3 scripts/check-performance-baseline.py \
+            --baseline backend.Benchmarks/Baselines/sab-api-baseline.json \
+            --candidates /tmp/nzbdav-perf/sab-api.json \
+            --deterministic-only \
+            --summary "${GITHUB_STEP_SUMMARY}"
+
       - name: Verify NuGet vulnerability gate fixtures
         run: bash scripts/test-nuget-vulnerability-gate.sh
+
+      - name: Verify performance baseline gate fixtures
+        run: bash scripts/test-performance-baseline-gate.sh
 
       - name: Audit NuGet production dependencies
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,254 @@
+name: Performance
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+    inputs:
+      rebaseline:
+        description: Write new baselines from this run and open a PR
+        type: boolean
+        default: false
+
+concurrency:
+  group: performance-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'infinidysk/infinidysk'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore benchmarks
+        run: dotnet restore backend.Benchmarks/NzbWebDAV.Benchmarks.csproj
+
+      - name: Build benchmarks
+        run: dotnet build backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-restore
+
+      - name: Measure and compare
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p performance-out
+
+          run_report() {
+            local name="$1"
+            local flag="$2"
+            local i
+            for i in 1 2 3; do
+              dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-build -- \
+                "${flag}" --json "performance-out/${name}-${i}.json"
+            done
+          }
+
+          compare_report() {
+            local name="$1"
+            python3 scripts/check-performance-baseline.py \
+              --baseline "backend.Benchmarks/Baselines/${name}-baseline.json" \
+              --candidates \
+                "performance-out/${name}-1.json" \
+                "performance-out/${name}-2.json" \
+                "performance-out/${name}-3.json" \
+              --summary "${GITHUB_STEP_SUMMARY}" \
+              2>&1 | tee -a performance-out/compare.log
+          }
+
+          run_with_retry() {
+            local name="$1"
+            local flag="$2"
+            run_report "${name}" "${flag}"
+            set +e
+            set -o pipefail
+            compare_report "${name}"
+            local status=$?
+            set -e
+            if [ "${status}" -eq 0 ]; then
+              return 0
+            fi
+            if [ "${status}" -eq 2 ]; then
+              echo "Deterministic/schema failure for ${name}; not retrying."
+              return 2
+            fi
+            echo "Envelope failure for ${name}; retrying once..."
+            run_report "${name}" "${flag}"
+            compare_report "${name}"
+          }
+
+          streaming_status=0
+          sab_status=0
+          set +e
+          run_with_retry streaming --streaming-report
+          streaming_status=$?
+          set -e
+          if [ "${streaming_status}" -eq 2 ]; then
+            exit 2
+          fi
+          set +e
+          run_with_retry sab-api --sab-api-report
+          sab_status=$?
+          set -e
+          if [ "${sab_status}" -eq 2 ]; then
+            exit 2
+          fi
+          if [ "${streaming_status}" -ne 0 ] || [ "${sab_status}" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Upload candidate artifacts
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: performance-candidates
+          path: performance-out/
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: Notify development Discord
+        if: ${{ failure() }}
+        env:
+          DISCORD_DEVELOPMENT_WEBHOOK_URL: ${{ secrets.DISCORD_DEVELOPMENT_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_DEVELOPMENT_WEBHOOK_URL}" ]; then
+            echo "Discord webhook not configured; skipping failure notification."
+            exit 0
+          fi
+          DETAILS=""
+          if [ -f performance-out/compare.log ]; then
+            DETAILS=$(tail -n 40 performance-out/compare.log)
+          fi
+          ANNOUNCEMENT_BODY=$(printf '📉 **Performance envelopes failed** (`%s`)\nRun: %s\n\n%s' \
+            "${SHA:0:7}" "${RUN_URL}" "${DETAILS}")
+          MAX_LEN=1900
+          if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then
+            ANNOUNCEMENT_BODY="${ANNOUNCEMENT_BODY:0:$((MAX_LEN - 3))}..."
+          fi
+          ESCAPED_BODY=$(printf '%s' "$ANNOUNCEMENT_BODY" | jq -Rsa .)
+          curl --fail-with-body -sS -H "Content-Type: application/json" \
+            -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4, \"allowed_mentions\": {\"parse\": []}}" \
+            "$DISCORD_DEVELOPMENT_WEBHOOK_URL"
+
+  rebaseline:
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.rebaseline && needs.measure.result != 'skipped' }}
+    needs: measure
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Download measurement artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: performance-candidates
+          path: performance-out
+
+      - name: Write baselines and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check-performance-baseline.py \
+            --candidates \
+              performance-out/streaming-1.json \
+              performance-out/streaming-2.json \
+              performance-out/streaming-3.json \
+            --write-baseline backend.Benchmarks/Baselines/streaming-baseline.json
+          python3 scripts/check-performance-baseline.py \
+            --candidates \
+              performance-out/sab-api-1.json \
+              performance-out/sab-api-2.json \
+              performance-out/sab-api-3.json \
+            --write-baseline backend.Benchmarks/Baselines/sab-api-baseline.json
+
+          BODY_FILE="$(mktemp)"
+          python3 - "${BODY_FILE}" "${RUN_URL}" <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          body_path = Path(sys.argv[1])
+          run_url = sys.argv[2]
+          files = [
+              ("streaming", "backend.Benchmarks/Baselines/streaming-baseline.json"),
+              ("sab-api", "backend.Benchmarks/Baselines/sab-api-baseline.json"),
+          ]
+          lines = [
+              "## Summary",
+              "",
+              f"Nightly/manual performance re-baseline from [this run]({run_url}).",
+              "",
+              "## Timing changes",
+              "",
+          ]
+          for report, path in files:
+              old = json.loads(subprocess.check_output(["git", "show", f"HEAD:{path}"]))
+              new = json.loads(Path(path).read_text(encoding="utf-8"))
+              lines.append(f"### {report}")
+              lines.append("")
+              lines.append("| Scenario | Field | Old baseline | New baseline |")
+              lines.append("| --- | --- | --- | --- |")
+              for scenario, payload in new["scenarios"].items():
+                  old_timing = old["scenarios"].get(scenario, {}).get("timing", {})
+                  for field, spec in payload["timing"].items():
+                      old_spec = old_timing.get(field, {})
+                      lines.append(
+                          f"| `{scenario}` | `{field}` | {old_spec.get('baseline', old_spec.get('floor', '_n/a_'))} "
+                          f"| {spec.get('baseline', spec.get('floor'))} |"
+                      )
+              lines.append("")
+          lines.extend(
+              [
+                  "## CI note",
+                  "",
+                  "Pull requests created with `GITHUB_TOKEN` do not trigger `pull_request` workflows "
+                  "(GitHub anti-recursion, same limitation as release-please). **Close and reopen this PR "
+                  "(or push an empty commit) to run checks.**",
+                  "",
+              ]
+          )
+          body_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "chore/performance-rebaseline-${RUN_ID}"
+          git add backend.Benchmarks/Baselines/streaming-baseline.json \
+            backend.Benchmarks/Baselines/sab-api-baseline.json
+          if git diff --cached --quiet; then
+            echo "Baselines are unchanged; no PR opened."
+            exit 0
+          fi
+          git commit -m "chore(ci): re-baseline performance envelopes"
+          git push -u origin "HEAD:chore/performance-rebaseline-${RUN_ID}"
+          gh pr create \
+            --title "chore(ci): re-baseline performance envelopes" \
+            --body-file "${BODY_FILE}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,9 @@ Backend tests use xUnit and live in `tests/NzbWebDAV.Tests/`. They cover streams
 NZB/PAR2 parsing, NNTP caching and concurrency, queue logic, and SQLite-backed
 database behavior. Frontend tests use Vitest and are colocated as `*.test.ts`.
 Performance benchmarks live in `backend.Benchmarks/` and are run manually with
-`dotnet run --project backend.Benchmarks -c Release`; do not run benchmarks in CI.
+`dotnet run --project backend.Benchmarks -c Release`. BenchmarkDotNet timing
+stays off CI; the deterministic streaming/SAB reports are compared in PR CI
+and against floored envelopes in `performance.yml`.
 
 ## In-tree libraries (UsenetSharp / SharpCompress / RapidYencSharp)
 
@@ -403,6 +405,7 @@ Skip this handoff if there are no local changes and nothing to push or PR. Do no
 | `release.yml` | Push to `main` | release-please versioning; publishes Linux archives plus release, `dev`, and `rc` Docker tags; refreshes the rolling `dev` pre-release; moves git `dev` and `rc` tags (`dev` first); deletes versioned `v*-rc.*` pre-releases and their image tags |
 | `release.yml` | Manual `workflow_dispatch` | Republishes Linux archives plus release, `dev`, and `rc` Docker tags for an existing version; refreshes the rolling `dev` pre-release; moves git `dev` and `rc` tags (`dev` first); deletes versioned `v*-rc.*` pre-releases and their image tags |
 | `promote-lts.yml` | Manual `workflow_dispatch` | Moves git `lts` and GHCR `:lts` to an existing published version (no rebuild) |
+| `performance.yml` | Nightly cron (`17 5 * * *`) + `workflow_dispatch` | Streaming and SAB API report compare (deterministic + floored timing envelopes); optional re-baseline PR |
 | `dependency-submission.yml` | GitHub Release `published` (plus manual `workflow_dispatch`) | Dependency graph submission (NuGet + npm) |
 | `docker-build-push.yml` | Reusable (called by refresh-dev/cut-prerelease/release) | Multi-arch Docker build with GHA cache |
 | `build-release-assets.yml` | Reusable/manual (called by refresh-dev/cut-prerelease/release) | Builds linux-x64/arm64 archives and attaches them to GitHub Releases |

--- a/backend.Benchmarks/Baselines/sab-api-baseline.json
+++ b/backend.Benchmarks/Baselines/sab-api-baseline.json
@@ -1,0 +1,144 @@
+{
+  "schemaVersion": 1,
+  "report": "sab-api",
+  "meta": {
+    "commit": "unknown",
+    "generatedAt": "2026-08-19T21:00:49.945346+00:00",
+    "runner": "local"
+  },
+  "scenarios": {
+    "queue-limit10": {
+      "deterministic": {
+        "rowsReturned": 10,
+        "totalCount": 50,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 98.356,
+          "envelope": 295.068,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.097,
+          "envelope": 0.347,
+          "policy": "warn"
+        }
+      }
+    },
+    "queue-limit50": {
+      "deterministic": {
+        "rowsReturned": 50,
+        "totalCount": 50,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 1.32,
+          "envelope": 16.32,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.001,
+          "envelope": 0.251,
+          "policy": "warn"
+        }
+      }
+    },
+    "queue-limit0": {
+      "deterministic": {
+        "rowsReturned": 50,
+        "totalCount": 50,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 0.292,
+          "envelope": 15.292,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        }
+      }
+    },
+    "history-limit10-start0": {
+      "deterministic": {
+        "rowsReturned": 10,
+        "totalCount": 500,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 14.119,
+          "envelope": 42.357,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.014,
+          "envelope": 0.264,
+          "policy": "warn"
+        }
+      }
+    },
+    "history-limit10-start490": {
+      "deterministic": {
+        "rowsReturned": 10,
+        "totalCount": 500,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 0.562,
+          "envelope": 15.562,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.001,
+          "envelope": 0.251,
+          "policy": "warn"
+        }
+      }
+    },
+    "history-limit0": {
+      "deterministic": {
+        "rowsReturned": 500,
+        "totalCount": 500,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 2.455,
+          "envelope": 17.455,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.002,
+          "envelope": 0.252,
+          "policy": "warn"
+        }
+      }
+    },
+    "history-category-filter": {
+      "deterministic": {
+        "rowsReturned": 10,
+        "totalCount": 50,
+        "dbCommands": 2
+      },
+      "timing": {
+        "elapsedMs": {
+          "baseline": 8.448,
+          "envelope": 25.344,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.008,
+          "envelope": 0.258,
+          "policy": "warn"
+        }
+      }
+    }
+  }
+}

--- a/backend.Benchmarks/Baselines/streaming-baseline.json
+++ b/backend.Benchmarks/Baselines/streaming-baseline.json
@@ -1,0 +1,214 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "unknown",
+    "generatedAt": "2026-08-19T21:00:49.908358+00:00",
+    "runner": "local"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.027,
+          "envelope": 15.027,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 0.115,
+          "envelope": 15.115,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 26691.822,
+          "floor": 8897.274,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        }
+      }
+    },
+    "cache-prime": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.198,
+          "envelope": 15.198,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 3.613,
+          "envelope": 18.613,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 830.719,
+          "floor": 276.907,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.004,
+          "envelope": 0.254,
+          "policy": "warn"
+        }
+      }
+    },
+    "warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 0,
+        "transportBytes": 0
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.194,
+          "envelope": 15.194,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 1.047,
+          "envelope": 16.047,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 2875.46,
+          "floor": 958.487,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.002,
+          "envelope": 0.252,
+          "policy": "warn"
+        }
+      }
+    },
+    "range-probe": {
+      "deterministic": {
+        "bytes": 65536,
+        "transportRequests": 0,
+        "transportBytes": 0
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.103,
+          "envelope": 15.103,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 0.103,
+          "envelope": 15.103,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 615.096,
+          "floor": 205.032,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        }
+      }
+    },
+    "tail-probe": {
+      "deterministic": {
+        "bytes": 65536,
+        "transportRequests": 0,
+        "transportBytes": 0
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.092,
+          "envelope": 15.092,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 0.092,
+          "envelope": 15.092,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 687.026,
+          "floor": 229.009,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        }
+      }
+    },
+    "seeks": {
+      "deterministic": {
+        "bytes": 262144,
+        "transportRequests": 0,
+        "transportBytes": 0
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.087,
+          "envelope": 15.087,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 0.46,
+          "envelope": 15.46,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 543.865,
+          "floor": 181.288,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.001,
+          "envelope": 0.251,
+          "policy": "warn"
+        }
+      }
+    },
+    "dead-article": {
+      "deterministic": {
+        "bytes": 262144,
+        "transportRequests": 2,
+        "transportBytes": 0
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.088,
+          "envelope": 15.088,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 0.088,
+          "envelope": 15.088,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 2850.559,
+          "floor": 950.186,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        }
+      }
+    }
+  }
+}

--- a/backend.Benchmarks/CountingDbCommandInterceptor.cs
+++ b/backend.Benchmarks/CountingDbCommandInterceptor.cs
@@ -1,0 +1,70 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace NzbWebDAV.Benchmarks;
+
+internal sealed class CountingDbCommandInterceptor : DbCommandInterceptor
+{
+    private int _count;
+
+    public int Count => Volatile.Read(ref _count);
+
+    public void Reset() => Interlocked.Exchange(ref _count, 0);
+
+    public override InterceptionResult<DbDataReader> ReaderExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result)
+    {
+        Interlocked.Increment(ref _count);
+        return base.ReaderExecuting(command, eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _count);
+        return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override InterceptionResult<object> ScalarExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<object> result)
+    {
+        Interlocked.Increment(ref _count);
+        return base.ScalarExecuting(command, eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<object> result,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _count);
+        return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override InterceptionResult<int> NonQueryExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<int> result)
+    {
+        Interlocked.Increment(ref _count);
+        return base.NonQueryExecuting(command, eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _count);
+        return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+    }
+}

--- a/backend.Benchmarks/PerformanceReportCli.cs
+++ b/backend.Benchmarks/PerformanceReportCli.cs
@@ -1,0 +1,48 @@
+namespace NzbWebDAV.Benchmarks;
+
+internal static class PerformanceReportCli
+{
+    public static async Task<bool> TryHandleAsync(string[] args)
+    {
+        if (args.Length == 0)
+            return false;
+
+        string? report = null;
+        string? jsonPath = null;
+        for (var i = 0; i < args.Length;)
+        {
+            var arg = args[i];
+            if (arg == "--streaming-report")
+            {
+                if (report is not null)
+                    throw new ArgumentException("Multiple performance reports in one invocation.");
+                report = "streaming";
+                i++;
+                continue;
+            }
+
+            if (arg == "--json")
+            {
+                if (i + 1 >= args.Length)
+                    throw new ArgumentException("--json requires a file path.");
+                jsonPath = args[i + 1];
+                i += 2;
+                continue;
+            }
+
+            if (report is not null || jsonPath is not null)
+                throw new ArgumentException($"Unexpected argument '{arg}'.");
+            return false;
+        }
+
+        if (report is null)
+        {
+            if (jsonPath is not null)
+                throw new ArgumentException("--json requires --streaming-report.");
+            return false;
+        }
+
+        await RepeatableStreamingReport.RunAsync(jsonPath).ConfigureAwait(false);
+        return true;
+    }
+}

--- a/backend.Benchmarks/PerformanceReportCli.cs
+++ b/backend.Benchmarks/PerformanceReportCli.cs
@@ -12,11 +12,11 @@ internal static class PerformanceReportCli
         for (var i = 0; i < args.Length;)
         {
             var arg = args[i];
-            if (arg == "--streaming-report")
+            if (arg is "--streaming-report" or "--sab-api-report")
             {
                 if (report is not null)
                     throw new ArgumentException("Multiple performance reports in one invocation.");
-                report = "streaming";
+                report = arg == "--streaming-report" ? "streaming" : "sab-api";
                 i++;
                 continue;
             }
@@ -38,11 +38,19 @@ internal static class PerformanceReportCli
         if (report is null)
         {
             if (jsonPath is not null)
-                throw new ArgumentException("--json requires --streaming-report.");
+                throw new ArgumentException("--json requires --streaming-report or --sab-api-report.");
             return false;
         }
 
-        await RepeatableStreamingReport.RunAsync(jsonPath).ConfigureAwait(false);
+        if (report == "streaming")
+        {
+            await RepeatableStreamingReport.RunAsync(jsonPath).ConfigureAwait(false);
+            return true;
+        }
+
+        if (jsonPath is null)
+            throw new ArgumentException("--sab-api-report requires --json <path>.");
+        await SabApiReport.RunAsync(jsonPath).ConfigureAwait(false);
         return true;
     }
 }

--- a/backend.Benchmarks/PerformanceReportJson.cs
+++ b/backend.Benchmarks/PerformanceReportJson.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Benchmarks;
+
+internal sealed record ScenarioSnapshot(
+    Dictionary<string, long> Deterministic,
+    Dictionary<string, double> Timing);
+
+internal static class PerformanceReportJson
+{
+    internal const int SchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static void Write(
+        string path,
+        string report,
+        IReadOnlyDictionary<string, ScenarioSnapshot> scenarios)
+    {
+        var document = new PerformanceReportDocument
+        {
+            SchemaVersion = SchemaVersion,
+            Report = report,
+            Meta = CreateMeta(),
+            Scenarios = scenarios.ToDictionary(
+                pair => pair.Key,
+                pair => new ScenarioPayload
+                {
+                    Deterministic = pair.Value.Deterministic,
+                    Timing = pair.Value.Timing,
+                },
+                StringComparer.Ordinal),
+        };
+
+        var json = JsonSerializer.Serialize(document, Options);
+        File.WriteAllText(path, json + Environment.NewLine);
+    }
+
+    public static Dictionary<string, double> StreamingTiming(
+        double firstByteMs,
+        double elapsedMs,
+        double throughputMiBs,
+        double cpuSeconds) =>
+        new(StringComparer.Ordinal)
+        {
+            ["firstByteMs"] = Round(firstByteMs),
+            ["elapsedMs"] = Round(elapsedMs),
+            ["throughputMiBs"] = Round(throughputMiBs),
+            ["cpuSeconds"] = Round(cpuSeconds),
+        };
+
+    public static Dictionary<string, double> ApiTiming(double elapsedMs, double cpuSeconds) =>
+        new(StringComparer.Ordinal)
+        {
+            ["elapsedMs"] = Round(elapsedMs),
+            ["cpuSeconds"] = Round(cpuSeconds),
+        };
+
+    public static double Round(double value) =>
+        Math.Round(value, 3, MidpointRounding.AwayFromZero);
+
+    private static Dictionary<string, string> CreateMeta() =>
+        new(StringComparer.Ordinal)
+        {
+            ["commit"] = Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "unknown",
+            ["generatedAt"] = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+            ["os"] = RuntimeInformation.OSDescription,
+            ["dotnet"] = RuntimeInformation.FrameworkDescription,
+        };
+
+    private sealed class PerformanceReportDocument
+    {
+        public int SchemaVersion { get; init; }
+        public required string Report { get; init; }
+        public required Dictionary<string, string> Meta { get; init; }
+        public required Dictionary<string, ScenarioPayload> Scenarios { get; init; }
+    }
+
+    private sealed class ScenarioPayload
+    {
+        public required Dictionary<string, long> Deterministic { get; init; }
+        public required Dictionary<string, double> Timing { get; init; }
+    }
+}

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -9,9 +9,7 @@ using NzbWebDAV.Streams;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
-if (args.SequenceEqual(["--streaming-report"], StringComparer.Ordinal))
-    await NzbWebDAV.Benchmarks.RepeatableStreamingReport.RunAsync();
-else
+if (!await NzbWebDAV.Benchmarks.PerformanceReportCli.TryHandleAsync(args))
     BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
 

--- a/backend.Benchmarks/README.md
+++ b/backend.Benchmarks/README.md
@@ -1,29 +1,95 @@
 # Backend benchmarks
 
-The benchmarks establish a repeatable baseline for Usenet segment decoding. They
-are intentionally excluded from CI because BenchmarkDotNet results are sensitive
-to runner contention and hardware.
+BenchmarkDotNet timing runs stay manual: they are sensitive to runner
+contention and hardware, and timing comparisons never block pull requests.
+Deterministic transport and SAB API fields from the report harnesses **are**
+compared in CI (see `.github/workflows/ci.yml` and
+`.github/workflows/performance.yml`).
 
-Run them from the repository root:
+Run BenchmarkDotNet from the repository root:
 
 ```bash
 dotnet run --project backend.Benchmarks -c Release
 ```
 
-Use the same machine and runtime when comparing results across UsenetSharp or
-streaming changes.
+Use the same machine and runtime when comparing BenchmarkDotNet results across
+UsenetSharp or streaming changes.
+
+## Tool decision
+
+Issue [#854](https://github.com/infinidysk/infinidysk/issues/854) asked to
+choose k6, wrk, or a custom .NET client. InfiniDysk uses a **custom in-process
+.NET harness** (`--streaming-report` and `--sab-api-report`) because the
+deterministic transport fake (`BenchmarkNntpClient`) and pre-seeded SQLite SAB
+corpus have to be wired inside the process. A live-socket load tool cannot
+see those counters or keep results independent of the network.
+
+Range-probe and tail-probe are the deterministic stand-in for ffprobe's access
+pattern (open, header read, tail seek). Full HTTP WebDAV GET percentiles and
+SAB `addfile` ingest are out of scope here.
 
 ## Repeatable streaming report
 
-Run the deterministic local streaming harness with:
-
 ```bash
 dotnet run --project backend.Benchmarks -c Release -- --streaming-report
+dotnet run --project backend.Benchmarks -c Release -- --streaming-report --json /tmp/streaming.json
 ```
 
-It uses generated in-memory segments and the local segment cache, so it makes
-no provider connections and is not intended for CI. The report verifies payload
-fidelity while printing cold sequential transport bytes/requests, first-byte
-latency, range and tail probes, warm cache re-reads, seeks, and a zero-filled
-dead-article read. Compare throughput and latency fields only on the same
-machine and runtime; transport fields remain deterministic across runs.
+It uses generated in-memory segments (`Random(1025)`, 12 × 256 KiB) and the
+local segment cache, so it makes no provider connections. The report verifies
+payload fidelity while recording cold sequential transport bytes/requests,
+first-byte latency, range and tail probes, warm cache re-reads, seeks, and a
+zero-filled dead-article read. Compare throughput and latency fields only on
+the same machine and runtime, or against the committed envelopes; transport
+fields remain deterministic across runs.
+
+## SAB API report
+
+```bash
+dotnet run --project backend.Benchmarks -c Release -- --sab-api-report --json /tmp/sab-api.json
+```
+
+Directly invokes `GetQueue` / `GetHistory` against a migrated temp SQLite
+database (same setup as the SAB limit-zero tests) with a fixed 50-queue /
+500-history corpus. Deterministic fields are `rowsReturned`, `totalCount`, and
+`dbCommands` (EF command count).
+
+## Regression layers
+
+1. **PR-blocking (no clocks):** xUnit exact-count coverage plus both reports
+   compared with `scripts/check-performance-baseline.py --deterministic-only`
+   against `backend.Benchmarks/Baselines/*.json`. An intentional
+   transport-contract or query-shape change must update the baseline JSON in
+   the same PR.
+2. **Scheduled envelopes:** `.github/workflows/performance.yml` runs each
+   report 3× on a cron / `workflow_dispatch` and fails when the median misses
+   a floored 3× envelope. Dispatch the workflow with `rebaseline: true` to
+   write new baselines and open (never merge) a PR. Locally:
+
+```bash
+python3 scripts/check-performance-baseline.py \
+  --candidates /tmp/streaming.json \
+  --write-baseline backend.Benchmarks/Baselines/streaming-baseline.json
+```
+
+`GITHUB_TOKEN`-created re-baseline PRs do not trigger `pull_request` CI;
+close/reopen or push to run checks.
+
+## Scenario → meaning
+
+A count change is a transport or query-shape contract change. Update the
+matching constant in
+`tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs`
+and/or the committed baseline JSON.
+
+| Scenario | Field going up usually means |
+| --- | --- |
+| `cold-sequential` `transportRequests` | extra BODY/ARTICLE traffic per byte (lost batching or smaller segments) |
+| `cache-prime` `transportRequests` | cache prime is no longer one request per fixture segment |
+| `warm-reread` `transportRequests` | segment cache miss on a path that should be warm |
+| `range-probe` `transportRequests` | read-ahead widened (or cache skipped) for a mid-file probe |
+| `tail-probe` `transportRequests` | tail/header-style probe is fetching extra segments |
+| `seeks` `transportRequests` | seek amplification (more articles per scrub) |
+| `dead-article` `transportRequests` / `transportBytes` | extra work around a missing article, or a gap that is no longer zero-filled |
+| SAB `rowsReturned` / `totalCount` | pagination or filter contract change |
+| SAB `dbCommands` | extra round-trips (often N+1) for the same page |

--- a/backend.Benchmarks/RepeatableStreamingReport.cs
+++ b/backend.Benchmarks/RepeatableStreamingReport.cs
@@ -10,11 +10,23 @@ internal static class RepeatableStreamingReport
     private const int SegmentSize = 256 * 1024;
     private const int SegmentCount = 12;
     private const int ProbeSize = 64 * 1024;
+    private const string ReportName = "streaming";
 
-    public static async Task RunAsync()
+    public static async Task RunAsync(string? jsonPath = null)
+    {
+        // Discarded warm-up: JIT/tiering must not pollute cold-sequential CPU/timing.
+        await RunOnceAsync(print: false).ConfigureAwait(false);
+
+        var scenarios = await RunOnceAsync(print: true).ConfigureAwait(false);
+        if (jsonPath is not null)
+            PerformanceReportJson.Write(jsonPath, ReportName, scenarios);
+    }
+
+    private static async Task<Dictionary<string, ScenarioSnapshot>> RunOnceAsync(bool print)
     {
         var fixture = CreateFixture();
         var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-repeatable-streaming-" + Guid.NewGuid().ToString("N"));
+        var scenarios = new Dictionary<string, ScenarioSnapshot>(StringComparer.Ordinal);
 
         try
         {
@@ -25,55 +37,155 @@ internal static class RepeatableStreamingReport
                 maxBytes: fixture.Source.Length * 2L);
             await WaitForCatalogAsync(cached).ConfigureAwait(false);
 
-            var cold = await ReadAllAsync(transport, fixture).ConfigureAwait(false);
-            Print("cold-sequential", cold, fixture.Source.Length, transport.BodyRequestCount,
-                transport.BodyBytesRequested);
+            await RecordAsync(
+                scenarios, print, transport, "cold-sequential",
+                async () =>
+                {
+                    var metrics = await ReadAllAsync(transport, fixture).ConfigureAwait(false);
+                    return (metrics, fixture.Source.Length);
+                }).ConfigureAwait(false);
 
-            var requestsBeforePrime = transport.BodyRequestCount;
-            var bytesBeforePrime = transport.BodyBytesRequested;
-            var cachePrime = await PrimeCacheAsync(cached, fixture).ConfigureAwait(false);
-            Print("cache-prime", cachePrime, fixture.Source.Length,
-                transport.BodyRequestCount - requestsBeforePrime,
-                transport.BodyBytesRequested - bytesBeforePrime);
+            await RecordAsync(
+                scenarios, print, transport, "cache-prime",
+                async () =>
+                {
+                    var metrics = await PrimeCacheAsync(cached, fixture).ConfigureAwait(false);
+                    return (metrics, fixture.Source.Length);
+                }).ConfigureAwait(false);
 
-            var requestsBeforeWarmRead = transport.BodyRequestCount;
-            var bytesBeforeWarmRead = transport.BodyBytesRequested;
-            var warm = await ReadAllAsync(cached, fixture).ConfigureAwait(false);
-            Print("warm-reread", warm, fixture.Source.Length,
-                transport.BodyRequestCount - requestsBeforeWarmRead,
-                transport.BodyBytesRequested - bytesBeforeWarmRead);
+            await RecordAsync(
+                scenarios, print, transport, "warm-reread",
+                async () =>
+                {
+                    var metrics = await ReadAllAsync(cached, fixture).ConfigureAwait(false);
+                    return (metrics, fixture.Source.Length);
+                }).ConfigureAwait(false);
 
-            var requestsBeforeRangeProbe = transport.BodyRequestCount;
-            var bytesBeforeRangeProbe = transport.BodyBytesRequested;
-            var range = await ProbeAsync(cached, fixture, SegmentSize * 4L + 137, ProbeSize).ConfigureAwait(false);
-            Print("range-probe", range, ProbeSize,
-                transport.BodyRequestCount - requestsBeforeRangeProbe,
-                transport.BodyBytesRequested - bytesBeforeRangeProbe);
+            await RecordAsync(
+                scenarios, print, transport, "range-probe",
+                async () =>
+                {
+                    var metrics = await ProbeAsync(cached, fixture, SegmentSize * 4L + 137, ProbeSize)
+                        .ConfigureAwait(false);
+                    return (metrics, ProbeSize);
+                }).ConfigureAwait(false);
 
-            var requestsBeforeTailProbe = transport.BodyRequestCount;
-            var bytesBeforeTailProbe = transport.BodyBytesRequested;
-            var tail = await ProbeAsync(cached, fixture, fixture.Source.Length - ProbeSize, ProbeSize).ConfigureAwait(false);
-            Print("tail-probe", tail, ProbeSize,
-                transport.BodyRequestCount - requestsBeforeTailProbe,
-                transport.BodyBytesRequested - bytesBeforeTailProbe);
+            await RecordAsync(
+                scenarios, print, transport, "tail-probe",
+                async () =>
+                {
+                    var metrics = await ProbeAsync(
+                            cached, fixture, fixture.Source.Length - ProbeSize, ProbeSize)
+                        .ConfigureAwait(false);
+                    return (metrics, ProbeSize);
+                }).ConfigureAwait(false);
 
-            var requestsBeforeSeeks = transport.BodyRequestCount;
-            var bytesBeforeSeeks = transport.BodyBytesRequested;
-            var seeks = await SeekAsync(cached, fixture).ConfigureAwait(false);
-            Print("seeks", seeks, seeks.BytesRead,
-                transport.BodyRequestCount - requestsBeforeSeeks,
-                transport.BodyBytesRequested - bytesBeforeSeeks,
-                extra: $"seek_count={seeks.OperationCount}");
+            await RecordAsync(
+                scenarios, print, transport, "seeks",
+                async () =>
+                {
+                    var metrics = await SeekAsync(cached, fixture).ConfigureAwait(false);
+                    return (metrics, metrics.BytesRead);
+                }, extra: static _ => "seek_count=4").ConfigureAwait(false);
 
-            var dead = await DeadArticleAsync(fixture).ConfigureAwait(false);
-            Print("dead-article", dead.Metrics, dead.ZeroFilledBytes, dead.TransportRequests,
-                dead.TransportBytes, $"zero_filled_bytes={dead.ZeroFilledBytes}");
+            var dead = await MeasureDeadArticleAsync(fixture).ConfigureAwait(false);
+            scenarios["dead-article"] = dead.Snapshot;
+            if (print)
+            {
+                Print(
+                    "dead-article",
+                    dead.Snapshot,
+                    extra: $"zero_filled_bytes={dead.Snapshot.Deterministic["bytes"]}");
+            }
         }
         finally
         {
             if (Directory.Exists(cacheDir))
                 Directory.Delete(cacheDir, recursive: true);
         }
+
+        return scenarios;
+    }
+
+    private static async Task RecordAsync(
+        Dictionary<string, ScenarioSnapshot> scenarios,
+        bool print,
+        BenchmarkNntpClient transport,
+        string name,
+        Func<Task<(StreamingMetrics Metrics, long Bytes)>> action,
+        Func<ScenarioSnapshot, string>? extra = null)
+    {
+        var requestsBefore = transport.BodyRequestCount;
+        var bytesBefore = transport.BodyBytesRequested;
+        var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var cpuBefore = process.TotalProcessorTime;
+        var (metrics, bytes) = await action().ConfigureAwait(false);
+        process.Refresh();
+        var cpuSeconds = (process.TotalProcessorTime - cpuBefore).TotalSeconds;
+        var snapshot = ToSnapshot(
+            metrics,
+            bytes,
+            transport.BodyRequestCount - requestsBefore,
+            transport.BodyBytesRequested - bytesBefore,
+            cpuSeconds);
+        scenarios[name] = snapshot;
+        if (print)
+            Print(name, snapshot, extra: extra?.Invoke(snapshot));
+    }
+
+    private static async Task<DeadArticleCapture> MeasureDeadArticleAsync(Fixture fixture)
+    {
+        var missingSegment = fixture.SegmentIds[5];
+        using var transport = new BenchmarkNntpClient(
+            fixture.Segments.Where(pair => pair.Key != missingSegment).ToDictionary(),
+            useCachedYencStreams: true,
+            fixture.RangesById);
+        var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var cpuBefore = process.TotalProcessorTime;
+        await using var stream = fixture.CreateStream(transport);
+        stream.Seek(SegmentSize * 5L, SeekOrigin.Begin);
+        var buffer = new byte[SegmentSize];
+        var stopwatch = Stopwatch.StartNew();
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true).ConfigureAwait(false);
+        stopwatch.Stop();
+        process.Refresh();
+        var cpuSeconds = (process.TotalProcessorTime - cpuBefore).TotalSeconds;
+
+        if (buffer.AsSpan(0, read).IndexOfAnyExcept((byte)0) >= 0)
+            throw new InvalidOperationException("Dead-article probe did not return an all-zero gap.");
+
+        var metrics = new StreamingMetrics(stopwatch.Elapsed, stopwatch.Elapsed, read, OperationCount: 1);
+        return new DeadArticleCapture(ToSnapshot(
+            metrics,
+            read,
+            transport.BodyRequestCount,
+            transport.BodyBytesRequested,
+            cpuSeconds));
+    }
+
+    private static ScenarioSnapshot ToSnapshot(
+        StreamingMetrics metrics,
+        long bytes,
+        int transportRequests,
+        long transportBytes,
+        double cpuSeconds)
+    {
+        var seconds = Math.Max(metrics.Elapsed.TotalSeconds, double.Epsilon);
+        var throughput = bytes / 1024d / 1024d / seconds;
+        return new ScenarioSnapshot(
+            new Dictionary<string, long>(StringComparer.Ordinal)
+            {
+                ["bytes"] = bytes,
+                ["transportRequests"] = transportRequests,
+                ["transportBytes"] = transportBytes,
+            },
+            PerformanceReportJson.StreamingTiming(
+                metrics.FirstByte.TotalMilliseconds,
+                metrics.Elapsed.TotalMilliseconds,
+                throughput,
+                cpuSeconds));
     }
 
     private static async Task<StreamingMetrics> ReadAllAsync(INntpClient client, Fixture fixture)
@@ -150,30 +262,6 @@ internal static class RepeatableStreamingReport
         return new StreamingMetrics(stopwatch.Elapsed, firstByte, bytesRead, offsets.Length);
     }
 
-    private static async Task<DeadArticleResult> DeadArticleAsync(Fixture fixture)
-    {
-        var missingSegment = fixture.SegmentIds[5];
-        using var transport = new BenchmarkNntpClient(
-            fixture.Segments.Where(pair => pair.Key != missingSegment).ToDictionary(),
-            useCachedYencStreams: true,
-            fixture.RangesById);
-        await using var stream = fixture.CreateStream(transport);
-        stream.Seek(SegmentSize * 5L, SeekOrigin.Begin);
-        var buffer = new byte[SegmentSize];
-        var stopwatch = Stopwatch.StartNew();
-        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true).ConfigureAwait(false);
-        stopwatch.Stop();
-
-        if (buffer.AsSpan(0, read).IndexOfAnyExcept((byte)0) >= 0)
-            throw new InvalidOperationException("Dead-article probe did not return an all-zero gap.");
-
-        return new DeadArticleResult(
-            new StreamingMetrics(stopwatch.Elapsed, stopwatch.Elapsed, read, OperationCount: 1),
-            read,
-            transport.BodyRequestCount,
-            transport.BodyBytesRequested);
-    }
-
     private static async Task WaitForCatalogAsync(SegmentCacheNntpClient client)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
@@ -184,20 +272,14 @@ internal static class RepeatableStreamingReport
             throw new TimeoutException("Segment cache catalog did not become ready.");
     }
 
-    private static void Print(
-        string scenario,
-        StreamingMetrics metrics,
-        long bytes,
-        int transportRequests,
-        long transportBytes,
-        string? extra = null)
+    private static void Print(string scenario, ScenarioSnapshot snapshot, string? extra = null)
     {
-        var seconds = Math.Max(metrics.Elapsed.TotalSeconds, double.Epsilon);
-        var throughput = bytes / 1024d / 1024d / seconds;
+        var deterministic = snapshot.Deterministic;
+        var timing = snapshot.Timing;
         Console.WriteLine(
-            $"{scenario} bytes={bytes} transport_requests={transportRequests} " +
-            $"transport_bytes={transportBytes} first_byte_ms={metrics.FirstByte.TotalMilliseconds:F3} " +
-            $"elapsed_ms={metrics.Elapsed.TotalMilliseconds:F3} throughput_mib_s={throughput:F3}" +
+            $"{scenario} bytes={deterministic["bytes"]} transport_requests={deterministic["transportRequests"]} " +
+            $"transport_bytes={deterministic["transportBytes"]} first_byte_ms={timing["firstByteMs"]:F3} " +
+            $"elapsed_ms={timing["elapsedMs"]:F3} throughput_mib_s={timing["throughputMiBs"]:F3}" +
             (extra is null ? string.Empty : $" {extra}"));
     }
 
@@ -248,9 +330,5 @@ internal static class RepeatableStreamingReport
         long BytesRead,
         int OperationCount);
 
-    private readonly record struct DeadArticleResult(
-        StreamingMetrics Metrics,
-        long ZeroFilledBytes,
-        int TransportRequests,
-        long TransportBytes);
+    private readonly record struct DeadArticleCapture(ScenarioSnapshot Snapshot);
 }

--- a/backend.Benchmarks/SabApiReport.cs
+++ b/backend.Benchmarks/SabApiReport.cs
@@ -1,0 +1,253 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.GetHistory;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Benchmarks;
+
+internal static class SabApiReport
+{
+    private const string ReportName = "sab-api";
+    private const int HistoryCount = 500;
+    private const int QueueCount = 50;
+    private const int TvHistoryCount = 50;
+    private const string MoviesCategory = "movies";
+    private const string TvCategory = "tv";
+
+    public static async Task RunAsync(string jsonPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jsonPath);
+
+        var configRoot = Path.Join(Path.GetTempPath(), $"nzbdav-sab-api-report-{Guid.NewGuid():N}");
+        var previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", configRoot);
+
+        var scenarios = new Dictionary<string, ScenarioSnapshot>(StringComparer.Ordinal);
+        try
+        {
+            var interceptor = new CountingDbCommandInterceptor();
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler(), interceptor)
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            await using var dbContext = new DavDatabaseContext(options);
+            await dbContext.Database.MigrateAsync().ConfigureAwait(false);
+            var dbClient = new DavDatabaseClient(dbContext);
+
+            var configManager = new ConfigManager();
+            configManager.UpdateValues(
+            [
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.UsenetProviders,
+                    ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+                },
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.ApiIgnoreHistoryLimit,
+                    ConfigValue = "false",
+                },
+            ]);
+
+            var websocketManager = new WebsocketManager();
+            using var metricsWriter = new MetricsWriter();
+            using var usenet = new UsenetStreamingClient(
+                configManager,
+                websocketManager,
+                new ProviderUsageTracker(),
+                metricsWriter,
+                new ProviderBytesTracker(),
+                new StreamTraceBuffer(100),
+                new ActiveReadRegistry());
+            using var queueManager = new QueueManager(
+                usenet,
+                configManager,
+                websocketManager,
+                new ProviderUsageTracker(),
+                new WatchdogLog(),
+                new QueueItemSourceTracker(),
+                new BenchmarkGate(),
+                startLoop: false);
+
+            SeedCorpus(dbContext);
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
+            dbContext.ChangeTracker.Clear();
+            interceptor.Reset();
+
+            await RecordQueueAsync(
+                scenarios, dbClient, queueManager, configManager, interceptor, "queue-limit10", "?limit=10")
+                .ConfigureAwait(false);
+            await RecordQueueAsync(
+                scenarios, dbClient, queueManager, configManager, interceptor, "queue-limit50", "?limit=50")
+                .ConfigureAwait(false);
+            await RecordQueueAsync(
+                scenarios, dbClient, queueManager, configManager, interceptor, "queue-limit0", "?limit=0")
+                .ConfigureAwait(false);
+            await RecordHistoryAsync(
+                scenarios, dbClient, configManager, interceptor, "history-limit10-start0", "?limit=10&start=0")
+                .ConfigureAwait(false);
+            await RecordHistoryAsync(
+                scenarios, dbClient, configManager, interceptor,
+                "history-limit10-start490", "?limit=10&start=490")
+                .ConfigureAwait(false);
+            await RecordHistoryAsync(
+                scenarios, dbClient, configManager, interceptor, "history-limit0", "?limit=0")
+                .ConfigureAwait(false);
+            await RecordHistoryAsync(
+                scenarios, dbClient, configManager, interceptor,
+                "history-category-filter", $"?limit=10&cat={TvCategory}")
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previousConfigPath);
+            try
+            {
+                Directory.Delete(configRoot, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best effort
+            }
+        }
+
+        foreach (var (name, snapshot) in scenarios)
+        {
+            Console.WriteLine(
+                $"{name} rows={snapshot.Deterministic["rowsReturned"]} " +
+                $"total={snapshot.Deterministic["totalCount"]} " +
+                $"db_commands={snapshot.Deterministic["dbCommands"]} " +
+                $"elapsed_ms={snapshot.Timing["elapsedMs"]:F3} " +
+                $"cpu_seconds={snapshot.Timing["cpuSeconds"]:F3}");
+        }
+
+        PerformanceReportJson.Write(jsonPath, ReportName, scenarios);
+    }
+
+    private static async Task RecordQueueAsync(
+        Dictionary<string, ScenarioSnapshot> scenarios,
+        DavDatabaseClient dbClient,
+        QueueManager queueManager,
+        ConfigManager configManager,
+        CountingDbCommandInterceptor interceptor,
+        string name,
+        string query)
+    {
+        interceptor.Reset();
+        var request = CreateQueueRequest(query, configManager);
+        var controller = new GetQueueController(
+            new DefaultHttpContext(), dbClient, queueManager, configManager, new ProviderUsageTracker());
+        var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var cpuBefore = process.TotalProcessorTime;
+        var stopwatch = Stopwatch.StartNew();
+        var response = await controller.GetQueueAsync(request).ConfigureAwait(false);
+        stopwatch.Stop();
+        process.Refresh();
+        var cpuSeconds = (process.TotalProcessorTime - cpuBefore).TotalSeconds;
+        scenarios[name] = new ScenarioSnapshot(
+            new Dictionary<string, long>(StringComparer.Ordinal)
+            {
+                ["rowsReturned"] = response.Queue.Slots.Count,
+                ["totalCount"] = response.Queue.TotalCount,
+                ["dbCommands"] = interceptor.Count,
+            },
+            PerformanceReportJson.ApiTiming(stopwatch.Elapsed.TotalMilliseconds, cpuSeconds));
+    }
+
+    private static async Task RecordHistoryAsync(
+        Dictionary<string, ScenarioSnapshot> scenarios,
+        DavDatabaseClient dbClient,
+        ConfigManager configManager,
+        CountingDbCommandInterceptor interceptor,
+        string name,
+        string query)
+    {
+        interceptor.Reset();
+        var request = CreateHistoryRequest(query, configManager);
+        var controller = new GetHistoryController(
+            new DefaultHttpContext(), dbClient, configManager, new ProviderUsageTracker());
+        var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var cpuBefore = process.TotalProcessorTime;
+        var stopwatch = Stopwatch.StartNew();
+        var response = await controller.GetHistoryAsync(request).ConfigureAwait(false);
+        stopwatch.Stop();
+        process.Refresh();
+        var cpuSeconds = (process.TotalProcessorTime - cpuBefore).TotalSeconds;
+        scenarios[name] = new ScenarioSnapshot(
+            new Dictionary<string, long>(StringComparer.Ordinal)
+            {
+                ["rowsReturned"] = response.History.Slots.Count,
+                ["totalCount"] = response.History.TotalCount,
+                ["dbCommands"] = interceptor.Count,
+            },
+            PerformanceReportJson.ApiTiming(stopwatch.Elapsed.TotalMilliseconds, cpuSeconds));
+    }
+
+    private static GetQueueRequest CreateQueueRequest(string query, ConfigManager configManager)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(query);
+        return new GetQueueRequest(context, configManager);
+    }
+
+    private static GetHistoryRequest CreateHistoryRequest(string query, ConfigManager configManager)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(query);
+        return new GetHistoryRequest(context, configManager);
+    }
+
+    private static void SeedCorpus(DavDatabaseContext dbContext)
+    {
+        var epoch = DateTime.UnixEpoch;
+        var queueItems = Enumerable.Range(0, QueueCount)
+            .Select(index => new QueueItem
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = epoch.AddMinutes(index),
+                SortOrder = index,
+                FileName = $"job-{index:D4}.nzb",
+                JobName = $"job-{index:D4}",
+                NzbFileSize = 1000 + index,
+                TotalSegmentBytes = 2000 + index,
+                Category = MoviesCategory,
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            });
+        dbContext.QueueItems.AddRange(queueItems);
+
+        var historyItems = Enumerable.Range(0, HistoryCount)
+            .Select(index => new HistoryItem
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = epoch.AddMinutes(index),
+                FileName = $"job-{index:D4}.nzb",
+                JobName = $"job-{index:D4}",
+                Category = index < TvHistoryCount ? TvCategory : MoviesCategory,
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 1000 + index,
+                DownloadTimeSeconds = 5,
+            });
+        dbContext.HistoryItems.AddRange(historyItems);
+    }
+}

--- a/backend/Properties/AssemblyInfo.cs
+++ b/backend/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("NzbWebDAV.Tests")]
+[assembly: InternalsVisibleTo("NzbWebDAV.Benchmarks")]

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -44,3 +44,34 @@ dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release
 ```
 
 Full details: repository [CONTRIBUTING.md](https://github.com/infinidysk/infinidysk/blob/main/CONTRIBUTING.md) and [AGENTS.md](https://github.com/infinidysk/infinidysk/blob/main/AGENTS.md).
+
+## Performance regression gates
+
+Pull request CI compares **deterministic** fields from the streaming and SAB API
+reports (`transportRequests`, `transportBytes`, SAB `rowsReturned` /
+`totalCount` / `dbCommands`) against
+[`backend.Benchmarks/Baselines/`](https://github.com/infinidysk/infinidysk/blob/main/backend.Benchmarks/Baselines).
+Timing never blocks a PR.
+
+If that gate fails because you **intentionally** changed transport or query
+shape, update the matching baseline JSON in the same PR (and any adjacent
+count constants in
+`tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs`):
+
+```bash
+dotnet run --project backend.Benchmarks -c Release -- --streaming-report --json /tmp/streaming.json
+dotnet run --project backend.Benchmarks -c Release -- --sab-api-report --json /tmp/sab-api.json
+python3 scripts/check-performance-baseline.py \
+  --candidates /tmp/streaming.json \
+  --write-baseline backend.Benchmarks/Baselines/streaming-baseline.json
+python3 scripts/check-performance-baseline.py \
+  --candidates /tmp/sab-api.json \
+  --write-baseline backend.Benchmarks/Baselines/sab-api-baseline.json
+```
+
+Nightly [Performance](https://github.com/infinidysk/infinidysk/actions/workflows/performance.yml)
+runs check latency / throughput / CPU against floored 3× envelopes. To refresh
+those envelopes: **Actions → Performance → Run workflow → rebaseline**. The
+workflow opens a PR and does not merge it. PRs created with `GITHUB_TOKEN` do
+not trigger CI — close/reopen (or push) to run checks.
+

--- a/scripts/check-performance-baseline.py
+++ b/scripts/check-performance-baseline.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Compare performance-report JSON against a committed baseline.
+
+Deterministic fields must match exactly (and be identical across candidates).
+Timing fields use floored envelopes; --deterministic-only skips them.
+
+Exit codes: 0 pass (warnings allowed), 1 envelope failure, 2 deterministic/schema failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+LATENCY_FLOOR_MS = 15.0
+CPU_FLOOR_S = 0.25
+ENVELOPE_MULTIPLIER = 3.0
+REBASELINE_HINT = (
+    "To re-baseline: Actions → Performance → Run workflow → rebaseline, "
+    "or locally: python3 scripts/check-performance-baseline.py "
+    "--candidates <report.json> "
+    "--write-baseline backend.Benchmarks/Baselines/<report>-baseline.json"
+)
+
+
+def round3(value: float) -> float:
+    quantized = Decimal(str(value)).quantize(Decimal("0.001"), rounding=ROUND_HALF_UP)
+    return float(quantized)
+
+
+def as_number(value: Any, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} is not a number: {value!r}")
+    return float(value)
+
+
+def as_int(value: Any, *, label: str) -> int:
+    number = as_number(value, label=label)
+    if number != int(number):
+        raise ValueError(f"{label} is not an integer: {value!r}")
+    return int(number)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a JSON object")
+    return data
+
+
+def scenario_names(report: dict[str, Any]) -> list[str]:
+    scenarios = report.get("scenarios")
+    if not isinstance(scenarios, dict):
+        raise ValueError("missing scenarios object")
+    return list(scenarios.keys())
+
+
+def classify_timing_field(name: str) -> str:
+    lowered = name.lower()
+    if "throughput" in lowered:
+        return "throughput"
+    if lowered == "cpuseconds":
+        return "cpu"
+    return "latency"
+
+
+def timing_envelope(median: float, kind: str) -> dict[str, Any]:
+    if kind == "throughput":
+        return {
+            "baseline": round3(median),
+            "floor": round3(median / ENVELOPE_MULTIPLIER),
+            "policy": "fail",
+        }
+    floor = CPU_FLOOR_S if kind == "cpu" else LATENCY_FLOOR_MS
+    return {
+        "baseline": round3(median),
+        "envelope": round3(max(ENVELOPE_MULTIPLIER * median, median + floor)),
+        "policy": "warn" if kind == "cpu" else "fail",
+    }
+
+
+def median(values: list[float]) -> float:
+    ordered = sorted(values)
+    count = len(ordered)
+    if count == 0:
+        raise ValueError("median of empty list")
+    mid = count // 2
+    if count % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def format_set(names: list[str]) -> str:
+    return "[" + ", ".join(names) + "]"
+
+
+class Gate:
+    def __init__(self) -> None:
+        self.schema_errors: list[str] = []
+        self.deterministic_errors: list[str] = []
+        self.envelope_failures: list[str] = []
+        self.warnings: list[str] = []
+        self.rows: list[tuple[str, str, str, str, str, str]] = []
+
+    def error_schema(self, message: str) -> None:
+        self.schema_errors.append(message)
+
+    def error_deterministic(self, message: str) -> None:
+        self.deterministic_errors.append(message)
+
+    def fail_envelope(self, message: str) -> None:
+        self.envelope_failures.append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def note(
+        self,
+        scenario: str,
+        field: str,
+        kind: str,
+        result: str,
+        expected: str,
+        actual: str,
+    ) -> None:
+        self.rows.append((scenario, field, kind, result, expected, actual))
+
+    def exit_code(self) -> int:
+        if self.schema_errors or self.deterministic_errors:
+            return 2
+        if self.envelope_failures:
+            return 1
+        return 0
+
+
+def validate_candidate_shape(
+    gate: Gate, path: Path, report: dict[str, Any], *, require_timing: bool
+) -> None:
+    prefix = str(path)
+    version = report.get("schemaVersion")
+    if version != SCHEMA_VERSION:
+        gate.error_schema(
+            f"{prefix} schemaVersion expected {SCHEMA_VERSION} but was {version!r}"
+        )
+    if not isinstance(report.get("report"), str) or not report["report"]:
+        gate.error_schema(f"{prefix} missing report name")
+    scenarios = report.get("scenarios")
+    if not isinstance(scenarios, dict) or not scenarios:
+        gate.error_schema(f"{prefix} missing scenarios")
+        return
+    for name, scenario in scenarios.items():
+        if not isinstance(scenario, dict):
+            gate.error_schema(f"{prefix} scenario {name} is not an object")
+            continue
+        deterministic = scenario.get("deterministic")
+        if not isinstance(deterministic, dict) or not deterministic:
+            gate.error_schema(f"{prefix}/{name} missing deterministic object")
+        timing = scenario.get("timing")
+        if require_timing and (not isinstance(timing, dict) or not timing):
+            gate.error_schema(f"{prefix}/{name} missing timing object")
+
+
+def deterministic_map(scenario: dict[str, Any]) -> dict[str, int]:
+    deterministic = scenario.get("deterministic")
+    if not isinstance(deterministic, dict):
+        raise ValueError("missing deterministic object")
+    return {
+        key: as_int(value, label=key) for key, value in deterministic.items()
+    }
+
+
+def candidate_timing_map(scenario: dict[str, Any]) -> dict[str, float]:
+    timing = scenario.get("timing")
+    if not isinstance(timing, dict):
+        raise ValueError("missing timing object")
+    return {key: as_number(value, label=key) for key, value in timing.items()}
+
+
+def compare_deterministic(
+    gate: Gate,
+    report_name: str,
+    baseline_scenarios: dict[str, Any],
+    candidates: list[tuple[Path, dict[str, Any]]],
+) -> None:
+    names = list(baseline_scenarios.keys())
+    for path, report in candidates:
+        candidate_names = scenario_names(report)
+        if set(candidate_names) != set(names):
+            gate.error_schema(
+                f"{report_name} scenarios expected {format_set(names)} "
+                f"but {path} has {format_set(candidate_names)}"
+            )
+
+    for name in names:
+        baseline_det = deterministic_map(baseline_scenarios[name])
+        per_candidate: list[dict[str, int]] = []
+        for path, report in candidates:
+            scenarios = report.get("scenarios")
+            if not isinstance(scenarios, dict) or name not in scenarios:
+                continue
+            try:
+                per_candidate.append(deterministic_map(scenarios[name]))
+            except ValueError as exc:
+                gate.error_schema(f"{path}/{name} {exc}")
+        if not per_candidate:
+            continue
+
+        keys = list(baseline_det.keys())
+        for candidate_det in per_candidate:
+            if set(candidate_det.keys()) != set(keys):
+                gate.error_deterministic(
+                    f"{report_name}/{name} deterministic fields expected "
+                    f"{format_set(keys)} but was {format_set(list(candidate_det.keys()))}"
+                )
+
+        for key in keys:
+            values = [item.get(key) for item in per_candidate]
+            unique = {value for value in values if value is not None}
+            if len(unique) > 1:
+                gate.error_deterministic(
+                    f"{report_name}/{name}/{key} candidates disagree: {values}. "
+                    "Deterministic variance is harness nondeterminism."
+                )
+                gate.note(name, key, "deterministic", "fail", str(baseline_det[key]), str(values))
+                continue
+            actual = next(iter(unique)) if unique else None
+            expected = baseline_det[key]
+            if actual != expected:
+                gate.error_deterministic(
+                    f"{report_name}/{name}/{key} expected {expected} but was {actual}"
+                )
+                gate.note(name, key, "deterministic", "fail", str(expected), str(actual))
+            else:
+                gate.note(name, key, "deterministic", "pass", str(expected), str(actual))
+
+
+def compare_timing(
+    gate: Gate,
+    report_name: str,
+    baseline_scenarios: dict[str, Any],
+    candidates: list[tuple[Path, dict[str, Any]]],
+) -> None:
+    for name, baseline_scenario in baseline_scenarios.items():
+        timing_spec = baseline_scenario.get("timing")
+        if not isinstance(timing_spec, dict):
+            gate.error_schema(f"{report_name}/{name} baseline missing timing object")
+            continue
+        collected: dict[str, list[float]] = {field: [] for field in timing_spec}
+        for path, report in candidates:
+            scenarios = report.get("scenarios")
+            if not isinstance(scenarios, dict) or name not in scenarios:
+                continue
+            try:
+                values = candidate_timing_map(scenarios[name])
+            except ValueError as exc:
+                gate.error_schema(f"{path}/{name} {exc}")
+                continue
+            for field in timing_spec:
+                if field not in values:
+                    gate.error_schema(f"{path}/{name} missing timing field {field}")
+                    continue
+                collected[field].append(values[field])
+
+        for field, spec in timing_spec.items():
+            if not isinstance(spec, dict):
+                gate.error_schema(f"{report_name}/{name}/{field} baseline timing is not an object")
+                continue
+            samples = collected.get(field) or []
+            if not samples:
+                continue
+            observed = median(samples)
+            policy = str(spec.get("policy") or "fail")
+            kind = classify_timing_field(field)
+            evaluate_timing_field(
+                gate,
+                report_name=report_name,
+                scenario=name,
+                field=field,
+                spec=spec,
+                observed=observed,
+                policy=policy,
+                kind=kind,
+            )
+
+
+def evaluate_timing_field(
+    gate: Gate,
+    *,
+    report_name: str,
+    scenario: str,
+    field: str,
+    spec: dict[str, Any],
+    observed: float,
+    policy: str,
+    kind: str,
+) -> None:
+    baseline = as_number(spec["baseline"], label=f"{scenario}/{field} baseline")
+    label = f"{report_name}/{scenario}/{field}"
+    if kind == "throughput":
+        floor = as_number(spec["floor"], label=f"{scenario}/{field} floor")
+        midpoint = baseline - 0.5 * (baseline - floor)
+        expected = f"floor {floor:.3f} (baseline {baseline:.3f})"
+        actual = f"median {observed:.3f}"
+        if observed < floor:
+            message = (
+                f"{label} median {observed:.3f} is below floor {floor:.3f} "
+                f"(baseline {baseline:.3f})"
+            )
+            if policy == "fail":
+                gate.fail_envelope(message)
+                gate.note(scenario, field, "timing", "fail", expected, actual)
+            else:
+                gate.warn(message)
+                gate.note(scenario, field, "timing", "warn", expected, actual)
+        elif observed < midpoint:
+            gate.warn(
+                f"{label} median {observed:.3f} is below warn midpoint {midpoint:.3f} "
+                f"(baseline {baseline:.3f}, floor {floor:.3f})"
+            )
+            gate.note(scenario, field, "timing", "warn", expected, actual)
+        else:
+            gate.note(scenario, field, "timing", "pass", expected, actual)
+        return
+
+    envelope = as_number(spec["envelope"], label=f"{scenario}/{field} envelope")
+    midpoint = baseline + 0.5 * (envelope - baseline)
+    expected = f"envelope {envelope:.3f} (baseline {baseline:.3f})"
+    actual = f"median {observed:.3f}"
+    if observed > envelope:
+        message = (
+            f"{label} median {observed:.3f} exceeds envelope {envelope:.3f} "
+            f"(baseline {baseline:.3f})"
+        )
+        if policy == "fail":
+            gate.fail_envelope(message)
+            gate.note(scenario, field, "timing", "fail", expected, actual)
+        else:
+            gate.warn(message)
+            gate.note(scenario, field, "timing", "warn", expected, actual)
+    elif observed > midpoint:
+        gate.warn(
+            f"{label} median {observed:.3f} exceeds warn midpoint {midpoint:.3f} "
+            f"(baseline {baseline:.3f}, envelope {envelope:.3f})"
+        )
+        gate.note(scenario, field, "timing", "warn", expected, actual)
+    else:
+        gate.note(scenario, field, "timing", "pass", expected, actual)
+
+
+def write_baseline(
+    path: Path,
+    candidates: list[tuple[Path, dict[str, Any]]],
+) -> None:
+    first = candidates[0][1]
+    names = scenario_names(first)
+    scenarios: dict[str, Any] = {}
+    for name in names:
+        det = deterministic_map(first["scenarios"][name])
+        timing_keys = list(candidate_timing_map(first["scenarios"][name]).keys())
+        timing: dict[str, Any] = {}
+        for field in timing_keys:
+            samples = [
+                candidate_timing_map(report["scenarios"][name])[field]
+                for _, report in candidates
+            ]
+            timing[field] = timing_envelope(median(samples), classify_timing_field(field))
+        scenarios[name] = {"deterministic": det, "timing": timing}
+
+    meta = first.get("meta") if isinstance(first.get("meta"), dict) else {}
+    document = {
+        "schemaVersion": SCHEMA_VERSION,
+        "report": first.get("report"),
+        "meta": {
+            "commit": meta.get("commit", "unknown"),
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "runner": os.environ.get("RUNNER_OS", "local"),
+        },
+        "scenarios": scenarios,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote baseline {path}")
+
+
+def write_summary(path: Path | None, gate: Gate, report_name: str) -> None:
+    if path is None:
+        return
+    lines = [
+        f"## Performance gate ({report_name})",
+        "",
+        f"- Deterministic/schema errors: **{len(gate.schema_errors) + len(gate.deterministic_errors)}**",
+        f"- Envelope failures: **{len(gate.envelope_failures)}**",
+        f"- Warnings: **{len(gate.warnings)}**",
+        "",
+        "| Scenario | Field | Kind | Result | Expected | Actual |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    if gate.rows:
+        for scenario, field, kind, result, expected, actual in gate.rows:
+            lines.append(
+                f"| `{scenario}` | `{field}` | {kind} | {result} | {expected} | {actual} |"
+            )
+    else:
+        lines.append("| _none_ |  |  |  |  |  |")
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        if not lines[-1].endswith("\n"):
+            handle.write("\n")
+
+
+def emit(gate: Gate) -> int:
+    for message in gate.warnings:
+        print(f"warning: {message}")
+    for message in gate.schema_errors + gate.deterministic_errors + gate.envelope_failures:
+        print(f"error: {message}", file=sys.stderr)
+    code = gate.exit_code()
+    if code == 2:
+        print(
+            f"Performance gate failed: deterministic/schema error(s). {REBASELINE_HINT}",
+            file=sys.stderr,
+        )
+    elif code == 1:
+        print(
+            f"Performance gate failed: envelope failure(s). {REBASELINE_HINT}",
+            file=sys.stderr,
+        )
+    elif gate.warnings:
+        print(f"Performance gate passed with {len(gate.warnings)} warning(s).")
+    else:
+        print("Performance gate passed.")
+    return code
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, default=None, help="Committed baseline JSON")
+    parser.add_argument(
+        "--candidates",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="Candidate report JSON files",
+    )
+    parser.add_argument(
+        "--deterministic-only",
+        action="store_true",
+        help="Skip timing/envelope comparison",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=None,
+        help="Append a Markdown summary (typically $GITHUB_STEP_SUMMARY)",
+    )
+    parser.add_argument(
+        "--write-baseline",
+        type=Path,
+        default=None,
+        help="Write a baseline from candidate medians and envelope formulas",
+    )
+    args = parser.parse_args(argv)
+
+    if args.baseline is None and args.write_baseline is None:
+        parser.error("either --baseline or --write-baseline is required")
+
+    candidates: list[tuple[Path, dict[str, Any]]] = []
+    gate = Gate()
+    for path in args.candidates:
+        try:
+            candidates.append((path, load_json(path)))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            gate.error_schema(f"{path} could not be read: {exc}")
+    if not candidates:
+        write_summary(args.summary, gate, "unknown")
+        return emit(gate)
+
+    require_timing = args.write_baseline is not None or not args.deterministic_only
+    for path, report in candidates:
+        try:
+            validate_candidate_shape(gate, path, report, require_timing=require_timing)
+        except ValueError as exc:
+            gate.error_schema(f"{path} {exc}")
+
+    first_report = candidates[0][1].get("report")
+    for path, report in candidates[1:]:
+        if report.get("report") != first_report:
+            gate.error_schema(
+                f"{path} report expected {first_report!r} but was {report.get('report')!r}"
+            )
+        try:
+            if set(scenario_names(report)) != set(scenario_names(candidates[0][1])):
+                gate.error_schema(
+                    f"{path} scenarios expected {format_set(scenario_names(candidates[0][1]))} "
+                    f"but has {format_set(scenario_names(report))}"
+                )
+        except ValueError as exc:
+            gate.error_schema(f"{path} {exc}")
+
+    # Cross-candidate deterministic identity even without a baseline.
+    if not gate.schema_errors:
+        try:
+            names = scenario_names(candidates[0][1])
+            for name in names:
+                maps = []
+                for path, report in candidates:
+                    maps.append(deterministic_map(report["scenarios"][name]))
+                for key in maps[0]:
+                    values = [item[key] for item in maps]
+                    if len(set(values)) > 1:
+                        gate.error_deterministic(
+                            f"{first_report}/{name}/{key} candidates disagree: {values}. "
+                            "Deterministic variance is harness nondeterminism."
+                        )
+        except (ValueError, KeyError) as exc:
+            gate.error_schema(str(exc))
+
+    report_name = str(first_report or "unknown")
+    if args.baseline is not None:
+        try:
+            baseline = load_json(args.baseline)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            gate.error_schema(f"{args.baseline} could not be read: {exc}")
+            write_summary(args.summary, gate, report_name)
+            return emit(gate)
+        if baseline.get("schemaVersion") != SCHEMA_VERSION:
+            gate.error_schema(
+                f"{args.baseline} schemaVersion expected {SCHEMA_VERSION} "
+                f"but was {baseline.get('schemaVersion')!r}"
+            )
+        if baseline.get("report") != first_report:
+            gate.error_schema(
+                f"report expected {baseline.get('report')!r} but candidates are {first_report!r}"
+            )
+        baseline_scenarios = baseline.get("scenarios")
+        if not isinstance(baseline_scenarios, dict) or not baseline_scenarios:
+            gate.error_schema(f"{args.baseline} missing scenarios")
+        else:
+            compare_deterministic(gate, report_name, baseline_scenarios, candidates)
+            if not args.deterministic_only:
+                compare_timing(gate, report_name, baseline_scenarios, candidates)
+
+    if args.write_baseline is not None and gate.exit_code() != 2:
+        try:
+            write_baseline(args.write_baseline, candidates)
+        except (OSError, ValueError, KeyError) as exc:
+            gate.error_schema(f"--write-baseline failed: {exc}")
+
+    write_summary(args.summary, gate, report_name)
+    return emit(gate)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/performance-gate-baseline.json
+++ b/scripts/fixtures/performance-gate-baseline.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "runner": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
+        "elapsedMs": { "baseline": 20.0, "envelope": 60.0, "policy": "fail" },
+        "throughputMiBs": { "baseline": 90.0, "floor": 30.0, "policy": "fail" },
+        "cpuSeconds": { "baseline": 0.1, "envelope": 0.35, "policy": "warn" }
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-clean-a.json
+++ b/scripts/fixtures/performance-gate-clean-a.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 10.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 0.1 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-clean-b.json
+++ b/scripts/fixtures/performance-gate-clean-b.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 12.0, "elapsedMs": 22.0, "throughputMiBs": 88.0, "cpuSeconds": 0.11 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-clean-c.json
+++ b/scripts/fixtures/performance-gate-clean-c.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 11.0, "elapsedMs": 21.0, "throughputMiBs": 85.0, "cpuSeconds": 0.12 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-count-regression.json
+++ b/scripts/fixtures/performance-gate-count-regression.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 3, "transportBytes": 100 },
+      "timing": { "firstByteMs": 10.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 0.1 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-envelope-breach.json
+++ b/scripts/fixtures/performance-gate-envelope-breach.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 50.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 0.1 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-outlier.json
+++ b/scripts/fixtures/performance-gate-outlier.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 100.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 0.1 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-warn-band.json
+++ b/scripts/fixtures/performance-gate-warn-band.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 21.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 0.1 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-warn-policy.json
+++ b/scripts/fixtures/performance-gate-warn-policy.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 10.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 1.0 }
+    }
+  }
+}

--- a/scripts/test-performance-baseline-gate.sh
+++ b/scripts/test-performance-baseline-gate.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Fixture checks for scripts/check-performance-baseline.py
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="${ROOT}/scripts/check-performance-baseline.py"
+FIXTURES="${ROOT}/scripts/fixtures"
+BASELINE="${FIXTURES}/performance-gate-baseline.json"
+
+run_gate() {
+  local expected="$1"
+  shift
+  local output=""
+  local actual=0
+  set +e
+  output="$(python3 "${GATE}" "$@" 2>&1)"
+  actual=$?
+  set -e
+  if [[ "${actual}" -ne "${expected}" ]]; then
+    echo "expected exit ${expected}, got ${actual} for: $*" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  printf '%s\n' "${output}"
+}
+
+output="$(run_gate 0 \
+  --baseline "${BASELINE}" \
+  --candidates \
+    "${FIXTURES}/performance-gate-clean-a.json" \
+    "${FIXTURES}/performance-gate-clean-b.json" \
+    "${FIXTURES}/performance-gate-clean-c.json")"
+if grep -q '^error:' <<<"${output}"; then
+  echo "clean candidates unexpectedly printed errors" >&2
+  exit 1
+fi
+
+output="$(run_gate 2 \
+  --baseline "${BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-count-regression.json")"
+if ! grep -q 'transportRequests expected 2 but was 3' <<<"${output}"; then
+  echo "count regression did not name the field" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+if ! grep -q 're-baseline' <<<"${output}"; then
+  echo "count regression did not print re-baseline instruction" >&2
+  exit 1
+fi
+
+run_gate 2 \
+  --baseline "${BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-count-regression.json" \
+  --deterministic-only >/dev/null
+
+output="$(run_gate 1 \
+  --baseline "${BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-envelope-breach.json")"
+if ! grep -q 'firstByteMs' <<<"${output}"; then
+  echo "envelope breach did not name firstByteMs" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+run_gate 0 \
+  --baseline "${BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-envelope-breach.json" \
+  --deterministic-only >/dev/null
+
+output="$(run_gate 0 \
+  --baseline "${BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-warn-band.json")"
+if ! grep -q '^warning:' <<<"${output}"; then
+  echo "warn-band candidate did not warn" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+output="$(run_gate 0 \
+  --baseline "${BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-warn-policy.json")"
+if ! grep -q '^warning:' <<<"${output}"; then
+  echo "warn-policy candidate did not warn" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+if grep -q '^error:' <<<"${output}"; then
+  echo "warn-policy candidate should not fail" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+output="$(run_gate 2 \
+  --baseline "${BASELINE}" \
+  --candidates \
+    "${FIXTURES}/performance-gate-clean-a.json" \
+    "${FIXTURES}/performance-gate-count-regression.json")"
+if ! grep -q 'candidates disagree' <<<"${output}"; then
+  echo "cross-candidate variance was not reported" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+run_gate 0 \
+  --baseline "${BASELINE}" \
+  --candidates \
+    "${FIXTURES}/performance-gate-clean-a.json" \
+    "${FIXTURES}/performance-gate-clean-b.json" \
+    "${FIXTURES}/performance-gate-outlier.json" >/dev/null
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+written="${tmpdir}/written-baseline.json"
+run_gate 0 \
+  --candidates \
+    "${FIXTURES}/performance-gate-clean-a.json" \
+    "${FIXTURES}/performance-gate-clean-b.json" \
+    "${FIXTURES}/performance-gate-clean-c.json" \
+  --write-baseline "${written}" >/dev/null
+
+python3 - "${written}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+timing = baseline["scenarios"]["cold-sequential"]["timing"]
+first = timing["firstByteMs"]
+# median(10, 12, 11) = 11; envelope = max(33, 11+15) = 33
+if first["baseline"] != 11.0:
+    raise SystemExit(f"write-baseline firstByteMs baseline: {first}")
+if first["envelope"] != 33.0:
+    raise SystemExit(f"write-baseline firstByteMs envelope: {first}")
+if first["policy"] != "fail":
+    raise SystemExit(f"write-baseline firstByteMs policy: {first}")
+cpu = timing["cpuSeconds"]
+# median(0.1, 0.11, 0.12) = 0.11; envelope = max(0.33, 0.11+0.25) = 0.36
+if cpu["baseline"] != 0.11:
+    raise SystemExit(f"write-baseline cpuSeconds baseline: {cpu}")
+if cpu["envelope"] != 0.36:
+    raise SystemExit(f"write-baseline cpuSeconds envelope: {cpu}")
+if cpu["policy"] != "warn":
+    raise SystemExit(f"write-baseline cpuSeconds policy: {cpu}")
+throughput = timing["throughputMiBs"]
+# median(90, 88, 85) = 88; floor = 88/3
+if abs(throughput["floor"] - (88.0 / 3.0)) > 0.001:
+    raise SystemExit(f"write-baseline throughput floor: {throughput}")
+PY
+
+run_gate 0 \
+  --baseline "${written}" \
+  --candidates \
+    "${FIXTURES}/performance-gate-clean-a.json" \
+    "${FIXTURES}/performance-gate-clean-b.json" \
+    "${FIXTURES}/performance-gate-clean-c.json" >/dev/null
+
+echo "Performance baseline gate fixtures passed."

--- a/tests/NzbWebDAV.Tests/Api/SabApiResponseShapeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabApiResponseShapeTests.cs
@@ -1,0 +1,288 @@
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.GetHistory;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class SabApiResponseShapeTests : IAsyncLifetime
+{
+    private const int HistoryCount = 500;
+    private const int QueueCount = 50;
+    private const int TvHistoryCount = 50;
+    private const string MoviesCategory = "movies";
+    private const string TvCategory = "tv";
+    private const string QueryCountMessage =
+        "Intentional query-shape change ⇒ update this assertion and the committed SAB API baseline.";
+
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-sab-shape-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private CountingDbCommandInterceptor _interceptor = null!;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        _interceptor = new CountingDbCommandInterceptor();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler(), _interceptor)
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiIgnoreHistoryLimit,
+                ConfigValue = "false",
+            },
+        ]);
+
+        var websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+
+        SeedCorpus(HistoryCount, QueueCount);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        _interceptor.Reset();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task QueueAndHistory_PaginationFingerprintsMatchSeededCorpus()
+    {
+        await AssertQueueAsync("?limit=10", expectedRows: 10, expectedTotal: QueueCount);
+        await AssertQueueAsync("?limit=50", expectedRows: QueueCount, expectedTotal: QueueCount);
+        await AssertQueueAsync("?limit=0", expectedRows: QueueCount, expectedTotal: QueueCount);
+
+        await AssertHistoryAsync("?limit=10&start=0", expectedRows: 10, expectedTotal: HistoryCount);
+        await AssertHistoryAsync("?limit=10&start=490", expectedRows: 10, expectedTotal: HistoryCount);
+        await AssertHistoryAsync("?limit=0", expectedRows: HistoryCount, expectedTotal: HistoryCount);
+        await AssertHistoryAsync($"?limit=10&cat={TvCategory}", expectedRows: 10, expectedTotal: TvHistoryCount);
+    }
+
+    [Fact]
+    public async Task HistoryPagedQuery_CommandCountIsInvariantWhenCorpusDoubles()
+    {
+        const string pagedQuery = "?limit=10&start=0";
+        _interceptor.Reset();
+        var first = await CreateGetHistoryController().GetHistoryAsync(
+            CreateHistoryRequest(pagedQuery));
+        var commandsAt500 = _interceptor.Count;
+        Assert.Equal(10, first.History.Slots.Count);
+        Assert.Equal(HistoryCount, first.History.TotalCount);
+        Assert.True(commandsAt500 > 0, QueryCountMessage);
+
+        SeedHistory(HistoryCount, HistoryCount);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        _interceptor.Reset();
+        var doubled = await CreateGetHistoryController().GetHistoryAsync(
+            CreateHistoryRequest(pagedQuery));
+        Assert.Equal(10, doubled.History.Slots.Count);
+        Assert.Equal(HistoryCount * 2, doubled.History.TotalCount);
+        Assert.True(
+            commandsAt500 == _interceptor.Count,
+            $"history-limit10 dbCommands expected {commandsAt500} after doubling corpus but was {_interceptor.Count}. {QueryCountMessage}");
+    }
+
+    private async Task AssertQueueAsync(string query, int expectedRows, int expectedTotal)
+    {
+        _interceptor.Reset();
+        var response = await CreateGetQueueController().GetQueueAsync(CreateQueueRequest(query));
+        Assert.Equal(expectedRows, response.Queue.Slots.Count);
+        Assert.Equal(expectedTotal, response.Queue.TotalCount);
+        Assert.True(
+            _interceptor.Count == 2,
+            $"queue {query} dbCommands expected 2 but was {_interceptor.Count}. {QueryCountMessage}");
+    }
+
+    private async Task AssertHistoryAsync(string query, int expectedRows, int expectedTotal)
+    {
+        _interceptor.Reset();
+        var response = await CreateGetHistoryController().GetHistoryAsync(CreateHistoryRequest(query));
+        Assert.Equal(expectedRows, response.History.Slots.Count);
+        Assert.Equal(expectedTotal, response.History.TotalCount);
+        Assert.True(
+            _interceptor.Count == 2,
+            $"history {query} dbCommands expected 2 but was {_interceptor.Count}. {QueryCountMessage}");
+    }
+
+    private GetQueueController CreateGetQueueController() =>
+        new(new DefaultHttpContext(), _dbClient, _queueManager, _configManager, new ProviderUsageTracker());
+
+    private GetHistoryController CreateGetHistoryController() =>
+        new(new DefaultHttpContext(), _dbClient, _configManager, new ProviderUsageTracker());
+
+    private GetQueueRequest CreateQueueRequest(string query)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(query);
+        return new GetQueueRequest(context, _configManager);
+    }
+
+    private GetHistoryRequest CreateHistoryRequest(string query)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(query);
+        return new GetHistoryRequest(context, _configManager);
+    }
+
+    private void SeedCorpus(int historyCount, int queueCount)
+    {
+        SeedQueue(queueCount);
+        SeedHistory(0, historyCount);
+    }
+
+    private void SeedQueue(int count)
+    {
+        var epoch = DateTime.UnixEpoch;
+        _context.QueueItems.AddRange(Enumerable.Range(0, count).Select(index => new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = epoch.AddMinutes(index),
+            SortOrder = index,
+            FileName = $"job-{index:D4}.nzb",
+            JobName = $"job-{index:D4}",
+            NzbFileSize = 1000 + index,
+            TotalSegmentBytes = 2000 + index,
+            Category = MoviesCategory,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        }));
+    }
+
+    private void SeedHistory(int startIndex, int count)
+    {
+        var epoch = DateTime.UnixEpoch;
+        _context.HistoryItems.AddRange(Enumerable.Range(startIndex, count).Select(index => new HistoryItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = epoch.AddMinutes(index),
+            FileName = $"job-{index:D4}.nzb",
+            JobName = $"job-{index:D4}",
+            Category = index < TvHistoryCount ? TvCategory : MoviesCategory,
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+            TotalSegmentBytes = 1000 + index,
+            DownloadTimeSeconds = 5,
+        }));
+    }
+
+    private sealed class CountingDbCommandInterceptor : DbCommandInterceptor
+    {
+        private int _count;
+        public int Count => _count;
+        public void Reset() => _count = 0;
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            _count++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            _count++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<object> ScalarExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            _count++;
+            return base.ScalarExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<object> result,
+            CancellationToken cancellationToken = default)
+        {
+            _count++;
+            return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            _count++;
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            _count++;
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/SabApiResponseShapeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabApiResponseShapeTests.cs
@@ -35,6 +35,7 @@ public sealed class SabApiResponseShapeTests : IAsyncLifetime
     private readonly string _configRoot =
         Path.Join(Path.GetTempPath(), $"nzbdav-sab-shape-cfg-{Guid.NewGuid():N}");
     private string? _previousConfigPath;
+    private bool _configPathOverridden;
     private CountingDbCommandInterceptor _interceptor = null!;
     private DavDatabaseContext _context = null!;
     private DavDatabaseClient _dbClient = null!;
@@ -44,67 +45,109 @@ public sealed class SabApiResponseShapeTests : IAsyncLifetime
     public async Task InitializeAsync()
     {
         _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
-        Directory.CreateDirectory(_configRoot);
-        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+        try
+        {
+            Directory.CreateDirectory(_configRoot);
+            Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+            _configPathOverridden = true;
 
-        _interceptor = new CountingDbCommandInterceptor();
-        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
-            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
-            .AddInterceptors(new SqliteForeignKeyEnabler(), _interceptor)
-            .ReplaceService<
-                IMigrationsSqlGenerator,
-                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
-            .Options;
-        _context = new DavDatabaseContext(options);
-        await _context.Database.MigrateAsync();
-        _dbClient = new DavDatabaseClient(_context);
+            _interceptor = new CountingDbCommandInterceptor();
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler(), _interceptor)
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            _context = new DavDatabaseContext(options);
+            await _context.Database.MigrateAsync();
+            _dbClient = new DavDatabaseClient(_context);
 
-        _configManager = new ConfigManager();
-        _configManager.UpdateValues(
-        [
-            new ConfigItem
+            _configManager = new ConfigManager();
+            _configManager.UpdateValues(
+            [
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.UsenetProviders,
+                    ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+                },
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.ApiIgnoreHistoryLimit,
+                    ConfigValue = "false",
+                },
+            ]);
+
+            var websocketManager = new WebsocketManager();
+            var usenet = new UsenetStreamingClient(
+                _configManager,
+                websocketManager,
+                new ProviderUsageTracker(),
+                new MetricsWriter(),
+                new ProviderBytesTracker(),
+                new StreamTraceBuffer(100),
+                new ActiveReadRegistry());
+            _queueManager = new QueueManager(
+                usenet,
+                _configManager,
+                websocketManager,
+                new ProviderUsageTracker(),
+                new WatchdogLog(),
+                new QueueItemSourceTracker(),
+                new BenchmarkGate(),
+                startLoop: false);
+
+            SeedCorpus(HistoryCount, QueueCount);
+            await _context.SaveChangesAsync();
+            _context.ChangeTracker.Clear();
+            _interceptor.Reset();
+        }
+        catch
+        {
+            try
             {
-                ConfigName = ConfigKeys.UsenetProviders,
-                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
-            },
-            new ConfigItem
+                await DisposeAsync();
+            }
+            catch
             {
-                ConfigName = ConfigKeys.ApiIgnoreHistoryLimit,
-                ConfigValue = "false",
-            },
-        ]);
+                // best-effort teardown after a failed InitializeAsync
+            }
 
-        var websocketManager = new WebsocketManager();
-        var usenet = new UsenetStreamingClient(
-            _configManager,
-            websocketManager,
-            new ProviderUsageTracker(),
-            new MetricsWriter(),
-            new ProviderBytesTracker(),
-            new StreamTraceBuffer(100),
-            new ActiveReadRegistry());
-        _queueManager = new QueueManager(
-            usenet,
-            _configManager,
-            websocketManager,
-            new ProviderUsageTracker(),
-            new WatchdogLog(),
-            new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
-
-        SeedCorpus(HistoryCount, QueueCount);
-        await _context.SaveChangesAsync();
-        _context.ChangeTracker.Clear();
-        _interceptor.Reset();
+            throw;
+        }
     }
 
     public async Task DisposeAsync()
     {
-        _queueManager.Dispose();
-        await _context.DisposeAsync();
-        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
-        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+        try
+        {
+            var queueManager = _queueManager;
+            _queueManager = null!;
+            queueManager?.Dispose();
+
+            var context = _context;
+            _context = null!;
+            if (!ReferenceEquals(context, null))
+                await context.DisposeAsync();
+        }
+        finally
+        {
+            if (_configPathOverridden)
+            {
+                Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+                _configPathOverridden = false;
+            }
+
+            try
+            {
+                if (Directory.Exists(_configRoot))
+                    Directory.Delete(_configRoot, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best effort
+            }
+        }
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
@@ -9,6 +10,19 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
 {
     private const int SegmentSize = 8 * 1024;
     private const int SegmentCount = 6;
+    private const int RangeProbeOffset = SegmentSize + 127;
+    private const int RangeProbeCount = 1024;
+    private const int TailProbeCount = 257;
+    private const int RangeProbeTransportRequests = 0;
+    private const int RangeProbeTransportBytes = 0;
+    private const int TailProbeTransportRequests = 0;
+    private const int TailProbeTransportBytes = 0;
+    private const int SeekTransportRequests = 0;
+    private const int SeekTransportBytes = 0;
+    private const int DeadArticleTransportRequests = 2;
+    private const int DeadArticleTransportBytes = 0;
+    private const string TransportContractMessage =
+        "Intentional transport-contract change ⇒ update this constant and the committed baseline.";
 
     [Fact]
     public async Task DeterministicFixture_CoversColdWarmRangeTailSeekAndDeadArticlePaths()
@@ -27,7 +41,7 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
 
             await AssertReadMatchesAsync(transport, fixture, offset: 0, count: fixture.Source.Length);
             var coldTransportRequests = transport.BodyRequestCount;
-            var coldTransportBytes = transport.RequestedSegmentIds.Sum(id => fixture.Segments[id].Length);
+            var coldTransportBytes = TransportBytes(transport, fixture.Segments);
             Assert.Equal(SegmentCount, coldTransportRequests);
             Assert.Equal(fixture.Source.Length, coldTransportBytes);
 
@@ -36,9 +50,16 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
             await AssertReadMatchesAsync(cached, fixture, offset: 0, count: fixture.Source.Length);
             Assert.Equal(requestsBeforeWarmRead, transport.BodyRequestCount);
 
-            await AssertReadMatchesAsync(cached, fixture, offset: SegmentSize + 127, count: 1024);
-            await AssertReadMatchesAsync(cached, fixture, offset: fixture.Source.Length - 257, count: 257);
+            await AssertTransportDeltaAsync(
+                transport, fixture.Segments, "range-probe", RangeProbeTransportRequests, RangeProbeTransportBytes,
+                () => AssertReadMatchesAsync(cached, fixture, RangeProbeOffset, RangeProbeCount));
+            await AssertTransportDeltaAsync(
+                transport, fixture.Segments, "tail-probe", TailProbeTransportRequests, TailProbeTransportBytes,
+                () => AssertReadMatchesAsync(
+                    cached, fixture, fixture.Source.Length - TailProbeCount, TailProbeCount));
 
+            var requestsBeforeSeeks = transport.BodyRequestCount;
+            var bytesBeforeSeeks = TransportBytes(transport, fixture.Segments);
             await using (var stream = fixture.CreateStream(cached))
             {
                 foreach (var offset in new[] { 17, SegmentSize * 3 + 91, SegmentSize * 2 + 7 })
@@ -49,6 +70,13 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
                     Assert.Equal(fixture.Source.AsSpan(offset, read).ToArray(), buffer);
                 }
             }
+
+            AssertTransportContract(
+                "seeks",
+                SeekTransportRequests,
+                transport.BodyRequestCount - requestsBeforeSeeks,
+                SeekTransportBytes,
+                TransportBytes(transport, fixture.Segments) - bytesBeforeSeeks);
 
             var deadSegments = fixture.Segments
                 .Where(pair => pair.Key != fixture.SegmentIds[2])
@@ -64,6 +92,12 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
                 deadBuffer, deadBuffer.Length, throwOnEndOfStream: true));
             Assert.Equal(new byte[SegmentSize], deadBuffer);
             Assert.Contains(fixture.SegmentIds[2], deadTransport.RequestedSegmentIds);
+            AssertTransportContract(
+                "dead-article",
+                DeadArticleTransportRequests,
+                deadTransport.BodyRequestCount,
+                DeadArticleTransportBytes,
+                TransportBytes(deadTransport, deadSegments));
         }
         finally
         {
@@ -71,6 +105,81 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
                 Directory.Delete(cacheDir, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task MaxConsecutiveZeroFills_ZeroFillsUpToBoundThenAborts()
+    {
+        var fixture = CreateFixture();
+        // Keep segment 0 so NzbFileStream does not fail-fast on the first article,
+        // then remove the next MaxConsecutiveZeroFills segments.
+        var missingIds = fixture.SegmentIds
+            .Skip(1)
+            .Take(GapFillLimits.MaxConsecutiveZeroFills)
+            .ToHashSet(StringComparer.Ordinal);
+        var remaining = fixture.Segments
+            .Where(pair => !missingIds.Contains(pair.Key))
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
+        var transport = new FakeNntpClient(
+            remaining,
+            useCachedYencStreams: true,
+            segmentRanges: fixture.RangesById);
+        await using var stream = fixture.CreateStream(transport);
+        var buffer = new byte[SegmentSize];
+
+        Assert.Equal(SegmentSize, await stream.ReadAtLeastAsync(
+            buffer, buffer.Length, throwOnEndOfStream: true));
+        Assert.Equal(fixture.Source.AsSpan(0, SegmentSize).ToArray(), buffer);
+
+        for (var index = 0; index < GapFillLimits.MaxConsecutiveZeroFills - 1; index++)
+        {
+            Assert.Equal(SegmentSize, await stream.ReadAtLeastAsync(
+                buffer, buffer.Length, throwOnEndOfStream: true));
+            Assert.Equal(new byte[SegmentSize], buffer);
+        }
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream.ReadAtLeastAsync(
+                buffer, buffer.Length, throwOnEndOfStream: false));
+        Assert.Equal(1 + GapFillLimits.MaxConsecutiveZeroFills, transport.BodyRequestCount);
+    }
+
+    private static async Task AssertTransportDeltaAsync(
+        FakeNntpClient transport,
+        IReadOnlyDictionary<string, byte[]> servedSegments,
+        string scenario,
+        int expectedRequests,
+        long expectedBytes,
+        Func<Task> action)
+    {
+        var requestsBefore = transport.BodyRequestCount;
+        var bytesBefore = TransportBytes(transport, servedSegments);
+        await action();
+        AssertTransportContract(
+            scenario,
+            expectedRequests,
+            transport.BodyRequestCount - requestsBefore,
+            expectedBytes,
+            TransportBytes(transport, servedSegments) - bytesBefore);
+    }
+
+    private static void AssertTransportContract(
+        string scenario,
+        int expectedRequests,
+        int actualRequests,
+        long expectedBytes,
+        long actualBytes)
+    {
+        Assert.True(
+            actualRequests == expectedRequests && actualBytes == expectedBytes,
+            $"{scenario} expected requests={expectedRequests} bytes={expectedBytes} " +
+            $"but was requests={actualRequests} bytes={actualBytes}. {TransportContractMessage}");
+    }
+
+    private static long TransportBytes(
+        FakeNntpClient transport,
+        IReadOnlyDictionary<string, byte[]> servedSegments) =>
+        transport.RequestedSegmentIds.Sum(id =>
+            servedSegments.TryGetValue(id, out var bytes) ? bytes.Length : 0);
 
     private static async Task AssertReadMatchesAsync(
         INntpClient client,


### PR DESCRIPTION
## Summary

Closes #854.

- Adds a two-layer performance regression gate: PR CI now compares **deterministic** transport and SAB API fields (`transportRequests`, `transportBytes`, `rowsReturned`, `totalCount`, EF `dbCommands`) from the `--streaming-report` and new `--sab-api-report` harnesses against committed baselines in `backend.Benchmarks/Baselines/` — no clocks anywhere in the PR-blocking path.
- A new nightly/manual `performance.yml` workflow runs each report 3×, checks timing medians against floored 3× envelopes (fail) with midpoint warnings and warn-only CPU, archives JSON artifacts for 90 days, retries envelope failures once, notifies the development Discord on failure, and offers a `rebaseline: true` dispatch that opens (never merges) a baseline-refresh PR.
- The streaming report gains schema-versioned JSON output, per-scenario CPU capture, and a discarded JIT warm-up pass; the SAB report measures queue/history pagination against a seeded temp-SQLite corpus with an EF command-count fingerprint as the N+1 guard; xUnit coverage now asserts exact transport counts for probe/seek/dead-article paths plus the `MaxConsecutiveZeroFills` boundary.
- Production diff is exactly one `InternalsVisibleTo("NzbWebDAV.Benchmarks")` line; the benchmarks assembly is never shipped and the Dockerfile is untouched.

## Acceptance-criteria deviations (for maintainer sign-off)

| Issue #854 asked for | This PR ships | Why |
|---|---|---|
| k6 / wrk / custom client choice | Custom in-process .NET harness | Deterministic transport fakes and EF command counting require in-process wiring; documented in `backend.Benchmarks/README.md` |
| WebDAV GET p50/p95/p99 over HTTP | Stream-level first-byte/elapsed/throughput + range/tail probes | Full-pipeline HTTP percentiles from tiny in-process samples are statistically meaningless; probes are the deterministic ffprobe proxy |
| Hard 10%/5% PR CI timing gates | Deterministic exact gates in PR CI + scheduled floored 3× envelopes | Per #1025's own constraint ("generous regression envelopes rather than flaky unit-test assertions"); shared runners jitter 2-5× |
| — | SAB `addfile` ingest excluded | AC names "queue/history response time"; addfile drags in queue processing/archive parsing |

## Coordination notes

- **PR #1042** (segment buffer pool) also touches `backend.Benchmarks/Program.cs`; whichever lands second resolves a trivial dispatch conflict, and any deterministic drift will surface in that PR's own CI gate.
- **Post-merge action required:** committed timing envelopes were captured on a local macOS machine (deterministic fields are platform-independent and verified in CI). Run **Actions → Performance → Run workflow → `rebaseline: true`** once after merge (and again after #1042 merges) to capture ubuntu-latest envelopes; until then the nightly may fail envelopes — it never blocks PRs.
- Re-baseline PRs are created with `GITHUB_TOKEN` and will not trigger CI automatically — close/reopen or push to run checks.

## Test plan

- [x] Backend suite: 3182 passed / 10 skipped / 0 failed (reviewer re-ran independently)
- [x] Benchmarks build clean under the warnings-as-errors gate
- [x] `scripts/test-performance-baseline-gate.sh` fixture self-test passes (exit codes 0/1/2, deterministic-only, cross-candidate variance, median outlier, `--write-baseline` round-trip)
- [x] Both reports run with `--json`; comparator `--deterministic-only` passes against committed baselines; deterministic fields byte-identical across runs
- [x] Both workflow YAML files parse
- [x] Production diff verified as exactly one `InternalsVisibleTo` line; Dockerfile untouched
- [ ] Post-merge: dispatch Performance workflow with `rebaseline: true` to capture ubuntu-latest envelopes