### PR TITLE
feat(arr): show Sonarr/Radarr import health on the Overview dashboard

### DIFF
--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthController.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthController.cs
@@ -30,20 +30,24 @@ public class GetArrHealthController(ConfigManager configManager, ArrHealthServic
         DateTimeOffset now,
         CancellationToken ct)
     {
-        if (!IsStoreQueryEnabled(configManager))
+        var enabled = configManager.GetArrConfig().GetEnabledInstances().ToList();
+        if (!configManager.IsArrHealthEnabled() || enabled.Count == 0)
             return new GetArrHealthResponse { Configured = false };
 
         var nowMs = now.ToUnixTimeMilliseconds();
         var windowStartMs = WindowStartMs(window, nowMs);
+        var enabledKeys = enabled
+            .Select(instance => ArrConfig.MakeInstanceKey(instance.AppType, instance.Details.Host))
+            .ToHashSet(StringComparer.Ordinal);
         await using var db = MetricsContextFactory();
         var events = await db.ArrImportEvents.AsNoTracking()
-            .Where(e => e.ImportedAtMs >= windowStartMs)
+            .Where(e => e.ImportedAtMs >= windowStartMs && enabledKeys.Contains(e.InstanceKey))
             .ToListAsync(ct).ConfigureAwait(false);
 
         return Build(
             events,
             arrHealthService.GetSnapshots(),
-            configManager.GetArrConfig().GetEnabledInstances().ToList(),
+            enabled,
             now);
     }
 

--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthController.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthController.cs
@@ -1,0 +1,147 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.Controllers.GetArrHealth;
+
+[ApiController]
+[Route("api/get-arr-health")]
+public class GetArrHealthController(ConfigManager configManager, ArrHealthService arrHealthService) : BaseApiController
+{
+    private const long OneHourMs = 60L * 60 * 1000;
+    private const long OneDayMs = 24 * OneHourMs;
+    internal const int AwaitingLimit = 10;
+
+    internal Func<MetricsDbContext> MetricsContextFactory { get; set; } = static () => new MetricsDbContext();
+
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var request = new GetArrHealthRequest(HttpContext);
+        var response = await BuildResponseAsync(request.Window, DateTimeOffset.UtcNow, request.CancellationToken)
+            .ConfigureAwait(false);
+        return Ok(response);
+    }
+
+    internal async Task<GetArrHealthResponse> BuildResponseAsync(
+        GetArrHealthRequest.ArrHealthWindow window,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        if (!IsStoreQueryEnabled(configManager))
+            return new GetArrHealthResponse { Configured = false };
+
+        var nowMs = now.ToUnixTimeMilliseconds();
+        var windowStartMs = WindowStartMs(window, nowMs);
+        await using var db = MetricsContextFactory();
+        var events = await db.ArrImportEvents.AsNoTracking()
+            .Where(e => e.ImportedAtMs >= windowStartMs)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        return Build(
+            events,
+            arrHealthService.GetSnapshots(),
+            configManager.GetArrConfig().GetEnabledInstances().ToList(),
+            now);
+    }
+
+    internal static bool IsStoreQueryEnabled(ConfigManager config) =>
+        config.IsArrHealthEnabled() && config.GetArrConfig().GetEnabledInstances().Any();
+
+    internal static long WindowStartMs(GetArrHealthRequest.ArrHealthWindow window, long nowMs) => window switch
+    {
+        GetArrHealthRequest.ArrHealthWindow.Last1Hour => nowMs - OneHourMs,
+        GetArrHealthRequest.ArrHealthWindow.Last24Hours => nowMs - OneDayMs,
+        GetArrHealthRequest.ArrHealthWindow.Last7Days => nowMs - 7 * OneDayMs,
+        GetArrHealthRequest.ArrHealthWindow.Last30Days => nowMs - 30 * OneDayMs,
+        GetArrHealthRequest.ArrHealthWindow.AllTime => 0,
+        _ => nowMs - OneDayMs,
+    };
+
+    internal static GetArrHealthResponse Build(
+        IReadOnlyList<ArrImportEvent> events,
+        IReadOnlyList<ArrHealthSnapshot> snapshots,
+        IReadOnlyList<(string AppType, ArrConfig.ConnectionDetails Details)> enabled,
+        DateTimeOffset now)
+    {
+        var snapshotByKey = snapshots.ToDictionary(s => s.InstanceKey, StringComparer.Ordinal);
+        var rows = new List<GetArrHealthResponse.ArrHealthInstanceRow>();
+        var awaiting = new List<GetArrHealthResponse.ArrAwaitingItem>();
+
+        foreach (var (appType, details) in enabled)
+        {
+            var key = ArrConfig.MakeInstanceKey(appType, details.Host);
+            snapshotByKey.TryGetValue(key, out var snapshot);
+            var name = snapshot?.DisplayName
+                       ?? (string.IsNullOrWhiteSpace(details.Name) ? details.Host : details.Name);
+            var instanceEvents = events.Where(e => e.InstanceKey == key).ToList();
+            var handoffs = instanceEvents.Where(e => e.HandoffMs != null).Select(e => e.HandoffMs!.Value);
+            rows.Add(new GetArrHealthResponse.ArrHealthInstanceRow
+            {
+                Key = key,
+                Name = name,
+                AppType = appType,
+                Host = details.Host,
+                Status = FormatStatus(snapshot?.Status ?? ArrInstanceHealthStatus.Pending),
+                Imports = instanceEvents.Count,
+                MedianHandoffMs = ArrHealthMath.Percentile(handoffs, 0.50),
+                P95HandoffMs = ArrHealthMath.Percentile(handoffs, 0.95),
+                QueueCount = snapshot?.QueueCount ?? 0,
+                AwaitingCount = snapshot?.AwaitingCount ?? 0,
+                LastImportAtMs = snapshot?.LastImportAtMs,
+                LastError = snapshot?.LastError,
+            });
+
+            if (snapshot is null) continue;
+            foreach (var item in snapshot.Awaiting)
+            {
+                var waitingMs = ArrHealthMath.ComputeWaitingMs(item.CreatedAt, now);
+                awaiting.Add(new GetArrHealthResponse.ArrAwaitingItem
+                {
+                    Title = item.Title,
+                    InstanceKey = key,
+                    InstanceName = name,
+                    WaitingMs = waitingMs,
+                    IsUnusual = ArrHealthMath.IsUnusual(
+                        waitingMs,
+                        snapshot.MedianHandoffMs30d,
+                        snapshot.MedianSampleCount30d),
+                });
+            }
+        }
+
+        var enabledKeys = rows.Select(r => r.Key).ToHashSet(StringComparer.Ordinal);
+        var includedEvents = events.Where(e => enabledKeys.Contains(e.InstanceKey)).ToList();
+        var includedHandoffs = includedEvents.Where(e => e.HandoffMs != null).Select(e => e.HandoffMs!.Value);
+
+        return new GetArrHealthResponse
+        {
+            Configured = true,
+            Summary = new GetArrHealthResponse.ArrHealthSummary
+            {
+                InstancesOnline = rows.Count(r => r.Status is "healthy" or "degraded"),
+                InstancesTotal = rows.Count,
+                ImportsCompleted = includedEvents.Count,
+                MedianHandoffMs = ArrHealthMath.Percentile(includedHandoffs, 0.50),
+                P95HandoffMs = ArrHealthMath.Percentile(includedHandoffs, 0.95),
+                AwaitingImport = rows.Sum(r => r.AwaitingCount),
+                Degraded = rows.Count(r => r.Status == "degraded"),
+            },
+            Instances = rows,
+            Awaiting = awaiting
+                .OrderByDescending(a => a.WaitingMs ?? long.MinValue)
+                .Take(AwaitingLimit)
+                .ToList(),
+        };
+    }
+
+    internal static string FormatStatus(ArrInstanceHealthStatus status) => status switch
+    {
+        ArrInstanceHealthStatus.Healthy => "healthy",
+        ArrInstanceHealthStatus.Degraded => "degraded",
+        ArrInstanceHealthStatus.Offline => "offline",
+        _ => "pending",
+    };
+}

--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthRequest.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthRequest.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.Controllers.GetArrHealth;
+
+public class GetArrHealthRequest
+{
+    public ArrHealthWindow Window { get; init; } = ArrHealthWindow.Last24Hours;
+    public CancellationToken CancellationToken { get; init; }
+
+    public GetArrHealthRequest(HttpContext context)
+    {
+        CancellationToken = context.RequestAborted;
+        var w = context.GetQueryParam("window");
+        if (w is not null)
+        {
+            Window = ParseWindow(w);
+        }
+    }
+
+    internal static ArrHealthWindow ParseWindow(string window) =>
+        window.ToLowerInvariant() switch
+        {
+            "1h" => ArrHealthWindow.Last1Hour,
+            "24h" => ArrHealthWindow.Last24Hours,
+            "7d" => ArrHealthWindow.Last7Days,
+            "30d" => ArrHealthWindow.Last30Days,
+            "all" => ArrHealthWindow.AllTime,
+            _ => throw new BadHttpRequestException("Invalid window parameter (use 1h, 24h, 7d, 30d, or all)"),
+        };
+
+    public enum ArrHealthWindow
+    {
+        Last1Hour,
+        Last24Hours,
+        Last7Days,
+        Last30Days,
+        AllTime,
+    }
+}

--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthResponse.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthResponse.cs
@@ -1,0 +1,45 @@
+namespace NzbWebDAV.Api.Controllers.GetArrHealth;
+
+public class GetArrHealthResponse : BaseApiResponse
+{
+    public bool Configured { get; init; }
+    public ArrHealthSummary Summary { get; init; } = new();
+    public List<ArrHealthInstanceRow> Instances { get; init; } = [];
+    public List<ArrAwaitingItem> Awaiting { get; init; } = [];
+
+    public class ArrHealthSummary
+    {
+        public int InstancesOnline { get; init; }
+        public int InstancesTotal { get; init; }
+        public int ImportsCompleted { get; init; }
+        public long? MedianHandoffMs { get; init; }
+        public long? P95HandoffMs { get; init; }
+        public int AwaitingImport { get; init; }
+        public int Degraded { get; init; }
+    }
+
+    public class ArrHealthInstanceRow
+    {
+        public string Key { get; init; } = "";
+        public string Name { get; init; } = "";
+        public string AppType { get; init; } = "";
+        public string Host { get; init; } = "";
+        public string Status { get; init; } = "pending";
+        public int Imports { get; init; }
+        public long? MedianHandoffMs { get; init; }
+        public long? P95HandoffMs { get; init; }
+        public int QueueCount { get; init; }
+        public int AwaitingCount { get; init; }
+        public long? LastImportAtMs { get; init; }
+        public string? LastError { get; init; }
+    }
+
+    public class ArrAwaitingItem
+    {
+        public string? Title { get; init; }
+        public string InstanceKey { get; init; } = "";
+        public string InstanceName { get; init; } = "";
+        public long? WaitingMs { get; init; }
+        public bool IsUnusual { get; init; }
+    }
+}

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -40,11 +40,14 @@ public class ArrClient(string host, string apiKey)
     public Task<ArrCommand> RefreshMonitoredDownloads(CancellationToken ct = default) =>
         CommandAsync(new { name = "RefreshMonitoredDownloads" }, ct);
 
-    public Task<ArrQueueStatus> GetQueueStatusAsync(CancellationToken ct = default) =>
+    public virtual Task<ArrQueueStatus> GetQueueStatusAsync(CancellationToken ct = default) =>
         Get<ArrQueueStatus>($"/queue/status", ct);
 
-    public Task<ArrQueue<ArrQueueRecord>> GetQueueAsync(CancellationToken ct = default) =>
+    public virtual Task<ArrQueue<ArrQueueRecord>> GetQueueAsync(CancellationToken ct = default) =>
         Get<ArrQueue<ArrQueueRecord>>($"/queue?protocol=usenet&pageSize=5000", ct);
