### PR TITLE
feat(health): replace releases with unplayable corrupt data instead of serving silent gaps

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -82,7 +82,8 @@ public interface INntpClient : IDisposable
         string? fileName = null,
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
-        int streamingBodyBatchWidth = 4);
+        int streamingBodyBatchWidth = 4,
+        HashSet<string>? knownCorruptSegmentIds = null);
 
     NzbFileStream GetFileStream(
         NzbFile nzbFile,
@@ -92,7 +93,8 @@ public interface INntpClient : IDisposable
         string? fileName = null,
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
-        int streamingBodyBatchWidth = 4);
+        int streamingBodyBatchWidth = 4,
+        HashSet<string>? knownCorruptSegmentIds = null);
 
     NzbFileStream GetFileStream(
         string[] segmentIds,
@@ -104,7 +106,8 @@ public interface INntpClient : IDisposable
         string[][]? segmentFallbacks = null,
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
-        int streamingBodyBatchWidth = 4);
+        int streamingBodyBatchWidth = 4,
+        HashSet<string>? knownCorruptSegmentIds = null);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -142,7 +142,8 @@ public abstract class NntpClient : INntpClient
         string? fileName = null,
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
-        int streamingBodyBatchWidth = 4)
+        int streamingBodyBatchWidth = 4,
+        HashSet<string>? knownCorruptSegmentIds = null)
     {
         var segmentIds = nzbFile.GetSegmentIds();
         var fileSize = await GetFileSizeAsync(nzbFile, ct).ConfigureAwait(false);
@@ -157,7 +158,8 @@ public abstract class NntpClient : INntpClient
             nzbFile.GetSegmentFallbackIds(),
             inFlightArticleBudget,
             useContainerAwareFill,
-            streamingBodyBatchWidth);
+            streamingBodyBatchWidth,
+            knownCorruptSegmentIds);
     }
 
     public virtual NzbFileStream GetFileStream(
@@ -168,7 +170,8 @@ public abstract class NntpClient : INntpClient
         string? fileName = null,
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
-        int streamingBodyBatchWidth = 4)
+        int streamingBodyBatchWidth = 4,
+        HashSet<string>? knownCorruptSegmentIds = null)
     {
         return new NzbFileStream(
             nzbFile.GetSegmentIds(),
@@ -181,7 +184,8 @@ public abstract class NntpClient : INntpClient
             nzbFile.GetSegmentFallbackIds(),
             inFlightArticleBudget,
             useContainerAwareFill,
-            streamingBodyBatchWidth
+            streamingBodyBatchWidth,
+            knownCorruptSegmentIds
         );
     }
 
@@ -195,7 +199,8 @@ public abstract class NntpClient : INntpClient
         string[][]? segmentFallbacks = null,
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
-        int streamingBodyBatchWidth = 4)
+        int streamingBodyBatchWidth = 4,
+        HashSet<string>? knownCorruptSegmentIds = null)
     {
         return new NzbFileStream(
             segmentIds,
@@ -208,7 +213,8 @@ public abstract class NntpClient : INntpClient
             segmentFallbacks,
             inFlightArticleBudget,
             useContainerAwareFill,
-            streamingBodyBatchWidth);
+            streamingBodyBatchWidth,
+            knownCorruptSegmentIds);
     }
 
     private static string? ResolveFileName(string? fileName, NzbFile nzbFile)

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -100,6 +100,7 @@ public static class ConfigKeys
     public const string RepairDegradedMaxConsecutiveMissing = "repair.degraded-max-consecutive-missing";
     public const string RepairDegradedMaxTotalMissing = "repair.degraded-max-total-missing";
     public const string RepairDegradedMaxMissingBytePercent = "repair.degraded-max-missing-byte-percent";
+    public const string RepairCorruptionTrackingEnabled = "repair.corruption-tracking-enabled";
     public const string ArrInstances = "arr.instances";
 
     // rclone

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1034,6 +1034,14 @@ public class ConfigManager
         return toleranceValue == null || bool.Parse(toleranceValue);
     }
 
+    public bool IsCorruptionTrackingEnabled()
+    {
+        var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
+        if (repairValue == null || !bool.Parse(repairValue)) return false;
+        var trackingValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairCorruptionTrackingEnabled));
+        return trackingValue == null || bool.Parse(trackingValue);
+    }
+
     public int GetDegradedMaxConsecutiveMissing()
     {
         var value = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairDegradedMaxConsecutiveMissing));

--- a/backend/Database/Models/DavNzbFile.cs
+++ b/backend/Database/Models/DavNzbFile.cs
@@ -53,6 +53,15 @@ public partial class DavNzbFile
     [MemoryPackOrder(6)]
     public long? CriticalHeadEndExclusive { get; set; }
 
+    /// <summary>
+    /// Absolute segment indices confirmed corrupt on all providers during streaming
+    /// (ascending). Null = no streaming-corruption record.
+    /// Blob/MemoryPack only — not an EF column. VersionTolerant / additive — no migration.
+    /// </summary>
+    [NotMapped]
+    [MemoryPackOrder(7)]
+    public int[]? CorruptSegmentIndices { get; set; }
+
     // navigation helpers
     [MemoryPackIgnore]
     public DavItem? DavItem { get; set; }

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -115,6 +115,45 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
+        catch (Exception e) when (
+            e.TryGetCausingException(out UsenetCorruptArticleException? corrupt) &&
+            e is not OutOfMemoryException &&
+            e is not TransientSegmentExhaustionException &&
+            e is not SeekPositionNotFoundException &&
+            !context.RequestAborted.IsCancellationRequested)
+        {
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 404;
+            }
+
+            var filePath = GetRequestFilePath(context);
+            var dedupeKey = $"{filePath}|{corrupt!.SegmentId}";
+            LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "File {FilePath} has corrupt articles: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath,
+                        corrupt.Message,
+                        suppressed);
+                else
+                    Log.Warning(
+                        "File {FilePath} has corrupt articles: {Reason}",
+                        filePath,
+                        corrupt.Message);
+            });
+            Log.Debug(e, "File {FilePath} corrupt-article stack", filePath);
+
+            if (context.Items["DavItem"] is DavItem davItem)
+            {
+                RecordMissingArticleForFailFast(davItem, corrupt.SegmentId);
+                ScheduleRepair(davItem);
+            }
+
+            AbortStartedResponse(context);
+        }
         catch (SeekPositionNotFoundException e)
         {
             if (!context.Response.HasStarted)
@@ -443,6 +482,8 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
     /// missing article discovered mid-stream must feed the step-0 queue precheck. Otherwise a
     /// re-grab of the same broken release imports cleanly again and loops through repair
     /// forever (issue #732). Failing the re-grab pre-import lets Arr blocklist it properly.
+    /// Persistently corrupt segments that break playback are seeded here too — the cache is
+    /// segment-ID keyed and cause-agnostic.
     /// </summary>
     internal static void RecordMissingArticleForFailFast(DavItem davItem, string segmentId)
     {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -763,29 +763,27 @@ public class HealthCheckService : BackgroundService
     /// the same transaction as the health row. The TR_DavItems_Update_AddBlobCleanup
     /// trigger queues the old blob for deferred cleanup and in-flight readers keep their
     /// open handle. The instance handed in is the shared MetadataCache entry — never
-    /// mutate it; write a fresh copy.
+    /// mutate it; write a fresh copy. Delegates to
+    /// <see cref="DavNzbFileBlobUpdater"/> so a concurrent corruption persist cannot
+    /// drop Missing/Container fields (and vice versa).
     /// </summary>
-    private static async Task SwapNzbFileBlobAsync(
+    private static Task SwapNzbFileBlobAsync(
         DavItem davItem,
         DavNzbFile nzbFile,
         int[]? missingSegmentIndices,
         byte? probedContainerClass,
-        long? probedCriticalHeadEndExclusive = null)
-    {
-        var updated = new DavNzbFile
-        {
-            Id = nzbFile.Id,
-            SegmentIds = nzbFile.SegmentIds,
-            SegmentByteRanges = nzbFile.SegmentByteRanges,
-            SegmentFallbackIds = nzbFile.SegmentFallbackIds,
-            MissingSegmentIndices = missingSegmentIndices,
-            ContainerClass = probedContainerClass ?? nzbFile.ContainerClass,
-            CriticalHeadEndExclusive = probedCriticalHeadEndExclusive ?? nzbFile.CriticalHeadEndExclusive,
-        };
-        var newBlobId = Guid.NewGuid();
-        await BlobStore.WriteBlob(newBlobId, updated).ConfigureAwait(false);
-        davItem.FileBlobId = newBlobId;
-    }
+        long? probedCriticalHeadEndExclusive = null) =>
+        DavNzbFileBlobUpdater.MutateAsync(
+            davItem,
+            current =>
+            {
+                current.MissingSegmentIndices = missingSegmentIndices;
+                current.ContainerClass = probedContainerClass ?? current.ContainerClass;
+                current.CriticalHeadEndExclusive =
+                    probedCriticalHeadEndExclusive ?? current.CriticalHeadEndExclusive;
+                return current;
+            },
+            fallback: nzbFile);
 
     private void CompleteHealthProgress(Guid davItemId)
     {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -401,10 +401,21 @@ public class HealthCheckService : BackgroundService
             }
             CompleteHealthProgress(davItem.Id);
 
-            if (confirmedHoles is { Count: > 0 })
+            var statHoles = confirmedHoles ?? [];
+            List<int> remainingCorrupt = [];
+            if (canClassify
+                && _configManager.IsCorruptionTrackingEnabled()
+                && nzbFile?.CorruptSegmentIndices is { Length: > 0 } recorded)
+            {
+                remainingCorrupt = await FilterRecordedCorruptIndicesAsync(nzbFile, recorded, ct)
+                    .ConfigureAwait(false);
+            }
+
+            if (canClassify && (statHoles.Count > 0 || remainingCorrupt.Count > 0))
             {
                 await HandleConfirmedHolesAsync(
-                        davItem, dbClient, nzbFile!, segments, segmentRanges!, confirmedHoles, ct)
+                        davItem, dbClient, nzbFile!, segments, segmentRanges!,
+                        statHoles, remainingCorrupt, ct)
                     .ConfigureAwait(false);
                 return;
             }
@@ -420,10 +431,12 @@ public class HealthCheckService : BackgroundService
             _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
 
             // A previously degraded file that now sweeps clean has recovered (provider-side
-            // restoration): drop the stale hole record. The probed container class is a
-            // permanent property of the file and survives the clear.
-            if (canClassify && nzbFile!.MissingSegmentIndices != null)
-                await SwapNzbFileBlobAsync(davItem, nzbFile, null, null).ConfigureAwait(false);
+            // restoration): drop the stale hole and corrupt records. The probed container
+            // class is a permanent property of the file and survives the clear.
+            if (canClassify && nzbFile is not null
+                && (nzbFile.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null))
+                await SwapNzbFileBlobAsync(davItem, nzbFile, null, null, replaceCorruptRecord: true)
+                    .ConfigureAwait(false);
 
             var repairedCount = nzbFile != null
                 ? Par2RepairService.CountRepairedSegments(nzbFile, _repairPatchStore)
@@ -564,9 +577,15 @@ public class HealthCheckService : BackgroundService
         DavNzbFile nzbFile,
         List<string> segments,
         LongRange[] segmentRanges,
-        List<int> holeIndices,
+        List<int> missingIndices,
+        List<int> corruptIndices,
         CancellationToken ct)
     {
+        var holeIndices = missingIndices
+            .Concat(corruptIndices)
+            .Distinct()
+            .OrderBy(index => index)
+            .ToList();
         var holeSegmentIds = holeIndices.Select(index => segments[index]).ToArray();
 
         // PAR2 first, with the full hole list: reconstruct from parity before any verdict.
@@ -578,9 +597,10 @@ public class HealthCheckService : BackgroundService
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             _failureTracker.ClearFailure(davItem.Id);
             _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
-            // The patched segments are served locally now; any earlier hole record is obsolete.
-            if (nzbFile.MissingSegmentIndices != null)
-                await SwapNzbFileBlobAsync(davItem, nzbFile, null, null).ConfigureAwait(false);
+            // The patched segments are served locally now; any earlier hole/corrupt record is obsolete.
+            if (nzbFile.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null)
+                await SwapNzbFileBlobAsync(davItem, nzbFile, null, null, replaceCorruptRecord: true)
+                    .ConfigureAwait(false);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Healthy,
@@ -628,13 +648,20 @@ public class HealthCheckService : BackgroundService
         // do not seed the fail-fast reimport cache (a re-grab of a release we chose to keep
         // must not fail), and do not clear the streaming-failure count: confirmed damage is
         // not health, and real playback failures keep escalating toward auto-remove.
-        var recordChanged = nzbFile.MissingSegmentIndices is not { } existing
-                            || !existing.SequenceEqual(holeIndices)
+        var missingToStore = missingIndices.Count == 0
+            ? null
+            : missingIndices.Distinct().OrderBy(index => index).ToArray();
+        var corruptToStore = corruptIndices.Count == 0
+            ? null
+            : corruptIndices.Distinct().OrderBy(index => index).ToArray();
+        var recordChanged = !SameIndexRecord(nzbFile.MissingSegmentIndices, missingToStore)
+                            || !SameIndexRecord(nzbFile.CorruptSegmentIndices, corruptToStore)
                             || (probedClass != null && nzbFile.ContainerClass != probedClass)
                             || (probedExtent != null && nzbFile.CriticalHeadEndExclusive != probedExtent);
         if (recordChanged)
             await SwapNzbFileBlobAsync(
-                    davItem, nzbFile, holeIndices.ToArray(), probedClass, probedExtent)
+                    davItem, nzbFile, missingToStore, probedClass, probedExtent,
+                    corruptToStore, replaceCorruptRecord: true)
                 .ConfigureAwait(false);
 
         Log.Warning(
@@ -772,7 +799,9 @@ public class HealthCheckService : BackgroundService
         DavNzbFile nzbFile,
         int[]? missingSegmentIndices,
         byte? probedContainerClass,
-        long? probedCriticalHeadEndExclusive = null) =>
+        long? probedCriticalHeadEndExclusive = null,
+        int[]? corruptSegmentIndices = null,
+        bool replaceCorruptRecord = false) =>
         DavNzbFileBlobUpdater.MutateAsync(
             davItem,
             current =>
@@ -781,9 +810,89 @@ public class HealthCheckService : BackgroundService
                 current.ContainerClass = probedContainerClass ?? current.ContainerClass;
                 current.CriticalHeadEndExclusive =
                     probedCriticalHeadEndExclusive ?? current.CriticalHeadEndExclusive;
+                if (replaceCorruptRecord)
+                    current.CorruptSegmentIndices = corruptSegmentIndices;
                 return current;
             },
             fallback: nzbFile);
