### PR TITLE
chore(test): freeze current SAB and admin API response contracts

### DIFF
--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -82,6 +82,14 @@ public class UsenetStreamingClient : WrappingNntpClient
         };
     }
 
+    /// <summary>
+    /// Test constructor that wraps a scripted <see cref="INntpClient"/> without
+    /// opening real provider pools.
+    /// </summary>
+    internal UsenetStreamingClient(INntpClient inner) : base(inner)
+    {
+    }
+
     private static HeaderCachingNntpClient CreateDownloadingNntpClient
     (
         ConfigManager configManager,

--- a/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
@@ -153,11 +153,11 @@ public sealed class AdminContractTests
             serverError.Content.Headers.ContentType?.MediaType);
     }
 
-    private static Task<HttpResponseMessage> PostConfigKeysAsync(HttpClient client, params string[] keys)
+    private static async Task<HttpResponseMessage> PostConfigKeysAsync(HttpClient client, params string[] keys)
     {
-        var form = new MultipartFormDataContent();
+        using var form = new MultipartFormDataContent();
         foreach (var key in keys)
             form.Add(new StringContent(key), "config-keys");
-        return client.PostAsync("/api/get-config", form);
+        return await client.PostAsync("/api/get-config", form);
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class AdminContractTests
+{
+    [Fact]
+    public async Task SettingsReadUpdateRead_UsesStableAdminContracts()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var initial = await PostConfigKeysAsync(client, ConfigKeys.WebdavShowHiddenFiles);
+        using var initialJson = await JsonDocument.ParseAsync(await initial.Content.ReadAsStreamAsync());
+        Assert.Equal(HttpStatusCode.OK, initial.StatusCode);
+        Assert.True(initialJson.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal(JsonValueKind.Array, initialJson.RootElement.GetProperty("configItems").ValueKind);
+
+        using var updateForm = new MultipartFormDataContent();
+        updateForm.Add(new StringContent("true"), ConfigKeys.WebdavShowHiddenFiles);
+        using var update = await client.PostAsync("/api/update-config", updateForm);
+        using var updateJson = await SabContractAssertions.AssertSuccessAsync(update);
+
+        using var reread = await PostConfigKeysAsync(client, ConfigKeys.WebdavShowHiddenFiles);
+        using var rereadJson = await JsonDocument.ParseAsync(await reread.Content.ReadAsStreamAsync());
+        Assert.Equal(HttpStatusCode.OK, reread.StatusCode);
+        var item = Assert.Single(rereadJson.RootElement.GetProperty("configItems").EnumerateArray());
+        Assert.Equal(ConfigKeys.WebdavShowHiddenFiles, item.GetProperty("configName").GetString());
+        Assert.Equal("true", item.GetProperty("configValue").GetString());
+        Assert.True(item.TryGetProperty("environmentVariableName", out _));
+    }
+
+    [Fact]
+    public async Task HealthCheckTrigger_ResetsScheduledItemIntoObservableQueue()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+
+        var scheduled = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "contract-health.mkv",
+            1024,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            DateTimeOffset.UtcNow.AddDays(-2),
+            DateTimeOffset.UtcNow.AddDays(-1),
+            historyItemId: null,
+            fileBlobId: null);
+        await factory.AddDavItemsAsync(scheduled);
+
+        using var before = await client.GetAsync("/api/get-health-check-queue?pageSize=30");
+        using var beforeJson = await JsonDocument.ParseAsync(await before.Content.ReadAsStreamAsync());
+        Assert.Equal(HttpStatusCode.OK, before.StatusCode);
+        Assert.True(beforeJson.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal(JsonValueKind.Number, beforeJson.RootElement.GetProperty("uncheckedCount").ValueKind);
+        var queued = Assert.Single(
+            beforeJson.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("id").GetString() == scheduled.Id.ToString());
+        Assert.Equal("contract-health.mkv", queued.GetProperty("name").GetString());
+        Assert.Equal(JsonValueKind.String, queued.GetProperty("path").ValueKind);
+
+        using var trigger = await client.PostAsync("/api/reset-health-check-queue", content: null);
+        using var triggerJson = await SabContractAssertions.AssertSuccessAsync(trigger);
+        Assert.Equal(JsonValueKind.Number, triggerJson.RootElement.GetProperty("resetCount").ValueKind);
+        Assert.Equal(1, triggerJson.RootElement.GetProperty("resetCount").GetInt32());
+
+        using var after = await client.GetAsync("/api/get-health-check-queue?pageSize=30");
+        using var afterJson = await JsonDocument.ParseAsync(await after.Content.ReadAsStreamAsync());
+        var resetItem = Assert.Single(
+            afterJson.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("id").GetString() == scheduled.Id.ToString());
+        Assert.Equal(JsonValueKind.Null, resetItem.GetProperty("nextHealthCheck").ValueKind);
+        Assert.True(afterJson.RootElement.GetProperty("uncheckedCount").GetInt32() >= 1);
+    }
+
+    [Fact]
+    public async Task WebDavItemList_ReturnsSeededDirectoryChildren()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+
+        var folder = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "contract-library",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+        await factory.AddDavItemsAsync(folder);
+
+        using var form = new MultipartFormDataContent();
+        form.Add(new StringContent("/content"), "directory");
+        using var response = await client.PostAsync("/api/list-webdav-directory", form);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        Assert.Equal(JsonValueKind.Array, json.RootElement.GetProperty("items").ValueKind);
+        Assert.Contains(
+            json.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("name").GetString() == "contract-library"
+                    && item.GetProperty("isDirectory").GetBoolean());
+    }
+
+    [Fact]
+    public async Task AdminAuthenticationAndErrorEnvelopes_StayStatusErrorShaped()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var anonymous = factory.CreateClient();
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var missingKey = await anonymous.GetAsync("/api/get-health-check-queue");
+        await SabContractAssertions.AssertFailureAsync(
+            missingKey, HttpStatusCode.Unauthorized, "API Key Required");
+
+        using var missingDirectoryForm = new MultipartFormDataContent();
+        missingDirectoryForm.Add(new StringContent("/content/does-not-exist"), "directory");
+        using var missingDirectory = await client.PostAsync(
+            "/api/list-webdav-directory", missingDirectoryForm);
+        await SabContractAssertions.AssertFailureAsync(
+            missingDirectory, HttpStatusCode.BadRequest, "does not exist");
+
+        using var readonlyDeleteForm = new MultipartFormDataContent();
+        readonlyDeleteForm.Add(new StringContent("/content/does-not-exist"), "path");
+        using var readonlyDelete = await client.PostAsync("/api/delete-webdav-item", readonlyDeleteForm);
+        await SabContractAssertions.AssertFailureAsync(
+            readonlyDelete, HttpStatusCode.Forbidden, "read-only");
+
+        using var disableReadonly = new MultipartFormDataContent();
+        disableReadonly.Add(new StringContent("false"), ConfigKeys.WebdavEnforceReadonly);
+        using var updated = await client.PostAsync("/api/update-config", disableReadonly);
+        await SabContractAssertions.AssertSuccessAsync(updated);
+
+        using var missingItemForm = new MultipartFormDataContent();
+        missingItemForm.Add(new StringContent("/content/does-not-exist"), "path");
+        using var missingItem = await client.PostAsync("/api/delete-webdav-item", missingItemForm);
+        await SabContractAssertions.AssertFailureAsync(
+            missingItem, HttpStatusCode.NotFound, "Item not found");
+
+        using var serverError = await client.GetAsync("/api/get-config");
+        await SabContractAssertions.AssertFailureAsync(
+            serverError, HttpStatusCode.InternalServerError, "internal server error");
+        Assert.Equal(
+            "application/json",
+            serverError.Content.Headers.ContentType?.MediaType);
+    }
+
+    private static Task<HttpResponseMessage> PostConfigKeysAsync(HttpClient client, params string[] keys)
+    {
+        var form = new MultipartFormDataContent();
+        foreach (var key in keys)
+            form.Add(new StringContent(key), "config-keys");
+        return client.PostAsync("/api/get-config", form);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
@@ -131,9 +131,11 @@ public sealed class SabHttpContractTests
         await SabContractAssertions.AssertFailureAsync(
             malformedHistory, HttpStatusCode.BadRequest, "Invalid nzo_ids");
 
+        using var serverErrorBody = new StringContent(
+            "{}", new MediaTypeHeaderValue("application/json"));
         using var serverError = await client.PostAsync(
             "/api?mode=addfile&output=json",
-            new StringContent("{}", new MediaTypeHeaderValue("application/json")));
+            serverErrorBody);
         await SabContractAssertions.AssertFailureAsync(
             serverError, HttpStatusCode.InternalServerError, "internal server error");
     }

