### PR TITLE
feat(health): keep known degraded gaps off Usenet providers

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -27,6 +27,13 @@ public interface INntpClient : IDisposable
     Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns an already-local decoded body (for example a PAR2 patch or segment-cache
+    /// entry) without opening an NNTP connection, or null when no local copy exists.
+    /// </summary>
+    Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId segmentId, CancellationToken cancellationToken);
+
     Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken);
@@ -83,7 +90,8 @@ public interface INntpClient : IDisposable
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         int streamingBodyBatchWidth = 4,
-        HashSet<string>? knownCorruptSegmentIds = null);
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null);
 
     NzbFileStream GetFileStream(
         NzbFile nzbFile,
@@ -94,7 +102,8 @@ public interface INntpClient : IDisposable
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         int streamingBodyBatchWidth = 4,
-        HashSet<string>? knownCorruptSegmentIds = null);
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null);
 
     NzbFileStream GetFileStream(
         string[] segmentIds,
@@ -107,7 +116,8 @@ public interface INntpClient : IDisposable
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         int streamingBodyBatchWidth = 4,
-        HashSet<string>? knownCorruptSegmentIds = null);
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -44,6 +44,10 @@ public abstract class NntpClient : INntpClient
     public abstract Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
         SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken);
 
+    public virtual Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId segmentId, CancellationToken cancellationToken) =>
+        Task.FromResult<UsenetDecodedBodyResponse?>(null);
+
     public abstract Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken);
@@ -143,7 +147,8 @@ public abstract class NntpClient : INntpClient
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         int streamingBodyBatchWidth = 4,
-        HashSet<string>? knownCorruptSegmentIds = null)
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null)
     {
         var segmentIds = nzbFile.GetSegmentIds();
         var fileSize = await GetFileSizeAsync(nzbFile, ct).ConfigureAwait(false);
@@ -159,7 +164,8 @@ public abstract class NntpClient : INntpClient
             inFlightArticleBudget,
             useContainerAwareFill,
             streamingBodyBatchWidth,
-            knownCorruptSegmentIds);
+            knownCorruptSegmentIds,
+            knownMissingSegmentIndices);
     }
 
     public virtual NzbFileStream GetFileStream(
@@ -171,7 +177,8 @@ public abstract class NntpClient : INntpClient
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         int streamingBodyBatchWidth = 4,
-        HashSet<string>? knownCorruptSegmentIds = null)
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null)
     {
         return new NzbFileStream(
             nzbFile.GetSegmentIds(),
@@ -185,7 +192,8 @@ public abstract class NntpClient : INntpClient
             inFlightArticleBudget,
             useContainerAwareFill,
             streamingBodyBatchWidth,
-            knownCorruptSegmentIds
+            knownCorruptSegmentIds,
+            knownMissingSegmentIndices
         );
     }
 
@@ -200,7 +208,8 @@ public abstract class NntpClient : INntpClient
         InFlightArticleBudget? inFlightArticleBudget = null,
         bool useContainerAwareFill = false,
         int streamingBodyBatchWidth = 4,
-        HashSet<string>? knownCorruptSegmentIds = null)
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null)
     {
         return new NzbFileStream(
             segmentIds,
@@ -214,7 +223,8 @@ public abstract class NntpClient : INntpClient
             inFlightArticleBudget,
             useContainerAwareFill,
             streamingBodyBatchWidth,
-            knownCorruptSegmentIds);
+            knownCorruptSegmentIds,
+            knownMissingSegmentIndices);
     }
 
     private static string? ResolveFileName(string? fileName, NzbFile nzbFile)

--- a/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
+++ b/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
@@ -25,8 +25,7 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
 
-        string id = segmentId;
-        if (_patchStore.TryGet(id, out var patched))
+        if (TryGetPatchedResponse(segmentId, out var patched))
         {
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
             PrometheusMetrics.Current?.RecordPar2PatchHit();
@@ -34,6 +33,21 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
         }
 
         return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
+    }
+
+    public override async Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId segmentId, CancellationToken ct)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value != null)
+            return await base.TryGetLocalDecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+
+        if (TryGetPatchedResponse(segmentId, out var patched))
+        {
+            PrometheusMetrics.Current?.RecordPar2PatchHit();
+            return patched;
+        }
+
+        return await base.TryGetLocalDecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
     }
 
     public override async Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
@@ -51,8 +65,7 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
 
-        string id = segmentId;
-        if (_patchStore.TryGet(id, out var patched))
+        if (TryGetPatchedResponse(segmentId, out var patched))
         {
             exclusiveConnection.OnConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
             PrometheusMetrics.Current?.RecordPar2PatchHit();
@@ -60,5 +73,11 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
         }
 
         return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