+
+    private static bool SameIndexRecord(int[]? stored, int[]? next) =>
+        (stored ?? []).SequenceEqual(next ?? []);
+
+    private async Task<List<int>> FilterRecordedCorruptIndicesAsync(
+        DavNzbFile nzbFile,
+        IReadOnlyList<int> recorded,
+        CancellationToken ct)
+    {
+        var remaining = new List<int>();
+        var cap = _configManager.GetDegradedMaxTotalMissing();
+        var probed = 0;
+        var ranges = nzbFile.SegmentByteRanges;
+        foreach (var index in recorded.Distinct().OrderBy(i => i))
+        {
+            if (index < 0 || index >= nzbFile.SegmentIds.Length)
+                continue;
+
+            var segmentId = nzbFile.SegmentIds[index];
+            var expectedSize = ranges is not null && index < ranges.Length ? ranges[index].Count : 0;
+            if (expectedSize > 0 && _repairPatchStore.IsRepaired(segmentId, expectedSize))
+                continue;
+
+            if (probed >= cap)
+            {
+                remaining.Add(index);
+                continue;
+            }
+
+            probed++;
+            if (await TryConfirmSegmentCleanAsync(segmentId, ct).ConfigureAwait(false))
+                continue;
+            remaining.Add(index);
+        }
+
+        return remaining;
+    }
+
+    private async Task<bool> TryConfirmSegmentCleanAsync(string segmentId, CancellationToken ct)
+    {
+        try
+        {
+            var body = await _usenetClient.DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+            var stream = body.Stream;
+            if (stream is null) return false;
+            var buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(8192);
+            try
+            {
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer.AsMemory(0, 8192), ct).ConfigureAwait(false);
+                    if (read == 0) return true;
+                }
+            }
+            finally
+            {
+                System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
+                await stream.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (OutOfMemoryException)
+        {
+            throw;
+        }
+        catch (Exception e) when (e is UsenetCorruptArticleException or UsenetArticleNotFoundException)
+        {
+            return false;
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(e, "Re-confirmation probe of recorded corrupt segment {SegmentId} failed", segmentId);
+            return false;
+        }
+    }
 
     private void CompleteHealthProgress(Guid davItemId)
     {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -14,6 +14,7 @@ using NzbWebDAV.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.PostProcessors;
 using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Serilog;
@@ -403,9 +404,10 @@ public class HealthCheckService : BackgroundService
 
             var statHoles = confirmedHoles ?? [];
             List<int> remainingCorrupt = [];
+            // canClassify is only true when SegmentByteRanges materialized from this nzbFile.
             if (canClassify
                 && _configManager.IsCorruptionTrackingEnabled()
-                && nzbFile?.CorruptSegmentIndices is { Length: > 0 } recorded)
+                && nzbFile!.CorruptSegmentIndices is { Length: > 0 } recorded)
             {
                 remainingCorrupt = await FilterRecordedCorruptIndicesAsync(nzbFile, recorded, ct)
                     .ConfigureAwait(false);
@@ -433,8 +435,8 @@ public class HealthCheckService : BackgroundService
             // A previously degraded file that now sweeps clean has recovered (provider-side
             // restoration): drop the stale hole and corrupt records. The probed container
             // class is a permanent property of the file and survives the clear.
-            if (canClassify && nzbFile is not null
-                && (nzbFile.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null))
+            if (canClassify
+                && (nzbFile!.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null))
                 await SwapNzbFileBlobAsync(davItem, nzbFile, null, null, replaceCorruptRecord: true)
                     .ConfigureAwait(false);
 
@@ -828,11 +830,9 @@ public class HealthCheckService : BackgroundService
         var cap = _configManager.GetDegradedMaxTotalMissing();
         var probed = 0;
         var ranges = nzbFile.SegmentByteRanges;
-        foreach (var index in recorded.Distinct().OrderBy(i => i))
+        foreach (var index in recorded.Distinct().OrderBy(i => i)
+                     .Where(i => (uint)i < (uint)nzbFile.SegmentIds.Length))
         {
-            if (index < 0 || index >= nzbFile.SegmentIds.Length)
-                continue;
-
             var segmentId = nzbFile.SegmentIds[index];
             var expectedSize = ranges is not null && index < ranges.Length ? ranges[index].Count : 0;
             if (expectedSize > 0 && _repairPatchStore.IsRepaired(segmentId, expectedSize))
@@ -858,6 +858,9 @@ public class HealthCheckService : BackgroundService
         try
         {
             var body = await _usenetClient.DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+            await SegmentResponseValidator
+                .ThrowOnSegmentIdMismatchAsync(segmentId, body)
+                .ConfigureAwait(false);
             var stream = body.Stream;
             if (stream is null) return false;
             var buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(8192);
@@ -883,7 +886,10 @@ public class HealthCheckService : BackgroundService
         {
             throw;
         }
-        catch (Exception e) when (e is UsenetCorruptArticleException or UsenetArticleNotFoundException)
+        catch (Exception e) when (
+            e is UsenetCorruptArticleException
+                or UsenetArticleNotFoundException
+                or UsenetUnexpectedResponseException)
         {
             return false;
         }

--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -44,6 +44,7 @@ public sealed class PrometheusMetrics
     private readonly Counter _par2PatchHits;
     private readonly Counter _par2PatchEvictions;
     private readonly Counter _par2RepairJobs;
+    private readonly Counter _streamingCorruptSegments;
     private readonly HashSet<string> _providerKeys = new(StringComparer.Ordinal);
 
     public PrometheusMetrics(CollectorRegistry registry)
@@ -103,6 +104,9 @@ public sealed class PrometheusMetrics
         _par2PatchEvictions = metrics.CreateCounter(
             "nzbdav_par2_patch_evictions_total",
             "Repair patch store evictions.");
+        _streamingCorruptSegments = metrics.CreateCounter(
+            "nzbdav_streaming_corrupt_segments_total",
+            "Streaming-confirmed corrupt Usenet articles.");
     }
 
     public static PrometheusMetrics? Current { get; set; }
@@ -137,6 +141,8 @@ public sealed class PrometheusMetrics
     public void RecordPar2PatchHit() => _par2PatchHits.Inc();
 
     public void RecordPar2PatchEviction() => _par2PatchEvictions.Inc();
+
+    public void RecordStreamingCorruptSegment() => _streamingCorruptSegments.Inc();
 
     public void Refresh(
         ActiveReadRegistry activeReads,

--- a/backend/Services/Repair/DavNzbFileBlobUpdater.cs
+++ b/backend/Services/Repair/DavNzbFileBlobUpdater.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Services.Repair;
+
+/// <summary>
+/// Writes a new NZB-file blob and swaps <see cref="DavItem.FileBlobId"/> under a
+/// per-item lock so health-check replace mutations and streaming-corruption union
+/// mutations cannot clobber each other's fields.
+/// </summary>
+/// <remarks>
+/// Residual race: <see cref="HealthCheckService"/> commits <c>SaveChangesAsync</c>
+/// outside this lock (transactionally with the health row). A corruption persist
+/// that lands between a health check's in-lock swap and its out-of-lock save can
+/// be overwritten at the <c>FileBlobId</c> column. Both writers are single
+/// background loops, the window is small, and a lost corrupt record is recreated
+/// on the next corrupt read. Do not move the health SaveChanges into this lock —
+/// that would break health-row atomicity.
+/// </remarks>
+internal static class DavNzbFileBlobUpdater
+{
+    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> Locks = new();
+    private static readonly ConcurrentDictionary<Guid, Guid> LatestBlobIds = new();
+
+    public static async Task MutateAsync(
+        DavItem davItem,
+        Func<DavNzbFile, DavNzbFile> mutate,
+        DavNzbFile? fallback = null)
+    {
+        var gate = Locks.GetOrAdd(davItem.Id, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var blobId = LatestBlobIds.TryGetValue(davItem.Id, out var latest)
+                ? latest
+                : davItem.FileBlobId;
+            DavNzbFile? current = null;
+            if (blobId is { } id)
+                current = await BlobStore.ReadBlob<DavNzbFile>(id).ConfigureAwait(false);
+            current ??= fallback;
+            if (current is null)
+                return;
+
+            var copy = Clone(current);
+            var updated = mutate(copy);
+            var newBlobId = Guid.NewGuid();
+            await BlobStore.WriteBlob(newBlobId, updated).ConfigureAwait(false);
+            LatestBlobIds[davItem.Id] = newBlobId;
+            davItem.FileBlobId = newBlobId;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    internal static DavNzbFile Clone(DavNzbFile source) => new()
+    {
+        Id = source.Id,
+        SegmentIds = source.SegmentIds,
+        SegmentByteRanges = source.SegmentByteRanges,
+        SegmentFallbackIds = source.SegmentFallbackIds,
+        MissingSegmentIndices = source.MissingSegmentIndices,
+        ContainerClass = source.ContainerClass,
+        CriticalHeadEndExclusive = source.CriticalHeadEndExclusive,
+        CorruptSegmentIndices = source.CorruptSegmentIndices,
+    };
+}

--- a/backend/Services/Repair/DavNzbFileBlobUpdater.cs
+++ b/backend/Services/Repair/DavNzbFileBlobUpdater.cs
@@ -17,18 +17,43 @@ namespace NzbWebDAV.Services.Repair;
 /// background loops, the window is small, and a lost corrupt record is recreated
 /// on the next corrupt read. Do not move the health SaveChanges into this lock —
 /// that would break health-row atomicity.
+/// <para>
+/// Item locks are striped (fixed SemaphoreSlim count) so a long-running server
+/// cannot retain one semaphore per mutated file. <see cref="LatestBlobIds"/> still
+/// maps item id → uncommitted blob id: the two writer loops can mutate different
+/// in-memory <see cref="DavItem"/> instances of the same row before SaveChanges,
+/// and the latest blob id is the only way the second writer sees the first swap.
+/// Entries are one Guid per item that has ever been mutated — far cheaper than a
+/// leaked SemaphoreSlim — and must outlive the lock or sequential unions on stale
+/// instances would drop fields.
+/// </para>
 /// </remarks>
 internal static class DavNzbFileBlobUpdater
 {
-    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> Locks = new();
+    private const int StripeCount = 32;
+    private static readonly SemaphoreSlim[] Stripes = CreateStripes();
     private static readonly ConcurrentDictionary<Guid, Guid> LatestBlobIds = new();
+
+    private static SemaphoreSlim[] CreateStripes()
+    {
+        var stripes = new SemaphoreSlim[StripeCount];
+        for (var i = 0; i < stripes.Length; i++)
+            stripes[i] = new SemaphoreSlim(1, 1);
+        return stripes;
+    }
+
+    private static SemaphoreSlim StripeFor(Guid itemId)
+    {
+        var hash = (uint)itemId.GetHashCode();
+        return Stripes[hash % StripeCount];
+    }
 
     public static async Task MutateAsync(
         DavItem davItem,
         Func<DavNzbFile, DavNzbFile> mutate,
         DavNzbFile? fallback = null)
     {
-        var gate = Locks.GetOrAdd(davItem.Id, static _ => new SemaphoreSlim(1, 1));
+        var gate = StripeFor(davItem.Id);
         await gate.WaitAsync().ConfigureAwait(false);
         try
         {

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -82,7 +82,15 @@ public class Par2RepairService : BackgroundService
             _pendingZeroFillPaths.TryRemove(path, out _);
     }
 
-    public async Task EnqueueAsync(
+    public void ReportCorruption(string path, string segmentId)
+    {
+        if (!_configManager.IsCorruptionTrackingEnabled()) return;
+        if (!_pendingZeroFillPaths.TryAdd(path, 0)) return;
+        if (!_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId, IsCorruption: true)))
+            _pendingZeroFillPaths.TryRemove(path, out _);
+    }
+
+    public virtual async Task EnqueueAsync(
         DavItem davItem,
         IReadOnlyList<string> missingSegmentIds,
         CancellationToken ct = default)
@@ -175,8 +183,57 @@ public class Par2RepairService : BackgroundService
     {
         await using var dbContext = new DavDatabaseContext();
         var dbClient = new DavDatabaseClient(dbContext);
+        if (evt.IsCorruption)
+        {
+            await ProcessCorruptionEventAsync(dbContext, dbClient, evt, ct).ConfigureAwait(false);
+            return;
+        }
+
         var davItem = await dbClient.GetItemByPathAsync(evt.Path, ct).ConfigureAwait(false);
         if (davItem != null)
+            await EnqueueAsync(davItem, [evt.SegmentId], ct).ConfigureAwait(false);
+    }
+
+    internal Task ProcessCorruptionEventForTestsAsync(string path, string segmentId, CancellationToken ct) =>
+        ProcessZeroFillEventAsync(new ZeroFillEvent(path, segmentId, IsCorruption: true), ct);
+
+    private async Task ProcessCorruptionEventAsync(
+        DavDatabaseContext dbContext,
+        DavDatabaseClient dbClient,
+        ZeroFillEvent evt,
+        CancellationToken ct)
+    {
+        if (!_configManager.IsCorruptionTrackingEnabled()) return;
+
+        var davItem = await dbContext.Items
+            .FirstOrDefaultAsync(x => x.Path == evt.Path, ct)
+            .ConfigureAwait(false);
+        if (davItem is null) return;
+
+        var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
+        if (nzbFile is null) return;
+
+        var index = Array.IndexOf(nzbFile.SegmentIds, evt.SegmentId);
+        if (index < 0) return;
+
+        await DavNzbFileBlobUpdater.MutateAsync(
+            davItem,
+            current =>
+            {
+                var existing = current.CorruptSegmentIndices ?? [];
+                if (existing.Contains(index))
+                    return current;
+                current.CorruptSegmentIndices = existing
+                    .Append(index)
+                    .Distinct()
+                    .OrderBy(i => i)
+                    .ToArray();
+                return current;
+            },
+            fallback: nzbFile).ConfigureAwait(false);
+        await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        if (_configManager.IsPar2RepairEnabled())
             await EnqueueAsync(davItem, [evt.SegmentId], ct).ConfigureAwait(false);
     }
 
@@ -955,7 +1012,7 @@ public class Par2RepairService : BackgroundService
 
     private sealed record RepairWorkItem(Guid DavItemId, string Path, string[] MissingSegmentIds);
 
-    private sealed record ZeroFillEvent(string Path, string SegmentId);
+    private sealed record ZeroFillEvent(string Path, string SegmentId, bool IsCorruption = false);
 
     private sealed record MissingSegment(string SegmentId, int Index);
 

--- a/backend/Services/Repair/Par2RepairTriggerSink.cs
+++ b/backend/Services/Repair/Par2RepairTriggerSink.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using NzbWebDAV.Services.Observability;
 
 namespace NzbWebDAV.Services.Repair;
 
@@ -40,6 +41,7 @@ public sealed class Par2RepairTriggerSink
     public static void ReportCorruption(string path, string segmentId)
     {
         TestReports?.Add((path, segmentId, true));
+        PrometheusMetrics.Current?.RecordStreamingCorruptSegment();
         Current?.OnCorruptionReported(path, segmentId);
     }
 

--- a/backend/Services/Repair/Par2RepairTriggerSink.cs
+++ b/backend/Services/Repair/Par2RepairTriggerSink.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace NzbWebDAV.Services.Repair;
 
 /// <summary>
@@ -17,8 +19,33 @@ public sealed class Par2RepairTriggerSink
 
     public static Par2RepairTriggerSink? Current { get; set; }
 
+    /// <summary>
+    /// Optional test observer. Production leaves this null so reports stay allocation-free
+    /// on the playback path. Tests assign a bag and filter by unique segment IDs.
+    /// </summary>
+    internal static ConcurrentBag<(string Path, string SegmentId, bool IsCorruption)>? TestReports;
+
     public void ReportZeroFill(string path, string segmentId, int segmentIndex, long fillBytes)
     {
+        TestReports?.Add((path, segmentId, false));
         _service.ReportZeroFill(path, segmentId);
+    }
+
+    /// <summary>
+    /// Reports a streaming-confirmed corrupt article. Persistence and PAR2 enqueue
+    /// are wired by the health-recording follow-up; playback reports here so tests
+    /// and later consumers can observe the event without blocking the read.
+    /// Static so the playback path can report even when <see cref="Current"/> is unset.
+    /// </summary>
+    public static void ReportCorruption(string path, string segmentId)
+    {
+        TestReports?.Add((path, segmentId, true));
+        Current?.OnCorruptionReported(path, segmentId);
+    }
+
+    private void OnCorruptionReported(string path, string segmentId)
+    {
+        // Persistence and PAR2 enqueue are wired by the health-recording follow-up.
+        _ = (path, segmentId);
     }
 }

--- a/backend/Services/Repair/Par2RepairTriggerSink.cs
+++ b/backend/Services/Repair/Par2RepairTriggerSink.cs
@@ -45,7 +45,6 @@ public sealed class Par2RepairTriggerSink
 
     private void OnCorruptionReported(string path, string segmentId)
     {
-        // Persistence and PAR2 enqueue are wired by the health-recording follow-up.
-        _ = (path, segmentId);
+        _service.ReportCorruption(path, segmentId);
     }
 }

--- a/backend/Services/Repair/SegmentDamageClassifier.cs
+++ b/backend/Services/Repair/SegmentDamageClassifier.cs
@@ -51,7 +51,7 @@ public static class SegmentDamageClassifier
         var totalBytes = exactSegmentSizes.Sum();
         var bytePercent = totalBytes == 0 ? 100d : missingBytes * 100d / totalBytes;
         var longestRun = GetLongestRun(missing);
-        reason = $"{missing.Length} missing segment(s) (largest run {longestRun}, {bytePercent:0.##}% of file)";
+        reason = $"{missing.Length} missing/corrupt segment(s) (largest run {longestRun}, {bytePercent:0.##}% of file)";
 
         if (missing.Length == 0) return SegmentDamageVerdict.Clean;
         if (containerClass is MediaContainerClass.Unknown or MediaContainerClass.Mp4MoovAtEnd)

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Services.Diagnostics;
@@ -655,10 +656,17 @@ public sealed class SupportPackService(
         try
         {
             var snapshot = par2RepairService.GetDiagnosticSnapshot();
+            var corruptRecords = CountCorruptRecords();
             return new
             {
                 enabled = configManager.IsPar2RepairEnabled(),
                 preferredOverArr = configManager.IsPar2PreferredOverArr(),
+                corruptionTracking = new
+                {
+                    enabled = configManager.IsCorruptionTrackingEnabled(),
+                    filesWithCorruptRecords = corruptRecords.Files,
+                    recordedCorruptSegments = corruptRecords.Segments,
+                },
                 maxMissingSlices = configManager.GetPar2MaxMissingSlices(),
                 maxReleaseGb = configManager.GetPar2MaxReleaseGb(),
                 maxMemoryMb = configManager.GetPar2MaxMemoryMb(),
@@ -690,6 +698,36 @@ public sealed class SupportPackService(
         {
             Log.Debug(e, "Support pack: could not read PAR2 repair diagnostics");
             return new { enabled = false, error = e.Message };
+        }
+    }
+
+    private static (int Files, int Segments) CountCorruptRecords()
+    {
+        try
+        {
+            using var db = new DavDatabaseContext();
+            var blobIds = db.Items.AsNoTracking()
+                .Where(item => item.SubType == DavItem.ItemSubType.NzbFile && item.FileBlobId != null)
+                .Select(item => item.FileBlobId!.Value)
+                .ToList();
+
+            var files = 0;
+            var segments = 0;
+            foreach (var blobId in blobIds)
+            {
+                var blob = BlobStore.ReadBlob<DavNzbFile>(blobId).GetAwaiter().GetResult();
+                if (blob?.CorruptSegmentIndices is not { Length: > 0 } indices)
+                    continue;
+                files++;
+                segments += indices.Length;
+            }
+
+            return (files, segments);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(e, "Support pack: could not count streaming-corrupt segment records");
+            return (0, 0);
         }
     }
 

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -656,14 +656,15 @@ public sealed class SupportPackService(
         try
         {
             var snapshot = par2RepairService.GetDiagnosticSnapshot();
-            var corruptRecords = CountCorruptRecords();
+            var trackingEnabled = configManager.IsCorruptionTrackingEnabled();
+            var corruptRecords = trackingEnabled ? CountCorruptRecords() : (Files: 0, Segments: 0);
             return new
             {
                 enabled = configManager.IsPar2RepairEnabled(),
                 preferredOverArr = configManager.IsPar2PreferredOverArr(),
                 corruptionTracking = new
                 {
-                    enabled = configManager.IsCorruptionTrackingEnabled(),
+                    enabled = trackingEnabled,
                     filesWithCorruptRecords = corruptRecords.Files,
                     recordedCorruptSegments = corruptRecords.Segments,
                 },

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -53,6 +53,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     // the producer; DisposeCoreAsync must join them so DisposeAsync does not return
     // while their BudgetedStream leases are still held (#840 scrub wedge).
     private readonly ConcurrentQueue<Task> _orphanedDisposals = new();
+    private readonly HashSet<string>? _knownCorruptSegmentIds;
+
+    private int GetCorruptionRetryLimit(string segmentId) =>
+        _knownCorruptSegmentIds is not null && _knownCorruptSegmentIds.Contains(segmentId)
+            ? 0
+            : MaxCorruptionRetries;
 
     /// <summary>
     /// Optional per-instance test hook invoked with the segment-boundary readiness sample,
@@ -83,7 +89,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
-        int bodyPipelineBatchWidth = BodyPipelineBatchSize)
+        int bodyPipelineBatchWidth = BodyPipelineBatchSize,
+        HashSet<string>? knownCorruptSegmentIds = null)
     {
         return Create(
             segmentIds,
@@ -99,7 +106,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             inFlightArticleBudget: inFlightArticleBudget,
             useContainerAwareFill: useContainerAwareFill,
             firstSegmentFileOffset: firstSegmentFileOffset,
-            bodyPipelineBatchWidth: bodyPipelineBatchWidth);
+            bodyPipelineBatchWidth: bodyPipelineBatchWidth,
+            knownCorruptSegmentIds: knownCorruptSegmentIds);
     }
 
     /// <param name="estimatedSegmentSize">
@@ -128,14 +136,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
-        int bodyPipelineBatchWidth = BodyPipelineBatchSize
+        int bodyPipelineBatchWidth = BodyPipelineBatchSize,
+        HashSet<string>? knownCorruptSegmentIds = null
     )
     {
         return articleBufferSize == 0
             ? new UnbufferedMultiSegmentStream(
                 segmentIds, usenetClient, estimatedSegmentSize, fileName, segmentFallbacks,
                 exactSegmentSizes, useContainerAwareFill, firstSegmentFileOffset,
-                failFastOnFirstSegment)
+                failFastOnFirstSegment, knownCorruptSegmentIds)
             : new MultiSegmentStream(
                 segmentIds,
                 usenetClient,
@@ -151,6 +160,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 useContainerAwareFill,
                 firstSegmentFileOffset,
                 bodyPipelineBatchWidth,
+                knownCorruptSegmentIds,
                 cancellationToken);
     }
 
@@ -175,7 +185,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
-        int bodyPipelineBatchWidth = BodyPipelineBatchSize)
+        int bodyPipelineBatchWidth = BodyPipelineBatchSize,
+        HashSet<string>? knownCorruptSegmentIds = null)
     {
         if (articleBufferSize == 0 || segmentIds.Length <= 1)
         {
@@ -183,7 +194,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 segmentIds, usenetClient, articleBufferSize, estimatedSegmentSize,
                 failFastOnFirstSegment, usePipelinedBodyRequests, cancellationToken, fileName,
                 readBudget, segmentFallbacks, exactSegmentSizes, inFlightArticleBudget,
-                useContainerAwareFill, firstSegmentFileOffset, bodyPipelineBatchWidth);
+                useContainerAwareFill, firstSegmentFileOffset, bodyPipelineBatchWidth,
+                knownCorruptSegmentIds);
         }
 
         var effectiveReadBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
@@ -214,14 +226,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             yield return Task.FromResult<Stream>(new UnbufferedMultiSegmentStream(
                 segmentIds[..1], usenetClient, estimatedSegmentSize, fileName, firstFallbacks,
                 firstExactSizes, useContainerAwareFill, firstSegmentFileOffset,
-                failFastOnFirstSegment));
+                failFastOnFirstSegment, knownCorruptSegmentIds));
 #pragma warning restore CA2000
             yield return Task.FromResult(Create(
                 segmentIds[1..], usenetClient, articleBufferSize, estimatedSegmentSize,
                 failFastOnFirstSegment: false, usePipelinedBodyRequests, cancellationToken,
                 fileName, remainingBudget, remainingFallbacks, remainingExactSizes,
                 inFlightArticleBudget, useContainerAwareFill, remainingOffset,
-                bodyPipelineBatchWidth));
+                bodyPipelineBatchWidth, knownCorruptSegmentIds));
         }
     }
 