--- a/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class SabHttpContractTests
+{
+    [Fact]
+    public async Task AddFileQueueDeleteHistoryRetry_UsesStableSabContracts()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var pauseResponse = await client.PostAsync("/api?mode=pause&output=json", content: null);
+        await SabContractAssertions.AssertSuccessAsync(pauseResponse);
+
+        using var form = new MultipartFormDataContent();
+        form.Add(new ByteArrayContent(TestNzbs.SingleFile), "name", "sample.nzb");
+        using var addResponse = await client.PostAsync("/api?mode=addfile&output=json&cat=tv", form);
+        using var addJson = await SabContractAssertions.AssertSuccessAsync(addResponse);
+        var nzoId = Assert.Single(addJson.RootElement.GetProperty("nzo_ids").EnumerateArray())
+            .GetString();
+        Assert.True(Guid.TryParse(nzoId, out var queuedId));
+
+        using var queueResponse = await client.GetAsync("/api?mode=queue&output=json");
+        using var queueJson = await SabContractAssertions.AssertSuccessAsync(queueResponse);
+        var queue = queueJson.RootElement.GetProperty("queue");
+        Assert.Equal(JsonValueKind.True, queue.GetProperty("paused").ValueKind);
+        Assert.Equal(JsonValueKind.Number, queue.GetProperty("noofslots").ValueKind);
+        Assert.Equal(JsonValueKind.String, queue.GetProperty("speedlimit").ValueKind);
+        Assert.Equal(JsonValueKind.String, queue.GetProperty("speedlimit_abs").ValueKind);
+        Assert.Equal(JsonValueKind.String, queue.GetProperty("pause_int").ValueKind);
+        Assert.Equal(JsonValueKind.String, queue.GetProperty("speed").ValueKind);
+        Assert.Equal(JsonValueKind.String, queue.GetProperty("kbpersec").ValueKind);
+        Assert.Equal(JsonValueKind.String, queue.GetProperty("timeleft").ValueKind);
+        var slot = Assert.Single(queue.GetProperty("slots").EnumerateArray());
+        SabContractAssertions.AssertQueueSlotShape(slot);
+        Assert.Equal(nzoId, slot.GetProperty("nzo_id").GetString());
+        Assert.Equal("sample.nzb", slot.GetProperty("filename").GetString());
+        Assert.Equal("tv", slot.GetProperty("cat").GetString());
+
+        using var deleteResponse = await client.GetAsync(
+            $"/api?mode=queue&name=delete&value={queuedId}&output=json");
+        await SabContractAssertions.AssertSuccessAsync(deleteResponse);
+
+        using var emptyQueueResponse = await client.GetAsync("/api?mode=queue&output=json");
+        using var emptyQueueJson = await SabContractAssertions.AssertSuccessAsync(emptyQueueResponse);
+        Assert.Empty(emptyQueueJson.RootElement.GetProperty("queue").GetProperty("slots").EnumerateArray());
+        Assert.Equal(0, emptyQueueJson.RootElement.GetProperty("queue").GetProperty("noofslots").GetInt32());
+
+        using var emptyHistoryResponse = await client.GetAsync("/api?mode=history&output=json");
+        using var emptyHistoryJson = await SabContractAssertions.AssertSuccessAsync(emptyHistoryResponse);
+        Assert.Empty(
+            emptyHistoryJson.RootElement.GetProperty("history").GetProperty("slots").EnumerateArray());
+
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(historyId, fileName: "sample.nzb", category: "tv");
+
+        using var historyResponse = await client.GetAsync("/api?mode=history&output=json");
+        using var historyJson = await SabContractAssertions.AssertSuccessAsync(historyResponse);
+        var history = historyJson.RootElement.GetProperty("history");
+        Assert.Equal(JsonValueKind.Number, history.GetProperty("noofslots").ValueKind);
+        var historySlot = Assert.Single(history.GetProperty("slots").EnumerateArray());
+        SabContractAssertions.AssertHistorySlotShape(historySlot);
+        Assert.Equal(historyId.ToString(), historySlot.GetProperty("nzo_id").GetString());
+        Assert.Equal("Failed", historySlot.GetProperty("status").GetString());
+        Assert.Equal("sample.nzb", historySlot.GetProperty("nzb_name").GetString());
+
+        using var retryResponse = await client.GetAsync(
+            $"/api?mode=retry&value={historyId}&output=json");
+        using var retryJson = await SabContractAssertions.AssertSuccessAsync(retryResponse);
+        var retriedId = retryJson.RootElement.GetProperty("nzo_id").GetString();
+        Assert.True(Guid.TryParse(retriedId, out var newQueueId));
+        Assert.NotEqual(historyId, newQueueId);
+        var retriedIds = retryJson.RootElement.GetProperty("nzo_ids").EnumerateArray()
+            .Select(x => x.GetString())
+            .ToArray();
+        Assert.Contains(retriedId, retriedIds);
+
+        using var retriedQueueResponse = await client.GetAsync("/api?mode=queue&output=json");
+        using var retriedQueueJson = await SabContractAssertions.AssertSuccessAsync(retriedQueueResponse);
+        var retriedSlot = Assert.Single(
+            retriedQueueJson.RootElement.GetProperty("queue").GetProperty("slots").EnumerateArray());
+        Assert.Equal(retriedId, retriedSlot.GetProperty("nzo_id").GetString());
+        Assert.Equal("sample.nzb", retriedSlot.GetProperty("filename").GetString());
+
+        using var keptHistoryResponse = await client.GetAsync("/api?mode=history&output=json");
+        using var keptHistoryJson = await SabContractAssertions.AssertSuccessAsync(keptHistoryResponse);
+        var keptSlot = Assert.Single(
+            keptHistoryJson.RootElement.GetProperty("history").GetProperty("slots").EnumerateArray());
+        Assert.Equal(historyId.ToString(), keptSlot.GetProperty("nzo_id").GetString());
+    }
+
+    [Fact]
+    public async Task AuthenticationInvalidModeAndMalformedRequests_UseStatusErrorEnvelope()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var anonymous = factory.CreateClient();
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var missingKey = await anonymous.GetAsync("/api?mode=queue&output=json");
+        await SabContractAssertions.AssertFailureAsync(
+            missingKey, HttpStatusCode.Unauthorized, "API Key Required");
+
+        using var wrongKeyRequest = new HttpRequestMessage(HttpMethod.Get, "/api?mode=queue&output=json");
+        wrongKeyRequest.Headers.Add("x-api-key", "not-the-key");
+        using var wrongKey = await anonymous.SendAsync(wrongKeyRequest);
+        await SabContractAssertions.AssertFailureAsync(
+            wrongKey, HttpStatusCode.Unauthorized, "API Key Incorrect");
+
+        using var queryKey = await anonymous.GetAsync(
+            $"/api?mode=queue&output=json&apikey={NzbDavWebApplicationFactory.ApiKey}");
+        await SabContractAssertions.AssertSuccessAsync(queryKey);
+
+        using var invalidMode = await client.GetAsync("/api?mode=not-a-mode&output=json");
+        await SabContractAssertions.AssertFailureAsync(
+            invalidMode, HttpStatusCode.BadRequest, "Invalid mode");
+
+        using var emptyForm = new MultipartFormDataContent();
+        emptyForm.Add(new StringContent("ignored"), "notfile");
+        using var malformedAdd = await client.PostAsync("/api?mode=addfile&output=json", emptyForm);
+        await SabContractAssertions.AssertFailureAsync(
+            malformedAdd, HttpStatusCode.BadRequest, "nzbFile");
+
+        using var malformedHistory = await client.GetAsync(
+            "/api?mode=history&output=json&nzo_ids=not-a-guid");
+        await SabContractAssertions.AssertFailureAsync(
+            malformedHistory, HttpStatusCode.BadRequest, "Invalid nzo_ids");
+
+        using var serverError = await client.PostAsync(
+            "/api?mode=addfile&output=json",
+            new StringContent("{}", new MediaTypeHeaderValue("application/json")));
+        await SabContractAssertions.AssertFailureAsync(
+            serverError, HttpStatusCode.InternalServerError, "internal server error");
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
@@ -28,7 +28,9 @@ public sealed class OomDiagnosticsTests
         var events = CaptureLogs(() =>
             OomDiagnostics.LogHeapStateOnOom(new InvalidOperationException("test"), "test operation"));
 