+    }
+
+    private bool TryGetPatchedResponse(SegmentId segmentId, out UsenetDecodedBodyResponse? response)
+    {
+        string id = segmentId;
+        return _patchStore.TryGet(id, out response);
     }
 }

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -86,6 +86,19 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         return await WrapForCachingAsync(id, response, ct).ConfigureAwait(false);
     }
 
+    public override async Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId segmentId, CancellationToken ct)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value == null
+            && TryServeFromCache(segmentId.ToString(), out var cached))
+        {
+            RecordCacheHit();
+            return cached;
+        }
+
+        return await base.TryGetLocalDecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+    }
+
     public override async Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
         string segmentId, CancellationToken ct)
     {

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -61,6 +61,10 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient, INntpCon
         SegmentId segmentId, ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken) =>
         _usenetClient.DecodedBodyAsync(segmentId, onConnectionReadyAgain, cancellationToken);
 
+    public override Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId segmentId, CancellationToken cancellationToken) =>
+        _usenetClient.TryGetLocalDecodedBodyAsync(segmentId, cancellationToken);
+
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken) =>

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -54,6 +54,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     // while their BudgetedStream leases are still held (#840 scrub wedge).
     private readonly ConcurrentQueue<Task> _orphanedDisposals = new();
     private readonly HashSet<string>? _knownCorruptSegmentIds;
+    private readonly IReadOnlySet<int>? _knownMissingSegmentIndices;
 
     private int GetCorruptionRetryLimit(string segmentId) =>
         _knownCorruptSegmentIds is not null && _knownCorruptSegmentIds.Contains(segmentId)
@@ -90,7 +91,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
         int bodyPipelineBatchWidth = BodyPipelineBatchSize,
-        HashSet<string>? knownCorruptSegmentIds = null)
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null)
     {
         return Create(
             segmentIds,
@@ -107,7 +109,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             useContainerAwareFill: useContainerAwareFill,
             firstSegmentFileOffset: firstSegmentFileOffset,
             bodyPipelineBatchWidth: bodyPipelineBatchWidth,
-            knownCorruptSegmentIds: knownCorruptSegmentIds);
+            knownCorruptSegmentIds: knownCorruptSegmentIds,
+            knownMissingSegmentIndices: knownMissingSegmentIndices);
     }
 
     /// <param name="estimatedSegmentSize">
@@ -137,14 +140,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
         int bodyPipelineBatchWidth = BodyPipelineBatchSize,
-        HashSet<string>? knownCorruptSegmentIds = null
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null
     )
     {
         return articleBufferSize == 0
             ? new UnbufferedMultiSegmentStream(
                 segmentIds, usenetClient, estimatedSegmentSize, fileName, segmentFallbacks,
                 exactSegmentSizes, useContainerAwareFill, firstSegmentFileOffset,
-                failFastOnFirstSegment, knownCorruptSegmentIds)
+                failFastOnFirstSegment, knownCorruptSegmentIds, knownMissingSegmentIndices)
             : new MultiSegmentStream(
                 segmentIds,
                 usenetClient,
@@ -161,6 +165,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 firstSegmentFileOffset,
                 bodyPipelineBatchWidth,
                 knownCorruptSegmentIds,
+                knownMissingSegmentIndices,
                 cancellationToken);
     }
 
@@ -186,7 +191,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
         int bodyPipelineBatchWidth = BodyPipelineBatchSize,
-        HashSet<string>? knownCorruptSegmentIds = null)
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null)
     {
         if (articleBufferSize == 0 || segmentIds.Length <= 1)
         {
@@ -195,7 +201,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 failFastOnFirstSegment, usePipelinedBodyRequests, cancellationToken, fileName,
                 readBudget, segmentFallbacks, exactSegmentSizes, inFlightArticleBudget,
                 useContainerAwareFill, firstSegmentFileOffset, bodyPipelineBatchWidth,
-                knownCorruptSegmentIds);
+                knownCorruptSegmentIds, knownMissingSegmentIndices);
         }
 
         var effectiveReadBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
@@ -207,6 +213,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             : default;
         var firstFallbacks = segmentFallbacks is { Length: > 0 } ? segmentFallbacks[..1] : null;
         var remainingFallbacks = segmentFallbacks is { Length: > 1 } ? segmentFallbacks[1..] : null;