@@ -241,6 +253,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool useContainerAwareFill,
         long? firstSegmentFileOffset,
         int bodyPipelineBatchWidth,
+        HashSet<string>? knownCorruptSegmentIds,
         CancellationToken cancellationToken
     )
     {
@@ -252,6 +265,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _failFastOnFirstSegment = failFastOnFirstSegment;
         _useContainerAwareFill = useContainerAwareFill;
         _firstSegmentFileOffset = firstSegmentFileOffset;
+        _knownCorruptSegmentIds = knownCorruptSegmentIds;
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _readBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         _budget = inFlightArticleBudget ?? InFlightArticleBudget.Current;
@@ -567,7 +581,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 lease?.Dispose();
                 lease = null;
-                if (attempt >= MaxCorruptionRetries)
+                if (attempt >= GetCorruptionRetryLimit(segmentId))
                 {
                     var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
                         .ConfigureAwait(false);
@@ -819,7 +833,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         CancellationToken cancellationToken)
     {
         var failure = initialFailure;
-        for (var attempt = 1; attempt <= MaxCorruptionRetries; attempt++)
+        for (var attempt = 1; attempt <= GetCorruptionRetryLimit(segmentId); attempt++)
         {
             Log.Debug(
                 failure,

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -795,6 +795,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)
             {
+                // A corrupt rescue response is swallowed here and the original non-corrupt
+                // batch failure is surfaced as TransientSegmentExhaustionException.
+                // Corruption evidence for this read is dropped; the next read hits the
+                // proper corrupt path.
                 Log.Debug(e, "Individual rescue of segment {SegmentId} failed (attempt {Attempt}).",
                     segmentId, attempt);
             }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -980,7 +980,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 fill, _fileName, segmentId);
         }
 
-        Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, fill);
+        if (exception.TryGetCausingException(out UsenetCorruptArticleException? _))
+            Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
+        else
+            Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, fill);
 
 #pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
         return SegmentDownloadResult.ZeroFill(

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -590,6 +590,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
                     if (_failFastOnFirstSegment && isFirstSegment)
                     {
+                        Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
                         e.LogWarningKnownOrStack(
                             "First article {SegmentId} persistently corrupt at playback start while reading {FileName}. " +
                             "Failing the stream so the player surfaces an error.",
@@ -702,7 +703,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
             catch (UsenetCorruptArticleException persistent)
             {
-                if (_failFastOnFirstSegment && isFirstSegment) throw;
+                if (_failFastOnFirstSegment && isFirstSegment)
+                {
+                    Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
+                    throw;
+                }
                 return ZeroFillSegment(
                     "Article {SegmentId} persistently corrupt while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
                     segmentId,
@@ -985,7 +990,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         Exception exception)
     {
         if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out var isExact))
+        {
+            if (exception.TryGetCausingException(out UsenetCorruptArticleException? _))
+                Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
             throw CreateUnknownLengthFailure(segmentId, segmentIndex, exception);
+        }
 
         if (!isExact)
         {

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -25,7 +25,8 @@ public class NzbFileStream(
     string[][]? segmentFallbacks = null,
     InFlightArticleBudget? inFlightArticleBudget = null,
     bool useContainerAwareFill = false,
-    int streamingBodyBatchWidth = 4
+    int streamingBodyBatchWidth = 4,
+    HashSet<string>? knownCorruptSegmentIds = null
 ) : FastReadOnlyStream
 {
     private const long MaximumForwardDrainBytes = 1024 * 1024;
@@ -504,7 +505,8 @@ public class NzbFileStream(
             inFlightArticleBudget: inFlightArticleBudget,
             useContainerAwareFill: useContainerAwareFill,
             firstSegmentFileOffset: firstSegmentFileOffset,
-            bodyPipelineBatchWidth: streamingBodyBatchWidth);
+            bodyPipelineBatchWidth: streamingBodyBatchWidth,
+            knownCorruptSegmentIds: knownCorruptSegmentIds);
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -352,6 +352,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 
         if (_failFastOnFirstSegment && segmentIndex == 0)
         {
+            Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
             failure.LogWarningKnownOrStack(
                 "First article {SegmentId} persistently corrupt at playback start while reading {FileName}. " +
                 "Failing the stream so the player surfaces an error.",
@@ -361,7 +362,10 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out _))
+        {
+            Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
             throw CreateUnknownLengthFailure(segmentIndex, failure);
+        }
 
         ApplyZeroFill(segmentIndex, segmentId, fill, failure, isCorruption: true);
     }

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -22,6 +22,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly bool _useContainerAwareFill;
     private readonly long? _firstSegmentFileOffset;
     private readonly bool _failFastOnFirstSegment;
+    private readonly HashSet<string>? _knownCorruptSegmentIds;
     private readonly byte[] _scratch = new byte[16];
     private Stream? _stream;
     private int _currentIndex;
@@ -44,7 +45,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         ReadOnlyMemory<long> exactSegmentSizes = default,
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
-        bool failFastOnFirstSegment = false)
+        bool failFastOnFirstSegment = false,
+        HashSet<string>? knownCorruptSegmentIds = null)
     {
         _segmentIds = segmentIds;
         _segmentFallbacks = segmentFallbacks;
@@ -54,6 +56,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         _useContainerAwareFill = useContainerAwareFill;
         _firstSegmentFileOffset = firstSegmentFileOffset;
         _failFastOnFirstSegment = failFastOnFirstSegment;
+        _knownCorruptSegmentIds = knownCorruptSegmentIds;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -305,7 +308,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         _hasProbedByte = false;
 
         var failure = initialFailure;
-        for (var attempt = 1; attempt <= MaxCorruptionRetries; attempt++)
+        for (var attempt = 1; attempt <= GetCorruptionRetryLimit(segmentId); attempt++)
         {
             Log.Debug(
                 failure,
@@ -362,6 +365,11 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 
         ApplyZeroFill(segmentIndex, segmentId, fill, failure, isCorruption: true);
     }
+
+    private int GetCorruptionRetryLimit(string segmentId) =>
+        _knownCorruptSegmentIds is not null && _knownCorruptSegmentIds.Contains(segmentId)
+            ? 0
+            : MaxCorruptionRetries;
 
     private async Task HandlePostEmissionCorruptionAsync(
         int segmentIndex,

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
@@ -10,6 +12,8 @@ namespace NzbWebDAV.Streams;
 
 public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 {
+    private const int MaxCorruptionRetries = 3;
+
     private readonly Memory<string> _segmentIds;
     private readonly string[][]? _segmentFallbacks;
     private readonly INntpClient _usenetClient;
@@ -18,12 +22,16 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly bool _useContainerAwareFill;
     private readonly long? _firstSegmentFileOffset;
     private readonly bool _failFastOnFirstSegment;
+    private readonly byte[] _scratch = new byte[16];
     private Stream? _stream;
     private int _currentIndex;
     private int _openSegmentIndex = -1;
     private long _openSegmentBytes;
     private long _pendingPadBytes;
     private int _consecutiveZeroFills;
+    private bool _openSegmentFromLiveFetch;
+    private bool _hasProbedByte;
+    private byte _probedByte;
     private bool _disposed;
 
 
@@ -67,32 +75,58 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 return fill;
             }
 
+            var written = 0;
+            if (_hasProbedByte)
+            {
+                if (TryGetRemainingExactBytes(out var remainingForProbe) && remainingForProbe == 0)
+                {
+                    _hasProbedByte = false;
+                }
+                else
+                {
+                    buffer.Span[0] = _probedByte;
+                    _hasProbedByte = false;
+                    _openSegmentBytes += 1;
+                    written = 1;
+                    if (written == buffer.Length)
+                        return written;
+                }
+            }
+
             // if the stream is null, get the next stream.
             if (_stream == null)
             {
+                if (written > 0)
+                    return written;
                 if (_currentIndex >= _segmentIds.Length) return 0;
                 var segmentIndex = _currentIndex;
                 var segmentId = _segmentIds.Span[_currentIndex++];
                 _openSegmentIndex = -1;
                 _openSegmentBytes = 0;
+                Stream? fetched = null;
                 try
                 {
                     var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken).ConfigureAwait(false);
+                    fetched = body.Stream;
                     await SegmentResponseValidator
                         .ThrowOnSegmentIdMismatchAsync(segmentId, body)
                         .ConfigureAwait(false);
-                    _stream = body.Stream!;
+                    _stream = fetched;
+                    fetched = null;
                     _openSegmentIndex = segmentIndex;
+                    _openSegmentFromLiveFetch = true;
                     _consecutiveZeroFills = 0;
                 }
                 catch (UsenetArticleNotFoundException e)
                 {
+                    await DisposeBodyStreamAsync(fetched).ConfigureAwait(false);
                     var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
                         .ConfigureAwait(false);
                     if (fallback is not null)
                     {
                         _stream = fallback;
                         _openSegmentIndex = segmentIndex;
+                        _openSegmentFromLiveFetch = true;
                         _consecutiveZeroFills = 0;
                     }
                     else
@@ -104,41 +138,77 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                         if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out _))
                             throw CreateUnknownLengthFailure(segmentIndex, e);
 
-                        _consecutiveZeroFills++;
-                        ZeroFillLogLimiter.Write(
-                            "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.",
-                            e.SegmentId,
-                            _fileName,
-                            fill,
-                            e);
-                        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
-                            StreamTrace.TryZeroFill(sessionId, e.SegmentId, fill);
-                        Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, e.SegmentId, segmentIndex, fill);
-                        if (_consecutiveZeroFills >= GapFillLimits.MaxConsecutiveZeroFills)
-                            throw;
-
-                        _stream = CreateGapFillStream(fill, segmentIndex);
+                        ApplyZeroFill(segmentIndex, e.SegmentId, fill, e, isCorruption: false);
                     }
                 }
