### PR TITLE
fix(docker): fail startup when the config directory is missing or unwritable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
             --deterministic-only \
             --summary "${GITHUB_STEP_SUMMARY}"
 
+      - name: Verify CONFIG_PATH preflight fixtures
+        run: sh scripts/test-entrypoint-config-preflight.sh
+
       - name: Verify NuGet vulnerability gate fixtures
         run: bash scripts/test-nuget-vulnerability-gate.sh
 
@@ -393,6 +396,7 @@ jobs:
             Dockerfile \
             .dockerignore \
             entrypoint.sh \
+            scripts/preflight-config-path.sh \
             backend/NzbWebDAV.csproj \
             backend/nuget.config \
             libs/ \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,10 @@ Environment variables:
 export CONFIG_PATH=/where/to/create/database/
 export FRONTEND_BACKEND_API_KEY=$(head -c 32 /dev/urandom | hexdump -ve '1/1 "%.2x"')
 export BACKEND_URL=http://localhost:5000
+mkdir -p "$CONFIG_PATH"
 ```
+
+The backend fails startup if `CONFIG_PATH` is missing, is a regular file, or is not writable. Create the directory yourself (or use `./scripts/run-backend.sh`, which does).
 
 ### PostgreSQL main database
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,9 @@ COPY --from=frontend-build /frontend/build ./frontend/build
 COPY --from=backend-build /src/backend/publish ./backend
 
 # Entry and runtime setup
+COPY scripts/preflight-config-path.sh /preflight-config-path.sh
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh /preflight-config-path.sh
 
 # Set env variables
 EXPOSE 3000

--- a/backend/Database/ConfigPathPreflight.cs
+++ b/backend/Database/ConfigPathPreflight.cs
@@ -3,9 +3,12 @@ using NzbWebDAV.Exceptions;
 namespace NzbWebDAV.Database;
 
 /// <summary>
-/// Fails fast with one actionable error when CONFIG_PATH or a known state file under
-/// it is not readable/writable by the process user, instead of aborting later with an
-/// unhandled UnauthorizedAccessException (which core-dumps and hides the cause).
+/// Fails fast with one actionable error when CONFIG_PATH is missing, is not a
+/// directory, or a known state file under it is not readable/writable by the
+/// process user, instead of aborting later with an unhandled
+/// UnauthorizedAccessException (which core-dumps and hides the cause).
+/// Does not create a missing CONFIG_PATH: forgotten volume mounts should fail
+/// rather than write into an ephemeral container directory.
 /// Best-effort early report: a file can become unreadable between this probe and the
 /// real open, so the open sites (e.g. DatabaseMigrationLease) remain the backstop.
 /// </summary>
@@ -26,6 +29,14 @@ internal static class ConfigPathPreflight
         "blobs",
         "data-protection",
         "migration-backups",
+        "backups",
+        "restore-staging",
+    ];
+
+    private static readonly string[] KnownStateFiles =
+    [
+        "pending-restore.json",
+        "session.key",
     ];
 
     public static void VerifyAccess()
@@ -33,21 +44,18 @@ internal static class ConfigPathPreflight
         var configPath = DavDatabaseContext.ConfigPath;
         var failures = new List<string>();
 
-        if (Directory.Exists(configPath))
+        if (File.Exists(configPath))
         {
-            if (!CanWriteToDirectory(configPath))
-                failures.Add($"{configPath} (directory is not writable)");
+            failures.Add($"{configPath} (path exists but is not a directory)");
         }
-        else
+        else if (!Directory.Exists(configPath))
         {
-            try
-            {
-                Directory.CreateDirectory(configPath);
-            }
-            catch (Exception e) when (e is UnauthorizedAccessException or IOException)
-            {
-                failures.Add($"{configPath} (directory cannot be created)");
-            }
+            failures.Add(
+                $"{configPath} (directory does not exist; create or mount it before startup, typically as /config)");
+        }
+        else if (!CanWriteToDirectory(configPath))
+        {
+            failures.Add($"{configPath} (directory is not writable)");
         }
 
         if (Directory.Exists(configPath))
@@ -71,6 +79,9 @@ internal static class ConfigPathPreflight
                 if (Directory.Exists(path) && !CanWriteToDirectory(path))
                     failures.Add($"{path} (directory is not writable)");
             }
+
+            foreach (var path in KnownStateFiles.Select(fileName => Path.Join(configPath, fileName)))
+                ProbeFile(path, failures);
         }
 
         if (failures.Count > 0)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -12,7 +12,7 @@ Advanced reference for **process / container** wiring and **legacy Settings fall
 
 | Variable | Default | Effect |
 |----------|---------|--------|
-| `CONFIG_PATH` | `/config` | SQLite, blobs, backups, session key |
+| `CONFIG_PATH` | `/config` | SQLite, blobs, backups, session key. Must already exist as a writable directory before startup; the backend does not create a missing path. |
 | `PUID` / `PGID` | `1000` | Container user/group for `/config` ownership |
 | `TZ` | unset | Schedules and log timestamps |
 | `BACKEND_URL` | `http://localhost:8080` | Frontend → backend (set by entrypoint if empty) |

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -47,6 +47,8 @@ docker compose up -d
 
 Set `PUID`/`PGID` from `id` on the host. Map `/mnt` (or your media paths) so completed downloads and library folders share paths with *Arr and media servers.
 
