### PR TITLE
fix(arr): Arr Health supports current Sonarr and Radarr history

### DIFF
--- a/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NzbWebDAV.Clients.RadarrSonarr.BaseModels;
@@ -20,8 +21,33 @@ public class ArrHistoryRecord
     public string? DownloadId { get; set; }
 
     [JsonPropertyName("eventType")]
+    [JsonConverter(typeof(ArrEventTypeJsonConverter))]
     public int EventType { get; set; }
 
     [JsonPropertyName("sourceTitle")]
     public string? SourceTitle { get; set; }
+}
+
+public sealed class ArrEventTypeJsonConverter : JsonConverter<int>
+{
+    public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        reader.TokenType switch
+        {
+            JsonTokenType.Number when reader.TryGetInt32(out var value) => value,
+            JsonTokenType.String => ParseEventType(reader.GetString()),
+            _ => 0,
+        };
+
+    public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(value);
+
+    private static int ParseEventType(string? value) =>
+        value switch
+        {
+            null => 0,
+            _ when int.TryParse(value, out var numericValue) => numericValue,
+            _ when value.Equals("grabbed", StringComparison.OrdinalIgnoreCase) => 1,
+            _ when value.Equals("downloadFolderImported", StringComparison.OrdinalIgnoreCase) => 3,
+            _ => 0,
+        };
 }

--- a/tests/NzbWebDAV.Tests/Clients/ArrHistoryJsonTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/ArrHistoryJsonTests.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+
+namespace NzbWebDAV.Tests.Clients;
+
+public class ArrHistoryJsonTests
+{
+    [Theory]
+    [InlineData("""{"records":[{"eventType":"downloadFolderImported"}]}""", 3)]
+    [InlineData("""{"records":[{"eventType":3}]}""", 3)]
+    [InlineData("""{"records":[{"eventType":"3"}]}""", 3)]
+    [InlineData("""{"records":[{"eventType":"futureEventType"}]}""", 0)]
+    public void Deserialize_AcceptsStringNumericAndUnknownEventTypes(string json, int expectedEventType)
+    {
+        var history = JsonSerializer.Deserialize<ArrHistory>(json);
+
+        Assert.Equal(expectedEventType, Assert.Single(history!.Records).EventType);
+    }
+}


### PR DESCRIPTION
## Summary
- accept string and numeric Arr history event types returned by current Sonarr/Radarr APIs
- keep unknown event types from failing the Arr health poll
- cover string, numeric, numeric-string, and unknown event type responses

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~ArrHistoryJsonTests\"`