+                catch (UsenetCorruptArticleException e) when (
+                    !cancellationToken.IsCancellationRequested
+                    && _openSegmentBytes == 0
+                    && _pendingPadBytes == 0)
+                {
+                    await DisposeBodyStreamAsync(fetched).ConfigureAwait(false);
+                    await HandlePreEmissionCorruptionAsync(segmentIndex, segmentId, e, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                // Re-enter so a 1-byte retry/donor probe is served before the next body read.
+                continue;
             }
 
             // Cap the open segment at its recorded length so a too-long body cannot
             // push every following byte out of place.
             if (TryGetRemainingExactBytes(out var remainingExact) && remainingExact == 0)
             {
+                if (written > 0)
+                    return written;
+                try
+                {
+                    await ObserveLiveSegmentTrailerAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (UsenetCorruptArticleException e) when (!cancellationToken.IsCancellationRequested)
+                {
+                    await HandlePostEmissionCorruptionAsync(
+                            _openSegmentIndex, _segmentIds.Span[_openSegmentIndex], e, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
                 await FinishOpenSegmentAsync().ConfigureAwait(false);
                 continue;
             }
 
-            var destination = remainingExact > 0 && remainingExact < buffer.Length
-                ? buffer[..(int)remainingExact]
-                : buffer;
-            var read = await _stream.ReadAsync(destination, cancellationToken).ConfigureAwait(false);
+            var available = buffer[written..];
+            var destination = remainingExact > 0 && remainingExact < available.Length
+                ? available[..(int)remainingExact]
+                : available;
+            int read;
+            try
+            {
+                read = await _stream!.ReadAsync(destination, cancellationToken).ConfigureAwait(false);
+            }
+            catch (UsenetCorruptArticleException e) when (!cancellationToken.IsCancellationRequested)
+            {
+                var openIndex = _openSegmentIndex;
+                var openId = _segmentIds.Span[openIndex];
+                if (_openSegmentBytes == 0 && _pendingPadBytes == 0)
+                {
+                    await HandlePreEmissionCorruptionAsync(openIndex, openId, e, cancellationToken)
+                        .ConfigureAwait(false);
+                    continue;
+                }
+
+                await HandlePostEmissionCorruptionAsync(openIndex, openId, e, cancellationToken)
+                    .ConfigureAwait(false);
+                throw;
+            }
+
             if (read > 0)
             {
                 _openSegmentBytes += read;
-                return read;
+                return written + read;
             }
+
+            if (written > 0)
+                return written;
 
             // Body ended early: pad to the recorded length so the next segment still
             // starts at the offset the rest of the file expects.
@@ -207,11 +277,9 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             _segmentSizes.RecordObservedSize(_openSegmentIndex, _openSegmentBytes);
         _openSegmentIndex = -1;
         _pendingPadBytes = 0;
-        if (_stream is not null)
-        {
-            await _stream.DisposeAsync().ConfigureAwait(false);
-            _stream = null;
-        }
+        _openSegmentFromLiveFetch = false;
+        _hasProbedByte = false;
+        await DisposeOpenBodyAsync().ConfigureAwait(false);
     }
 
     private Exception CreateUnknownLengthFailure(int segmentIndex, Exception failure)
@@ -223,6 +291,193 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         return failure.IsNonRetryableDownloadException()
             ? new NonRetryableDownloadException(message, failure)
             : new RetryableDownloadException(message, failure);
+    }
+
+    private async Task HandlePreEmissionCorruptionAsync(
+        int segmentIndex,
+        string segmentId,
+        UsenetCorruptArticleException initialFailure,
+        CancellationToken cancellationToken)
+    {
+        // Dispose first so the transport drains without parsing and fires its
+        // completion callback exactly once before we issue another BODY.
+        await DisposeOpenBodyAsync().ConfigureAwait(false);
+        _hasProbedByte = false;
+
+        var failure = initialFailure;
+        for (var attempt = 1; attempt <= MaxCorruptionRetries; attempt++)
+        {
+            Log.Debug(
+                failure,
+                "Corrupt segment {SegmentId} from provider {Provider}; retrying to allow provider failover (attempt {Attempt}).",
+                segmentId,
+                failure.ProviderKey,
+                attempt);
+            await Task.Delay(TimeSpan.FromMilliseconds(250 * attempt), cancellationToken)
+                .ConfigureAwait(false);
+
+            Stream? retryStream = null;
+            try
+            {
+                var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                    .ConfigureAwait(false);
+                retryStream = body.Stream;
+                await SegmentResponseValidator
+                    .ThrowOnSegmentIdMismatchAsync(segmentId, body)
+                    .ConfigureAwait(false);
+                await ProbeLiveStreamAsync(retryStream!, cancellationToken).ConfigureAwait(false);
+                AcceptLiveStream(retryStream!, segmentIndex);
+                return;
+            }
+            catch (UsenetCorruptArticleException e)
+            {
+                await DisposeBodyStreamAsync(retryStream).ConfigureAwait(false);
+                failure = e;
+            }
+        }
+
+        var fallback = await TryFallbackSegmentsAsync(segmentIndex, cancellationToken)
+            .ConfigureAwait(false);
+        if (fallback is not null)
+        {
+            _stream = fallback;
+            _openSegmentIndex = segmentIndex;
+            _openSegmentFromLiveFetch = true;
+            _consecutiveZeroFills = 0;
+            return;
+        }
+
+        if (_failFastOnFirstSegment && segmentIndex == 0)
+        {
+            failure.LogWarningKnownOrStack(
+                "First article {SegmentId} persistently corrupt at playback start while reading {FileName}. " +
+                "Failing the stream so the player surfaces an error.",
+                segmentId, _fileName);
+            ExceptionDispatchInfo.Capture(failure).Throw();
+            throw failure;
+        }
+
+        if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out _))
+            throw CreateUnknownLengthFailure(segmentIndex, failure);
+
+        ApplyZeroFill(segmentIndex, segmentId, fill, failure, isCorruption: true);
+    }
+
+    private async Task HandlePostEmissionCorruptionAsync(
+        int segmentIndex,
+        string segmentId,
+        UsenetCorruptArticleException corrupt,
+        CancellationToken cancellationToken)
+    {
+        Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
+
+        await DisposeOpenBodyAsync().ConfigureAwait(false);
+        _hasProbedByte = false;
+
+        try
+        {
+            var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                .ConfigureAwait(false);
+            await SegmentResponseValidator
+                .ThrowOnSegmentIdMismatchAsync(segmentId, body)
+                .ConfigureAwait(false);
+            await DrainAndDisposeAsync(body.Stream!, cancellationToken).ConfigureAwait(false);
+
+            Log.Debug(
+                corrupt,
+                "Segment {SegmentId} of {FileName} failed CRC after bytes were delivered, but a confirmation re-fetch was clean; corruption was transient/provider-specific.",
+                segmentId,
+                _fileName);
+            throw new TransientSegmentExhaustionException(
+                $"Segment {segmentIndex + 1} of {_segmentIds.Length} ({segmentId}) of \"{_fileName}\" failed CRC after bytes were delivered, but a confirmation re-fetch was clean; corruption was transient/provider-specific. The client should retry this range request.");
+        }
+        catch (TransientSegmentExhaustionException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (OutOfMemoryException)
+        {
+            throw;
+        }
+        catch (UsenetCorruptArticleException)
+        {
+            ExceptionDispatchInfo.Capture(corrupt).Throw();
+            throw;
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(
+                e,
+                "Confirmation re-fetch of corrupt segment {SegmentId} of {FileName} failed",
+                segmentId,
+                _fileName);
+            ExceptionDispatchInfo.Capture(corrupt).Throw();
+            throw;
+        }
+    }
+
+    private async Task ObserveLiveSegmentTrailerAsync(CancellationToken cancellationToken)
+    {
+        if (!_openSegmentFromLiveFetch || _stream is null)
+            return;
+
+        // One extra read against the in-memory pipe: 0 is clean EOF, a trailer CRC
+        // throw is post-emission corruption on a fully emitted exact-size segment.
+        _ = await _stream.ReadAsync(_scratch, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ProbeLiveStreamAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var probed = await stream.ReadAsync(_scratch.AsMemory(0, 1), cancellationToken)
+            .ConfigureAwait(false);
+        if (probed > 0)
+        {
+            _hasProbedByte = true;
+            _probedByte = _scratch[0];
+        }
+    }
+
+    private void AcceptLiveStream(Stream stream, int segmentIndex)
+    {
+        _stream = stream;
+        _openSegmentIndex = segmentIndex;
+        _openSegmentFromLiveFetch = true;
+        _consecutiveZeroFills = 0;
+    }
+
+    private void ApplyZeroFill(
+        int segmentIndex,
+        string segmentId,
+        long fill,
+        Exception cause,
+        bool isCorruption)
+    {
+        _consecutiveZeroFills++;
+        var template = isCorruption
+            ? "Article {SegmentId} persistently corrupt while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets."
+            : "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.";
+        ZeroFillLogLimiter.Write(template, segmentId, _fileName, fill, cause);
+        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+            StreamTrace.TryZeroFill(sessionId, segmentId, fill);
+        if (isCorruption)
+            Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
+        else
+            Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, fill);
+        if (_consecutiveZeroFills >= GapFillLimits.MaxConsecutiveZeroFills)
+        {
+            ExceptionDispatchInfo.Capture(cause).Throw();
+            throw cause;
+        }
+
+        _stream = CreateGapFillStream(fill, segmentIndex);
+        _openSegmentIndex = segmentIndex;
+        _openSegmentFromLiveFetch = false;
+        _openSegmentBytes = 0;
+        _hasProbedByte = false;
     }
 
     private async Task<Stream?> TryFallbackSegmentsAsync(
@@ -237,37 +492,89 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         var fallbacks = _segmentFallbacks[segmentIndex] ?? [];
         foreach (var fallbackId in fallbacks)
         {
+            Stream? fallbackStream = null;
             try
             {
                 var body = await _usenetClient
                     .DecodedBodyAsync(fallbackId, cancellationToken)
                     .ConfigureAwait(false);
+                fallbackStream = body.Stream;
                 await SegmentResponseValidator
                     .ThrowOnSegmentIdMismatchAsync(fallbackId, body)
                     .ConfigureAwait(false);
                 if (!await SegmentResponseValidator.IsFallbackPartSizeCompatibleAsync(
-                        body.Stream!, _segmentSizes, segmentIndex, cancellationToken)
+                        fallbackStream!, _segmentSizes, segmentIndex, cancellationToken)
                         .ConfigureAwait(false))
                 {
                     Log.Debug(
                         "Fallback MessageId {FallbackId} for segment {PrimaryIndex} of {FileName} has a mismatched yEnc part size; skipping.",
                         fallbackId, segmentIndex, _fileName);
-                    await body.Stream!.DisposeAsync().ConfigureAwait(false);
+                    await DisposeBodyStreamAsync(fallbackStream).ConfigureAwait(false);
+                    fallbackStream = null;
                     continue;
                 }
-                return body.Stream!;
+
+                await ProbeLiveStreamAsync(fallbackStream!, cancellationToken).ConfigureAwait(false);
+                var accepted = fallbackStream;
+                fallbackStream = null;
+                return accepted;
             }
             catch (UsenetArticleNotFoundException)
             {
-                // Try the next alternate MessageId.
+                await DisposeBodyStreamAsync(fallbackStream).ConfigureAwait(false);
+            }
+            catch (UsenetCorruptArticleException)
+            {
+                // Corrupt fallback — try the next alternate MessageId.
+                await DisposeBodyStreamAsync(fallbackStream).ConfigureAwait(false);
             }
             catch (UsenetUnexpectedResponseException e)
             {
+                await DisposeBodyStreamAsync(fallbackStream).ConfigureAwait(false);
                 Log.Debug(e, "Fallback MessageId {FallbackId} returned another article.", fallbackId);
             }
         }
 
         return null;
+    }
+
+    private async Task DisposeOpenBodyAsync()
+    {
+        var stream = _stream;
+        _stream = null;
+        await DisposeBodyStreamAsync(stream).ConfigureAwait(false);
+    }
+
+    private static async Task DisposeBodyStreamAsync(Stream? stream)
+    {
+        if (stream is null) return;
+        try
+        {
+            await stream.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Debug(e, "Failed to dispose a BODY stream before re-fetch");
+        }
+    }
+
+    private static async Task DrainAndDisposeAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(8192);
+        try
+        {
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, 8192), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0) break;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            await DisposeBodyStreamAsync(stream).ConfigureAwait(false);
+        }
     }
 
     private void ThrowIfDisposed()

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -381,8 +381,6 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         UsenetCorruptArticleException corrupt,
         CancellationToken cancellationToken)
     {
-        Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
-
         await DisposeOpenBodyAsync().ConfigureAwait(false);
         _hasProbedByte = false;
 
@@ -417,6 +415,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
         catch (UsenetCorruptArticleException)
         {
+            Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
             ExceptionDispatchInfo.Capture(corrupt).Throw();
             throw;
         }
@@ -427,6 +426,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 "Confirmation re-fetch of corrupt segment {SegmentId} of {FileName} failed",
                 segmentId,
                 _fileName);