-        Assert.Empty(events);
+        Assert.DoesNotContain(
+            events,
+            e => e.MessageTemplate.Text.Contains("OutOfMemoryException during"));
     }
 
     private static IReadOnlyList<LogEvent> CaptureLogs(Action action)

--- a/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/NzbDavWebApplicationFactory.cs
@@ -2,14 +2,19 @@ using System.Net.Http.Headers;
 using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Tests.Fakes;
 
 namespace NzbWebDAV.Tests.TestUtils;
 
@@ -22,10 +27,16 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
     private readonly string _configPath =
         Path.Join(Path.GetTempPath(), $"nzbdav-http-tests-{Guid.NewGuid():N}");
     private readonly Dictionary<string, string?> _previousEnvironment = new();
+    private readonly FakeNntpClient? _fakeNntpClient;
     private int _disposed;
 
-    public NzbDavWebApplicationFactory()
+    public NzbDavWebApplicationFactory() : this(fakeNntpClient: null)
     {
+    }
+
+    internal NzbDavWebApplicationFactory(FakeNntpClient? fakeNntpClient)
+    {
+        _fakeNntpClient = fakeNntpClient;
         Directory.CreateDirectory(_configPath);
         SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
         SetEnvironmentVariable("CONFIG_PATH", _configPath);
@@ -38,9 +49,34 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
         InitializeDatabases();
     }
 
