### PR TITLE
feat(ui): choose the category when uploading NZBs from the queue page

### DIFF
--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -12,7 +12,7 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 |---------|------------|---------|--------|
 | API Key | `api.key` | from `FRONTEND_BACKEND_API_KEY` if unset | *Arr download client auth |
 | Categories | `api.categories` | env/`audio,software,tv,movies` | Letters/numbers/dashes |
-| Manual Upload Category | `api.manual-category` | `uncategorized` | Queue page uploads |
+| Manual Upload Category (upload-time picker [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }) | `api.manual-category` | `uncategorized` | Queue page uploads; default for the category picker beside the Upload NZB button |
 | Import Strategy | `api.import-strategy` | `symlinks` | Symlinks (Plex) / STRM (Emby/Jellyfin) |
 | Rclone Mount Directory | `rclone.mount-dir` | env `MOUNT_DIR` or `/mnt/nzbdav` | When symlinks |
 | Completed Downloads Dir | `api.completed-downloads-dir` | backend default under `/data` | When STRM |

--- a/frontend/app/routes/queue/components/queue-table/queue-table.tsx
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.tsx
@@ -34,7 +34,6 @@ export type QueueTableProps = {
     onPageSelected: (page: number) => void,
     onPageSizeSelected: (pageSize: number) => void,
     categories: string[],
-    manualCategoryRef: React.RefObject<string>,
     onIsSelectedChanged: (nzo_ids: Set<string>, isSelected: boolean) => void,
     onIsRemovingChanged: (nzo_ids: Set<string>, isRemoving: boolean) => void,
     onRemoved: (nzo_ids: Set<string>) => void,
@@ -94,7 +93,6 @@ export function QueueTable({
     onPageSelected,
     onPageSizeSelected,
     categories,
-    manualCategoryRef,
     onIsSelectedChanged,
     onIsRemovingChanged,
     onRemoved,
@@ -233,12 +231,6 @@ export function QueueTable({
 
 
     // view
-    const categoryDropdown = useMemo(() => isReadOnly ? null : (
-        <Tooltip content="Choose the category for manual nzb uploads.">
-            <SimpleDropdown options={categories} valueRef={manualCategoryRef} />
-        </Tooltip>
-    ), [categories, isReadOnly, manualCategoryRef]);
-
     const sectionTitle = (
         <div className="flex flex-wrap items-center gap-2.5">
             <h2
@@ -289,15 +281,6 @@ export function QueueTable({
                     <ActionButton type="delete" onClick={onRemove} />
                 </>
             }
-            <div className="ml-2.5 hidden min-[450px]:block">
-                {categoryDropdown}
-            </div>
-        </div>
-    );
-
-    const sectionSubTitle = (
-        <div className="block min-[450px]:hidden">
-            {categoryDropdown}
         </div>
     );
 
@@ -319,7 +302,6 @@ export function QueueTable({
     return (
         <PageSection
             title={sectionTitle}
-            subTitle={sectionSubTitle}
             {...(totalQueueCount > 0 ? { badgeText: String(totalQueueCount) } : {})}
         >
             <ListToolbar

--- a/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.test.tsx
+++ b/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+/* global HTMLSelectElement */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode, SelectHTMLAttributes } from "react";
+
+vi.mock("~/components/ui", () => ({
+    Select: ({ children, ...props }: SelectHTMLAttributes<HTMLSelectElement> & { children?: ReactNode }) => (
+        <select {...props}>{children}</select>
+    ),
+}));
+
+import { SimpleDropdown } from "./simple-dropdown";
+
+afterEach(cleanup);
+
+describe("SimpleDropdown", () => {
+    it("displays valueRef.current on first render when it differs from options[0]", () => {
+        const valueRef = { current: "anime" };
+
+        render(
+            <SimpleDropdown
+                options={["tv", "movies", "anime"]}
+                valueRef={valueRef}
+                ariaLabel="Upload category"
+            />,
+        );
+
+        expect(screen.getByRole<HTMLSelectElement>("combobox", { name: "Upload category" }).value).toBe("anime");
+    });
+
+    it("writes the selected option through valueRef and updates the display", async () => {
+        const user = userEvent.setup();
+        const valueRef = { current: "tv" };
+
+        render(
+            <SimpleDropdown
+                options={["tv", "movies", "anime"]}
+                valueRef={valueRef}
+                ariaLabel="Upload category"
+            />,
+        );
+
+        const select = screen.getByRole<HTMLSelectElement>("combobox", { name: "Upload category" });
+        await user.selectOptions(select, "movies");
+
+        expect(valueRef.current).toBe("movies");
+        expect(select.value).toBe("movies");
+    });
+
+    it("renders the provided value and calls onChange in value/onChange mode", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+
+        render(
+            <SimpleDropdown
+                options={["tv", "movies", "anime"]}
+                value="movies"
+                onChange={onChange}
+                ariaLabel="Bulk category"
+            />,
+        );
+
+        const select = screen.getByRole<HTMLSelectElement>("combobox", { name: "Bulk category" });
+        expect(select.value).toBe("movies");
+
+        await user.selectOptions(select, "anime");
+
+        expect(onChange).toHaveBeenCalledWith("anime");
+        expect(select.value).toBe("movies");
+    });
+});

--- a/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.tsx
+++ b/frontend/app/routes/queue/components/simple-dropdown/simple-dropdown.tsx
@@ -15,7 +15,9 @@ export const SimpleDropdown = memo(({ type, options, value, onChange, valueRef, 
         throw new Error("SimpleDropdown requires either the valueRef prop or both the value and onChange props.")
     }
 
-    const [internalValue, setInternalValue] = useState(options.length > 0 ? options[0] : "");
+    const [internalValue, setInternalValue] = useState(
+        () => valueRef?.current ?? (options.length > 0 ? options[0] : ""),
+    );
     const renderedValue = value ?? internalValue;
 
     const handleNativeChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/app/routes/queue/route.component.test.tsx
+++ b/frontend/app/routes/queue/route.component.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
-
+/* global HTMLSelectElement */
 import { cleanup, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode, SelectHTMLAttributes } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isReadOnlyMock, openMock } = vi.hoisted(() => ({
+const { isReadOnlyMock, openMock, dropzoneArgs } = vi.hoisted(() => ({
     isReadOnlyMock: vi.fn(),
     openMock: vi.fn(),
+    dropzoneArgs: { current: [] as unknown[] },
 }));
 
 vi.mock("react-router", () => ({
@@ -45,18 +47,24 @@ vi.mock("./controllers/nzb-upload-controller", () => ({
 }));
 
 vi.mock("./controllers/dropzone-controller", () => ({
-    useQueueDropzone: () => ({
-        getRootProps: () => ({}),
-        getInputProps: () => ({}),
-        isDragActive: false,
-        open: openMock,
-    }),
+    useQueueDropzone: (...args: unknown[]) => {
+        dropzoneArgs.current = args;
+        return {
+            getRootProps: () => ({}),
+            getInputProps: () => ({}),
+            isDragActive: false,
+            open: openMock,
+        };
+    },
 }));
 
 vi.mock("~/components/ui", () => ({
     Alert: ({ children }: { children: ReactNode }) => <>{children}</>,
     Button: ({ children, onClick }: { children: ReactNode, onClick: () => void }) => (
         <button type="button" onClick={onClick}>{children}</button>
+    ),
+    Select: ({ children, ...props }: SelectHTMLAttributes<HTMLSelectElement> & { children?: ReactNode }) => (
+        <select {...props}>{children}</select>
     ),
 }));
 
@@ -77,8 +85,8 @@ function renderQueue(queueSlots: Array<{ nzo_id: string }> = []) {
                     historySlots: [],
                     totalQueueCount: queueSlots.length,
                     totalHistoryCount: 0,
-                    categories: ["uncategorized"],
-                    manualCategory: "uncategorized",
+                    categories: ["tv", "movies", "anime"],
+                    manualCategory: "anime",
                     queuePage: 1,
                     historyPage: 1,
                     queuePageSize: 100,
@@ -91,11 +99,20 @@ function renderQueue(queueSlots: Array<{ nzo_id: string }> = []) {
     );
 }
 
+function getUploadCategorySelect() {
+    return screen.getByRole<HTMLSelectElement>("combobox", { name: "Upload category" });
+}
+
+function getManualCategoryRef() {
+    return dropzoneArgs.current[2] as { current: string };
+}
+
 describe("Queue upload control", () => {
     beforeEach(() => {
         isReadOnlyMock.mockReset();
         isReadOnlyMock.mockReturnValue(false);
         openMock.mockReset();
+        dropzoneArgs.current = [];
     });
 
     it.each([
@@ -107,6 +124,35 @@ describe("Queue upload control", () => {
         expect(screen.getByRole("button", { name: "Upload NZB" })).toBeTruthy();
     });
 
+    it.each([
+        ["the queue is empty", []],
+        ["the queue has items", [{ nzo_id: "queue-1" }]],
+    ])("renders a labeled Category selector next to Upload NZB when %s", (_, queueSlots) => {
+        renderQueue(queueSlots);
+
+        expect(screen.getByText("Category")).toBeTruthy();
+        expect(getUploadCategorySelect()).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Upload NZB" })).toBeTruthy();
+    });
+
+    it("displays the loader manual category in the selector", () => {
+        renderQueue();
+
+        expect(getUploadCategorySelect().value).toBe("anime");
+    });
+
+    it("updates the dropzone manualCategoryRef when the selector changes", async () => {
+        const user = userEvent.setup();
+        renderQueue();
+
+        expect(getManualCategoryRef().current).toBe("anime");
+
+        await user.selectOptions(getUploadCategorySelect(), "movies");
+
+        expect(getManualCategoryRef().current).toBe("movies");
+        expect(getUploadCategorySelect().value).toBe("movies");
+    });
+
     it("opens the file picker from the page-level action", () => {
         renderQueue([{ nzo_id: "queue-1" }]);
 
@@ -115,11 +161,13 @@ describe("Queue upload control", () => {
         expect(openMock).toHaveBeenCalledOnce();
     });
 
-    it("hides Upload NZB for read-only users", () => {
+    it("hides Upload NZB and the category selector for read-only users", () => {
         isReadOnlyMock.mockReturnValue(true);
 
         renderQueue([{ nzo_id: "queue-1" }]);
 
         expect(screen.queryByRole("button", { name: "Upload NZB" })).toBeNull();
+        expect(screen.queryByRole("combobox", { name: "Upload category" })).toBeNull();
+        expect(screen.queryByText("Category")).toBeNull();
     });
 });

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -9,6 +9,7 @@ import { useQueueHistoryWebsocket } from "./controllers/websocket-controller";
 import { useUploadController } from "./controllers/nzb-upload-controller";
 import { useQueueDropzone } from "./controllers/dropzone-controller";
 import { Alert, Button } from "~/components/ui";
+import { SimpleDropdown } from "./components/simple-dropdown/simple-dropdown";
 import { useIsReadOnly } from "~/auth/authorization";
 import { isDefaultList, parseHistoryListParams, parseQueueListParams } from "./list-params";
 
@@ -206,7 +207,16 @@ export default function Queue(props: Route.ComponentProps) {
             {/* queue */}
             <div className="min-h-[413.9px] min-[450px]:min-h-[382.9px]">
                 {!isReadOnly && (
-                    <div className="mb-3 flex justify-end">
+                    <div className="mb-3 flex flex-wrap items-center justify-end gap-2">
+                        <label className="flex items-center gap-2 text-xs text-base-content/60">
+                            Category
+                            <SimpleDropdown
+                                type="bordered"
+                                options={props.loaderData.categories}
+                                valueRef={manualCategoryRef}
+                                ariaLabel="Upload category"
+                            />
+                        </label>
                         <Button variant="primary" size="small" onClick={dropzone.open}>
                             Upload NZB
                         </Button>
@@ -232,7 +242,6 @@ export default function Queue(props: Route.ComponentProps) {
                         onPageSelected={onQueuePageSelected}
                         onPageSizeSelected={onQueuePageSizeSelected}
                         categories={props.loaderData.categories}
-                        manualCategoryRef={manualCategoryRef}
                         onIsSelectedChanged={queueEvents.onSelectQueueSlots}
                         onIsRemovingChanged={queueEvents.onRemovingQueueSlots}
                         onRemoved={queueEvents.onRemoveQueueSlots}


### PR DESCRIPTION
## Summary

- Adds a labeled category picker beside the Upload NZB button on the Queue page, defaulting to the Manual Upload Category setting (`api.manual-category`). The selection applies to both button uploads and drag-and-drop, and resets to the settings default on each page load — no persistence, no config write-back.
- Fixes the pre-existing dropdown bug where the displayed category was wrong on first render whenever the manual category wasn't first in the configured list (uploads used the correct value; only the display was wrong).
- Replaces the undiscoverable tooltip-only dropdown in the Queue card header — the picker now lives next to the action it controls.
- Part 2 of the issue (upload access while items are downloading) already shipped on main via #1008; this PR completes part 1. Search-page category selection is deferred to #1048.

No backend, API, or config changes; the default upload path is unchanged.

Closes #997

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (63 files / 662 tests, incl. new SimpleDropdown regression tests and queue-page picker coverage: initial display, ref updates, read-only hiding)
- [ ] Manual: upload with a non-default category → item lands under `/content/<category>/`; drag-and-drop honors the picker; reload resets to the settings default