+            Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
             ExceptionDispatchInfo.Capture(corrupt).Throw();
             throw;
         }

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -48,6 +48,22 @@ public class DatabaseStoreNzbFile(
             nzbFile.SegmentFallbackIds,
             inFlightArticleBudget,
             useContainerAwareFill: Config.IsContainerAwareFillEnabled(),
-            streamingBodyBatchWidth: Config.GetStreamingBodyBatchWidth());
+            streamingBodyBatchWidth: Config.GetStreamingBodyBatchWidth(),
+            knownCorruptSegmentIds: ResolveKnownCorruptSegmentIds(nzbFile));
+    }
+
+    private HashSet<string>? ResolveKnownCorruptSegmentIds(DavNzbFile nzbFile)
+    {
+        if (!Config.IsCorruptionTrackingEnabled()) return null;
+        if (nzbFile.CorruptSegmentIndices is not { Length: > 0 } indices) return null;
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var index in indices)
+        {
+            if ((uint)index < (uint)nzbFile.SegmentIds.Length)
+                ids.Add(nzbFile.SegmentIds[index]);
+        }
+
+        return ids.Count == 0 ? null : ids;
     }
 }

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -58,11 +58,8 @@ public class DatabaseStoreNzbFile(
         if (nzbFile.CorruptSegmentIndices is not { Length: > 0 } indices) return null;
 
         var ids = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var index in indices)
-        {
-            if ((uint)index < (uint)nzbFile.SegmentIds.Length)
-                ids.Add(nzbFile.SegmentIds[index]);
-        }
+        foreach (var index in indices.Where(i => (uint)i < (uint)nzbFile.SegmentIds.Length))
+            ids.Add(nzbFile.SegmentIds[index]);
 
         return ids.Count == 0 ? null : ids;
     }

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -18,6 +18,7 @@ Background health monitoring and replacement of unhealthy library items.
 | Repair After Streaming Failures | `repair.auto-remove-after-failures` | `0` | Consecutive streaming failures before urgent repair; `0` = immediate repair |
 | Auto-remove unlinked files only | `repair.auto-remove-unlinked-only` | on | At the threshold, linked items are removed and blocklisted through *Arr instead of force-deleted |
 | Degraded damage tolerance [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `repair.degraded-tolerance-enabled` | on | Keep slightly damaged videos playable instead of replacing the release |
+| Track corrupt articles during playback [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `repair.corruption-tracking-enabled` | on | Record streaming-confirmed corrupt articles, include them in health classification, and skip the retry storm on later reads |
 | Max consecutive missing segments | `repair.degraded-max-consecutive-missing` | `2` | Longest tolerable run of adjacent holes (1–2) |
 | Max total missing segments | `repair.degraded-max-total-missing` | `5` | Total tolerable holes per file (1–1000) |
 | Max missing data (% of file) | `repair.degraded-max-missing-byte-percent` | `1.0` | Tolerable hole share of file bytes (0.01–50) |
@@ -90,6 +91,31 @@ Degraded verdicts compose with the rest of the repair pipeline:
 
 Degraded files appear on the [Health page](../operations/health-repairs.md) with a warning
 badge, a dedicated history filter, and an overview stat card.
+
+## Realtime corruption detection [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+A corrupt-but-present article (right size, STAT succeeds, yEnc CRC fails) used to play as
+silent garbage. InfiniDysk now detects that on the playback path:
+
+1. **Detect** — yEnc CRC failures surface as corrupt articles, including trailer-CRC
+   corruption on exact-size segments in the unbuffered first-segment reader.
+2. **Re-fetch / failover** — the reader retries across providers, then sibling donor
+   Message-Ids, then gap-fills a known-length hole so later bytes stay aligned. There is
+   **no synchronous PAR2** on the read path (reconstruction stays in the background).
+3. **Record** — persistently corrupt segment IDs are stored on the file payload when
+   `repair.corruption-tracking-enabled` is on (the default whenever Background Repairs is
+   on). Later reads of those IDs probe once instead of repeating the retry storm.
+4. **Classify** — full-coverage health sweeps union remaining recorded corruption with
+   STAT holes, so a present-but-corrupt file is no longer reported Healthy.
+5. **Escalate** — when playback actually breaks, the same streaming-failure path used for
+   missing articles runs: PAR2-first when enabled, then *Arr remove-and-blocklist, with
+   re-grab protection.
+
+Disable **Track corrupt articles during playback** if you need the previous retry-only
+behavior. Playback-breaking corruption still schedules repair whenever Background Repairs
+is on.
+
+[Health and repairs](../operations/health-repairs.md)
 
 ## Replacement-loop protection [since 0.9.4](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.4){ .nzbdav-since }
 

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -17,6 +17,11 @@ failures before InfiniDysk starts a repair or asks *Arr to find a replacement. A
 playback or background health check resets that count. The counter is in memory, so it also resets
 when InfiniDysk restarts.
 
+Corrupt-but-present articles (CRC failures on otherwise complete files) now follow the same
+escalation path when playback breaks. Confirmed corrupt segments are recorded and included in
+full-coverage health classification so those files are not reported healthy — see
+[Realtime corruption detection](../configuration/repairs.md).
+
 ## Health-check retention
 
 Health result rows prune by age (**Maintenance** retention or `DATABASE_HEALTHCHECK_RETENTION_DAYS`). Reset counters from Maintenance when needed.

--- a/docs/operations/prometheus.md
+++ b/docs/operations/prometheus.md
@@ -2,8 +2,8 @@
 
 InfiniDysk exposes Prometheus metrics at `/metrics`. The endpoint includes standard
 .NET process/runtime metrics plus `nzbdav_` metrics for active streaming, seek
-latency, NNTP provider pools, circuit breakers, article outcomes, and internal
-metrics-pipeline health.
+latency, NNTP provider pools, circuit breakers, article outcomes, PAR2 repair,
+streaming-confirmed corrupt articles, and internal metrics-pipeline health.
 
 Metric labels are deliberately bounded. Provider metrics use the configured provider
 identity; other labels are fixed enums such as `region`, `kind`, `state`, and

--- a/frontend/app/routes/settings/repairs/repairs.test.ts
+++ b/frontend/app/routes/settings/repairs/repairs.test.ts
@@ -17,6 +17,7 @@ const baseConfig: Record<string, string> = {
     "repair.par2-fetch-concurrency": "2",
     "repair.par2-failure-cooldown-hours": "6",
     "repair.degraded-tolerance-enabled": "true",
+    "repair.corruption-tracking-enabled": "true",
     "repair.degraded-max-consecutive-missing": "2",
     "repair.degraded-max-total-missing": "5",
     "repair.degraded-max-missing-byte-percent": "1.0",
@@ -57,6 +58,14 @@ describe("Repairs settings helpers", () => {
         expect(isRepairsSettingsUpdated(baseConfig, {
             ...baseConfig,
             "repair.degraded-max-missing-byte-percent": "2.5",
+        })).toBe(true);
+        expect(isRepairsSettingsUpdated(baseConfig, baseConfig)).toBe(false);
+    });
+
+    it("detects corruption tracking setting changes", () => {
+        expect(isRepairsSettingsUpdated(baseConfig, {
+            ...baseConfig,
+            "repair.corruption-tracking-enabled": "false",
         })).toBe(true);
         expect(isRepairsSettingsUpdated(baseConfig, baseConfig)).toBe(false);
     });

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -324,6 +324,18 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                 />
             </Tooltip>
             </ManagedSetting>
+            <ManagedSetting configKey="repair.corruption-tracking-enabled">
+            <Tooltip content="Record streaming-confirmed corrupt articles on the file, include them in health classification, and skip the retry storm on later reads. Enabled by default. Disable to stop persistence and the known-corrupt fast path. Playback-breaking corruption still escalates to repair when Background Repairs is on.">
+                <Toggle
+                    id="corruption-tracking-enabled-checkbox"
+                    className="cursor-pointer gap-2 p-0"
+                    checked={isRepairEnabled && (config["repair.corruption-tracking-enabled"] ?? "true") === "true"}
+                    disabled={!isRepairEnabled}
+                    onChange={e => setNewConfig({ ...config, "repair.corruption-tracking-enabled": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Track corrupt articles during playback</span>}
+                />
+            </Tooltip>
+            </ManagedSetting>
             <ManagedSetting
                 configKeys={[
                     "repair.degraded-max-consecutive-missing",
@@ -397,6 +409,7 @@ export function isRepairsSettingsUpdated(config: Record<string, string>, newConf
         || config["repair.par2-fetch-concurrency"] !== newConfig["repair.par2-fetch-concurrency"]
         || config["repair.par2-failure-cooldown-hours"] !== newConfig["repair.par2-failure-cooldown-hours"]
         || config["repair.degraded-tolerance-enabled"] !== newConfig["repair.degraded-tolerance-enabled"]
+        || config["repair.corruption-tracking-enabled"] !== newConfig["repair.corruption-tracking-enabled"]
         || config["repair.degraded-max-consecutive-missing"] !== newConfig["repair.degraded-max-consecutive-missing"]
         || config["repair.degraded-max-total-missing"] !== newConfig["repair.degraded-max-total-missing"]
         || config["repair.degraded-max-missing-byte-percent"] !== newConfig["repair.degraded-max-missing-byte-percent"]

--- a/tests/NzbWebDAV.Tests/Config/DegradedToleranceConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/DegradedToleranceConfigTests.cs
@@ -35,6 +35,33 @@ public sealed class DegradedToleranceConfigTests
     }
 
     [Fact]
+    public void CorruptionTracking_DefaultsToOffWhenRepairsAreOff()
+    {
+        Assert.False(new ConfigManager().IsCorruptionTrackingEnabled());
+    }
+
+    [Fact]
+    public void CorruptionTracking_DefaultsToOnWhenRepairsAreOn()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([Item(ConfigKeys.RepairEnable, "true")]);
+
+        Assert.True(config.IsCorruptionTrackingEnabled());
+    }
+
+    [Fact]
+    public void CorruptionTracking_RespectsExplicitDisable()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([
+            Item(ConfigKeys.RepairEnable, "true"),
+            Item(ConfigKeys.RepairCorruptionTrackingEnabled, "false"),
+        ]);
+
+        Assert.False(config.IsCorruptionTrackingEnabled());
+    }
+
+    [Fact]
     public void MaxConsecutiveMissing_DefaultsToTwo()
     {
         Assert.Equal(2, new ConfigManager().GetDegradedMaxConsecutiveMissing());

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -28,6 +28,12 @@ internal sealed class FakeNntpClient(
     /// <summary>Adds or restores an article (e.g. provider-side recovery between checks).</summary>
     public void Serve(string segmentId, byte[] content) => _segments[segmentId] = content;
 
+    /// <summary>
+    /// When set, BODY responses claim this SegmentId instead of the requested one
+    /// so tests can exercise mismatch rejection without a live NNTP scramble.
+    /// </summary>
+    public string? ForcedResponseSegmentId { get; set; }
+
     public override Task ConnectAsync(
         string host, int port, bool useSsl, CancellationToken cancellationToken) =>
         Task.CompletedTask;
@@ -169,7 +175,7 @@ internal sealed class FakeNntpClient(
             : new YencStream(new MemoryStream(EncodeYenc(bytes), writable: false));
         return new UsenetDecodedBodyResponse
         {
-            SegmentId = key,
+            SegmentId = ForcedResponseSegmentId ?? key,
             ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
             ResponseMessage = "222 fake body",
             Stream = stream,

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -575,6 +575,180 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task CorruptArticleWithDavItem_RecordsFailureAndSeedsFailFastCache()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetCorruptArticleException(
+                segmentId, "provider-a", new InvalidDataException("CRC mismatch")),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(lifetimeFeature.Aborted);
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+        Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+    }
+
+    [Fact]
+    public async Task CorruptArticleAfterResponseStarted_AbortsConnection()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetCorruptArticleException(
+                segmentId, "provider-a", new InvalidDataException("CRC mismatch")),
+            CreateRepairEnabledConfig());
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task CorruptArticleWithRepairsDisabled_WarnsWithoutRecordingFailureCount()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetCorruptArticleException(
+                segmentId, "provider-a", new InvalidDataException("CRC mismatch")),
+            new ConfigManager(),
+            failureTracker);
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        var logged = Assert.Single(events, e =>
+            e.RenderMessage().Contains("will not trigger repair", StringComparison.Ordinal));
+        Assert.Equal(LogEventLevel.Warning, logged.Level);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+        Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+    }
+
+    [Fact]
+    public async Task CorruptArticleWrappedInRetryableDownloadException_StillEscalates()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var inner = new UsenetCorruptArticleException(
+            segmentId, "provider-a", new InvalidDataException("CRC mismatch"));
+        var middleware = CreateMiddleware(
+            _ => throw new RetryableDownloadException(
+                "Segment could not be downloaded.", inner),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+        Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+    }
+
+    [Fact]
+    public async Task CorruptArticleWhenRequestAborted_DoesNotEscalate()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature
+        {
+            RequestAborted = new CancellationToken(canceled: true),
+        };
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetCorruptArticleException(
+                segmentId, "provider-a", new InvalidDataException("CRC mismatch")),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+        HealthCheckService.CheckCachedMissingSegmentIds([segmentId]);
+    }
+
+    [Fact]
+    public async Task SeekFailureWithCorruptInner_DoesNotEscalate()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new SeekPositionNotFoundException(
+                "Corrupt file. Cannot find byte position 50.",
+                new UsenetCorruptArticleException(
+                    segmentId, "provider-a", new InvalidDataException("CRC mismatch"))),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+        HealthCheckService.CheckCachedMissingSegmentIds([segmentId]);
+    }
+
+    [Fact]
+    public async Task TransientSegmentExhaustion_DoesNotEscalateEvenWithCorruptInner()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new TransientSegmentExhaustionException(
+                $"Segment ({segmentId}) failed CRC after bytes were delivered, but a confirmation re-fetch was clean; corruption was transient/provider-specific."),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+        HealthCheckService.CheckCachedMissingSegmentIds([segmentId]);
+    }
+
+    [Fact]
+    public async Task TransientSegmentExhaustionWithCorruptInner_DoesNotEscalate()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new TransientSegmentExhaustionException(
+                "range retry",
+                new UsenetCorruptArticleException(
+                    segmentId, "provider-a", new InvalidDataException("CRC mismatch"))),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+        HealthCheckService.CheckCachedMissingSegmentIds([segmentId]);
+    }
+
+    [Fact]
     public void RecordMissingArticleForFailFast_IgnoresUnimportantFileTypes()
     {
         var segmentId = $"<{Guid.NewGuid():N}@test>";

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -607,6 +607,26 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ReconfirmationProbe_MismatchedSegmentId_KeepsCorruptRecord()
+    {
+        var segments = NewSegmentIds(4);
+        var sizes = new long[] { 10_000, 10_000, 50, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: [2]);
+        var fake = NewFakeClient(segments, missing: []);
+        fake.ForcedResponseSegmentId = "wrong@example.com";
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Degraded, row.Result);
+        Assert.Equal([segments[2]], Assert.Single(par2.Requests));
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(ReloadItem(item.Id).FileBlobId!.Value);
+        Assert.Equal([2], blob!.CorruptSegmentIndices!);
+    }
+
+    [Fact]
     public async Task HealthyBranchDetour_ClearsStaleCorruptRecordWhenProbesPass()
     {
         var segments = NewSegmentIds(4);

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -126,7 +126,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         var row = Assert.Single(GetHealthRows(item.Id));
         Assert.Equal(HealthCheckResult.HealthResult.Degraded, row.Result);
         Assert.Equal(HealthCheckResult.RepairAction.None, row.RepairStatus);
-        Assert.Contains("1 missing segment(s) (largest run 1", row.Message);
+        Assert.Contains("1 missing/corrupt segment(s) (largest run 1", row.Message);
         Assert.Contains("within tolerance for a resync-tolerant container", row.Message);
         Assert.Equal(1, _context.Items.AsNoTracking().Count(x => x.Id == item.Id));
 
@@ -490,15 +490,179 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Equal([2], blob!.MissingSegmentIndices!);
     }
 
+    [Fact]
+    public async Task RecordedCorrupt_StatClean_MarksDegradedWithinCaps()
+    {
+        var segments = NewSegmentIds(6);
+        var sizes = new long[] { 10_000, 10_000, 50, 10_000, 10_000, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: [2]);
+        var fake = NewFakeClient(segments, missing: [], corrupt: [2]);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Degraded, row.Result);
+        Assert.Contains("1 missing/corrupt segment(s)", row.Message);
+        Assert.Equal([segments[2]], Assert.Single(par2.Requests));
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(ReloadItem(item.Id).FileBlobId!.Value);
+        Assert.Equal([2], blob!.CorruptSegmentIndices!);
+        Assert.Null(blob.MissingSegmentIndices);
+    }
+
+    [Fact]
+    public async Task RecordedCorruptOverCap_FailsAndRepairs()
+    {
+        var segments = NewSegmentIds(8);
+        var sizes = Enumerable.Repeat(10_000L, 8).ToArray();
+        var corrupt = new[] { 1, 2, 3, 4, 5, 6 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: corrupt);
+        var fake = NewFakeClient(segments, missing: [], corrupt: corrupt);
+        var (service, _) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+    }
+
+    [Fact]
+    public async Task RecordedCorruptAtSegmentZero_Fails()
+    {
+        var segments = NewSegmentIds(4);
+        var sizes = new long[] { 10_000, 10_000, 10_000, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: [0]);
+        var fake = NewFakeClient(segments, missing: [], corrupt: [0]);
+        var (service, _) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+    }
+
+    [Fact]
+    public async Task RecordedCorruptUnionsWithStatHoles()
+    {
+        var segments = NewSegmentIds(6);
+        var sizes = new long[] { 10_000, 10_000, 50, 10_000, 50, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: [4]);
+        var fake = NewFakeClient(segments, missing: [2], corrupt: [4]);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Degraded, row.Result);
+        Assert.Equal([segments[2], segments[4]], Assert.Single(par2.Requests));
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(ReloadItem(item.Id).FileBlobId!.Value);
+        Assert.Equal([2], blob!.MissingSegmentIndices!);
+        Assert.Equal([4], blob.CorruptSegmentIndices!);
+    }
+
+    [Fact]
+    public async Task PatchedCorruptIndices_AreExcludedFromClassification()
+    {
+        var segments = NewSegmentIds(4);
+        var sizes = new long[] { 10_000, 100, 50, 10_000 };
+        var (item, oldBlobId) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: [1]);
+        CommitPatch(segments[1], (int)sizes[1]);
+        var fake = NewFakeClient(segments, missing: []);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, row.Result);
+        Assert.Empty(par2.Requests);
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(ReloadItem(item.Id).FileBlobId!.Value);
+        Assert.Null(blob!.CorruptSegmentIndices);
+        Assert.NotEqual(oldBlobId, ReloadItem(item.Id).FileBlobId);
+    }
+
+    [Fact]
+    public async Task ReconfirmationProbe_ClearsNowCleanCorruptRecord()
+    {
+        var segments = NewSegmentIds(4);
+        var sizes = new long[] { 10_000, 10_000, 50, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingCorrupt: [2]);
+        var fake = NewFakeClient(segments, missing: []);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, row.Result);
+        Assert.Empty(par2.Requests);
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(ReloadItem(item.Id).FileBlobId!.Value);
+        Assert.Null(blob!.CorruptSegmentIndices);
+        Assert.Null(blob.MissingSegmentIndices);
+    }
+
+    [Fact]
+    public async Task HealthyBranchDetour_ClearsStaleCorruptRecordWhenProbesPass()
+    {
+        var segments = NewSegmentIds(4);
+        var sizes = new long[] { 10_000, 10_000, 10_000, 10_000 };
+        var (item, oldBlobId) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingHoles: [1], preExistingCorrupt: [2]);
+        var fake = NewFakeClient(segments, missing: []);
+        var (service, _) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, row.Result);
+        var persisted = ReloadItem(item.Id);
+        Assert.NotEqual(oldBlobId, persisted.FileBlobId);
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(persisted.FileBlobId!.Value);
+        Assert.Null(blob!.MissingSegmentIndices);
+        Assert.Null(blob.CorruptSegmentIndices);
+    }
+
     private static string[] NewSegmentIds(int count) =>
         Enumerable.Range(0, count).Select(i => $"seg{i}-{Guid.NewGuid():N}@test").ToArray();
 