+The container fails startup before migrations if `/config` is missing, is a file, or is not writable by `PUID`/`PGID`. Ownership repair is best-effort; ACLs and group-writable mounts are accepted when the runtime user can create and delete a probe file. The image already contains an empty `/config` directory, so a path existing inside the container is not proof a host volume is mounted.
+
 !!! tip "Headless Settings [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }"
 
     Prefer infrastructure-as-code for Usenet, WebDAV, *Arr, and other Settings? Use authoritative

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -3,7 +3,8 @@
 ## Container unhealthy / won't start
 
 - Check `docker logs nzbdav` for migration or backend health failures.
-- Ensure `CONFIG_PATH` (`/config`) is writable by `PUID`/`PGID`.
+- Ensure `CONFIG_PATH` (`/config`) exists as a directory and is writable by `PUID`/`PGID`. Startup now fails before migrations with a message that names the path and expected `PUID`/`PGID` instead of a later SQLite/EF error.
+- A `/config` path inside the image is not proof a persistent volume is mounted. Confirm the Compose `volumes:` mapping on the host.
 - Frontend `/healthz` should pass during long migrations; backend `/health` must eventually succeed.
 
 ## Locked out of the web UI

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,12 @@ if [ -z "${CONFIG_PATH}" ]; then
     export CONFIG_PATH="/config"
 fi
 
+# Fail before frontend start or migrations when the config path is missing
+# or not writable by the runtime user. Ownership repair is best-effort.
+# shellcheck disable=SC1091
+. /preflight-config-path.sh
+preflight_config_path || exit 1
+
 # Recursively update permissions when either database or its WAL files were
 # created by a different container user.
 chown "$PUID:$PGID" "$CONFIG_PATH"