+
+    public virtual Task<ArrHistory> GetImportHistoryAsync(int page, int pageSize, CancellationToken ct = default) =>
+        Get<ArrHistory>($"/history?eventType=3&page={page}&pageSize={pageSize}&sortKey=date&sortDirection=descending", ct);
 
     public async Task<int> GetQueueCountAsync() =>
         (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1").ConfigureAwait(false)).TotalRecords;

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
@@ -12,4 +12,16 @@ public class ArrHistoryRecord
 {
     [JsonPropertyName("id")]
     public int Id { get; set; }
+
+    [JsonPropertyName("date")]
+    public DateTimeOffset Date { get; set; }
+
+    [JsonPropertyName("downloadId")]
+    public string? DownloadId { get; set; }
+
+    [JsonPropertyName("eventType")]
+    public int EventType { get; set; }
+
+    [JsonPropertyName("sourceTitle")]
+    public string? SourceTitle { get; set; }
 }

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrQueueRecord.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrQueueRecord.cs
@@ -31,6 +31,20 @@ public class ArrQueueRecord
     [JsonPropertyName("statusMessages")]
     public List<ArrQueueStatusMessage> StatusMessages { get; set; } = [];
 
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("sizeleft")]
+    public long Sizeleft { get; set; }
+
+    [JsonPropertyName("downloadId")]
+    public string? DownloadId { get; set; }
+
+    public bool IsAwaitingImport =>
+        string.Equals(Status, "completed", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(TrackedDownloadState, "importPending", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(TrackedDownloadState, "importing", StringComparison.OrdinalIgnoreCase);
+
     public bool HasStatusMessage(string message)
     {
         return StatusMessages

--- a/backend/Config/ArrConfig.cs
+++ b/backend/Config/ArrConfig.cs
@@ -8,19 +8,34 @@ public class ArrConfig
     public List<ConnectionDetails> SonarrInstances { get; set; } = [];
     public List<QueueRule> QueueRules { get; set; } = [];
 
+    /// <summary>
+    /// Clients for enabled instances only. Disabling an instance opts it out of
+    /// queue management, Arr-linked repairs, and Arr Health polling.
+    /// <see cref="ConnectionDetails.Enabled"/> defaults true so legacy JSON
+    /// without the property keeps today's behavior.
+    /// </summary>
     // ReSharper disable once InvokeAsExtensionMethod
     public IEnumerable<ArrClient> GetArrClients() => Enumerable.Concat(
-        RadarrInstances.Select(ArrClient (x) => new RadarrClient(x.Host, x.ApiKey)),
-        SonarrInstances.Select(ArrClient (x) => new SonarrClient(x.Host, x.ApiKey))
+        RadarrInstances.Where(x => x.Enabled).Select(ArrClient (x) => new RadarrClient(x.Host, x.ApiKey)),
+        SonarrInstances.Where(x => x.Enabled).Select(ArrClient (x) => new SonarrClient(x.Host, x.ApiKey))
     );
+
+    public IEnumerable<(string AppType, ConnectionDetails Details)> GetEnabledInstances() =>
+        RadarrInstances.Where(x => x.Enabled).Select(x => ("radarr", x))
+            .Concat(SonarrInstances.Where(x => x.Enabled).Select(x => ("sonarr", x)));
 
     public int GetInstanceCount() =>
         RadarrInstances.Count + SonarrInstances.Count;
 
+    public static string MakeInstanceKey(string appType, string host) =>
+        $"{appType}|{host.TrimEnd('/').ToLowerInvariant()}";
+
     public class ConnectionDetails
     {
+        public string? Name { get; set; }
         public required string Host { get; set; }
         public required string ApiKey { get; set; }
+        public bool Enabled { get; set; } = true;
     }
 
     public class QueueRule

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -108,6 +108,7 @@ public static class ConfigKeys
     public const string RepairDegradedMaxMissingBytePercent = "repair.degraded-max-missing-byte-percent";
     public const string RepairCorruptionTrackingEnabled = "repair.corruption-tracking-enabled";
     public const string ArrInstances = "arr.instances";
+    public const string ArrHealthEnabled = "arr.health-enabled";
 
     // rclone
     public const string RcloneHost = "rclone.host";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -474,6 +474,7 @@ public class ConfigManager
                 case ConfigKeys.BackupScheduleEnabled:
                 case ConfigKeys.QueuePaused:
                 case ConfigKeys.ProwlarrSyncEnabled:
+                case ConfigKeys.ArrHealthEnabled:
                     RequireBool(item.ConfigName, value);
                     break;
 
@@ -1904,6 +1905,16 @@ public class ConfigManager
     {
         var defaultValue = new ArrConfig();
         return GetConfigValue<ArrConfig>(ConfigKeys.ArrInstances) ?? defaultValue;
+    }
+
+    /// <summary>
+    /// Master switch for Arr Health polling and the Overview widget.
+    /// Defaults true; the feature is dormant until at least one instance is enabled.
+    /// </summary>
+    public bool IsArrHealthEnabled()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ArrHealthEnabled));
+        return v == null || bool.Parse(v);
     }
 
     public UsenetProviderConfig GetUsenetProviderConfig()

--- a/backend/Database/MetricsDbContext.cs
+++ b/backend/Database/MetricsDbContext.cs
@@ -50,6 +50,7 @@ public sealed class MetricsDbContext : DbContext
     public DbSet<FailoverHourly> FailoverHourly => Set<FailoverHourly>();
     public DbSet<CatalogueDaily> CatalogueDaily => Set<CatalogueDaily>();
     public DbSet<ProviderLifetimeTotal> ProviderLifetimeTotals => Set<ProviderLifetimeTotal>();
+    public DbSet<ArrImportEvent> ArrImportEvents => Set<ArrImportEvent>();
 
     protected override void OnModelCreating(ModelBuilder b)
     {
@@ -191,6 +192,21 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.Retries).IsRequired();
             e.Property(x => x.SumDurationMs).IsRequired();
             e.Property(x => x.FailoverSaves).IsRequired();
+        });
+
+        b.Entity<ArrImportEvent>(e =>
+        {
+            e.ToTable("ArrImportEvents");
+            e.HasKey(x => x.Id);
+
+            e.Property(x => x.InstanceKey).IsRequired().HasMaxLength(512);
+            e.Property(x => x.ArrRecordId).IsRequired();
+            e.Property(x => x.DownloadId).IsRequired();
+            e.Property(x => x.ImportedAtMs).IsRequired();
+
+            e.HasIndex(x => new { x.InstanceKey, x.ArrRecordId }).IsUnique();
+            e.HasIndex(x => x.ImportedAtMs);
+            e.HasIndex(x => new { x.InstanceKey, x.ImportedAtMs });
         });
     }
 }

--- a/backend/Database/MetricsMigrations/20260820020431_Add-ArrImportEvents.Designer.cs
+++ b/backend/Database/MetricsMigrations/20260820020431_Add-ArrImportEvents.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NzbWebDAV.Database;
 