+        var firstKnownMissing = knownMissingSegmentIndices?.Where(index => index == 0).ToHashSet();
+        var remainingKnownMissing = knownMissingSegmentIndices?
+            .Where(index => index > 0)
+            .Select(index => index - 1)
+            .ToHashSet();
         var remainingOffset = firstSegmentFileOffset;
         if (remainingOffset is not null && firstExactSizes.Length == 1)
         {
@@ -226,14 +237,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             yield return Task.FromResult<Stream>(new UnbufferedMultiSegmentStream(
                 segmentIds[..1], usenetClient, estimatedSegmentSize, fileName, firstFallbacks,
                 firstExactSizes, useContainerAwareFill, firstSegmentFileOffset,
-                failFastOnFirstSegment, knownCorruptSegmentIds));
+                failFastOnFirstSegment, knownCorruptSegmentIds, firstKnownMissing));
 #pragma warning restore CA2000
             yield return Task.FromResult(Create(
                 segmentIds[1..], usenetClient, articleBufferSize, estimatedSegmentSize,
                 failFastOnFirstSegment: false, usePipelinedBodyRequests, cancellationToken,
                 fileName, remainingBudget, remainingFallbacks, remainingExactSizes,
                 inFlightArticleBudget, useContainerAwareFill, remainingOffset,
-                bodyPipelineBatchWidth, knownCorruptSegmentIds));
+                bodyPipelineBatchWidth, knownCorruptSegmentIds, remainingKnownMissing));
         }
     }
 
@@ -254,6 +265,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         long? firstSegmentFileOffset,
         int bodyPipelineBatchWidth,
         HashSet<string>? knownCorruptSegmentIds,
+        IReadOnlySet<int>? knownMissingSegmentIndices,
         CancellationToken cancellationToken
     )
     {
@@ -266,6 +278,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _useContainerAwareFill = useContainerAwareFill;
         _firstSegmentFileOffset = firstSegmentFileOffset;
         _knownCorruptSegmentIds = knownCorruptSegmentIds;
+        _knownMissingSegmentIndices = knownMissingSegmentIndices;
         _fileName = string.IsNullOrEmpty(fileName) ? "unknown" : fileName;
         _readBudget = readBudget ?? NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         _budget = inFlightArticleBudget ?? InFlightArticleBudget.Current;
@@ -380,27 +393,42 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         GetPlannedSegmentBytes(batchStart + index), cancellationToken).ConfigureAwait(false);
                 }
 