-    private static FakeNntpClient NewFakeClient(string[] segments, int[] missing)
+    private static FakeNntpClient NewFakeClient(string[] segments, int[] missing, int[]? corrupt = null)
     {
+        var corruptSet = new HashSet<int>(corrupt ?? []);
         var present = segments
             .Where((_, index) => !missing.Contains(index))
             .ToDictionary(id => id, _ => new byte[128], StringComparer.Ordinal);
-        return new FakeNntpClient(present);
+        if (corruptSet.Count == 0)
+            return new FakeNntpClient(present);
+
+        return new FakeNntpClient(
+            present,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (id, bytes) =>
+            {
+                var index = Array.IndexOf(segments, id);
+                if (index >= 0 && corruptSet.Contains(index))
+                    return new ThrowingReadStream(id);
+                return new MemoryStream(bytes, writable: false);
+            });
+    }
+
+    private sealed class ThrowingReadStream(string segmentId) : MemoryStream
+    {
+        private UsenetCorruptArticleException CreateException() =>
+            new(segmentId, "provider-a", new InvalidDataException("CRC mismatch"));
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw CreateException();
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<int>(CreateException());
     }
 
     private async Task<(HealthCheckService Service, ScriptedPar2RepairService Par2)> NewServiceAsync(
@@ -525,6 +689,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         long[] segmentSizes,
         string[][]? fallbackIds = null,
         int[]? preExistingHoles = null,
+        int[]? preExistingCorrupt = null,
         byte? containerClass = null,
         long? criticalHeadEndExclusive = null)
     {
@@ -545,6 +710,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             SegmentByteRanges = ranges,
             SegmentFallbackIds = fallbackIds,
             MissingSegmentIndices = preExistingHoles,
+            CorruptSegmentIndices = preExistingCorrupt,
             ContainerClass = containerClass,
             CriticalHeadEndExclusive = criticalHeadEndExclusive,
         });

--- a/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
@@ -1,0 +1,233 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class DavNzbFileCorruptionRecordTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-corrupt-record-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private ConfigManager _config = null!;
+
+    public Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+        DavDatabaseContext.ResetOptionsForTests();
+        _config = new ConfigManager();
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+        ]);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        DavDatabaseContext.ResetOptionsForTests();
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Consumer_ResolvesAbsoluteIndexFromSegmentId()
+    {
+        var segments = new[] { "head@test", "mid@test", "tail@test", "last@test" };
+        var (item, _) = await AddFileAsync(segments, missing: [1], containerClass: 2);
+        // A post-seek stream sliced at "tail@test" would see relative index 0.
+        var service = NewService();
+
+        await service.ProcessCorruptionEventForTestsAsync(item.Path, segments[2], CancellationToken.None);
+
+        var blob = await ReadCurrentBlobAsync(item.Id);
+        Assert.Equal([2], blob.CorruptSegmentIndices!);
+        Assert.Equal([1], blob.MissingSegmentIndices!);
+        Assert.Equal((byte)2, blob.ContainerClass);
+    }
+
+    [Fact]
+    public async Task Consumer_MergesCorruptIndicesWithoutDroppingExistingFields()
+    {
+        var segments = NewSegmentIds(4);
+        var (item, _) = await AddFileAsync(segments, missing: [0, 3], containerClass: 1, criticalHead: 56);
+        var service = NewService();
+
+        await service.ProcessCorruptionEventForTestsAsync(item.Path, segments[2], CancellationToken.None);
+        await service.ProcessCorruptionEventForTestsAsync(item.Path, segments[0], CancellationToken.None);
+
+        var blob = await ReadCurrentBlobAsync(item.Id);
+        Assert.Equal([0, 2], blob.CorruptSegmentIndices!);
+        Assert.Equal([0, 3], blob.MissingSegmentIndices!);
+        Assert.Equal((byte)1, blob.ContainerClass);
+        Assert.Equal(56, blob.CriticalHeadEndExclusive);
+    }
+
+    [Fact]
+    public async Task ConcurrentMutations_LoseNoBlobFields()
+    {
+        var segments = NewSegmentIds(4);
+        var (item, _) = await AddFileAsync(segments, missing: null, containerClass: 3);
+        var instanceA = ReloadTracked(item.Id);
+        var instanceB = ReloadTracked(item.Id);
+
+        await Task.WhenAll(
+            DavNzbFileBlobUpdater.MutateAsync(instanceA, current =>
+            {
+                current.MissingSegmentIndices = [1];
+                return current;
+            }),
+            DavNzbFileBlobUpdater.MutateAsync(instanceB, current =>
+            {
+                current.CorruptSegmentIndices = [2];
+                return current;
+            }));
+
+        var blobA = await BlobStore.ReadBlob<DavNzbFile>(instanceA.FileBlobId!.Value);
+        var blobB = await BlobStore.ReadBlob<DavNzbFile>(instanceB.FileBlobId!.Value);
+        Assert.Contains(
+            new[] { blobA!, blobB! },
+            blob => blob.MissingSegmentIndices is [1]
+                    && blob.CorruptSegmentIndices is [2]
+                    && blob.ContainerClass == 3
+                    && blob.SegmentIds.SequenceEqual(segments));
+    }
+
+    [Fact]
+    public async Task Consumer_EnqueuesPar2OnlyWhenPar2Enabled()
+    {
+        var segments = NewSegmentIds(3);
+        var (item, _) = await AddFileAsync(segments);
+
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "false" },
+        ]);
+        var trackingOnly = new RecordingEnqueuePar2RepairService(_config, Path.Join(_configRoot, "patches-off"));
+        await trackingOnly.ProcessCorruptionEventForTestsAsync(item.Path, segments[1], CancellationToken.None);
+        Assert.Empty(trackingOnly.Enqueued);
+        var trackingBlob = await ReadCurrentBlobAsync(item.Id);
+        Assert.Equal([1], trackingBlob.CorruptSegmentIndices!);
+
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "true" },
+        ]);
+        var withPar2 = new RecordingEnqueuePar2RepairService(_config, Path.Join(_configRoot, "patches-on"));
+        await withPar2.ProcessCorruptionEventForTestsAsync(item.Path, segments[1], CancellationToken.None);
+        Assert.Equal([segments[1]], Assert.Single(withPar2.Enqueued));
+    }
+
+    [Fact]
+    public async Task HealthReplaceMutation_PreservesCorruptRecord()
+    {
+        var segments = NewSegmentIds(3);
+        var (item, _) = await AddFileAsync(segments);
+        await DavNzbFileBlobUpdater.MutateAsync(item, current =>
+        {
+            current.CorruptSegmentIndices = [2];
+            return current;
+        });
+
+        await DavNzbFileBlobUpdater.MutateAsync(item, current =>
+        {
+            current.MissingSegmentIndices = [0];
+            return current;
+        });
+
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(item.FileBlobId!.Value);
+        Assert.Equal([0], blob!.MissingSegmentIndices!);
+        Assert.Equal([2], blob.CorruptSegmentIndices!);
+    }
+
+    private Par2RepairService NewService() =>
+        new(_config, null!, new RepairPatchStore(Path.Join(_configRoot, "patches"), 1024 * 1024));
+
+    private async Task<(DavItem Item, Guid BlobId)> AddFileAsync(
+        string[] segmentIds,
+        int[]? missing = null,
+        byte? containerClass = null,
+        long? criticalHead = null)
+    {
+        await using var context = new DavDatabaseContext();
+        await context.Database.MigrateAsync();
+
+        var itemId = Guid.NewGuid();
+        var blobId = Guid.NewGuid();
+        var sizes = Enumerable.Repeat(100L, segmentIds.Length).ToArray();
+        var ranges = new LongRange[sizes.Length];
+        long offset = 0;
+        for (var i = 0; i < sizes.Length; i++)
+        {
+            ranges[i] = LongRange.FromStartAndSize(offset, sizes[i]);
+            offset += sizes[i];
+        }
+
+        await BlobStore.WriteBlob(blobId, new DavNzbFile
+        {
+            Id = itemId,
+            SegmentIds = segmentIds,
+            SegmentByteRanges = ranges,
+            MissingSegmentIndices = missing,
+            ContainerClass = containerClass,
+            CriticalHeadEndExclusive = criticalHead,
+        });
+
+        var item = DavItem.New(
+            itemId,
+            DavItem.ContentFolder,
+            $"movie-{itemId:N}.mkv",
+            fileSize: offset,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: blobId);
+        context.Items.Add(item);
+        await context.SaveChangesAsync();
+        return (item, blobId);
+    }
+
+    private static async Task<DavNzbFile> ReadCurrentBlobAsync(Guid itemId)
+    {
+        await using var context = new DavDatabaseContext();
+        var item = await context.Items.AsNoTracking().SingleAsync(x => x.Id == itemId);
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(item.FileBlobId!.Value);
+        return blob!;
+    }
+
+    private static DavItem ReloadTracked(Guid itemId)
+    {
+        using var context = new DavDatabaseContext();
+        return context.Items.AsNoTracking().Single(x => x.Id == itemId);
+    }
+
+    private static string[] NewSegmentIds(int count) =>
+        Enumerable.Range(0, count).Select(i => $"seg{i}-{Guid.NewGuid():N}@test").ToArray();
+
+    private sealed class RecordingEnqueuePar2RepairService(ConfigManager config, string patchDir)
+        : Par2RepairService(config, null!, new RepairPatchStore(patchDir, 1024 * 1024))
+    {
+        public List<string[]> Enqueued { get; } = [];
+
+        public override Task EnqueueAsync(
+            DavItem davItem,
+            IReadOnlyList<string> missingSegmentIds,
+            CancellationToken ct = default)
+        {
+            Enqueued.Add(missingSegmentIds.ToArray());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -146,6 +146,107 @@ public sealed class Par2RepairIntegrationTests
     }
 
     [Fact]
+    public async Task Reconstruct_CorruptTargetSegment_CommitsPatch_AndServesPatchedBytes()
+    {
+        var fileData = new byte[4096 * 3];
+        for (var i = 0; i < fileData.Length; i++)
+            fileData[i] = (byte)(i ^ 0x5A);
+
+        const ulong sliceSize = 4096;
+        var (_, volume) = Par2TestEncoder.EncodeSet("corrupt-target.bin", fileData, sliceSize, [0u, 1u]);
+
+        var descriptors = new Dictionary<string, FileDesc>();
+        var ifscs = new Dictionary<string, IfscPacket>();
+        MainPacket? main = null;
+        var recovery = new List<Par2Reconstructor.RecoverySlice>();
+
+        await using (var stream = new MemoryStream(volume))
+        {
+            while (stream.Position < stream.Length)
+            {
+                var packet = await Par2RepairReader.ReadVerifiedPacketAsync(stream, true, CancellationToken.None);
+                switch (packet)
+                {
+                    case FileDesc fd:
+                        descriptors[Convert.ToHexString(fd.FileID)] = fd;
+                        break;
+                    case MainPacket mp:
+                        main = mp;
+                        break;
+                    case IfscPacket ifsc:
+                        ifscs[Convert.ToHexString(ifsc.FileId)] = ifsc;
+                        break;
+                    case RecvSlic recv:
+                        recovery.Add(new Par2Reconstructor.RecoverySlice(recv.Exponent, recv.Payload));
+                        break;
+                }
+            }
+        }
+
+        Assert.NotNull(main);
+        var slices = BuildSliceBytes(fileData, sliceSize);
+        const int corruptIndex = 1;
+        var garbage = (byte[])slices[corruptIndex].Clone();
+        garbage[0] ^= 0xFF;
+
+        var reconstructor = new Par2Reconstructor();
+        var result = await reconstructor.ReconstructAsync(
+            main!,
+            descriptors,
+            ifscs,
+            [corruptIndex],
+            recovery,
+            (globalSlice, size, _) =>
+            {
+                // Present-but-corrupt: the IFSC-failing slice is treated as missing so
+                // Reed-Solomon can rebuild it. Returning the garbage would fail the
+                // present-slice IFSC gate instead of reconstructing.
+                if (globalSlice == corruptIndex)
+                    return Task.FromResult<byte[]?>(null);
+                return Task.FromResult<byte[]?>(slices[globalSlice]);
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success, result.FailureReason);
+        Assert.Equal(slices[corruptIndex], result.ReconstructedSlices[corruptIndex]);
+        Assert.NotEqual(garbage, result.ReconstructedSlices[corruptIndex]);
+
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-corrupt-par2-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "corrupt-target-seg1@test";
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            store.CommitPatch(segmentId, result.ReconstructedSlices[corruptIndex], new UsenetYencHeader
+            {
+                FileName = "corrupt-target.bin",
+                FileSize = fileData.Length,
+                LineLength = 128,
+                PartNumber = corruptIndex + 1,
+                TotalParts = slices.Length,
+                PartSize = (int)sliceSize,
+                PartOffset = corruptIndex * (int)sliceSize,
+            });
+
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = garbage },
+                useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(0, inner.BodyRequestCount);
+
+            await using var ms = new MemoryStream();
+            await response.Stream!.CopyToAsync(ms);
+            Assert.Equal(slices[corruptIndex], ms.ToArray());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Reconstruct_CorruptRecoverySlice_GateFailure_NothingPersisted()
     {
         var fileData = new byte[4096 * 2];

--- a/tests/NzbWebDAV.Tests/Services/Repair/SegmentDamageClassifierTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/SegmentDamageClassifierTests.cs
@@ -13,7 +13,7 @@ public class SegmentDamageClassifierTests
             [], [100L, 100, 100, 100], MediaContainerClass.ResyncTolerant, out var reason);
 
         Assert.Equal(SegmentDamageVerdict.Clean, verdict);
-        Assert.Contains("0 missing segment(s)", reason);
+        Assert.Contains("0 missing/corrupt segment(s)", reason);
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class SegmentDamageClassifierTests
             [4, 5], Sizes(10, (4, 100), (5, 100)), MediaContainerClass.ResyncTolerant,
             out var reason);
 
-        Assert.Contains("2 missing segment(s)", reason);
+        Assert.Contains("2 missing/corrupt segment(s)", reason);
         Assert.Contains("largest run 2", reason);
         Assert.Contains("of file", reason);
     }