--- a/scripts/preflight-config-path.sh
+++ b/scripts/preflight-config-path.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# CONFIG_PATH preflight used by the container entrypoint.
+# Requires CONFIG_PATH, PUID, PGID, and USER_NAME in the environment.
+# chown / su-exec may be stubbed via PATH in tests.
+
+preflight_config_path() {
+    if [ -z "$CONFIG_PATH" ]; then
+        echo "Fatal: CONFIG_PATH is not set." >&2
+        return 1
+    fi
+
+    if [ -e "$CONFIG_PATH" ] && [ ! -d "$CONFIG_PATH" ]; then
+        echo "Fatal: CONFIG_PATH '$CONFIG_PATH' exists but is not a directory." >&2
+        echo "Mount a persistent directory at /config and grant PUID=${PUID:-?} PGID=${PGID:-?} read/write access." >&2
+        return 1
+    fi
+
+    if [ ! -d "$CONFIG_PATH" ]; then
+        echo "Fatal: CONFIG_PATH '$CONFIG_PATH' is not an existing directory." >&2
+        echo "Mount a persistent directory at /config and grant PUID=${PUID:-?} PGID=${PGID:-?} read/write access." >&2
+        echo "The image contains an empty /config; a path existing inside the container is not proof a host volume is mounted." >&2
+        return 1
+    fi
+
+    if ! chown "$PUID:$PGID" "$CONFIG_PATH"; then
+        echo "Warning: could not adjust ownership of '$CONFIG_PATH'; checking effective access." >&2
+    fi
+
+    probe_path="$CONFIG_PATH/.config-path-probe-$$"
+    if ! su-exec "$USER_NAME" sh -c 'umask 077; : > "$1" && rm -f "$1"' sh "$probe_path"; then
+        echo "Fatal: CONFIG_PATH '$CONFIG_PATH' is not writable by PUID=$PUID PGID=$PGID." >&2
+        echo "Verify the persistent /config mount and host permissions." >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/scripts/preflight-config-path.sh
+++ b/scripts/preflight-config-path.sh
@@ -11,14 +11,14 @@ preflight_config_path() {
 
     if [ -e "$CONFIG_PATH" ] && [ ! -d "$CONFIG_PATH" ]; then
         echo "Fatal: CONFIG_PATH '$CONFIG_PATH' exists but is not a directory." >&2
-        echo "Mount a persistent directory at /config and grant PUID=${PUID:-?} PGID=${PGID:-?} read/write access." >&2
+        echo "Mount a persistent directory at '$CONFIG_PATH' (default /config) and grant PUID=${PUID:-?} PGID=${PGID:-?} read/write access." >&2
         return 1
     fi
 
     if [ ! -d "$CONFIG_PATH" ]; then
         echo "Fatal: CONFIG_PATH '$CONFIG_PATH' is not an existing directory." >&2
-        echo "Mount a persistent directory at /config and grant PUID=${PUID:-?} PGID=${PGID:-?} read/write access." >&2
-        echo "The image contains an empty /config; a path existing inside the container is not proof a host volume is mounted." >&2
+        echo "Mount a persistent directory at '$CONFIG_PATH' (default /config) and grant PUID=${PUID:-?} PGID=${PGID:-?} read/write access." >&2
+        echo "The image contains an empty default /config; a path existing inside the container is not proof a host volume is mounted." >&2
         return 1
     fi
 
@@ -26,10 +26,9 @@ preflight_config_path() {
         echo "Warning: could not adjust ownership of '$CONFIG_PATH'; checking effective access." >&2
     fi
 
-    probe_path="$CONFIG_PATH/.config-path-probe-$$"
-    if ! su-exec "$USER_NAME" sh -c 'umask 077; : > "$1" && rm -f "$1"' sh "$probe_path"; then
+    if ! su-exec "$USER_NAME" sh -c 'umask 077; probe=$(mktemp "$1/.config-path-probe.XXXXXX") && rm -f "$probe"' sh "$CONFIG_PATH"; then
         echo "Fatal: CONFIG_PATH '$CONFIG_PATH' is not writable by PUID=$PUID PGID=$PGID." >&2
-        echo "Verify the persistent /config mount and host permissions." >&2
+        echo "Verify the persistent mount at '$CONFIG_PATH' and host permissions." >&2
         return 1
     fi
 

--- a/scripts/test-entrypoint-config-preflight.sh
+++ b/scripts/test-entrypoint-config-preflight.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Fixture checks for scripts/preflight-config-path.sh
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+PREFLIGHT="$ROOT/scripts/preflight-config-path.sh"
+STUBS="$(mktemp -d "${TMPDIR:-/tmp}/nzbdav-preflight-stubs.XXXXXX")"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/nzbdav-preflight-work.XXXXXX")"
+FAILED=0
+
+cleanup() {
+    rm -rf "$STUBS" "$WORKDIR"
+}
+trap cleanup EXIT INT HUP TERM
+
+write_stub() {
+    name=$1
+    body=$2
+    path="$STUBS/$name"
+    printf '%s\n' "#!/bin/sh" "$body" > "$path"
+    chmod +x "$path"
+}
+
+pass() {
+    printf 'ok - %s\n' "$1"
+}
+
+fail() {
+    printf 'not ok - %s\n' "$1" >&2
+    FAILED=1
+}
+
+# Ignore the requested user and run the remaining command as the test user.
+write_stub su-exec 'shift; exec "$@"'
+write_stub chown 'exit 0'
+
+export PATH="$STUBS:$PATH"
+# shellcheck disable=SC1090
+. "$PREFLIGHT"
+
+export PUID=1000
+export PGID=1000
+export USER_NAME=appuser
+
+missing="$WORKDIR/missing"
+if CONFIG_PATH="$missing" preflight_config_path >/dev/null 2>"$WORKDIR/missing.err"; then
+    fail "missing path should fail"
+else
+    grep -q "not an existing directory" "$WORKDIR/missing.err" || fail "missing path message"
+    [ ! -e "$missing" ] || fail "missing path must not be created"
+    pass "missing path"
+fi
+
+regular="$WORKDIR/regular-file"
+: > "$regular"
+if CONFIG_PATH="$regular" preflight_config_path >/dev/null 2>"$WORKDIR/regular.err"; then
+    fail "regular file should fail"
+else
+    grep -q "not a directory" "$WORKDIR/regular.err" || fail "regular file message"
+    pass "regular file"
+fi
+
+readonly_dir="$WORKDIR/readonly"
+mkdir "$readonly_dir"
+chmod a-w "$readonly_dir"
+if ( : > "$readonly_dir/.write-check" ) 2>/dev/null; then
+    rm -f "$readonly_dir/.write-check"
+    chmod u+w "$readonly_dir"
+    pass "read-only directory skipped (running as root)"
+else
+    if CONFIG_PATH="$readonly_dir" preflight_config_path >/dev/null 2>"$WORKDIR/readonly.err"; then
+        fail "read-only directory should fail"
+    else
+        grep -q "not writable" "$WORKDIR/readonly.err" || fail "read-only directory message"
+        pass "read-only directory"
+    fi
+    chmod u+w "$readonly_dir"
+fi
+
+write_stub chown 'echo "chown invoked" >&2; exit 1'
+# shellcheck disable=SC1090
+. "$PREFLIGHT"
+writable="$WORKDIR/writable-after-chown-fail"
+mkdir "$writable"
+if CONFIG_PATH="$writable" preflight_config_path >"$WORKDIR/chown.out" 2>"$WORKDIR/chown.err"; then
+    grep -q "could not adjust ownership" "$WORKDIR/chown.err" || fail "failed chown warning"
+    pass "failed chown with effective write access"
+else
+    fail "failed chown should still pass when the directory is writable"
+fi
+
+write_stub chown 'exit 0'
+# shellcheck disable=SC1090
+. "$PREFLIGHT"
+success="$WORKDIR/success"
+mkdir "$success"
+if CONFIG_PATH="$success" preflight_config_path >/dev/null 2>"$WORKDIR/success.err"; then
+    [ ! -e "$success/.config-path-probe-$$" ] || fail "probe file leaked"
+    pass "writable directory"
+else
+    fail "writable directory should pass"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "CONFIG_PATH preflight fixtures failed." >&2
+    exit 1
+fi
+
+echo "CONFIG_PATH preflight fixtures passed."

--- a/scripts/test-entrypoint-config-preflight.sh
+++ b/scripts/test-entrypoint-config-preflight.sh
@@ -95,7 +95,12 @@ write_stub chown 'exit 0'
 success="$WORKDIR/success"
 mkdir "$success"
 if CONFIG_PATH="$success" preflight_config_path >/dev/null 2>"$WORKDIR/success.err"; then
-    [ ! -e "$success/.config-path-probe-$$" ] || fail "probe file leaked"
+    leaked=0
+    for probe in "$success"/.config-path-probe*; do
+        [ -e "$probe" ] || continue
+        leaked=1
+    done
+    [ "$leaked" -eq 0 ] || fail "probe file leaked"
     pass "writable directory"
 else
     fail "writable directory should pass"

--- a/tests/NzbWebDAV.Tests/Database/ConfigPathPreflightTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/ConfigPathPreflightTests.cs
@@ -34,14 +34,40 @@ public sealed class ConfigPathPreflightTests : IDisposable
     }
 
     [Fact]
-    public void VerifyAccess_CreatesMissingConfigDirectory()
+    public void VerifyAccess_ThrowsWhenConfigDirectoryIsMissing()
     {
         var missing = Path.Join(_configRoot, "nested", "config");
         Environment.SetEnvironmentVariable("CONFIG_PATH", missing);
 
-        ConfigPathPreflight.VerifyAccess();
+        var exception = Assert.Throws<ConfigPathAccessException>(() => ConfigPathPreflight.VerifyAccess());
 
-        Assert.True(Directory.Exists(missing));
+        Assert.Contains(missing, exception.Message);
+        Assert.Contains("does not exist", exception.Message);
+        Assert.False(Directory.Exists(missing));
+    }
+
+    [Fact]
+    public void VerifyAccess_ThrowsWhenConfigPathIsARegularFile()
+    {
+        var filePath = Path.Join(_configRoot, "not-a-directory");
+        File.WriteAllText(filePath, "not a directory");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", filePath);
+
+        var exception = Assert.Throws<ConfigPathAccessException>(() => ConfigPathPreflight.VerifyAccess());
+
+        Assert.Contains(filePath, exception.Message);
+        Assert.Contains("not a directory", exception.Message);
+    }
+
+    [Fact]
+    public void VerifyAccess_PassesWithExistingBackupAndSessionStateFiles()
+    {
+        Directory.CreateDirectory(Path.Join(_configRoot, "backups"));
+        Directory.CreateDirectory(Path.Join(_configRoot, "restore-staging"));
+        File.WriteAllText(Path.Join(_configRoot, "pending-restore.json"), "{}");
+        File.WriteAllText(Path.Join(_configRoot, "session.key"), "test-session-key");
+
+        ConfigPathPreflight.VerifyAccess();
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Fail before migrations when `CONFIG_PATH` is missing, is a regular file, or is not writable, instead of auto-creating the directory.
- Run the same check in the container entrypoint before the frontend or `--db-migration` starts, with best-effort `chown` and an effective write probe as the runtime user.
- Document that an in-image `/config` path is not proof a host volume is mounted.

Fixes #899

## Test plan
- [x] `sh -n entrypoint.sh`
- [x] `sh scripts/test-entrypoint-config-preflight.sh`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ConfigPathPreflightTests|FullyQualifiedName~DatabaseMigrationLeaseTests|FullyQualifiedName~StartupDatabaseMigrationTests"`
- [x] `zensical build --clean --strict`
- [ ] Start a container without a `/config` mount (or with `/config` as a file) and confirm the fatal message names the path and PUID/PGID