@@ -10,9 +11,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.MetricsMigrations
 {
     [DbContext(typeof(MetricsDbContext))]
-    partial class MetricsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820020431_Add-ArrImportEvents")]
+    partial class AddArrImportEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/backend/Database/MetricsMigrations/20260820020431_Add-ArrImportEvents.cs
+++ b/backend/Database/MetricsMigrations/20260820020431_Add-ArrImportEvents.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.MetricsMigrations
+{
+    /// <inheritdoc />
+    public partial class AddArrImportEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ArrImportEvents",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    InstanceKey = table.Column<string>(type: "TEXT", maxLength: 512, nullable: false),
+                    ArrRecordId = table.Column<int>(type: "INTEGER", nullable: false),
+                    DownloadId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ImportedAtMs = table.Column<long>(type: "INTEGER", nullable: false),
+                    HandoffMs = table.Column<long>(type: "INTEGER", nullable: true),
+                    Title = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ArrImportEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArrImportEvents_ImportedAtMs",
+                table: "ArrImportEvents",
+                column: "ImportedAtMs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArrImportEvents_InstanceKey_ArrRecordId",
+                table: "ArrImportEvents",
+                columns: new[] { "InstanceKey", "ArrRecordId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArrImportEvents_InstanceKey_ImportedAtMs",
+                table: "ArrImportEvents",
+                columns: new[] { "InstanceKey", "ImportedAtMs" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ArrImportEvents");
+        }
+    }
+}

--- a/backend/Database/Models/Metrics/ArrImportEvent.cs
+++ b/backend/Database/Models/Metrics/ArrImportEvent.cs
@@ -1,0 +1,17 @@
+namespace NzbWebDAV.Database.Models.Metrics;
+
+/// <summary>
+/// One successful Arr DownloadFolderImported event correlated with an InfiniDysk
+/// history item (Guid downloadId). Stored in the metrics database so the Overview
+/// Arr Health widget never queries Arr APIs or the operational DB.
+/// </summary>
+public class ArrImportEvent
+{
+    public long Id { get; set; }
+    public string InstanceKey { get; set; } = null!;
+    public int ArrRecordId { get; set; }
+    public Guid DownloadId { get; set; }
+    public long ImportedAtMs { get; set; }
+    public long? HandoffMs { get; set; }
+    public string? Title { get; set; }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -381,6 +381,8 @@ public partial class Program
                 .AddHostedService<HealthCheckService>()
                 .AddHostedService<HealthCheckRetentionService>()
                 .AddHostedService<ArrMonitoringService>()
+                .AddSingleton<ArrHealthService>()
+                .AddHostedService(sp => sp.GetRequiredService<ArrHealthService>())
                 .AddHostedService<BlobCleanupService>()
                 .AddHostedService<NzbBlobCleanupService>()
                 .AddHostedService<NzbBackupRetentionService>()

--- a/backend/Services/ArrHealthMath.cs
+++ b/backend/Services/ArrHealthMath.cs
@@ -1,0 +1,40 @@
+namespace NzbWebDAV.Services;
+
+internal static class ArrHealthMath
+{
+    internal const int UnusualMedianMinSamples = 5;
+    internal const double UnusualWaitMultiplier = 3.0;
+    internal static readonly TimeSpan MedianWindow = TimeSpan.FromDays(30);
+
+    internal static long? ComputeHandoffMs(DateTimeOffset importedAt, DateTime? createdAt)
+    {
+        if (createdAt is null) return null;
+        var createdAtUtc = DateTime.SpecifyKind(createdAt.Value, DateTimeKind.Local).ToUniversalTime();
+        var ms = (long)(importedAt.UtcDateTime - createdAtUtc).TotalMilliseconds;
+        return Math.Max(0L, ms);
+    }
+
+    internal static long? ComputeWaitingMs(DateTime? createdAt, DateTimeOffset now)
+    {
+        if (createdAt is null) return null;
+        var createdAtUtc = DateTime.SpecifyKind(createdAt.Value, DateTimeKind.Local).ToUniversalTime();
+        var ms = (long)(now.UtcDateTime - createdAtUtc).TotalMilliseconds;
+        return Math.Max(0L, ms);
+    }
+
+    internal static long? Percentile(IEnumerable<long> samples, double p)
+    {
+        var sorted = samples.ToList();
+        if (sorted.Count == 0) return null;
+        sorted.Sort();
+        var idx = (int)Math.Ceiling(p * sorted.Count) - 1;
+        return sorted[Math.Clamp(idx, 0, sorted.Count - 1)];
+    }
+
+    internal static bool IsUnusual(long? waitingMs, long? medianMs, int sampleCount)
+    {
+        if (waitingMs is null || medianMs is null || medianMs.Value <= 0 || sampleCount < UnusualMedianMinSamples)
+            return false;
+        return waitingMs.Value > UnusualWaitMultiplier * medianMs.Value;
+    }
+}

--- a/backend/Services/ArrHealthService.cs
+++ b/backend/Services/ArrHealthService.cs
@@ -296,14 +296,12 @@ public sealed class ArrHealthService : BackgroundService
         MetricsDbContext metrics,
         CancellationToken ct)
     {
-        var downloadIds = new List<Guid>();
-        var candidates = new List<(ArrHistoryRecord Record, Guid DownloadId)>();
-        foreach (var record in records)
-        {
-            if (!Guid.TryParse(record.DownloadId, out var downloadId)) continue;
-            candidates.Add((record, downloadId));
-            downloadIds.Add(downloadId);
-        }
+        var candidates = records
+            .Select(record => (Record: record, DownloadId: Guid.TryParse(record.DownloadId, out var id) ? id : (Guid?)null))
+            .Where(candidate => candidate.DownloadId is not null)
+            .Select(candidate => (Record: candidate.Record, DownloadId: candidate.DownloadId!.Value))
+            .ToList();
+        var downloadIds = candidates.Select(candidate => candidate.DownloadId).ToList();
 
         if (candidates.Count == 0) return;
 
@@ -366,12 +364,11 @@ public sealed class ArrHealthService : BackgroundService
         var awaitingRecords = records.Where(r => r.IsAwaitingImport).Take(MaxAwaitingPerInstance).ToList();
         if (awaitingRecords.Count == 0) return [];
 
-        var downloadIds = new List<Guid>();
-        foreach (var record in awaitingRecords)
-        {
-            if (Guid.TryParse(record.DownloadId, out var id))
-                downloadIds.Add(id);
-        }
+        var downloadIds = awaitingRecords
+            .Select(record => Guid.TryParse(record.DownloadId, out var id) ? id : (Guid?)null)
+            .Where(id => id is not null)
+            .Select(id => id!.Value)
+            .ToList();
 
         Dictionary<Guid, DateTime> createdAtById = [];
         if (downloadIds.Count > 0)

--- a/backend/Services/ArrHealthService.cs
+++ b/backend/Services/ArrHealthService.cs
@@ -1,0 +1,462 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Extensions;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Polls enabled Radarr/Sonarr instances for import handoff telemetry. Completely
+/// dormant (no timer, no HTTP, no DB, no logs) unless Arr Health is enabled and at
+/// least one instance is enabled.
+/// </summary>
+public sealed class ArrHealthService : BackgroundService
+{
+    internal const int MaxHistoryPages = 5;
+    internal const int HistoryPageSize = 100;
+    internal const int MaxAwaitingPerInstance = 100;
+    internal const int OfflineFailureThreshold = 2;
+    internal const int ImportEventType = 3;
+    private static readonly TimeSpan PerCallTimeout = TimeSpan.FromSeconds(10);
+    private static readonly HashSet<string> WakeConfigKeys =
+    [
+        ConfigKeys.ArrInstances,
+        ConfigKeys.ArrHealthEnabled,
+    ];
+
+    private readonly ConfigManager _configManager;
+    private readonly SemaphoreSlim _cycleGate = new(1, 1);
+    private readonly object _snapshotLock = new();
+    private readonly Dictionary<string, ArrHealthSnapshot> _snapshots = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _consecutiveFailures = new(StringComparer.Ordinal);
+    private TaskCompletionSource _wake = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    internal TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(60);
+    internal Func<string, ArrConfig.ConnectionDetails, ArrClient> ClientFactory { get; set; } = CreateClient;
+    internal Func<MetricsDbContext> MetricsContextFactory { get; set; } = static () => new MetricsDbContext();
+    internal Func<DavDatabaseContext> DavContextFactory { get; set; } = static () => new DavDatabaseContext();
+    internal int CycleAttempts => _cycleAttempts;
+    private int _cycleAttempts;
+
+    public ArrHealthService(ConfigManager configManager)
+    {
+        _configManager = configManager;
+        _configManager.OnConfigChanged += OnConfigChanged;
+    }
+
+    public override void Dispose()
+    {
+        _configManager.OnConfigChanged -= OnConfigChanged;
+        _cycleGate.Dispose();
+        base.Dispose();
+    }
+
+    public IReadOnlyList<ArrHealthSnapshot> GetSnapshots()
+    {
+        lock (_snapshotLock)
+            return _snapshots.Values.ToList();
+    }
+
+    internal void ReplaceSnapshotsForTests(IEnumerable<ArrHealthSnapshot> snapshots)
+    {
+        lock (_snapshotLock)
+        {
+            _snapshots.Clear();
+            foreach (var snapshot in snapshots)
+                _snapshots[snapshot.InstanceKey] = snapshot;
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                if (!IsActive())
+                {
+                    try
+                    {
+                        await CurrentWake.WaitAsync(stoppingToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    continue;
+                }
+
+                var wakeBeforeCycle = CurrentWake;
+                await TryRunCycleAsync(stoppingToken).ConfigureAwait(false);
+                if (wakeBeforeCycle.IsCompleted) continue;
+
+                try
+                {
+                    var delay = Task.Delay(PollInterval, stoppingToken);
+                    await Task.WhenAny(CurrentWake, delay).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // shutdown
+        }
+    }
+
+    internal async Task<bool> TryRunCycleAsync(CancellationToken ct)
+    {
+        if (!_cycleGate.Wait(0, CancellationToken.None))
+            return false;
+
+        try
+        {
+            Interlocked.Increment(ref _cycleAttempts);
+            await RunCycleAsync(ct).ConfigureAwait(false);
+            return true;
+        }
+        finally
+        {
+            _cycleGate.Release();
+        }
+    }
+
+    private bool IsActive()
+    {
+        return _configManager.IsArrHealthEnabled()
+               && _configManager.GetArrConfig().GetEnabledInstances().Any();
+    }
+
+    private Task CurrentWake => Volatile.Read(ref _wake).Task;
+
+    private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs e)
+    {
+        if (!e.ChangedConfig.Keys.Any(WakeConfigKeys.Contains)) return;
+        var previous = Interlocked.Exchange(
+            ref _wake,
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+        previous.TrySetResult();
+    }
+
+    private async Task RunCycleAsync(CancellationToken ct)
+    {
+        if (!_configManager.IsArrHealthEnabled())
+        {
+            PruneSnapshots([]);
+            return;
+        }
+
+        var instances = _configManager.GetArrConfig().GetEnabledInstances().ToList();
+        if (instances.Count == 0)
+        {
+            PruneSnapshots([]);
+            return;
+        }
+
+        await Task.WhenAll(instances.Select(instance =>
+            PollInstanceAsync(instance.AppType, instance.Details, ct))).ConfigureAwait(false);
+
+        var enabledKeys = instances
+            .Select(i => ArrConfig.MakeInstanceKey(i.AppType, i.Details.Host))
+            .ToHashSet(StringComparer.Ordinal);
+        PruneSnapshots(enabledKeys);
+    }
+
+    private async Task PollInstanceAsync(string appType, ArrConfig.ConnectionDetails details, CancellationToken ct)
+    {
+        var key = ArrConfig.MakeInstanceKey(appType, details.Host);
+        var displayName = string.IsNullOrWhiteSpace(details.Name) ? details.Host : details.Name;
+        ArrClient client;
+        try
+        {
+            client = ClientFactory(appType, details);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException && e is not OperationCanceledException)
+        {
+            RecordFailure(key, appType, details.Host, displayName, e);
+            return;
+        }
+
+        try
+        {
+            var queueStatus = await CallAsync(callCt => client.GetQueueStatusAsync(callCt), ct).ConfigureAwait(false);
+            var queue = await CallAsync(callCt => client.GetQueueAsync(callCt), ct).ConfigureAwait(false);
+
+            await using var dav = DavContextFactory();
+            await using var metrics = MetricsContextFactory();
+
+            var awaiting = await BuildAwaitingAsync(queue.Records, dav, ct).ConfigureAwait(false);
+            await IngestHistoryAsync(key, client, dav, metrics, ct).ConfigureAwait(false);
+
+            var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var cutoff30d = nowMs - (long)ArrHealthMath.MedianWindow.TotalMilliseconds;
+            var handoffs = await metrics.ArrImportEvents
+                .Where(e => e.InstanceKey == key && e.HandoffMs != null && e.ImportedAtMs >= cutoff30d)
+                .Select(e => e.HandoffMs!.Value)
+                .ToListAsync(ct).ConfigureAwait(false);
+            var median = ArrHealthMath.Percentile(handoffs, 0.50);
+            var lastImport = await metrics.ArrImportEvents
+                .Where(e => e.InstanceKey == key)
+                .Select(e => (long?)e.ImportedAtMs)
+                .MaxAsync(ct).ConfigureAwait(false);
+
+            var now = DateTimeOffset.UtcNow;
+            var unusual = awaiting.Any(item =>
+                ArrHealthMath.IsUnusual(
+                    ArrHealthMath.ComputeWaitingMs(item.CreatedAt, now),
+                    median,
+                    handoffs.Count));
+
+            var hasWarnings = queueStatus.Warnings || queueStatus.UnknownWarnings;
+            var hasErrors = queueStatus.Errors || queueStatus.UnknownErrors;
+            var status = hasWarnings || hasErrors || unusual
+                ? ArrInstanceHealthStatus.Degraded
+                : ArrInstanceHealthStatus.Healthy;
+
+            RecordSuccess(new ArrHealthSnapshot
+            {
+                InstanceKey = key,
+                DisplayName = displayName,
+                AppType = appType,
+                Host = details.Host,
+                Status = status,
+                QueueCount = queueStatus.TotalCount,
+                AwaitingCount = awaiting.Count,
+                HasWarnings = hasWarnings,
+                HasErrors = hasErrors,
+                LastImportAtMs = lastImport,
+                LastPolledAt = now,
+                LastError = null,
+                MedianHandoffMs30d = median,
+                MedianSampleCount30d = handoffs.Count,
+                Awaiting = awaiting,
+            });
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // shutdown — do not log or mark Offline
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            e.LogWarningKnownOrStack("Arr health poll failed for {Host}", details.Host);
+            RecordFailure(key, appType, details.Host, displayName, e);
+        }
+    }
+
+    private static async Task<T> CallAsync<T>(Func<CancellationToken, Task<T>> call, CancellationToken ct)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(PerCallTimeout);
+        return await call(timeout.Token).ConfigureAwait(false);
+    }
+
+    private async Task IngestHistoryAsync(
+        string instanceKey,
+        ArrClient client,
+        DavDatabaseContext dav,
+        MetricsDbContext metrics,
+        CancellationToken ct)
+    {
+        var cursor = await metrics.ArrImportEvents
+            .Where(e => e.InstanceKey == instanceKey)
+            .Select(e => (int?)e.ArrRecordId)
+            .MaxAsync(ct).ConfigureAwait(false) ?? 0;
+
+        for (var page = 1; page <= MaxHistoryPages; page++)
+        {
+            var history = await CallAsync(
+                callCt => client.GetImportHistoryAsync(page, HistoryPageSize, callCt),
+                ct).ConfigureAwait(false);
+            var records = history.Records ?? [];
+            if (records.Count == 0) break;
+
+            var newRecords = records.Where(r => r.Id > cursor && r.EventType == ImportEventType).ToList();
+            if (newRecords.Count == 0) break;
+
+            await InsertNewEventsAsync(instanceKey, newRecords, dav, metrics, ct).ConfigureAwait(false);
+
+            if (records.Any(r => r.Id <= cursor)) break;
+        }
+    }
+
+    private static async Task InsertNewEventsAsync(
+        string instanceKey,
+        List<ArrHistoryRecord> records,
+        DavDatabaseContext dav,
+        MetricsDbContext metrics,
+        CancellationToken ct)
+    {
+        var downloadIds = new List<Guid>();
+        var candidates = new List<(ArrHistoryRecord Record, Guid DownloadId)>();
+        foreach (var record in records)
+        {
+            if (!Guid.TryParse(record.DownloadId, out var downloadId)) continue;
+            candidates.Add((record, downloadId));
+            downloadIds.Add(downloadId);
+        }
+
+        if (candidates.Count == 0) return;
+
+        var historyById = await dav.HistoryItems
+            .AsNoTracking()
+            .Where(h => downloadIds.Contains(h.Id) && h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed)
+            .ToDictionaryAsync(h => h.Id, ct).ConfigureAwait(false);
+
+        var toInsert = new List<ArrImportEvent>();
+        foreach (var (record, downloadId) in candidates)
+        {
+            historyById.TryGetValue(downloadId, out var historyItem);
+            toInsert.Add(new ArrImportEvent
+            {
+                InstanceKey = instanceKey,
+                ArrRecordId = record.Id,
+                DownloadId = downloadId,
+                ImportedAtMs = record.Date.ToUnixTimeMilliseconds(),
+                HandoffMs = ArrHealthMath.ComputeHandoffMs(record.Date, historyItem?.CreatedAt),
+                Title = record.SourceTitle,
+            });
+        }
+
+        await SaveNewEventsAsync(metrics, toInsert, ct).ConfigureAwait(false);
+    }
+
+    private static async Task SaveNewEventsAsync(
+        MetricsDbContext metrics,
+        List<ArrImportEvent> toInsert,
+        CancellationToken ct)
+    {
+        metrics.ArrImportEvents.AddRange(toInsert);
+        try
+        {
+            await metrics.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e.IsUniqueConstraintException())
+        {
+            metrics.ChangeTracker.Clear();
+            foreach (var item in toInsert)
+            {
+                metrics.ArrImportEvents.Add(item);
+                try
+                {
+                    await metrics.SaveChangesAsync(ct).ConfigureAwait(false);
+                }
+                catch (Exception inner) when (inner.IsUniqueConstraintException())
+                {
+                    metrics.ChangeTracker.Clear();
+                }
+            }
+        }
+    }
+
+    private static async Task<List<ArrAwaitingSnapshot>> BuildAwaitingAsync(
+        IReadOnlyList<ArrQueueRecord> records,
+        DavDatabaseContext dav,
+        CancellationToken ct)
+    {
+        var awaitingRecords = records.Where(r => r.IsAwaitingImport).Take(MaxAwaitingPerInstance).ToList();
+        if (awaitingRecords.Count == 0) return [];
+
+        var downloadIds = new List<Guid>();
+        foreach (var record in awaitingRecords)
+        {
+            if (Guid.TryParse(record.DownloadId, out var id))
+                downloadIds.Add(id);
+        }
+
+        Dictionary<Guid, DateTime> createdAtById = [];
+        if (downloadIds.Count > 0)
+        {
+            createdAtById = await dav.HistoryItems
+                .AsNoTracking()
+                .Where(h => downloadIds.Contains(h.Id))
+                .Select(h => new { h.Id, h.CreatedAt })
+                .ToDictionaryAsync(h => h.Id, h => h.CreatedAt, ct).ConfigureAwait(false);
+        }
+
+        return awaitingRecords.Select(record =>
+        {
+            Guid? downloadId = Guid.TryParse(record.DownloadId, out var parsed) ? parsed : null;
+            DateTime? createdAt = downloadId is { } id && createdAtById.TryGetValue(id, out var at) ? at : null;
+            return new ArrAwaitingSnapshot
+            {
+                Title = record.Title,
+                DownloadId = downloadId,
+                CreatedAt = createdAt,
+            };
+        }).ToList();
+    }
+
+    private void RecordSuccess(ArrHealthSnapshot snapshot)
+    {
+        lock (_snapshotLock)
+        {
+            _consecutiveFailures[snapshot.InstanceKey] = 0;
+            _snapshots[snapshot.InstanceKey] = snapshot;
+        }
+    }
+
+    private void RecordFailure(
+        string key,
+        string appType,
+        string host,
+        string displayName,
+        Exception exception)
+    {
+        lock (_snapshotLock)
+        {
+            _consecutiveFailures.TryGetValue(key, out var failures);
+            failures++;
+            _consecutiveFailures[key] = failures;
+            _snapshots.TryGetValue(key, out var previous);
+            var status = failures >= OfflineFailureThreshold
+                ? ArrInstanceHealthStatus.Offline
+                : previous?.Status ?? ArrInstanceHealthStatus.Pending;
+            _snapshots[key] = new ArrHealthSnapshot
+            {
+                InstanceKey = key,
+                DisplayName = displayName,
+                AppType = appType,
+                Host = host,
+                Status = status,
+                QueueCount = previous?.QueueCount ?? 0,
+                AwaitingCount = previous?.AwaitingCount ?? 0,
+                HasWarnings = previous?.HasWarnings ?? false,
+                HasErrors = previous?.HasErrors ?? false,
+                LastImportAtMs = previous?.LastImportAtMs,
+                LastPolledAt = DateTimeOffset.UtcNow,
+                LastError = exception.TryGetKnownErrorMessage(out var reason) ? reason : exception.Message,
+                MedianHandoffMs30d = previous?.MedianHandoffMs30d,
+                MedianSampleCount30d = previous?.MedianSampleCount30d ?? 0,
+                Awaiting = previous?.Awaiting ?? [],
+            };
+        }
+    }
+
+    private void PruneSnapshots(HashSet<string> enabledKeys)
+    {
+        lock (_snapshotLock)
+        {
+            var stale = _snapshots.Keys.Where(k => !enabledKeys.Contains(k)).ToList();
+            foreach (var key in stale)
+            {
+                _snapshots.Remove(key);
+                _consecutiveFailures.Remove(key);
+            }
+        }
+    }
+
+    private static ArrClient CreateClient(string appType, ArrConfig.ConnectionDetails details) =>
+        appType == "radarr"
+            ? new RadarrClient(details.Host, details.ApiKey)
+            : new SonarrClient(details.Host, details.ApiKey);
+}

--- a/backend/Services/ArrHealthSnapshot.cs
+++ b/backend/Services/ArrHealthSnapshot.cs
@@ -1,0 +1,35 @@
+namespace NzbWebDAV.Services;
+
+public enum ArrInstanceHealthStatus
+{
+    Pending,
+    Healthy,
+    Degraded,
+    Offline,
+}
+
+public sealed class ArrHealthSnapshot
+{
+    public required string InstanceKey { get; init; }
+    public required string DisplayName { get; init; }
+    public required string AppType { get; init; }
+    public required string Host { get; init; }
+    public ArrInstanceHealthStatus Status { get; init; }
+    public int QueueCount { get; init; }
+    public int AwaitingCount { get; init; }
+    public bool HasWarnings { get; init; }
+    public bool HasErrors { get; init; }
+    public long? LastImportAtMs { get; init; }
+    public DateTimeOffset? LastPolledAt { get; init; }
+    public string? LastError { get; init; }
+    public long? MedianHandoffMs30d { get; init; }
+    public int MedianSampleCount30d { get; init; }
+    public IReadOnlyList<ArrAwaitingSnapshot> Awaiting { get; init; } = [];
+}
+
+public sealed class ArrAwaitingSnapshot
+{
+    public string? Title { get; init; }
+    public Guid? DownloadId { get; init; }
+    public DateTime? CreatedAt { get; init; }
+}

--- a/backend/Services/ArrHealthSnapshot.cs
+++ b/backend/Services/ArrHealthSnapshot.cs
@@ -8,7 +8,7 @@ public enum ArrInstanceHealthStatus
     Offline,
 }
 
-public sealed class ArrHealthSnapshot
+public sealed record ArrHealthSnapshot
 {
     public required string InstanceKey { get; init; }
     public required string DisplayName { get; init; }
@@ -27,7 +27,7 @@ public sealed class ArrHealthSnapshot
     public IReadOnlyList<ArrAwaitingSnapshot> Awaiting { get; init; } = [];
 }
 
-public sealed class ArrAwaitingSnapshot
+public sealed record ArrAwaitingSnapshot
 {
     public string? Title { get; init; }
     public Guid? DownloadId { get; init; }

--- a/backend/Services/Metrics/MetricsRetentionService.cs
+++ b/backend/Services/Metrics/MetricsRetentionService.cs
@@ -24,6 +24,7 @@ public class MetricsRetentionService(ConfigManager configManager) : BackgroundSe
     private static readonly TimeSpan MinuteRollupTtl = TimeSpan.FromDays(7);
     private static readonly TimeSpan SessionTtl = TimeSpan.FromDays(90);
     private static readonly TimeSpan HourlyRollupTtl = TimeSpan.FromDays(365);
+    private static readonly TimeSpan ArrImportEventTtl = TimeSpan.FromDays(90);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -77,6 +78,9 @@ public class MetricsRetentionService(ConfigManager configManager) : BackgroundSe
             "DELETE FROM FailoverMisses WHERE At < {0}", Cutoff(nowMs, fetchTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
             "DELETE FROM FailoverHourly WHERE Hour < {0}", Cutoff(nowMs, HourlyRollupTtl)).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync(
+            "DELETE FROM ArrImportEvents WHERE ImportedAtMs < {0}", Cutoff(nowMs, ArrImportEventTtl))
+            .ConfigureAwait(false);
 
         await db.Database.ExecuteSqlRawAsync("PRAGMA incremental_vacuum;").ConfigureAwait(false);
     }

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -7,8 +7,11 @@ additional Arr apps such as Lidarr in the future. Config key: `arr.instances`
 
 | Control | Effect |
 |---------|--------|
+| Name | Optional display name (Overview Arr Health falls back to the host URL) |
+| Enabled | When off, the instance is excluded from queue management, Arr-linked repairs, **and** Arr Health |
 | Radarr Host / API Key | Test Conn available |
 | Sonarr Host / API Key | Test Conn available |
+| Arr Health | Master toggle `arr.health-enabled` (`NZBDAV_CONFIG__ARR__HEALTH_ENABLED`) — default on |
 | Automatic Queue Management | Per status message: Do Nothing / Remove / Remove+Blocklist / Remove+Blocklist+Search |
 
 **Test Conn** validates host reachability, API key auth, and a successful API response
@@ -23,5 +26,25 @@ Only **Usenet** queue items are acted upon. Typical mappings:
 - **Do Nothing** — ID mismatches and similar manual-import cases
 
 Any action other than **Do Nothing** tells the Arr to delete the queue record with `removeFromClient=true`. The Arr then removes the download from InfiniDysk History even when its own **Remove Completed** checkbox is off. That is independent of mounted files, which stay.
+
+Disabling an instance opts it out of stuck-queue actions, Arr-linked repairs, and health polling. Use **Arr Health** off when you still want queue rules without Overview polling.
+
+## Arr Health on the Overview dashboard [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+When at least one Radarr or Sonarr instance is configured **and enabled**, Overview shows a compact **Arr Health** section: instance reachability, imports in the selected dashboard window, median/P95 handoff latency (InfiniDysk download completed → Arr `DownloadFolderImported`), queue depth, and items waiting unusually long for import.
+
+The feature is **completely dormant** otherwise:
+
+- No Overview widget
+- No background polling or Arr HTTP
+- No metrics writes or Arr Health log lines
+
+Turn off **Show Arr Health on Overview** (`arr.health-enabled`) to keep instances for queue rules/repairs without health polling.
+
+Handoff events are stored in the local metrics database (`metrics.sqlite`) for **90 days**, so the Overview **All** window for this widget is effectively ~90 days. API keys are never sent to the widget.
+
+Back up `/config` before upgrading: the metrics store gains an additive `ArrImportEvents` table that auto-applies on startup.
+
+Headless `NZBDAV_CONFIG__ARR__INSTANCES` JSON that includes the new `Name` / `Enabled` properties **cannot roll back** to an older image (structured ENV config is not forward compatible — see [headless](headless.md)).
 
 [Connect *Arr](../getting-started/connect-arr.md)

--- a/docs/configuration/headless.md
+++ b/docs/configuration/headless.md
@@ -143,6 +143,10 @@ services:
 
       NZBDAV_CONFIG__ARR__INSTANCES: >-
         {"RadarrInstances":[{"Host":"http://radarr:7878","ApiKey":"${RADARR_API_KEY:?set RADARR_API_KEY}"}],"SonarrInstances":[{"Host":"http://sonarr:8989","ApiKey":"${SONARR_API_KEY:?set SONARR_API_KEY}"}],"QueueRules":[]}
+      # Optional. Default on. Set false to keep Arr queue rules without Overview health polling.
+      # NZBDAV_CONFIG__ARR__HEALTH_ENABLED: "true"
+      # Optional Name/Enabled on each instance (since 1.2.0) are not forward compatible
+      # with older images — see Validation and restart.
 
       NZBDAV_CONFIG__INDEXERS__INSTANCES: >-
         {"Indexers":[{"Name":"Example","Url":"https://indexer.example/api","ApiKey":"${INDEXER_API_KEY:?set INDEXER_API_KEY}","Enabled":true}]}

--- a/docs/getting-started/connect-arr.md
+++ b/docs/getting-started/connect-arr.md
@@ -24,7 +24,7 @@ Test the connection. Prefer `addfile` when clients can upload NZB bytes; `addurl
 2. Add Sonarr host (`http://sonarr:8989`) + API key.
 3. Configure **Automatic Queue Management** for stuck import messages (remove / blocklist / search).
 
-Only Usenet queue items are acted on. See [Radarr/Sonarr settings](../configuration/arrs.md).
+Registered and enabled instances light up the Overview **Arr Health** widget [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }. See [Radarr/Sonarr settings](../configuration/arrs.md).
 
 ## Align import paths
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -736,6 +736,48 @@ export type OverviewStatsResponse = {
     },
 }
 
+export type ArrInstanceStatus = "pending" | "healthy" | "degraded" | "offline";
+
+export type ArrHealthSummary = {
+    instancesOnline: number,
+    instancesTotal: number,
+    importsCompleted: number,
+    medianHandoffMs: number | null,
+    p95HandoffMs: number | null,
+    awaitingImport: number,
+    degraded: number,
+}
+
+export type ArrHealthInstanceRow = {
+    key: string,
+    name: string,
+    appType: string,
+    host: string,
+    status: ArrInstanceStatus,
+    imports: number,
+    medianHandoffMs: number | null,
+    p95HandoffMs: number | null,
+    queueCount: number,
+    awaitingCount: number,
+    lastImportAtMs: number | null,
+    lastError: string | null,
+}
+
+export type ArrAwaitingItem = {
+    title: string | null,
+    instanceKey: string,
+    instanceName: string,
+    waitingMs: number | null,
+    isUnusual: boolean,
+}
+
+export type ArrHealthResponse = {
+    configured: boolean,
+    summary: ArrHealthSummary,
+    instances: ArrHealthInstanceRow[],
+    awaiting: ArrAwaitingItem[],
+}
+
 export type FailoverBlock = {
     articlesRecovered: number,
     previousArticlesRecovered: number | null,

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -1,0 +1,175 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { ArrHealthResponse } from "~/clients/backend-client.server";
+import { ArrHealth } from "./arr-health";
+
+const emptySummary = {
+    instancesOnline: 0,
+    instancesTotal: 0,
+    importsCompleted: 0,
+    medianHandoffMs: null,
+    p95HandoffMs: null,
+    awaitingImport: 0,
+    degraded: 0,
+};
+
+function render(data: ArrHealthResponse, window: "24h" | "all" = "24h") {
+    return renderToStaticMarkup(<ArrHealth data={data} window={window} />);
+}
+
+describe("ArrHealth", () => {
+    it("renders healthy, degraded, offline, and pending badges with summary chips", () => {
+        const markup = render({
+            configured: true,
+            summary: {
+                instancesOnline: 2,
+                instancesTotal: 4,
+                importsCompleted: 121,
+                medianHandoffMs: 7800,
+                p95HandoffMs: 21000,
+                awaitingImport: 3,
+                degraded: 1,
+            },
+            instances: [
+                {
+                    key: "sonarr|http://sonarr:8989",
+                    name: "Sonarr Main",
+                    appType: "sonarr",
+                    host: "http://sonarr:8989",
+                    status: "healthy",
+                    imports: 121,
+                    medianHandoffMs: 7800,
+                    p95HandoffMs: 21000,
+                    queueCount: 0,
+                    awaitingCount: 0,
+                    lastImportAtMs: Date.now() - 180_000,
+                    lastError: null,
+                },
+                {
+                    key: "sonarr|http://sonarr-4k:8989",
+                    name: "Sonarr 4K",
+                    appType: "sonarr",
+                    host: "http://sonarr-4k:8989",
+                    status: "degraded",
+                    imports: 29,
+                    medianHandoffMs: 41000,
+                    p95HandoffMs: 138000,
+                    queueCount: 3,
+                    awaitingCount: 3,
+                    lastImportAtMs: Date.now() - 19 * 60_000,
+                    lastError: null,
+                },
+                {
+                    key: "radarr|http://radarr:7878",
+                    name: "Radarr",
+                    appType: "radarr",
+                    host: "http://radarr:7878",
+                    status: "offline",
+                    imports: 0,
+                    medianHandoffMs: null,
+                    p95HandoffMs: null,
+                    queueCount: 0,
+                    awaitingCount: 0,
+                    lastImportAtMs: null,
+                    lastError: "Unreachable",
+                },
+                {
+                    key: "radarr|http://radarr-new:7878",
+                    name: "Radarr New",
+                    appType: "radarr",
+                    host: "http://radarr-new:7878",
+                    status: "pending",
+                    imports: 0,
+                    medianHandoffMs: null,
+                    p95HandoffMs: null,
+                    queueCount: 0,
+                    awaitingCount: 0,
+                    lastImportAtMs: null,
+                    lastError: null,
+                },
+            ],
+            awaiting: [],
+        });
+
+        expect(markup).toContain("Arr Health");
+        expect(markup).toContain("2/4");
+        expect(markup).toContain("7.8s");
+        expect(markup).toContain("21s");
+        expect(markup).toContain("badge-success");
+        expect(markup).toContain("badge-warning");
+        expect(markup).toContain("badge-error");
+        expect(markup).toContain("badge-ghost");
+        expect(markup).toContain("healthy");
+        expect(markup).toContain("degraded");
+        expect(markup).toContain("offline");
+        expect(markup).toContain("pending");
+        expect(markup).toContain("Unreachable");
+    });
+
+    it("shows the empty state when no instances have imported yet", () => {
+        const markup = render({
+            configured: true,
+            summary: emptySummary,
+            instances: [],
+            awaiting: [],
+        });
+        expect(markup).toContain("No imports recorded yet.");
+    });
+
+    it("highlights unusually long awaits and shows an em dash for unknown waits", () => {
+        const markup = render({
+            configured: true,
+            summary: {
+                ...emptySummary,
+                instancesOnline: 1,
+                instancesTotal: 1,
+                awaitingImport: 2,
+            },
+            instances: [{
+                key: "sonarr|http://sonarr:8989",
+                name: "Sonarr Main",
+                appType: "sonarr",
+                host: "http://sonarr:8989",
+                status: "degraded",
+                imports: 0,
+                medianHandoffMs: 8000,
+                p95HandoffMs: 20000,
+                queueCount: 2,
+                awaitingCount: 2,
+                lastImportAtMs: null,
+                lastError: null,
+            }],
+            awaiting: [
+                {
+                    title: "Example Show S04E06",
+                    instanceKey: "sonarr|http://sonarr:8989",
+                    instanceName: "Sonarr Main",
+                    waitingMs: 47 * 60_000,
+                    isUnusual: true,
+                },
+                {
+                    title: "Unknown release",
+                    instanceKey: "sonarr|http://sonarr:8989",
+                    instanceName: "Sonarr Main",
+                    waitingMs: null,
+                    isUnusual: false,
+                },
+            ],
+        });
+
+        expect(markup).toContain("Example Show S04E06");
+        expect(markup).toContain("unusually long");
+        expect(markup).toContain("text-warning");
+        expect(markup).toContain("waiting —");
+    });
+
+    it("notes the 90-day retention on the All window", () => {
+        const markup = render({
+            configured: true,
+            summary: emptySummary,
+            instances: [],
+            awaiting: [],
+        }, "all");
+        expect(markup).toContain("~90 days of stored events");
+    });
+});

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -1,0 +1,128 @@
+import type { ArrHealthResponse, ArrInstanceStatus, OverviewWindow } from "~/clients/backend-client.server";
+import { formatDurationMs, formatNumber, formatTimeAgo } from "../../utils/format";
+
+export type ArrHealthProps = {
+    data: ArrHealthResponse,
+    window: OverviewWindow,
+}
+
+const STATUS_BADGE: Record<ArrInstanceStatus, string> = {
+    healthy: "badge-success",
+    degraded: "badge-warning",
+    offline: "badge-error",
+    pending: "badge-ghost",
+};
+
+export function ArrHealth({ data, window }: ArrHealthProps) {
+    const { summary, instances, awaiting } = data;
+    const sinceLabel = window === "all"
+        ? "all time (~90 days of stored events)"
+        : `last ${window}`;
+
+    return (
+        <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
+            <div className="card-body gap-3 p-4">
+                <div>
+                    <h3 className="card-title text-base">Arr Health</h3>
+                    <p className="text-xs text-base-content/50">
+                        InfiniDysk completion → Sonarr/Radarr import, {sinceLabel}
+                    </p>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                    <Chip
+                        label="Instances online"
+                        value={`${summary.instancesOnline}/${summary.instancesTotal}`}
+                    />
+                    <Chip label="Imports" value={formatNumber(summary.importsCompleted)} />
+                    <Chip label="Median handoff" value={formatDurationMs(summary.medianHandoffMs)} />
+                    <Chip label="P95" value={formatDurationMs(summary.p95HandoffMs)} />
+                    <Chip label="Awaiting" value={formatNumber(summary.awaitingImport)} />
+                    {summary.degraded > 0 && (
+                        <Chip label="Degraded" value={formatNumber(summary.degraded)} warning />
+                    )}
+                </div>
+
+                {instances.length === 0 ? (
+                    <p className="py-6 text-center text-xs text-base-content/50">No imports recorded yet.</p>
+                ) : (
+                    <div className="overflow-x-auto">
+                        <table className="table table-sm min-w-[720px]">
+                            <thead>
+                                <tr>
+                                    <th>Instance</th>
+                                    <th>Status</th>
+                                    <th>Imports</th>
+                                    <th>Median</th>
+                                    <th>P95</th>
+                                    <th>Queue</th>
+                                    <th>Awaiting</th>
+                                    <th>Last import</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {instances.map(instance => (
+                                    <tr key={instance.key}>
+                                        <td className="max-w-[220px] font-medium">
+                                            <span className="inline-block max-w-full truncate align-middle" title={instance.host}>
+                                                {instance.name}
+                                            </span>
+                                            <span className="mt-0.5 block text-[11px] font-normal capitalize text-base-content/45">
+                                                {instance.appType}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <span className={`badge badge-sm ${STATUS_BADGE[instance.status]}`}>
+                                                {instance.status}
+                                            </span>
+                                        </td>
+                                        <td className="font-mono tabular-nums">{formatNumber(instance.imports)}</td>
+                                        <td className="font-mono tabular-nums">{formatDurationMs(instance.medianHandoffMs)}</td>
+                                        <td className="font-mono tabular-nums">{formatDurationMs(instance.p95HandoffMs)}</td>
+                                        <td className="font-mono tabular-nums">{formatNumber(instance.queueCount)}</td>
+                                        <td className="font-mono tabular-nums">{formatNumber(instance.awaitingCount)}</td>
+                                        <td className="font-mono tabular-nums text-base-content/80">
+                                            {instance.status === "offline" && !instance.lastImportAtMs
+                                                ? (instance.lastError ?? "Unreachable")
+                                                : formatTimeAgo(instance.lastImportAtMs)}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+
+                {summary.importsCompleted === 0 && instances.length > 0 && (
+                    <p className="text-xs text-base-content/50">No imports recorded yet.</p>
+                )}
+
+                {awaiting.length > 0 && (
+                    <div>
+                        <h4 className="mb-2 text-xs uppercase tracking-wide text-base-content/50">Awaiting import</h4>
+                        <ul className="space-y-1">
+                            {awaiting.map((item, index) => (
+                                <li
+                                    key={`${item.instanceKey}-${item.title ?? "item"}-${index}`}
+                                    className={`text-xs ${item.isUnusual ? "text-warning" : "text-base-content/80"}`}
+                                >
+                                    {item.title ?? "(untitled)"} — {item.instanceName} — waiting {formatDurationMs(item.waitingMs)}
+                                    {item.isUnusual ? " — unusually long" : ""}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+}
+
+function Chip({ label, value, warning = false }: { label: string, value: string, warning?: boolean }) {
+    return (
+        <span className={`badge badge-sm gap-1 ${warning ? "badge-warning" : "badge-ghost"}`}>
+            <span className="text-base-content/60">{label}</span>
+            <span className="font-mono tabular-nums">{value}</span>
+        </span>
+    );
+}

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -23,7 +23,7 @@ import { SortableRow } from "./components/sortable-row/sortable-row";
 import { backendClient, type ArrHealthResponse } from "~/clients/backend-client.server";
 import { useRowOrder } from "./utils/use-row-order";
 import { hasConfiguredIndexers } from "./utils/has-configured-indexers";
-import { hasConfiguredArrs } from "./utils/has-configured-arrs";
+import { hasConfiguredArrs, isArrHealthEnabled } from "./utils/has-configured-arrs";
 import {
     EMPTY_OVERVIEW_STATS,
     mergeOverviewStats,
@@ -65,15 +65,15 @@ const DEFAULT_ROW_ORDER = [
 
 /** Shell-only loader — stats load client-side in sections so first paint is instant. */
 export async function loader() {
-    const config = await backendClient.getConfig(["indexers.instances", "arr.instances"]);
+    const config = await backendClient.getConfig(["indexers.instances", "arr.instances", "arr.health-enabled"]);
     return {
         stats: null as OverviewStatsResponse | null,
         hasConfiguredIndexers: hasConfiguredIndexers(
             config.find(item => item.configName === "indexers.instances")?.configValue,
         ),
-        hasConfiguredArrs: hasConfiguredArrs(
-            config.find(item => item.configName === "arr.instances")?.configValue,
-        ),
+        hasConfiguredArrs: isArrHealthEnabled(
+            config.find(item => item.configName === "arr.health-enabled")?.configValue,
+        ) && hasConfiguredArrs(config.find(item => item.configName === "arr.instances")?.configValue),
     };
 }
 

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -18,10 +18,12 @@ import { CatalogueBlock } from "./components/catalogue-block/catalogue-block";
 import { LifetimeBlock } from "./components/lifetime-block/lifetime-block";
 import { RecordsBlock } from "./components/records-block/records-block";
 import { FailoverSaves } from "./components/failover-saves/failover-saves";
+import { ArrHealth } from "./components/arr-health/arr-health";
 import { SortableRow } from "./components/sortable-row/sortable-row";
-import { backendClient } from "~/clients/backend-client.server";
+import { backendClient, type ArrHealthResponse } from "~/clients/backend-client.server";
 import { useRowOrder } from "./utils/use-row-order";
 import { hasConfiguredIndexers } from "./utils/has-configured-indexers";
+import { hasConfiguredArrs } from "./utils/has-configured-arrs";
 import {
     EMPTY_OVERVIEW_STATS,
     mergeOverviewStats,
@@ -54,6 +56,7 @@ const DEFAULT_ROW_ORDER = [
     "latency",
     "errorsSessions",
     "failover",
+    "arrHealth",
     "indexers",
     "indexerApiUsage",
     "recordsCatalogue",
@@ -62,11 +65,14 @@ const DEFAULT_ROW_ORDER = [
 
 /** Shell-only loader — stats load client-side in sections so first paint is instant. */
 export async function loader() {
-    const config = await backendClient.getConfig(["indexers.instances"]);
+    const config = await backendClient.getConfig(["indexers.instances", "arr.instances"]);
     return {
         stats: null as OverviewStatsResponse | null,
         hasConfiguredIndexers: hasConfiguredIndexers(
             config.find(item => item.configName === "indexers.instances")?.configValue,
+        ),
+        hasConfiguredArrs: hasConfiguredArrs(
+            config.find(item => item.configName === "arr.instances")?.configValue,
         ),
     };
 }
@@ -96,6 +102,8 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     const [windowLoaded, setWindowLoaded] = useState(false);
     const [detailLoaded, setDetailLoaded] = useState(false);
     const [staticLoaded, setStaticLoaded] = useState(false);
+    const [arrHealth, setArrHealth] = useState<ArrHealthResponse | null>(null);
+    const [arrHealthLoaded, setArrHealthLoaded] = useState(false);
     const { order, save, reset } = useRowOrder(DEFAULT_ROW_ORDER);
     const editModeRef = useRef(editMode);
     editModeRef.current = editMode;
@@ -139,6 +147,41 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
             document.removeEventListener("visibilitychange", onVisible);
         };
     }, [window, isLongWindow]);
+
+    // Arr Health: poll on the same 30s cadence, only when Arr instances are configured.
+    useEffect(() => {
+        if (!loaderData.hasConfiguredArrs) return;
+        let cancelled = false;
+        setArrHealthLoaded(false);
+
+        const fetchArrHealth = async () => {
+            if (typeof document !== "undefined" && document.hidden) return;
+            try {
+                const res = await fetch(withUrlBase(`/api/get-arr-health?window=${window}`));
+                if (!res.ok || cancelled) return;
+                const data = await res.json() as ArrHealthResponse;
+                if (cancelled) return;
+                setArrHealth(data);
+                setArrHealthLoaded(true);
+            } catch { /* network blip, retry next tick */ }
+        };
+
+        void fetchArrHealth();
+        const interval = setInterval(() => {
+            if (editModeRef.current) return;
+            void fetchArrHealth();
+        }, 30_000);
+        const onVisible = () => {
+            if (editModeRef.current) return;
+            if (!document.hidden) void fetchArrHealth();
+        };
+        document.addEventListener("visibilitychange", onVisible);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+            document.removeEventListener("visibilitychange", onVisible);
+        };
+    }, [window, loaderData.hasConfiguredArrs]);
 
     // Detail (latency + errors): once per 24h window selection — not on the 30s poll.
     useEffect(() => {
@@ -275,6 +318,11 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         failover: windowLoaded
             ? <FailoverSaves failover={stats.failover} window={window} />
             : <Skeleton height={180} />,
+        arrHealth: loaderData.hasConfiguredArrs
+            ? (arrHealthLoaded && arrHealth
+                ? <ArrHealth data={arrHealth} window={window} />
+                : <Skeleton height={140} />)
+            : null,
         indexers: loaderData.hasConfiguredIndexers && staticLoaded
             ? <IndexerScoreboard indexers={stats.indexers} />
             : loaderData.hasConfiguredIndexers ? <Skeleton height={140} /> : null,
@@ -294,13 +342,15 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         lifetime: staticLoaded
             ? <LifetimeBlock lifetime={stats.lifetime} />
             : <Skeleton height={120} />,
-    }), [liveTiles, stats, window, isLongWindow, windowLoaded, detailLoaded, staticLoaded, editMode, loaderData.hasConfiguredIndexers]);
+    }), [liveTiles, stats, window, isLongWindow, windowLoaded, detailLoaded, staticLoaded, editMode, loaderData.hasConfiguredIndexers, loaderData.hasConfiguredArrs, arrHealth, arrHealthLoaded]);
 
     const visibleOrder = useMemo(
-        () => loaderData.hasConfiguredIndexers
-            ? order
-            : order.filter(id => id !== "indexers" && id !== "indexerApiUsage"),
-        [loaderData.hasConfiguredIndexers, order],
+        () => order.filter(id => {
+            if (!loaderData.hasConfiguredIndexers && (id === "indexers" || id === "indexerApiUsage")) return false;
+            if (!loaderData.hasConfiguredArrs && id === "arrHealth") return false;
+            return true;
+        }),
+        [loaderData.hasConfiguredIndexers, loaderData.hasConfiguredArrs, order],
     );
 
     const sensors = useSensors(

--- a/frontend/app/routes/overview/utils/format.test.ts
+++ b/frontend/app/routes/overview/utils/format.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatDurationMs } from "./format";
+
+describe("formatDurationMs", () => {
+    it("renders em dash for missing or invalid values", () => {
+        expect(formatDurationMs(null)).toBe("—");
+        expect(formatDurationMs(undefined)).toBe("—");
+        expect(formatDurationMs(Number.NaN)).toBe("—");
+        expect(formatDurationMs(-1)).toBe("—");
+    });
+
+    it("formats seconds, minutes, and hours", () => {
+        expect(formatDurationMs(7_800)).toBe("7.8s");
+        expect(formatDurationMs(21_000)).toBe("21s");
+        expect(formatDurationMs(138_000)).toBe("2m 18s");
+        expect(formatDurationMs(10_800_000)).toBe("3h");
+        expect(formatDurationMs(3_660_000)).toBe("1h 1m");
+        expect(formatDurationMs(60_000)).toBe("1m");
+    });
+});

--- a/frontend/app/routes/overview/utils/format.ts
+++ b/frontend/app/routes/overview/utils/format.ts
@@ -20,3 +20,26 @@ export function formatNumber(n: number): string {
 export function formatPercent(p: number, digits = 1): string {
     return `${p.toFixed(digits)}%`;
 }
+
+export function formatDurationMs(ms: number | null | undefined): string {
+    if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
+    if (ms < 60_000) {
+        const seconds = ms / 1000;
+        return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
+    }
+    const totalSeconds = Math.round(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+export function formatTimeAgo(ms: number | null | undefined, now = Date.now()): string {
+    if (ms == null || !Number.isFinite(ms)) return "—";
+    const age = Math.max(0, Math.round((now - ms) / 1000));
+    if (age < 60) return `${age}s ago`;
+    if (age < 3600) return `${Math.floor(age / 60)}m ago`;
+    if (age < 86400) return `${Math.floor(age / 3600)}h ago`;
+    return `${Math.floor(age / 86400)}d ago`;
+}

--- a/frontend/app/routes/overview/utils/has-configured-arrs.test.ts
+++ b/frontend/app/routes/overview/utils/has-configured-arrs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hasConfiguredArrs } from "./has-configured-arrs";
+import { hasConfiguredArrs, isArrHealthEnabled } from "./has-configured-arrs";
 
 describe("hasConfiguredArrs", () => {
     it.each([
@@ -16,5 +16,17 @@ describe("hasConfiguredArrs", () => {
         ['{"RadarrInstances":[{"Enabled":false}],"SonarrInstances":[{"Host":"http://sonarr","Enabled":true}]}', true],
     ])("returns %s for %j", (configValue, expected) => {
         expect(hasConfiguredArrs(configValue)).toBe(expected);
+    });
+});
+
+describe("isArrHealthEnabled", () => {
+    it.each([
+        [undefined, true],
+        ["", true],
+        ["true", true],
+        ["false", false],
+        ["FALSE", false],
+    ])("returns %s for %j", (configValue, expected) => {
+        expect(isArrHealthEnabled(configValue)).toBe(expected);
     });
 });

--- a/frontend/app/routes/overview/utils/has-configured-arrs.test.ts
+++ b/frontend/app/routes/overview/utils/has-configured-arrs.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { hasConfiguredArrs } from "./has-configured-arrs";
+
+describe("hasConfiguredArrs", () => {
+    it.each([
+        [undefined, false],
+        ["", false],
+        ["not json", false],
+        ["{}", false],
+        ['{"RadarrInstances":[],"SonarrInstances":[]}', false],
+        ['{"RadarrInstances":[{"Host":"http://radarr","Enabled":false}],"SonarrInstances":[]}', false],
+        ['{"SonarrInstances":[{"Host":"http://sonarr","Enabled":false}]}', false],
+        ['{"RadarrInstances":[{"Host":"http://radarr"}],"SonarrInstances":[]}', true],
+        ['{"RadarrInstances":[{"Host":"http://radarr","Enabled":true}],"SonarrInstances":[]}', true],
+        ['{"RadarrInstances":[],"SonarrInstances":[{"Host":"http://sonarr"}]}', true],
+        ['{"RadarrInstances":[{"Enabled":false}],"SonarrInstances":[{"Host":"http://sonarr","Enabled":true}]}', true],
+    ])("returns %s for %j", (configValue, expected) => {
+        expect(hasConfiguredArrs(configValue)).toBe(expected);
+    });
+});

--- a/frontend/app/routes/overview/utils/has-configured-arrs.ts
+++ b/frontend/app/routes/overview/utils/has-configured-arrs.ts
@@ -1,0 +1,22 @@
+export function hasConfiguredArrs(configValue?: string): boolean {
+    if (!configValue) return false;
+
+    try {
+        const config: unknown = JSON.parse(configValue);
+        if (typeof config !== "object" || config === null) return false;
+
+        const radarr = "RadarrInstances" in config && Array.isArray(config.RadarrInstances)
+            ? config.RadarrInstances
+            : [];
+        const sonarr = "SonarrInstances" in config && Array.isArray(config.SonarrInstances)
+            ? config.SonarrInstances
+            : [];
+
+        return [...radarr, ...sonarr].some((instance) =>
+            typeof instance === "object"
+            && instance !== null
+            && (!("Enabled" in instance) || instance.Enabled !== false));
+    } catch {
+        return false;
+    }
+}

--- a/frontend/app/routes/overview/utils/has-configured-arrs.ts
+++ b/frontend/app/routes/overview/utils/has-configured-arrs.ts
@@ -18,3 +18,7 @@ export function hasConfiguredArrs(configValue?: string): boolean {
         return false;
     }
 }
+
+export function isArrHealthEnabled(configValue?: string): boolean {
+    return configValue?.toLowerCase() !== "false";
+}

--- a/frontend/app/routes/overview/utils/has-configured-arrs.ts
+++ b/frontend/app/routes/overview/utils/has-configured-arrs.ts
@@ -5,17 +5,15 @@ export function hasConfiguredArrs(configValue?: string): boolean {
         const config: unknown = JSON.parse(configValue);
         if (typeof config !== "object" || config === null) return false;
 
-        const radarr = "RadarrInstances" in config && Array.isArray(config.RadarrInstances)
-            ? config.RadarrInstances
-            : [];
-        const sonarr = "SonarrInstances" in config && Array.isArray(config.SonarrInstances)
-            ? config.SonarrInstances
-            : [];
+        const record = config as Record<string, unknown>;
+        const radarr: unknown[] = Array.isArray(record["RadarrInstances"]) ? record["RadarrInstances"] : [];
+        const sonarr: unknown[] = Array.isArray(record["SonarrInstances"]) ? record["SonarrInstances"] : [];
 
-        return [...radarr, ...sonarr].some((instance) =>
-            typeof instance === "object"
-            && instance !== null
-            && (!("Enabled" in instance) || instance.Enabled !== false));
+        return [...radarr, ...sonarr].some((instance) => {
+            if (typeof instance !== "object" || instance === null) return false;
+            const arrInstance = instance as Record<string, unknown>;
+            return !("Enabled" in arrInstance) || arrInstance["Enabled"] !== false;
+        });
     } catch {
         return false;
     }

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -1,7 +1,7 @@
 import { Button } from "~/components/ui/button";
 import { Alert, Spinner, Tooltip } from "~/components/ui/feedback";
 import { SettingsCard, SettingsIntro, SettingsPage, ManagedSetting } from "~/components/ui";
-import { Input, Select } from "~/components/ui/form";
+import { Input, Select, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
 import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
 import { withUrlBase } from "~/utils/url-base";
@@ -12,8 +12,10 @@ type ArrsSettingsProps = {
 };
 
 interface ConnectionDetails {
+    Name?: string;
     Host: string;
     ApiKey: string;
+    Enabled?: boolean;
 }
 
 interface QueueRule {
@@ -129,7 +131,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
             ...arrConfig,
             RadarrInstances: [
                 ...arrConfig.RadarrInstances,
-                { Host: "", ApiKey: "" }
+                { Host: "", ApiKey: "", Enabled: true }
             ]
         });
     }, [arrConfig, updateConfig]);
@@ -142,7 +144,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
         });
     }, [arrConfig, updateConfig]);
 
-    const updateRadarrInstance = useCallback((index: number, field: keyof ConnectionDetails, value: string) => {
+    const updateRadarrInstance = useCallback((index: number, field: keyof ConnectionDetails, value: string | boolean) => {
         updateConfig({
             ...arrConfig,
             RadarrInstances: arrConfig.RadarrInstances
@@ -157,7 +159,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
             ...arrConfig,
             SonarrInstances: [
                 ...arrConfig.SonarrInstances,
-                { Host: "", ApiKey: "" }
+                { Host: "", ApiKey: "", Enabled: true }
             ]
         });
     }, [arrConfig, updateConfig]);
@@ -170,7 +172,7 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
         });
     }, [arrConfig, updateConfig]);
 
-    const updateSonarrInstance = useCallback((index: number, field: keyof ConnectionDetails, value: string) => {
+    const updateSonarrInstance = useCallback((index: number, field: keyof ConnectionDetails, value: string | boolean) => {
         updateConfig({
             ...arrConfig,
             SonarrInstances: arrConfig.SonarrInstances
@@ -267,6 +269,27 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
             </SettingsCard>
             </div>
 
+            <ManagedSetting configKey="arr.health-enabled">
+            <SettingsCard
+                icon="monitor_heart"
+                title="Arr Health"
+                description="Optional Overview metrics for import handoff from InfiniDysk to Sonarr and Radarr."
+            >
+                <Toggle
+                    id="arr-health-enabled"
+                    className="cursor-pointer gap-2 p-0"
+                    checked={config["arr.health-enabled"] !== "false"}
+                    onChange={e => setNewConfig({ ...config, "arr.health-enabled": "" + e.target.checked })}
+                    label={<span className="text-sm text-base-content">Show Arr Health on Overview</span>}
+                />
+                <p className="text-[11px] leading-relaxed text-base-content/45">
+                    When this is off, enabled instances still handle queue rules and repairs, but InfiniDysk
+                    does not poll Arr APIs for import health and hides the Overview widget.
+                    The widget is also hidden when no instance is enabled.
+                </p>
+            </SettingsCard>
+            </ManagedSetting>
+
             <SettingsCard
                 icon="rule"
                 title="Automatic queue management"
@@ -314,7 +337,7 @@ interface InstanceFormProps {
     instance: ConnectionDetails;
     index: number;
     type: 'radarr' | 'sonarr';
-    onUpdate: (index: number, field: keyof ConnectionDetails, value: string) => void;
+    onUpdate: (index: number, field: keyof ConnectionDetails, value: string | boolean) => void;
     onRemove: (index: number) => void;
 }
 
@@ -371,6 +394,25 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
                 <Icon name="close" className="!text-[18px]" />
             </button>
             <div className="space-y-4">
+                <Toggle
+                    id={`${type}-${index}-enabled`}
+                    className="cursor-pointer gap-2 p-0"
+                    checked={instance.Enabled !== false}
+                    onChange={e => onUpdate(index, "Enabled", e.target.checked)}
+                    label={<span className="text-sm text-base-content">Enabled</span>}
+                />
+                <div className="space-y-2">
+                    <label className="block text-sm font-medium text-base-content" htmlFor={`${type}-${index}-name`}>Name</label>
+                    <Input
+                        id={`${type}-${index}-name`}
+                        type="text"
+                        placeholder={type === "radarr" ? "Radarr" : "Sonarr"}
+                        value={instance.Name ?? ""}
+                        onChange={e => onUpdate(index, "Name", e.target.value)} />
+                    <p className="text-[11px] leading-relaxed text-base-content/45">
+                        Optional display name on Overview. Defaults to the host URL.
+                    </p>
+                </div>
                 <div className="space-y-2">
                     <label className="block text-sm font-medium text-base-content">Host</label>
                     <div className="flex w-full">
@@ -428,7 +470,8 @@ function InstanceForm({ instance, index, type, onUpdate, onRemove }: InstanceFor
 }
 
 export function isArrsSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
-    return config["arr.instances"] !== newConfig["arr.instances"];
+    return config["arr.instances"] !== newConfig["arr.instances"]
+        || config["arr.health-enabled"] !== newConfig["arr.health-enabled"];
 }
 
 export function isArrsSettingsValid(newConfig: Record<string, string>) {

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -96,6 +96,7 @@ const defaultConfig = {
     "rclone.mount-dir": "",
     "media.library-dir": "",
     "arr.instances": "{\"RadarrInstances\":[],\"SonarrInstances\":[],\"QueueRules\":[]}",
+    "arr.health-enabled": "true",
     "indexers.instances": "{\"Indexers\":[]}",
     "profiles.instances": "{\"Profiles\":[]}",
     "prowlarr.url": "",

--- a/tests/NzbWebDAV.Tests/Api/GetArrHealthControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetArrHealthControllerTests.cs
@@ -1,0 +1,238 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Controllers.GetArrHealth;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Api;
+
+public sealed class GetArrHealthControllerTests
+{
+    [Fact]
+    public async Task BuildResponseAsync_WhenUnconfigured_ReturnsConfiguredFalseWithoutOpeningDb()
+    {
+        var config = new ConfigManager();
+        using var service = new ArrHealthService(config);
+        var controller = new GetArrHealthController(config, service)
+        {
+            MetricsContextFactory = () => throw new InvalidOperationException("metrics must not open"),
+        };
+
+        var disabled = await controller.BuildResponseAsync(
+            GetArrHealthRequest.ArrHealthWindow.Last24Hours,
+            DateTimeOffset.UtcNow,
+            CancellationToken.None);
+        Assert.False(disabled.Configured);
+
+        config.UpdateValues([
+            new ConfigItem { ConfigName = ConfigKeys.ArrHealthEnabled, ConfigValue = "false" },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ArrInstances,
+                ConfigValue = JsonSerializer.Serialize(new ArrConfig
+                {
+                    SonarrInstances =
+                    [
+                        new ArrConfig.ConnectionDetails { Host = "http://sonarr:8989", ApiKey = "k" },
+                    ],
+                }),
+            },
+        ]);
+        var masterOff = await controller.BuildResponseAsync(
+            GetArrHealthRequest.ArrHealthWindow.Last24Hours,
+            DateTimeOffset.UtcNow,
+            CancellationToken.None);
+        Assert.False(masterOff.Configured);
+    }
+
+    [Fact]
+    public async Task Build_FiltersWindow_ComputesPercentiles_AndExcludesOrphanedInstances()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var now = DateTimeOffset.Parse("2026-08-19T20:00:00Z");
+        var nowMs = now.ToUnixTimeMilliseconds();
+        var sonarrKey = "sonarr|http://sonarr:8989";
+        var orphanKey = "sonarr|http://gone:8989";
+
+        harness.Context.ArrImportEvents.AddRange(
+            Event(sonarrKey, 1, nowMs - 30_000, 10_000),
+            Event(sonarrKey, 2, nowMs - 40_000, 20_000),
+            Event(sonarrKey, 3, nowMs - 50_000, 30_000),
+            Event(sonarrKey, 4, nowMs - 60_000, 40_000),
+            Event(sonarrKey, 5, nowMs - 70_000, 50_000),
+            Event(sonarrKey, 6, nowMs - 3 * 24 * 60 * 60 * 1000L, 999_000),
+            Event(orphanKey, 7, nowMs - 10_000, 5_000));
+        await harness.Context.SaveChangesAsync();
+
+        var config = EnabledSonarrConfig();
+        using var service = new ArrHealthService(config);
+        var controller = new GetArrHealthController(config, service)
+        {
+            MetricsContextFactory = () => Clone(harness),
+        };
+
+        var response = await controller.BuildResponseAsync(
+            GetArrHealthRequest.ArrHealthWindow.Last24Hours,
+            now,
+            CancellationToken.None);
+
+        Assert.True(response.Configured);
+        var row = Assert.Single(response.Instances);
+        Assert.Equal(sonarrKey, row.Key);
+        Assert.Equal(5, row.Imports);
+        Assert.Equal(30_000, row.MedianHandoffMs);
+        Assert.Equal(50_000, row.P95HandoffMs);
+        Assert.Equal(5, response.Summary.ImportsCompleted);
+        Assert.Equal(30_000, response.Summary.MedianHandoffMs);
+        Assert.Equal(50_000, response.Summary.P95HandoffMs);
+        Assert.DoesNotContain(response.Instances, r => r.Key == orphanKey);
+    }
+
+    [Fact]
+    public void Build_OrdersAwaitingTop10_AndFlagsUnusualWaits()
+    {
+        var now = DateTimeOffset.Parse("2026-08-19T20:00:00Z");
+        var created = DateTime.SpecifyKind(now.UtcDateTime.AddMinutes(-10).ToLocalTime(), DateTimeKind.Unspecified);
+        var snapshot = new ArrHealthSnapshot
+        {
+            InstanceKey = "sonarr|http://sonarr:8989",
+            DisplayName = "Sonarr Main",
+            AppType = "sonarr",
+            Host = "http://sonarr:8989",
+            Status = ArrInstanceHealthStatus.Degraded,
+            MedianHandoffMs30d = 10_000,
+            MedianSampleCount30d = 5,
+            AwaitingCount = 12,
+            Awaiting = Enumerable.Range(0, 12).Select(i => new ArrAwaitingSnapshot
+            {
+                Title = $"item-{i}",
+                DownloadId = Guid.NewGuid(),
+                CreatedAt = DateTime.SpecifyKind(
+                    now.UtcDateTime.AddMinutes(-1 - i).ToLocalTime(),
+                    DateTimeKind.Unspecified),
+            }).ToList(),
+        };
+
+        var details = new ArrConfig.ConnectionDetails { Host = "http://sonarr:8989", ApiKey = "k", Name = "Sonarr Main" };
+        var response = GetArrHealthController.Build(
+            [],
+            [snapshot],
+            [("sonarr", details)],
+            now);
+
+        Assert.Equal(10, response.Awaiting.Count);
+        Assert.Equal("item-11", response.Awaiting[0].Title);
+        Assert.True(response.Awaiting[0].WaitingMs >= response.Awaiting[^1].WaitingMs);
+        Assert.Contains(response.Awaiting, a => a.IsUnusual);
+        Assert.Equal("degraded", Assert.Single(response.Instances).Status);
+        Assert.Equal(1, response.Summary.Degraded);
+        Assert.Equal(1, response.Summary.InstancesOnline);
+
+        var notUnusual = GetArrHealthController.Build(
+            [],
+            [snapshot with
+            {
+                MedianSampleCount30d = 4,
+                AwaitingCount = 1,
+                Awaiting = [new ArrAwaitingSnapshot { Title = "short", CreatedAt = created }],
+            }],
+            [("sonarr", details)],
+            now);
+        Assert.False(Assert.Single(notUnusual.Awaiting).IsUnusual);
+
+        var noHistory = GetArrHealthController.Build(
+            [],
+            [snapshot with
+            {
+                AwaitingCount = 1,
+                Awaiting = [new ArrAwaitingSnapshot { Title = "unknown" }],
+            }],
+            [("sonarr", details)],
+            now);
+        Assert.Null(Assert.Single(noHistory.Awaiting).WaitingMs);
+        Assert.False(noHistory.Awaiting[0].IsUnusual);
+    }
+
+    private static ArrImportEvent Event(string key, int recordId, long importedAtMs, long handoffMs) =>
+        new()
+        {
+            InstanceKey = key,
+            ArrRecordId = recordId,
+            DownloadId = Guid.NewGuid(),
+            ImportedAtMs = importedAtMs,
+            HandoffMs = handoffMs,
+            Title = $"t-{recordId}",
+        };
+
+    private static ConfigManager EnabledSonarrConfig()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ArrInstances,
+                ConfigValue = JsonSerializer.Serialize(new ArrConfig
+                {
+                    SonarrInstances =
+                    [
+                        new ArrConfig.ConnectionDetails { Host = "http://sonarr:8989", ApiKey = "k", Name = "Sonarr Main" },
+                    ],
+                }),
+            },
+        ]);
+        return config;
+    }
+
+    private static MetricsDbContext Clone(MetricsHarness harness)
+    {
+        var options = new DbContextOptionsBuilder<MetricsDbContext>()
+            .UseSqlite($"Data Source={harness.Path}")
+            .AddInterceptors(new SqliteMetricsPragmas())
+            .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        return new MetricsDbContext(options);
+    }
+
+    private sealed class MetricsHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+
+        private MetricsHarness(string dir, string path, MetricsDbContext context)
+        {
+            _dir = dir;
+            Path = path;
+            Context = context;
+        }
+
+        public string Path { get; }
+        public MetricsDbContext Context { get; }
+
+        public static async Task<MetricsHarness> CreateAsync()
+        {
+            var dir = System.IO.Path.Join(System.IO.Path.GetTempPath(), $"nzbdav-arr-health-api-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = System.IO.Path.Join(dir, "metrics.sqlite");
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={path}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new MetricsDbContext(options);
+            await context.Database.MigrateAsync();
+            return new MetricsHarness(dir, path, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            try { Directory.Delete(_dir, recursive: true); }
+            catch (IOException) { /* best effort */ }
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ArrConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ArrConfigTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ArrConfigTests
+{
+    [Fact]
+    public void LegacyJson_WithoutNameOrEnabled_DefaultsEnabledTrueAndNameNull()
+    {
+        const string json = """
+            {"RadarrInstances":[{"Host":"http://Radarr:7878/","ApiKey":"k"}],"SonarrInstances":[],"QueueRules":[]}
+            """;
+
+        var parsed = JsonSerializer.Deserialize<ArrConfig>(json)!;
+        var instance = Assert.Single(parsed.RadarrInstances);
+        Assert.Null(instance.Name);
+        Assert.True(instance.Enabled);
+        Assert.Equal("http://Radarr:7878/", instance.Host);
+    }
+
+    [Fact]
+    public void GetArrClients_OmitsDisabledInstances_AndKeepsLegacyUnspecifiedEnabled()
+    {
+        var config = new ArrConfig
+        {
+            RadarrInstances =
+            [
+                new ArrConfig.ConnectionDetails { Host = "http://radarr-on", ApiKey = "a", Enabled = true },
+                new ArrConfig.ConnectionDetails { Host = "http://radarr-off", ApiKey = "b", Enabled = false },
+            ],
+            SonarrInstances =
+            [
+                new ArrConfig.ConnectionDetails { Host = "http://sonarr-legacy", ApiKey = "c" },
+            ],
+        };
+
+        var hosts = config.GetArrClients().Select(c => c.Host).ToList();
+        Assert.Equal(2, hosts.Count);
+        Assert.Contains("http://radarr-on", hosts);
+        Assert.Contains("http://sonarr-legacy", hosts);
+        Assert.DoesNotContain("http://radarr-off", hosts);
+    }
+
+    [Fact]
+    public void GetEnabledInstances_UsesStableKeysAndSkipsDisabled()
+    {
+        var config = new ArrConfig
+        {
+            RadarrInstances =
+            [
+                new ArrConfig.ConnectionDetails
+                {
+                    Name = "Movies 4K",
+                    Host = "http://Radarr:7878/",
+                    ApiKey = "a",
+                },
+                new ArrConfig.ConnectionDetails { Host = "http://radarr-off", ApiKey = "b", Enabled = false },
+            ],
+            SonarrInstances =
+            [
+                new ArrConfig.ConnectionDetails { Host = "http://sonarr:8989", ApiKey = "c" },
+            ],
+        };
+
+        var enabled = config.GetEnabledInstances().ToList();
+        Assert.Equal(2, enabled.Count);
+        Assert.Equal("radarr", enabled[0].AppType);
+        Assert.Equal("Movies 4K", enabled[0].Details.Name);
+        Assert.Equal(
+            "radarr|http://radarr:7878",
+            ArrConfig.MakeInstanceKey(enabled[0].AppType, enabled[0].Details.Host));
+        Assert.Equal("sonarr", enabled[1].AppType);
+        Assert.Equal(
+            "sonarr|http://sonarr:8989",
+            ArrConfig.MakeInstanceKey(enabled[1].AppType, enabled[1].Details.Host));
+    }
+
+    [Fact]
+    public void IsArrHealthEnabled_DefaultsTrueAndParsesExplicitValues()
+    {
+        Assert.True(new ConfigManager().IsArrHealthEnabled());
+
+        var disabled = new ConfigManager();
+        disabled.UpdateValues([Item(ConfigKeys.ArrHealthEnabled, "false")]);
+        Assert.False(disabled.IsArrHealthEnabled());
+
+        var enabled = new ConfigManager();
+        enabled.UpdateValues([Item(ConfigKeys.ArrHealthEnabled, "true")]);
+        Assert.True(enabled.IsArrHealthEnabled());
+    }
+
+    [Theory]
+    [InlineData("yes")]
+    [InlineData("1")]
+    public void ArrHealthEnabled_RejectsNonBooleanValues(string value)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([Item(ConfigKeys.ArrHealthEnabled, value)]));
+        Assert.Contains(ConfigKeys.ArrHealthEnabled, ex.Message);
+    }
+
+    private static ConfigItem Item(string name, string value) =>
+        new() { ConfigName = name, ConfigValue = value };
+}

--- a/tests/NzbWebDAV.Tests/Services/ArrHealthServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrHealthServiceTests.cs
@@ -1,0 +1,467 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class ArrHealthServiceTests
+{
+    [Fact]
+    public void ComputeHandoffMs_ConvertsLocalCreatedAtToUtcAndClampsNegative()
+    {
+        var localCreated = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Unspecified);
+        var createdUtc = DateTime.SpecifyKind(localCreated, DateTimeKind.Local).ToUniversalTime();
+        var imported = new DateTimeOffset(createdUtc.AddSeconds(10), TimeSpan.Zero);
+
+        Assert.Equal(10_000, ArrHealthMath.ComputeHandoffMs(imported, localCreated));
+        Assert.Equal(0, ArrHealthMath.ComputeHandoffMs(imported.AddSeconds(-30), localCreated));
+        Assert.Null(ArrHealthMath.ComputeHandoffMs(imported, null));
+    }
+
+    [Theory]
+    [InlineData("completed", null, true)]
+    [InlineData("Completed", null, true)]
+    [InlineData("downloading", "importPending", true)]
+    [InlineData("downloading", "importing", true)]
+    [InlineData("downloading", "downloading", false)]
+    [InlineData("paused", null, false)]
+    public void IsAwaitingImport_MatchesCompletedAndImportStates(string? status, string? tracked, bool expected)
+    {
+        var record = new ArrQueueRecord { Status = status, TrackedDownloadState = tracked };
+        Assert.Equal(expected, record.IsAwaitingImport);
+    }
+
+    [Fact]
+    public async Task Ingest_ComputesHandoff_SkipsMissingHistory_AndClampsNegative()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var matchedId = Guid.NewGuid();
+        var missingId = Guid.NewGuid();
+        var skewId = Guid.NewGuid();
+        var localCreated = DateTime.Now.AddMinutes(-2);
+        harness.Dav.HistoryItems.Add(CompletedHistory(matchedId, localCreated));
+        harness.Dav.HistoryItems.Add(CompletedHistory(skewId, DateTime.Now.AddMinutes(5)));
+        await harness.Dav.SaveChangesAsync();
+
+        var imported = DateTimeOffset.UtcNow;
+        var client = new ScriptedArrClient("http://sonarr:8989")
+        {
+            ImportHistory = (_, _, _) => Task.FromResult(new ArrHistory
+            {
+                Records =
+                [
+                    History(1, matchedId, imported, "matched"),
+                    History(2, missingId, imported, "missing"),
+                    History(3, skewId, imported, "skew"),
+                ],
+            }),
+        };
+
+        using var service = harness.CreateService(client, "http://sonarr:8989");
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+
+        var events = await harness.Metrics.ArrImportEvents.AsNoTracking().OrderBy(e => e.ArrRecordId).ToListAsync();
+        Assert.Equal(3, events.Count);
+        Assert.NotNull(events[0].HandoffMs);
+        Assert.True(events[0].HandoffMs >= 0);
+        Assert.Null(events[1].HandoffMs);
+        Assert.Equal(0, events[2].HandoffMs);
+    }
+
+    [Fact]
+    public async Task Ingest_IsIncremental_Dedupes_SkipsNonGuid_AndCapsAtFivePages()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var guid = Guid.NewGuid();
+        var pagesRequested = 0;
+        var client = new ScriptedArrClient("http://sonarr:8989")
+        {
+            ImportHistory = (page, pageSize, _) =>
+            {
+                Interlocked.Increment(ref pagesRequested);
+                Assert.Equal(100, pageSize);
+                if (page > 6) return Task.FromResult(new ArrHistory());
+                var startId = 600 - (page - 1) * 100;
+                var records = Enumerable.Range(0, 100).Select(i =>
+                {
+                    var id = startId - i;
+                    var downloadId = id == 599
+                        ? "SABnzbd_nzo_abc"
+                        : guid.ToString();
+                    return History(id, downloadId, DateTimeOffset.UtcNow, $"t-{id}");
+                }).ToList();
+                return Task.FromResult(new ArrHistory { Records = records });
+            },
+        };
+
+        using var service = harness.CreateService(client, "http://sonarr:8989");
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+        Assert.Equal(5, pagesRequested);
+        var firstCount = await harness.Metrics.ArrImportEvents.AsNoTracking().CountAsync();
+        Assert.Equal(499, firstCount);
+
+        pagesRequested = 0;
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+        Assert.Equal(1, pagesRequested);
+        Assert.Equal(firstCount, await harness.Metrics.ArrImportEvents.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task FailureIsolation_MarksOfflineAfterTwoFailures_WithoutBlockingOthers()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var healthy = new ScriptedArrClient("http://sonarr:8989");
+        var broken = new ScriptedArrClient("http://radarr:7878")
+        {
+            QueueStatus = _ => throw new HttpRequestException("connection refused"),
+        };
+        var clients = new Dictionary<string, ArrClient>(StringComparer.Ordinal)
+        {
+            [healthy.Host] = healthy,
+            [broken.Host] = broken,
+        };
+
+        var config = new ConfigManager();
+        SetInstances(config,
+            ("sonarr", healthy.Host, true),
+            ("radarr", broken.Host, true));
+        using var service = harness.CreateService(config, clients);
+
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+        var first = service.GetSnapshots().ToDictionary(s => s.Host);
+        Assert.Equal(ArrInstanceHealthStatus.Healthy, first[healthy.Host].Status);
+        Assert.Equal(ArrInstanceHealthStatus.Pending, first[broken.Host].Status);
+
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+        var second = service.GetSnapshots().ToDictionary(s => s.Host);
+        Assert.Equal(ArrInstanceHealthStatus.Healthy, second[healthy.Host].Status);
+        Assert.Equal(ArrInstanceHealthStatus.Offline, second[broken.Host].Status);
+    }
+
+    [Fact]
+    public async Task Status_DegradedOnWarningsOrUnusualWait()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var warningsClient = new ScriptedArrClient("http://sonarr:8989")
+        {
+            QueueStatus = _ => Task.FromResult(new ArrQueueStatus { Warnings = true, TotalCount = 2 }),
+        };
+        using (var warningsService = harness.CreateService(warningsClient, "http://sonarr:8989"))
+        {
+            Assert.True(await warningsService.TryRunCycleAsync(CancellationToken.None));
+            Assert.Equal(ArrInstanceHealthStatus.Degraded, Assert.Single(warningsService.GetSnapshots()).Status);
+        }
+
+        var downloadId = Guid.NewGuid();
+        var createdAt = DateTime.Now.AddMinutes(-10);
+        harness.Dav.HistoryItems.Add(CompletedHistory(downloadId, createdAt));
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < 5; i++)
+        {
+            harness.Metrics.ArrImportEvents.Add(new ArrImportEvent
+            {
+                InstanceKey = "sonarr|http://sonarr-median:8989",
+                ArrRecordId = i + 1,
+                DownloadId = Guid.NewGuid(),
+                ImportedAtMs = nowMs - i * 1000,
+                HandoffMs = 10_000,
+                Title = $"sample-{i}",
+            });
+        }
+
+        await harness.Dav.SaveChangesAsync();
+        await harness.Metrics.SaveChangesAsync();
+
+        var unusualClient = new ScriptedArrClient("http://sonarr-median:8989")
+        {
+            Queue = _ => Task.FromResult(new ArrQueue<ArrQueueRecord>
+            {
+                Records =
+                [
+                    new ArrQueueRecord
+                    {
+                        Title = "stuck",
+                        Status = "completed",
+                        DownloadId = downloadId.ToString(),
+                    },
+                ],
+            }),
+        };
+        var config = new ConfigManager();
+        SetInstances(config, ("sonarr", unusualClient.Host, true));
+        using var unusualService = harness.CreateService(config, new Dictionary<string, ArrClient>
+        {
+            [unusualClient.Host] = unusualClient,
+        });
+        Assert.True(await unusualService.TryRunCycleAsync(CancellationToken.None));
+        var snap = Assert.Single(unusualService.GetSnapshots());
+        Assert.Equal(ArrInstanceHealthStatus.Degraded, snap.Status);
+        Assert.Equal(5, snap.MedianSampleCount30d);
+        Assert.Equal(10_000, snap.MedianHandoffMs30d);
+        Assert.True(ArrHealthMath.IsUnusual(
+            ArrHealthMath.ComputeWaitingMs(createdAt, DateTimeOffset.UtcNow),
+            snap.MedianHandoffMs30d,
+            snap.MedianSampleCount30d));
+    }
+
+    [Fact]
+    public async Task Dormancy_DoesNotPollWhenDisabledOrWhenNoEnabledInstances()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var calls = 0;
+        var client = new ScriptedArrClient("http://sonarr:8989")
+        {
+            QueueStatus = _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult(new ArrQueueStatus());
+            },
+        };
+
+        var config = new ConfigManager();
+        using var service = harness.CreateService(config, new Dictionary<string, ArrClient>
+        {
+            [client.Host] = client,
+        });
+        service.MetricsContextFactory = () => throw new InvalidOperationException("metrics must stay dormant");
+        service.DavContextFactory = () => throw new InvalidOperationException("dav must stay dormant");
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+        await Task.Delay(250);
+        Assert.Equal(0, calls);
+        Assert.Equal(0, service.CycleAttempts);
+
+        SetInstances(config, ("sonarr", client.Host, false));
+        await Task.Delay(250);
+        Assert.Equal(0, calls);
+
+        config.UpdateValues([
+            new ConfigItem { ConfigName = ConfigKeys.ArrHealthEnabled, ConfigValue = "false" },
+        ]);
+        SetInstancesEnabled(config, ("sonarr", client.Host, true));
+        await Task.Delay(250);
+        Assert.Equal(0, calls);
+
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task CycleOverlap_SkipsWhenACycleIsAlreadyRunning()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new ScriptedArrClient("http://sonarr:8989")
+        {
+            QueueStatus = async _ =>
+            {
+                started.TrySetResult();
+                await release.Task;
+                return new ArrQueueStatus();
+            },
+        };
+        using var service = harness.CreateService(client, "http://sonarr:8989");
+
+        var first = service.TryRunCycleAsync(CancellationToken.None);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(await service.TryRunCycleAsync(CancellationToken.None));
+        release.TrySetResult();
+        Assert.True(await first);
+        Assert.Equal(1, service.CycleAttempts);
+    }
+
+    [Fact]
+    public async Task UniqueConstraint_OnDuplicateArrRecordId_IsTolerated()
+    {
+        await using var harness = await DualDbHarness.CreateAsync();
+        var downloadId = Guid.NewGuid();
+        var client = new ScriptedArrClient("http://sonarr:8989")
+        {
+            ImportHistory = (page, _, _) => Task.FromResult(new ArrHistory
+            {
+                Records = page <= 2
+                    ? [History(10, downloadId, DateTimeOffset.UtcNow, "dup")]
+                    : [],
+            }),
+        };
+        using var service = harness.CreateService(client, "http://sonarr:8989");
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+        harness.Metrics.ChangeTracker.Clear();
+        Assert.Equal(1, await harness.Metrics.ArrImportEvents.CountAsync());
+    }
+
+    private static ArrHistoryRecord History(int id, Guid downloadId, DateTimeOffset date, string title) =>
+        History(id, downloadId.ToString(), date, title);
+
+    private static ArrHistoryRecord History(int id, string downloadId, DateTimeOffset date, string title) =>
+        new()
+        {
+            Id = id,
+            Date = date,
+            DownloadId = downloadId,
+            EventType = ArrHealthService.ImportEventType,
+            SourceTitle = title,
+        };
+
+    private static HistoryItem CompletedHistory(Guid id, DateTime createdAt) =>
+        new()
+        {
+            Id = id,
+            CreatedAt = createdAt,
+            FileName = $"{id}.nzb",
+            JobName = "job",
+            Category = "tv",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+            TotalSegmentBytes = 1,
+            DownloadTimeSeconds = 1,
+        };
+
+    private static void SetInstances(ConfigManager config, params (string AppType, string Host, bool Enabled)[] instances)
+    {
+        config.UpdateValues([
+            new ConfigItem { ConfigName = ConfigKeys.ArrHealthEnabled, ConfigValue = "true" },
+        ]);
+        SetInstancesEnabled(config, instances);
+    }
+
+    private static void SetInstancesEnabled(ConfigManager config, params (string AppType, string Host, bool Enabled)[] instances)
+    {
+        var arr = new ArrConfig();
+        foreach (var instance in instances)
+        {
+            var details = new ArrConfig.ConnectionDetails
+            {
+                Host = instance.Host,
+                ApiKey = "k",
+                Enabled = instance.Enabled,
+            };
+            if (instance.AppType == "radarr") arr.RadarrInstances.Add(details);
+            else arr.SonarrInstances.Add(details);
+        }
+
+        config.UpdateValues([
+            new ConfigItem { ConfigName = ConfigKeys.ArrInstances, ConfigValue = JsonSerializer.Serialize(arr) },
+        ]);
+    }
+
+    private sealed class DualDbHarness : IAsyncDisposable
+    {
+        private readonly string _dir;
+        private readonly string _metricsPath;
+        private readonly string _davPath;
+
+        private DualDbHarness(string dir, string metricsPath, string davPath, MetricsDbContext metrics, DavDatabaseContext dav)
+        {
+            _dir = dir;
+            _metricsPath = metricsPath;
+            _davPath = davPath;
+            Metrics = metrics;
+            Dav = dav;
+        }
+
+        public MetricsDbContext Metrics { get; }
+        public DavDatabaseContext Dav { get; }
+
+        public static async Task<DualDbHarness> CreateAsync()
+        {
+            var dir = Path.Join(Path.GetTempPath(), $"nzbdav-arr-health-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var metricsPath = Path.Join(dir, "metrics.sqlite");
+            var davPath = Path.Join(dir, "db.sqlite");
+            var metricsOptions = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={metricsPath}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var davOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={davPath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var metrics = new MetricsDbContext(metricsOptions);
+            var dav = new DavDatabaseContext(davOptions);
+            await metrics.Database.MigrateAsync();
+            await dav.Database.MigrateAsync();
+            return new DualDbHarness(dir, metricsPath, davPath, metrics, dav);
+        }
+
+        public ArrHealthService CreateService(ScriptedArrClient client, string host)
+        {
+            var config = new ConfigManager();
+            SetInstances(config, ("sonarr", host, true));
+            return CreateService(config, new Dictionary<string, ArrClient> { [host] = client });
+        }
+
+        public ArrHealthService CreateService(ConfigManager config, IReadOnlyDictionary<string, ArrClient> clients)
+        {
+            return new ArrHealthService(config)
+            {
+                ClientFactory = (_, details) => clients[details.Host],
+                MetricsContextFactory = CloneMetrics,
+                DavContextFactory = CloneDav,
+            };
+        }
+
+        private MetricsDbContext CloneMetrics()
+        {
+            var options = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={_metricsPath}")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            return new MetricsDbContext(options);
+        }
+
+        private DavDatabaseContext CloneDav()
+        {
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={_davPath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            return new DavDatabaseContext(options);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Metrics.DisposeAsync();
+            await Dav.DisposeAsync();
+            try { Directory.Delete(_dir, recursive: true); }
+            catch (IOException) { /* best effort */ }
+        }
+    }
+
+    private sealed class ScriptedArrClient : ArrClient
+    {
+        public Func<CancellationToken, Task<ArrQueueStatus>> QueueStatus { get; init; } =
+            _ => Task.FromResult(new ArrQueueStatus());
+
+        public Func<CancellationToken, Task<ArrQueue<ArrQueueRecord>>> Queue { get; init; } =
+            _ => Task.FromResult(new ArrQueue<ArrQueueRecord>());
+
+        public Func<int, int, CancellationToken, Task<ArrHistory>> ImportHistory { get; init; } =
+            (_, _, _) => Task.FromResult(new ArrHistory());
+
+        public ScriptedArrClient(string host) : base(host, "test-key")
+        {
+        }
+
+        public override Task<ArrQueueStatus> GetQueueStatusAsync(CancellationToken ct = default) => QueueStatus(ct);
+
+        public override Task<ArrQueue<ArrQueueRecord>> GetQueueAsync(CancellationToken ct = default) => Queue(ct);
+
+        public override Task<ArrHistory> GetImportHistoryAsync(int page, int pageSize, CancellationToken ct = default) =>
+            ImportHistory(page, pageSize, ct);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRetentionServiceTests.cs
@@ -115,6 +115,39 @@ public sealed class MetricsRetentionServiceTests
     }
 
     [Fact]
+    public async Task SweepAsync_PrunesArrImportEventsOlderThanNinetyDays()
+    {
+        await using var harness = await MetricsHarness.CreateAsync();
+        var db = harness.Context;
+        var nowMs = 200L * OneDayMs;
+        var cutoff = MetricsRetentionService.Cutoff(nowMs, TimeSpan.FromDays(90));
+
+        db.ArrImportEvents.AddRange(
+            new ArrImportEvent
+            {
+                InstanceKey = "sonarr|http://sonarr:8989",
+                ArrRecordId = 1,
+                DownloadId = Guid.NewGuid(),
+                ImportedAtMs = cutoff - OneDayMs,
+                Title = "old",
+            },
+            new ArrImportEvent
+            {
+                InstanceKey = "sonarr|http://sonarr:8989",
+                ArrRecordId = 2,
+                DownloadId = Guid.NewGuid(),
+                ImportedAtMs = cutoff + OneDayMs,
+                Title = "fresh",
+            });
+        await db.SaveChangesAsync();
+
+        await MetricsRetentionService.SweepAsync(db, nowMs, TimeSpan.FromHours(24));
+
+        Assert.Equal(1, await db.ArrImportEvents.CountAsync());
+        Assert.Equal("fresh", await db.ArrImportEvents.Select(x => x.Title).SingleAsync());
+    }
+
+    [Fact]
     public async Task SweepAsync_UsesOneHourFloorWhenConfiguredRetentionIsZero()
     {
         await using var harness = await MetricsHarness.CreateAsync();


### PR DESCRIPTION
Closes #1017

## Summary

- Adds an optional Arr Health section to the Overview dashboard: per-instance reachability, imports, median/P95 handoff latency (download completed → Arr import), queue depth, and items waiting unusually long for import — all scoped to the selected dashboard timeframe.
- Completely dormant unless at least one Arr instance is configured and enabled: no widget, no polling, no API calls, no logs. Master toggle `arr.health-enabled` (default on) plus per-instance Name/Enabled fields in Settings → Arr Apps.
- Handoff events are collected by a lightweight 60s background poller into the local metrics database; the dashboard never calls Arr APIs directly, so Arr outages can't stall the UI.
- Includes an additive metrics-database migration (auto-applies on startup) — **back up `/config` before upgrading**. Note: ENV-managed `arr.instances` configs that adopt the new `Name`/`Enabled` properties cannot roll back to older images (documented headless-config behavior).

## Upgrade notes

- Back up `/config` before upgrading. This PR adds an additive `ArrImportEvents` table to `metrics.sqlite` (not a main-DB / Postgres migration). It auto-applies at startup.
- Existing `arr.instances` JSON keeps working: `Enabled` defaults true and `Name` falls back to the host URL, so configured Arr users get the widget and 60s polling after upgrade.
- **ENV rollback hazard:** `NZBDAV_CONFIG__ARR__INSTANCES` JSON that includes `Name`/`Enabled` is not forward compatible with older images and will abort startup on rollback (documented in `docs/configuration/headless.md`). Leave those properties off until you no longer need to roll back, or pin the image.

## Playback impact

No NNTP, streaming, WebDAV, or queue-playback path changes. Arr Health uses ArrClient's existing static `HttpClient` only (10s per-call timeout). The Overview endpoint reads `metrics.sqlite` + in-memory snapshots and never calls Arr APIs.

## Test plan

- [x] Backend xUnit: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3268 passed, 10 skipped)
- [x] Frontend: `cd frontend && npm run typecheck && npm run build && npm test` (680 passed)
- [ ] Manual: live Sonarr/Radarr grab → complete → import, correlate widget numbers with Arr history
- [ ] Manual: stuck import shows Awaiting + Degraded
- [ ] Manual: stopped Arr instance shows Offline after two failed polls
- [ ] Manual: zero-instance dormancy (no widget, no `/api/get-arr-health` in devtools, no log lines, no metrics writes)
- [ ] Manual: upgrade with a pre-existing `arr.instances` (feature on, names fall back to host)