@@ -201,7 +201,7 @@ public class SegmentDamageClassifierTests
             [2, 2], Sizes(10, (2, 10)), MediaContainerClass.ResyncTolerant, out var reason);
 
         Assert.Equal(SegmentDamageVerdict.Degraded, verdict);
-        Assert.Contains("1 missing segment(s)", reason);
+        Assert.Contains("1 missing/corrupt segment(s)", reason);
     }
 
     [Theory]

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -115,9 +115,9 @@ public sealed class SupportPackContentsTests : IDisposable
 
         using var environment = JsonDocument.Parse(entries["environment.json"]);
         var tracking = environment.RootElement.GetProperty("par2Repair").GetProperty("corruptionTracking");
-        Assert.True(tracking.TryGetProperty("enabled", out _));
-        Assert.True(tracking.GetProperty("filesWithCorruptRecords").GetInt32() >= 0);
-        Assert.True(tracking.GetProperty("recordedCorruptSegments").GetInt32() >= 0);
+        Assert.False(tracking.GetProperty("enabled").GetBoolean());
+        Assert.Equal(0, tracking.GetProperty("filesWithCorruptRecords").GetInt32());
+        Assert.Equal(0, tracking.GetProperty("recordedCorruptSegments").GetInt32());
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -109,6 +109,18 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_ReportsCorruptionTrackingCountsInPar2RepairSection()
+    {
+        var entries = await ReadPackEntriesAsync(new LogBufferSink(10), new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var tracking = environment.RootElement.GetProperty("par2Repair").GetProperty("corruptionTracking");
+        Assert.True(tracking.TryGetProperty("enabled", out _));
+        Assert.True(tracking.GetProperty("filesWithCorruptRecords").GetInt32() >= 0);
+        Assert.True(tracking.GetProperty("recordedCorruptSegments").GetInt32() >= 0);
+    }
+
+    [Fact]
     public async Task Pack_ReportsCpuGcAndThreadPoolCountersForBottleneckTriage()
     {
         var entries = await ReadPackEntriesAsync(new LogBufferSink(10), new WarningLogBuffer(new LogBufferSink(50)));

--- a/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
@@ -109,24 +109,27 @@ public class CorruptionDetectionTests
     }
 
     [Fact]
-    public async Task UnbufferedStream_PostEmissionCleanConfirmation_ThrowsTransientWithoutCorruptInner()
+    public async Task UnbufferedStream_PostEmissionCleanConfirmation_ThrowsTransientWithoutReporting()
     {
         var payload = "hello"u8.ToArray();
+        var segmentId = $"segment-{Guid.NewGuid():N}@example";
+        var reports = Par2RepairTriggerSink.TestReports ??= new();
         using var client = new ScriptedNntpClient((id, n) => n == 1
             ? new PayloadThenCorruptYencStream(payload, id)
             : new BytesYencStream(payload));
         await using var stream = CreateUnbuffered(
-            client, ["segment@example"], exactSizes: [payload.Length]);
+            client, [segmentId], exactSizes: [payload.Length]);
         using var output = new MemoryStream();
 
         var exception = await Assert.ThrowsAsync<TransientSegmentExhaustionException>(
             () => stream.CopyToAsync(output));
 
         Assert.Contains("transient/provider-specific", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("segment@example", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(segmentId, exception.Message, StringComparison.Ordinal);
         Assert.Null(exception.InnerException);
         Assert.False(exception.TryGetCausingException(out UsenetCorruptArticleException? _));
         Assert.Equal(2, client.BodyRequestCount);
+        Assert.DoesNotContain(reports, e => e.SegmentId == segmentId);
     }
 
     [Fact]
@@ -306,7 +309,7 @@ public class CorruptionDetectionTests
             {
                 inner = factory(key, BodyRequestCounts[key]);
             }
-            catch
+            catch (Exception)
             {
                 return Task.FromException<UsenetDecodedBodyResponse>(
                     new UsenetCorruptArticleException(key, "provider-a",

--- a/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
@@ -1,6 +1,8 @@
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -44,6 +46,366 @@ public class CorruptionDetectionTests
 
         Assert.Equal(expected, output.ToArray());
         Assert.Equal(4, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_PreEmissionCorruption_RetriesAndServesValidBytes()
+    {
+        var expected = "validated payload"u8.ToArray();
+        using var client = new ScriptedNntpClient((id, n) => n == 1
+            ? ImmediateCorruptStream(id)
+            : new BytesYencStream(expected));
+        await using var stream = CreateUnbuffered(client, ["segment@example"], exactSizes: [expected.Length]);
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(expected, output.ToArray());
+        Assert.Equal(2, client.BodyRequestCount);
+        Assert.Equal(0, client.OverlappingFetches);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_PersistentPreEmissionCorruption_ZeroFillsAndReportsCorruption()
+    {
+        var fill = 8;
+        var segmentId = $"segment-{Guid.NewGuid():N}@example";
+        var fileName = $"movie-{Guid.NewGuid():N}.mkv";
+        var reports = Par2RepairTriggerSink.TestReports ??= new();
+        using var client = new ScriptedNntpClient((id, _) => ImmediateCorruptStream(id));
+        await using var stream = CreateUnbuffered(
+            client, [segmentId], exactSizes: [fill], fileName: fileName);
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(new byte[fill], output.ToArray());
+        Assert.Equal(4, client.BodyRequestCount);
+        var report = Assert.Single(reports, e => e.SegmentId == segmentId);
+        Assert.Equal(fileName, report.Path);
+        Assert.True(report.IsCorruption);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_ExactSizeCorruptTrailer_SurfacesCorruptionInsteadOfSilentGarbage()
+    {
+        var payload = "hello"u8.ToArray();
+        var segmentId = $"segment-{Guid.NewGuid():N}@example";
+        var reports = Par2RepairTriggerSink.TestReports ??= new();
+        using var client = new ScriptedNntpClient(
+            (id, _) => new PayloadThenCorruptYencStream(payload, id));
+        await using var stream = CreateUnbuffered(
+            client, [segmentId], exactSizes: [payload.Length]);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<UsenetCorruptArticleException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.Equal(segmentId, exception.SegmentId);
+        Assert.Equal(payload, output.ToArray());
+        Assert.Equal(2, client.BodyRequestCount);
+        var report = Assert.Single(reports, e => e.SegmentId == segmentId);
+        Assert.True(report.IsCorruption);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_PostEmissionCleanConfirmation_ThrowsTransientWithoutCorruptInner()
+    {
+        var payload = "hello"u8.ToArray();
+        using var client = new ScriptedNntpClient((id, n) => n == 1
+            ? new PayloadThenCorruptYencStream(payload, id)
+            : new BytesYencStream(payload));
+        await using var stream = CreateUnbuffered(
+            client, ["segment@example"], exactSizes: [payload.Length]);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<TransientSegmentExhaustionException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.Contains("transient/provider-specific", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("segment@example", exception.Message, StringComparison.Ordinal);
+        Assert.Null(exception.InnerException);
+        Assert.False(exception.TryGetCausingException(out UsenetCorruptArticleException? _));
+        Assert.Equal(2, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_PostEmissionCorruptConfirmation_RethrowsAndReports()
+    {
+        var payload = "hello"u8.ToArray();
+        var segmentId = $"segment-{Guid.NewGuid():N}@example";
+        var reports = Par2RepairTriggerSink.TestReports ??= new();
+        using var client = new ScriptedNntpClient(
+            (id, _) => new PayloadThenCorruptYencStream(payload, id));
+        await using var stream = CreateUnbuffered(
+            client, [segmentId], exactSizes: [payload.Length]);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<UsenetCorruptArticleException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.Equal(segmentId, exception.SegmentId);
+        Assert.True(Assert.Single(reports, e => e.SegmentId == segmentId).IsCorruption);
+        Assert.Equal(2, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_FailFastOnFirstSegment_RethrowsPersistentCorruption()
+    {
+        using var client = new ScriptedNntpClient((id, _) => ImmediateCorruptStream(id));
+        await using var stream = CreateUnbuffered(
+            client, ["segment@example"], exactSizes: [8], failFast: true);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<UsenetCorruptArticleException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.Equal("segment@example", exception.SegmentId);
+        Assert.Equal(4, client.BodyRequestCount);
+        Assert.Equal(0, output.Length);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_CorruptDonor_IsSkippedForNextDonor()
+    {
+        var expected = "donor-ok"u8.ToArray();
+        using var client = new ScriptedNntpClient((id, _) => id switch
+        {
+            "primary@example" or "donor-corrupt@example" => ImmediateCorruptStream(id),
+            "donor-good@example" => new BytesYencStream(expected),
+            _ => throw new InvalidOperationException(id),
+        });
+        await using var stream = CreateUnbuffered(
+            client,
+            ["primary@example"],
+            exactSizes: [expected.Length],
+            fallbacks: [["donor-corrupt@example", "donor-good@example"]]);
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(expected, output.ToArray());
+        Assert.Equal(4, client.BodyRequestCounts["primary@example"]);
+        Assert.Equal(1, client.BodyRequestCounts["donor-corrupt@example"]);
+        Assert.Equal(1, client.BodyRequestCounts["donor-good@example"]);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_DisposesFailedBodyBeforeRefetch()
+    {
+        var expected = "validated payload"u8.ToArray();
+        using var client = new ScriptedNntpClient((id, n) => n <= 2
+            ? ImmediateCorruptStream(id)
+            : new BytesYencStream(expected));
+        await using var stream = CreateUnbuffered(client, ["segment@example"], exactSizes: [expected.Length]);
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(expected, output.ToArray());
+        Assert.Equal(3, client.BodyRequestCount);
+        Assert.Equal(0, client.OverlappingFetches);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_UnknownLengthPersistentCorruption_PreservesCorruptInner()
+    {
+        using var client = new ScriptedNntpClient((id, _) => ImmediateCorruptStream(id));
+        await using var stream = CreateUnbuffered(client, ["segment@example"]);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<RetryableDownloadException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.False(exception is UsenetCorruptArticleException);
+        Assert.IsType<UsenetCorruptArticleException>(exception.InnerException);
+        Assert.Contains("exact length is unknown", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static Stream CreateUnbuffered(
+        INntpClient client,
+        string[] segmentIds,
+        long[]? exactSizes = null,
+        string[][]? fallbacks = null,
+        bool failFast = false,
+        string? fileName = "movie.mkv") =>
+        MultiSegmentStream.Create(
+            segmentIds.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            estimatedSegmentSize: exactSizes is { Length: > 0 } ? exactSizes[0] : 16,
+            failFastOnFirstSegment: failFast,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: fileName,
+            segmentFallbacks: fallbacks,
+            exactSegmentSizes: exactSizes);
+
+    private static YencStream ImmediateCorruptStream(string segmentId) =>
+        new ThrowingYencStream(
+            new UsenetCorruptArticleException(segmentId, "provider-a",
+                new InvalidDataException("CRC mismatch")));
+
+    private sealed class PayloadThenCorruptYencStream(byte[] bytes, string segmentId) : YencStream(Null)
+    {
+        private int _position;
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_position < bytes.Length)
+            {
+                var count = Math.Min(buffer.Length, bytes.Length - _position);
+                bytes.AsMemory(_position, count).CopyTo(buffer);
+                _position += count;
+                return ValueTask.FromResult(count);
+            }
+
+            return ValueTask.FromException<int>(
+                new UsenetCorruptArticleException(segmentId, "provider-a",
+                    new InvalidDataException("CRC mismatch")));
+        }
+    }
+
+    private sealed class ScriptedNntpClient(Func<string, int, YencStream> factory) : NntpClient
+    {
+        public int BodyRequestCount { get; private set; }
+        public Dictionary<string, int> BodyRequestCounts { get; } = new(StringComparer.Ordinal);
+        public int OverlappingFetches { get; private set; }
+        private int _openStreams;
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            CancellationToken cancellationToken) =>
+            CreateResponse(segmentId);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            CreateResponse(segmentId);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            CreateResponse(segmentId);
+
+        private Task<UsenetDecodedBodyResponse> CreateResponse(SegmentId segmentId)
+        {
+            BodyRequestCount++;
+            var key = segmentId.ToString();
+            BodyRequestCounts[key] = BodyRequestCounts.GetValueOrDefault(key) + 1;
+            if (_openStreams > 0)
+                OverlappingFetches++;
+
+            YencStream inner;
+            try
+            {
+                inner = factory(key, BodyRequestCounts[key]);
+            }
+            catch
+            {
+                return Task.FromException<UsenetDecodedBodyResponse>(
+                    new UsenetCorruptArticleException(key, "provider-a",
+                        new InvalidDataException("CRC mismatch")));
+            }
+
+            _openStreams++;
+            var stream = new TrackingYencStream(inner, () => _openStreams--);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "body follows",
+                Stream = stream,
+            });
+        }
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string segmentId,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class TrackingYencStream(YencStream inner, Action onDispose) : YencStream(Null)
+    {
+        private int _disposed;
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            inner.ReadAsync(buffer, cancellationToken);
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+            CancellationToken cancellationToken = default) =>
+            inner.GetYencHeadersAsync(cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                onDispose();
+            if (disposing)
+                inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                onDispose();
+            if (inner is IAsyncDisposable asyncInner)
+                await asyncInner.DisposeAsync().ConfigureAwait(false);
+            else
+                inner.Dispose();
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private sealed class ThrowingYencStream(Exception exception) : YencStream(Null)

--- a/tests/NzbWebDAV.Tests/Streams/KnownCorruptFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownCorruptFastPathTests.cs
@@ -1,0 +1,283 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class KnownCorruptFastPathTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task KnownCorruptId_FetchesOnceThenZeroFills(bool usePipelinedBodyRequests)
+    {
+        var segmentId = $"known-corrupt-{Guid.NewGuid():N}@example";
+        const int fill = 8;
+        var client = NewCorruptClient(segmentId);
+        await using var stream = MultiSegmentStream.Create(
+            new[] { segmentId }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: fill,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { fill },
+            knownCorruptSegmentIds: new HashSet<string>(StringComparer.Ordinal) { segmentId });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(new byte[fill], output.ToArray());
+        Assert.Equal(1, client.BodyRequestCount);
+        Assert.Equal(1, client.BodyRequestCounts[segmentId]);
+    }
+
+    [Fact]
+    public async Task KnownCorruptId_Unbuffered_FetchesOnceThenZeroFills()
+    {
+        var segmentId = $"known-corrupt-{Guid.NewGuid():N}@example";
+        const int fill = 8;
+        var client = NewCorruptClient(segmentId);
+        await using var stream = MultiSegmentStream.Create(
+            new[] { segmentId }.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            estimatedSegmentSize: fill,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { fill },
+            knownCorruptSegmentIds: new HashSet<string>(StringComparer.Ordinal) { segmentId });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(new byte[fill], output.ToArray());
+        Assert.Equal(1, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task KnownCorruptId_PatchedBytesAreServedWithoutProviderFetch()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-known-corrupt-patch-" + Guid.NewGuid().ToString("N"));
+        var segmentId = $"patched-{Guid.NewGuid():N}@example";
+        var patched = "repaired!"u8.ToArray();
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            store.CommitPatch(segmentId, patched, new UsenetYencHeader
+            {
+                FileName = "movie.mkv",
+                FileSize = patched.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartSize = patched.Length,
+                PartOffset = 0,
+            });
+
+            var inner = NewCorruptClient(segmentId);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+            await using var stream = MultiSegmentStream.Create(
+                new[] { segmentId }.AsMemory(),
+                client,
+                articleBufferSize: 4,
+                estimatedSegmentSize: patched.Length,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: false,
+                CancellationToken.None,
+                fileName: "movie.mkv",
+                exactSegmentSizes: new long[] { patched.Length },
+                knownCorruptSegmentIds: new HashSet<string>(StringComparer.Ordinal) { segmentId });
+            using var output = new MemoryStream();
+
+            await stream.CopyToAsync(output);
+
+            Assert.Equal(patched, output.ToArray());
+            Assert.Equal(0, inner.BodyRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task KnownCorruptId_DonorStillServedAfterSinglePrimaryFetch()
+    {
+        var primary = $"primary-{Guid.NewGuid():N}@example";
+        var donor = $"donor-{Guid.NewGuid():N}@example";
+        var payload = "donorok"u8.ToArray();
+        var present = new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            [primary] = new byte[payload.Length],
+            [donor] = payload,
+        };
+        var client = new FakeNntpClient(
+            present,
+            useCachedYencStreams: true,
+            decodedStreamFactory: (id, bytes) => id == primary
+                ? new ThrowingReadStream(id)
+                : new MemoryStream(bytes, writable: false));
+        await using var stream = MultiSegmentStream.Create(
+            new[] { primary }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: payload.Length,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            segmentFallbacks: [[donor]],
+            exactSegmentSizes: new long[] { payload.Length },
+            knownCorruptSegmentIds: new HashSet<string>(StringComparer.Ordinal) { primary });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal(payload, output.ToArray());
+        Assert.Equal(1, client.BodyRequestCounts[primary]);
+        Assert.Equal(1, client.BodyRequestCounts[donor]);
+    }
+
+    [Fact]
+    public async Task KnownCorruptId_FailFastOnFirstSegment_ThrowsAfterOneFetch()
+    {
+        var segmentId = $"failfast-{Guid.NewGuid():N}@example";
+        var client = NewCorruptClient(segmentId);
+        await using var stream = MultiSegmentStream.Create(
+            new[] { segmentId }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: 8,
+            failFastOnFirstSegment: true,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { 8 },
+            knownCorruptSegmentIds: new HashSet<string>(StringComparer.Ordinal) { segmentId });
+
+        var thrown = await Assert.ThrowsAsync<UsenetCorruptArticleException>(
+            async () => await stream.ReadExactlyAsync(new byte[1]));
+        Assert.Equal(segmentId, thrown.SegmentId);
+        Assert.Equal(1, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task GetFileStream_ThreadsKnownCorruptIdsIntoTheReader()
+    {
+        var segmentId = $"threaded-{Guid.NewGuid():N}@example";
+        const int fill = 8;
+        var client = NewCorruptClient(segmentId);
+        await using var stream = client.GetFileStream(
+            [segmentId],
+            fill,
+            articleBufferSize: 4,
+            segmentByteRanges: [LongRange.FromStartAndSize(0, fill)],
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv",
+            knownCorruptSegmentIds: new HashSet<string>(StringComparer.Ordinal) { segmentId });
+
+        var thrown = await Assert.ThrowsAsync<UsenetCorruptArticleException>(
+            async () => await stream.CopyToAsync(Stream.Null));
+        Assert.Equal(segmentId, thrown.SegmentId);
+        Assert.Equal(1, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task TwoConcurrentStreams_BothGapFill_AndDedupToOneSinkEvent()
+    {
+        var segmentId = $"concurrent-{Guid.NewGuid():N}@example";
+        const int fill = 8;
+        var path = $"/view/concurrent-{Guid.NewGuid():N}.mkv";
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-known-corrupt-sink-" + Guid.NewGuid().ToString("N"));
+        var prev = Par2RepairTriggerSink.Current;
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            ]);
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            var service = new Par2RepairService(config, null!, store);
+            Par2RepairTriggerSink.Current = new Par2RepairTriggerSink(service);
+
+            var clientA = NewCorruptClient(segmentId);
+            var clientB = NewCorruptClient(segmentId);
+            var known = new HashSet<string>(StringComparer.Ordinal) { segmentId };
+
+            await using var streamA = CreateZeroFillStream(clientA, segmentId, fill, path, known);
+            await using var streamB = CreateZeroFillStream(clientB, segmentId, fill, path, known);
+            using var outputA = new MemoryStream();
+            using var outputB = new MemoryStream();
+
+            await Task.WhenAll(streamA.CopyToAsync(outputA), streamB.CopyToAsync(outputB));
+
+            Assert.Equal(new byte[fill], outputA.ToArray());
+            Assert.Equal(new byte[fill], outputB.ToArray());
+            Assert.Equal(1, clientA.BodyRequestCount);
+            Assert.Equal(1, clientB.BodyRequestCount);
+            Assert.Equal(1, service.PendingZeroFillCount);
+        }
+        finally
+        {
+            Par2RepairTriggerSink.Current = prev;
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static Stream CreateZeroFillStream(
+        INntpClient client,
+        string segmentId,
+        int fill,
+        string fileName,
+        HashSet<string> knownCorrupt) =>
+        MultiSegmentStream.Create(
+            new[] { segmentId }.AsMemory(),
+            client,
+            articleBufferSize: 4,
+            estimatedSegmentSize: fill,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: fileName,
+            exactSegmentSizes: new long[] { fill },
+            knownCorruptSegmentIds: knownCorrupt);
+
+    private static FakeNntpClient NewCorruptClient(string segmentId) =>
+        new(
+            new Dictionary<string, byte[]>(StringComparer.Ordinal)
+            {
+                [segmentId] = new byte[8],
+            },
+            useCachedYencStreams: true,
+            decodedStreamFactory: (id, _) => new ThrowingReadStream(id));
+
+    private sealed class ThrowingReadStream(string segmentId) : MemoryStream
+    {
+        private UsenetCorruptArticleException CreateException() =>
+            new(segmentId, "provider-a", new InvalidDataException("CRC mismatch"));
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw CreateException();
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<int>(CreateException());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1000.

- Corrupt Usenet articles detected during playback (bad yEnc CRC) now escalate like missing articles when playback actually breaks: the failure counts toward Repair After Streaming Failures, urgent repair runs (PAR2 first, then Arr remove-and-blocklist), and re-grabs of the same release fail fast in the download queue.
- Persistently corrupt segments are recorded on the file and included in health-check damage classification, so corrupt-but-present files no longer verdict "Healthy" while playing gaps — small damage stays Degraded and playable; heavy damage is replaced.
- The first-segment/unbuffered reader now detects, retries, and fails over corrupt articles across providers and sibling copies — including trailer-CRC corruption on exact-size segments that previously played silent garbage.
- Repeat reads of a known-corrupt segment stop re-running the full retry storm — one probe, then donors/patch store/gap-fill.
- New toggle: Settings → Repairs → corruption tracking (default on when Background Repairs are enabled).

## Notes

- The issue comment's link to "#1026" should read #1027 (the PAR2 recovery-slice proposal, shipped as background repair in #1032); this PR implements the realtime detection/re-fetch/failover + Arr escalation half.
- **Behavior deltas for repairs-on installs:** (a) corrupt-article escapes now schedule urgent repair and seed the re-grab fail-fast cache; (b) health verdicts for corrupt-damaged files change from Healthy to Degraded/Failed (more truthful); (c) repeat reads of known-corrupt segments gap-fill after one probe instead of four fetch attempts; (d) the unbuffered reader now surfaces trailer-CRC corruption for exact-size segments instead of silently serving garbage. Repairs-off installs see no behavior change beyond fail-fast seeding (matching the missing-article precedent) and the unbuffered robustness hardening.
- **Documented residual race (accepted, self-healing):** the corruption consumer's blob persist can lose to a concurrent health-check `SaveChangesAsync` on the same item (narrow window; the record is recreated on the next corrupt read). Documented in `DavNzbFileBlobUpdater`.
- A follow-up issue tracks teaching PAR2 repair jobs to treat corrupt *source* segments as reconstruction targets (today a corrupt source fails the job, which correctly falls through to Arr).

## Test plan

- [x] Backend suite: 3243 passed / 10 skipped / 0 failed (incl. new middleware escalation/non-escalation tests, unbuffered corruption parity tests incl. the exact-size boundary-observe case, blob-updater concurrency, classification union, known-corrupt fast path, corrupt-target PAR2 integration)
- [x] Frontend: typecheck + build + 656 Vitest passed (repairs settings toggle)
- [ ] Manual: rclone scrub across a known-corrupt region (offsets correct, no stalls)
- [ ] Manual: Plex/Infuse/VLC playback through a corrupt gap (container-aware fill)
- [ ] Manual: persistently corrupt release removed + blocklisted in Sonarr; re-grab of the same NZB fails the queue precheck
- [ ] Manual: PAR2-repairable corrupt release self-heals and later reads serve real bytes