-                // Use the normal client path so cache hits still bypass admission.
-                var batch = await _usenetClient.DecodedBodiesAsync(
-                    segmentIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
-                if (batch.Responses.Count != batchCount)
-                    throw new InvalidOperationException(
-                        $"Pipelined BODY returned {batch.Responses.Count} responses for {batchCount} requests.");
+                // Known degraded holes never enter a provider batch. They still ask local
+                // patch/cache layers first, and their tasks stay in file order with live
+                // results so the consumer's segment-boundary contract is unchanged.
+                var liveIndexes = Enumerable.Range(0, batchCount)
+                    .Where(index => _knownMissingSegmentIndices?.Contains(batchStart + index) != true)
+                    .ToArray();
+                Task<UsenetDecodedBodyResponse>[] liveResponses = [];
+                if (liveIndexes.Length > 0)
+                {
+                    var liveIds = liveIndexes.Select(index => segmentIds[index]).ToArray();
+                    var batch = await _usenetClient.DecodedBodiesAsync(
+                        liveIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
+                    if (batch.Responses.Count != liveIndexes.Length)
+                        throw new InvalidOperationException(
+                            $"Pipelined BODY returned {batch.Responses.Count} responses for {liveIndexes.Length} requests.");
+                    liveResponses = batch.Responses.ToArray();
+                }
 
-                streamTasks = batch.Responses
-                    .Select((response, index) =>
-                    {
-                        var lease = leases[index]!;
-                        leases[index] = null;
-                        return DownloadBatchSegment(
-                            response,
+                streamTasks = new Task<SegmentDownloadResult>[batchCount];
+                var liveResponseIndex = 0;
+                for (var index = 0; index < batchCount; index++)
+                {
+                    var lease = leases[index]!;
+                    leases[index] = null;
+                    var segmentIndex = batchStart + index;
+                    streamTasks[index] = _knownMissingSegmentIndices?.Contains(segmentIndex) == true
+                        ? DownloadKnownMissingSegment(
+                            segmentIds[index], segmentIndex, lease, isFirstSegment: segmentIndex == 0, cancellationToken)
+                        : DownloadBatchSegment(
+                            liveResponses[liveResponseIndex++],
                             segmentIds[index],
-                            segmentIndex: batchStart + index,
-                            isFirstSegment: batchStart + index == 0,
+                            segmentIndex,
+                            isFirstSegment: segmentIndex == 0,
                             lease,
                             cancellationToken);
-                    })
-                    .ToArray();
+                }
             }
             catch
             {
@@ -536,6 +564,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var lease = initialLease;
         try
         {
+            if (_knownMissingSegmentIndices?.Contains(segmentIndex) == true)
+            {
+                var result = await DownloadKnownMissingSegment(
+                    segmentId, segmentIndex, lease, isFirstSegment, cancellationToken).ConfigureAwait(false);
+                lease = null;
+                return result;
+            }
+
             for (var attempt = 0; ; attempt++)
             {
                 try
@@ -653,6 +689,89 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             lease?.Dispose();
         }
+    }
+
+    private async Task<SegmentDownloadResult> DownloadKnownMissingSegment(
+        string segmentId,
+        int segmentIndex,
+        ArticleByteLease initialLease,
+        bool isFirstSegment,
+        CancellationToken cancellationToken)
+    {
+        var estimate = GetPlannedSegmentBytes(segmentIndex);
+        var lease = initialLease;
+        try
+        {
+            var local = await TryGetLocalSegmentAsync(segmentId, segmentIndex, lease, cancellationToken)
+                .ConfigureAwait(false);
+            if (local is null)
+                local = await TryGetLocalFallbackSegmentsAsync(segmentIndex, lease, cancellationToken)
+                    .ConfigureAwait(false);
+            if (local is not null)
+            {
+                lease = null;
+                return SegmentDownloadResult.Success(local, estimate);
+            }
+
+            var missing = new UsenetArticleNotFoundException(segmentId);
+            if (_failFastOnFirstSegment && isFirstSegment)
+                throw missing;
+            return ZeroFillSegment(
+                "Article {SegmentId} is a health-confirmed missing segment of {FileName}. Filling the {Bytes}-byte gap without a provider request.",
+                segmentId,
+                segmentIndex,
+                missing);
+        }
+        finally
+        {
+            lease?.Dispose();
+        }
+    }
+
+    private async Task<Stream?> TryGetLocalSegmentAsync(
+        string segmentId,
+        int segmentIndex,
+        ArticleByteLease? lease,
+        CancellationToken cancellationToken)
+    {
+        var body = await _usenetClient.TryGetLocalDecodedBodyAsync(segmentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (body?.Stream is not { } stream) return null;
+
+        try
+        {
+            await ThrowOnSegmentIdMismatchAsync(segmentId, body).ConfigureAwait(false);
+            if (!await SegmentResponseValidator.IsFallbackPartSizeCompatibleAsync(
+                    stream, _segmentSizes, segmentIndex, cancellationToken).ConfigureAwait(false))
+            {
+                await stream.DisposeAsync().ConfigureAwait(false);
+                return null;
+            }
+
+            return await DrainSegmentAsync(
+                    stream, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            await stream.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<Stream?> TryGetLocalFallbackSegmentsAsync(
+        int segmentIndex,
+        ArticleByteLease? lease,
+        CancellationToken cancellationToken)
+    {
+        foreach (var fallbackId in GetFallbacks(segmentIndex))
+        {
+            var local = await TryGetLocalSegmentAsync(fallbackId, segmentIndex, lease, cancellationToken)
+                .ConfigureAwait(false);
+            if (local is not null) return local;
+        }
+
+        return null;
     }
 
     private async Task<SegmentDownloadResult> DownloadBatchSegment(

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -715,7 +715,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
             var missing = new UsenetArticleNotFoundException(segmentId);
             if (_failFastOnFirstSegment && isFirstSegment)
+            {
+                missing.LogWarningKnownOrStack(
+                    "First article {SegmentId} is health-confirmed missing at playback start while reading {FileName}. " +
+                    "Failing the stream so the player surfaces an error.",
+                    segmentId, _fileName);
                 throw missing;
+            }
             return ZeroFillSegment(
                 "Article {SegmentId} is a health-confirmed missing segment of {FileName}. Filling the {Bytes}-byte gap without a provider request.",
                 segmentId,

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -26,7 +26,8 @@ public class NzbFileStream(
     InFlightArticleBudget? inFlightArticleBudget = null,
     bool useContainerAwareFill = false,
     int streamingBodyBatchWidth = 4,
-    HashSet<string>? knownCorruptSegmentIds = null
+    HashSet<string>? knownCorruptSegmentIds = null,
+    IReadOnlySet<int>? knownMissingSegmentIndices = null
 ) : FastReadOnlyStream
 {
     private const long MaximumForwardDrainBytes = 1024 * 1024;
@@ -48,6 +49,10 @@ public class NzbFileStream(
         AreSegmentByteRangesValid(segmentByteRanges, fileSegmentIds.Length, fileSize)
             ? segmentByteRanges
             : LogInvalidAndDiscard(segmentByteRanges, fileSegmentIds.Length, fileSize, fileName);
+    private readonly HashSet<int>? _knownMissingSegmentIndices =
+        knownMissingSegmentIndices is { Count: > 0 }
+            ? new HashSet<int>(knownMissingSegmentIndices.Where(index => (uint)index < (uint)fileSegmentIds.Length))
+            : null;
 
     private long[]? _exactSegmentSizes;
 
@@ -291,7 +296,7 @@ public class NzbFileStream(
     private async Task<Stream> GetFileStream(long rangeStart, CancellationToken cancellationToken)
     {
         if (rangeStart == 0) return GetMultiSegmentStream(0, failFastOnFirstSegment: true, cancellationToken);
-        if (!ShouldUseDirectRangePath())
+        if (!IsKnownMissingSegment(foundSegment: null, rangeStart) && !ShouldUseDirectRangePath())
         {
             var fast = await TryGetSeekStreamFast(rangeStart, cancellationToken).ConfigureAwait(false);
             if (fast != null) return fast;
@@ -330,6 +335,17 @@ public class NzbFileStream(
     {
         var budget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
         return budget is > 0 and <= MaximumDirectRangeBytes;
+    }
+
+    private bool IsKnownMissingSegment(InterpolationSearch.Result? foundSegment, long rangeStart)
+    {
+        if (_knownMissingSegmentIndices is null || _segmentByteRanges is null) return false;
+        var segment = foundSegment ?? InterpolationSearch.Find(
+            rangeStart,
+            new LongRange(0, _segmentByteRanges.Length),
+            new LongRange(0, fileSize),
+            guess => _segmentByteRanges[guess]);
+        return _knownMissingSegmentIndices.Contains(segment.FoundIndex);
     }
 
     private const int MaxSeekGuessCorrection = 3;
@@ -536,6 +552,10 @@ public class NzbFileStream(
             ? sizes.AsMemory(firstSegmentIndex)
             : default;
         var firstSegmentFileOffset = _segmentByteRanges?[firstSegmentIndex].StartInclusive;
+        var knownMissing = _knownMissingSegmentIndices?
+            .Where(index => index >= firstSegmentIndex)
+            .Select(index => index - firstSegmentIndex)
+            .ToHashSet();
 
         return MultiSegmentStream.CreateFirstSegmentHybrid(
             segmentIds,
@@ -552,7 +572,8 @@ public class NzbFileStream(
             useContainerAwareFill: useContainerAwareFill,
             firstSegmentFileOffset: firstSegmentFileOffset,
             bodyPipelineBatchWidth: streamingBodyBatchWidth,
-            knownCorruptSegmentIds: knownCorruptSegmentIds);
+            knownCorruptSegmentIds: knownCorruptSegmentIds,
+            knownMissingSegmentIndices: knownMissing);
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -23,6 +23,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly long? _firstSegmentFileOffset;
     private readonly bool _failFastOnFirstSegment;
     private readonly HashSet<string>? _knownCorruptSegmentIds;
+    private readonly IReadOnlySet<int>? _knownMissingSegmentIndices;
     private readonly byte[] _scratch = new byte[16];
     private Stream? _stream;
     private int _currentIndex;
@@ -46,7 +47,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         bool useContainerAwareFill = false,
         long? firstSegmentFileOffset = null,
         bool failFastOnFirstSegment = false,
-        HashSet<string>? knownCorruptSegmentIds = null)
+        HashSet<string>? knownCorruptSegmentIds = null,
+        IReadOnlySet<int>? knownMissingSegmentIndices = null)
     {
         _segmentIds = segmentIds;
         _segmentFallbacks = segmentFallbacks;
@@ -57,6 +59,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         _firstSegmentFileOffset = firstSegmentFileOffset;
         _failFastOnFirstSegment = failFastOnFirstSegment;
         _knownCorruptSegmentIds = knownCorruptSegmentIds;
+        _knownMissingSegmentIndices = knownMissingSegmentIndices;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -106,6 +109,13 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 var segmentId = _segmentIds.Span[_currentIndex++];
                 _openSegmentIndex = -1;
                 _openSegmentBytes = 0;
+                if (_knownMissingSegmentIndices?.Contains(segmentIndex) == true)
+                {
+                    await OpenKnownMissingSegmentAsync(segmentIndex, segmentId, cancellationToken)
+                        .ConfigureAwait(false);
+                    continue;
+                }
+
                 Stream? fetched = null;
                 try
                 {
@@ -262,6 +272,71 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return ContainerAwareFillStream.Create(_fileName, fill, fileOffset);
+    }
+
+    private async Task OpenKnownMissingSegmentAsync(
+        int segmentIndex,
+        string segmentId,
+        CancellationToken cancellationToken)
+    {
+        var local = await TryGetLocalSegmentAsync(segmentId, segmentIndex, cancellationToken)
+            .ConfigureAwait(false)
+            ?? await TryGetLocalFallbackAsync(segmentIndex, cancellationToken).ConfigureAwait(false);
+        if (local is not null)
+        {
+            _stream = local;
+            _openSegmentIndex = segmentIndex;
+            _openSegmentFromLiveFetch = false;
+            _consecutiveZeroFills = 0;
+            return;
+        }
+
+        var missing = new UsenetArticleNotFoundException(segmentId);
+        if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out _))
+            throw CreateUnknownLengthFailure(segmentIndex, missing);
+        ApplyZeroFill(segmentIndex, segmentId, fill, missing, isCorruption: false);
+    }
+
+    private async Task<Stream?> TryGetLocalSegmentAsync(
+        string segmentId,
+        int segmentIndex,
+        CancellationToken cancellationToken)
+    {
+        var body = await _usenetClient.TryGetLocalDecodedBodyAsync(segmentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (body?.Stream is not { } stream) return null;
+
+        try
+        {
+            await SegmentResponseValidator.ThrowOnSegmentIdMismatchAsync(segmentId, body).ConfigureAwait(false);
+            if (!await SegmentResponseValidator.IsFallbackPartSizeCompatibleAsync(
+                    stream, _segmentSizes, segmentIndex, cancellationToken).ConfigureAwait(false))
+            {
+                await DisposeBodyStreamAsync(stream).ConfigureAwait(false);
+                return null;
+            }
+
+            return stream;
+        }
+        catch
+        {
+            await DisposeBodyStreamAsync(stream).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<Stream?> TryGetLocalFallbackAsync(int segmentIndex, CancellationToken cancellationToken)
+    {
+        if (_segmentFallbacks is null || segmentIndex >= _segmentFallbacks.Length) return null;
+
+        foreach (var fallbackId in _segmentFallbacks[segmentIndex] ?? [])
+        {
+            var local = await TryGetLocalSegmentAsync(fallbackId, segmentIndex, cancellationToken)
+                .ConfigureAwait(false);
+            if (local is not null) return local;
+        }
+
+        return null;
     }
 
     private bool TryGetRemainingExactBytes(out long remaining)

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -292,6 +292,14 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         var missing = new UsenetArticleNotFoundException(segmentId);
+        if (_failFastOnFirstSegment && segmentIndex == 0)
+        {
+            missing.LogWarningKnownOrStack(
+                "First article {SegmentId} is health-confirmed missing at playback start while reading {FileName}. " +
+                "Failing the stream so the player surfaces an error.",
+                segmentId, _fileName);
+            throw missing;
+        }
         if (!_segmentSizes.TryGetFillLength(segmentIndex, out var fill, out _))
             throw CreateUnknownLengthFailure(segmentIndex, missing);
         ApplyZeroFill(segmentIndex, segmentId, fill, missing, isCorruption: false);

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -49,7 +49,8 @@ public class DatabaseStoreNzbFile(
             inFlightArticleBudget,
             useContainerAwareFill: Config.IsContainerAwareFillEnabled(),
             streamingBodyBatchWidth: Config.GetStreamingBodyBatchWidth(),
-            knownCorruptSegmentIds: ResolveKnownCorruptSegmentIds(nzbFile));
+            knownCorruptSegmentIds: ResolveKnownCorruptSegmentIds(nzbFile),
+            knownMissingSegmentIndices: ResolveKnownMissingSegmentIndices(nzbFile));
     }
 
     private HashSet<string>? ResolveKnownCorruptSegmentIds(DavNzbFile nzbFile)
@@ -62,5 +63,18 @@ public class DatabaseStoreNzbFile(
             ids.Add(nzbFile.SegmentIds[index]);
 
         return ids.Count == 0 ? null : ids;
+    }
+
+    private HashSet<int>? ResolveKnownMissingSegmentIndices(DavNzbFile nzbFile)
+    {
+        if (!Config.IsDegradedToleranceEnabled()) return null;
+        if (nzbFile.SegmentByteRanges is not { } ranges || ranges.Length != nzbFile.SegmentIds.Length)
+            return null;
+        if (nzbFile.MissingSegmentIndices is not { Length: > 0 } indices) return null;
+
+        var validIndices = indices
+            .Where(index => index > 0 && (uint)index < (uint)nzbFile.SegmentIds.Length)
+            .ToHashSet();
+        return validIndices.Count == 0 ? null : validIndices;
     }
 }

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -63,7 +63,9 @@ enabled, releases old enough to be sampled are not classified.
 - **Degraded** — holes within all three caps (longest consecutive run, total count, and share
   of the file's bytes) in a container that tolerant decoders can resync past. The file stays
   mounted, playback zero-fills the gaps, and **no Arr repair is triggered**. The confirmed
-  holes are recorded on the item so the status survives restarts.
+  holes are recorded on the item so the status survives restarts; later playback fills them
+  without sending a provider BODY request. A local PAR2 patch or segment-cache entry still wins
+  over a gap fill, and the next full health sweep detects a provider-side recovery.
 - **Failed** — over any cap, any hole in an unsafe layout, or an unrecognized container.
   These take the normal repair path (PAR2 reconstruction first when enabled, then Arr
   remove-and-replace), exactly as before.

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -13,11 +13,14 @@ internal sealed class FakeNntpClient(
     IReadOnlyDictionary<string, byte[]> segments,
     bool useCachedYencStreams = false,
     IReadOnlyDictionary<string, LongRange>? segmentRanges = null,
-    Func<string, byte[], Stream>? decodedStreamFactory = null) : NntpClient
+    Func<string, byte[], Stream>? decodedStreamFactory = null,
+    IReadOnlyDictionary<string, byte[]>? localSegments = null) : NntpClient
 {
     // Copied at construction so tests can add/restore articles via Serve() without
     // mutating the caller's dictionary.
     private readonly Dictionary<string, byte[]> _segments = new(segments, StringComparer.Ordinal);
+    private readonly IReadOnlyDictionary<string, byte[]> _localSegments =
+        localSegments ?? new Dictionary<string, byte[]>(StringComparer.Ordinal);
 
     public int BatchRequestCount { get; private set; }
     public int BodyRequestCount { get; private set; }
@@ -93,6 +96,17 @@ internal sealed class FakeNntpClient(
         }
     }
 
+    public override Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId segmentId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var key = segmentId.ToString();
+        return _localSegments.ContainsKey(key)
+            ? Task.FromResult<UsenetDecodedBodyResponse?>(CreateBodyResponse(segmentId, _localSegments))
+            : Task.FromResult<UsenetDecodedBodyResponse?>(null);
+    }
+
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
         ArticleBodyCompletionHandler? onConnectionReadyAgain,
@@ -150,10 +164,15 @@ internal sealed class FakeNntpClient(
     {
     }
 
-    private UsenetDecodedBodyResponse CreateBodyResponse(SegmentId segmentId)
+    private UsenetDecodedBodyResponse CreateBodyResponse(SegmentId segmentId) =>
+        CreateBodyResponse(segmentId, _segments);
+
+    private UsenetDecodedBodyResponse CreateBodyResponse(
+        SegmentId segmentId,
+        IReadOnlyDictionary<string, byte[]> segments)
     {
         var key = segmentId.ToString();
-        if (!_segments.TryGetValue(key, out var bytes))
+        if (!segments.TryGetValue(key, out var bytes))
             throw new UsenetArticleNotFoundException(key, "430 No such article");
 
         YencStream stream = useCachedYencStreams
@@ -166,7 +185,7 @@ internal sealed class FakeNntpClient(
                         : bytes.Length,
                     LineLength = 128,
                     PartNumber = 1,
-                    TotalParts = _segments.Count,
+                    TotalParts = segments.Count,
                     PartOffset = segmentRanges?[key].StartInclusive ?? 0,
                     PartSize = segmentRanges?[key].Count ?? bytes.Length,
                 },

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -174,6 +174,8 @@ internal sealed class FakeNntpClient(
         var key = segmentId.ToString();
         if (!segments.TryGetValue(key, out var bytes))
             throw new UsenetArticleNotFoundException(key, "430 No such article");
+        var range = default(LongRange);
+        var hasRange = segmentRanges is not null && segmentRanges.TryGetValue(key, out range);
 
         YencStream stream = useCachedYencStreams
             ? new CachedYencStream(
@@ -186,8 +188,8 @@ internal sealed class FakeNntpClient(
                     LineLength = 128,
                     PartNumber = 1,
                     TotalParts = segments.Count,
-                    PartOffset = segmentRanges?[key].StartInclusive ?? 0,
-                    PartSize = segmentRanges?[key].Count ?? bytes.Length,
+                    PartOffset = hasRange ? range!.StartInclusive : 0,
+                    PartSize = hasRange ? range!.Count : bytes.Length,
                 },
                 decodedStreamFactory?.Invoke(key, bytes)
                     ?? new MemoryStream(bytes, writable: false))

--- a/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
@@ -83,6 +83,36 @@ public class KnownMissingFastPathTests
     }
 
     [Fact]
+    public async Task KnownMissingSegment_UsesLocalFallbackWithoutRangeMetadata()
+    {
+        const string primary = "missing@test";
+        const string fallback = "fallback@test";
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>(),
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange> { [primary] = new(0, 5) },
+            localSegments: new Dictionary<string, byte[]> { [fallback] = "local"u8.ToArray() });
+        await using var stream = MultiSegmentStream.Create(
+            new[] { primary }.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            estimatedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            segmentFallbacks: [new[] { fallback }],
+            exactSegmentSizes: new long[] { 5 },
+            knownMissingSegmentIndices: new HashSet<int> { 0 });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal("local", Encoding.ASCII.GetString(output.ToArray()));
+        Assert.Equal(0, client.BodyRequestCount);
+    }
+
+    [Fact]
     public async Task ThirdConsecutiveKnownMissingSegment_FailsWithoutProviderRequests()
     {
         var ids = new[] { "missing-one", "missing-two", "missing-three" };
@@ -98,6 +128,31 @@ public class KnownMissingFastPathTests
             fileName: "movie.mkv",
             exactSegmentSizes: new long[] { 5, 5, 5 },
             knownMissingSegmentIndices: new HashSet<int> { 0, 1, 2 });
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream.CopyToAsync(Stream.Null));
+
+        Assert.Equal(0, client.BodyRequestCount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public async Task KnownMissingFirstSegment_PreservesFailFastBehavior(int articleBufferSize)
+    {
+        const string segmentId = "missing@test";
+        var client = new FakeNntpClient(new Dictionary<string, byte[]>());
+        await using var stream = MultiSegmentStream.Create(
+            new[] { segmentId }.AsMemory(),
+            client,
+            articleBufferSize,
+            estimatedSegmentSize: 5,
+            failFastOnFirstSegment: true,
+            usePipelinedBodyRequests: articleBufferSize > 0,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { 5 },
+            knownMissingSegmentIndices: new HashSet<int> { 0 });
 
         await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
             async () => await stream.CopyToAsync(Stream.Null));

--- a/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class KnownMissingFastPathTests
+{
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(4, true)]
+    public async Task KnownMissingSegment_SkipsProviderAndPreservesOrder(
+        int articleBufferSize,
+        bool usePipelinedBodyRequests)
+    {
+        const string first = "first@test";
+        const string missing = "missing@test";
+        const string last = "last@test";
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                [first] = "one"u8.ToArray(),
+                [last] = "two"u8.ToArray(),
+            },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange>
+            {
+                [first] = new(0, 3),
+                [missing] = new(3, 6),
+                [last] = new(6, 9),
+            });
+        await using var stream = MultiSegmentStream.Create(
+            new[] { first, missing, last }.AsMemory(),
+            client,
+            articleBufferSize,
+            estimatedSegmentSize: 3,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { 3, 3, 3 },
+            knownMissingSegmentIndices: new HashSet<int> { 1 });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal("one\0\0\0two", Encoding.ASCII.GetString(output.ToArray()));
+        Assert.Equal(0, client.BodyRequestCounts.GetValueOrDefault(missing));
+        Assert.Equal(1, client.BodyRequestCounts[first]);
+        Assert.Equal(1, client.BodyRequestCounts[last]);
+        Assert.Equal(usePipelinedBodyRequests, client.BatchRequestCount > 0);
+    }
+
+    [Fact]
+    public async Task KnownMissingSegment_UsesLocalCopyBeforeGapFill()
+    {
+        const string segmentId = "missing@test";
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>(),
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange> { [segmentId] = new(0, 5) },
+            localSegments: new Dictionary<string, byte[]> { [segmentId] = "local"u8.ToArray() });
+        await using var stream = MultiSegmentStream.Create(
+            new[] { segmentId }.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            estimatedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { 5 },
+            knownMissingSegmentIndices: new HashSet<int> { 0 });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal("local", Encoding.ASCII.GetString(output.ToArray()));
+        Assert.Equal(0, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task ThirdConsecutiveKnownMissingSegment_FailsWithoutProviderRequests()
+    {
+        var ids = new[] { "missing-one", "missing-two", "missing-three" };
+        var client = new FakeNntpClient(new Dictionary<string, byte[]>());
+        await using var stream = MultiSegmentStream.Create(
+            ids.AsMemory(),
+            client,
+            articleBufferSize: 0,
+            estimatedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: "movie.mkv",
+            exactSegmentSizes: new long[] { 5, 5, 5 },
+            knownMissingSegmentIndices: new HashSet<int> { 0, 1, 2 });
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream.CopyToAsync(Stream.Null));
+
+        Assert.Equal(0, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task SeekIntoKnownMissingSegment_SkipsDirectProviderFetch()
+    {
+        string[] ids = ["first@test", "missing@test", "last@test"];
+        var ranges = new[] { new LongRange(0, 3), new LongRange(3, 6), new LongRange(6, 9) };
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                [ids[0]] = "one"u8.ToArray(),
+                [ids[2]] = "two"u8.ToArray(),
+            },
+            useCachedYencStreams: true,
+            segmentRanges: ids.Zip(ranges).ToDictionary(pair => pair.First, pair => pair.Second));
+        await using var stream = new NzbFileStream(
+            ids,
+            fileSize: 9,
+            client,
+            articleBufferSize: 4,
+            segmentByteRanges: ranges,
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv",
+            knownMissingSegmentIndices: new HashSet<int> { 1 });
+        stream.Seek(3, SeekOrigin.Begin);
+        var destination = new byte[3];
+
+        var read = await stream.ReadAsync(destination);
+
+        Assert.Equal(3, read);
+        Assert.Equal(new byte[3], destination);
+        Assert.Equal(0, client.BodyRequestCounts.GetValueOrDefault(ids[1]));
+    }
+}


### PR DESCRIPTION
## Summary
- skip NNTP BODY requests for health-confirmed degraded holes while preserving gap alignment
- serve local PAR2 patches and segment-cache entries before filling a known gap
- cover buffered, unbuffered, pipelined, and seek playback paths

Closes #461

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] `cd frontend && npm run typecheck && npm run build && npm test -- --run`
- [x] `zensical build --clean --strict`
- [x] Focused known-missing playback regressions