+    public string ConfigPath => _configPath;
+    internal FakeNntpClient? FakeNntpClient => _fakeNntpClient;
+
+    internal static NzbDavWebApplicationFactory CreateWithFakeNntp(
+        IReadOnlyDictionary<string, byte[]> segments)
+    {
+        return new NzbDavWebApplicationFactory(
+            new FakeNntpClient(segments, useCachedYencStreams: true));
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+        if (_fakeNntpClient is null)
+            return;
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<UsenetStreamingClient>();
+            services.AddSingleton(_ => new UsenetStreamingClient(_fakeNntpClient));
+        });
+    }
+
+    public HttpClient CreateAuthenticatedClient()
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Add("x-api-key", ApiKey);
+        return client;
     }
 
     public HttpRequestMessage CreateWebDavRequest(HttpMethod method, string path, string? depth = null)
@@ -71,6 +107,84 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
         await context.SaveChangesAsync();
     }
 
+    public async Task WriteNzbBlobAsync(Guid id, byte[] nzbBytes)
+    {
+        _ = Services;
+        await using var stream = new MemoryStream(nzbBytes);
+        await BlobStore.WriteBlob(id, stream);
+    }
+
+    public async Task<QueueItem> SeedQueueItemAsync(
+        Guid id,
+        string fileName = "sample.nzb",
+        string category = "tv",
+        byte[]? nzbBytes = null)
+    {
+        await WriteNzbBlobAsync(id, nzbBytes ?? TestNzbs.SingleFile);
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DavDatabaseContext>();
+        var item = new QueueItem
+        {
+            Id = id,
+            CreatedAt = DateTime.UtcNow,
+            SortOrder = DateTime.UtcNow.Ticks,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            NzbFileSize = nzbBytes?.Length ?? TestNzbs.SingleFile.Length,
+            TotalSegmentBytes = 128,
+            Category = category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+        context.QueueItems.Add(item);
+        context.NzbNames.Add(new NzbName { Id = id, FileName = fileName });
+        await context.SaveChangesAsync();
+        return item;
+    }
+
+    public async Task<HistoryItem> SeedHistoryItemAsync(
+        Guid id,
+        HistoryItem.DownloadStatusOption status = HistoryItem.DownloadStatusOption.Failed,
+        string fileName = "sample.nzb",
+        string category = "tv",
+        byte[]? nzbBytes = null)
+    {
+        await WriteNzbBlobAsync(id, nzbBytes ?? TestNzbs.SingleFile);
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DavDatabaseContext>();
+        var item = new HistoryItem
+        {
+            Id = id,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = category,
+            DownloadStatus = status,
+            TotalSegmentBytes = 128,
+            DownloadTimeSeconds = 5,
+            FailMessage = status == HistoryItem.DownloadStatusOption.Failed
+                ? "Timeout reading from NNTP stream."
+                : "",
+            NzbBlobId = id,
+        };
+        context.HistoryItems.Add(item);
+        context.NzbNames.Add(new NzbName { Id = id, FileName = fileName });
+        await context.SaveChangesAsync();
+        return item;
+    }
+
+    public async Task WaitUntilQueueIdleAsync(
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        timeout ??= TimeSpan.FromSeconds(10);
+        var queueManager = Services.GetRequiredService<QueueManager>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout.Value);
+        while (queueManager.HasActiveQueueItems)
+            await Task.Delay(25, cts.Token);
+    }
+
     protected override void Dispose(bool disposing)
     {
         try
@@ -81,6 +195,7 @@ public sealed class NzbDavWebApplicationFactory : WebApplicationFactory<Program>
         {
             if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
             {
+                _fakeNntpClient?.Dispose();
                 SqliteConnection.ClearAllPools();
                 foreach (var variable in _previousEnvironment)
                     Environment.SetEnvironmentVariable(variable.Key, variable.Value);

--- a/tests/NzbWebDAV.Tests/TestUtils/SabContractAssertions.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/SabContractAssertions.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Text.Json;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal static class SabContractAssertions
+{
+    public static async Task<JsonDocument> AssertSuccessAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await ParseJsonAsync(response);
+        Assert.True(json.RootElement.GetProperty("status").GetBoolean());
+        if (json.RootElement.TryGetProperty("error", out var error) &&
+            error.ValueKind is not JsonValueKind.Null)
+        {
+            Assert.True(string.IsNullOrEmpty(error.GetString()));
+        }
+
+        return json;
+    }
+
+    public static async Task<JsonDocument> AssertFailureAsync(
+        HttpResponseMessage response,
+        HttpStatusCode statusCode,
+        string? errorContains = null)
+    {
+        Assert.Equal(statusCode, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        var json = await ParseJsonAsync(response);
+        Assert.False(json.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal(JsonValueKind.String, json.RootElement.GetProperty("error").ValueKind);
+        Assert.False(json.RootElement.TryGetProperty("type", out _));
+        Assert.False(json.RootElement.TryGetProperty("title", out _));
+        Assert.False(json.RootElement.TryGetProperty("traceId", out _));
+        if (errorContains is not null)
+        {
+            Assert.Contains(
+                errorContains,
+                json.RootElement.GetProperty("error").GetString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        return json;
+    }
+
+    public static void AssertQueueSlotShape(JsonElement slot)
+    {
+        Assert.Equal(JsonValueKind.Number, slot.GetProperty("index").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("nzo_id").ValueKind);
+        Assert.True(Guid.TryParse(slot.GetProperty("nzo_id").GetString(), out _));
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("priority").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("filename").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("cat").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("percentage").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("true_percentage").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("status").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("timeleft").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("mb").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("mbleft").ValueKind);
+    }
+
+    public static void AssertHistorySlotShape(JsonElement slot)
+    {
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("nzo_id").ValueKind);
+        Assert.True(Guid.TryParse(slot.GetProperty("nzo_id").GetString(), out _));
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("nzb_name").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("name").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("category").ValueKind);
+        Assert.Equal(JsonValueKind.String, slot.GetProperty("status").ValueKind);
+        Assert.Equal(JsonValueKind.Number, slot.GetProperty("bytes").ValueKind);
+        Assert.Equal(JsonValueKind.Number, slot.GetProperty("download_time").ValueKind);
+        Assert.Equal(JsonValueKind.Number, slot.GetProperty("completed").ValueKind);
+        Assert.True(
+            slot.GetProperty("fail_message").ValueKind is JsonValueKind.String or JsonValueKind.Null);
+    }
+
+    private static async Task<JsonDocument> ParseJsonAsync(HttpResponseMessage response)
+    {
+        return await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+    }
+}

--- a/tests/NzbWebDAV.Tests/TestUtils/SabContractAssertions.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/SabContractAssertions.cs
@@ -8,6 +8,7 @@ internal static class SabContractAssertions
     public static async Task<JsonDocument> AssertSuccessAsync(HttpResponseMessage response)
     {
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
         var json = await ParseJsonAsync(response);
         Assert.True(json.RootElement.GetProperty("status").GetBoolean());
         if (json.RootElement.TryGetProperty("error", out var error) &&

--- a/tests/NzbWebDAV.Tests/TestUtils/TestNzbs.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/TestNzbs.cs
@@ -1,0 +1,21 @@
+using System.Text;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal static class TestNzbs
+{
+    public const string SingleFileSegmentId = "contract-seg1@example.test";
+
+    public static readonly byte[] SingleFile = Encoding.UTF8.GetBytes(
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+          <file poster="contract@example.test" date="1" subject="sample.mkv">
+            <groups><group>alt.binaries.test</group></groups>
+            <segments>
+              <segment bytes="128" number="1">contract-seg1@example.test</segment>
+            </segments>
+          </file>
+        </nzb>
+        """);
+}


### PR DESCRIPTION
## Summary
- Add in-process HTTP characterization tests for the SABnzbd `addfile` → `queue` → `delete` → `history` → `retry` lifecycle through `/api?mode=*`.
- Freeze admin settings read/update, health-check queue trigger, WebDAV directory listing, and current `status`/`error` envelopes (including 401/400/403/404/500) before later ProblemDetails work.
- Extend `NzbDavWebApplicationFactory` with authenticated clients, blob/queue/history seeding, queue-idle waits, and optional `FakeNntpClient` injection.

Related to #850 (Phase 1 characterization only; remaining schema, cross-stack, WebDAV, and CI work will follow in a later PR and should close the issue).

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~SabHttpContractTests|FullyQualifiedName~AdminContractTests"`
- [x] Existing HTTP integration tests (`HttpPipelineIntegrationTests`, `DatabaseStoreHttpIntegrationTests`, `AdminOpenApiIntegrationTests`, `GcDiagnosticsHttpIntegrationTests`) still pass
- [ ] Confirm Arr clients still see the same SAB JSON field names after merge